### PR TITLE
Fix replayed text doubling and split the overloaded Codex E2E gate

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -177,44 +177,33 @@ A capture that genuinely cannot be refreshed goes in `STALE_RECORDED_REQUEST_EXC
 
   Temporarily enable the selected Copilot variant. Re-record narrowly if the current capture does not exist.
 
-### Codex duplicated or unstable response behavior
+### Codex has no file tools
 
-- Scope: Codex deterministic replay.
-- Expected: a model-backed scenario emits one coherent response and honors exact-response prompts.
-- Gate: `stableNewScenarioResponse: false` in the Codex provider config.
+- Scope: Codex.
+- Gate: `supportsFileTools: false` in the Codex provider config.
 
-This single flag currently covers **two distinct problems**, which need different work. Splitting it is a prerequisite for reducing it.
+Codex exposes a single tool, `exec_command`. Every committed `captures/codex-*.yaml` confirms it: the only tool name that appears is `exec_command`, where Claude's captures contain `Read`, `Write` and `Bash`.
 
-**(a) Recorded but unstable.** A Codex capture exists; replay duplicates response content, or an exact-response prompt does not produce the expected response. Flipping the gate is enough to reevaluate these.
+The shared file-operation scenarios steer the agent away from the shell (`Use your file tools; do not run a shell command.`) so that their captures stay platform-neutral. Codex cannot satisfy that instruction and does not fall back — it refuses, in its own words:
 
-- `retains context across consecutive turns`
-- `reads an existing text file`
-- `reads a file from a nested directory`
-- `lists workspace entries`
-- `handles a missing file without a session error`
-- `creates a new text file`
-- `edits an existing text file`
-- `creates a file in a new nested directory`
-- `renames a workspace file`
-- `deletes a workspace file`
-- `reads a filename containing spaces`
-
-Reproduce by temporarily enabling only the selected scenario:
-
-```bash
-./scripts/test-integration.sh --run \
-  src/vs/platform/agentHost/test/node/e2e/providers/codexAgentHostE2E.integrationTest.ts \
-  --grep "<exact test title>"
+```
+I can't access file contents without using a shell command in this environment,
+and you asked me not to run one.
 ```
 
-**(b) Never recorded.** No `captures/codex-*.yaml` exists at all, so replay fails at fixture resolution rather than on an assertion. Flipping the gate cannot re-enable these — recording has to succeed first, with `AGENT_HOST_REPLAY_RECORD=1` and a real Codex binary.
+`counts lines in a file` shows the sharper version of the same failure: Codex flails and answers `3` for a four-line file rather than refusing outright.
 
-- `reads a value from JSON`
-- `counts lines in a file`
-- `runs a deterministic shell command`
-- `inspects git status`
+This is a provider capability difference, not a bug to be fixed by re-recording. Making these scenarios run against Codex means giving them a provider-specific prompt that pins a portable shell command instead of steering to file tools — the "pin, don't steer" half of [Steering versus pinning](#steering-versus-pinning). That is worth doing and is the actionable next step here.
 
-These four are the actionable item: until they are recorded, the reason Codex skips them is unknown, and it may be a product bug rather than replay instability.
+Reproduce with any of the gated scenarios:
+
+```bash
+AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
+  src/vs/platform/agentHost/test/node/e2e/providers/codexAgentHostE2E.integrationTest.ts \
+  --grep "reads a file from a nested directory"
+```
+
+The same gate also covers the file-operation scenarios that pin a shell command rather than steering. Codex performs those through `exec_command` too, and they do not replay stably once several of them share one server: the failing scenario moves between runs, which is the [shared-server load ceiling](./README.md#server-lifecycle) rather than a fault in any one test. Enabling them needs that lifecycle understood first; enabling them naively turns a green suite into one that fails about one run in four.
 
 ## Platform and deterministic-replay limitations
 
@@ -312,6 +301,7 @@ These pending tests do not currently indicate bugs. They are listed by capabilit
 | Multiple chats | `supportsMultipleChats` | Codex | All model-backed peer-chat scenarios in `multiChatSuite` skip. The negative test `provider without multiple chat capability rejects peer creation` runs *because* of the gate. Host-owned peer-catalog semantics are unaffected — they moved to the conformance tier and run once regardless of provider. |
 | Chat fork (E2E) | `supportsChatForkE2E` | Claude, Codex | `forkProviderTest` scenarios skip. For Claude this is **not** an expected skip — see [Claude provider-context fork](#claude-provider-context-fork). |
 | Subagents | `supportsSubagents` | Codex | `subagent tool calls are routed to the subagent session, not flat in the parent`, `reopening a session keeps sub-agent messages out of the parent transcript (replay path)`. |
+| File tools | `supportsFileTools` | Codex | The file-operation scenarios in `fileOperationsSuite`. See [Codex has no file tools](#codex-has-no-file-tools). |
 | Plan mode | `supportsPlanMode` | Codex, Claude | `planning-mode session-state writes are auto-approved in default mode`. For Claude this is a prompt-portability problem — see [Claude plan-mode prompt](#claude-plan-mode-prompt). |
 | Host terminal tool | `supportsHostTerminalTool` | Claude, Codex | Worktree isolation is verified via the resolved working directory alone rather than terminal `pwd` output. |
 | Worktree isolation | `supportsWorktreeIsolation` | none | Now host-owned; enabled for all providers. |
@@ -327,7 +317,7 @@ The complete Claude or Codex deterministic suite is skipped when its bundled SDK
 Periodically:
 
 1. Run the full provider files and the conformance file, not only focused tests, because shared-process failures may depend on suite order.
-2. Reevaluate broad gates such as `stableNewScenarioResponse` one test at a time, and check first whether the capture exists.
+2. Reevaluate broad gates such as `supportsFileTools` one test at a time, and check first whether the capture exists. A gate that covers more than one distinct cause hides all but the loudest of them: prefer splitting it over flipping it.
 3. Check whether new provider SDK/CLI versions changed tool selection or completion behavior.
 4. Re-record narrowly when wire behavior changed, then review every generated capture.
 5. Enable fixed variants and remove stale entries, comments, config flags, and orphaned captures together.

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -195,7 +195,7 @@ and you asked me not to run one.
 
 This is a provider capability difference, not a bug to be fixed by re-recording. Making these scenarios run against Codex means giving them a provider-specific prompt that pins a portable shell command instead of steering to file tools — the "pin, don't steer" half of [Steering versus pinning](#steering-versus-pinning). That is worth doing and is the actionable next step here.
 
-Reproduce with any of the gated scenarios:
+Reproduce by temporarily enabling `supportsFileTools` for Codex and recording one scenario:
 
 ```bash
 AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
@@ -203,7 +203,16 @@ AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
   --grep "reads a file from a nested directory"
 ```
 
-The same gate also covers the file-operation scenarios that pin a shell command rather than steering. Codex performs those through `exec_command` too, and they do not replay stably once several of them share one server: the failing scenario moves between runs, which is the [shared-server load ceiling](./README.md#server-lifecycle) rather than a fault in any one test. Enabling them needs that lifecycle understood first; enabling them naively turns a green suite into one that fails about one run in four.
+Recording is required rather than incidental: these scenarios have no Codex capture, so plain replay stops at fixture resolution and never reaches the provider. **Note that this rewrites captures and AHP snapshots**, so `git checkout` the artifacts afterwards unless the new recording is the intended result. The failure appears in the run output — Codex says it cannot read a file without a shell — rather than in the artifacts.
+
+### Codex file scenarios are unstable on a shared server
+
+- Scope: Codex.
+- Gate: `stableSharedServerFileScenarios: false`.
+
+Separate from the capability gap above, and tracked separately because the two need different work. The file-operation scenarios that pin a portable shell command need no file tools, so Codex can run them — but it performs each through `exec_command`, and several such turns on one long-lived server do not replay stably: the tool-call completion is reported inconsistently, and **the failing scenario moves between runs**.
+
+That signature is the [shared-server load ceiling](./README.md#server-lifecycle), not a fault in any single test; each replays cleanly in isolation via `--grep`. Enabling the family naively turns a green suite into one that fails roughly one run in four, so it needs the lifecycle understood first.
 
 ## Platform and deterministic-replay limitations
 
@@ -301,7 +310,8 @@ These pending tests do not currently indicate bugs. They are listed by capabilit
 | Multiple chats | `supportsMultipleChats` | Codex | All model-backed peer-chat scenarios in `multiChatSuite` skip. The negative test `provider without multiple chat capability rejects peer creation` runs *because* of the gate. Host-owned peer-catalog semantics are unaffected — they moved to the conformance tier and run once regardless of provider. |
 | Chat fork (E2E) | `supportsChatForkE2E` | Claude, Codex | `forkProviderTest` scenarios skip. For Claude this is **not** an expected skip — see [Claude provider-context fork](#claude-provider-context-fork). |
 | Subagents | `supportsSubagents` | Codex | `subagent tool calls are routed to the subagent session, not flat in the parent`, `reopening a session keeps sub-agent messages out of the parent transcript (replay path)`. |
-| File tools | `supportsFileTools` | Codex | The file-operation scenarios in `fileOperationsSuite`. See [Codex has no file tools](#codex-has-no-file-tools). |
+| File tools | `supportsFileTools` | Codex | The `fileOperationsSuite` scenarios whose prompt steers to file tools. See [Codex has no file tools](#codex-has-no-file-tools). |
+| Shared-server file scenarios | `stableSharedServerFileScenarios` | Codex | The `fileOperationsSuite` scenarios that pin a shell command. See [Codex file scenarios are unstable on a shared server](#codex-file-scenarios-are-unstable-on-a-shared-server). |
 | Plan mode | `supportsPlanMode` | Codex, Claude | `planning-mode session-state writes are auto-approved in default mode`. For Claude this is a prompt-portability problem — see [Claude plan-mode prompt](#claude-plan-mode-prompt). |
 | Host terminal tool | `supportsHostTerminalTool` | Claude, Codex | Worktree isolation is verified via the resolved working directory alone rather than terminal `pwd` output. |
 | Worktree isolation | `supportsWorktreeIsolation` | none | Now host-owned; enabled for all providers. |

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -423,6 +423,12 @@ Codex fixtures use its unified `exec_command` tool, so Codex record/replay serve
 
 When a test times out waiting for a notification and it is **not** platform-specific local execution (above), the failure is usually inside the bundled provider SDK/CLI. For the **Copilot** provider, a failed test tails the most recent Copilot runtime (`@github/copilot` CLI) `process-*.log` into the test output — look for the `[agent-host-e2e] # …` lines. That is the SDK/CLI's own account of startup, auth, the model request, and the turn lifecycle; a turn that started but never produced a model response, a panic, or an out-of-order / protocol error points at the SDK/CLI. Re-record after an SDK bump if the fixture is stale; otherwise treat it as a genuine regression. The Copilot runtime runs at `--log trace` in this harness, and the full logs live under the server's temp home (`${homeDir}/.copilot/logs`) until the suite tears down. (Claude and Codex use their own runtimes and are not captured here — check their provider CLI's own logs.)
 
+### Replayed text is doubled (`VALUEVALUE`)
+
+The Responses (`/responses`) regenerator announces each output item before streaming it. If `response.output_item.added` carries the item's final content, a consumer that accumulates that content *and* the following deltas counts the same text twice, so a recorded `SHELL_VALUE_73` replays as `SHELL_VALUE_73SHELL_VALUE_73`.
+
+`responsesMessageToSse` therefore sends the added item empty. Recording is unaffected (it proxies real bytes), which is why this only ever showed up on replay — and why the recorded capture looked correct while the replayed snapshot did not.
+
 ### A test passes on macOS/Linux but fails on Windows
 
 Same as above — it's platform-specific real execution, not the proxy. See the worktree and subagent gates for established patterns.

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-creates-a-file-in-a-new-nested-directory.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-creates-a-file-in-a-new-nested-directory.yaml
@@ -6,41 +6,39 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
     response:
       content:
-        - type: text
-          text: Creating `output/report.txt` now with the exact required content `NESTED_CREATED`.
         - type: tool_use
           id: toolcall_0
           name: exec_command
           input:
-            cmd: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt
+            cmd: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+            workdir: ${workdir}
       stopReason: tool_use
   - request:
       model: gpt-5.3-codex
       system: ${system}
       messages:
         - role: user
-          content: Create output/report.txt containing exactly NESTED_CREATED.
-        - role: assistant
-          content: Creating `output/report.txt` now with the exact required content `NESTED_CREATED`.
+          content: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
         - role: assistant
           content:
             - type: tool_use
               name: exec_command
               input:
-                cmd: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt
+                cmd: node -e "const fs=require('fs');fs.mkdirSync('output',{recursive:true});fs.writeFileSync('output/report.txt','NESTED_CREATED')"
+                workdir: ${workdir}
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                Chunk ID: a11418
+                Chunk ID: d9cc3f
                 Wall time: 0.0000 seconds
                 Process exited with code 0
                 Original token count: 0
                 Output:
     response:
-      content: Done. `output/report.txt` now contains exactly `NESTED_CREATED`.
+      content: created
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-lists-workspace-entries.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-lists-workspace-entries.yaml
@@ -6,47 +6,44 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
     response:
       content:
         - type: text
-          text: I’m listing the current working directory now and will return only the filenames.
+          text: Running the exact command now and I’ll return only the filenames it prints.
         - type: tool_use
           id: toolcall_0
           name: exec_command
           input:
-            cmd: ls -1
-            workdir: ${workdir}/ahp-coverage-list-${temp}
+            cmd: node -e "console.log(require('fs').readdirSync('.').join(' '))"
+            workdir: ${workdir}
       stopReason: tool_use
   - request:
       model: gpt-5.3-codex
       system: ${system}
       messages:
         - role: user
-          content: List the files in the current working directory. Reply with the filenames only.
+          content: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
         - role: assistant
-          content: I’m listing the current working directory now and will return only the filenames.
+          content: Running the exact command now and I’ll return only the filenames it prints.
         - role: assistant
           content:
             - type: tool_use
               name: exec_command
               input:
-                cmd: ls -1
-                workdir: ${workdir}/ahp-coverage-list-${temp}
+                cmd: node -e "console.log(require('fs').readdirSync('.').join(' '))"
+                workdir: ${workdir}
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                Chunk ID: 2edea4
+                Chunk ID: e12fae
                 Wall time: 0.0000 seconds
                 Process exited with code 0
                 Original token count: 5
                 Output:
-                first.txt
-                second.md
+                first.txt second.md
     response:
-      content: |-
-        first.txt
-        second.md
+      content: first.txt second.md
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-reads-a-filename-containing-spaces.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-reads-a-filename-containing-spaces.yaml
@@ -10,13 +10,13 @@ exchanges:
     response:
       content:
         - type: text
-          text: I’m reading `file with spaces.txt` now and will return the file contents exactly as-is.
+          text: I’m going to read `file with spaces.txt` now and return its contents exactly as-is.
         - type: tool_use
           id: toolcall_0
           name: exec_command
           input:
             cmd: cat 'file with spaces.txt'
-            workdir: ${workdir}/ahp-coverage-spaces-${temp}
+            workdir: ${workdir}
       stopReason: tool_use
   - request:
       model: gpt-5.3-codex
@@ -25,20 +25,20 @@ exchanges:
         - role: user
           content: Read "file with spaces.txt" and reply with its exact contents only.
         - role: assistant
-          content: I’m reading `file with spaces.txt` now and will return the file contents exactly as-is.
+          content: I’m going to read `file with spaces.txt` now and return its contents exactly as-is.
         - role: assistant
           content:
             - type: tool_use
               name: exec_command
               input:
                 cmd: cat 'file with spaces.txt'
-                workdir: ${workdir}/ahp-coverage-spaces-${temp}
+                workdir: ${workdir}
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                Chunk ID: a2091f
+                Chunk ID: 397217
                 Wall time: 0.0000 seconds
                 Process exited with code 0
                 Original token count: 3

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-renames-a-workspace-file.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-renames-a-workspace-file.yaml
@@ -6,43 +6,39 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
     response:
       content:
-        - type: text
-          text: I’ll rename `before.txt` to `after.txt` in place and keep the file contents unchanged. I’m doing that now.
         - type: tool_use
           id: toolcall_0
           name: exec_command
           input:
-            cmd: mv before.txt after.txt
-            workdir: ${workdir}/ahp-coverage-rename-${temp}
+            cmd: node -e "require('fs').renameSync('before.txt','after.txt')"
+            workdir: ${workdir}
       stopReason: tool_use
   - request:
       model: gpt-5.3-codex
       system: ${system}
       messages:
         - role: user
-          content: Rename before.txt to after.txt without changing its contents.
-        - role: assistant
-          content: I’ll rename `before.txt` to `after.txt` in place and keep the file contents unchanged. I’m doing that now.
+          content: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
         - role: assistant
           content:
             - type: tool_use
               name: exec_command
               input:
-                cmd: mv before.txt after.txt
-                workdir: ${workdir}/ahp-coverage-rename-${temp}
+                cmd: node -e "require('fs').renameSync('before.txt','after.txt')"
+                workdir: ${workdir}
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                Chunk ID: 993beb
+                Chunk ID: a620b7
                 Wall time: 0.0000 seconds
                 Process exited with code 0
                 Original token count: 0
                 Output:
     response:
-      content: Renamed `before.txt` to `after.txt` with contents unchanged.
+      content: renamed
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-runs-a-deterministic-shell-command.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-runs-a-deterministic-shell-command.yaml
@@ -6,16 +6,16 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create result.txt containing exactly CREATED_VALUE.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
     response:
       content:
         - type: text
-          text: Creating `result.txt` in the workspace now with the exact required content and no extra characters.
+          text: Running the exact command now and will return only its output value.
         - type: tool_use
           id: toolcall_0
           name: exec_command
           input:
-            cmd: printf %s CREATED_VALUE > result.txt
+            cmd: echo SHELL_VALUE_73
             workdir: ${workdir}
       stopReason: tool_use
   - request:
@@ -23,26 +23,27 @@ exchanges:
       system: ${system}
       messages:
         - role: user
-          content: Create result.txt containing exactly CREATED_VALUE.
+          content: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
         - role: assistant
-          content: Creating `result.txt` in the workspace now with the exact required content and no extra characters.
+          content: Running the exact command now and will return only its output value.
         - role: assistant
           content:
             - type: tool_use
               name: exec_command
               input:
-                cmd: printf %s CREATED_VALUE > result.txt
+                cmd: echo SHELL_VALUE_73
                 workdir: ${workdir}
         - role: user
           content:
             - type: tool_result
               tool_use_id: toolcall_0
               content: |-
-                Chunk ID: 6567bb
-                Wall time: 0.0000 seconds
+                Chunk ID: 527f38
+                Wall time: 0.0002 seconds
                 Process exited with code 0
-                Original token count: 0
+                Original token count: 4
                 Output:
+                SHELL_VALUE_73
     response:
-      content: Done. `result.txt` now contains exactly `CREATED_VALUE`.
+      content: SHELL_VALUE_73
       stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/conformance/agentHostConformance.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/conformance/agentHostConformance.integrationTest.ts
@@ -50,7 +50,7 @@ const REFERENCE_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsMultipleChats: true,
 	supportsChatFork: true,
 	supportsChatForkE2E: true,
-	stableNewScenarioResponse: true,
+	supportsFileTools: true,
 };
 
 defineAgentHostConformanceTests(REFERENCE_CONFIG);

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -324,6 +324,17 @@ export interface IAgentHostE2EProviderConfig {
 	 */
 	readonly supportsFileTools: boolean;
 	/**
+	 * Whether this provider's file-manipulation scenarios replay stably when the
+	 * whole suite shares one server.
+	 *
+	 * A provider without file tools performs each of them through its shell, and
+	 * several such turns on one long-lived server hit the shared-server load
+	 * ceiling: the tool-call completion is reported inconsistently and the
+	 * failing scenario moves between runs. Individually they replay fine, so
+	 * this gates the family rather than any single test.
+	 */
+	readonly stableSharedServerFileScenarios?: boolean;
+	/**
 	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
 	 * this provider, which rebuilds the reopened transcript from the bundled SDK's
 	 * on-disk `subagents/agent-*.jsonl` files — not reliably visible on Windows

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -313,20 +313,16 @@ export interface IAgentHostE2EProviderConfig {
 	 */
 	readonly shellToolReplayUnstableOnLinux?: boolean;
 	/**
-	 * Gates the whole "new scenario" family of model-backed tests — the file,
-	 * shell, and multi-turn scenarios added after the original suite.
+	 * Whether this provider offers file-reading/writing tools of its own.
 	 *
-	 * Set this to `false` only while a provider genuinely cannot run them. Note
-	 * that it currently conflates two different states, and a provider that
-	 * needs it should say which one applies:
+	 * Scenarios whose prompt steers the agent to its file tools ("Use your file
+	 * tools; do not run a shell command.") cannot be satisfied by a provider
+	 * that only has a shell: it refuses the operation rather than falling back.
+	 * Codex is the current example — its captures contain only `exec_command`.
 	 *
-	 * - a fixture exists but the provider replays it unstably, and
-	 * - no fixture was ever recorded, in which case the test cannot be re-enabled
-	 *   by flipping this flag alone — recording has to succeed first.
-	 *
-	 * See `KNOWN_ISSUES.md` for the current per-test state.
+	 * Scenarios that pin a portable shell command instead are unaffected.
 	 */
-	readonly stableNewScenarioResponse: boolean;
+	readonly supportsFileTools: boolean;
 	/**
 	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
 	 * this provider, which rebuilds the reopened transcript from the bundled SDK's

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiWireCodec.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiWireCodec.ts
@@ -500,7 +500,14 @@ export function responsesMessageToSse(message: IAnthropicMessage): string {
 	chunks.push(sseEvent('response.in_progress', { type: 'response.in_progress', sequence_number: seq++, response: skeleton }));
 
 	outputItems.forEach((item, index) => {
-		chunks.push(sseEvent('response.output_item.added', { type: 'response.output_item.added', sequence_number: seq++, output_index: index, item }));
+		// An item is *announced* here and streamed below, so it must arrive
+		// empty: a consumer that accumulates this content and then the deltas
+		// would otherwise count the same text twice (`SHELL_VALUE_73` replayed
+		// as `SHELL_VALUE_73SHELL_VALUE_73`).
+		const addedItem = item.type === 'message'
+			? { ...item, status: 'in_progress' as const, content: [] }
+			: { ...item, status: 'in_progress' as const, arguments: '' };
+		chunks.push(sseEvent('response.output_item.added', { type: 'response.output_item.added', sequence_number: seq++, output_index: index, item: addedItem }));
 		if (item.type === 'message') {
 			const text = item.content[0].text;
 			const part = { type: 'output_text', text, annotations: [], logprobs: [] };

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_creates_a_file_in_a_new_nested_directory.traffic.ahp.yaml
@@ -6,63 +6,31 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Create output/report.txt containing exactly NESTED_CREATED.
+            text: 'Run exactly this shell command, with no modifications: `node -e "const fs=require(''fs'');fs.mkdirSync(''output'',{recursive:true});fs.writeFileSync(''output/report.txt'',''NESTED_CREATED'')"`. Then reply with exactly "created".'
             origin:
               kind: user
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
-      - channel: ${chat_0}
-        action:
-          type: chat/responsePart
-          turnId: ${turn_0}
-          part:
-            kind: markdown
-            content: Creating `output/report.txt` now with the exact required content `NESTED_CREATED`.Creating `output/report.txt` now with the exact required content `NESTED_CREATED`.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt
-          toolInput: mkdir -p output && printf 'NESTED_CREATED' > output/report.txt
-          confirmed: not-needed
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -70,21 +38,13 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `mkdir -p output && printf 'NESTED_CREATED' > output/report.txt`
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Done. `output/report.txt` now contains exactly `NESTED_CREATED`.Done. `output/report.txt` now contains exactly `NESTED_CREATED`.
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: created
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_creates_a_new_text_file.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_creates_a_new_text_file.traffic.ahp.yaml
@@ -10,9 +10,6 @@ rounds:
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
@@ -24,45 +21,23 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Creating `result.txt` in the workspace now with exactly the required content and no extra characters.Creating `result.txt` in the workspace now with exactly the required content and no extra characters.
+            content: Creating `result.txt` in the workspace now with the exact required content and no extra characters.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: printf 'CREATED_VALUE' > result.txt
-          toolInput: printf 'CREATED_VALUE' > result.txt
-          confirmed: not-needed
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -70,21 +45,16 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `printf 'CREATED_VALUE' > result.txt`
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Done. `result.txt` now contains exactly `CREATED_VALUE`.Done. `result.txt` now contains exactly `CREATED_VALUE`.
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: |-
+
+
+              Done. `result.txt` now contains exactly `CREATED_VALUE`.
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_handles_a_missing_file_without_a_session_error.traffic.ahp.yaml
@@ -6,59 +6,38 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Try to read missing.txt. If it does not exist, reply exactly "missing".
+            text: Try to read missing.txt. If it does not exist, reply exactly "missing". Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: Checking whether `missing.txt` exists, and I’ll return its contents if present or `missing` if not.Checking whether `missing.txt` exists, and I’ll return its contents if present or `missing` if not.
+            content: Checking whether `missing.txt` exists, and I’ll return its contents if present or `missing` if not.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: if [ -f missing.txt ]; then cat missing.txt; else echo missing; fi
-          toolInput: if [ -f missing.txt ]; then cat missing.txt; else echo missing; fi
-          confirmed: not-needed
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -66,29 +45,16 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `if [ -f missing.txt ]; then cat missing.txt; else echo missing; fi`
-            content:
-              - type: text
-                text: |
-                  missing
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: missingmissing
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: |-
+
+
+              missing
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_lists_workspace_entries.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_lists_workspace_entries.traffic.ahp.yaml
@@ -6,59 +6,38 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: List the files in the current working directory. Reply with the filenames only.
+            text: 'Run exactly this shell command, with no modifications: `node -e "console.log(require(''fs'').readdirSync(''.'').join('' ''))"`. Then reply with the filenames it printed and nothing else.'
             origin:
               kind: user
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I’m listing the current working directory now and will return only the filenames.I’m listing the current working directory now and will return only the filenames.
+            content: Running the exact command now and I’ll return only the filenames it prints.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: ls -1
-          toolInput: ls -1
-          confirmed: not-needed
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -66,16 +45,6 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `ls -1`
-            content:
-              - type: text
-                text: |
-                  first.txt
-                  second.md
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/responsePart
@@ -83,16 +52,9 @@ rounds:
           part:
             kind: markdown
             content: |-
-              first.txt
-              second.mdfirst.txt
-              second.md
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+
+
+              first.txt second.md
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_reads_a_file_from_a_nested_directory.traffic.ahp.yaml
@@ -6,59 +6,38 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: Read nested/value.txt and reply with its exact contents only.
+            text: Read nested/value.txt and reply with its exact contents only. Use your file tools; do not run a shell command.
             origin:
               kind: user
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I’m reading `nested/value.txt` now and will return its contents exactly with no extra text.I’m reading `nested/value.txt` now and will return its contents exactly with no extra text.
+            content: I’m reading `nested/value.txt` now and will return its contents exactly with no extra text.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: cat nested/value.txt
-          toolInput: cat nested/value.txt
-          confirmed: not-needed
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -66,28 +45,16 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `cat nested/value.txt`
-            content:
-              - type: text
-                text: NESTED_VALUE_42
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: NESTED_VALUE_42NESTED_VALUE_42
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: |-
+
+
+              NESTED_VALUE_42
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_reads_a_filename_containing_spaces.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_reads_a_filename_containing_spaces.traffic.ahp.yaml
@@ -10,9 +10,6 @@ rounds:
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
@@ -24,41 +21,23 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: I’m reading `file with spaces.txt` now and will return the file contents exactly as-is.I’m reading `file with spaces.txt` now and will return the file contents exactly as-is.
+            content: I’m going to read `file with spaces.txt` now and return its contents exactly as-is.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
           turnId: ${turn_0}
           toolCallId: ${toolCall_0}
           toolName: shell
-          displayName: Run shell command
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallDelta
-      - channel: ${chat_0}
-        action:
-          type: chat/toolCallReady
-          turnId: ${turn_0}
-          toolCallId: ${toolCall_0}
-          invocationMessage: cat 'file with spaces.txt'
-          toolInput: cat 'file with spaces.txt'
-          confirmed: not-needed
       - channel: ${chat_0}
         action:
           type: chat/toolCallComplete
@@ -66,28 +45,16 @@ rounds:
           toolCallId: ${toolCall_0}
           result:
             success: true
-            pastTenseMessage: Ran `cat 'file with spaces.txt'`
-            content:
-              - type: text
-                text: SPACED_VALUE
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: SPACED_VALUESPACED_VALUE
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: |-
+
+
+              SPACED_VALUE
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_retains_context_across_consecutive_turns.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_retains_context_across_consecutive_turns.traffic.ahp.yaml
@@ -10,9 +10,6 @@ rounds:
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
@@ -24,30 +21,17 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/titleChanged
-      - channel: ${session_0}
-        action:
-          type: session/serverToolsChanged
       - method: root/sessionAdded
       - channel: ${session_0}
         action:
           type: session/ready
-      - channel: ${session_0}
-        action:
-          type: session/changesetsChanged
       - channel: ${chat_0}
         action:
           type: chat/responsePart
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: readyready
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_0}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: ready
       - channel: ${chat_0}
         action:
           type: chat/turnComplete
@@ -62,9 +46,6 @@ rounds:
             origin:
               kind: user
     serverToClient:
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
       - channel: ${chat_0}
         action:
           type: chat/turnStarted
@@ -79,14 +60,7 @@ rounds:
           turnId: ${turn_1}
           part:
             kind: markdown
-            content: ORCHIDORCHID
-      - channel: ${chat_0}
-        action:
-          type: chat/usage
-          turnId: ${turn_1}
-      - channel: ${session_0}
-        action:
-          type: session/chatUpdated
+            content: ORCHID
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_runs_a_deterministic_shell_command.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_runs_a_deterministic_shell_command.traffic.ahp.yaml
@@ -6,7 +6,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
     serverToClient:
@@ -15,7 +15,7 @@ rounds:
           type: chat/turnStarted
           turnId: ${turn_0}
           message:
-            text: 'Run exactly this shell command, with no modifications: `node -e "require(''fs'').renameSync(''before.txt'',''after.txt'')"`. Then reply with exactly "renamed".'
+            text: 'Run exactly this shell command, with no modifications: `echo SHELL_VALUE_73`. Then reply with that exact value only.'
             origin:
               kind: user
       - channel: ${session_0}
@@ -25,6 +25,13 @@ rounds:
       - channel: ${session_0}
         action:
           type: session/ready
+      - channel: ${chat_0}
+        action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: Running the exact command now and will return only its output value.
       - channel: ${chat_0}
         action:
           type: chat/toolCallStart
@@ -44,7 +51,10 @@ rounds:
           turnId: ${turn_0}
           part:
             kind: markdown
-            content: renamed
+            content: |-
+
+
+              SHELL_VALUE_73
       - channel: ${chat_0}
         action:
           type: chat/turnComplete

--- a/src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts
@@ -84,7 +84,7 @@ const CLAUDE_CONFIG: IAgentHostE2EProviderConfig = {
 	// The Claude SDK currently receives the AHP turn id as upToMessageId and
 	// rejects it as invalid when the fork is exercised against a real transcript.
 	supportsChatForkE2E: false,
-	stableNewScenarioResponse: true,
+	supportsFileTools: true,
 };
 
 defineAgentHostE2ETests(CLAUDE_CONFIG);

--- a/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
@@ -30,8 +30,8 @@ export const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsMultipleChats: false,
 	supportsChatFork: false,
 	supportsChatForkE2E: false,
-	// Codex either duplicates the previous response or has no recorded fixture for
-	// the newer file/shell scenarios; see KNOWN_ISSUES.md.
-	stableNewScenarioResponse: false,
+	// Codex exposes only `exec_command`; it has no file tools, so prompts that
+	// steer away from the shell cannot be satisfied. See KNOWN_ISSUES.md.
+	supportsFileTools: false,
 	shellToolReplayUnstableOnLinux: true,
 };

--- a/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
@@ -33,5 +33,8 @@ export const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	// Codex exposes only `exec_command`; it has no file tools, so prompts that
 	// steer away from the shell cannot be satisfied. See KNOWN_ISSUES.md.
 	supportsFileTools: false,
+	// Codex drives every file scenario through its shell; several of them on one
+	// shared server replay inconsistently. See KNOWN_ISSUES.md.
+	stableSharedServerFileScenarios: false,
 	shellToolReplayUnstableOnLinux: true,
 };

--- a/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
@@ -57,7 +57,7 @@ const COPILOT_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsMultipleChats: true,
 	supportsChatFork: true,
 	supportsChatForkE2E: true,
-	stableNewScenarioResponse: true,
+	supportsFileTools: true,
 };
 
 const RECORD_ONLY = process.env['AGENT_HOST_REPLAY_RECORD'] === '1';

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+const isLinux = process.platform === 'linux';
 import { AgentHostE2EServerLease, type IAgentHostE2EProviderConfig, removeTempDirs } from '../harness/agentHostE2ETestHarness.js';
 import type { IAgentHostTarget } from '../harness/agentHostTarget.js';
 import type { TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
@@ -19,7 +20,6 @@ import type { AgentHostE2ETier, IAgentHostE2ETestContext } from './e2eTestContex
 
 const RECORD = process.env['AGENT_HOST_REPLAY_RECORD'] === '1' || process.env['AGENT_HOST_UPDATE_SNAPSHOTS'] === '1';
 const RUN_RECORD_ONLY_TESTS = process.env['AGENT_HOST_REPLAY_RECORD'] === '1';
-const isLinux = process.platform === 'linux';
 const isWindows = process.platform === 'win32';
 
 interface IDefineOptions {
@@ -43,7 +43,7 @@ function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOption
 			createdSessions,
 			tempDirs,
 			portableShellToolReplayEnabled,
-			stableNewScenarioResponse: config.stableNewScenarioResponse,
+			supportsFileTools: config.supportsFileTools,
 			isWindows,
 			runRecordOnlyTests: RUN_RECORD_ONLY_TESTS,
 			registerNoModelTrafficTest: title => noModelTrafficTestTitles.add(title),

--- a/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/agentHostE2ESuites.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-const isLinux = process.platform === 'linux';
 import { AgentHostE2EServerLease, type IAgentHostE2EProviderConfig, removeTempDirs } from '../harness/agentHostE2ETestHarness.js';
 import type { IAgentHostTarget } from '../harness/agentHostTarget.js';
 import type { TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
@@ -17,6 +16,8 @@ import { defineSubagentTests } from './subagentSuite.js';
 import { defineTurnLifecycleTests } from './turnLifecycleSuite.js';
 import { defineWorkspaceTests } from './workspaceSuite.js';
 import type { AgentHostE2ETier, IAgentHostE2ETestContext } from './e2eTestContext.js';
+
+const isLinux = process.platform === 'linux';
 
 const RECORD = process.env['AGENT_HOST_REPLAY_RECORD'] === '1' || process.env['AGENT_HOST_UPDATE_SNAPSHOTS'] === '1';
 const RUN_RECORD_ONLY_TESTS = process.env['AGENT_HOST_REPLAY_RECORD'] === '1';
@@ -44,6 +45,7 @@ function defineSuite(config: IAgentHostE2EProviderConfig, options: IDefineOption
 			tempDirs,
 			portableShellToolReplayEnabled,
 			supportsFileTools: config.supportsFileTools,
+			stableSharedServerFileScenarios: config.stableSharedServerFileScenarios ?? true,
 			isWindows,
 			runRecordOnlyTests: RUN_RECORD_ONLY_TESTS,
 			registerNoModelTrafficTest: title => noModelTrafficTestTitles.add(title),

--- a/src/vs/platform/agentHost/test/node/e2e/suites/coreSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/coreSuite.ts
@@ -24,7 +24,7 @@ import { getActionEnvelope, isActionNotification } from '../../serverIntegration
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineCoreTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, stableNewScenarioResponse } = context;
+	const { config, createdSessions, tempDirs } = context;
 	const behaviorSnapshot = { profile: 'behavior' } as const;
 	test('sends a simple message and receives a response', async function () {
 		this.timeout(120_000);
@@ -101,7 +101,7 @@ export function defineCoreTests(context: IAgentHostE2ETestContext): void {
 		}
 	});
 
-	(stableNewScenarioResponse ? test : test.skip)('retains context across consecutive turns', async function () {
+	test('retains context across consecutive turns', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-memory-'));
 		tempDirs.push(workspace);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
@@ -39,6 +39,7 @@ export interface IAgentHostE2ETestContext {
 	 */
 	readonly portableShellToolReplayEnabled: boolean;
 	readonly supportsFileTools: boolean;
+	readonly stableSharedServerFileScenarios: boolean;
 	readonly isWindows: boolean;
 	readonly runRecordOnlyTests: boolean;
 	readonly registerNoModelTrafficTest: (title: string) => void;

--- a/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/e2eTestContext.ts
@@ -38,7 +38,7 @@ export interface IAgentHostE2ETestContext {
 	 * reason is visible at the call site.
 	 */
 	readonly portableShellToolReplayEnabled: boolean;
-	readonly stableNewScenarioResponse: boolean;
+	readonly supportsFileTools: boolean;
 	readonly isWindows: boolean;
 	readonly runRecordOnlyTests: boolean;
 	readonly registerNoModelTrafficTest: (title: string) => void;

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -14,7 +14,7 @@ import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, stableNewScenarioResponse } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, supportsFileTools } = context;
 	const BEHAVIOR_SNAPSHOT = { profile: 'behavior' } as const;
 	/**
 	 * Steers the agent toward its own file tools instead of a shell command.
@@ -28,7 +28,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	 */
 	const PREFER_FILE_TOOLS = ' Use your file tools; do not run a shell command.';
 	// Expected to pass, but Copilot never completed this turn during recording and Codex duplicates its response.
-	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('reads an existing text file', async function () {
+	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('reads an existing text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-read-'));
 		tempDirs.push(workspace);
@@ -41,7 +41,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse ? test : test.skip)('reads a file from a nested directory', async function () {
+	(supportsFileTools ? test : test.skip)('reads a file from a nested directory', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-nested-read-'));
 		tempDirs.push(workspace);
@@ -55,7 +55,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
+	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-list-'));
 		tempDirs.push(workspace);
@@ -75,7 +75,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Codex does not honor the exact-response contract on replay; Copilot never completes the replayed turn.
-	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('reads a value from JSON', async function () {
+	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('reads a value from JSON', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-json-'));
 		tempDirs.push(workspace);
@@ -89,7 +89,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Codex duplicates its response.
-	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('counts lines in a file', async function () {
+	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('counts lines in a file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-lines-'));
 		tempDirs.push(workspace);
@@ -106,7 +106,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse ? test : test.skip)('handles a missing file without a session error', async function () {
+	(supportsFileTools ? test : test.skip)('handles a missing file without a session error', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-missing-'));
 		tempDirs.push(workspace);
@@ -119,7 +119,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot does not consistently emit tool completion for this scenario.
-	(stableNewScenarioResponse && config.provider !== 'copilotcli' ? test : test.skip)('creates a new text file', async function () {
+	(supportsFileTools && config.provider !== 'copilotcli' ? test : test.skip)('creates a new text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-create-'));
 		tempDirs.push(workspace);
@@ -132,7 +132,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot never completes this turn.
-	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('edits an existing text file', async function () {
+	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('edits an existing text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-edit-'));
 		tempDirs.push(workspace);
@@ -146,7 +146,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot's fixture uses a POSIX shell.
-	(stableNewScenarioResponse ? test : test.skip)('creates a file in a new nested directory', async function () {
+	(supportsFileTools ? test : test.skip)('creates a file in a new nested directory', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-nested-create-'));
 		tempDirs.push(workspace);
@@ -163,7 +163,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse && portableShellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
+	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-rename-'));
 		tempDirs.push(workspace);
@@ -183,7 +183,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot never completed this turn.
-	(stableNewScenarioResponse && config.provider === 'claude' ? test : test.skip)('deletes a workspace file', async function () {
+	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('deletes a workspace file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-delete-'));
 		tempDirs.push(workspace);
@@ -199,7 +199,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(portableShellToolReplayEnabled && stableNewScenarioResponse ? test : test.skip)('runs a deterministic shell command', async function () {
+	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('runs a deterministic shell command', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-shell-'));
 		tempDirs.push(workspace);
@@ -217,7 +217,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Claude and Codex emit customization/changeset updates at nondeterministic points in this snapshot.
-	(portableShellToolReplayEnabled && stableNewScenarioResponse && config.provider === 'copilotcli' ? test : test.skip)('inspects git status', async function () {
+	(portableShellToolReplayEnabled && config.provider === 'copilotcli' ? test : test.skip)('inspects git status', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-git-'));
 		tempDirs.push(workspace);
@@ -235,7 +235,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(stableNewScenarioResponse ? test : test.skip)('reads a filename containing spaces', async function () {
+	(supportsFileTools ? test : test.skip)('reads a filename containing spaces', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-spaces-'));
 		tempDirs.push(workspace);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -14,7 +14,7 @@ import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import type { IAgentHostE2ETestContext } from './e2eTestContext.js';
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
-	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, supportsFileTools } = context;
+	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, supportsFileTools, stableSharedServerFileScenarios } = context;
 	const BEHAVIOR_SNAPSHOT = { profile: 'behavior' } as const;
 	/**
 	 * Steers the agent toward its own file tools instead of a shell command.
@@ -27,7 +27,8 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	 * and exercises the more meaningful path.
 	 */
 	const PREFER_FILE_TOOLS = ' Use your file tools; do not run a shell command.';
-	// Expected to pass, but Copilot never completed this turn during recording and Codex duplicates its response.
+	// Expected to pass. Copilot never completed this turn during recording; Codex
+	// has no file tools, so it cannot honor this prompt's steer away from the shell.
 	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('reads an existing text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-read-'));
@@ -55,7 +56,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
+	(stableSharedServerFileScenarios && portableShellToolReplayEnabled ? test : test.skip)('lists workspace entries', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-list-'));
 		tempDirs.push(workspace);
@@ -74,7 +75,8 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	// Codex does not honor the exact-response contract on replay; Copilot never completes the replayed turn.
+	// Copilot never completes the replayed turn; Codex has no file tools, so it
+	// cannot honor this prompt's steer away from the shell.
 	(supportsFileTools && config.provider === 'claude' ? test : test.skip)('reads a value from JSON', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-json-'));
@@ -88,7 +90,8 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	// Codex duplicates its response.
+	// Codex has no file tools, so it cannot honor this prompt's steer away from
+	// the shell — it answers from guesswork instead of reading the file.
 	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('counts lines in a file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-lines-'));
@@ -119,7 +122,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot does not consistently emit tool completion for this scenario.
-	(supportsFileTools && config.provider !== 'copilotcli' ? test : test.skip)('creates a new text file', async function () {
+	(supportsFileTools && stableSharedServerFileScenarios && config.provider !== 'copilotcli' ? test : test.skip)('creates a new text file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-create-'));
 		tempDirs.push(workspace);
@@ -146,7 +149,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 	});
 
 	// Copilot's fixture uses a POSIX shell.
-	(supportsFileTools ? test : test.skip)('creates a file in a new nested directory', async function () {
+	(stableSharedServerFileScenarios ? test : test.skip)('creates a file in a new nested directory', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-nested-create-'));
 		tempDirs.push(workspace);
@@ -163,7 +166,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
+	(stableSharedServerFileScenarios && portableShellToolReplayEnabled ? test : test.skip)('renames a workspace file', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-rename-'));
 		tempDirs.push(workspace);
@@ -199,7 +202,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(supportsFileTools && portableShellToolReplayEnabled ? test : test.skip)('runs a deterministic shell command', async function () {
+	(stableSharedServerFileScenarios && portableShellToolReplayEnabled ? test : test.skip)('runs a deterministic shell command', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-shell-'));
 		tempDirs.push(workspace);
@@ -235,7 +238,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	(supportsFileTools ? test : test.skip)('reads a filename containing spaces', async function () {
+	(stableSharedServerFileScenarios ? test : test.skip)('reads a filename containing spaces', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-spaces-'));
 		tempDirs.push(workspace);


### PR DESCRIPTION
Three findings from actually running the gated Codex scenarios rather than trusting the inventory. Two of them turned out to be different from what `KNOWN_ISSUES.md` recorded.

## The replayed text doubling was ours, not the provider's

The doc attributed a family of Codex failures to the provider duplicating response content. It reproduces exactly — a recorded `SHELL_VALUE_73` replays as `SHELL_VALUE_73SHELL_VALUE_73` — but the cause is in our own SSE regenerator.

`responsesMessageToSse` announced each output item via `response.output_item.added` with the item's **final content already attached**, then streamed that same text as deltas. A consumer that accumulates both counts it twice. An announced item now arrives empty, which is what the event means.

Recording proxies real CAPI bytes and was never affected — which is exactly why the recorded capture looked correct while the replayed snapshot did not, and why this survived so long.

Found by bisecting the regenerator's events one at a time; four other candidates (`content_part.done`, `output_item.done`, `output_text.done`, `response.completed`) were eliminated first.

## Codex has no file tools

Its captures contain only `exec_command`; Claude's contain `Read`, `Write`, `Bash`.

The shared file-operation prompts steer the agent away from the shell (`Use your file tools; do not run a shell command.`) so captures stay platform-neutral. Codex cannot satisfy that and does not fall back:

```
I can't access file contents without using a shell command in this environment,
and you asked me not to run one.
```

`counts lines in a file` shows the sharper version: it flails and answers `3` for a four-line file. This is a capability difference, not something re-recording fixes — which is why the previous entry ("no fixture recorded → record it") could never have worked.

## The gate conflated three things

`stableNewScenarioResponse` meant "replays unstably" *and* "never recorded" *and* "cannot run this at all". `KNOWN_ISSUES.md` already said splitting it was a prerequisite for reducing it.

It is replaced by `supportsFileTools`. `retains context across consecutive turns` — which involves no files and no tools, and was only ever caught by the same overloaded flag — now runs for Codex.

## Result

Codex **8 → 9 passing**, stable across repeated runs. Conformance 57, Copilot 49, Claude 44, 0 failing; 2683 unit tests pass.

A modest test-count win on purpose. I enabled the six shell-based scenarios first and measured: the suite then failed about one run in four, with the failing scenario **moving between runs** — the shared-server load ceiling, not a fault in any one test. Rather than ship that, they stay gated with the real reason recorded, and `KNOWN_ISSUES.md` now names what has to be understood before they can be enabled.

(Written by Copilot)
