### PR TITLE
Map managed permission policies into Agent Host sessions

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -38,8 +38,9 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostManagedPermissionsConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import { getAgentHostConfigurationSyncEntries, resolveAgentHostConfigurationSyncPatch, resolveAgentHostConfigurationSyncValue } from '../common/agentHostConfigurationSync.js';
+import { managedPermissionsSettingMappings, resolveManagedPermissions } from '../common/agentHostManagedSettings.js';
 import { AgentHostClientConnectionKind, toClientConnectionTelemetryMeta } from '../common/agentHostTelemetry.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
@@ -50,7 +51,6 @@ import { isFileResourceRead } from '../common/resourceReadLogging.js';
 import { ResourceSet } from '../../../base/common/map.js';
 
 const AHP_CLIENT_CONNECTION_CLOSED = -32000;
-
 /** Initial delay before the first transport-level reconnect attempt. */
 const RECONNECT_INITIAL_DELAY_MS = 1_000;
 
@@ -362,6 +362,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			if (e.affectsConfiguration(TELEMETRY_SETTING_ID) || e.affectsConfiguration(TELEMETRY_OLD_SETTING_ID) || e.affectsConfiguration(TELEMETRY_CRASH_REPORTER_SETTING_ID)) {
 				this._updateTelemetryLevel();
 			}
+			if (managedPermissionsSettingMappings.some(entry => e.affectsConfiguration(entry.settingId))) {
+				this._updateManagedPermissions();
+			}
 			if (e.affectsConfiguration(PREFER_LONG_CONTEXT_SETTING_ID)) {
 				this._updatePreferLongContextEnabled();
 			}
@@ -616,6 +619,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 			this._applyReconnectResult(result, freshInitialize);
 			if (freshInitialize && result.type === ReconnectResultType.Snapshot) {
+				this._forwardClientConfig(true);
 				await this._restoreAuthenticationAfterFreshInitialize();
 				await this._restoreSubscriptionsAfterFreshInitialize(result.snapshots);
 			}
@@ -627,7 +631,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			// be a freshly restarted process that never received these values (the
 			// reconnect result itself carries none), which would otherwise leave
 			// early-read config like the migrate flag at its host-side default.
-			this._forwardClientConfig();
+			if (!freshInitialize) {
+				this._forwardClientConfig();
+			}
 
 			// Drain the outbox BEFORE the transition so listeners reacting to
 			// {@link onDidChangeConnectionState} that synchronously dispatch see
@@ -643,6 +649,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			this._logService.info(`[RemoteAgentHostProtocol] Reconnected to ${this._address}.`);
 		} catch (err) {
 			this._logService.warn(`[RemoteAgentHostProtocol] Reconnect attempt failed for ${this._address}: ${err instanceof Error ? err.message : String(err)}`);
+			if (err instanceof ProtocolError && err.code === AhpErrorCodes.UnsupportedProtocolVersion) {
+				this._cancelLivenessTimers();
+				reconnect.outbox.length = 0;
+				this._rejectPendingRequests(err);
+				this._transitionTo({ kind: AgentHostClientState.Incompatible, error: err });
+				reconnect.gate.error(err);
+				return;
+			}
 			transport?.dispose();
 			if (this._state.kind !== AgentHostClientState.Reconnecting) {
 				return;
@@ -681,7 +695,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			...this._clientConnectionTelemetryMeta(),
 			initialSubscriptions: subscriptions,
 		}, { bypassReconnectGate: true });
-		this._applyInitializeResult(initializeResult);
+		this._applyInitializeResult(initializeResult, false);
 		return {
 			result: { type: ReconnectResultType.Snapshot, snapshots: initializeResult.snapshots ?? [] },
 			freshInitialize: true,
@@ -737,14 +751,16 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return meta ? { _meta: meta } : {};
 	}
 
-	private _applyInitializeResult(result: CommandMap['initialize']['result']): void {
+	private _applyInitializeResult(result: CommandMap['initialize']['result'], forwardClientConfig = true): void {
 		this._initializeResult.set(result, undefined);
 		this._serverSeq = result.serverSeq;
 		if (result.defaultDirectory) {
 			const directory = result.defaultDirectory;
 			this._defaultDirectory = typeof directory === 'string' ? URI.parse(directory).path : URI.revive(directory).path;
 		}
-		this._forwardClientConfig();
+		if (forwardClientConfig) {
+			this._forwardClientConfig();
+		}
 	}
 
 	/**
@@ -760,13 +776,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * key-plus-transform can't express: values derived from several settings, and
 	 * settings contributed by an extension rather than by core.
 	 */
-	private _forwardClientConfig(): void {
-		this._dispatchRootConfig(resolveAgentHostConfigurationSyncPatch(this._configurationService, this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY));
-		this._updateTelemetryLevel();
-		this._updatePreferLongContextEnabled();
-		this._updateTerminalAutoApproveEnabled();
-		this._updateTerminalAutoApproveRules();
-		this._updateDisableRepoInfoTelemetry();
+	private _forwardClientConfig(sendDuringReconnect = false): void {
+		this._dispatchRootConfig(resolveAgentHostConfigurationSyncPatch(this._configurationService, this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY), sendDuringReconnect);
+		this._updateTelemetryLevel(sendDuringReconnect);
+		this._updateManagedPermissions(sendDuringReconnect);
+		this._updatePreferLongContextEnabled(sendDuringReconnect);
+		this._updateTerminalAutoApproveEnabled(sendDuringReconnect);
+		this._updateTerminalAutoApproveRules(sendDuringReconnect);
+		this._updateDisableRepoInfoTelemetry(sendDuringReconnect);
 	}
 
 	/**
@@ -935,9 +952,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	/**
 	 * Dispatch a client action to the server. Returns the clientSeq used.
 	 */
-	private dispatchAction(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, _clientId: string, clientSeq: number): void {
+	private dispatchAction(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, _clientId: string, clientSeq: number, sendDuringReconnect = false): void {
 		this._grantImplicitReadsForOutgoingAction(action);
-		this._sendNotification('dispatchAction', { channel, clientSeq, action });
+		this._sendNotification('dispatchAction', { channel, clientSeq, action }, sendDuringReconnect);
 	}
 
 	/**
@@ -1515,7 +1532,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	/** Send a typed JSON-RPC notification for a protocol-defined method. */
-	private _sendNotification<M extends keyof ClientNotificationMap>(method: M, params: ClientNotificationMap[M]['params']): void {
+	private _sendNotification<M extends keyof ClientNotificationMap>(method: M, params: ClientNotificationMap[M]['params'], sendDuringReconnect = false): void {
 		if (this._state.kind === AgentHostClientState.Closed || this._state.kind === AgentHostClientState.Incompatible) {
 			return;
 		}
@@ -1526,7 +1543,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			this._state.outbox.push(message);
 			return;
 		}
-		if (this._state.kind === AgentHostClientState.Reconnecting) {
+		if (this._state.kind === AgentHostClientState.Reconnecting && !sendDuringReconnect) {
 			// Queue for the new transport — drained by {@link _drainAfterReconnect}
 			// once the soft-reconnect handshake completes. The outbox persists
 			// across failed attempts so a message rides through retry cycles
@@ -1547,40 +1564,55 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return this._dispatchRequest<IRemoteAgentHostExtensionCommandMap[M]['result']>(method, params);
 	}
 
-	private _updateTelemetryLevel(): void {
-		this._dispatchRootConfig({ [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(getTelemetryLevel(this._configurationService)) });
+	private _updateTelemetryLevel(sendDuringReconnect = false): void {
+		this._dispatchRootConfig({ [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(getTelemetryLevel(this._configurationService)) }, sendDuringReconnect);
 	}
 
 	/** Merge a patch into the agent host's root configuration. */
-	private _dispatchRootConfig(config: Record<string, unknown>): void {
+	private _dispatchRootConfig(config: Record<string, unknown>, sendDuringReconnect = false): void {
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config,
-		}, this._clientId, 0);
+		}, this._clientId, 0, sendDuringReconnect);
 	}
 
-	private _updateDisableRepoInfoTelemetry(): void {
+	private _updateDisableRepoInfoTelemetry(sendDuringReconnect = false): void {
 		const disabled = this._configurationService.getValue<boolean>(DISABLE_REPO_INFO_TELEMETRY_SETTING_ID) === true;
-		this._dispatchRootConfig({ [AgentHostDisableRepoInfoTelemetryConfigKey]: disabled });
+		this._dispatchRootConfig({ [AgentHostDisableRepoInfoTelemetryConfigKey]: disabled }, sendDuringReconnect);
 	}
 
-	private _updatePreferLongContextEnabled(): void {
+	/**
+	 * Forward permission restrictions derived from the effective VS Code
+	 * settings. The SDK/runtime owns validation and enforcement.
+	 */
+	private _updateManagedPermissions(sendDuringReconnect = false): void {
+		const permissions = this._deriveManagedPermissions();
+		// Root config patches merge over existing values. An empty object is
+		// the wire-safe clear sentinel because JSON drops `undefined`.
+		this._dispatchRootConfig({ [AgentHostManagedPermissionsConfigKey]: permissions ?? {} }, sendDuringReconnect);
+	}
+
+	private _deriveManagedPermissions() {
+		return resolveManagedPermissions(this._configurationService);
+	}
+
+	private _updatePreferLongContextEnabled(sendDuringReconnect = false): void {
 		const enabled = this._configurationService.getValue<boolean>(PREFER_LONG_CONTEXT_SETTING_ID) === true;
-		this._dispatchRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: enabled });
+		this._dispatchRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: enabled }, sendDuringReconnect);
 	}
 
-	private _updateTerminalAutoApproveEnabled(): void {
+	private _updateTerminalAutoApproveEnabled(sendDuringReconnect = false): void {
 		// Deliberately on the manual, workspace-aware path rather than declaring
 		// `agentHost` on its schema: the setting is `restricted` and settable per
 		// workspace, and its companion rule set (`terminalAutoApproveRules`) is
 		// workspace-aware too. Resolving only the global value here would let a
 		// workspace that turned auto-approval off still have it applied.
 		const enabled = this._configurationService.getValue<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID) !== false;
-		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled });
+		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled }, sendDuringReconnect);
 	}
 
-	private _updateTerminalAutoApproveRules(): void {
-		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) });
+	private _updateTerminalAutoApproveRules(sendDuringReconnect = false): void {
+		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) }, sendDuringReconnect);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from '../../configuration/common/configuration.js';
+import { GLOBAL_AUTO_APPROVE_SETTING_ID, IManagedPermissions, MANAGED_PERMISSION_TERMINAL_ASK_RULE, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
+
+export interface IManagedPermissionsSettingMapping {
+	readonly settingId: string;
+	readonly transform: (value: unknown) => IManagedPermissions | undefined;
+}
+
+export function createManagedPermissionsSettingMapping<T>(settingId: string, transform: (value: T | undefined) => IManagedPermissions | undefined): IManagedPermissionsSettingMapping {
+	return { settingId, transform: value => transform(value as T | undefined) };
+}
+
+export const managedPermissionsSettingMappings: readonly IManagedPermissionsSettingMapping[] = [
+	createManagedPermissionsSettingMapping<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, value => value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
+	createManagedPermissionsSettingMapping<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, value => value === false ? { ask: [MANAGED_PERMISSION_TERMINAL_ASK_RULE] } : undefined),
+];
+
+export function resolveManagedPermissions(configurationService: IConfigurationService): IManagedPermissions | undefined {
+	const permissions: IManagedPermissions = {};
+	for (const entry of managedPermissionsSettingMappings) {
+		const contribution = entry.transform(configurationService.getValue(entry.settingId));
+		if (contribution) {
+			Object.assign(permissions, contribution);
+		}
+	}
+	return Object.keys(permissions).length > 0 ? permissions : undefined;
+}

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -297,6 +297,52 @@ const permissionsProperty = schemaProperty<IPermissionsValue>({
 	sessionMutable: true,
 });
 
+/** Managed runtime restrictions synthesized from effective VS Code settings. */
+export interface IManagedPermissions {
+	readonly disableBypassPermissionsMode?: 'disable';
+	/** Canonical all-shell prompt rule; active runtime rule policy defaults other governed kinds to ask. */
+	readonly ask?: readonly ['Shell'];
+}
+
+export const MANAGED_PERMISSION_TERMINAL_ASK_RULE = 'Shell';
+
+/**
+ * Treat the empty object used as the merge-safe root-config clear sentinel as
+ * no managed permissions.
+ */
+export function normalizeManagedPermissions(permissions: IManagedPermissions | undefined): IManagedPermissions | undefined {
+	const disableBypassPermissionsMode = permissions?.disableBypassPermissionsMode === 'disable';
+	const askForShell = permissions?.ask?.includes(MANAGED_PERMISSION_TERMINAL_ASK_RULE) === true;
+	return disableBypassPermissionsMode || askForShell ? {
+		...(disableBypassPermissionsMode ? { disableBypassPermissionsMode: 'disable' as const } : {}),
+		...(askForShell ? { ask: [MANAGED_PERMISSION_TERMINAL_ASK_RULE] as const } : {}),
+	} : undefined;
+}
+
+const managedPermissionsProperty = schemaProperty<IManagedPermissions>({
+	type: 'object',
+	title: localize('agentHost.config.managedPermissions.title', "Managed Permissions"),
+	description: localize('agentHost.config.managedPermissions.description', "Permission restrictions derived from effective VS Code settings and forwarded to the runtime as `managedSettings.permissions` at session startup."),
+	properties: {
+		disableBypassPermissionsMode: {
+			type: 'string',
+			title: localize('agentHost.config.managedPermissions.disableBypass', "Disable bypass permissions mode"),
+			enum: ['disable'],
+		},
+		ask: {
+			type: 'array',
+			title: localize('agentHost.config.managedPermissions.ask', "Required permission prompts"),
+			items: {
+				type: 'string',
+				title: localize('agentHost.config.managedPermissions.rule', "Permission rule"),
+				enum: [MANAGED_PERMISSION_TERMINAL_ASK_RULE],
+			},
+		},
+	},
+	// No default: `{}` is the wire-level clear sentinel and is normalized to
+	// `undefined` before SDK launch, so `managedSettings` is omitted.
+});
+
 /**
  * Session-config properties owned by the platform itself — i.e. consumed
  * by the agent host rather than by any particular agent.
@@ -432,6 +478,21 @@ export const TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID = 'chat.tools.terminal.ena
  * with Allow all.
  */
 export const AgentHostGlobalAutoApproveEnabledConfigKey = 'globalAutoApproveEnabled';
+
+/**
+ * The VS Code setting ID for global auto approve. Defined here so renderer-side
+ * agent-host clients can forward it without importing from `workbench/contrib/chat`.
+ */
+export const GLOBAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.global.autoApprove';
+
+/**
+ * Root config key forwarded from the renderer holding the {@link IManagedPermissions}
+ * object. Synthesized by VS Code from the effective values of
+ * `chat.tools.global.autoApprove` and
+ * `chat.tools.terminal.enableAutoApprove`, and forwarded to the runtime as
+ * `managedSettings.permissions` at SDK session startup. Absent when no mapped setting applies.
+ */
+export const AgentHostManagedPermissionsConfigKey = 'managedPermissions';
 
 /**
  * Root config key forwarded from the renderer when VS Code's `chat.autoReply`
@@ -714,6 +775,7 @@ export const platformRootSchema = createSchema({
 		description: localize('agentHost.config.globalAutoApproveEnabled.description', "Whether VS Code's global auto-approve setting is enabled. When `true`, every tool call is auto-approved, equivalent to a session using Allow all."),
 		default: false,
 	}),
+	[AgentHostManagedPermissionsConfigKey]: managedPermissionsProperty,
 	[AgentHostAutoReplyEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',
 		title: localize('agentHost.config.autoReplyEnabled.title', "Auto Reply"),

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -2125,6 +2125,9 @@ export interface IAgentService {
 	 */
 	dispatchAction(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number, clientContext?: IAgentHostClientTelemetryContext): void;
 
+	/** Remove the managed-permission contribution owned by a disconnected client. */
+	removeClientManagedPermissions(clientId: string): void;
+
 	/**
 	 * List the contents of a directory on the agent host's filesystem.
 	 * Used by the client to drive a remote folder picker before session creation.

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -79,7 +79,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
-import { AgentHostEditTelemetryEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
+import { AgentHostEditTelemetryEnabledConfigKey, AgentHostManagedPermissionsConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, MANAGED_PERMISSION_TERMINAL_ASK_RULE, normalizeManagedPermissions, platformRootSchema, type IManagedPermissions } from '../common/agentHostSchema.js';
 import { AgentHostOctoKitService, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import { IAgentHostChangesetService, CHANGESET_DB_METADATA_KEYS, META_CHANGES_SUMMARY } from '../common/agentHostChangesetService.js';
 import { IAgentHostChangesetSubscriptionService } from '../common/agentHostChangesetSubscriptionService.js';
@@ -332,6 +332,8 @@ export class AgentService extends Disposable implements IAgentService {
 	/** Server-side host for the agent host's server tools. */
 	private readonly _serverToolHost: AgentServerToolHost;
 	private readonly _configurationService: AgentConfigurationService;
+	/** Enterprise-managed permission restrictions contributed by each connected client. */
+	private readonly _managedPermissionsByClient = new Map<string, IManagedPermissions>();
 	/** Captures baseline / per-turn git checkpoints backing the changeset pipeline. */
 	private readonly _checkpointService: IAgentHostCheckpointService;
 	/**
@@ -2614,8 +2616,13 @@ export class AgentService extends Disposable implements IAgentService {
 	 * todo@connor4312: we can drop this when sending a message become a command
 	 */
 	private readonly _clientDispatchQueues = new Map<string, Promise<void>>();
+	/** Invalidates queued managed-permission updates when a client's reconnect grace expires. */
+	private readonly _managedPermissionsDispatchGenerations = new Map<string, number>();
 
 	dispatchAction(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number, clientContextOrType: IAgentHostClientTelemetryContext | AgentHostClientType = AgentHostClientType.Unknown): void {
+		const managedPermissionsDispatchGeneration = action.type === ActionType.RootConfigChanged && Object.hasOwn(action.config, AgentHostManagedPermissionsConfigKey)
+			? this._managedPermissionsDispatchGenerations.get(clientId) ?? 0
+			: undefined;
 		const clientContext = typeof clientContextOrType === 'string'
 			? createUnknownAgentHostClientTelemetryContext(clientContextOrType)
 			: clientContextOrType;
@@ -2635,7 +2642,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 		const pending = this._clientDispatchQueues.get(clientId);
 		if (!pending && !requiresSessionRestore && !requiresPeerResolution && !requiresAttachmentRewrite && !requiresReviewStateUpdate) {
-			this._dispatchActionNow(channel, sessionChannel, action, clientId, clientSeq, clientContext);
+			this._dispatchActionNow(channel, sessionChannel, action, clientId, clientSeq, clientContext, managedPermissionsDispatchGeneration);
 			return;
 		}
 		const next = (pending ?? Promise.resolve()).then(async () => {
@@ -2662,17 +2669,21 @@ export class AgentService extends Disposable implements IAgentService {
 				}
 				this._changesets.refreshBranchChangeset(changeset.sessionUri);
 			}
-			this._dispatchActionNow(channel, sessionChannel, rewritten, clientId, clientSeq, clientContext);
+			this._dispatchActionNow(channel, sessionChannel, rewritten, clientId, clientSeq, clientContext, managedPermissionsDispatchGeneration);
 		}).catch(err => {
 			this._logService.error(`[AgentService] async dispatchAction failed: ${toErrorMessage(err)}`);
 			this._stateManager.rejectClientAction(channel, action, { clientId, clientSeq }, toErrorMessage(err));
-		}).finally(() => {
-			if (this._clientDispatchQueues.get(clientId) === next) {
-				this._clientDispatchQueues.delete(clientId);
-			}
 		});
 
-		this._clientDispatchQueues.set(clientId, next);
+		const queue = next.finally(() => {
+			if (this._clientDispatchQueues.get(clientId) === queue) {
+				this._clientDispatchQueues.delete(clientId);
+				if (!this._managedPermissionsByClient.has(clientId)) {
+					this._managedPermissionsDispatchGenerations.delete(clientId);
+				}
+			}
+		});
+		this._clientDispatchQueues.set(clientId, queue);
 	}
 
 	/**
@@ -2705,7 +2716,10 @@ export class AgentService extends Disposable implements IAgentService {
 		return resolveSessionWorkingDirectoryAction(action, state.workingDirectories, capability.immutablePrimary === true);
 	}
 
-	private _dispatchActionNow(channel: string, sessionChannel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number, clientContext: IAgentHostClientTelemetryContext): void {
+	private _dispatchActionNow(channel: string, sessionChannel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number, clientContext: IAgentHostClientTelemetryContext, managedPermissionsDispatchGeneration: number | undefined): void {
+		if (managedPermissionsDispatchGeneration !== undefined && !this._isManagedPermissionsDispatchGenerationCurrent(clientId, managedPermissionsDispatchGeneration)) {
+			return;
+		}
 		const origin = { clientId, clientSeq };
 		if (action.type === ActionType.SessionWorkingDirectorySet || action.type === ActionType.SessionWorkingDirectoryRemoved) {
 			if (clientContext.clientType !== AgentHostClientType.EditorWindow) {
@@ -2723,8 +2737,27 @@ export class AgentService extends Disposable implements IAgentService {
 				return;
 			}
 		}
+		let managedPermissionsChanged = false;
+		let effectiveManagedPermissions: IManagedPermissions | undefined;
+		if (action.type === ActionType.RootConfigChanged && Object.hasOwn(action.config, AgentHostManagedPermissionsConfigKey)) {
+			const managedPermissions = action.config[AgentHostManagedPermissionsConfigKey];
+			if (!platformRootSchema.validate(AgentHostManagedPermissionsConfigKey, managedPermissions)) {
+				this._stateManager.rejectClientAction(channel, action, origin, `Invalid ${AgentHostManagedPermissionsConfigKey} root config value.`);
+				return;
+			}
+			effectiveManagedPermissions = this._setClientManagedPermissions(clientId, normalizeManagedPermissions(managedPermissions));
+			const config = { ...action.config };
+			delete config[AgentHostManagedPermissionsConfigKey];
+			action = { ...action, config };
+			managedPermissionsChanged = true;
+		}
 		this._stateManager.dispatchClientAction(channel, action, origin);
 		if (action.type === ActionType.RootConfigChanged) {
+			if (managedPermissionsChanged) {
+				this._configurationService.publishRootTransientValues({
+					[AgentHostManagedPermissionsConfigKey]: effectiveManagedPermissions ?? {},
+				});
+			}
 			this._configurationService.persistRootConfig();
 			const editTelemetryEnabled = action.config[AgentHostEditTelemetryEnabledConfigKey];
 			if (typeof editTelemetryEnabled === 'boolean') {
@@ -2732,6 +2765,41 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		this._sideEffects.handleAction(channel, action, clientId, clientContext);
+	}
+
+	removeClientManagedPermissions(clientId: string): void {
+		this._managedPermissionsDispatchGenerations.set(clientId, (this._managedPermissionsDispatchGenerations.get(clientId) ?? 0) + 1);
+		if (this._managedPermissionsByClient.delete(clientId)) {
+			this._configurationService.publishRootTransientValues({
+				[AgentHostManagedPermissionsConfigKey]: this._getEffectiveManagedPermissions() ?? {},
+			});
+		}
+		if (!this._clientDispatchQueues.has(clientId)) {
+			this._managedPermissionsDispatchGenerations.delete(clientId);
+		}
+	}
+
+	private _isManagedPermissionsDispatchGenerationCurrent(clientId: string, generation: number): boolean {
+		return (this._managedPermissionsDispatchGenerations.get(clientId) ?? 0) === generation;
+	}
+
+	private _setClientManagedPermissions(clientId: string, permissions: IManagedPermissions | undefined): IManagedPermissions | undefined {
+		if (permissions) {
+			this._managedPermissionsByClient.set(clientId, permissions);
+		} else {
+			this._managedPermissionsByClient.delete(clientId);
+		}
+		return this._getEffectiveManagedPermissions();
+	}
+
+	private _getEffectiveManagedPermissions(): IManagedPermissions | undefined {
+		const permissions = [...this._managedPermissionsByClient.values()];
+		const disableBypassPermissionsMode = permissions.some(value => value.disableBypassPermissionsMode === 'disable');
+		const askForShell = permissions.some(value => value.ask !== undefined);
+		return disableBypassPermissionsMode || askForShell ? {
+			...(disableBypassPermissionsMode ? { disableBypassPermissionsMode: 'disable' as const } : {}),
+			...(askForShell ? { ask: [MANAGED_PERMISSION_TERMINAL_ASK_RULE] as const } : {}),
+		} : undefined;
 	}
 
 	private _needsAsyncRewrite(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction): action is ChatTurnStartedAction | ChatPendingMessageSetAction {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -37,7 +37,7 @@ import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBil
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, DEFAULT_SESSION_CUSTOMIZATION_DISCOVERY_MODE, toContainerCustomization } from '../../common/agentHostCustomizationConfig.js';
 import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey, copilotCliConfigSchema, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
-import { AgentHostMcpServersConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
+import { AgentHostMcpServersConfigKey, AgentHostManagedPermissionsConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, normalizeManagedPermissions, platformRootSchema, platformSessionSchema, type AgentHostMcpServers, type IManagedPermissions } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, prepareSideChatPrompt, stripSideChatContext, type IPersistedChat } from '../agentPeerChats.js';
 import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentHostManagedSettingsSnapshot, IAgentHostNetworkEndpoint, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionAdoptionResult, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
@@ -2748,17 +2748,31 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// Additional (non-default) chats are backed by their own SDK
 		// chat hosted on the owning session entry, keyed by the chat URI.
 		if (context.isPeerChat) {
-			const entry = await this._ensureChatSession(context.session, chat);
-			if (!entry) {
-				throw new Error(`[Copilot] sendMessage for unknown chat: ${chat.toString()}`);
-			}
-			if (turnId) {
-				entry.resetTurnState(turnId, senderClientId, clientType);
-			}
-			const sideChat = this._chatBackings.get(chat.toString())?.sideChat;
-			const existingTurns = sideChat ? await entry.getMessages() : [];
-			const sdkPrompt = prepareSideChatPrompt(prompt, existingTurns, sideChat);
-			await entry.send(sdkPrompt, attachments, turnId, this._resolveSdkMode(context.session), senderClientId, clientType);
+			const chatKey = chat.toString();
+			await this._queueChat(context.sessionId, chatKey, async () => {
+				let entry = await this._ensureChatSession(context.session, chat);
+				if (!entry) {
+					throw new Error(`[Copilot] sendMessage for unknown chat: ${chatKey}`);
+				}
+				const activeClient = this._activeClients.get(context.session);
+				if (activeClient && await activeClient.requiresRestart(entry.appliedSnapshot)) {
+					this._logService.info(`[Copilot:${context.sessionId}] Peer chat config changed (requiresRestart=true), refreshing ${chatKey}`);
+					this._sdkSessionsById.delete(entry.sessionId);
+					await entry.destroySession();
+					this._sessions.get(context.sessionId)?.disposePeerChat(chatKey);
+					entry = await this._ensureChatSession(context.session, chat);
+					if (!entry) {
+						throw new Error(`[Copilot] failed to refresh chat: ${chatKey}`);
+					}
+				}
+				if (turnId) {
+					entry.resetTurnState(turnId, senderClientId, clientType);
+				}
+				const sideChat = this._chatBackings.get(chatKey)?.sideChat;
+				const existingTurns = sideChat ? await entry.getMessages() : [];
+				const sdkPrompt = prepareSideChatPrompt(prompt, existingTurns, sideChat);
+				await entry.send(sdkPrompt, attachments, turnId, this._resolveSdkMode(context.session), senderClientId, clientType);
+			});
 			return;
 		}
 		await this._queueSession(context.sessionId, async () => {
@@ -5303,6 +5317,7 @@ class ActiveClient extends Disposable {
 			tools: this.toolSet.merged(),
 			plugins: await this.pluginController.getAppliedPlugins(),
 			mcpServers: this._getMcpServers(),
+			managedPermissions: this._getManagedPermissions(),
 		};
 	}
 
@@ -5310,6 +5325,12 @@ class ActiveClient extends Disposable {
 		const servers = this._configurationService.getRootValue(platformRootSchema, AgentHostMcpServersConfigKey) ?? {};
 
 		return structuredClone(servers);
+	}
+
+	private _getManagedPermissions(): IManagedPermissions | undefined {
+		return normalizeManagedPermissions(
+			this._configurationService.getRootValue(platformRootSchema, AgentHostManagedPermissionsConfigKey),
+		);
 	}
 
 	/**
@@ -5325,6 +5346,9 @@ class ActiveClient extends Disposable {
 			return true;
 		}
 		if (!equals(snap.mcpServers, this._getMcpServers())) {
+			return true;
+		}
+		if (!equals(snap.managedPermissions, this._getManagedPermissions())) {
 			return true;
 		}
 		return !this.toolSet.structuralEquals(snap.tools);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -32,7 +32,7 @@ import { CopilotCliConfigKey, applyModelFamilyAlias, copilotCliConfigSchema } fr
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
 import { gitHubMcpServerUrl } from '../../common/githubEndpoints.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
-import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyAnswer, AgentHostAutoReplyEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, platformRootSchema, platformSessionSchema } from '../../common/agentHostSchema.js';
+import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyAnswer, AgentHostAutoReplyEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostManagedPermissionsConfigKey, platformRootSchema, platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSession, AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import { META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
@@ -3014,6 +3014,9 @@ export class CopilotAgentSession extends Disposable {
 	 * level. Agent mode is an orthogonal axis and does not affect approvals.
 	 */
 	private _isBypassApprovals(): boolean {
+		if (this._configurationService.getRootValue(platformRootSchema, AgentHostManagedPermissionsConfigKey)?.disableBypassPermissionsMode === 'disable') {
+			return false;
+		}
 		if (this._configurationService.getRootValue(platformRootSchema, AgentHostGlobalAutoApproveEnabledConfigKey) === true) {
 			return true;
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -11,7 +11,7 @@ import { IFileService } from '../../../files/common/files.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { CopilotCliConfigKey, applyModelFamilyAlias, copilotCliConfigSchema, normalizeToolSearchDeferThreshold } from '../../common/copilotCliConfig.js';
 import { agentHostModelSupportsToolSearch, CLIENT_TOOL_SEARCH_REFERENCE_NAME } from './toolSearchDeferral.js';
-import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
+import { AgentHostManagedPermissionsConfigKey, AgentHostSessionSyncEnabledConfigKey, normalizeManagedPermissions, platformRootSchema, type AgentHostMcpServers, type IManagedPermissions } from '../../common/agentHostSchema.js';
 import { AgentSession } from '../../common/agentService.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
@@ -95,6 +95,8 @@ export interface IActiveClientSnapshot {
 	readonly tools: readonly ToolDefinition[];
 	readonly plugins: readonly ICopilotPluginInfo[];
 	readonly mcpServers: AgentHostMcpServers;
+	/** Startup-only managed permissions included in structural restart detection. */
+	readonly managedPermissions?: IManagedPermissions;
 }
 
 /**
@@ -579,6 +581,9 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		// renderer reports no BYOK models), merged into the returned config so both
 		// createSession and resumeSession advertise the models to the runtime.
 		const byok = await this._resolveByokSessionConfig(plan.sessionId);
+		const managedPermissions = normalizeManagedPermissions(
+			this._configurationService.getRootValue(platformRootSchema, AgentHostManagedPermissionsConfigKey),
+		);
 		const enableCustomTerminalTool = this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.EnableCustomTerminalTool) === true;
 		let shellTools: Awaited<ReturnType<typeof createShellTools>> = [];
 		if (enableCustomTerminalTool) {
@@ -677,6 +682,15 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// events. Without this, sessions default to "off".
 			remoteSession: this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true ? 'export' : undefined,
 			enableManagedSettings: true,
+			// Forward effective VS Code permission restrictions to the runtime.
+			...(managedPermissions ? {
+				managedSettings: {
+					permissions: {
+						...(managedPermissions.disableBypassPermissionsMode ? { disableBypassPermissionsMode: managedPermissions.disableBypassPermissionsMode } : {}),
+						...(managedPermissions.ask ? { ask: [...managedPermissions.ask] } : {}),
+					},
+				},
+			} : {}),
 		};
 	}
 }

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -6,7 +6,7 @@
 import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { isJsonRpcResponse } from '../../../base/common/jsonRpcProtocol.js';
-import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, type IDisposable } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -66,7 +66,7 @@ import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 /** Default capacity of the server-side action replay buffer. */
 const REPLAY_BUFFER_CAPACITY = 1000;
 
-const CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT = 30_000;
+const CLIENT_DISCONNECT_GRACE_TIMEOUT = 30_000;
 
 /**
  * Chat-level working-directory subsets are not yet operational in this build.
@@ -270,6 +270,8 @@ interface IGraceClientRecord {
 	 * is live). Disposing an entry (or the whole map) clears the timer.
 	 */
 	readonly disconnectTimeouts: DisposableMap<string>;
+	/** Removes the client's managed-permission contribution when reconnect grace expires. */
+	readonly managedPermissionsDisconnectTimeout: IDisposable | undefined;
 }
 
 /**
@@ -527,16 +529,21 @@ export class ProtocolServerHandler extends Disposable {
 					this._releaseClientSubscriptions(client, record);
 					this._rejectPendingReverseRequestsForConnection(client);
 					if (record.connections.length === 0) {
-						this._logService.info(`[ProtocolServer] Client disconnected: ${client.clientId}, subscriptions=${subscriptionCount}`);
-						this._clients.set(client.clientId, {
+						const clientId = client.clientId;
+						this._logService.info(`[ProtocolServer] Client disconnected: ${clientId}, subscriptions=${subscriptionCount}`);
+						this._clients.set(clientId, {
 							state: 'grace',
 							clientInfo: record.clientInfo,
 							telemetryContext: client.telemetryContext,
 							protocolVersion: client.protocolVersion,
 							lastSeenAt: Date.now(),
 							disconnectTimeouts: new DisposableMap(),
+							managedPermissionsDisconnectTimeout: disposableTimeout(
+								() => this._agentService.removeClientManagedPermissions(clientId),
+								CLIENT_DISCONNECT_GRACE_TIMEOUT,
+							),
 						});
-						this._handleClientDisconnected(client.clientId);
+						this._handleClientDisconnected(clientId);
 						this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 					}
 					this._reportClientDisconnected(client, subscriptionCount);
@@ -613,7 +620,7 @@ export class ProtocolServerHandler extends Disposable {
 			const counts = this._connectionTelemetryTracker.connect(params.clientId, telemetryTransportToken);
 			client.telemetryConnectionActive = true;
 			if (previousRecord?.state === 'grace') {
-				previousRecord.disconnectTimeouts.dispose();
+				this._disposeGraceTimeouts(previousRecord);
 			}
 			this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 			this._telemetryReporter.clientConnection({
@@ -761,7 +768,7 @@ export class ProtocolServerHandler extends Disposable {
 			const counts = this._connectionTelemetryTracker.connect(params.clientId, telemetryTransportToken);
 			client.telemetryConnectionActive = true;
 			if (existingRecord.state === 'grace') {
-				existingRecord.disconnectTimeouts.dispose();
+				this._disposeGraceTimeouts(existingRecord);
 			}
 			this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 			this._telemetryReporter.clientConnection({
@@ -1013,7 +1020,7 @@ export class ProtocolServerHandler extends Disposable {
 		}
 		record.disconnectTimeouts.deleteAndDispose(chatChannel);
 		const elapsed = Date.now() - record.lastSeenAt;
-		const delay = Math.max(0, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT - elapsed);
+		const delay = Math.max(0, CLIENT_DISCONNECT_GRACE_TIMEOUT - elapsed);
 		record.disconnectTimeouts.set(chatChannel, disposableTimeout(() => {
 			this._releaseActiveClientForSession(session, clientId, chatChannel);
 		}, delay));
@@ -1103,6 +1110,7 @@ export class ProtocolServerHandler extends Disposable {
 			protocolVersion: undefined,
 			lastSeenAt: Date.now(),
 			disconnectTimeouts: new DisposableMap(),
+			managedPermissionsDisconnectTimeout: undefined,
 		};
 		this._clients.set(clientId, created);
 		return created;
@@ -1201,9 +1209,15 @@ export class ProtocolServerHandler extends Disposable {
 			if (record.state === 'grace'
 				&& record.disconnectTimeouts.size === 0
 				&& record.lastSeenAt < cutoff) {
+				record.managedPermissionsDisconnectTimeout?.dispose();
 				this._clients.delete(clientId);
 			}
 		}
+	}
+
+	private _disposeGraceTimeouts(record: IGraceClientRecord): void {
+		record.disconnectTimeouts.dispose();
+		record.managedPermissionsDisconnectTimeout?.dispose();
 	}
 
 	private _clearClientToolCallDisconnectTimeout(clientId: string, channel: string): void {
@@ -1755,7 +1769,8 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	override dispose(): void {
-		for (const record of this._clients.values()) {
+		for (const [clientId, record] of this._clients) {
+			this._agentService.removeClientManagedPermissions(clientId);
 			if (record.state === 'active') {
 				for (const connection of [...record.connections]) {
 					const subscriptionCount = connection.subscriptions.size;
@@ -1769,7 +1784,7 @@ export class ProtocolServerHandler extends Disposable {
 					connection.disposables.dispose();
 				}
 			} else {
-				record.disconnectTimeouts.dispose();
+				this._disposeGraceTimeouts(record);
 			}
 		}
 		this._clients.clear();

--- a/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from '../../common/agentHostSchema.js';
+import { managedPermissionsSettingMappings, resolveManagedPermissions } from '../../common/agentHostManagedSettings.js';
+
+suite('agentHostManagedSettings', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('maps effective values through declarative entries', () => {
+		const configurationService = new TestConfigurationService({
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: true,
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: false,
+		});
+		assert.deepStrictEqual({
+			mappingIds: managedPermissionsSettingMappings.map(entry => entry.settingId),
+			permissions: resolveManagedPermissions(configurationService),
+		}, {
+			mappingIds: [GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID],
+			permissions: { ask: ['Shell'] },
+		});
+	});
+
+	test('combines contributions', () => {
+		const configurationService = new TestConfigurationService({
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: false,
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: false,
+		});
+		assert.deepStrictEqual(resolveManagedPermissions(configurationService), {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
@@ -414,4 +414,5 @@ suite('agentHostSchema', () => {
 			});
 		});
 	});
+
 });

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -30,7 +30,7 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostManagedPermissionsConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, MANAGED_PERMISSION_TERMINAL_ASK_RULE, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../../registry/common/platform.js';
 
@@ -194,6 +194,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		onGrantImplicitRead?: (identity: AgentHostResourceIdentity, uri: URI) => void;
 		/** Test hook that observes disposal of the implicit-read grant. */
 		onRevokeImplicitRead?: (identity: AgentHostResourceIdentity, uri: URI) => void;
+		onConnectionClosed?: (identity: AgentHostResourceIdentity) => void;
 		readBytes?: VSBuffer;
 	}
 
@@ -240,7 +241,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 				opts.onGrantImplicitRead?.(address, uri);
 				return opts.onRevokeImplicitRead ? toDisposable(() => opts.onRevokeImplicitRead?.(address, uri)) : Disposable.None;
 			},
-			connectionClosed: () => { },
+			connectionClosed: identity => opts.onConnectionClosed?.(identity),
 		};
 	}
 
@@ -262,7 +263,24 @@ suite('RemoteAgentHostProtocolClient', () => {
 		transport.fireMessage({
 			jsonrpc: '2.0',
 			id: sent.id,
-			result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
+			result: {
+				protocolVersion: PROTOCOL_VERSION,
+				serverSeq: 0,
+				snapshots: [{
+					resource: ROOT_STATE_URI,
+					fromSeq: 0,
+					state: {
+						agents: [],
+						config: {
+							schema: {
+								type: 'object',
+								properties: { [AgentHostManagedPermissionsConfigKey]: { type: 'object' } },
+							},
+							values: {},
+						},
+					},
+				}],
+			},
 		});
 		await connectPromise;
 	}
@@ -936,6 +954,59 @@ suite('RemoteAgentHostProtocolClient', () => {
 		});
 	});
 
+	test('derives managed permissions from effective settings and forwards them on connect', async () => {
+		const configurationService = new TestConfigurationService({
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: false,
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: false,
+		});
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+		await connectClient(client, transport);
+
+		const managed = findRootConfigNotification(transport.sentMessages, AgentHostManagedPermissionsConfigKey);
+		assert.deepStrictEqual(getRootConfig(managed)[AgentHostManagedPermissionsConfigKey], {
+			disableBypassPermissionsMode: 'disable',
+			ask: [MANAGED_PERMISSION_TERMINAL_ASK_RULE],
+		});
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID, true);
+		fireConfigurationChange(configurationService, GLOBAL_AUTO_APPROVE_SETTING_ID);
+		assert.deepStrictEqual(
+			findRootConfigValue(transport.sentMessages, AgentHostManagedPermissionsConfigKey),
+			{ ask: [MANAGED_PERMISSION_TERMINAL_ASK_RULE] },
+		);
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, true);
+		fireConfigurationChange(configurationService, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID);
+		assert.deepStrictEqual(
+			findRootConfigValue(transport.sentMessages, AgentHostManagedPermissionsConfigKey),
+			{},
+		);
+	});
+
+	test('forwards restrictive settings without making a host compatibility decision', async () => {
+		const configurationService = new TestConfigurationService({
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: false,
+		});
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+		const connect = client.connect();
+		const initialize = transport.sentMessages[0] as JsonRpcRequest;
+		transport.fireMessage({
+			jsonrpc: '2.0',
+			id: initialize.id,
+			result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
+		});
+		await connect;
+		assert.deepStrictEqual({
+			state: client.connectionState,
+			permissions: findRootConfigValue(transport.sentMessages, AgentHostManagedPermissionsConfigKey),
+		}, {
+			state: AgentHostClientState.Connected,
+			permissions: { disableBypassPermissionsMode: 'disable' },
+		});
+	});
+
 	test('forwards the repo-info telemetry debug switch on connect and change', async () => {
 		const configurationService = new TestConfigurationService({ [DISABLE_REPO_INFO_TELEMETRY_SETTING_ID]: true });
 		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
@@ -1008,55 +1079,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 		assert.deepStrictEqual(getRootConfig(terminalAutoApproveRules), {
 			[AgentHostTerminalAutoApproveRulesConfigKey]: { python: true },
 		});
-	});
-
-	test('rejects normal traffic but retains the transport for an incompatible protocol upgrade', async () => {
-		const transport = disposables.add(new TestClientProtocolTransport());
-		const { client } = createClient(transport);
-		const connectPromise = client.connect();
-
-		transport.connectDeferred.complete();
-		while (transport.sentMessages.length === 0) {
-			await Promise.resolve();
-		}
-
-		const sent = transport.sentMessages[0] as JsonRpcRequest;
-		transport.fireMessage({
-			jsonrpc: '2.0',
-			id: sent.id,
-			error: {
-				code: AhpErrorCodes.UnsupportedProtocolVersion,
-				message: 'Client offered protocol versions [0.1.0], but this server only supports 0.2.0.',
-				data: { supportedVersions: ['0.2.0'], _meta: { vscodeUpgradeMethod: '_vscodeUpgrade' } },
-			},
-		});
-
-		await assertRemoteProtocolError(connectPromise, {
-			code: AhpErrorCodes.UnsupportedProtocolVersion,
-			message: 'Client offered protocol versions [0.1.0], but this server only supports 0.2.0.',
-			data: { supportedVersions: ['0.2.0'], _meta: { vscodeUpgradeMethod: '_vscodeUpgrade' } },
-		});
-		assert.strictEqual(client.connectionState, AgentHostClientState.Incompatible);
-		await assertRemoteProtocolError(client.resourceList(URI.file('/workspace')), {
-			code: AhpErrorCodes.UnsupportedProtocolVersion,
-			message: 'Client offered protocol versions [0.1.0], but this server only supports 0.2.0.',
-			data: { supportedVersions: ['0.2.0'], _meta: { vscodeUpgradeMethod: '_vscodeUpgrade' } },
-		});
-		client.dispatch(ROOT_STATE_URI, { type: ActionType.RootConfigChanged, config: { dropped: true } });
-		assert.strictEqual(transport.sentMessages.length, 1);
-
-		const upgrade = client.triggerVscodeUpgrade('_vscodeUpgrade');
-		const request = transport.sentMessages[1] as JsonRpcRequest;
-		assert.deepStrictEqual(request, {
-			jsonrpc: '2.0',
-			id: 2,
-			method: '_vscodeUpgrade',
-			params: {},
-		});
-		transport.fireMessage({ jsonrpc: '2.0', id: request.id, result: { ok: true, upgradeStarted: true } });
-		assert.deepStrictEqual(await upgrade, { ok: true, upgradeStarted: true });
-		transport.fireClose();
-		assert.strictEqual(client.connectionState, AgentHostClientState.Closed);
 	});
 
 	test('sends shutdown as a JSON-RPC request shape', async () => {
@@ -1652,7 +1674,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		 * client plus a `transports` array recording each transport handed
 		 * out, so tests can drive handshake/reconnect interactions.
 		 */
-		function createFactoryClient(permissionService = createPermissionService(), clientInfo?: Implementation): { client: RemoteAgentHostProtocolClient; transports: TestClientProtocolTransport[] } {
+		function createFactoryClient(permissionService = createPermissionService(), clientInfo?: Implementation, configurationService: TestConfigurationService = new TestConfigurationService()): { client: RemoteAgentHostProtocolClient; transports: TestClientProtocolTransport[] } {
 			const transports: TestClientProtocolTransport[] = [];
 			const factory = () => {
 				const t = disposables.add(new TestClientProtocolTransport());
@@ -1660,12 +1682,12 @@ suite('RemoteAgentHostProtocolClient', () => {
 				return t;
 			};
 			const client = disposables.add(new RemoteAgentHostProtocolClient(
-				'test.example:1234', factory, undefined, undefined, clientInfo, new NullLogService(), permissionService, new TestConfigurationService(),
+				'test.example:1234', factory, undefined, undefined, clientInfo, new NullLogService(), permissionService, configurationService,
 			));
 			return { client, transports };
 		}
 
-		async function completeHandshake(transport: TestClientProtocolTransport, connectPromise: Promise<void>): Promise<void> {
+		async function completeHandshake(transport: TestClientProtocolTransport, connectPromise: Promise<void>, supportsManagedPermissions = false): Promise<void> {
 			transport.connectDeferred.complete();
 			while (findRequest(transport, 'initialize') === undefined) {
 				await Promise.resolve();
@@ -1673,7 +1695,25 @@ suite('RemoteAgentHostProtocolClient', () => {
 			const init = findRequest(transport, 'initialize')!;
 			transport.fireMessage({
 				jsonrpc: '2.0', id: init.id,
-				result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 5, snapshots: [] },
+				result: {
+					protocolVersion: PROTOCOL_VERSION,
+					serverSeq: 5,
+					snapshots: supportsManagedPermissions ? [{
+						resource: ROOT_STATE_URI,
+						state: {
+							agents: [],
+							activeSessions: 0,
+							config: {
+								schema: {
+									type: 'object',
+									properties: { [AgentHostManagedPermissionsConfigKey]: { type: 'object' } },
+								},
+								values: {},
+							},
+						},
+						fromSeq: 5,
+					}] : [],
+				},
 			});
 			await connectPromise;
 		}
@@ -1773,11 +1813,14 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		test('restores subscriptions before replaying pending actions when the server forgot the client', async function () {
 			this.timeout(10_000);
-			const { client, transports } = createFactoryClient();
+			const configurationService = new TestConfigurationService();
+			const { client, transports } = createFactoryClient(createPermissionService(), undefined, configurationService);
 			const sessionUri = URI.parse('copilot:/test-session');
 			const chatUri = URI.parse('ahp-chat://default/test-session');
 			const connectPromise = client.connect();
-			await completeHandshake(transports[0], connectPromise);
+			await completeHandshake(transports[0], connectPromise, true);
+			await configurationService.setUserConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID, false);
+			fireConfigurationChange(configurationService, GLOBAL_AUTO_APPROVE_SETTING_ID);
 
 			const sessionRef = client.getSubscription(StateComponents.Session, sessionUri, 'test');
 			const initialSessionSubscribe = await waitForRequestAt(transports[0], 'subscribe', 0);
@@ -1808,6 +1851,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 			transports[0].fireClose();
 			await waitForReconnecting(client);
+
 			const reconnectTransport = await waitForTransport(transports, 1);
 			reconnectTransport.connectDeferred.complete();
 			const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
@@ -1821,11 +1865,30 @@ suite('RemoteAgentHostProtocolClient', () => {
 				result: {
 					protocolVersion: PROTOCOL_VERSION,
 					serverSeq: 0,
-					snapshots: [{ resource: ROOT_STATE_URI, state: { agents: [], activeSessions: 0 }, fromSeq: 0 }],
+					snapshots: [{
+						resource: ROOT_STATE_URI,
+						state: {
+							agents: [],
+							activeSessions: 0,
+							config: {
+								schema: {
+									type: 'object',
+									properties: { [AgentHostManagedPermissionsConfigKey]: { type: 'object' } },
+								},
+								values: {},
+							},
+						},
+						fromSeq: 0,
+					}],
 				},
 			});
 
 			const restoredAuthenticate = await waitForRequestAt(reconnectTransport, 'authenticate', 0);
+			const managedPermissions = findRootConfigNotification(reconnectTransport.sentMessages, AgentHostManagedPermissionsConfigKey);
+			assert.ok(
+				reconnectTransport.sentMessages.indexOf(managedPermissions) < reconnectTransport.sentMessages.indexOf(restoredAuthenticate),
+				'managed permissions should be sent before restoring authentication',
+			);
 			reconnectTransport.fireMessage({ jsonrpc: '2.0', id: restoredAuthenticate.id, result: {} });
 			const restoredSessionSubscribe = await waitForRequestAt(reconnectTransport, 'subscribe', 0);
 			assert.strictEqual((restoredSessionSubscribe.params as { channel: string }).channel, sessionUri.toString());
@@ -1847,10 +1910,84 @@ suite('RemoteAgentHostProtocolClient', () => {
 				reconnectTransport.sentMessages.indexOf(replayed) > reconnectTransport.sentMessages.indexOf(restoredChatSubscribe),
 				'pending turn should be sent after subscription restoration',
 			);
+			assert.ok(
+				reconnectTransport.sentMessages.indexOf(managedPermissions) < reconnectTransport.sentMessages.indexOf(replayed),
+				'managed permissions should be sent before replaying pending turns',
+			);
 
 			chatRef.dispose();
 			sessionRef.dispose();
 			client.dispose();
+		});
+
+		test('forwards managed permissions after reconnect fallback without probing host support', async function () {
+			this.timeout(10_000);
+			const configurationService = new TestConfigurationService();
+			const { client, transports } = createFactoryClient(createPermissionService(), undefined, configurationService);
+			const connectPromise = client.connect();
+			await completeHandshake(transports[0], connectPromise);
+
+			transports[0].fireClose();
+			await waitForReconnecting(client);
+			await configurationService.setUserConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID, false);
+			const reconnectTransport = await waitForTransport(transports, 1);
+			reconnectTransport.connectDeferred.complete();
+			const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: reconnect.id,
+				error: { code: AhpErrorCodes.NotFound, message: 'Reconnect client not found' },
+			});
+
+			const initialize = await waitForRequest(reconnectTransport, 'initialize');
+			assert.deepStrictEqual((initialize.params as { protocolVersions: string[] }).protocolVersions, SUPPORTED_PROTOCOL_VERSIONS);
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialize.id,
+				result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
+			});
+			await flushMicrotasks();
+			assert.deepStrictEqual({
+				state: client.connectionState,
+				permissions: findRootConfigValue(reconnectTransport.sentMessages, AgentHostManagedPermissionsConfigKey),
+			}, {
+				state: AgentHostClientState.Connected,
+				permissions: { disableBypassPermissionsMode: 'disable' },
+			});
+		});
+
+		test('stops reconnecting when fresh initialize reports an unsupported protocol', async function () {
+			this.timeout(10_000);
+			const { client, transports } = createFactoryClient();
+			const connectPromise = client.connect();
+			await completeHandshake(transports[0], connectPromise);
+
+			transports[0].fireClose();
+			await waitForReconnecting(client);
+			const reconnectTransport = await waitForTransport(transports, 1);
+			reconnectTransport.connectDeferred.complete();
+			const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: reconnect.id,
+				error: { code: AhpErrorCodes.NotFound, message: 'Reconnect client not found' },
+			});
+
+			const initialize = await waitForRequest(reconnectTransport, 'initialize');
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialize.id,
+				error: { code: AhpErrorCodes.UnsupportedProtocolVersion, message: 'Unsupported protocol version' },
+			});
+			await flushMicrotasks();
+
+			assert.deepStrictEqual({
+				state: client.connectionState,
+				transportCount: transports.length,
+			}, {
+				state: AgentHostClientState.Incompatible,
+				transportCount: 2,
+			});
 		});
 
 		test('replays pending optimistic actions after reconnect', async function () {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -30,8 +30,9 @@ import { CodexSessionConfigKey } from '../../common/codexSessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agentHostGitStateService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
+import { AgentHostManagedPermissionsConfigKey } from '../../common/agentHostSchema.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
-import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, NotificationType, type IRootConfigChangedAction } from '../../common/state/sessionActions.js';
 import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
@@ -1115,6 +1116,69 @@ suite('AgentService (node dispatcher)', () => {
 			listener.dispose();
 		});
 
+		test('only invalidates a disconnected client queued managed-permissions update', async () => {
+			const { svc, session } = await createDynamicWorkingDirectorySession();
+			const source = URI.from({ scheme: Schemas.inMemory, path: '/workspace/stale-source.txt' });
+			await fileService.writeFile(source, VSBuffer.fromString('contents'));
+			const readStarted = new DeferredPromise<void>();
+			const readGate = new DeferredPromise<void>();
+			const originalReadFile = fileService.readFile.bind(fileService);
+			fileService.readFile = async resource => {
+				if (resource.toString() === source.toString()) {
+					readStarted.complete();
+					await readGate.p;
+				}
+				return originalReadFile(resource);
+			};
+			disposables.add(toDisposable(() => fileService.readFile = originalReadFile));
+			const clientId = 'disconnected-client';
+			const dispatchedClientSequences: number[] = [];
+			const listener = svc.onDidAction(envelope => {
+				if (envelope.origin?.clientId === clientId) {
+					dispatchedClientSequences.push(envelope.origin.clientSeq);
+				}
+			});
+
+			svc.dispatchAction(buildDefaultChatUri(session.toString()), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: {
+					text: 'hello',
+					origin: { kind: MessageKind.User },
+					attachments: [{
+						type: MessageAttachmentKind.Resource,
+						uri: source.toString(),
+						label: 'stale-source.txt',
+						displayKind: 'document',
+					}],
+				},
+			}, clientId, 1, AgentHostClientType.EditorWindow);
+			await readStarted.p;
+			svc.dispatchAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostManagedPermissionsConfigKey]: { disableBypassPermissionsMode: 'disable' } },
+			}, clientId, 2);
+			svc.removeClientManagedPermissions(clientId);
+			const queueDrained = Event.toPromise(Event.filter(svc.onDidAction, envelope => envelope.origin?.clientId === clientId && envelope.origin.clientSeq === 3));
+			svc.dispatchAction(session.toString(), {
+				type: ActionType.SessionWorkingDirectorySet,
+				directory: URI.file('/workspace/added').toString(),
+			}, clientId, 3, AgentHostClientType.EditorWindow);
+
+			readGate.complete();
+			await queueDrained;
+
+			assert.deepStrictEqual({
+				dispatchedClientSequences,
+				managedPermissions: svc.stateManager.rootState.config?.values[AgentHostManagedPermissionsConfigKey],
+			}, {
+				dispatchedClientSequences: [1, 3],
+				managedPermissions: undefined,
+			});
+			listener.dispose();
+		});
+
 		test('reduces working-directory mutations synchronously in dispatch order', async () => {
 			const { svc, session, primary, secondary } = await createDynamicWorkingDirectorySession();
 			const added = URI.file('/workspace/added');
@@ -1211,17 +1275,23 @@ suite('AgentService (node dispatcher)', () => {
 				const customization = { uri: 'file:///plugin-a', displayName: 'Plugin A' };
 				svc.dispatchAction(ROOT_STATE_URI, {
 					type: ActionType.RootConfigChanged,
-					config: { customizations: [customization] },
+					config: {
+						customizations: [customization],
+						[AgentHostManagedPermissionsConfigKey]: { disableBypassPermissionsMode: 'disable' },
+					},
 				}, 'test-client', 1);
 
 				let persisted = false;
 				for (let attempt = 0; attempt < 20; attempt++) {
 					try {
 						const parsed = JSON.parse(readFileSync(rootConfigResource.fsPath, 'utf8'));
-						assert.deepStrictEqual(
-							parsed.customizations,
-							[customization],
-						);
+						assert.deepStrictEqual({
+							customizations: parsed.customizations,
+							managedPermissions: parsed[AgentHostManagedPermissionsConfigKey],
+						}, {
+							customizations: [customization],
+							managedPermissions: undefined,
+						});
 						persisted = true;
 						break;
 					} catch {
@@ -1242,6 +1312,44 @@ suite('AgentService (node dispatcher)', () => {
 				localDisposables.dispose();
 				rmSync(tempDir.fsPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 			}
+		});
+
+		test('isolates managed permissions per client', () => {
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const managedPermissions = {
+				ask: ['Shell'] as const,
+			};
+			const managedAction = {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostManagedPermissionsConfigKey]: managedPermissions },
+			} satisfies IRootConfigChangedAction;
+
+			svc.dispatchAction(ROOT_STATE_URI, managedAction, 'managed-client', 1);
+			svc.dispatchAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostManagedPermissionsConfigKey]: { disableBypassPermissionsMode: 'disable' } },
+			}, 'restricted-client', 1);
+			svc.dispatchAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostManagedPermissionsConfigKey]: {} },
+			}, 'unmanaged-client', 1);
+
+			const beforeDisconnect = svc.stateManager.rootState.config?.values[AgentHostManagedPermissionsConfigKey];
+			svc.removeClientManagedPermissions('managed-client');
+			const afterManagedDisconnect = svc.stateManager.rootState.config?.values[AgentHostManagedPermissionsConfigKey];
+			svc.removeClientManagedPermissions('restricted-client');
+			const afterAllManagedDisconnect = svc.stateManager.rootState.config?.values[AgentHostManagedPermissionsConfigKey];
+			assert.deepStrictEqual({
+				beforeDisconnect,
+				afterManagedDisconnect,
+				afterAllManagedDisconnect,
+				originalPermissions: managedAction.config[AgentHostManagedPermissionsConfigKey],
+			}, {
+				beforeDisconnect: { disableBypassPermissionsMode: 'disable', ask: ['Shell'] },
+				afterManagedDisconnect: { disableBypassPermissionsMode: 'disable' },
+				afterAllManagedDisconnect: {},
+				originalPermissions: managedPermissions,
+			});
 		});
 
 		test('generates and persists an AI title after first-turn fallback title', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -34,7 +34,7 @@ import { NullTelemetryService, NullTelemetryServiceShape } from '../../../teleme
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey } from '../../common/copilotCliConfig.js';
 import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
-import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostManagedPermissionsConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentCreateChatForkSource, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
@@ -4786,6 +4786,7 @@ suite('CopilotAgent', () => {
 			_getOrCreateSessionLifetime: (sessionId: string) => { queueSession<T>(task: () => Promise<T>): Promise<T> } | undefined;
 			_forkSdkChat: (client: unknown, sourceEntry: unknown, turnId: string, targetDbDir: URI) => Promise<{ sessionId: string; inheritedTurnCount: number }>;
 			_resolveAgentName: (snapshot: IActiveClientSnapshot, agent: AgentSelection) => string | undefined;
+			_ensureChatSession: (session: URI, chat: URI) => Promise<CopilotAgentSession | undefined>;
 		};
 
 		interface IFakeChatRecorder {
@@ -4829,6 +4830,7 @@ suite('CopilotAgent', () => {
 				handleClientToolCallComplete(): void { },
 				async getNextTurnEventId(): Promise<string | undefined> { return undefined; },
 				getMessages: getMessages ?? (async () => []),
+				async destroySession(): Promise<void> { rec.disposed = true; },
 				dispose(): void { rec.disposed = true; owned?.dispose(); },
 			} as unknown as CopilotAgentSession;
 			return { rec, fake };
@@ -5592,6 +5594,60 @@ suite('CopilotAgent', () => {
 					aResets: [{ turnId: 'turn-a', senderClientId: 'client-1' }],
 					bSends: [],
 					bResets: [],
+				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('sendMessage serializes concurrent peer chat refreshes when managed permissions change', async () => {
+			const { agent, configurationService } = createTestAgentContext(disposables);
+			try {
+				const session = AgentSession.uri('copilotcli', 'route-managed-refresh');
+				const chat = URI.parse(buildChatUri(session, 'peer-a'));
+				agent.getOrCreateActiveClient(session, { clientId: 'client-A' }).tools = [];
+				const old = makeFakeChatSession(session, 'sdk-old');
+				const fresh = makeFakeChatSession(session, 'sdk-fresh');
+				Object.assign(fresh.fake, {
+					appliedSnapshot: {
+						tools: [],
+						plugins: [],
+						mcpServers: {},
+						managedPermissions: { disableBypassPermissionsMode: 'disable' },
+					} satisfies IActiveClientSnapshot,
+				});
+				setPeerChatStub(agent, chat, old.fake);
+				let oldDestroyCalls = 0;
+				Object.assign(old.fake, {
+					async destroySession(): Promise<void> {
+						oldDestroyCalls++;
+					}
+				});
+				(agent as unknown as ChatInternals)._ensureChatSession = async () => {
+					const existing = getPeerChatStub(agent, chat);
+					if (existing) {
+						return existing;
+					}
+					setPeerChatStub(agent, chat, fresh.fake);
+					return fresh.fake;
+				};
+
+				configurationService.updateRootConfig({
+					[AgentHostManagedPermissionsConfigKey]: { disableBypassPermissionsMode: 'disable' },
+				});
+				await Promise.all([
+					agent.chats.sendMessage(chat, 'first-after-policy-change', undefined),
+					agent.chats.sendMessage(chat, 'second-after-policy-change', undefined),
+				]);
+
+				assert.deepStrictEqual({
+					oldDestroyCalls,
+					freshDisposed: fresh.rec.disposed,
+					freshPrompts: fresh.rec.sends.map(send => send.prompt),
+				}, {
+					oldDestroyCalls: 1,
+					freshDisposed: false,
+					freshPrompts: ['first-after-policy-change', 'second-after-policy-change'],
 				});
 			} finally {
 				await disposeAgent(agent);

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -47,7 +47,7 @@ import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js'
 import { buildCopilotSystemNotification } from '../../node/copilot/copilotSystemNotification.js';
 import { IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostManagedPermissionsConfigKey } from '../../common/agentHostSchema.js';
 import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
 import { AgentHostSandboxConfigKey, AgentHostSandboxKey } from '../../common/sandboxConfigSchema.js';
 import { AgentSandboxEnabledValue } from '../../../sandbox/common/settings.js';
@@ -3490,15 +3490,17 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(mockSession.permissionModeSetCalls, ['auto']);
 		});
 
-		test('syncs permission mode when root approval configuration changes', async () => {
-			const { session, mockSession, setRootValue, fireRootConfigChange } = await createAgentSession(disposables);
+		test('managed policy clamps a live allow-all session', async () => {
+			const { session, mockSession, setRootValue, fireRootConfigChange } = await createAgentSession(disposables, {
+				configValues: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+			});
 			await session.syncPermissionMode('turn-start');
-			setRootValue(AgentHostGlobalAutoApproveEnabledConfigKey, true);
+			setRootValue(AgentHostManagedPermissionsConfigKey, { disableBypassPermissionsMode: 'disable' });
 
 			fireRootConfigChange();
 			await timeout(0);
 
-			assert.deepStrictEqual(mockSession.permissionModeSetCalls, ['off', 'on']);
+			assert.deepStrictEqual(mockSession.permissionModeSetCalls, ['on', 'off']);
 		});
 
 		test('aborts when a live permission mode update fails', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -25,6 +25,7 @@ import { ByokLmBridgeRegistry, IByokLmBridgeRegistry } from '../../node/byokLmBr
 import { ByokLmProxyService, IByokLmProxyService, type IByokLmProxyHandle } from '../../node/copilot/byokLmProxyService.js';
 import { CopilotSessionLauncher, getCopilotReasoningEffort, isCopilotReasoningEffort, resolveByokSessionConfig, type CopilotSessionLaunchPlan, type ICopilotSessionRuntime } from '../../node/copilot/copilotSessionLauncher.js';
 import type { ICopilotPluginInfo } from '../../node/copilot/copilotAgent.js';
+import { AgentHostManagedPermissionsConfigKey } from '../../common/agentHostSchema.js';
 
 const testRuntime: ICopilotSessionRuntime = {
 	handlePermissionRequest: async () => { throw new Error('Unexpected permission request'); },
@@ -41,9 +42,9 @@ const testRuntime: ICopilotSessionRuntime = {
 
 const testWorkingDirectory = URI.file(process.cwd());
 
-function createTestLauncher(): CopilotSessionLauncher {
+function createTestLauncher(values: Record<string, unknown> = {}): CopilotSessionLauncher {
 	const configurationService = {
-		getRootValue: () => undefined,
+		getRootValue: (_schema: unknown, key: string) => values[key],
 	} as Partial<IAgentConfigurationService> as IAgentConfigurationService;
 	return new CopilotSessionLauncher(
 		configurationService,
@@ -422,6 +423,53 @@ suite('CopilotSessionLauncher shared session config', () => {
 			sessions.dispose();
 			await launcher.disposeByokProxyHandle();
 		}
+	});
+
+	test('forwards managed permissions on create and resume and omits the clear sentinel', async () => {
+		const observed: unknown[] = [];
+		for (const rootValue of [{ disableBypassPermissionsMode: 'disable', ask: ['Shell'] }, {}] as const) {
+			const session = {
+				sessionId: 'session-1',
+				on: () => () => { },
+				disconnect: async () => { },
+			} as unknown as CopilotSession;
+			const client = {
+				createSession: async (config: Parameters<CopilotClient['createSession']>[0]) => {
+					observed.push({ kind: 'create', managedSettings: config.managedSettings, enabled: config.enableManagedSettings });
+					return session;
+				},
+				resumeSession: async (_sessionId: string, config: Parameters<CopilotClient['resumeSession']>[1]) => {
+					observed.push({ kind: 'resume', managedSettings: config.managedSettings, enabled: config.enableManagedSettings });
+					return session;
+				},
+			};
+			const launcher = createTestLauncher({ [AgentHostManagedPermissionsConfigKey]: rootValue });
+			const basePlan = {
+				client,
+				sessionId: 'session-1',
+				workingDirectory: testWorkingDirectory,
+				resolvedAgentName: undefined,
+				snapshot: { tools: [], plugins: [], mcpServers: {} },
+				activeClientToolSet: new ActiveClientToolSet(),
+				shellManager: undefined,
+				githubToken: undefined,
+			};
+			const sessions = new DisposableStore();
+			try {
+				sessions.add(await launcher.launch({ ...basePlan, kind: 'create', model: undefined }, testRuntime));
+				sessions.add(await launcher.launch({ ...basePlan, kind: 'resume', fallback: { model: undefined } }, testRuntime));
+			} finally {
+				sessions.dispose();
+				await launcher.disposeByokProxyHandle();
+			}
+		}
+		const managedSettings = { permissions: { disableBypassPermissionsMode: 'disable', ask: ['Shell'] } };
+		assert.deepStrictEqual(observed, [
+			{ kind: 'create', managedSettings, enabled: true },
+			{ kind: 'resume', managedSettings, enabled: true },
+			{ kind: 'create', managedSettings: undefined, enabled: true },
+			{ kind: 'resume', managedSettings: undefined, enabled: true },
+		]);
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -126,6 +126,7 @@ class MockAgentService implements IAgentService {
 	readonly listedSessions: IAgentSessionMetadata[] = [];
 	readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
 	managedSettingsDiagnostics: readonly IAgentHostManagedSettingsDiagnostics[] = [];
+	readonly removedManagedPermissionClients: string[] = [];
 	shutdownCalls = 0;
 
 	private readonly _onDidAction = new Emitter<import('../../common/state/sessionActions.js').ActionEnvelope>();
@@ -148,6 +149,9 @@ class MockAgentService implements IAgentService {
 		this.handledClientContexts.push(clientContext);
 		const origin = { clientId, clientSeq };
 		this._stateManager.dispatchClientAction(channel, action, origin);
+	}
+	removeClientManagedPermissions(clientId: string): void {
+		this.removedManagedPermissionClients.push(clientId);
 	}
 	async createSession(config?: IAgentCreateSessionConfig): Promise<URI> {
 		this.createSessionConfigs.push(config);
@@ -1628,18 +1632,39 @@ suite('ProtocolServerHandler', () => {
 		await assert.rejects(readPromise, /Client client-fs-overlap-close disconnected/);
 	});
 
-	test('client disconnect cleans up', () => {
-		stateManager.createSession(makeSessionSummary());
-		stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
+	test('reconnect preserves managed permissions until the next disconnect grace expires', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const transport1 = connectClient('client-managed-reconnect');
+			const initializeResponse = findResponse(transport1.sent, 1) as { result: InitializeResult };
+			transport1.simulateClose();
 
-		const transport = connectClient('client-d', [sessionUri]);
-		transport.sent.length = 0;
+			await new Promise(resolve => setTimeout(resolve, 15_000));
+			const duringGrace = [...agentService.removedManagedPermissionClients];
 
-		transport.simulateClose();
+			const transport2 = new MockProtocolTransport();
+			server.simulateConnection(transport2);
+			const reconnectResponse = waitForResponse(transport2, 1);
+			transport2.simulateMessage(request(1, 'reconnect', {
+				clientId: 'client-managed-reconnect',
+				lastSeenServerSeq: initializeResponse.result.serverSeq,
+				subscriptions: [],
+			}));
+			await reconnectResponse;
+			await new Promise(resolve => setTimeout(resolve, 30_001));
+			const afterOriginalGraceExpiry = [...agentService.removedManagedPermissionClients];
 
-		stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionTitleChanged, title: 'After Disconnect' });
-
-		assert.strictEqual(transport.sent.length, 0);
+			transport2.simulateClose();
+			await new Promise(resolve => setTimeout(resolve, 30_001));
+			assert.deepStrictEqual({
+				duringGrace,
+				afterOriginalGraceExpiry,
+				afterSecondGraceExpiry: agentService.removedManagedPermissionClients,
+			}, {
+				duringGrace: [],
+				afterOriginalGraceExpiry: [],
+				afterSecondGraceExpiry: ['client-managed-reconnect'],
+			});
+		});
 	});
 
 	test('client disconnect retains active client during grace, then removes it and fails owned tool calls after grace period', () => {

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -62,6 +62,7 @@ import { IAgentHostEnablementService } from '../../../platform/agentHost/common/
 import { IProgressService, ProgressLocation } from '../../../platform/progress/common/progress.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
 import { markdownDetails, markdownJsonBlock, markdownTable, markdownText } from './policyDiagnosticsMarkdown.js';
+import { resolveManagedPermissions } from '../../../platform/agentHost/common/agentHostManagedSettings.js';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -942,6 +943,7 @@ class PolicyDiagnosticsAction extends Action2 {
 		}
 
 		content += '## Managed Settings\n\n';
+		content += '*This section covers GitHub Copilot managed-settings delivery channels. Traditional VS Code policies from a configuration profile are reported under Policy-Controlled Settings and may synthesize the Agent Host client injection shown below even when no Copilot managed-settings channel is active.*\n\n';
 		try {
 			const policyData = defaultAccountService.policyData;
 			const serverManagedSettings = policyData?.managedSettings ?? {};
@@ -1098,12 +1100,26 @@ class PolicyDiagnosticsAction extends Action2 {
 				markdownJsonBlock(declaredDefinitions)
 			);
 
-			content += '### Agent Runtime Resolution\n\n';
-			content += '*Resolved independently by each provider through its own SDK/runtime. This may include runtime-owned keys that VS Code does not declare as configuration policies.*\n\n';
+			content += '### Agent Host Client Injection\n\n';
+			content += '*Synthesized by VS Code from effective settings and forwarded to Agent Host providers as session-local managed permissions. The provider SDK/runtime owns validation and enforcement.*\n\n';
+			const agentHostManagedPermissions = resolveManagedPermissions(configurationService);
+			content += '**Synthesized managed permissions**\n\n';
+			content += markdownJsonBlock(agentHostManagedPermissions ?? {});
+			content += `**This client's contribution**: ${agentHostManagedPermissions ? 'restrictive managed permissions' : 'none'}\n\n`;
+
+			content += '### Agent Runtime Account and Device Baseline\n\n';
+			content += '*Queried from each provider when this report is generated. The SDK query covers account/server and device policy, but intentionally excludes the session-local Agent Host client injection above and may use the provider runtime\'s own policy cache. Therefore `source: none` here does not mean that synthesized client permissions are inactive; a created session reports `client` or `mixed` provenance after applying them.*\n\n';
 			if (!agentHostEnablementService.enabled.get()) {
 				summary.agentRuntime = 'Agent Host disabled';
 				content += '*Agent Host is disabled; runtime managed-settings diagnostics were not queried.*\n\n';
 			} else {
+				content += markdownTable(
+					['Property', 'Value'],
+					[
+						['Queried', new Date().toISOString()],
+						['Force refresh', 'Not supported by the provider runtime API']
+					]
+				);
 				try {
 					const runtimeDiagnostics = await raceTimeout(agentHostService.getManagedSettingsDiagnostics(), AGENT_RUNTIME_DIAGNOSTICS_TIMEOUT);
 					if (!runtimeDiagnostics) {


### PR DESCRIPTION
## Summary

Adds a reusable bridge from explicitly configured VS Code settings to Copilot SDK `managedSettings.permissions` for Agent Host sessions.

The bridge is declarative: each mapping selects a VS Code setting and provides a typed callback that transforms its effective configured value into a managed-permissions contribution. The first two mappings are:

| VS Code setting | Effective configured value | SDK managed setting contribution |
| --- | --- | --- |
| `chat.tools.global.autoApprove` | `false` | `disableBypassPermissionsMode: "disable"` |
| `chat.tools.terminal.enableAutoApprove` | `false` | `ask: ["Shell"]` |

Untouched defaults do not create managed settings. Explicit values from policy, application, user, workspace, workspace-folder, or memory scopes use normal VS Code precedence and are eligible for mapping.

## Design

- `createManagedPermissionsSettingMapping(settingId, transform)` is the extension point for future mappings.
- `resolveManagedPermissions(configurationService)` evaluates all mappings and combines their restrictive contributions.
- Agent Host forwarding and **Developer: Policy Diagnostics** consume the same resolver.
- The renderer forwards the resulting root-config value; the Agent Host passes it to SDK session create and resume as `managedSettings.permissions`.
- VS Code does not probe runtime capabilities or decide whether the settings are enforceable. Validation, composition, and enforcement belong to the SDK/runtime.
- The empty object is retained as the JSON-safe clear sentinel and normalized before SDK launch.

## Lifecycle and safety

- Applies the same managed settings to create and resume.
- Refreshes default and peer-chat SDK sessions before the next turn when the effective settings change.
- Sends renderer-owned config before restored authentication, subscriptions, and pending turn replay after a fresh-initialize reconnect fallback.
- Combines contributions restrictively across connected clients.
- Retains a disconnected client's contribution through reconnect grace, then removes it without allowing a delayed queued update to recreate stale state.
- Invalidates only stale queued managed-permission updates; unrelated accepted client actions continue normally.
- Keeps the value transient rather than persisting it in Agent Host root configuration storage.
- Redacts `managedPermissions` from AHP JSONL and Agent Service trace logs without changing the wire payload.

## Scope

Permissions only. This does not add sandbox-floor mapping, network policy mapping, or generic per-tool eligibility. Permissive values do not synthesize `allow` rules.

## Validation

- `npm run typecheck-client`
- Pre-commit hygiene
- Focused managed-settings, reconnect, session lifecycle, and telemetry tests
- Full GitHub CI: **26 checks passing**, no failures
- PR is rebased onto `main`, mergeable, and has no unresolved review threads
