### PR TITLE
Voice Mode onboarding preview polish

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -358,6 +358,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			placeholder?: string;
 			renderSessionTypePickerInControls?: boolean;
 			supportsBackground?: boolean;
+			onDidChangeInputOnboardingVisible?: (visible: boolean) => void;
 			/**
 			 * Keep this composer a valid voice target even while a created session
 			 * is active. Used by the in-session "new chat" composer so dictation
@@ -463,12 +464,15 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		// First-run Voice Mode introduction, docked above the input area
 		const voiceOnboardingContainer = dom.append(chatInputContainer, dom.$('.voice-mode-onboarding-container'));
-		this._register(this.voiceModeOnboardingService.registerHost(voiceOnboardingContainer, chatInputContainer, () => this.focus()));
+		const onDidChangeInputOnboardingVisible = () => this.options.onDidChangeInputOnboardingVisible?.(
+			this.voiceModeOnboardingService.isVisible || this.dictationOnboardingService.isVisible
+		);
+		this._register(this.voiceModeOnboardingService.registerHost(voiceOnboardingContainer, chatInputContainer, () => this.focus(), onDidChangeInputOnboardingVisible));
 
 		// First-run dictation introduction, docked directly above the input area
 		// so it reads as one stack with it - the same slot the chat view uses.
 		const dictationOnboardingContainer = dom.append(chatInputContainer, dom.$('.dictation-onboarding-container'));
-		this._register(this.dictationOnboardingService.registerHost(dictationOnboardingContainer, chatInputContainer));
+		this._register(this.dictationOnboardingService.registerHost(dictationOnboardingContainer, chatInputContainer, onDidChangeInputOnboardingVisible));
 
 		// Input area inside the input slot
 		const inputAreaWrapper = dom.append(chatInputContainer, dom.$('.new-chat-input-area-wrapper'));

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -358,6 +358,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			placeholder?: string;
 			renderSessionTypePickerInControls?: boolean;
 			supportsBackground?: boolean;
+			getInputOnboardingTipContainer?: () => HTMLElement | undefined;
 			onDidChangeInputOnboardingVisible?: (visible: boolean) => void;
 			/**
 			 * Keep this composer a valid voice target even while a created session
@@ -467,12 +468,13 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		const onDidChangeInputOnboardingVisible = () => this.options.onDidChangeInputOnboardingVisible?.(
 			this.voiceModeOnboardingService.isVisible || this.dictationOnboardingService.isVisible
 		);
-		this._register(this.voiceModeOnboardingService.registerHost(voiceOnboardingContainer, chatInputContainer, () => this.focus(), onDidChangeInputOnboardingVisible));
+		const tipContainer = this.options.getInputOnboardingTipContainer?.();
+		this._register(this.voiceModeOnboardingService.registerHost(voiceOnboardingContainer, chatInputContainer, () => this.focus(), tipContainer, onDidChangeInputOnboardingVisible));
 
 		// First-run dictation introduction, docked directly above the input area
 		// so it reads as one stack with it - the same slot the chat view uses.
 		const dictationOnboardingContainer = dom.append(chatInputContainer, dom.$('.dictation-onboarding-container'));
-		this._register(this.dictationOnboardingService.registerHost(dictationOnboardingContainer, chatInputContainer, onDidChangeInputOnboardingVisible));
+		this._register(this.dictationOnboardingService.registerHost(dictationOnboardingContainer, chatInputContainer, tipContainer, onDidChangeInputOnboardingVisible));
 
 		// Input area inside the input slot
 		const inputAreaWrapper = dom.append(chatInputContainer, dom.$('.new-chat-input-area-wrapper'));

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -173,6 +173,7 @@ export class NewChatWidget extends Disposable {
 			historyKey: constObservable(undefined), // no persisted history for the new-session view
 			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
+			getInputOnboardingTipContainer: () => this._chatTipContainer,
 			onDidChangeInputOnboardingVisible: visible => this.setInputOnboardingVisible(visible),
 		});
 		this._register(toDisposable(() => newChatInput.saveState()));

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -5,6 +5,7 @@
 
 import './media/chatWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
+import { Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { constObservable, derived, derivedObservableWithCache, autorun, IObservable, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { isWeb } from '../../../../base/common/platform.js';

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -5,7 +5,6 @@
 
 import './media/chatWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
-import { Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { constObservable, derived, derivedObservableWithCache, autorun, IObservable, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { isWeb } from '../../../../base/common/platform.js';
@@ -49,6 +48,7 @@ export class NewChatWidget extends Disposable {
 	private readonly _chatTipPart = this._register(new MutableDisposable<DisposableStore>());
 	private _chatTipContainer: HTMLElement | undefined;
 	private _isChatTipSessionInitialized = false;
+	private _isInputOnboardingVisible = false;
 	private _aquariumToggle: IMountedToggleHandle | undefined;
 
 	/** Recreates the draft once a better/late-registering provider can serve the folder (see {@link _createNewSession}). */
@@ -173,6 +173,7 @@ export class NewChatWidget extends Disposable {
 			historyKey: constObservable(undefined), // no persisted history for the new-session view
 			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
+			onDidChangeInputOnboardingVisible: visible => this.setInputOnboardingVisible(visible),
 		});
 		this._register(toDisposable(() => newChatInput.saveState()));
 		this._newChatInput = this._register(newChatInput);
@@ -354,6 +355,10 @@ export class NewChatWidget extends Disposable {
 		if (!this._chatTipContainer) {
 			return;
 		}
+		if (this.isInputOnboardingVisible()) {
+			this._clearChatTip();
+			return;
+		}
 		// Don't show a tip in the no-agent-host empty state — there is no usable composer.
 		if (this._chatTipContainer.parentElement?.classList.contains('no-agent-host')) {
 			return;
@@ -398,6 +403,19 @@ export class NewChatWidget extends Disposable {
 		if (this._chatTipContainer) {
 			dom.clearNode(this._chatTipContainer);
 			dom.setVisibility(false, this._chatTipContainer);
+		}
+	}
+
+	private isInputOnboardingVisible(): boolean {
+		return this._isInputOnboardingVisible;
+	}
+
+	private setInputOnboardingVisible(visible: boolean): void {
+		this._isInputOnboardingVisible = visible;
+		if (visible) {
+			this._clearChatTip();
+		} else {
+			this._renderChatTip();
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
@@ -8,7 +8,10 @@ import { Event } from '../../../../../base/common/event.js';
 import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IVoiceSessionController } from '../../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
+import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { INewChatVoiceComposer, NewChatVoiceTargetService } from '../../browser/newChatVoice.js';
 import { SessionsVoiceNewComposerContribution } from '../../browser/voiceBridge.contribution.js';
 
@@ -36,8 +39,18 @@ suite('SessionsVoiceNewComposerContribution', () => {
 		return { controller, getDisconnectCount: () => disconnectCount };
 	}
 
+	function createTarget(): NewChatVoiceTargetService {
+		const sessionsService = new class extends mock<ISessionsService>() {
+			override readonly activeSession = observableValue<IActiveSession | undefined>('activeSession', undefined);
+		}();
+		const chatWidgetService = new class extends mock<IChatWidgetService>() {
+			override readonly onDidChangeFocusedSession = Event.None;
+		}();
+		return new NewChatVoiceTargetService(sessionsService, chatWidgetService);
+	}
+
 	test('disconnects when a fresh welcome composer takes over a connected voice session', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 
@@ -55,7 +68,7 @@ suite('SessionsVoiceNewComposerContribution', () => {
 	});
 
 	test('keeps voice connected when switching to an in-session composer that opts to route', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 
@@ -72,7 +85,7 @@ suite('SessionsVoiceNewComposerContribution', () => {
 	});
 
 	test('does not disconnect when voice is not connected', () => {
-		const target = disposables.add(new NewChatVoiceTargetService());
+		const target = disposables.add(createTarget());
 		const isConnected = observableValue<boolean>('isConnected', false);
 		const { controller, getDisconnectCount } = createController(isConnected);
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
+++ b/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
@@ -189,6 +189,13 @@
 
 /* --- Voice options --- */
 
+.voice-mode-onboarding-voices-label {
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-fontSize-label2);
+	white-space: nowrap;
+}
+
 /*
  * The options are buttons and have to look like it. Bare text gave no sign it
  * could be clicked, let alone that clicking would speak *and* stick.

--- a/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
+++ b/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
@@ -170,15 +170,6 @@
 	outline: none;
 }
 
-.voice-mode-onboarding-microphone-label {
-	overflow: hidden;
-	min-width: 0;
-	font-size: var(--vscode-fontSize-label2);
-	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
 /* --- Voices and confirmation --- */
 
 .voice-mode-onboarding-actions {

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -782,7 +782,7 @@ export class VoiceModeOnboardingBanner extends Disposable {
 				'Preserve the double square brackets: they mark the text that becomes a link.',
 				'The link opens Voice Mode settings.',
 			],
-		}, "Your agent can speak back to you, free of charge. Adjust [[settings]] anytime.");
+		}, "Choose how your agent speaks to you. Adjust [[settings]] anytime.");
 
 		dom.append(description, renderFormattedText(text, {
 			actionHandler: {

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -710,15 +710,18 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	 * because bare text gave no sign it could be clicked at all.
 	 */
 	private renderVoices(container: HTMLElement): void {
+		const labelText = localize('voiceMode.onboarding.voices', "Agent Voice:");
+		const label = dom.append(container, dom.$('.voice-mode-onboarding-voices-label'));
+		label.textContent = labelText;
+
 		const group = dom.append(container, dom.$('.voice-mode-onboarding-voices'));
 		group.setAttribute('role', 'radiogroup');
-		group.setAttribute('aria-label', localize('voiceMode.onboarding.voices', "Voice Mode voice"));
+		group.setAttribute('aria-label', labelText);
 
 		for (const voice of VOICES) {
 			const option = dom.append(group, dom.$('.voice-mode-onboarding-voice'));
 			option.setAttribute('role', 'radio');
-			// Spells out both halves of what a click does: it speaks, and it sticks.
-			option.setAttribute('aria-label', localize('voiceMode.onboarding.voice.ariaLabel', "{0}. Hear this voice and use it for every conversation.", voice.label));
+			option.setAttribute('aria-label', this.voiceAriaLabel(voice, false));
 
 			// The icon is the affordance: it says "this will speak" before the
 			// click, and "this is yours" after it.
@@ -743,6 +746,12 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	}
 
 	// --- Shared behaviour ---
+
+	private voiceAriaLabel(voice: IVoiceModeVoice, playing: boolean): string {
+		return playing
+			? localize('voiceMode.onboarding.voice.stopPreview', "Stop {0} preview.", voice.label)
+			: localize('voiceMode.onboarding.voice.ariaLabel', "{0}. Hear this voice and use it for every conversation.", voice.label);
+	}
 
 	private handleOptionKey(event: KeyboardEvent, voice: IVoiceModeVoice): void {
 		const keyboardEvent = new StandardKeyboardEvent(event);
@@ -873,7 +882,12 @@ export class VoiceModeOnboardingBanner extends Disposable {
 
 	private updatePlaying(playingVoice: string | undefined): void {
 		for (const [id, element] of this.voiceElements) {
-			element.classList.toggle('playing', id === playingVoice);
+			const playing = id === playingVoice;
+			element.classList.toggle('playing', playing);
+			const voice = VOICES.find(candidate => candidate.id === id);
+			if (voice) {
+				element.setAttribute('aria-label', this.voiceAriaLabel(voice, playing));
+			}
 		}
 		this.domNode.classList.toggle('playing', playingVoice !== undefined);
 	}

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -922,7 +922,7 @@ export interface IVoiceModeOnboardingService {
 	 * Passed explicitly because `focusRoot` is a container, not a control - the
 	 * host knows where its caret belongs and this service does not.
 	 */
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, tipContainer?: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
 
 	/**
 	 * Show the introduction if the user has never seen it. Marks it as seen on
@@ -955,8 +955,8 @@ export class VoiceModeOnboardingService extends Disposable implements IVoiceMode
 		}));
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
-		return this.onboarding.registerHost(container, focusRoot, focus, onDidChangeVisible);
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, tipContainer?: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
+		return this.onboarding.registerHost(container, focusRoot, focus, tipContainer, onDidChangeVisible);
 	}
 
 	showIfNeeded(): void {

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -663,16 +663,15 @@ export class VoiceModeOnboardingBanner extends Disposable {
 		this.microphonePicker.clear();
 		dom.clearNode(this.microphonePickerContainer);
 
+		this.microphonePickerContainer.hidden = this.microphoneOptions.length <= 1;
+		if (this.microphonePickerContainer.hidden) {
+			return;
+		}
+
 		dom.append(this.microphonePickerContainer, dom.$(`span.codicon.codicon-${Codicon.mic.id}.voice-mode-onboarding-microphone-icon`))
 			.setAttribute('aria-hidden', 'true');
 
 		const selected = indexOfMicrophone(this.microphoneOptions, this.currentMicrophoneId());
-		if (this.microphoneOptions.length <= 1) {
-			const label = dom.append(this.microphonePickerContainer, dom.$('.voice-mode-onboarding-microphone-label'));
-			label.textContent = this.microphoneOptions[selected]?.label ?? localize('voiceMode.onboarding.noMicrophone', "No microphone found");
-			label.title = label.textContent;
-			return;
-		}
 
 		const store = new DisposableStore();
 		const selectBox = store.add(new SelectBox(

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -78,7 +78,7 @@ interface IWave {
 const VOICES: readonly IVoiceModeVoice[] = [
 	{
 		id: 'maya_neutral',
-		label: localize('voiceMode.onboarding.voice.maya', "Maya"),
+		label: localize('voiceMode.onboarding.voice.maya', "Maya (Default)"),
 		// Flowing mid-range: even spread, gentle drift.
 		signature: [
 			{ frequency: 1.0, amplitude: 0.42, speed: 0.42, phase: 0.0 },
@@ -422,6 +422,7 @@ class VoiceSamplePlayer extends Disposable {
 
 	constructor(
 		private readonly element: HTMLElement,
+		private readonly audioFactory: (() => HTMLAudioElement) | undefined,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
@@ -480,7 +481,7 @@ class VoiceSamplePlayer extends Disposable {
 		}
 
 		const targetWindow = dom.getWindow(this.element);
-		const audio = new targetWindow.Audio();
+		const audio = this.audioFactory?.() ?? new targetWindow.Audio();
 		this.audio = audio;
 		this._register(toDisposable(() => {
 			audio.pause();
@@ -522,6 +523,8 @@ export interface IVoiceModeOnboardingBannerOptions {
 	readonly container: HTMLElement;
 	readonly onDismiss: () => void;
 	readonly source: 'automatic' | 'manual';
+	/** Allows tests to provide a deterministic media element. */
+	readonly audioFactory?: () => HTMLAudioElement;
 }
 
 /**
@@ -574,7 +577,7 @@ export class VoiceModeOnboardingBanner extends Disposable {
 			},
 		}));
 		this.domNode = this.card.domNode;
-		this.player = this._register(instantiationService.createInstance(VoiceSamplePlayer, this.domNode));
+		this.player = this._register(instantiationService.createInstance(VoiceSamplePlayer, this.domNode, options.audioFactory));
 		this._register(this.player.onDidChangePlayingVoice(voiceId => this.updatePlaying(voiceId)));
 
 		const copy = dom.append(this.domNode, dom.$('.voice-mode-onboarding-copy'));
@@ -832,6 +835,11 @@ export class VoiceModeOnboardingBanner extends Disposable {
 	}
 
 	private selectVoice(voice: IVoiceModeVoice): void {
+		if (this.player.playingVoice === voice.id) {
+			this.player.stop();
+			status(localize('voiceMode.onboarding.voice.previewStopped', "{0} preview stopped.", voice.label));
+			return;
+		}
 		this.logAction('selectVoice');
 		this.selectedVoice = voice;
 		this.updateSelection();

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -909,6 +909,7 @@ export const IVoiceModeOnboardingService = createDecorator<IVoiceModeOnboardingS
 
 export interface IVoiceModeOnboardingService {
 	readonly _serviceBrand: undefined;
+	readonly isVisible: boolean;
 
 	/**
 	 * Register a container that can host the banner (a chat input). The most
@@ -921,7 +922,7 @@ export interface IVoiceModeOnboardingService {
 	 * Passed explicitly because `focusRoot` is a container, not a control - the
 	 * host knows where its caret belongs and this service does not.
 	 */
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void): IDisposable;
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
 
 	/**
 	 * Show the introduction if the user has never seen it. Marks it as seen on
@@ -939,6 +940,10 @@ export class VoiceModeOnboardingService extends Disposable implements IVoiceMode
 
 	private readonly onboarding: ChatInputOnboarding;
 
+	get isVisible(): boolean {
+		return this.onboarding.isVisible;
+	}
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
@@ -950,8 +955,8 @@ export class VoiceModeOnboardingService extends Disposable implements IVoiceMode
 		}));
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void): IDisposable {
-		return this.onboarding.registerHost(container, focusRoot, focus);
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
+		return this.onboarding.registerHost(container, focusRoot, focus, onDidChangeVisible);
 	}
 
 	showIfNeeded(): void {

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -94,7 +94,7 @@ suite('Voice Mode onboarding', () => {
 		const selectedOnOpen = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 		const voices = [...host.container.querySelectorAll<HTMLElement>('.voice-mode-onboarding-voice-label')].map(element => element.textContent);
 		const voicesLabel = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voices-label')?.textContent;
-		const hasMicrophonePicker = host.container.querySelector('.voice-mode-onboarding-microphone-picker') !== null;
+		const microphonePickerHidden = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-microphone-picker')?.hidden;
 		host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!.click();
 		const selectedAfterPick = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 
@@ -107,7 +107,7 @@ suite('Voice Mode onboarding', () => {
 		assert.deepStrictEqual(
 			{
 				shown,
-				hasMicrophonePicker,
+				microphonePickerHidden,
 				selectedOnOpen,
 				voices,
 				voicesLabel,
@@ -118,7 +118,7 @@ suite('Voice Mode onboarding', () => {
 			},
 			{
 				shown: true,
-				hasMicrophonePicker: true,
+				microphonePickerHidden: true,
 				selectedOnOpen: 0,
 				voices: ['Maya (Default)', 'Victoria', 'Kevin', 'Daniel'],
 				voicesLabel: 'Agent Voice:',

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -93,6 +93,7 @@ suite('Voice Mode onboarding', () => {
 		// rather than arriving with an answer already filled in.
 		const selectedOnOpen = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 		const voices = [...host.container.querySelectorAll<HTMLElement>('.voice-mode-onboarding-voice-label')].map(element => element.textContent);
+		const voicesLabel = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voices-label')?.textContent;
 		const hasMicrophonePicker = host.container.querySelector('.voice-mode-onboarding-microphone-picker') !== null;
 		host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!.click();
 		const selectedAfterPick = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
@@ -109,6 +110,7 @@ suite('Voice Mode onboarding', () => {
 				hasMicrophonePicker,
 				selectedOnOpen,
 				voices,
+				voicesLabel,
 				selectedAfterPick,
 				shownAfterClose,
 				shownAgain,
@@ -119,6 +121,7 @@ suite('Voice Mode onboarding', () => {
 				hasMicrophonePicker: true,
 				selectedOnOpen: 0,
 				voices: ['Maya (Default)', 'Victoria', 'Kevin', 'Daniel'],
+				voicesLabel: 'Agent Voice:',
 				selectedAfterPick: 1,
 				shownAfterClose: false,
 				shownAgain: false,
@@ -159,6 +162,7 @@ suite('Voice Mode onboarding', () => {
 		const maya = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!;
 		maya.click();
 		const playingAfterFirstClick = maya.classList.contains('playing');
+		const ariaLabelAfterFirstClick = maya.getAttribute('aria-label');
 		maya.click();
 
 		assert.deepStrictEqual(
@@ -167,7 +171,9 @@ suite('Voice Mode onboarding', () => {
 				playCount,
 				pauseCount,
 				playingAfterFirstClick,
+				ariaLabelAfterFirstClick,
 				playingAfterSecondClick: maya.classList.contains('playing'),
+				ariaLabelAfterSecondClick: maya.getAttribute('aria-label'),
 				selectedAfterSecondClick: maya.classList.contains('selected'),
 			},
 			{
@@ -175,7 +181,9 @@ suite('Voice Mode onboarding', () => {
 				playCount: 1,
 				pauseCount: 1,
 				playingAfterFirstClick: true,
+				ariaLabelAfterFirstClick: 'Stop Maya (Default) preview.',
 				playingAfterSecondClick: false,
+				ariaLabelAfterSecondClick: 'Maya (Default). Hear this voice and use it for every conversation.',
 				selectedAfterSecondClick: true,
 			});
 	});

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -18,7 +18,7 @@ import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/com
 import { AgentsVoiceStorageKeys } from '../../common/agentsVoice.js';
 import { IVoiceSessionController, VoiceState } from '../../../chat/browser/voiceClient/voiceSessionController.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
-import { VoiceModeOnboardingService } from '../../browser/voiceModeOnboarding.js';
+import { VoiceModeOnboardingBanner, VoiceModeOnboardingService } from '../../browser/voiceModeOnboarding.js';
 
 suite('Voice Mode onboarding', () => {
 
@@ -118,7 +118,7 @@ suite('Voice Mode onboarding', () => {
 				shown: true,
 				hasMicrophonePicker: true,
 				selectedOnOpen: 0,
-				voices: ['Maya', 'Victoria', 'Kevin', 'Daniel'],
+				voices: ['Maya (Default)', 'Victoria', 'Kevin', 'Daniel'],
 				selectedAfterPick: 1,
 				shownAfterClose: false,
 				shownAgain: false,
@@ -127,6 +127,56 @@ suite('Voice Mode onboarding', () => {
 					{ name: 'voiceModeOnboarding.action', data: { action: 'selectVoice', source: 'automatic' } },
 					{ name: 'voiceModeOnboarding.action', data: { action: 'close', source: 'automatic' } },
 				],
+			});
+	});
+
+	test('clicking the playing voice stops its preview without changing the selection', () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
+			override readonly onDidChangeScreenReaderOptimized = Event.None;
+			override readonly onDidChangeReducedMotion = Event.None;
+			override isScreenReaderOptimized(): boolean { return false; }
+			override isMotionReduced(): boolean { return false; }
+		});
+
+		const audio = document.createElement('audio');
+		let playCount = 0;
+		let pauseCount = 0;
+		audio.play = () => {
+			playCount++;
+			return Promise.resolve();
+		};
+		audio.pause = () => pauseCount++;
+
+		const host = createHost(disposables);
+		disposables.add(instantiationService.createInstance(VoiceModeOnboardingBanner, {
+			container: host.container,
+			onDismiss: () => undefined,
+			source: 'manual',
+			audioFactory: () => audio,
+		}));
+
+		const maya = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!;
+		maya.click();
+		const playingAfterFirstClick = maya.classList.contains('playing');
+		maya.click();
+
+		assert.deepStrictEqual(
+			{
+				label: maya.querySelector('.voice-mode-onboarding-voice-label')?.textContent,
+				playCount,
+				pauseCount,
+				playingAfterFirstClick,
+				playingAfterSecondClick: maya.classList.contains('playing'),
+				selectedAfterSecondClick: maya.classList.contains('selected'),
+			},
+			{
+				label: 'Maya (Default)',
+				playCount: 1,
+				pauseCount: 1,
+				playingAfterFirstClick: true,
+				playingAfterSecondClick: false,
+				selectedAfterSecondClick: true,
 			});
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -824,6 +824,7 @@ export const IDictationOnboardingService = createDecorator<IDictationOnboardingS
 
 export interface IDictationOnboardingService {
 	readonly _serviceBrand: undefined;
+	readonly isVisible: boolean;
 
 	/**
 	 * Register a container that can host the card (a chat input). The most
@@ -833,7 +834,7 @@ export interface IDictationOnboardingService {
 	 * @param focusRoot the element whose focus marks this host as the active one
 	 * (typically the chat input part the container lives in).
 	 */
-	registerHost(container: HTMLElement, focusRoot: HTMLElement): IDisposable;
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
 
 	/**
 	 * Show the card alongside the user's first dictation. Dictation starts
@@ -858,6 +859,10 @@ export class DictationOnboardingService extends Disposable implements IDictation
 
 	private readonly onboarding: ChatInputOnboarding;
 
+	get isVisible(): boolean {
+		return this.onboarding.isVisible;
+	}
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IStorageService private readonly storageService: IStorageService,
@@ -870,8 +875,8 @@ export class DictationOnboardingService extends Disposable implements IDictation
 		}));
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement): IDisposable {
-		return this.onboarding.registerHost(container, focusRoot);
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
+		return this.onboarding.registerHost(container, focusRoot, undefined, onDidChangeVisible);
 	}
 
 	showIfNeeded(): boolean {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -834,7 +834,7 @@ export interface IDictationOnboardingService {
 	 * @param focusRoot the element whose focus marks this host as the active one
 	 * (typically the chat input part the container lives in).
 	 */
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, tipContainer?: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable;
 
 	/**
 	 * Show the card alongside the user's first dictation. Dictation starts
@@ -875,8 +875,8 @@ export class DictationOnboardingService extends Disposable implements IDictation
 		}));
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
-		return this.onboarding.registerHost(container, focusRoot, undefined, onDidChangeVisible);
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, tipContainer?: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
+		return this.onboarding.registerHost(container, focusRoot, undefined, tipContainer, onDidChangeVisible);
 	}
 
 	showIfNeeded(): boolean {

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -715,10 +715,7 @@ export class DictationOnboardingBanner extends Disposable {
 		this.renderPicker();
 	}
 
-	/**
-	 * A picker with one entry is not a choice - it is a label that happens to
-	 * open a menu. With a single microphone the card just names it.
-	 */
+	/** A picker with one entry is not a choice, so only show this row for multiple microphones. */
 	private renderPicker(): void {
 		if (!this.pickerContainer) {
 			return;
@@ -726,17 +723,15 @@ export class DictationOnboardingBanner extends Disposable {
 		this.picker.clear();
 		dom.clearNode(this.pickerContainer);
 
+		this.pickerContainer.hidden = this.options.length <= 1;
+		if (this.pickerContainer.hidden) {
+			return;
+		}
+
 		dom.append(this.pickerContainer, dom.$(`span.codicon.codicon-${Codicon.mic.id}.dictation-onboarding-picker-icon`))
 			.setAttribute('aria-hidden', 'true');
 
 		const selected = indexOfMicrophone(this.options, this.currentDeviceId());
-
-		if (this.options.length <= 1) {
-			const label = dom.append(this.pickerContainer, dom.$('span.dictation-onboarding-picker-label'));
-			label.textContent = this.options[selected]?.label ?? localize('dictation.onboarding.noMicrophone', "No microphone found");
-			label.title = label.textContent;
-			return;
-		}
 
 		const store = new DisposableStore();
 		// Custom-drawn rather than the platform control, and with the face colors

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
@@ -171,15 +171,7 @@
 	outline: none;
 }
 
-/* A lone microphone is stated rather than offered. */
-.dictation-onboarding-picker-label {
-	overflow: hidden;
-	min-width: 0;
-	font-size: var(--vscode-fontSize-label2);
-	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
+
 
 /* --- Waveform --- */
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -55,11 +55,6 @@
 	width: 100%;
 }
 
-:is(.interactive-input-part, .new-chat-widget-content):has(.voice-mode-onboarding-container.has-voice-mode-onboarding) .chat-getting-started-tip-container,
-:is(.interactive-input-part, .new-chat-widget-content):has(.dictation-onboarding-container.has-dictation-onboarding) .chat-getting-started-tip-container {
-	display: none;
-}
-
 .chat-getting-started-tip-container .chat-tip-widget {
 	display: flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -55,8 +55,8 @@
 	width: 100%;
 }
 
-.interactive-input-part:has(.voice-mode-onboarding-container.has-voice-mode-onboarding) .chat-getting-started-tip-container,
-.interactive-input-part:has(.dictation-onboarding-container.has-dictation-onboarding) .chat-getting-started-tip-container {
+:is(.interactive-input-part, .new-chat-widget-content):has(.voice-mode-onboarding-container.has-voice-mode-onboarding) .chat-getting-started-tip-container,
+:is(.interactive-input-part, .new-chat-widget-content):has(.dictation-onboarding-container.has-dictation-onboarding) .chat-getting-started-tip-container {
 	display: none;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -301,6 +301,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private readonly _gettingStartedTipPart = this._register(new MutableDisposable<DisposableStore>());
 	private _gettingStartedTipPartRef: ChatTipContentPart | undefined;
+	private _isInputOnboardingVisible = false;
 
 	private readonly chatSuggestNextWidget: ChatSuggestNextWidget;
 
@@ -1185,6 +1186,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (!this.inputPart || !this.viewModel) {
 			return;
 		}
+		if (this.isInputOnboardingVisible()) {
+			this.clearGettingStartedTip();
+			return;
+		}
 
 		const tipContainer = this.inputPart.gettingStartedTipContainerElement;
 
@@ -1234,6 +1239,19 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			const tipContainer = this.inputPart.gettingStartedTipContainerElement;
 			dom.clearNode(tipContainer);
 			dom.setVisibility(false, tipContainer);
+		}
+	}
+
+	private isInputOnboardingVisible(): boolean {
+		return this._isInputOnboardingVisible;
+	}
+
+	private setInputOnboardingVisible(visible: boolean): void {
+		this._isInputOnboardingVisible = visible;
+		if (visible) {
+			this.clearGettingStartedTip();
+		} else if (this.isEmpty()) {
+			this.renderGettingStartedTipIfNeeded();
 		}
 	}
 
@@ -2031,6 +2049,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			sessionTypePickerDelegate: this.viewOptions.sessionTypePickerDelegate,
 			workspacePickerDelegate: this.viewOptions.workspacePickerDelegate,
 			isSessionsWindow: this.viewOptions.isSessionsWindow,
+			onDidChangeInputOnboardingVisible: visible => this.setInputOnboardingVisible(visible),
 		};
 
 		if (this.viewModel?.editing) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputOnboarding.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addDisposableListener, EventType, trackFocus } from '../../../../../../base/browser/dom.js';
+import { addDisposableListener, EventType, setVisibility, trackFocus } from '../../../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -14,6 +14,7 @@ interface IChatInputOnboardingHost {
 	readonly container: HTMLElement;
 	readonly focusRoot: HTMLElement;
 	readonly focus: (() => void) | undefined;
+	readonly tipContainer: HTMLElement | undefined;
 	readonly onDidChangeVisible: ((visible: boolean) => void) | undefined;
 	lastFocused: number;
 }
@@ -60,11 +61,12 @@ export class ChatInputOnboarding extends Disposable {
 		super();
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus?: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus?: () => void, tipContainer?: HTMLElement, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
 		const host: IChatInputOnboardingHost = {
 			container,
 			focusRoot,
 			focus,
+			tipContainer,
 			onDidChangeVisible,
 			lastFocused: 0,
 		};
@@ -118,6 +120,7 @@ export class ChatInputOnboarding extends Disposable {
 		}
 
 		this.currentOnboarding.value = onboardingStore;
+		this.setTipsVisible(host, false);
 		host.onDidChangeVisible?.(true);
 		this.storageService.store(this.options.storageKey, true, StorageScope.APPLICATION, StorageTarget.USER);
 		return true;
@@ -138,10 +141,17 @@ export class ChatInputOnboarding extends Disposable {
 		this.activeHost = undefined;
 		this.currentOnboarding.clear();
 		if (wasVisible) {
+			this.setTipsVisible(host, true);
 			host?.onDidChangeVisible?.(false);
 		}
 		if (restoreFocus) {
 			host?.focus?.();
+		}
+	}
+
+	private setTipsVisible(host: IChatInputOnboardingHost | undefined, visible: boolean): void {
+		if (host?.tipContainer) {
+			setVisibility(visible, host.tipContainer);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputOnboarding.ts
@@ -14,6 +14,7 @@ interface IChatInputOnboardingHost {
 	readonly container: HTMLElement;
 	readonly focusRoot: HTMLElement;
 	readonly focus: (() => void) | undefined;
+	readonly onDidChangeVisible: ((visible: boolean) => void) | undefined;
 	lastFocused: number;
 }
 
@@ -48,6 +49,10 @@ export class ChatInputOnboarding extends Disposable {
 	private readonly currentOnboarding = this._register(new MutableDisposable<IDisposable>());
 	private activeHost: IChatInputOnboardingHost | undefined;
 
+	get isVisible(): boolean {
+		return !!this.currentOnboarding.value;
+	}
+
 	constructor(
 		private readonly options: IChatInputOnboardingOptions,
 		@IStorageService private readonly storageService: IStorageService,
@@ -55,11 +60,12 @@ export class ChatInputOnboarding extends Disposable {
 		super();
 	}
 
-	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus?: () => void): IDisposable {
+	registerHost(container: HTMLElement, focusRoot: HTMLElement, focus?: () => void, onDidChangeVisible?: (visible: boolean) => void): IDisposable {
 		const host: IChatInputOnboardingHost = {
 			container,
 			focusRoot,
 			focus,
+			onDidChangeVisible,
 			lastFocused: 0,
 		};
 		this.hosts.add(host);
@@ -112,6 +118,7 @@ export class ChatInputOnboarding extends Disposable {
 		}
 
 		this.currentOnboarding.value = onboardingStore;
+		host.onDidChangeVisible?.(true);
 		this.storageService.store(this.options.storageKey, true, StorageScope.APPLICATION, StorageTarget.USER);
 		return true;
 	}
@@ -127,8 +134,12 @@ export class ChatInputOnboarding extends Disposable {
 
 	private hide(restoreFocus: boolean): void {
 		const host = this.activeHost;
+		const wasVisible = this.isVisible;
 		this.activeHost = undefined;
 		this.currentOnboarding.clear();
+		if (wasVisible) {
+			host?.onDidChangeVisible?.(false);
+		}
 		if (restoreFocus) {
 			host?.focus?.();
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -250,6 +250,7 @@ export interface IChatInputPartOptions {
 	 * can pass `0` so the editor fills the box and its scrollbar sits at the edge.
 	 */
 	inputPartHorizontalPadding?: number;
+	onDidChangeInputOnboardingVisible?: (visible: boolean) => void;
 }
 
 export interface IWorkingSetEntry {
@@ -2977,8 +2978,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.chatToolConfirmationCarouselContainer = elements.chatToolConfirmationCarouselContainer;
 		dom.hide(this.chatToolConfirmationCarouselContainer);
 		this.chatInputNotificationContainer = elements.chatInputNotificationContainer;
-		this._register(this.voiceModeOnboardingService.registerHost(elements.voiceModeOnboardingContainer, this.container, () => this.focus()));
-		this._register(this.dictationOnboardingService.registerHost(elements.dictationOnboardingContainer, this.container));
+		const onDidChangeInputOnboardingVisible = () => this.options.onDidChangeInputOnboardingVisible?.(
+			this.voiceModeOnboardingService.isVisible || this.dictationOnboardingService.isVisible
+		);
+		this._register(this.voiceModeOnboardingService.registerHost(elements.voiceModeOnboardingContainer, this.container, () => this.focus(), onDidChangeInputOnboardingVisible));
+		this._register(this.dictationOnboardingService.registerHost(elements.dictationOnboardingContainer, this.container, onDidChangeInputOnboardingVisible));
 		this.chatGoalBannerContainer = elements.chatGoalBannerContainer;
 		this.contextUsageWidgetContainer = elements.contextUsageWidgetContainer;
 		this.statusToolbarContainer = elements.statusToolbarContainer;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2981,8 +2981,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const onDidChangeInputOnboardingVisible = () => this.options.onDidChangeInputOnboardingVisible?.(
 			this.voiceModeOnboardingService.isVisible || this.dictationOnboardingService.isVisible
 		);
-		this._register(this.voiceModeOnboardingService.registerHost(elements.voiceModeOnboardingContainer, this.container, () => this.focus(), onDidChangeInputOnboardingVisible));
-		this._register(this.dictationOnboardingService.registerHost(elements.dictationOnboardingContainer, this.container, onDidChangeInputOnboardingVisible));
+		this._register(this.voiceModeOnboardingService.registerHost(elements.voiceModeOnboardingContainer, this.container, () => this.focus(), elements.chatGettingStartedTipContainer, onDidChangeInputOnboardingVisible));
+		this._register(this.dictationOnboardingService.registerHost(elements.dictationOnboardingContainer, this.container, elements.chatGettingStartedTipContainer, onDidChangeInputOnboardingVisible));
 		this.chatGoalBannerContainer = elements.chatGoalBannerContainer;
 		this.contextUsageWidgetContainer = elements.contextUsageWidgetContainer;
 		this.statusToolbarContainer = elements.statusToolbarContainer;

--- a/src/vs/workbench/contrib/chat/test/browser/chatInputOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatInputOnboarding.test.ts
@@ -43,7 +43,8 @@ suite('Chat input onboarding', () => {
 		const onboarding = createOnboarding(disposables, 'test.chatInputOnboarding.ownsCard');
 		const host = createHost(disposables);
 		let focusCalls = 0;
-		disposables.add(onboarding.registerHost(host.container, host.root, () => focusCalls++));
+		const visibleChanges: boolean[] = [];
+		disposables.add(onboarding.registerHost(host.container, host.root, () => focusCalls++, visible => visibleChanges.push(visible)));
 
 		let context: IChatInputOnboardingContext | undefined;
 		let cardsCreated = 0;
@@ -63,9 +64,11 @@ suite('Chat input onboarding', () => {
 				stillTakenOver,
 				cardsCreated,
 				visible: host.container.classList.contains('has-chat-input-onboarding'),
+				isVisible: onboarding.isVisible,
+				visibleChanges: [...visibleChanges],
 				cards: host.container.querySelectorAll('.chat-input-onboarding-card').length,
 			},
-			{ shown: true, stillTakenOver: true, cardsCreated: 1, visible: true, cards: 1 });
+			{ shown: true, stillTakenOver: true, cardsCreated: 1, visible: true, isVisible: true, visibleChanges: [true], cards: 1 });
 
 		context!.dismiss();
 
@@ -73,10 +76,12 @@ suite('Chat input onboarding', () => {
 			{
 				focusCalls,
 				visible: host.container.classList.contains('has-chat-input-onboarding'),
+				isVisible: onboarding.isVisible,
+				visibleChanges,
 				cards: host.container.querySelectorAll('.chat-input-onboarding-card').length,
 				shownAgain: onboarding.showIfNeeded(createCard),
 			},
-			{ focusCalls: 1, visible: false, cards: 0, shownAgain: false });
+			{ focusCalls: 1, visible: false, isVisible: false, visibleChanges: [true, false], cards: 0, shownAgain: false });
 	});
 
 	test('does not consume first-run state until a card can be shown', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatInputOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatInputOnboarding.test.ts
@@ -18,6 +18,7 @@ suite('Chat input onboarding', () => {
 	function createHost(store: Pick<DisposableStore, 'add'>): { root: HTMLElement; container: HTMLElement } {
 		const root = dom.$('div');
 		root.tabIndex = 0;
+		dom.append(root, dom.$('.chat-getting-started-tip-container'));
 		const container = dom.append(root, dom.$('.chat-input-onboarding-container'));
 		document.body.appendChild(root);
 		store.add(toDisposable(() => root.remove()));
@@ -44,7 +45,8 @@ suite('Chat input onboarding', () => {
 		const host = createHost(disposables);
 		let focusCalls = 0;
 		const visibleChanges: boolean[] = [];
-		disposables.add(onboarding.registerHost(host.container, host.root, () => focusCalls++, visible => visibleChanges.push(visible)));
+		const tipContainer = host.root.querySelector<HTMLElement>('.chat-getting-started-tip-container')!;
+		disposables.add(onboarding.registerHost(host.container, host.root, () => focusCalls++, tipContainer, visible => visibleChanges.push(visible)));
 
 		let context: IChatInputOnboardingContext | undefined;
 		let cardsCreated = 0;
@@ -66,9 +68,10 @@ suite('Chat input onboarding', () => {
 				visible: host.container.classList.contains('has-chat-input-onboarding'),
 				isVisible: onboarding.isVisible,
 				visibleChanges: [...visibleChanges],
+				tipsVisible: host.root.querySelector<HTMLElement>('.chat-getting-started-tip-container')?.style.display !== 'none',
 				cards: host.container.querySelectorAll('.chat-input-onboarding-card').length,
 			},
-			{ shown: true, stillTakenOver: true, cardsCreated: 1, visible: true, isVisible: true, visibleChanges: [true], cards: 1 });
+			{ shown: true, stillTakenOver: true, cardsCreated: 1, visible: true, isVisible: true, visibleChanges: [true], tipsVisible: false, cards: 1 });
 
 		context!.dismiss();
 
@@ -78,10 +81,11 @@ suite('Chat input onboarding', () => {
 				visible: host.container.classList.contains('has-chat-input-onboarding'),
 				isVisible: onboarding.isVisible,
 				visibleChanges,
+				tipsVisible: host.root.querySelector<HTMLElement>('.chat-getting-started-tip-container')?.style.display !== 'none',
 				cards: host.container.querySelectorAll('.chat-input-onboarding-card').length,
 				shownAgain: onboarding.showIfNeeded(createCard),
 			},
-			{ focusCalls: 1, visible: false, isVisible: false, visibleChanges: [true, false], cards: 0, shownAgain: false });
+			{ focusCalls: 1, visible: false, isVisible: false, visibleChanges: [true, false], tipsVisible: true, cards: 0, shownAgain: false });
 	});
 
 	test('does not consume first-run state until a card can be shown', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -167,8 +167,9 @@ suite('Dictation onboarding', () => {
 				visible: host.container.classList.contains('has-dictation-onboarding'),
 				cards: host.container.querySelectorAll('.dictation-onboarding-banner').length,
 				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
+				microphonePickerHidden: host.container.querySelector<HTMLElement>('.dictation-onboarding-picker')?.hidden,
 			},
-			{ visible: true, cards: 1, hasMicrophoneControls: true });
+			{ visible: true, cards: 1, hasMicrophoneControls: true, microphonePickerHidden: true });
 	});
 
 	test('reset shows the introduction on the next dictation', () => {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -194,9 +194,11 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 		override acceptElicitation() { }
 	}());
 	reg.defineInstance(IDictationOnboardingService, new class extends mock<IDictationOnboardingService>() {
+		override readonly isVisible = false;
 		override registerHost() { return Disposable.None; }
 	}());
 	reg.defineInstance(IVoiceModeOnboardingService, new class extends mock<IVoiceModeOnboardingService>() {
+		override readonly isVisible = false;
 		override registerHost() { return Disposable.None; }
 	}());
 	reg.defineInstance(IWorkbenchEnvironmentService, new class extends mock<IWorkbenchEnvironmentService>() {

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -328,9 +328,11 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 				override announceRendered() { }
 			}());
 			reg.defineInstance(IDictationOnboardingService, new class extends mock<IDictationOnboardingService>() {
+				override readonly isVisible = false;
 				override registerHost() { return Disposable.None; }
 			}());
 			reg.defineInstance(IVoiceModeOnboardingService, new class extends mock<IVoiceModeOnboardingService>() {
+				override readonly isVisible = false;
 				override registerHost() { return Disposable.None; }
 			}());
 			reg.defineInstance(ICustomizationHarnessService, new class extends mock<ICustomizationHarnessService>() {


### PR DESCRIPTION
## Summary
- make Voice Mode onboarding previews toggleable so clicking the active voice again stops playback while keeping it selected
- label Maya as the default voice
- change the introduction copy to “Choose how your agent speaks to you.”
- add an “Agent Voice:” label before the voice choices
- announce the active preview as “Stop {voice} preview” for screen-reader users and restore the original label when playback ends
- hide the microphone picker on both Voice Mode and Dictation onboarding cards unless multiple microphone choices are available
- directly clear chat tips when either onboarding card opens in normal chat and agent session windows, and prevent tips from reappearing until onboarding closes

## Testing
- `npm run hygiene`
- `./scripts/test.sh --runGlob '**/{chat/test/browser/chatInputOnboarding.test,agentsVoice/test/browser/voiceModeOnboarding.test,chat/test/browser/dictationOnboarding.test}.js'`\n- transpiled current sources into local `out` for OSS testing