### PR TITLE
xtab: clamp tagged patch range to document

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -1048,9 +1048,10 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				case xtabPromptOptions.ResponseFormat.CustomDiffPatch: {
 					const activeDoc = request.getActiveDocument();
 					const currentDocument = promptPieces.currentDocument;
-					const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
+					const keptRangeEndExclusive = Math.min(clippedTaggedCurrentDoc.keptRange.endExclusive, currentDocument.lines.length);
+					const lastLine = currentDocument.lines[keptRangeEndExclusive - 1];
 					const lastLineLength = lastLine.length;
-					const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
+					const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, keptRangeEndExclusive, lastLineLength + 1));
 					const duplicateAdditionsMode = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabDuplicateAdditionsMode, this.expService);
 					const fastYieldLineWithCursor = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderPatchFastYieldLineWithCursor, this.expService);
 					const fastYieldLineWithCursorMultiLine = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderPatchFastYieldLineWithCursorMultiLine, this.expService);

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -1413,6 +1413,29 @@ describe('XtabProvider integration', () => {
 			expect(finalReason.v).toBeInstanceOf(NoNextEditReason.NoSuggestions);
 		});
 
+		it('CustomDiffPatch clamps tagged content range to the source document', async () => {
+			const provider = createProvider();
+			mockModelService.setSelectedConfig({
+				promptingStrategy: PromptingStrategy.PatchBased02,
+				includeTagsInCurrentFile: true,
+			});
+
+			const lines = Array.from({ length: 30 }, (_, i) => `line ${i}`);
+			const request = createRequestWithEdit(lines, { insertionOffset: 3, insertedText: 'e' });
+			streamingFetcher.setStreamingLines([]);
+
+			const gen = provider.provideNextEdit(request, createMockLogger(), createLogContext(), CancellationToken.None);
+			const { edits, finalReason } = await collectEdits(gen);
+
+			expect({
+				editCount: edits.length,
+				finalReason: finalReason.v.constructor.name,
+			}).toEqual({
+				editCount: 0,
+				finalReason: NoNextEditReason.NoSuggestions.name,
+			});
+		});
+
 		it('UnifiedWithXml INSERT yields insertion edit at cursor line', async () => {
 			const provider = createProvider();
 


### PR DESCRIPTION
## Summary

Tagged current-file content can contain prompt-only lines, so its kept range may extend beyond the source document. Clamp the CustomDiffPatch pseudo edit window to the source document range instead of indexing past the final source line.

## Tests

- Added a focused XtabProvider regression for PatchBased02 with current-file tags on a short document
- Confirmed the test returns `Unexpected` without the fix and `NoSuggestions` with it
- `npm run test:unit -- src/extension/xtab/test/node/xtabProvider.spec.ts` (189 passed)
- `npx tsc --noEmit --project tsconfig.json`
- staged-file pre-commit hygiene