### PR TITLE
Address review feedback from #328087

### DIFF
--- a/build/checker/layersChecker.ts
+++ b/build/checker/layersChecker.ts
@@ -192,6 +192,10 @@ function collectMemberReferences(sourceFile: SourceFile, memberNames: ReadonlySe
 	return identifiers;
 }
 
+function isSymbol(symbol: Symbol | undefined): symbol is Symbol {
+	return !!symbol;
+}
+
 async function getSymbols(checker: Checker, nodes: readonly Node[]): Promise<(Symbol | undefined)[]> {
 	const symbols: (Symbol | undefined)[] = [];
 
@@ -272,7 +276,7 @@ async function resolveRemainingTypes(program: Program, checker: Checker, fileNam
 		}
 
 		const symbols = await getSymbols(checker, nodes);
-		await addDisallowedSymbols(checker, symbols.filter(symbol => !!symbol), disallowedTypes, disallowed);
+		await addDisallowedSymbols(checker, symbols.filter(isSymbol), disallowedTypes, disallowed);
 
 		for (const type of disallowed.resolvedTypes) {
 			remaining.delete(type);
@@ -284,20 +288,28 @@ async function resolveRemainingTypes(program: Program, checker: Checker, fileNam
 	}
 }
 
-function toViolations(candidates: readonly ICandidate[], symbols: readonly (Symbol | undefined)[], disallowed: IDisallowedSymbols): ILayerViolation[] {	const violations: ILayerViolation[] = [];
+function toViolations(candidates: readonly ICandidate[], symbols: readonly (Symbol | undefined)[], disallowed: IDisallowedSymbols): ILayerViolation[] {
+	const violations: ILayerViolation[] = [];
 
 	for (let i = 0; i < candidates.length; i++) {
 		const candidate = candidates[i];
 		const symbol = symbols[i];
-		if (!symbol) {
+		const disallowedTypes = candidate.rule.disallowedTypes;
+		if (!symbol || !disallowedTypes?.length) {
 			continue;
 		}
 
-		// A symbol matches when it is (or aliases) a disallowed type or one of
-		// its members. The name check also catches aliases the compiler could
-		// not resolve, where the reference is still spelled out in the source.
-		const type = candidate.rule.disallowedTypes?.includes(symbol.name) ? symbol.name : disallowed.symbolIds.get(symbol.id);
-		if (type && candidate.rule.disallowedTypes?.includes(type)) {
+		// The name check catches references the compiler could not resolve to a
+		// declaration, where the disallowed type is still spelled out in the source.
+		if (disallowedTypes.includes(symbol.name)) {
+			violations.push(toViolation(candidate, symbol.name));
+			continue;
+		}
+
+		// Otherwise the symbol matches if it is (or aliases) a disallowed type or
+		// one of its members.
+		const type = disallowed.symbolIds.get(symbol.id);
+		if (type && disallowedTypes.includes(type)) {
 			violations.push(toViolation(candidate, type));
 		}
 	}
@@ -323,9 +335,10 @@ export async function checkProject(project: Project, fileNames: readonly string[
 		}
 	}
 
-	// Pass 1: identifiers that name a disallowed type. Files that a rule exempts
-	// are deliberately visited too, because that is where the disallowed types
-	// are usually declared and where their members are read from.
+	// Pass 1: identifiers that name a disallowed type. Files matched by a rule
+	// that disallows nothing are visited too, because that is where those types
+	// are declared and where their members are read from. Files that are skipped
+	// or match no rule at all are left to resolveRemainingTypes below.
 	const disallowedTypes = new Set(rules.flatMap(rule => rule.disallowedTypes ?? []));
 	const namedCandidates: ICandidate[] = [];
 	for (const { sourceFile, rule } of sourceFiles) {
@@ -336,7 +349,7 @@ export async function checkProject(project: Project, fileNames: readonly string[
 
 	const disallowed: IDisallowedSymbols = { symbolIds: new Map(), memberNames: new Set(), resolvedTypes: new Set() };
 	const namedSymbols = await getSymbols(checker, namedCandidates.map(candidate => candidate.node));
-	await addDisallowedSymbols(checker, namedSymbols.filter(symbol => !!symbol), disallowedTypes, disallowed);
+	await addDisallowedSymbols(checker, namedSymbols.filter(isSymbol), disallowedTypes, disallowed);
 	await resolveRemainingTypes(program, checker, otherFileNames, disallowedTypes, disallowed);
 
 	// Pass 2: property accesses that may resolve to a member of a disallowed type.

--- a/build/checker/layersTypeCheck.ts
+++ b/build/checker/layersTypeCheck.ts
@@ -63,7 +63,8 @@ function typeCheck(project: string): Promise<string> {
 		child.stderr.on('data', data => output += data.toString());
 
 		child.on('error', reject);
-		child.on('exit', code => resolve(code === 0 ? '' : output.trim() || `tsc exited with code ${code ?? 'unknown'}.`));
+		// `close` rather than `exit`, so the captured output is complete before it is inspected.
+		child.on('close', code => resolve(code === 0 ? '' : output.trim() || `tsc exited with code ${code ?? 'unknown'}.`));
 	});
 }
 


### PR DESCRIPTION
Follow-up to #328087, which auto-merged while I was still addressing review feedback. These fixes were pushed to the branch a moment after the squash landed, so they never made it into `main`.

Addresses the remaining comments from @DanielRosenwasser and Copilot on that PR.

## Changes

**Resolve on `close` rather than `exit`** (`layersTypeCheck.ts`) — the only functional fix. `exit` can fire before the stdout/stderr pipes finish draining, so a failing type check could have reported truncated or empty diagnostics. Verified that errors are still captured with a non-zero exit and that clean runs still exit 0.

**Drop the redundant `includes()`** (`layersChecker.ts`) — @DanielRosenwasser spotted the double search of `symbol.name` in `toViolations`. Split the direct name match from the symbol id lookup so each path does exactly one `includes`. To answer the question on the PR: the list is per-rule `disallowedTypes`, so at most 7 entries (`NATIVE_TYPES`) and usually 1, which is why this was a readability issue rather than a hot spot.

**Explicit type predicate** — replaced `.filter(symbol => !!symbol)` with a named `isSymbol` guard at both call sites, rather than relying on inferred narrowing of `Symbol | undefined`.

**Formatting and comment** — fixed a function signature that had collapsed onto one line with its first statement, and reworded the pass 1 comment. It described files matched by a rule that disallows nothing as "exempt", which read as though `skip: true` files were being traversed.

## Not taken

@DanielRosenwasser suggested `disallowedTypes.difference(disallowed.resolvedTypes)`. The runtime is fine (`.nvmrc` is Node 24), but `build/tsconfig.json` sets `lib: ["ES2024"]` and `Set.prototype.difference` is ES2025, so it does not typecheck as-is.

I tried bumping that lib to `ES2025` and all of `build/` typechecks clean, but that widens the permitted API surface for every build script to save one line here, so I did not want to make that call unilaterally in a follow-up. Happy to take it as a separate change if you want it — just say the word.

## Validation

- `build` typecheck, ESLint and `build/hygiene.ts` all clean
- Unit tests 4/4
- Diffed checker output before/after the `toViolations` restructure against 12 seeded violations covering direct references, import aliases, inherited members, nested member access and `ipcMain` — **identical**
- Full `valid-layers-check` run on this branch: **21.7s**, exit 0