### PR TITLE
agentHost: Remove obsolete tool arguments metadata

### DIFF
--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -32,8 +32,6 @@ export interface IToolCallMeta {
 	readonly subagentAgentName?: string;
 	/** Chat URI of the subagent this tool call spawns, stamped by the host (see {@link buildSubagentChatUri}); the resource may not be registered yet. */
 	readonly subagentChatUri?: string;
-	/** Raw, pre-stringified tool arguments captured for display/debugging. */
-	readonly toolArguments?: unknown;
 	/** Originating MCP server name, when the call came from an MCP server. */
 	readonly mcpServerName?: string;
 	/** Originating MCP tool name, when the call came from an MCP server. */
@@ -129,7 +127,6 @@ export function readToolCallMeta(source: IHasToolCallMeta): IToolCallMeta {
 	if (typeof meta['subagentDescription'] === 'string') { result.subagentDescription = meta['subagentDescription']; }
 	if (typeof meta['subagentAgentName'] === 'string') { result.subagentAgentName = meta['subagentAgentName']; }
 	if (typeof meta['subagentChatUri'] === 'string') { result.subagentChatUri = meta['subagentChatUri']; }
-	if (meta['toolArguments'] !== undefined) { result.toolArguments = meta['toolArguments']; }
 	if (typeof meta['mcpServerName'] === 'string') { result.mcpServerName = meta['mcpServerName']; }
 	if (typeof meta['mcpToolName'] === 'string') { result.mcpToolName = meta['mcpToolName']; }
 	if (typeof meta['autoApproveBySetting'] === 'boolean') { result.autoApproveBySetting = meta['autoApproveBySetting']; }

--- a/src/vs/platform/agentHost/node/copilot/buildSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/buildSessionEvents.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { SessionEvent } from '@github/copilot-sdk';
+import { isObject } from '../../../../base/common/types.js';
 import { generateUuid, isUUID } from '../../../../base/common/uuid.js';
 import { ResponsePartKind, ToolCallStatus, ToolResultContentType, TurnState, type ToolCallCompletedState, type ToolResultContent, type ToolResultSubagentContent, type Turn } from '../../common/state/sessionState.js';
 
@@ -91,7 +92,7 @@ export function buildSessionEventsFromTurns(turns: readonly Turn[], options: IBu
 		if (tc.toolInput) {
 			try {
 				const parsed = JSON.parse(tc.toolInput);
-				if (parsed && typeof parsed === 'object') {
+				if (isObject(parsed)) {
 					parsedToolInput = parsed as Record<string, unknown>;
 				}
 			} catch {

--- a/src/vs/platform/agentHost/node/copilot/buildSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/buildSessionEvents.ts
@@ -87,12 +87,12 @@ export function buildSessionEventsFromTurns(turns: readonly Turn[], options: IBu
 
 	/** Emits the `tool.execution_start` + `tool.execution_complete` pair for a completed tool call. */
 	const pushCompletedToolCall = (tc: ToolCallCompletedState): void => {
-		let toolArguments: Record<string, unknown> | undefined;
+		let parsedToolInput: Record<string, unknown> | undefined;
 		if (tc.toolInput) {
 			try {
 				const parsed = JSON.parse(tc.toolInput);
 				if (parsed && typeof parsed === 'object') {
-					toolArguments = parsed as Record<string, unknown>;
+					parsedToolInput = parsed as Record<string, unknown>;
 				}
 			} catch {
 				// Non-JSON tool input: omit structured arguments (the forward
@@ -126,7 +126,7 @@ export function buildSessionEventsFromTurns(turns: readonly Turn[], options: IBu
 			data: {
 				toolCallId: tc.toolCallId,
 				toolName: tc.toolName,
-				...(toolArguments ? { arguments: toolArguments } : {}),
+				...(parsedToolInput ? { arguments: parsedToolInput } : {}),
 			},
 		});
 		const resultText = extractToolResultText(tc.content);
@@ -276,4 +276,3 @@ export function serializeSessionEventsToJsonl(events: readonly SessionEvent[]): 
 export function buildSessionEventLogFromTurns(turns: readonly Turn[], options: IBuildSessionEventsOptions): string {
 	return serializeSessionEventsToJsonl(buildSessionEventsFromTurns(turns, options));
 }
-

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3447,9 +3447,6 @@ export class CopilotAgentSession extends Disposable {
 			if (subagentMeta?.agentName) {
 				meta.subagentAgentName = subagentMeta.agentName;
 			}
-			if (toolArgs !== undefined) {
-				meta.toolArguments = toolArgs;
-			}
 			if (e.data.mcpServerName) {
 				meta.mcpServerName = e.data.mcpServerName;
 			}

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -66,11 +66,6 @@ suite('Agent host _meta readers', () => {
 			assert.deepStrictEqual(result, {});
 		});
 
-		test('preserves a present toolArguments value, drops undefined', () => {
-			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolArguments: { a: 1 } })), { toolArguments: { a: 1 } });
-			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolArguments: undefined })), {});
-		});
-
 		test('reads valid tool-search candidates and drops malformed corpora', () => {
 			const candidates = [{ name: 'everything-get-sum', description: 'Adds numbers' }];
 			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolSearchCandidates: candidates })), { toolSearchCandidates: candidates });

--- a/src/vs/platform/agentHost/test/node/buildSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/buildSessionEvents.test.ts
@@ -206,6 +206,16 @@ suite('buildSessionEventsFromTurns — reverse of mapSessionEvents', () => {
 		}]);
 	});
 
+	test('omits array tool input from structured session event arguments', () => {
+		const events = buildSessionEventsFromTurns([
+			userTurn(generateUuid(), 'run it', [toolCallPart(generateUuid(), 'tool', '["one", "two"]', '')]),
+		], { sessionId });
+		const started = events.find(e => e.type === 'tool.execution_start');
+
+		assert.ok(started && started.type === 'tool.execution_start');
+		assert.strictEqual(started.data.arguments, undefined);
+	});
+
 	test('round-trips a failed tool call preserving the error message', async () => {
 		const id = generateUuid();
 		const toolCallId = generateUuid();

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3544,7 +3544,6 @@ suite('CopilotAgentSession', () => {
 					},
 					meta: {
 						mcpServerName: 'docs',
-						toolArguments: '{"topic":"metadata"}',
 						ui: {
 							resourceUri: 'ui://docs',
 							channel: 'mcp://copilot/test-session-1/docs',
@@ -4025,15 +4024,6 @@ suite('CopilotAgentSession', () => {
 			if (isAction(readySignal, ActionType.ChatToolCallReady)) {
 				const action = readySignal.action as ChatToolCallReadyAction;
 				assert.strictEqual(action.toolInput, 'npm test');
-			}
-			// toolArguments in _meta on the tool_start signal (signals[0])
-			const startSignal = signals[0];
-			assert.ok(isAction(startSignal, ActionType.ChatToolCallStart));
-			if (isAction(startSignal, ActionType.ChatToolCallStart)) {
-				const meta = (startSignal.action as ChatToolCallStartAction)._meta;
-				const toolArgs = meta?.['toolArguments'] as string | undefined;
-				assert.ok(toolArgs && toolArgs.includes('"npm test"'), `toolArguments should contain rewritten command, was: ${toolArgs}`);
-				assert.ok(!toolArgs?.includes('cd /repo/project'), 'toolArguments should not contain stripped prefix');
 			}
 		});
 

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
@@ -407,7 +407,7 @@ suite('mapSessionEventsToHistoryRecords', () => {
 				},
 			], cwd);
 			const start = getStart(result);
-			assert.deepStrictEqual(JSON.parse(start.toolInput), { command: 'cd /workspace/proj && ls' });
+			assert.strictEqual(start.toolInput, '{\n  "command": "cd /workspace/proj && ls"\n}');
 		});
 
 		test('handles trailing slash on workingDirectory', async () => {

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.test.ts
@@ -372,7 +372,7 @@ suite('mapSessionEventsToHistoryRecords', () => {
 		}
 
 		function getStart(events: ReturnType<typeof mapSessionEventsToHistoryRecords> extends Promise<infer R> ? R : never) {
-			return events[0] as { toolInput: string; toolArguments?: string };
+			return events[0] as { toolInput: string };
 		}
 
 		test('strips redundant bash cd prefix matching workingDirectory', async () => {
@@ -381,7 +381,6 @@ suite('mapSessionEventsToHistoryRecords', () => {
 			], cwd);
 			const start = getStart(result);
 			assert.strictEqual(start.toolInput, 'ls -la');
-			assert.deepStrictEqual(JSON.parse(start.toolArguments!), { command: 'ls -la' });
 		});
 
 		test('leaves command unchanged when cd dir does not match', async () => {
@@ -408,8 +407,7 @@ suite('mapSessionEventsToHistoryRecords', () => {
 				},
 			], cwd);
 			const start = getStart(result);
-			// edit tool's toolInput is derived from filePath, not command — but toolArguments preserves original
-			assert.deepStrictEqual(JSON.parse(start.toolArguments!), { command: 'cd /workspace/proj && ls' });
+			assert.deepStrictEqual(JSON.parse(start.toolInput), { command: 'cd /workspace/proj && ls' });
 		});
 
 		test('handles trailing slash on workingDirectory', async () => {

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -57,7 +57,6 @@ export interface IHistoryToolStartRecord extends IHistoryRecordBase {
 	readonly toolInput?: string;
 	readonly toolKind?: 'terminal' | 'subagent' | 'search';
 	readonly language?: string;
-	readonly toolArguments?: string;
 	readonly subagentAgentName?: string;
 	readonly subagentDescription?: string;
 	readonly mcpServerName?: string;
@@ -487,7 +486,6 @@ export async function mapSessionEventsToHistoryRecords(
 				toolInput: getToolInputString(d.toolName, info?.parameters, toolArgs),
 				toolKind,
 				language: toolKind === 'terminal' ? getShellLanguage(d.toolName) : undefined,
-				toolArguments: toolArgs,
 				subagentAgentName: subagentMeta?.agentName,
 				subagentDescription: subagentMeta?.description,
 				mcpServerName: d.mcpServerName,

--- a/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
@@ -8,7 +8,9 @@ import { Event } from '../../../../../base/common/event.js';
 import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IVoiceSessionController } from '../../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { INewChatVoiceComposer, NewChatVoiceTargetService } from '../../browser/newChatVoice.js';
 import { SessionsVoiceNewComposerContribution } from '../../browser/voiceBridge.contribution.js';
 
@@ -36,8 +38,19 @@ suite('SessionsVoiceNewComposerContribution', () => {
 		return { controller, getDisconnectCount: () => disconnectCount };
 	}
 
+	function createTarget(): NewChatVoiceTargetService {
+		const sessionsService = new class extends mock<ISessionsService>() {
+			override readonly activeSession = constObservable(undefined);
+		}();
+		const chatWidgetService = new class extends mock<IChatWidgetService>() {
+			override readonly onDidChangeFocusedSession = Event.None;
+			override readonly lastFocusedWidget = undefined;
+		}();
+		return new NewChatVoiceTargetService(sessionsService, chatWidgetService);
+	}
+
 	test('disconnects when a fresh welcome composer takes over a connected voice session', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 
@@ -55,7 +68,7 @@ suite('SessionsVoiceNewComposerContribution', () => {
 	});
 
 	test('keeps voice connected when switching to an in-session composer that opts to route', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 
@@ -72,7 +85,7 @@ suite('SessionsVoiceNewComposerContribution', () => {
 	});
 
 	test('does not disconnect when voice is not connected', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3954,21 +3954,6 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
 		}));
 
-		test('malformed toolArguments does not throw', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
-
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
-
-			fire({ type: 'chat/toolCallStart', session, turnId, toolCallId: 'tc-bad', toolName: 'bash', displayName: 'Bash' } as ChatAction);
-			fire({ type: 'chat/toolCallReady', session, turnId, toolCallId: 'tc-bad', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ChatAction);
-			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
-
-			await turnPromise;
-
-			assert.strictEqual(collected.length, 1);
-			assert.strictEqual(collected[0][0].kind, 'toolInvocation');
-		}));
-
 		test('outstanding tool invocations are completed on idle', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -1038,13 +1038,6 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(invocation.invocationMessage, 'Running shell command');
 		});
 
-		test('creates invocation without toolArguments', () => {
-			const tc = createToolCallState({});
-
-			const invocation = toolCallStateToInvocation(tc);
-			assert.strictEqual(invocation.toolCallId, 'tc-1');
-		});
-
 		test('sets subagent toolSpecificData from _meta for subagent toolKind', () => {
 			const tc = createToolCallState({
 				_meta: { toolKind: 'subagent', subagentDescription: 'Review code', subagentAgentName: 'code-reviewer' },


### PR DESCRIPTION
## What changed

- Stop publishing serialized tool arguments through the provider-specific `_meta.toolArguments` slot on Agent Host tool calls.
- Remove the corresponding typed metadata reader and obsolete tests.
- Keep AHP's official `toolInput` field as the sole tool invocation input representation, including history reconstruction.

## Why

`_meta.toolArguments` had no production consumer in VS Code and duplicated `toolInput`. Because completion re-emits tracked metadata, the duplicate payload appeared on both `chat/toolCallStart` and `chat/toolCallComplete` without serving a client requirement.

## Validation

- `npm run compile-client`
- 680 targeted Agent Host/workbench tests
- `npm run precommit`

(Written by Copilot)