### PR TITLE
Speed up valid-layers-check (~76s to ~23s) and fix its OOMs

### DIFF
--- a/build/checker/layersChecker.ts
+++ b/build/checker/layersChecker.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import ts from 'typescript';
-import { readFileSync, existsSync } from 'fs';
-import { resolve, dirname, join, relative } from 'path';
+import { API, SymbolFlags, type Checker, type Program, type Project, type Symbol } from '@typescript/native/unstable/async';
+import { isExportSpecifier, isIdentifier, isImportSpecifier, isPropertyAccessExpression, type Identifier, type Node, type SourceFile } from '@typescript/native/unstable/ast';
+import { dirname, join, relative, resolve } from 'path';
 import minimatch from 'minimatch';
 
 //
@@ -100,6 +100,13 @@ export const RULES: IRule[] = [
 
 const TS_CONFIG_PATH = join(import.meta.dirname, '../../', 'src', 'tsconfig.json');
 
+/**
+ * Upper bound on how many nodes are sent to the checker in a single request.
+ * Batching is what makes this checker fast: resolving symbols one at a time
+ * would mean a round trip to the compiler for every single identifier.
+ */
+const SYMBOL_BATCH_SIZE = 20_000;
+
 export interface IRule {
 	target: string;
 	skip?: boolean;
@@ -114,87 +121,22 @@ export interface ILayerViolation {
 	character: number;
 }
 
-function checkFile(checker: ts.TypeChecker, sourceFile: ts.SourceFile, rule: IRule, violations: ILayerViolation[]): void {
-	if (!rule.disallowedTypes?.length) {
-		return;
-	}
-
-	const disallowedTypes = new Set(rule.disallowedTypes);
-	const candidateNames = new Set(disallowedTypes);
-
-	collectAliases(sourceFile);
-	checkNode(sourceFile);
-
-	function collectAliases(node: ts.Node): void {
-		if ((ts.isImportSpecifier(node) || ts.isExportSpecifier(node)) && disallowedTypes.has((node.propertyName ?? node.name).text)) {
-			candidateNames.add(node.name.text);
-		}
-
-		ts.forEachChild(node, collectAliases);
-	}
-
-	function checkNode(node: ts.Node): void {
-		if (!ts.isIdentifier(node)) {
-			return ts.forEachChild(node, checkNode); // recurse down
-		}
-
-		if (!candidateNames.has(node.text) && !(ts.isPropertyAccessExpression(node.parent) && node.parent.name === node)) {
-			return;
-		}
-
-		const symbol = checker.getSymbolAtLocation(node);
-
-		if (!symbol) {
-			return;
-		}
-
-		const type = findDisallowedType(checker, symbol, disallowedTypes);
-		if (type) {
-			const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-			violations.push({
-				type,
-				target: rule.target,
-				fileName: sourceFile.fileName,
-				line: line + 1,
-				character: character + 1,
-			});
-		}
-	}
+interface ICandidate {
+	readonly node: Identifier;
+	readonly sourceFile: SourceFile;
+	readonly rule: IRule;
 }
 
-function findDisallowedType(checker: ts.TypeChecker, symbol: ts.Symbol, disallowedTypes: Set<string>): string | undefined {
-	const seen = new Set<ts.Symbol>();
-	let current: ts.Symbol | undefined = symbol;
-
-	while (current && !seen.has(current)) {
-		seen.add(current);
-
-		const name = current.getName();
-		if (disallowedTypes.has(name)) {
-			return name;
-		}
-
-		if (current.flags & ts.SymbolFlags.Alias) {
-			current = checker.getAliasedSymbol(current);
-		} else {
-			current = getContainingSymbol(checker, current);
-		}
-	}
-
-	return undefined;
-}
-
-function getContainingSymbol(checker: ts.TypeChecker, symbol: ts.Symbol): ts.Symbol | undefined {
-	for (const declaration of symbol.declarations ?? []) {
-		const container = declaration.parent;
-		if (ts.isClassDeclaration(container) || ts.isClassExpression(container) || ts.isInterfaceDeclaration(container) || ts.isEnumDeclaration(container) || ts.isModuleDeclaration(container)) {
-			if (container.name) {
-				return checker.getSymbolAtLocation(container.name);
-			}
-		}
-	}
-
-	return undefined;
+/**
+ * The disallowed types resolved into symbols: `symbolIds` maps the id of a type
+ * symbol and of each of its members to the name of the disallowed type,
+ * `memberNames` holds the names of those members and `resolvedTypes` the names
+ * of the disallowed types that have been resolved so far.
+ */
+interface IDisallowedSymbols {
+	readonly symbolIds: Map<number, string>;
+	readonly memberNames: Set<string>;
+	readonly resolvedTypes: Set<string>;
 }
 
 export function getRule(fileName: string, rootPath: string, rules: readonly IRule[]): IRule | undefined {
@@ -202,37 +144,242 @@ export function getRule(fileName: string, rootPath: string, rules: readonly IRul
 	return rules.find(rule => minimatch(relativeFileName, rule.target));
 }
 
-export function createProgram(tsconfigPath: string, rules: readonly IRule[]): ts.Program {
-	const tsConfig = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
-
-	const configHostParser: ts.ParseConfigHost = { fileExists: existsSync, readDirectory: ts.sys.readDirectory, readFile: file => readFileSync(file, 'utf8'), useCaseSensitiveFileNames: process.platform === 'linux' };
-	const rootPath = resolve(dirname(tsconfigPath));
-	const tsConfigParsed = ts.parseJsonConfigFileContent(tsConfig.config, configHostParser, rootPath, { noEmit: true });
-	const rootFileNames = tsConfigParsed.fileNames.filter(fileName => !getRule(fileName, rootPath, rules)?.skip);
-
-	const compilerHost = ts.createCompilerHost(tsConfigParsed.options, true);
-
-	return ts.createProgram(rootFileNames, tsConfigParsed.options, compilerHost);
+function forEachNode(node: Node, callback: (node: Node) => void): void {
+	callback(node);
+	node.forEachChild(child => {
+		forEachNode(child, callback);
+		return undefined;
+	});
 }
 
-export function checkProgram(program: ts.Program, rootPath: string, rules: readonly IRule[]): ILayerViolation[] {
-	const checker = program.getTypeChecker();
-	const violations: ILayerViolation[] = [];
+/**
+ * Collects every identifier that names a disallowed type, either directly or
+ * through an import or export alias.
+ */
+function collectNamedReferences(sourceFile: SourceFile, disallowedTypes: ReadonlySet<string>): Identifier[] {
+	const candidateNames = new Set(disallowedTypes);
+	const identifiers: Identifier[] = [];
 
-	for (const sourceFile of program.getSourceFiles()) {
-		const rule = getRule(sourceFile.fileName, rootPath, rules);
-		if (rule && !rule.skip) {
-			checkFile(checker, sourceFile, rule, violations);
+	forEachNode(sourceFile, node => {
+		if ((isImportSpecifier(node) || isExportSpecifier(node)) && disallowedTypes.has((node.propertyName ?? node.name).text)) {
+			candidateNames.add(node.name.text);
+		}
+	});
+
+	forEachNode(sourceFile, node => {
+		if (isIdentifier(node) && candidateNames.has(node.text)) {
+			identifiers.push(node);
+		}
+	});
+
+	return identifiers;
+}
+
+/**
+ * Collects every property access whose name matches a member of a disallowed
+ * type. These are accesses on values of an inferred type, so the name alone is
+ * not conclusive and the symbol still has to be resolved.
+ */
+function collectMemberReferences(sourceFile: SourceFile, memberNames: ReadonlySet<string>): Identifier[] {
+	const identifiers: Identifier[] = [];
+
+	forEachNode(sourceFile, node => {
+		if (isIdentifier(node) && memberNames.has(node.text) && isPropertyAccessExpression(node.parent) && node.parent.name === node) {
+			identifiers.push(node);
+		}
+	});
+
+	return identifiers;
+}
+
+async function getSymbols(checker: Checker, nodes: readonly Node[]): Promise<(Symbol | undefined)[]> {
+	const symbols: (Symbol | undefined)[] = [];
+
+	for (let i = 0; i < nodes.length; i += SYMBOL_BATCH_SIZE) {
+		symbols.push(...await checker.getSymbolAtLocation(nodes.slice(i, i + SYMBOL_BATCH_SIZE)));
+	}
+
+	return symbols;
+}
+
+/**
+ * Expands the symbols the disallowed types resolved to into the set of symbols
+ * that a reference to such a type can produce. Doing this once up front turns
+ * the per-reference check into a local id lookup instead of walking the alias
+ * and containment chain of every symbol.
+ */
+async function addDisallowedSymbols(checker: Checker, symbols: readonly Symbol[], disallowedTypes: ReadonlySet<string>, disallowed: IDisallowedSymbols): Promise<void> {
+	for (const symbol of symbols) {
+		if (disallowed.symbolIds.has(symbol.id)) {
+			continue; // already seen through another reference to the same type
+		}
+
+		const declaration = symbol.flags & SymbolFlags.Alias ? await checker.getAliasedSymbol(symbol) : symbol;
+		if (!disallowedTypes.has(declaration.name)) {
+			continue; // the name matched but the symbol is an unrelated declaration
+		}
+
+		disallowed.symbolIds.set(symbol.id, declaration.name);
+		disallowed.symbolIds.set(declaration.id, declaration.name);
+
+		if (disallowed.resolvedTypes.has(declaration.name)) {
+			continue; // members already collected via another reference to this type
+		}
+		disallowed.resolvedTypes.add(declaration.name);
+
+		for (const members of [await declaration.getMembers(), await declaration.getExports()]) {
+			for (const member of members.values()) {
+				disallowed.symbolIds.set(member.id, declaration.name);
+				disallowed.memberNames.add(member.name);
+			}
+		}
+	}
+}
+
+function toViolation(candidate: ICandidate, type: string): ILayerViolation {
+	const { line, character } = candidate.sourceFile.getLineAndCharacterOfPosition(candidate.node.getStart(candidate.sourceFile));
+
+	return {
+		type,
+		target: candidate.rule.target,
+		fileName: candidate.sourceFile.fileName,
+		line: line + 1,
+		character: character + 1,
+	};
+}
+
+/**
+ * Resolves disallowed types that no checked file happens to reference by name,
+ * because a type that is never named there can still leak in through inference.
+ * Their declarations are searched for in the files no rule applies to, which is
+ * skipped entirely as long as every disallowed type is already accounted for.
+ */
+async function resolveRemainingTypes(program: Program, checker: Checker, fileNames: readonly string[], disallowedTypes: ReadonlySet<string>, disallowed: IDisallowedSymbols): Promise<void> {
+	const remaining = new Set([...disallowedTypes].filter(type => !disallowed.resolvedTypes.has(type)));
+	if (!remaining.size) {
+		return;
+	}
+
+	for (const fileName of fileNames) {
+		const sourceFile = await program.getSourceFile(fileName);
+		if (!sourceFile) {
+			continue;
+		}
+
+		const nodes = collectNamedReferences(sourceFile, remaining);
+		if (!nodes.length) {
+			continue;
+		}
+
+		const symbols = await getSymbols(checker, nodes);
+		await addDisallowedSymbols(checker, symbols.filter(symbol => !!symbol), disallowedTypes, disallowed);
+
+		for (const type of disallowed.resolvedTypes) {
+			remaining.delete(type);
+		}
+
+		if (!remaining.size) {
+			return;
+		}
+	}
+}
+
+function toViolations(candidates: readonly ICandidate[], symbols: readonly (Symbol | undefined)[], disallowed: IDisallowedSymbols): ILayerViolation[] {	const violations: ILayerViolation[] = [];
+
+	for (let i = 0; i < candidates.length; i++) {
+		const candidate = candidates[i];
+		const symbol = symbols[i];
+		if (!symbol) {
+			continue;
+		}
+
+		// A symbol matches when it is (or aliases) a disallowed type or one of
+		// its members. The name check also catches aliases the compiler could
+		// not resolve, where the reference is still spelled out in the source.
+		const type = candidate.rule.disallowedTypes?.includes(symbol.name) ? symbol.name : disallowed.symbolIds.get(symbol.id);
+		if (type && candidate.rule.disallowedTypes?.includes(type)) {
+			violations.push(toViolation(candidate, type));
 		}
 	}
 
 	return violations;
 }
 
-export function runLayerChecker(tsconfigPath: string, rules: readonly IRule[]): number {
+export async function checkProject(project: Project, fileNames: readonly string[], rootPath: string, rules: readonly IRule[]): Promise<ILayerViolation[]> {
+	const { program, checker } = project;
+
+	const sourceFiles: { sourceFile: SourceFile; rule: IRule }[] = [];
+	const otherFileNames: string[] = [];
+	for (const fileName of fileNames) {
+		const rule = getRule(fileName, rootPath, rules);
+		if (!rule || rule.skip) {
+			otherFileNames.push(fileName);
+			continue;
+		}
+
+		const sourceFile = await program.getSourceFile(fileName);
+		if (sourceFile) {
+			sourceFiles.push({ sourceFile, rule });
+		}
+	}
+
+	// Pass 1: identifiers that name a disallowed type. Files that a rule exempts
+	// are deliberately visited too, because that is where the disallowed types
+	// are usually declared and where their members are read from.
+	const disallowedTypes = new Set(rules.flatMap(rule => rule.disallowedTypes ?? []));
+	const namedCandidates: ICandidate[] = [];
+	for (const { sourceFile, rule } of sourceFiles) {
+		for (const node of collectNamedReferences(sourceFile, disallowedTypes)) {
+			namedCandidates.push({ node, sourceFile, rule });
+		}
+	}
+
+	const disallowed: IDisallowedSymbols = { symbolIds: new Map(), memberNames: new Set(), resolvedTypes: new Set() };
+	const namedSymbols = await getSymbols(checker, namedCandidates.map(candidate => candidate.node));
+	await addDisallowedSymbols(checker, namedSymbols.filter(symbol => !!symbol), disallowedTypes, disallowed);
+	await resolveRemainingTypes(program, checker, otherFileNames, disallowedTypes, disallowed);
+
+	// Pass 2: property accesses that may resolve to a member of a disallowed type.
+	const memberCandidates: ICandidate[] = [];
+	for (const { sourceFile, rule } of sourceFiles) {
+		if (!rule.disallowedTypes?.length) {
+			continue;
+		}
+
+		for (const node of collectMemberReferences(sourceFile, disallowed.memberNames)) {
+			memberCandidates.push({ node, sourceFile, rule });
+		}
+	}
+
+	const memberSymbols = await getSymbols(checker, memberCandidates.map(candidate => candidate.node));
+
+	return [
+		...toViolations(namedCandidates, namedSymbols, disallowed),
+		...toViolations(memberCandidates, memberSymbols, disallowed),
+	];
+}
+
+export async function checkLayers(tsconfigPath: string, rules: readonly IRule[]): Promise<ILayerViolation[]> {
 	const rootPath = resolve(dirname(tsconfigPath));
-	const program = createProgram(tsconfigPath, rules);
-	const violations = checkProgram(program, rootPath, rules);
+	const api = new API({ cwd: rootPath });
+
+	try {
+		const { fileNames } = await api.parseConfigFile(tsconfigPath);
+		const snapshot = await api.updateSnapshot({ openProjects: [tsconfigPath] });
+
+		const project = snapshot.getProject(tsconfigPath);
+		if (!project) {
+			throw new Error(`Unable to load a project from '${tsconfigPath}'.`);
+		}
+
+		return await checkProject(project, fileNames, rootPath, rules);
+	} finally {
+		await api.close();
+	}
+}
+
+export async function runLayerChecker(tsconfigPath: string, rules: readonly IRule[]): Promise<number> {
+	const violations = await checkLayers(tsconfigPath, rules);
 
 	for (const violation of violations) {
 		console.log(`[build/checker/layersChecker.ts]: Reference to type '${violation.type}' violates layer '${violation.target}' (${violation.fileName}:${violation.line}:${violation.character}). Learn more about our source code organization at https://github.com/microsoft/vscode/wiki/Source-Code-Organization.`);
@@ -242,5 +389,5 @@ export function runLayerChecker(tsconfigPath: string, rules: readonly IRule[]): 
 }
 
 if (import.meta.main) {
-	process.exitCode = runLayerChecker(TS_CONFIG_PATH, RULES) ? 1 : 0;
+	process.exitCode = await runLayerChecker(TS_CONFIG_PATH, RULES) ? 1 : 0;
 }

--- a/build/checker/layersTypeCheck.ts
+++ b/build/checker/layersTypeCheck.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as cp from 'child_process';
+import { createRequire } from 'module';
+import { availableParallelism, freemem } from 'os';
+import { dirname, join } from 'path';
+
+//
+// Type checks the sources of every target environment against the lib and type
+// definitions that environment actually provides. A file that reaches out to an
+// API of another layer fails to compile here.
+//
+// NOTE: The type based layer checks live in build/checker/layersChecker.ts.
+//
+
+const PROJECTS = [
+	'browser',
+	'worker',
+	'node',
+	'electron-browser',
+	'electron-main',
+	'electron-utility',
+];
+
+/**
+ * Memory to budget for a single type check. The largest of the projects peaks at
+ * around 3.5GB, so this leaves a little room on top of that.
+ */
+const MEMORY_PER_CHECK = 4 * 1024 * 1024 * 1024;
+
+/** Share of the free memory to leave untouched so the machine does not start swapping. */
+const MEMORY_HEADROOM = 0.25;
+
+/**
+ * Absolute path to the TypeScript 7 (native) compiler entrypoint. It is installed
+ * under the `@typescript/native` alias, so resolving it explicitly and invoking it
+ * via `node` guarantees we run TS7 rather than the `typescript` (<= 6.x) install.
+ */
+const tscPath = join(dirname(createRequire(import.meta.url).resolve('@typescript/native/package.json')), 'bin', 'tsc');
+
+/**
+ * The projects overlap heavily but are independent, so they can be checked in
+ * parallel. Each check is memory hungry enough that running all of them at once
+ * can push a smaller machine into swapping, which costs far more than checking
+ * the projects one after another, so free memory is what decides how many run
+ * at a time.
+ */
+function getConcurrency(): number {
+	const affordableChecks = Math.floor(freemem() * (1 - MEMORY_HEADROOM) / MEMORY_PER_CHECK);
+
+	return Math.max(1, Math.min(PROJECTS.length, availableParallelism(), affordableChecks));
+}
+
+function typeCheck(project: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = cp.spawn(process.execPath, [tscPath, '--project', join(import.meta.dirname, `tsconfig.${project}.json`), '--pretty', 'false'], { stdio: ['ignore', 'pipe', 'pipe'] });
+
+		let output = '';
+		child.stdout.on('data', data => output += data.toString());
+		child.stderr.on('data', data => output += data.toString());
+
+		child.on('error', reject);
+		child.on('exit', code => resolve(code === 0 ? '' : output.trim() || `tsc exited with code ${code ?? 'unknown'}.`));
+	});
+}
+
+async function typeCheckAll(projects: readonly string[], concurrency: number): Promise<string[]> {
+	const results: string[] = [];
+	let next = 0;
+
+	async function runNext(): Promise<void> {
+		while (next < projects.length) {
+			const index = next++;
+			results[index] = await typeCheck(projects[index]);
+		}
+	}
+
+	await Promise.all(Array.from({ length: concurrency }, runNext));
+
+	return results;
+}
+
+// Report the output in a stable order once all checks are done.
+const results = await typeCheckAll(PROJECTS, getConcurrency());
+
+for (const result of results) {
+	if (result) {
+		console.log(result);
+	}
+}
+
+process.exitCode = results.some(result => result) ? 1 : 0;

--- a/build/lib/test/layersChecker.test.ts
+++ b/build/lib/test/layersChecker.test.ts
@@ -5,10 +5,10 @@
 
 import assert from 'assert';
 import { afterEach, beforeEach, suite, test } from 'node:test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
-import { checkProgram, createProgram, getRule, type ILayerViolation, type IRule } from '../../checker/layersChecker.ts';
+import { checkLayers, getRule, type ILayerViolation, type IRule } from '../../checker/layersChecker.ts';
 
 suite('layersChecker', () => {
 	let rootPath: string;
@@ -20,7 +20,7 @@ suite('layersChecker', () => {
 	];
 
 	beforeEach(() => {
-		rootPath = mkdtempSync(join(tmpdir(), '.layers-checker-'));
+		rootPath = realpathSync(mkdtempSync(join(tmpdir(), '.layers-checker-')));
 		tsconfigPath = join(rootPath, 'tsconfig.json');
 		writeFileSync(tsconfigPath, JSON.stringify({
 			compilerOptions: {
@@ -43,37 +43,38 @@ suite('layersChecker', () => {
 		assert.strictEqual(getRule(fileName, rootPath, rules), rules[1]);
 	});
 
-	test('excludes skipped root files from the program', () => {
-		writeSource('vs/feature/browser/feature.ts', 'export const value = 1;');
-		const skippedFile = writeSource('vs/feature/test/feature.test.ts', 'export const value = 1;');
+	test('ignores skipped files', async () => {
+		writeForbiddenService();
+		writeSource('vs/feature/browser/test/feature.test.ts', `
+			import { ForbiddenService } from '../../../platform/common/service.js';
+			export const service: ForbiddenService | undefined = undefined;
+		`);
 
-		const program = createProgram(tsconfigPath, rules);
-
-		assert.strictEqual(program.getRootFileNames().includes(skippedFile), false);
+		assert.deepStrictEqual(await getViolations(), []);
 	});
 
-	test('detects aliased forbidden types', () => {
+	test('detects aliased forbidden types', async () => {
 		writeForbiddenService();
 		writeSource('vs/feature/browser/feature.ts', `
 			import { ForbiddenService as Service } from '../../platform/common/service.js';
 			export const service: Service | undefined = undefined;
 		`);
 
-		assert.deepStrictEqual(getViolations(), [
+		assert.deepStrictEqual(await getViolations(), [
 			{ type: 'ForbiddenService', fileName: 'vs/feature/browser/feature.ts', line: 2, character: 13 },
 			{ type: 'ForbiddenService', fileName: 'vs/feature/browser/feature.ts', line: 2, character: 33 },
 			{ type: 'ForbiddenService', fileName: 'vs/feature/browser/feature.ts', line: 3, character: 26 },
 		]);
 	});
 
-	test('detects members of inferred forbidden types', () => {
+	test('detects members of inferred forbidden types', async () => {
 		writeForbiddenService();
 		writeSource('vs/feature/browser/feature.ts', `
 			import { getService } from '../../platform/common/service.js';
 			getService().run();
 		`);
 
-		assert.deepStrictEqual(getViolations(), [
+		assert.deepStrictEqual(await getViolations(), [
 			{ type: 'ForbiddenService', fileName: 'vs/feature/browser/feature.ts', line: 3, character: 17 },
 		]);
 	});
@@ -92,13 +93,15 @@ suite('layersChecker', () => {
 		return fileName;
 	}
 
-	function getViolations(): Pick<ILayerViolation, 'type' | 'fileName' | 'line' | 'character'>[] {
-		const program = createProgram(tsconfigPath, rules);
-		return checkProgram(program, rootPath, rules).map(violation => ({
-			type: violation.type,
-			fileName: violation.fileName.slice(rootPath.length + 1).replaceAll('\\', '/'),
-			line: violation.line,
-			character: violation.character,
-		}));
+	async function getViolations(): Promise<Pick<ILayerViolation, 'type' | 'fileName' | 'line' | 'character'>[]> {
+		const violations = await checkLayers(tsconfigPath, rules);
+		return violations
+			.map(violation => ({
+				type: violation.type,
+				fileName: violation.fileName.slice(rootPath.length + 1).replaceAll('\\', '/'),
+				line: violation.line,
+				character: violation.character,
+			}))
+			.sort((a, b) => a.line - b.line || a.character - b.character);
 	}
 });

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "monaco-compile-check": "tsc --project src/tsconfig.monaco.json --noEmit",
     "tsec-compile-check": "node --max-old-space-size=8192 node_modules/tsec/bin/tsec -p src/tsconfig.tsec.json",
     "vscode-dts-compile-check": "tsc --project src/tsconfig.vscode-dts.json && tsc --project src/tsconfig.vscode-proposed-dts.json",
-    "valid-layers-check": "node --max-old-space-size=8192 build/checker/layersChecker.ts && tsc --project build/checker/tsconfig.browser.json && tsc --project build/checker/tsconfig.worker.json && tsc --project build/checker/tsconfig.node.json && tsc --project build/checker/tsconfig.electron-browser.json && tsc --project build/checker/tsconfig.electron-main.json && tsc --project build/checker/tsconfig.electron-utility.json",
+    "valid-layers-check": "node build/checker/layersChecker.ts && node build/checker/layersTypeCheck.ts",
     "define-class-fields-check": "node build/lib/propertyInitOrderChecker.ts && tsc --project src/tsconfig.defineClassFields.json",
     "update-distro": "node build/npm/update-distro.ts",
     "export-policy-data": "node build/lib/policies/exportPolicyData.ts",


### PR DESCRIPTION
> **Correction (post-merge):** the original numbers in this description overstated the speedup. `tsc` in npm scripts resolves to `node_modules/.bin/tsc` → `@typescript/native/bin/tsc`, i.e. **TS7 native already**. My "before" measurements for the six projects mistakenly invoked TS6 explicitly (`node_modules/typescript/lib/tsc.js`, which is the `@typescript/typescript6` alias). The corrected figures are below. The `layersChecker.ts` improvement and the OOM fix are unaffected.

## Problem

`npm run valid-layers-check` took **~76s** and would sometimes run out of memory.

## 1. `layersChecker.ts`: 48.6s / 3.8GB peak → 11.7s / 0.8GB peak

This was the OOM. The old implementation built a full in-process `ts.Program` (15s, 2GB) and then called `checker.getSymbolAtLocation()` on **every property access in the program** — ~2.5M identifiers. Each lookup materialized symbol and type objects, driving the heap past 3.6GB. It then walked the alias/containment chain separately per symbol.

It now uses the TS7 native API (`@typescript/native/unstable/{async,ast}`) that the repo already vendors for `build/lib/tsgo.ts`:

- **`updateSnapshot` replaces `createProgram`** — 1.7s instead of 15s, and the program lives in the compiler rather than the V8 heap.
- **The disallowed types are resolved to symbols once up front** via `getMembers()`/`getExports()`, so the per-reference check is a local `Map` lookup with no round trips for alias/parent chasing.
- **Symbol lookups are batched** (20k nodes per request) instead of one node at a time.
- **Property accesses are prefiltered by member name**, so only those that could name a member of a disallowed type are resolved.

Isolating the two effects, since both are in the shipped version:

| Variant | `checkProgram` | Peak RSS | Total |
|---|---:|---:|---:|
| Original | 26,471 ms | 3,825 MB | 48.6s |
| Member prefilter only | 5,335 ms | 2,700 MB | 31.6s |
| Prefilter + native API (shipped) | — | 1,229 MB | 11.7s |

The prefilter did most of the work on the OOM; the native API then removed the 15s/2GB `createProgram` floor.

## 2. The six layer projects: 27.7s → ~11s

These were **already** running on TS7 native via `.bin/tsc`; the win here is **parallelism, not a compiler switch**. They move into `build/checker/layersTypeCheck.ts`, which also resolves the native compiler by path rather than relying on `.bin` resolution.

Concurrency is derived from free memory rather than fixed. Measured peaks are ~3.5GB for `browser`/`electron-browser` and ~1.0–1.5GB for the rest, so it budgets 4GB per check against 75% of `os.freemem()`, capped by `availableParallelism()`. On a memory-constrained machine it degrades toward serial instead of swapping.

## Result

| Phase | Before | After |
|---|---:|---:|
| `layersChecker.ts` | 48.6s, 3.8GB | 11.7s, 0.8GB |
| 6 layer projects | 27.7s | ~11s |
| **Total** | **~76s** | **~23s** |

Roughly **3.3x** overall, with the memory reduction (3.8GB → 0.8GB peak) being the fix for the intermittent OOMs.

## Verification

- Diffed old vs. new checker output on the full repo with **13 seeded violations** covering direct references, import aliases, inherited members, nested member access and `ipcMain` — **byte-identical**, including line and column.
- Unit tests updated to the async API and all pass. The `getRootFileNames` test became a behavioral "ignores skipped files" test.
- Confirmed `layersTypeCheck.ts` surfaces type errors and exits non-zero.
- `build` typecheck, ESLint and `build/hygiene.ts` all clean.

## Notes

- `resolveRemainingTypes` covers the case where a disallowed type is declared in a file no rule matches. It only runs when a type was not already resolved from the checked files, so this repo never pays for it. Without it, "member of an inferred type" detection silently regressed — the existing unit test caught this.
- Caching the `NATIVE_TYPES` member lookups on disk would not help: resolving those symbols and their members is only **49ms** of the run. The remaining time is source file fetching and AST walking.
- Review feedback that arrived just as this auto-merged is in #328093.