### PR TITLE
Copilot cloud sandbox sessions over a live Agent Host Protocol relay

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -27,7 +27,7 @@ import { AgentHostResourceIdentity, AgentHostResourcePermissionError, IAgentHost
 import type { ClientNotificationMap, CommandMap, JsonRpcErrorResponse, JsonRpcRequest } from '../common/state/protocol/messages.js';
 import { ActionType, type ActionEnvelope, type ChatAction, type ClientAnnotationsAction, type ClientChangesetAction, type INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import { MessageAttachmentKind, SessionSummary, ROOT_STATE_URI, StateComponents, isAhpRootChannel, type ClientPluginCustomization, type Message, type RootState } from '../common/state/sessionState.js';
-import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
+import { SUPPORTED_PROTOCOL_VERSIONS } from '../common/state/protocol/version/registry.js';
 import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, ProtocolError, ReconnectResultType, type ProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { type IVscodeUpgradeResult } from '../common/state/protocolUpgrade.js';
 import { isClientTransport, type IProtocolTransport } from '../common/state/sessionTransport.js';
@@ -483,7 +483,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 			const result = await this._dispatchRequest<CommandMap['initialize']['result']>('initialize', {
 				channel: ROOT_STATE_URI,
-				protocolVersions: [PROTOCOL_VERSION],
+				// Advertise every version this client can negotiate, most-preferred first, so an
+				// older host (a cloud sandbox running a 0.5.x `copilotd`) can negotiate down
+				// instead of rejecting the connection. A current host still picks the newest.
+				protocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
 				clientId: this._clientId,
 				clientInfo: this._clientInfo,
 				initialSubscriptions: [ROOT_STATE_URI],
@@ -685,7 +688,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._logService.info(`[RemoteAgentHostProtocol] Server forgot client ${this._clientId}; initializing a fresh connection.`);
 		const initializeResult = await this._dispatchRequest<CommandMap['initialize']['result']>('initialize', {
 			channel: ROOT_STATE_URI,
-			protocolVersions: [PROTOCOL_VERSION],
+			protocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
 			clientId: this._clientId,
 			clientInfo: this._clientInfo,
 			initialSubscriptions: subscriptions,

--- a/src/vs/platform/agentHost/browser/webPubSubRelayTransport.ts
+++ b/src/vs/platform/agentHost/browser/webPubSubRelayTransport.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Adapted from github-ui `packages/ahp-relay/webpubsub/wps-transport.ts`
+// Adapted from github-ui `https://github.com/github/github-ui/blob/main/packages/ahp-relay/webpubsub/wps-transport.ts`
 // (Microsoft, MIT) to VS Code's push-based {@link IClientTransport} contract.
 //
 // Connects to Azure Web PubSub using the reliable JSON subprotocol and
@@ -259,6 +259,14 @@ export class WebPubSubRelayTransport extends Disposable implements IClientTransp
 		}
 	}
 
+	/**
+	 * TODO: publish acks are requested but not tracked — a `success: false` ack is dropped by
+	 * {@link _ingestGroupFrame}, so the message never reaches the host, no JSON-RPC reply can
+	 * arrive, and the request stays pending forever while the transport still looks open. The
+	 * symptom is a session that stops responding mid-turn with no error. Fixing it means tracking
+	 * publish ack ids here and failing the transport on a rejected ack — kept as-is for now to stay
+	 * in sync with github-ui `ahp-relay/webpubsub/wps-transport.ts`, which behaves the same way.
+	 */
 	send(message: ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest): void {
 		if (this._closed || !this._ws) {
 			throw new Error('WebPubSubRelayTransport is closed');

--- a/src/vs/platform/agentHost/browser/webPubSubRelayTransport.ts
+++ b/src/vs/platform/agentHost/browser/webPubSubRelayTransport.ts
@@ -1,0 +1,313 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Adapted from github-ui `packages/ahp-relay/webpubsub/wps-transport.ts`
+// (Microsoft, MIT) to VS Code's push-based {@link IClientTransport} contract.
+//
+// Connects to Azure Web PubSub using the reliable JSON subprotocol and
+// translates between AHP JSON-RPC messages and WPS `sendToGroup` /
+// group-message framing via the framing/chunking adapters. Token refresh is the
+// caller's responsibility — when a token expires, dispose the old transport and
+// create a new one with a fresh token.
+
+import { Emitter } from '../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { IntervalTimer, disposableTimeout } from '../../../base/common/async.js';
+import type { AhpServerNotification, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ProtocolMessage } from '../common/state/sessionProtocol.js';
+import type { IClientTransport } from '../common/state/sessionTransport.js';
+import { Reassembler } from '../common/webPubSub/chunking.js';
+import { type InboundResult, RELIABLE_JSON_SUBPROTOCOL, buildPublish, parseInbound } from '../common/webPubSub/framing.js';
+import type { ParseGroupNameOptions } from '../common/webPubSub/groups.js';
+
+/** How often to sweep the reassembler for abandoned partial-chunk buffers. */
+const REASSEMBLY_SWEEP_INTERVAL_MS = 15_000;
+
+/** Upper bound on the WPS handshake (socket open → `connected` → all joinGroup acks). */
+const WPS_HANDSHAKE_TIMEOUT_MS = 30_000;
+
+/**
+ * Minimal structural subset of the browser `WebSocket` interface this transport
+ * depends on, so a fake socket can be injected in tests via
+ * {@link IWebPubSubRelayTransportOptions.webSocketFactory}.
+ */
+export interface IWebSocketLike {
+	send(data: string): void;
+	close(code?: number, reason?: string): void;
+	onopen: (() => void) | null;
+	onmessage: ((event: { data: unknown }) => void) | null;
+	onclose: ((event: { code: number; reason: string }) => void) | null;
+	onerror: ((event: unknown) => void) | null;
+}
+
+/** Opens an {@link IWebSocketLike} for `url` negotiating `subprotocol`. */
+export type WebSocketFactory = (url: string, subprotocol: string) => IWebSocketLike;
+
+/** Default factory: a real browser WebSocket (available in the Electron renderer). */
+const defaultWebSocketFactory: WebSocketFactory = (url, subprotocol) =>
+	new WebSocket(url, subprotocol) as unknown as IWebSocketLike;
+
+const inboundDecoder = new TextDecoder('utf-8');
+
+/**
+ * Coerce an inbound WebSocket message payload to a string. WPS reliable JSON
+ * frames are text, but `ArrayBuffer`/typed-array payloads are tolerated
+ * defensively.
+ */
+function frameDataToString(data: unknown): string {
+	if (typeof data === 'string') {
+		return data;
+	}
+	if (data instanceof ArrayBuffer) {
+		return inboundDecoder.decode(data);
+	}
+	if (ArrayBuffer.isView(data)) {
+		return inboundDecoder.decode(data);
+	}
+	return String(data);
+}
+
+export interface IWebPubSubRelayTransportOptions {
+	/** Full WebSocket URL (including the `access_token` and `clientId` query params). */
+	readonly url: string;
+	/** Group to publish outbound AHP messages to (the `to_host` lane). */
+	readonly toHostGroup: string;
+	/** Groups to join on connect (`broadcast` + `to_client`). */
+	readonly joinGroups: readonly string[];
+	/** Forwarded to {@link parseInbound} for uid/eid/cid pinning. */
+	readonly groupValidation?: ParseGroupNameOptions;
+	/** Opens the underlying WebSocket. Defaults to a real browser socket. */
+	readonly webSocketFactory?: WebSocketFactory;
+	/** Invoked when an inbound frame can't be parsed or framed. */
+	readonly onProtocolError?: (err: unknown) => void;
+}
+
+/**
+ * AHP client transport over the Web PubSub reliable JSON subprotocol.
+ *
+ * Lifecycle:
+ * 1. {@link connect} opens the WebSocket, waits for the WPS `connected` system
+ *    event, joins the requested groups, and resolves once every joinGroup ack
+ *    has arrived (so the host can't publish before we're subscribed).
+ * 2. Inbound group-fanout frames are reassembled and surfaced via
+ *    {@link onMessage}; outbound messages are chunked and published to the
+ *    `to_host` lane by {@link send}.
+ * 3. {@link dispose} (or a socket close/error) fires {@link onClose} once.
+ */
+export class WebPubSubRelayTransport extends Disposable implements IClientTransport {
+
+	private readonly _onMessage = this._register(new Emitter<ProtocolMessage>());
+	readonly onMessage = this._onMessage.event;
+
+	private readonly _onClose = this._register(new Emitter<void>());
+	readonly onClose = this._onClose.event;
+
+	private readonly _reassembler = new Reassembler();
+	private readonly _sweepTimer = this._register(new IntervalTimer());
+
+	private _ws: IWebSocketLike | undefined;
+	private _ackId = 0;
+	private readonly _pendingJoinAcks = new Map<number, string>();
+
+	/** Guards against firing onClose / resolving connect more than once. */
+	private _closed = false;
+	private _connectResolved = false;
+
+	constructor(private readonly _options: IWebPubSubRelayTransportOptions) {
+		super();
+	}
+
+	get isOpen(): boolean {
+		return this._ws !== undefined && !this._closed && this._connectResolved;
+	}
+
+	/**
+	 * Open a WPS WebSocket connection with the reliable JSON subprotocol and
+	 * complete the join handshake. Resolves once connected, rejects on
+	 * error/timeout/early-close.
+	 */
+	connect(): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			if (this._store.isDisposed) {
+				reject(new Error('Transport is disposed'));
+				return;
+			}
+
+			const factory = this._options.webSocketFactory ?? defaultWebSocketFactory;
+			const ws = factory(this._options.url, RELIABLE_JSON_SUBPROTOCOL);
+			this._ws = ws;
+
+			// Handshake-scoped disposables (timeout timer). Cleared once connected or failed.
+			const handshakeStore = new DisposableStore();
+
+			const settleReject = (err: Error) => {
+				handshakeStore.dispose();
+				this._failConnect();
+				reject(err);
+			};
+
+			const settleResolve = () => {
+				handshakeStore.dispose();
+				this._connectResolved = true;
+				this._startObserving();
+				resolve();
+			};
+
+			handshakeStore.add(disposableTimeout(() => {
+				settleReject(new Error('WPS handshake timed out'));
+			}, WPS_HANDSHAKE_TIMEOUT_MS));
+
+			ws.onopen = () => {
+				// WPS reliable JSON sends a `connected` system message after open;
+				// we wait for it (handled in onmessage) before joining groups.
+			};
+
+			ws.onmessage = event => {
+				let frame: Record<string, unknown>;
+				try {
+					frame = JSON.parse(frameDataToString(event.data)) as Record<string, unknown>;
+				} catch (err) {
+					this._options.onProtocolError?.(err);
+					return;
+				}
+				this._handleHandshakeFrame(frame, settleResolve, settleReject);
+			};
+
+			ws.onerror = () => {
+				settleReject(new Error('WebSocket error during WPS connect'));
+			};
+
+			ws.onclose = ev => {
+				settleReject(new Error(`WebSocket closed before connection was established: ${ev.code} ${ev.reason}`));
+			};
+		});
+	}
+
+	/**
+	 * Handle a frame received during the connect handshake: the WPS `connected`
+	 * system event, joinGroup acks, or (defensively) early payload frames.
+	 */
+	private _handleHandshakeFrame(frame: Record<string, unknown>, onConnected: () => void, onFail: (err: Error) => void): void {
+		if (frame['type'] === 'system' && frame['event'] === 'connected') {
+			for (const group of this._options.joinGroups) {
+				const ackId = ++this._ackId;
+				this._pendingJoinAcks.set(ackId, group);
+				this._sendRaw({ type: 'joinGroup', group, ackId });
+			}
+			if (this._pendingJoinAcks.size === 0) {
+				onConnected();
+			}
+			return;
+		}
+
+		if (frame['type'] === 'ack') {
+			const ackId = typeof frame['ackId'] === 'number' ? frame['ackId'] : undefined;
+			if (ackId === undefined || !this._pendingJoinAcks.has(ackId)) {
+				return;
+			}
+			const group = this._pendingJoinAcks.get(ackId);
+			this._pendingJoinAcks.delete(ackId);
+			if (frame['success'] === false) {
+				onFail(new Error(`WPS joinGroup failed for group '${group}'`));
+				return;
+			}
+			if (this._pendingJoinAcks.size === 0) {
+				onConnected();
+			}
+			return;
+		}
+
+		// Any group-fanout frames that arrive before the handshake completes are
+		// buffered by the reassembler and surfaced once observing starts.
+		this._ingestGroupFrame(frame);
+	}
+
+	/** Switch the socket handlers over to steady-state observation. */
+	private _startObserving(): void {
+		const ws = this._ws;
+		if (!ws) {
+			return;
+		}
+		this._sweepTimer.cancelAndSet(() => this._reassembler.sweepExpired(), REASSEMBLY_SWEEP_INTERVAL_MS);
+
+		ws.onmessage = event => {
+			let frame: Record<string, unknown>;
+			try {
+				frame = JSON.parse(frameDataToString(event.data)) as Record<string, unknown>;
+			} catch (err) {
+				this._options.onProtocolError?.(err);
+				return;
+			}
+			this._ingestGroupFrame(frame);
+		};
+		ws.onclose = () => this._fireClose();
+		ws.onerror = () => this._fireClose();
+	}
+
+	/** Reassemble and surface a group-fanout frame as a {@link ProtocolMessage}. */
+	private _ingestGroupFrame(frame: Record<string, unknown>): void {
+		let result: InboundResult;
+		try {
+			result = parseInbound(frame, { reassembler: this._reassembler, groupValidation: this._options.groupValidation });
+		} catch (err) {
+			this._options.onProtocolError?.(err);
+			return;
+		}
+		if (result.kind === 'payload') {
+			this._onMessage.fire(result.payload as ProtocolMessage);
+		}
+	}
+
+	send(message: ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest): void {
+		if (this._closed || !this._ws) {
+			throw new Error('WebPubSubRelayTransport is closed');
+		}
+		const frames = buildPublish({
+			group: this._options.toHostGroup,
+			nextAckId: () => ++this._ackId,
+			payload: message,
+		});
+		for (const frame of frames) {
+			this._sendRaw(frame);
+		}
+	}
+
+	private _sendRaw(obj: unknown): void {
+		this._ws?.send(JSON.stringify(obj));
+	}
+
+	/** Fire onClose exactly once and stop background work. */
+	private _fireClose(): void {
+		if (this._closed) {
+			return;
+		}
+		this._closed = true;
+		this._sweepTimer.cancel();
+		this._onClose.fire();
+	}
+
+	/** Tear down a failed/incomplete connect without firing onClose to observers. */
+	private _failConnect(): void {
+		this._closed = true;
+		this._sweepTimer.cancel();
+		try {
+			this._ws?.close();
+		} catch {
+			// best-effort
+		}
+	}
+
+	override dispose(): void {
+		if (!this._closed) {
+			this._closed = true;
+			this._sweepTimer.cancel();
+			try {
+				this._ws?.close();
+			} catch {
+				// best-effort
+			}
+		}
+		super.dispose();
+	}
+}

--- a/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
+++ b/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
@@ -46,7 +46,16 @@ export function cloudSandboxEnvironmentId(address: string): string | undefined {
 		: undefined;
 }
 
-/** The Copilot cloud agent slug whose tasks run inside a Mission Control sandbox. */
+/**
+ * The Copilot cloud agent slug whose tasks run inside a Mission Control sandbox.
+ *
+ * Sandbox tasks carry this slug today, which is why {@link CloudSandboxEnabledSettingId} exists and
+ * defaults to off: the Copilot extension's cloud provider lists tasks by an allowlist of cloud
+ * slugs (`copilot-developer`, `copilot-swe-agent`) that excludes this one, so the two providers do
+ * not overlap. Sandbox tasks are expected to move under one of those slugs eventually, at which
+ * point both providers would list the same task and the sessions list would show it twice — the
+ * setting keeps that from reaching everyone before the overlap is resolved.
+ */
 export const CLOUD_SANDBOX_AGENT_SLUG = 'copilot-developer-cli';
 
 /** A sandbox session discovered from the Copilot task list, enough to seed a session entry. */
@@ -200,7 +209,7 @@ export interface ICloudSandboxCredentialsService {
 	getEnvironment(environmentId: string, token: CancellationToken): Promise<ICloudSandboxEnvironment>;
 
 	/** Enumerate the caller's sandbox-backed cloud sessions, enough to seed session entries. */
-	listSessions(token: CancellationToken): Promise<readonly ICloudSandboxDiscoveredSession[]>;
+	listSessions(token: CancellationToken): Promise<ICloudSandboxDiscoveryResult>;
 }
 
 /**
@@ -213,6 +222,19 @@ export class CloudSandboxEnvironmentOfflineError extends Error {
 		this.name = 'CloudSandboxEnvironmentOfflineError';
 	}
 }
+
+/**
+ * Outcome of a discovery pass. Only a `complete` result describes the full set of sandbox sessions,
+ * so only it may be reconciled against — a `partial` result is missing entries that still exist, and
+ * treating it as authoritative would tear down live sessions.
+ */
+export type ICloudSandboxDiscoveryResult =
+	/** Every task was scanned and resolved; absent sessions really are gone. */
+	| { readonly kind: 'complete'; readonly sessions: readonly ICloudSandboxDiscoveredSession[] }
+	/** Some tasks could not be resolved. Seed what was found, but do not remove anything. */
+	| { readonly kind: 'partial'; readonly sessions: readonly ICloudSandboxDiscoveredSession[] }
+	/** Discovery could not run (auth not ready, request failed). Existing state must be left alone. */
+	| { readonly kind: 'failed'; readonly reason: string };
 
 /** Thrown when no GitHub session with the required scopes is available. */
 export class CloudSandboxAuthenticationRequiredError extends Error {

--- a/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
+++ b/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
@@ -1,0 +1,264 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Contracts for connecting to Copilot cloud "sandbox" sessions (agent slug
+// `copilot-developer-cli`), which run the Copilot agent runtime (`copilotd`) inside a Mission
+// Control managed sandbox and speak the Agent Host Protocol over an Azure Web PubSub relay.
+//
+// Like `tunnelAgentHost.ts` / `sshRemoteAgentHost.ts` / `wslRemoteAgentHost.ts`, this describes how
+// to reach an agent host over one transport; it does not define a new kind of agent host.
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { localize } from '../../../nls.js';
+
+/** Configuration key gating the cloud-sandbox connection path. Disabled by default. */
+export const CloudSandboxEnabledSettingId = 'chat.agentHost.cloudSandbox.enabled';
+
+/** Prefix for the synthesized display address of a cloud sandbox connection. */
+export const CLOUD_SANDBOX_ADDRESS_PREFIX = 'cloudsandbox:';
+
+/**
+ * Session URI scheme the Copilot host uses when it creates and lists sessions
+ * (`ahp-session:/<uuid>`). Differs from its agent provider ({@link CLOUD_SANDBOX_AGENT_PROVIDER}):
+ * the UI routes by provider, but backend calls must address sessions under this scheme because the
+ * host's session registry is keyed by the exact URI.
+ */
+export const CLOUD_SANDBOX_SESSION_SCHEME = 'ahp-session';
+
+/** The agent provider advertised by the Copilot host inside the sandbox. */
+export const CLOUD_SANDBOX_AGENT_PROVIDER = 'copilot';
+
+/** Prefix of a sealed token envelope (`copilot-sealed.v1.<key_id>.<b64url>`). */
+export const CLOUD_SANDBOX_SEALED_TOKEN_PREFIX = 'copilot-sealed.v1.';
+
+/** Whether {@link token} is a sealed envelope, and so safe to forward over the relay. */
+export function isCloudSandboxSealedToken(token: string | undefined): boolean {
+	return typeof token === 'string' && token.startsWith(CLOUD_SANDBOX_SEALED_TOKEN_PREFIX);
+}
+
+/** The Mission Control environment id encoded in a cloud sandbox connection address, if any. */
+export function cloudSandboxEnvironmentId(address: string): string | undefined {
+	return address.startsWith(CLOUD_SANDBOX_ADDRESS_PREFIX)
+		? address.slice(CLOUD_SANDBOX_ADDRESS_PREFIX.length)
+		: undefined;
+}
+
+/** The Copilot cloud agent slug whose tasks run inside a Mission Control sandbox. */
+export const CLOUD_SANDBOX_AGENT_SLUG = 'copilot-developer-cli';
+
+/** A sandbox session discovered from the Copilot task list, enough to seed a session entry. */
+export interface ICloudSandboxDiscoveredSession {
+	/** Mission Control environment id the session's sandbox is bound to. */
+	readonly environmentId: string;
+	/**
+	 * Session id, used as the native session's raw id. Mission Control creates the session as
+	 * `ahp-session:/<sessionId>` and the host lists it back under the same id, so seeded entries
+	 * reconcile with the host's `listSessions()` on connect.
+	 */
+	readonly sessionId: string;
+	/** Display name for the session/host. */
+	readonly name: string;
+	/** Owning repository as `owner/name`, when known. */
+	readonly repoName?: string;
+	/** Last-updated timestamp (ISO 8601), when known, for ordering. */
+	readonly updatedAt?: string;
+}
+
+/** Build the synthesized remote-agent-host address for a sandbox environment. */
+export function cloudSandboxAddress(environmentId: string): string {
+	return `${CLOUD_SANDBOX_ADDRESS_PREFIX}${environmentId}`;
+}
+
+/** Build the Web PubSub URL for a client token. The scheme is forced to `wss://`. */
+export function buildWpsUrl(token: ICloudSandboxClientToken): string {
+	const base = token.wps_endpoint.replace(/^ws:\/\//i, 'wss://').replace(/^http:\/\//i, 'wss://').replace(/^https:\/\//i, 'wss://');
+	const withScheme = /^wss:\/\//i.test(base) ? base : `wss://${base}`;
+	const separator = withScheme.includes('?') ? '&' : '?';
+	return `${withScheme}${separator}access_token=${encodeURIComponent(token.access_token)}&clientId=${encodeURIComponent(token.client_id)}`;
+}
+
+/**
+ * The three per-client Web PubSub group "lanes". The client joins {@link broadcast} and
+ * {@link to_client} (inbound) and publishes to {@link to_host} (outbound).
+ */
+export interface IWebPubSubClientGroups {
+	/** Host → this-client broadcast lane the client subscribes to. */
+	readonly broadcast: string;
+	/** Host → this-client lane the client subscribes to. */
+	readonly to_client: string;
+	/** This-client → host lane the client publishes to. */
+	readonly to_host: string;
+}
+
+/** A public sealing key advertised by the sandbox host. */
+export interface IHostEncryptionKey {
+	/** Stateless key fingerprint; names the key in a sealed value's envelope. */
+	readonly key_id: string;
+	/** Trust domain the key serves (e.g. `auth-token`). */
+	readonly use: string;
+	/** Sealing scheme (only `x25519-sealedbox` is defined today). */
+	readonly algorithm: string;
+	/** Recipient public key in standard (padded) base64. */
+	readonly public_key: string;
+}
+
+/**
+ * A client Web PubSub connection token (`/connect` and `/reconnect`, HTTP 200). Field names mirror
+ * the wire shape so the extension can pass them through the bridge without remapping.
+ */
+export interface ICloudSandboxClientToken {
+	/** Short-lived Web PubSub JWT. Never persisted. */
+	readonly access_token: string;
+	/** ISO-8601 expiry of {@link access_token}. */
+	readonly expires_at: string;
+	/** Web PubSub endpoint URL (without the access-token query param). */
+	readonly wps_endpoint: string;
+	/** Web PubSub hub name. */
+	readonly hub: string;
+	/** WebSocket subprotocol to negotiate (e.g. the reliable JSON subprotocol). */
+	readonly subprotocol: string;
+	/** MC-issued stable client identity used for group lanes, `initialize`, and reconnect. */
+	readonly client_id: string;
+	/** The per-client group lanes. */
+	readonly groups: IWebPubSubClientGroups;
+	/** Opaque `copilot-sealed.v1.<key_id>.<b64url>` envelope, when MC sealed a token. */
+	readonly encrypted_github_token?: string;
+	/** The host key the {@link encrypted_github_token} was sealed to, when present. */
+	readonly host_encryption_key?: IHostEncryptionKey;
+}
+
+/**
+ * Mission Control signalled that the environment is waking (HTTP 202). The
+ * client must retry `/connect` after {@link retryAfterSeconds} until it gets a
+ * token (HTTP 200).
+ */
+export interface ICloudSandboxWaking {
+	/** Seconds to wait before retrying, from the `Retry-After` header. */
+	readonly retryAfterSeconds: number;
+}
+
+/** Result of a credentials mint: either a usable token or a "waking" retry signal. */
+export type CloudSandboxConnectResult =
+	| { readonly kind: 'token'; readonly token: ICloudSandboxClientToken }
+	| { readonly kind: 'waking'; readonly waking: ICloudSandboxWaking };
+
+/**
+ * Operational state of a sandbox environment. Only `online` has a daemon listening on the relay;
+ * connecting to any other state leaves the AHP `initialize` unanswered.
+ */
+export type CloudSandboxEnvironmentStatus = 'online' | 'offline' | 'degraded' | 'waking' | 'draining';
+
+/** A sandbox environment's current record, as reported by Mission Control. */
+export interface ICloudSandboxEnvironment {
+	readonly id: string;
+	readonly status: CloudSandboxEnvironmentStatus;
+	readonly capabilities?: {
+		/** The copilotd **host** version (e.g. `0.6.3`), not the AHP wire protocol version. */
+		readonly ahp_version?: string;
+	};
+}
+
+/** Identifies which sandbox environment/session credentials are being minted for. */
+export interface ICloudSandboxConnectionRequest {
+	/** Stable environment identifier (`env_<uuid>`) of the sandbox. */
+	readonly environmentId: string;
+	/**
+	 * The cloud session/task id the client is connecting to. Mission Control
+	 * uses it to resolve the repository when minting the token.
+	 */
+	readonly sessionId?: string;
+}
+
+export const ICloudSandboxCredentialsService = createDecorator<ICloudSandboxCredentialsService>('cloudSandboxCredentialsService');
+
+/**
+ * Mints and refreshes the Mission Control Web PubSub credentials a cloud sandbox connection needs,
+ * and reads an environment's current record.
+ */
+export interface ICloudSandboxCredentialsService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Mint a fresh client Web PubSub connection token for a new logical connection. May resolve to a
+	 * "waking" result the caller should retry.
+	 */
+	connect(request: ICloudSandboxConnectionRequest, token: CancellationToken): Promise<CloudSandboxConnectResult>;
+
+	/**
+	 * Refresh the credentials for an existing logical connection identified by {@link clientId}
+	 * (e.g. after the access token expired).
+	 */
+	reconnect(request: ICloudSandboxConnectionRequest, clientId: string, token: CancellationToken): Promise<CloudSandboxConnectResult>;
+
+	/**
+	 * Read an environment's current record so the caller can gate connecting on it actually being
+	 * online (and speaking a compatible host version).
+	 */
+	getEnvironment(environmentId: string, token: CancellationToken): Promise<ICloudSandboxEnvironment>;
+
+	/** Enumerate the caller's sandbox-backed cloud sessions, enough to seed session entries. */
+	listSessions(token: CancellationToken): Promise<readonly ICloudSandboxDiscoveredSession[]>;
+}
+
+/**
+ * Thrown when the sandbox environment cannot serve a connection and waiting will not help. Retrying
+ * re-mints credentials and wakes the sandbox again, so callers should surface this rather than retry.
+ */
+export class CloudSandboxEnvironmentOfflineError extends Error {
+	constructor(readonly status: CloudSandboxEnvironmentStatus) {
+		super(localize('cloudSandbox.environmentOffline', "The environment for this session is offline. It will become available again when the host reconnects."));
+		this.name = 'CloudSandboxEnvironmentOfflineError';
+	}
+}
+
+/** Thrown when no GitHub session with the required scopes is available. */
+export class CloudSandboxAuthenticationRequiredError extends Error {
+	constructor() {
+		super('Connecting to a cloud sandbox requires a signed-in GitHub account.');
+		this.name = 'CloudSandboxAuthenticationRequiredError';
+	}
+}
+
+export const ICloudSandboxAgentHostService = createDecorator<ICloudSandboxAgentHostService>('cloudSandboxAgentHostService');
+
+/** Options for establishing a live AHP relay to a cloud sandbox environment. */
+export interface ICloudSandboxConnectOptions {
+	/** Stable Mission Control environment identifier (`env_<uuid>`). */
+	readonly environmentId: string;
+	/** The cloud session/task id this connection is for, used for token minting. */
+	readonly sessionId?: string;
+	/** Human-readable display name for the connection. */
+	readonly name: string;
+}
+
+/**
+ * Renderer-side coordinator that establishes and manages live Agent Host
+ * Protocol relay connections to Copilot cloud sandbox environments. Mints
+ * credentials via {@link ICloudSandboxCredentialsService}, opens a
+ * {@link WebPubSubRelayTransport}, drives the AHP handshake (including the
+ * sealed-token `authenticate`), and registers the connection with
+ * {@link IRemoteAgentHostService} so it surfaces as a native agent-host session.
+ */
+export interface ICloudSandboxAgentHostService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Establish (or reuse) a live AHP relay connection to the given sandbox
+	 * environment. Resolves with the connection's display address once the
+	 * connection is registered with {@link IRemoteAgentHostService}.
+	 *
+	 * Retries while the environment is waking (bounded), honoring the
+	 * server-provided Retry-After delay.
+	 */
+	connect(options: ICloudSandboxConnectOptions, token: CancellationToken): Promise<string>;
+
+	/**
+	 * The sealed GitHub token for a live connection to the given environment, as minted by
+	 * `/connect` and refreshed by `/reconnect`, or `undefined` when there is no connection.
+	 */
+	getSealedGitHubToken(environmentId: string): string | undefined;
+}
+

--- a/src/vs/platform/agentHost/common/githubEndpoints.ts
+++ b/src/vs/platform/agentHost/common/githubEndpoints.ts
@@ -25,7 +25,12 @@ export interface IGitHubEndpoints {
 	readonly enterpriseHost: string | undefined;
 }
 
-const GITHUB_DOT_COM_COPILOT_API_BASE_URI = 'https://api.githubcopilot.com';
+/**
+ * The github.com Copilot API host. Distinct from {@link IGitHubEndpoints.apiBaseUri}
+ * (`api.github.com`): enterprise installs override this per user via the Copilot token's
+ * `endpoints.api`, which is not derivable from the enterprise URI.
+ */
+export const GITHUB_DOT_COM_COPILOT_API_BASE_URI = 'https://api.githubcopilot.com';
 
 /** Canonical github.com endpoints, used when no enterprise URI is configured. */
 const GITHUB_DOT_COM_ENDPOINTS: IGitHubEndpoints = {

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -106,6 +106,7 @@ export const enum RemoteAgentHostEntryType {
 	SSH = 'ssh',
 	WSL = 'wsl',
 	Tunnel = 'tunnel',
+	CloudSandbox = 'cloudSandbox',
 }
 
 export interface IRemoteAgentHostWebSocketConnection {
@@ -166,7 +167,23 @@ export interface IRemoteAgentHostWSLConnection {
 	readonly distro: string;
 }
 
-export type RemoteAgentHostConnection = IRemoteAgentHostWebSocketConnection | IRemoteAgentHostSSHConnection | IRemoteAgentHostWSLConnection | IRemoteAgentHostTunnelConnection;
+/**
+ * A connection to a Copilot cloud "sandbox" environment (agent integration slug
+ * `copilot-developer-cli`), reached over a Mission Control-brokered Azure Web
+ * PubSub relay. Not persisted to settings — the connection is established
+ * on demand with freshly-minted, short-lived credentials.
+ */
+export interface IRemoteAgentHostCloudSandboxConnection {
+	readonly type: RemoteAgentHostEntryType.CloudSandbox;
+	/** Synthesized display address: `cloudsandbox:<environmentId>`. */
+	readonly address: string;
+	/** Stable Mission Control environment identifier (`env_<uuid>`). */
+	readonly environmentId: string;
+	/** The cloud session/task id this connection is for, when known. */
+	readonly sessionId?: string;
+}
+
+export type RemoteAgentHostConnection = IRemoteAgentHostWebSocketConnection | IRemoteAgentHostSSHConnection | IRemoteAgentHostWSLConnection | IRemoteAgentHostTunnelConnection | IRemoteAgentHostCloudSandboxConnection;
 
 /** A configured remote agent host entry. WebSocket entries are persisted in {@link RemoteAgentHostsSettingId}; SSH entries are persisted in storage. */
 export interface IRemoteAgentHostEntry {
@@ -180,6 +197,7 @@ export function getEntryAddress(entry: IRemoteAgentHostEntry): string {
 		case RemoteAgentHostEntryType.WebSocket:
 		case RemoteAgentHostEntryType.SSH:
 		case RemoteAgentHostEntryType.WSL:
+		case RemoteAgentHostEntryType.CloudSandbox:
 			return entry.connection.address;
 		case RemoteAgentHostEntryType.Tunnel:
 			return `${TUNNEL_ADDRESS_PREFIX}${entry.connection.tunnelId}`;
@@ -488,6 +506,7 @@ export function entryToRawEntry(entry: IRemoteAgentHostEntry): IRawRemoteAgentHo
 			};
 		case RemoteAgentHostEntryType.WSL:
 		case RemoteAgentHostEntryType.Tunnel:
+		case RemoteAgentHostEntryType.CloudSandbox:
 			return undefined;
 	}
 }

--- a/src/vs/platform/agentHost/common/webPubSub/chunking.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/chunking.ts
@@ -1,0 +1,380 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Ported from github-ui `packages/ahp-relay/webpubsub/chunking.ts` (Microsoft, MIT).
+//
+// Chunking codec for the Web PubSub transport (`ChunkEnvelope`). Azure Web
+// PubSub rejects any WebSocket frame larger than 1 MB, and the reliable
+// subprotocol has no service-side chunking primitive. `ChunkEnvelope` is the
+// sole chunking layer on this transport — every publish is wrapped in one (the
+// unchunked `kind: "message"` shape is the happy case for small payloads).
+
+import { VSBuffer, decodeBase64, encodeBase64 } from '../../../../base/common/buffer.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+
+/**
+ * `ChunkEnvelope` wire shape (snake_case field names per spec).
+ *
+ * `data` for the `"message"` variant is the complete inner application payload.
+ * `bytes` for the `"chunk"` variant is a base64-encoded byte slice (RFC 4648
+ * standard, with padding) of the serialised inner payload.
+ */
+export type ChunkEnvelope =
+	| { readonly kind: 'message'; readonly data: unknown }
+	| {
+		readonly kind: 'chunk';
+		readonly group_id: string;
+		readonly seq: number;
+		readonly total: number;
+		readonly bytes: string;
+	};
+
+/** Default per-segment ceiling (serialised `ChunkEnvelope` bytes). */
+export const DEFAULT_MAX_CHUNK_BYTES = 900 * 1024;
+
+/** Default reassembly timeout in milliseconds. */
+export const DEFAULT_REASSEMBLY_TIMEOUT_MS = 30_000;
+
+/** Recommended per-buffer ceiling (decoded payload bytes). */
+export const DEFAULT_MAX_REASSEMBLY_BYTES = 32 * 1024 * 1024;
+
+/** Recommended aggregate ceiling across all incomplete reassembly groups. */
+export const DEFAULT_MAX_REASSEMBLY_TOTAL_BYTES = 64 * 1024 * 1024;
+
+/** Recommended cap on the number of concurrent in-flight reassembly groups. */
+export const DEFAULT_MAX_CONCURRENT_GROUPS = 64;
+
+/** Defensive cap on the `total` field of an individual chunked group. */
+export const DEFAULT_MAX_SEGMENTS_PER_GROUP = 4096;
+
+/**
+ * Error thrown by {@link Reassembler} on a contract violation and by
+ * {@link chunk} on caller-side failures.
+ */
+export class ChunkingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ChunkingError';
+	}
+}
+
+/** Options accepted by {@link chunk}. */
+export interface ChunkOptions {
+	/** Per-segment ceiling in serialised-bytes. Defaults to {@link DEFAULT_MAX_CHUNK_BYTES}. */
+	readonly maxChunkBytes?: number;
+
+	/** UUID factory invoked once per chunked publish to mint a `group_id`. */
+	readonly newGroupId?: () => string;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+/** Strict canonical base64 (RFC 4648 standard alphabet, with padding, no whitespace). */
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/** Encode a byte slice as a base64 string (RFC 4648 standard, with padding). */
+function bytesToBase64(bytes: Uint8Array): string {
+	return encodeBase64(VSBuffer.wrap(bytes), true /* padded */, false /* urlSafe */);
+}
+
+/** Inverse of {@link bytesToBase64}. */
+function base64ToBytes(b64: string): Uint8Array {
+	return decodeBase64(b64).buffer;
+}
+
+/**
+ * Split an application payload into one or more {@link ChunkEnvelope}s.
+ *
+ * If the serialised single-frame envelope fits inside the ceiling, returns a
+ * one-element array containing the `kind: "message"` envelope. Otherwise mints
+ * a `group_id` and returns `total = ceil(len(B) / R)` `kind: "chunk"`
+ * envelopes. The raw-byte budget is derived from the actual group id and the
+ * widest permitted sequence fields so every serialized envelope fits.
+ */
+export function chunk(payload: unknown, options: ChunkOptions = {}): ChunkEnvelope[] {
+	const maxChunkBytes = options.maxChunkBytes ?? DEFAULT_MAX_CHUNK_BYTES;
+	if (maxChunkBytes <= 0 || !Number.isFinite(maxChunkBytes)) {
+		throw new ChunkingError(`maxChunkBytes must be a positive finite number, got ${maxChunkBytes}`);
+	}
+
+	let payloadSerialised: string | undefined;
+	try {
+		payloadSerialised = JSON.stringify(payload);
+	} catch (cause) {
+		throw new ChunkingError(`payload is not JSON-serialisable: ${(cause as Error).message}`);
+	}
+	if (payloadSerialised === undefined) {
+		throw new ChunkingError('payload is not JSON-serialisable');
+	}
+	const rawBytes = textEncoder.encode(payloadSerialised);
+	if (rawBytes.byteLength > DEFAULT_MAX_REASSEMBLY_BYTES) {
+		throw new ChunkingError(
+			`serialized payload is ${rawBytes.byteLength} bytes, exceeds ${DEFAULT_MAX_REASSEMBLY_BYTES}-byte ceiling`,
+		);
+	}
+
+	const singleSerialised = JSON.stringify({ kind: 'message', data: payload });
+	if (textEncoder.encode(singleSerialised).byteLength <= maxChunkBytes) {
+		return [{ kind: 'message', data: payload }];
+	}
+
+	const newGroupId = options.newGroupId ?? generateUuid;
+	const groupId = newGroupId();
+	if (typeof groupId !== 'string' || groupId.length === 0) {
+		throw new ChunkingError('newGroupId() must return a non-empty string');
+	}
+
+	const emptyEnvelope: ChunkEnvelope = {
+		kind: 'chunk',
+		group_id: groupId,
+		seq: DEFAULT_MAX_SEGMENTS_PER_GROUP - 1,
+		total: DEFAULT_MAX_SEGMENTS_PER_GROUP,
+		bytes: '',
+	};
+	const overhead = textEncoder.encode(JSON.stringify(emptyEnvelope)).byteLength;
+	const encodedBudget = Math.floor((maxChunkBytes - overhead) / 4) * 4;
+	if (encodedBudget < 4) {
+		throw new ChunkingError(
+			`maxChunkBytes (${maxChunkBytes}) leaves no complete base64 quantum after ${overhead} bytes of envelope overhead`,
+		);
+	}
+	const rawBudget = (encodedBudget / 4) * 3;
+	const total = Math.ceil(rawBytes.byteLength / rawBudget);
+	if (total > DEFAULT_MAX_SEGMENTS_PER_GROUP) {
+		throw new ChunkingError(`payload requires ${total} chunks, exceeds ${DEFAULT_MAX_SEGMENTS_PER_GROUP}-chunk ceiling`);
+	}
+
+	const out: ChunkEnvelope[] = new Array<ChunkEnvelope>(total);
+	for (let i = 0; i < total; i++) {
+		const start = i * rawBudget;
+		const end = Math.min(start + rawBudget, rawBytes.byteLength);
+		const slice = rawBytes.subarray(start, end);
+		out[i] = {
+			kind: 'chunk',
+			group_id: groupId,
+			seq: i,
+			total,
+			bytes: bytesToBase64(slice),
+		};
+	}
+	return out;
+}
+
+/** Options accepted by {@link Reassembler}. */
+export interface ReassemblerOptions {
+	/** Drop partial buffers older than this many milliseconds. */
+	readonly timeoutMs?: number;
+
+	/** Maximum total decoded bytes a single in-flight group may accumulate. */
+	readonly maxBufferBytes?: number;
+
+	/** Maximum decoded bytes retained across every in-flight group. */
+	readonly maxTotalBufferBytes?: number;
+
+	/** Maximum number of concurrent in-flight groups. */
+	readonly maxConcurrentGroups?: number;
+
+	/** Maximum `total` value the reassembler will accept on any chunked envelope. */
+	readonly maxSegmentsPerGroup?: number;
+
+	/** Clock source. Defaults to {@link Date.now}. */
+	readonly now?: () => number;
+}
+
+interface ReassemblyBuffer {
+	total: number;
+	received: number;
+	segments: Map<number, Uint8Array>;
+	accumulatedBytes: number;
+	startedAt: number;
+}
+
+/**
+ * Stateful reassembler. One instance per Web PubSub subscriber connection.
+ *
+ * On `kind: "message"` {@link Reassembler.ingest} returns the inner payload
+ * immediately. On `kind: "chunk"` it returns `null` while waiting for sibling
+ * segments and the reassembled inner payload once the final segment arrives.
+ * All contract violations throw {@link ChunkingError}.
+ */
+export class Reassembler {
+	private readonly buffers = new Map<string, ReassemblyBuffer>();
+	private readonly timeoutMs: number;
+	private readonly maxBufferBytes: number;
+	private readonly maxTotalBufferBytes: number;
+	private readonly maxConcurrentGroups: number;
+	private readonly maxSegmentsPerGroup: number;
+	private readonly now: () => number;
+	private accumulatedBytes = 0;
+
+	constructor(options: ReassemblerOptions = {}) {
+		this.timeoutMs = options.timeoutMs ?? DEFAULT_REASSEMBLY_TIMEOUT_MS;
+		this.maxBufferBytes = options.maxBufferBytes ?? DEFAULT_MAX_REASSEMBLY_BYTES;
+		this.maxTotalBufferBytes = options.maxTotalBufferBytes ?? DEFAULT_MAX_REASSEMBLY_TOTAL_BYTES;
+		this.maxConcurrentGroups = options.maxConcurrentGroups ?? DEFAULT_MAX_CONCURRENT_GROUPS;
+		this.maxSegmentsPerGroup = options.maxSegmentsPerGroup ?? DEFAULT_MAX_SEGMENTS_PER_GROUP;
+		this.now = options.now ?? Date.now;
+	}
+
+	/**
+	 * Process one inbound envelope. Returns the inner payload when reassembly
+	 * completes (or immediately, for a `kind: "message"` envelope), `null` while
+	 * waiting for sibling chunks.
+	 */
+	ingest(envelope: ChunkEnvelope): unknown {
+		if (envelope === null || typeof envelope !== 'object') {
+			throw new ChunkingError(`ChunkEnvelope must be an object, got ${typeof envelope}`);
+		}
+		if (envelope.kind === 'message') {
+			if (envelope.data === undefined) {
+				throw new ChunkingError(`ChunkEnvelope kind:'message' is missing the required 'data' field`);
+			}
+			return envelope.data;
+		}
+
+		if (envelope.kind !== 'chunk') {
+			throw new ChunkingError(`unknown ChunkEnvelope kind: ${String((envelope as { kind: unknown }).kind)}`);
+		}
+
+		const { group_id: groupId, seq, total, bytes } = envelope;
+
+		if (!Number.isInteger(total) || total < 1) {
+			throw new ChunkingError(`total must be a positive integer, got ${total}`);
+		}
+		if (total > this.maxSegmentsPerGroup) {
+			throw new ChunkingError(`total ${total} exceeds maxSegmentsPerGroup ${this.maxSegmentsPerGroup}`);
+		}
+		if (typeof groupId !== 'string' || groupId.length === 0) {
+			throw new ChunkingError('group_id must be a non-empty string');
+		}
+		if (typeof bytes !== 'string') {
+			throw new ChunkingError('bytes must be a base64 string');
+		}
+
+		let buffer = this.buffers.get(groupId);
+		if (buffer === undefined) {
+			if (this.buffers.size >= this.maxConcurrentGroups) {
+				throw new ChunkingError(
+					`refusing new group_id '${groupId}': ${this.buffers.size} concurrent groups already in flight`,
+				);
+			}
+			buffer = {
+				total,
+				received: 0,
+				segments: new Map<number, Uint8Array>(),
+				accumulatedBytes: 0,
+				startedAt: this.now(),
+			};
+			this.buffers.set(groupId, buffer);
+		} else if (buffer.total !== total) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`total mismatch for group_id '${groupId}': existing ${buffer.total}, incoming ${total}`);
+		}
+
+		if (!Number.isInteger(seq) || seq < 0 || seq >= total) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`seq ${seq} out of range [0, ${total})`);
+		}
+
+		if (buffer.segments.has(seq)) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`duplicate seq ${seq} for group_id '${groupId}'`);
+		}
+
+		if (!CANONICAL_BASE64.test(bytes)) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`base64 segment for group_id '${groupId}' is not canonical`);
+		}
+
+		let decoded: Uint8Array;
+		try {
+			decoded = base64ToBytes(bytes);
+		} catch (cause) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`base64 decode failed for group_id '${groupId}': ${(cause as Error).message}`);
+		}
+
+		if (buffer.accumulatedBytes + decoded.byteLength > this.maxBufferBytes) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`group_id '${groupId}' exceeded ${this.maxBufferBytes}-byte reassembly ceiling`);
+		}
+		if (this.accumulatedBytes + decoded.byteLength > this.maxTotalBufferBytes) {
+			this.dropBuffer(groupId);
+			throw new ChunkingError(`aggregate reassembly bytes would exceed ${this.maxTotalBufferBytes}-byte ceiling`);
+		}
+
+		buffer.segments.set(seq, decoded);
+		buffer.received += 1;
+		buffer.accumulatedBytes += decoded.byteLength;
+		this.accumulatedBytes += decoded.byteLength;
+
+		if (buffer.received < buffer.total) {
+			return null;
+		}
+
+		const totalBytes = buffer.accumulatedBytes;
+		const merged = new Uint8Array(totalBytes);
+		let offset = 0;
+		for (let i = 0; i < buffer.total; i++) {
+			const slice = buffer.segments.get(i);
+			if (slice === undefined) {
+				this.dropBuffer(groupId);
+				throw new ChunkingError(`internal: segment ${i} missing despite received==total`);
+			}
+			merged.set(slice, offset);
+			offset += slice.byteLength;
+		}
+		this.dropBuffer(groupId);
+
+		let text: string;
+		try {
+			text = textDecoder.decode(merged);
+		} catch (cause) {
+			throw new ChunkingError(
+				`reassembled payload for group_id '${groupId}' is not valid UTF-8: ${(cause as Error).message}`,
+			);
+		}
+		try {
+			return JSON.parse(text) as unknown;
+		} catch (cause) {
+			throw new ChunkingError(
+				`reassembled payload for group_id '${groupId}' is not valid JSON: ${(cause as Error).message}`,
+			);
+		}
+	}
+
+	/** Drop any buffer older than the configured timeout, returning dropped `group_id`s. */
+	sweepExpired(): string[] {
+		const dropped: string[] = [];
+		const cutoff = this.now() - this.timeoutMs;
+		for (const [groupId, buffer] of this.buffers) {
+			if (buffer.startedAt <= cutoff) {
+				this.dropBuffer(groupId);
+				dropped.push(groupId);
+			}
+		}
+		return dropped;
+	}
+
+	/** Number of in-flight reassembly buffers. Exposed for diagnostics + tests. */
+	get inFlightGroupCount(): number {
+		return this.buffers.size;
+	}
+
+	/** Decoded bytes currently retained across all incomplete groups. */
+	get inFlightBytes(): number {
+		return this.accumulatedBytes;
+	}
+
+	private dropBuffer(groupId: string): void {
+		const buffer = this.buffers.get(groupId);
+		if (buffer === undefined) {
+			return;
+		}
+		this.accumulatedBytes -= buffer.accumulatedBytes;
+		this.buffers.delete(groupId);
+	}
+}

--- a/src/vs/platform/agentHost/common/webPubSub/chunking.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/chunking.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Ported from github-ui `packages/ahp-relay/webpubsub/chunking.ts` (Microsoft, MIT).
+// Ported from github-ui `https://github.com/github/github-ui/blob/main/packages/ahp-relay/webpubsub/chunking.ts` (Microsoft, MIT).
 //
 // Chunking codec for the Web PubSub transport (`ChunkEnvelope`). Azure Web
 // PubSub rejects any WebSocket frame larger than 1 MB, and the reliable

--- a/src/vs/platform/agentHost/common/webPubSub/framing.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/framing.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Ported from github-ui `packages/ahp-relay/webpubsub/framing.ts` (Microsoft, MIT).
+// Ported from github-ui `https://github.com/github/github-ui/blob/main/packages/ahp-relay/webpubsub/framing.ts` (Microsoft, MIT).
 //
 // Web PubSub `sendToGroup` framing — outbound envelope builder + inbound parser.
 //

--- a/src/vs/platform/agentHost/common/webPubSub/framing.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/framing.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Ported from github-ui `packages/ahp-relay/webpubsub/framing.ts` (Microsoft, MIT).
+//
+// Web PubSub `sendToGroup` framing — outbound envelope builder + inbound parser.
+//
+// The layer above {@link chunk}: every outbound payload is wrapped in one or
+// more {@link ChunkEnvelope}s, each carried by a Web PubSub `sendToGroup`
+// command. The inbound path is the mirror image. This module is pure JSON ↔
+// JSON; it owns no WebSocket and speaks no handshake.
+
+import { type ChunkEnvelope, type ChunkOptions, Reassembler, chunk } from './chunking.js';
+import { parseGroupName, type ParseGroupNameOptions, type ParsedGroup } from './groups.js';
+
+/**
+ * The Web PubSub subprotocol used by every consumer of this transport. All
+ * framing is text-frame JSON.
+ */
+export const RELIABLE_JSON_SUBPROTOCOL = 'json.reliable.webpubsub.azure.v1';
+
+/**
+ * Web PubSub `sendToGroup` command on the outbound wire. `ackId` is a monotonic
+ * per-publisher counter scoped to the connection.
+ */
+export interface SendToGroupCommand {
+	readonly type: 'sendToGroup';
+	readonly group: string;
+	readonly ackId: number;
+	readonly dataType: 'json';
+	readonly noEcho: true;
+	readonly data: ChunkEnvelope;
+}
+
+/**
+ * Web PubSub group-message envelope on the inbound wire. The `from: 'group'`
+ * discriminant distinguishes group-fanout messages from service-level events.
+ */
+export interface GroupMessage {
+	readonly type: 'message';
+	readonly from: 'group';
+	readonly group: string;
+	readonly dataType: 'json';
+	readonly data: ChunkEnvelope;
+	readonly fromUserId?: string;
+	readonly sequenceId?: number;
+}
+
+/** Options accepted by {@link buildPublish}. */
+export interface BuildPublishOptions {
+	/** Target group name (must be a valid {@link parseGroupName} input). */
+	readonly group: string;
+
+	/** Source of monotonic `ackId` values for the publishing connection. */
+	readonly nextAckId: () => number;
+
+	/** Inner application payload. */
+	readonly payload: unknown;
+
+	/** Forwarded to {@link chunk}. */
+	readonly chunkOptions?: ChunkOptions;
+}
+
+/**
+ * Build the list of {@link SendToGroupCommand}s to publish for a single
+ * application payload. An oversized payload chunks into multiple envelopes,
+ * each carried by its own frame with its own `ackId`.
+ */
+export function buildPublish(options: BuildPublishOptions): SendToGroupCommand[] {
+	const envelopes = chunk(options.payload, options.chunkOptions);
+	return envelopes.map(
+		envelope => ({
+			type: 'sendToGroup',
+			group: options.group,
+			ackId: options.nextAckId(),
+			dataType: 'json',
+			noEcho: true,
+			data: envelope,
+		} satisfies SendToGroupCommand),
+	);
+}
+
+/**
+ * Result of {@link parseInbound}.
+ *
+ * - `kind: 'payload'` — a complete inner application payload is ready.
+ * - `kind: 'pending'` — a chunk segment was accepted; reassembly continues.
+ * - `kind: 'ignored'` — the frame was not a group-fanout message.
+ */
+export type InboundResult =
+	| { readonly kind: 'payload'; readonly group: ParsedGroup; readonly payload: unknown }
+	| { readonly kind: 'pending'; readonly group: ParsedGroup }
+	| { readonly kind: 'ignored' };
+
+/**
+ * Error thrown by {@link parseInbound} when a frame is definitely a
+ * group-fanout message but the receive envelope itself is malformed.
+ */
+export class FramingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'FramingError';
+	}
+}
+
+/** Options accepted by {@link parseInbound}. */
+export interface ParseInboundOptions {
+	/** Reassembler instance for this subscriber connection. */
+	readonly reassembler: Reassembler;
+
+	/** Forwarded to {@link parseGroupName}. */
+	readonly groupValidation?: ParseGroupNameOptions;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Decode one inbound Web PubSub frame (already JSON-parsed) into a structured
+ * {@link InboundResult}. Non group-fanout frames are `kind: 'ignored'`;
+ * malformed group-fanout frames raise a {@link FramingError}.
+ */
+export function parseInbound(frame: unknown, options: ParseInboundOptions): InboundResult {
+	if (!isObject(frame)) {
+		return { kind: 'ignored' };
+	}
+	if (frame['type'] !== 'message' || frame['from'] !== 'group') {
+		return { kind: 'ignored' };
+	}
+	if (frame['dataType'] !== 'json') {
+		throw new FramingError(`group-fanout frame has unsupported dataType '${String(frame['dataType'])}'`);
+	}
+	if (typeof frame['group'] !== 'string') {
+		throw new FramingError(`group-fanout frame is missing a string 'group' field`);
+	}
+	if (!isObject(frame['data'])) {
+		throw new FramingError(`group-fanout frame is missing a 'data' ChunkEnvelope`);
+	}
+
+	const group = parseGroupName(frame['group'], options.groupValidation);
+	const envelope = frame['data'] as ChunkEnvelope;
+	const payload = options.reassembler.ingest(envelope);
+	if (payload === null) {
+		return { kind: 'pending', group };
+	}
+	return { kind: 'payload', group, payload };
+}

--- a/src/vs/platform/agentHost/common/webPubSub/groups.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/groups.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Ported from github-ui `packages/ahp-relay/webpubsub/groups.ts` (Microsoft, MIT).
+//
+// Group-name validator/parser for the Web PubSub transport. Validates and
+// classifies inbound Web PubSub group names against the portable group-name
+// wire grammar. The lane names a client needs are received from Mission
+// Control's connect response; this module validates inbound names.
+//
+// Grammar:
+//
+//   group-name           = "user." <uid> "." "env." <eid> "." lane
+//   per-client-lane      = "client." <cid> "." direction
+//   direction            = "broadcast" | "to-host" | "to-client"
+//   per-environment-lane = "root" | "events" | "lifecycle" | "control" | "ingest-ack"
+//
+// Identifier segments are opaque and restricted to ASCII letters, digits,
+// underscores, and hyphens. The total group name must fit in
+// {@link MAX_GROUP_NAME_BYTES} UTF-8 bytes.
+
+/** Maximum length of a group name in UTF-8 bytes (operational-safety ceiling). */
+export const MAX_GROUP_NAME_BYTES = 256;
+
+/** Per-environment lane suffixes — the complete lane catalogue for env lanes. */
+export type EnvLane = 'root' | 'events' | 'lifecycle' | 'control' | 'ingest-ack';
+
+/** Per-client lane discriminator. */
+export type ClientLaneKind = 'broadcast' | 'to-host' | 'to-client';
+
+/** Structured result of {@link parseGroupName} for a per-client lane. */
+export type ParsedClientLane = {
+	readonly scope: 'client';
+	readonly lane: ClientLaneKind;
+	readonly cid: string;
+};
+
+/** Structured result of {@link parseGroupName} for a per-environment lane. */
+export type ParsedEnvLane = {
+	readonly scope: 'env';
+	readonly lane: EnvLane;
+};
+
+/** Parsed group name. Always carries `uid` and `eid`; `lane` discriminates scope. */
+export type ParsedGroup = (ParsedClientLane | ParsedEnvLane) & {
+	readonly uid: string;
+	readonly eid: string;
+};
+
+/**
+ * Error thrown by {@link parseGroupName} when a name violates the grammar's
+ * validation rules or the {@link MAX_GROUP_NAME_BYTES} ceiling.
+ */
+export class GroupNameError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'GroupNameError';
+	}
+}
+
+/** Options accepted by {@link parseGroupName}. */
+export interface ParseGroupNameOptions {
+	/**
+	 * If set, the parser rejects any group name whose `<uid>`, `<eid>`, or
+	 * per-client `<cid>` segment does not match. Omit a field to skip that check.
+	 */
+	readonly expected?: { readonly uid?: string; readonly eid?: string; readonly cid?: string };
+}
+
+const encoder = new TextEncoder();
+const OPAQUE_ID = /^[A-Za-z0-9_-]+$/;
+
+function validateOpaqueId(name: 'uid' | 'eid' | 'cid', value: string): void {
+	if (value.length === 0) {
+		throw new GroupNameError(`${name} segment is empty`);
+	}
+	if (!OPAQUE_ID.test(value)) {
+		throw new GroupNameError(`${name} segment contains characters outside the opaque-id grammar`);
+	}
+}
+
+/**
+ * Parse a group name into its structured components, throwing a
+ * {@link GroupNameError} on any rule violation.
+ */
+export function parseGroupName(name: string, options: ParseGroupNameOptions = {}): ParsedGroup {
+	const byteLength = encoder.encode(name).byteLength;
+	if (byteLength > MAX_GROUP_NAME_BYTES) {
+		throw new GroupNameError(`group name is ${byteLength} bytes, exceeds ${MAX_GROUP_NAME_BYTES}-byte cap`);
+	}
+	if (byteLength === 0) {
+		throw new GroupNameError('group name is empty');
+	}
+
+	const segments = name.split('.');
+	if (segments.length < 5) {
+		throw new GroupNameError(`expected at least 5 segments, got ${segments.length}: ${name}`);
+	}
+
+	if (segments[0] !== 'user') {
+		throw new GroupNameError(`expected first segment 'user', got '${segments[0]}'`);
+	}
+	const uid = segments[1] ?? '';
+	validateOpaqueId('uid', uid);
+	if (options.expected?.uid !== undefined && uid !== options.expected.uid) {
+		throw new GroupNameError(`uid '${uid}' does not match expected '${options.expected.uid}'`);
+	}
+
+	if (segments[2] !== 'env') {
+		throw new GroupNameError(`expected third segment 'env', got '${segments[2]}'`);
+	}
+	const eid = segments[3] ?? '';
+	validateOpaqueId('eid', eid);
+	if (options.expected?.eid !== undefined && eid !== options.expected.eid) {
+		throw new GroupNameError(`eid '${eid}' does not match expected '${options.expected.eid}'`);
+	}
+
+	const lane = segments.slice(4);
+
+	if (lane[0] === 'client') {
+		if (lane.length < 3) {
+			throw new GroupNameError(`client lane truncated: ${name}`);
+		}
+		const cid = lane[1] ?? '';
+		validateOpaqueId('cid', cid);
+		if (options.expected?.cid !== undefined && cid !== options.expected.cid) {
+			throw new GroupNameError(`cid '${cid}' does not match expected '${options.expected.cid}'`);
+		}
+		const direction = lane[2];
+		if (direction === 'broadcast' || direction === 'to-host' || direction === 'to-client') {
+			if (lane.length !== 3) {
+				throw new GroupNameError(`unexpected trailing segments after '${direction}': ${lane.slice(3).join('.')}`);
+			}
+			return { scope: 'client', lane: direction, uid, eid, cid };
+		}
+		throw new GroupNameError(`unknown client direction '${direction}'`);
+	}
+
+	if (lane.length !== 1) {
+		throw new GroupNameError(`env lane must be a single segment, got ${lane.length}: ${lane.join('.')}`);
+	}
+	const envLane = lane[0];
+	if (
+		envLane !== 'root' &&
+		envLane !== 'events' &&
+		envLane !== 'lifecycle' &&
+		envLane !== 'control' &&
+		envLane !== 'ingest-ack'
+	) {
+		throw new GroupNameError(`unknown env lane '${envLane}'`);
+	}
+	return { scope: 'env', lane: envLane, uid, eid };
+}

--- a/src/vs/platform/agentHost/common/webPubSub/groups.ts
+++ b/src/vs/platform/agentHost/common/webPubSub/groups.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Ported from github-ui `packages/ahp-relay/webpubsub/groups.ts` (Microsoft, MIT).
+// Ported from github-ui `https://github.com/github/github-ui/blob/main/packages/ahp-relay/webpubsub/groups.ts` (Microsoft, MIT).
 //
 // Group-name validator/parser for the Web PubSub transport. Validates and
 // classifies inbound Web PubSub group names against the portable group-name

--- a/src/vs/platform/agentHost/test/browser/webPubSubRelayTransport.test.ts
+++ b/src/vs/platform/agentHost/test/browser/webPubSubRelayTransport.test.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IWebSocketLike, WebPubSubRelayTransport } from '../../browser/webPubSubRelayTransport.js';
+
+const BROADCAST = 'user.u1.env.e1.client.c1.broadcast';
+const TO_CLIENT = 'user.u1.env.e1.client.c1.to-client';
+const TO_HOST = 'user.u1.env.e1.client.c1.to-host';
+
+/** A fake WebSocket the test drives directly. */
+class FakeWebSocket implements IWebSocketLike {
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	onclose: ((event: { code: number; reason: string }) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+
+	readonly sent: unknown[] = [];
+	closed = false;
+
+	send(data: string): void {
+		this.sent.push(JSON.parse(data));
+	}
+	close(): void {
+		this.closed = true;
+	}
+
+	/** Deliver an inbound JSON frame. */
+	emit(frame: unknown): void {
+		this.onmessage?.({ data: JSON.stringify(frame) });
+	}
+	emitClose(code = 1000, reason = ''): void {
+		this.onclose?.({ code, reason });
+	}
+	emitError(): void {
+		this.onerror?.(undefined);
+	}
+
+	/** Frames sent to the wire of the given WPS command `type`. */
+	sentOfType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter((f): f is Record<string, unknown> => typeof f === 'object' && f !== null && (f as Record<string, unknown>)['type'] === type);
+	}
+}
+
+suite('WebPubSubRelayTransport', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createTransport(fake: FakeWebSocket): WebPubSubRelayTransport {
+		return store.add(new WebPubSubRelayTransport({
+			url: 'wss://wps.example/client/hubs/h?access_token=tok&clientId=c1',
+			toHostGroup: TO_HOST,
+			joinGroups: [BROADCAST, TO_CLIENT],
+			webSocketFactory: () => fake,
+		}));
+	}
+
+	/** Drive the handshake to completion: connected → joinGroup acks. */
+	async function connectHandshake(transport: WebPubSubRelayTransport, fake: FakeWebSocket): Promise<void> {
+		const connected = transport.connect();
+		fake.emit({ type: 'system', event: 'connected' });
+		for (const join of fake.sentOfType('joinGroup')) {
+			fake.emit({ type: 'ack', ackId: join['ackId'], success: true });
+		}
+		await connected;
+	}
+
+	test('completes the handshake by joining broadcast + to_client and awaiting acks', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		await connectHandshake(transport, fake);
+
+		assert.deepStrictEqual(
+			fake.sentOfType('joinGroup').map(f => f['group']),
+			[BROADCAST, TO_CLIENT],
+		);
+		assert.strictEqual(transport.isOpen, true);
+	});
+
+	test('rejects the connect when a joinGroup ack reports failure', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		const connected = transport.connect();
+		fake.emit({ type: 'system', event: 'connected' });
+		const firstJoin = fake.sentOfType('joinGroup')[0];
+		fake.emit({ type: 'ack', ackId: firstJoin['ackId'], success: false });
+		await assert.rejects(() => connected, /joinGroup failed/);
+	});
+
+	test('rejects the connect when the socket closes during the handshake', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		const connected = transport.connect();
+		fake.emitClose(1006, 'gone');
+		await assert.rejects(() => connected, /closed before connection/);
+	});
+
+	test('surfaces an inbound group payload as an onMessage event', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		await connectHandshake(transport, fake);
+
+		const received = Event.toPromise(transport.onMessage);
+		const ahpMessage = { jsonrpc: '2.0', id: 7, result: { ok: true } };
+		fake.emit({ type: 'message', from: 'group', group: TO_CLIENT, dataType: 'json', data: { kind: 'message', data: ahpMessage } });
+
+		assert.deepStrictEqual(await received, ahpMessage);
+	});
+
+	test('publishes outbound messages to the to_host lane as sendToGroup frames', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		await connectHandshake(transport, fake);
+
+		const outbound = { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} };
+		transport.send(outbound as never);
+
+		const publishes = fake.sentOfType('sendToGroup');
+		assert.strictEqual(publishes.length, 1);
+		assert.deepStrictEqual(
+			{ group: publishes[0]['group'], dataType: publishes[0]['dataType'], noEcho: publishes[0]['noEcho'], data: publishes[0]['data'] },
+			{ group: TO_HOST, dataType: 'json', noEcho: true, data: { kind: 'message', data: outbound } },
+		);
+	});
+
+	test('fires onClose once when the socket closes after connect', async () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		await connectHandshake(transport, fake);
+
+		let closes = 0;
+		store.add(transport.onClose(() => closes++));
+		fake.emitClose();
+		fake.emitError();
+
+		assert.strictEqual(closes, 1);
+	});
+
+	test('throws when sending after dispose', () => {
+		const fake = new FakeWebSocket();
+		const transport = createTransport(fake);
+		transport.dispose();
+		assert.throws(() => transport.send({ jsonrpc: '2.0', id: 1, method: 'x' } as never));
+	});
+});

--- a/src/vs/platform/agentHost/test/common/cloudSandboxAgentHost.test.ts
+++ b/src/vs/platform/agentHost/test/common/cloudSandboxAgentHost.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	buildWpsUrl,
+	cloudSandboxAddress,
+	ICloudSandboxClientToken,
+} from '../../common/cloudSandboxAgentHost.js';
+
+suite('cloudSandbox url/address helpers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function token(overrides: Partial<ICloudSandboxClientToken>): ICloudSandboxClientToken {
+		return {
+			access_token: 'tok/with+special=',
+			expires_at: '2019-08-24T14:15:22Z',
+			wps_endpoint: 'wss://wps.example/client/hubs/h',
+			hub: 'h',
+			subprotocol: 'json.reliable.webpubsub.azure.v1',
+			client_id: 'client 1',
+			groups: { broadcast: 'b', to_client: 'tc', to_host: 'th' },
+			...overrides,
+		};
+	}
+
+	test('cloudSandboxAddress prefixes the environment id', () => {
+		assert.strictEqual(cloudSandboxAddress('env_42'), 'cloudsandbox:env_42');
+	});
+
+	test('buildWpsUrl attaches url-encoded access_token and clientId and forces wss', () => {
+		assert.strictEqual(
+			buildWpsUrl(token({})),
+			'wss://wps.example/client/hubs/h?access_token=tok%2Fwith%2Bspecial%3D&clientId=client%201',
+		);
+	});
+
+	test('buildWpsUrl upgrades ws/https endpoints to wss and respects existing query', () => {
+		assert.strictEqual(
+			buildWpsUrl(token({ wps_endpoint: 'https://wps.example/hubs/h?x=1', access_token: 't', client_id: 'c' })),
+			'wss://wps.example/hubs/h?x=1&access_token=t&clientId=c',
+		);
+		assert.strictEqual(
+			buildWpsUrl(token({ wps_endpoint: 'ws://wps.example/hubs/h', access_token: 't', client_id: 'c' })),
+			'wss://wps.example/hubs/h?access_token=t&clientId=c',
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/common/webPubSub/chunking.test.ts
+++ b/src/vs/platform/agentHost/test/common/webPubSub/chunking.test.ts
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer, encodeBase64 } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { type ChunkEnvelope, ChunkingError, Reassembler, chunk } from '../../../common/webPubSub/chunking.js';
+
+/** Standard base64 (padded) of an ASCII string — equivalent to `btoa(s)` for ASCII input. */
+function b64(s: string): string {
+	return encodeBase64(VSBuffer.fromString(s), true /* padded */, false /* urlSafe */);
+}
+
+function reassembleAll(envelopes: ChunkEnvelope[], r = new Reassembler()): unknown {
+	let result: unknown = null;
+	for (const env of envelopes) {
+		result = r.ingest(env);
+	}
+	return result;
+}
+
+suite('WebPubSub - chunk', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('wraps a small payload in a single message envelope', () => {
+		const envelopes = chunk({ hello: 'world' });
+		assert.deepStrictEqual(envelopes, [{ kind: 'message', data: { hello: 'world' } }]);
+	});
+
+	test('splits an oversized payload into multiple chunk envelopes', () => {
+		const big = { blob: 'x'.repeat(5000) };
+		const envelopes = chunk(big, { maxChunkBytes: 1024, newGroupId: () => 'g1' });
+		assert.ok(envelopes.length > 1);
+		assert.ok(envelopes.every(e => e.kind === 'chunk'));
+		const total = envelopes.length;
+		envelopes.forEach((e, i) => {
+			assert.deepStrictEqual(
+				{ kind: e.kind, group_id: (e as Extract<ChunkEnvelope, { kind: 'chunk' }>).group_id, seq: (e as Extract<ChunkEnvelope, { kind: 'chunk' }>).seq, total: (e as Extract<ChunkEnvelope, { kind: 'chunk' }>).total },
+				{ kind: 'chunk', group_id: 'g1', seq: i, total },
+			);
+		});
+	});
+
+	test('matches the pinned 200-byte portable split vector', () => {
+		const payload = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.repeat(7);
+		const groupId = '00000000-0000-4000-8000-000000000000';
+		assert.deepStrictEqual(chunk(payload, { maxChunkBytes: 200, newGroupId: () => groupId }), [
+			{
+				kind: 'chunk',
+				group_id: groupId,
+				seq: 0,
+				total: 3,
+				bytes: 'IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpBQkNERUZHSElKS0xNTk9QUVJT',
+			},
+			{
+				kind: 'chunk',
+				group_id: groupId,
+				seq: 1,
+				total: 3,
+				bytes: 'VFVWV1hZWkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpBQkNERUZHSElKS0xN',
+			},
+			{
+				kind: 'chunk',
+				group_id: groupId,
+				seq: 2,
+				total: 3,
+				bytes: 'Tk9QUVJTVFVWV1hZWkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIg==',
+			},
+		]);
+	});
+
+	test('round-trips a chunked payload through the reassembler', () => {
+		const original = { items: Array.from({ length: 200 }, (_, i) => ({ i, v: `value-${i}` })) };
+		const envelopes = chunk(original, { maxChunkBytes: 1024, newGroupId: () => 'g1' });
+		assert.deepStrictEqual(reassembleAll(envelopes), original);
+	});
+
+	test('rejects a non-positive ceiling', () => {
+		assert.throws(() => chunk({ a: 1 }, { maxChunkBytes: 0 }), ChunkingError);
+	});
+
+	test('rejects serialized logical payloads above 32 MiB before emitting chunks', () => {
+		assert.throws(() => chunk('x'.repeat(32 * 1024 * 1024 + 1), { newGroupId: () => 'g1' }), /exceeds 33554432-byte ceiling/);
+	});
+});
+
+suite('WebPubSub - Reassembler', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns message-envelope data immediately', () => {
+		const r = new Reassembler();
+		assert.deepStrictEqual(r.ingest({ kind: 'message', data: { a: 1 } }), { a: 1 });
+	});
+
+	test('returns null until the final chunk arrives', () => {
+		const envelopes = chunk({ blob: 'y'.repeat(4000) }, { maxChunkBytes: 1024, newGroupId: () => 'g1' });
+		const r = new Reassembler();
+		for (let i = 0; i < envelopes.length - 1; i++) {
+			assert.strictEqual(r.ingest(envelopes[i]!), null);
+		}
+		assert.deepStrictEqual(r.ingest(envelopes.at(-1)!), { blob: 'y'.repeat(4000) });
+		assert.strictEqual(r.inFlightGroupCount, 0);
+	});
+
+	test('throws on a total mismatch within a group', () => {
+		const r = new Reassembler();
+		r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') });
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g1', seq: 1, total: 3, bytes: b64('bb') }), /total mismatch/);
+	});
+
+	test('throws on a duplicate seq', () => {
+		const r = new Reassembler();
+		r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') });
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') }), /duplicate seq/);
+	});
+
+	test('throws on an out-of-range seq', () => {
+		const r = new Reassembler();
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g1', seq: 5, total: 2, bytes: b64('aa') }), /out of range/);
+	});
+
+	test('throws on non-canonical base64', () => {
+		const r = new Reassembler();
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 1, bytes: 'not base64!!' }), /not canonical/);
+	});
+
+	test('throws when total exceeds the segment cap', () => {
+		const r = new Reassembler({ maxSegmentsPerGroup: 2 });
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 3, bytes: b64('aa') }), /exceeds maxSegmentsPerGroup/);
+	});
+
+	test('sweeps expired partial buffers', () => {
+		let clock = 0;
+		const r = new Reassembler({ timeoutMs: 100, now: () => clock });
+		r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') });
+		assert.strictEqual(r.inFlightGroupCount, 1);
+		clock = 200;
+		assert.deepStrictEqual(r.sweepExpired(), ['g1']);
+		assert.strictEqual(r.inFlightGroupCount, 0);
+		assert.strictEqual(r.inFlightBytes, 0);
+	});
+
+	test('enforces the aggregate retained-byte ceiling and releases the rejected group', () => {
+		const r = new Reassembler({ maxBufferBytes: 10, maxTotalBufferBytes: 3 });
+		assert.strictEqual(r.ingest({ kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') }), null);
+		assert.throws(() => r.ingest({ kind: 'chunk', group_id: 'g2', seq: 0, total: 2, bytes: b64('bb') }), /aggregate reassembly bytes/);
+		assert.strictEqual(r.inFlightGroupCount, 1);
+		assert.strictEqual(r.inFlightBytes, 2);
+	});
+});

--- a/src/vs/platform/agentHost/test/common/webPubSub/framing.test.ts
+++ b/src/vs/platform/agentHost/test/common/webPubSub/framing.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer, encodeBase64 } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Reassembler } from '../../../common/webPubSub/chunking.js';
+import { FramingError, RELIABLE_JSON_SUBPROTOCOL, buildPublish, parseInbound } from '../../../common/webPubSub/framing.js';
+
+/** Standard base64 (padded) of an ASCII string — equivalent to `btoa(s)` for ASCII input. */
+function b64(s: string): string {
+	return encodeBase64(VSBuffer.fromString(s), true /* padded */, false /* urlSafe */);
+}
+
+const GROUP = 'user.u1.env.e1.client.c1.to-client';
+
+suite('WebPubSub - framing', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('exposes the reliable JSON subprotocol constant', () => {
+		assert.strictEqual(RELIABLE_JSON_SUBPROTOCOL, 'json.reliable.webpubsub.azure.v1');
+	});
+
+	test('builds a single sendToGroup command for a small payload', () => {
+		let ack = 0;
+		const commands = buildPublish({ group: GROUP, nextAckId: () => ++ack, payload: { hi: true } });
+		assert.deepStrictEqual(commands, [{
+			type: 'sendToGroup',
+			group: GROUP,
+			ackId: 1,
+			dataType: 'json',
+			noEcho: true,
+			data: { kind: 'message', data: { hi: true } },
+		}]);
+	});
+
+	test('builds one command per chunk with monotonic ackIds', () => {
+		let ack = 0;
+		const commands = buildPublish({
+			group: GROUP,
+			nextAckId: () => ++ack,
+			payload: { blob: 'z'.repeat(5000) },
+			chunkOptions: { maxChunkBytes: 1024, newGroupId: () => 'g1' },
+		});
+		assert.ok(commands.length > 1);
+		assert.deepStrictEqual(commands.map(c => c.ackId), commands.map((_, i) => i + 1));
+	});
+
+	test('parses an inbound group payload frame', () => {
+		const reassembler = new Reassembler();
+		const result = parseInbound(
+			{ type: 'message', from: 'group', group: GROUP, dataType: 'json', data: { kind: 'message', data: { ok: 1 } } },
+			{ reassembler },
+		);
+		assert.deepStrictEqual(result, {
+			kind: 'payload',
+			group: { scope: 'client', lane: 'to-client', uid: 'u1', eid: 'e1', cid: 'c1' },
+			payload: { ok: 1 },
+		});
+	});
+
+	test('reports pending while chunks are still arriving', () => {
+		const reassembler = new Reassembler();
+		const first = parseInbound(
+			{
+				type: 'message',
+				from: 'group',
+				group: GROUP,
+				dataType: 'json',
+				data: { kind: 'chunk', group_id: 'g1', seq: 0, total: 2, bytes: b64('aa') },
+			},
+			{ reassembler },
+		);
+		assert.strictEqual(first.kind, 'pending');
+	});
+
+	test('ignores non group-fanout frames', () => {
+		const reassembler = new Reassembler();
+		assert.strictEqual(parseInbound({ type: 'ack', ackId: 1 }, { reassembler }).kind, 'ignored');
+		assert.strictEqual(parseInbound(null, { reassembler }).kind, 'ignored');
+		assert.strictEqual(parseInbound({ type: 'message', from: 'server' }, { reassembler }).kind, 'ignored');
+	});
+
+	test('throws FramingError on malformed group-fanout frames', () => {
+		const reassembler = new Reassembler();
+		assert.throws(
+			() => parseInbound({ type: 'message', from: 'group', dataType: 'json', data: { kind: 'message', data: 1 } }, { reassembler }),
+			FramingError,
+		);
+		assert.throws(
+			() => parseInbound({ type: 'message', from: 'group', group: GROUP, dataType: 'xml', data: {} }, { reassembler }),
+			FramingError,
+		);
+		assert.throws(
+			() => parseInbound({ type: 'message', from: 'group', group: GROUP, dataType: 'json' }, { reassembler }),
+			FramingError,
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/common/webPubSub/groups.test.ts
+++ b/src/vs/platform/agentHost/test/common/webPubSub/groups.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { GroupNameError, MAX_GROUP_NAME_BYTES, parseGroupName } from '../../../common/webPubSub/groups.js';
+
+suite('WebPubSub - parseGroupName', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('parses a per-client broadcast lane', () => {
+		const parsed = parseGroupName('user.u1.env.e1.client.c1.broadcast');
+		assert.deepStrictEqual(parsed, { scope: 'client', lane: 'broadcast', uid: 'u1', eid: 'e1', cid: 'c1' });
+	});
+
+	test('parses per-client to-host and to-client lanes', () => {
+		assert.strictEqual(parseGroupName('user.u1.env.e1.client.c1.to-host').lane, 'to-host');
+		assert.strictEqual(parseGroupName('user.u1.env.e1.client.c1.to-client').lane, 'to-client');
+	});
+
+	test('parses per-environment lanes', () => {
+		for (const lane of ['root', 'events', 'lifecycle', 'control', 'ingest-ack'] as const) {
+			const parsed = parseGroupName(`user.u1.env.e1.${lane}`);
+			assert.deepStrictEqual(parsed, { scope: 'env', lane, uid: 'u1', eid: 'e1' });
+		}
+	});
+
+	test('enforces expected uid/eid/cid when provided', () => {
+		assert.throws(() => parseGroupName('user.u1.env.e1.events', { expected: { uid: 'u2' } }), GroupNameError);
+		assert.throws(() => parseGroupName('user.u1.env.e1.events', { expected: { eid: 'e2' } }), GroupNameError);
+		assert.throws(() => parseGroupName('user.u1.env.e1.client.c1.broadcast', { expected: { cid: 'c2' } }), GroupNameError);
+		assert.strictEqual(parseGroupName('user.u1.env.e1.events', { expected: { uid: 'u1', eid: 'e1' } }).scope, 'env');
+	});
+
+	test('rejects an empty name', () => {
+		assert.throws(() => parseGroupName(''), GroupNameError);
+	});
+
+	test('rejects names with too few segments', () => {
+		assert.throws(() => parseGroupName('user.u1.env.e1'), GroupNameError);
+	});
+
+	test('rejects a wrong leading segment', () => {
+		assert.throws(() => parseGroupName('usr.u1.env.e1.events'), /expected first segment/);
+	});
+
+	test('rejects a wrong env segment', () => {
+		assert.throws(() => parseGroupName('user.u1.envx.e1.events'), /third segment/);
+	});
+
+	test('rejects empty uid/eid/cid segments', () => {
+		assert.throws(() => parseGroupName('user..env.e1.events'), /uid segment is empty/);
+		assert.throws(() => parseGroupName('user.u1.env..events'), /eid segment is empty/);
+		assert.throws(() => parseGroupName('user.u1.env.e1.client..broadcast'), /cid segment is empty/);
+	});
+
+	test('rejects identifier characters outside the portable opaque-id grammar', () => {
+		assert.throws(() => parseGroupName('user.user@github.env.e1.events'), /opaque-id grammar/);
+		assert.throws(() => parseGroupName('user.u1.env.e/1.events'), /opaque-id grammar/);
+		assert.throws(() => parseGroupName('user.u1.env.e1.client.c:1.broadcast'), /opaque-id grammar/);
+	});
+
+	test('rejects unknown env lanes and multi-segment env lanes', () => {
+		assert.throws(() => parseGroupName('user.u1.env.e1.bogus'), /unknown env lane/);
+		assert.throws(() => parseGroupName('user.u1.env.e1.events.extra'), /single segment/);
+	});
+
+	test('rejects unknown client directions and trailing segments', () => {
+		assert.throws(() => parseGroupName('user.u1.env.e1.client.c1.sideways'), /unknown client direction/);
+		assert.throws(() => parseGroupName('user.u1.env.e1.client.c1.broadcast.extra'), /trailing segments/);
+		assert.throws(() => parseGroupName('user.u1.env.e1.client.c1'), /client lane truncated/);
+	});
+
+	test('rejects names exceeding the byte cap', () => {
+		const huge = `user.u1.env.${'e'.repeat(MAX_GROUP_NAME_BYTES)}.events`;
+		assert.throws(() => parseGroupName(huge), /exceeds/);
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -20,7 +20,7 @@ import { ConfigurationTarget, type IConfigurationValue } from '../../../configur
 import { ContentEncoding, ReconnectResultType } from '../../common/state/protocol/commands.js';
 import { ChatSourceKind } from '../../common/state/protocol/channels-chat/commands.js';
 import { AhpErrorCodes } from '../../common/state/protocol/errors.js';
-import { PROTOCOL_VERSION } from '../../common/state/protocol/version/registry.js';
+import { PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '../../common/state/protocol/version/registry.js';
 import { ActionType, type ChatTurnStartedAction, type SessionActiveClientSetAction, type SessionActiveClientRemovedAction, type SessionTitleChangedAction } from '../../common/state/sessionActions.js';
 import { ProtocolError, type AhpServerNotification, type JsonRpcNotification, type JsonRpcRequest, type JsonRpcResponse, type ProtocolMessage } from '../../common/state/sessionProtocol.js';
 import { hasKey } from '../../../../base/common/types.js';
@@ -796,10 +796,13 @@ suite('RemoteAgentHostProtocolClient', () => {
 			clientId: params.clientId,
 			clientInfo: params.clientInfo,
 		}, {
-			protocolVersions: [PROTOCOL_VERSION],
+			// Every negotiable version is offered so an older host can negotiate down,
+			// newest first so a current host still picks it.
+			protocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
 			clientId: 'renderer-client-id',
 			clientInfo,
 		});
+		assert.strictEqual(params.protocolVersions[0], PROTOCOL_VERSION);
 
 		// Reply with a successful handshake so `connect()` resolves and the
 		// test can finish cleanly.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -735,8 +735,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		// Files created/edited/deleted outside the workspace, plus the last turn's
 		// changes, parsed from the chat-state turns. Computed lazily from the same
 		// active-session subscriptions used for changes.
-		const sessionUri = AgentSession.uri(this.sessionType, rawId);
-		const sessionOutput = createSessionOutputObs(sessionUri, this._options, this.isActiveSessionObs, this.isArchived, this.workspace);
+		const sessionOutput = createSessionOutputObs(this.backendUri, this._options, this.isActiveSessionObs, this.isArchived, this.workspace);
 		this._sessionOutput = sessionOutput;
 		this.externalChanges = sessionOutput.externalFiles;
 
@@ -747,7 +746,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			updatedAt: this.updatedAt,
 			status: derived(this, reader => this._defaultChatStatusOverride.read(reader) ?? this.status.read(reader)),
 			changes: this.changes,
-			lastTurnChanges: sessionOutput.getLastTurnChanges(URI.parse(buildDefaultChatUri(sessionUri))),
+			lastTurnChanges: sessionOutput.getLastTurnChanges(URI.parse(buildDefaultChatUri(this.backendUri))),
 			checkpoints: observableValue(this, undefined),
 			modelId: this.modelId,
 			mode: this.mode,
@@ -1282,9 +1281,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			return;
 		}
 
-		const rawId = AgentSession.id(this.resource);
-		const sessionUri = AgentSession.uri(this.sessionType, rawId);
-		const changesets = createChangesets(sessionUri, this._options, this.isActiveSessionObs, changesetsMetadata);
+		const changesets = createChangesets(this.backendUri, this._options, this.isActiveSessionObs, changesetsMetadata);
 
 		this.changesets.set(changesets, undefined);
 	}
@@ -1802,9 +1799,7 @@ class NewSession extends Disposable {
 			return;
 		}
 
-		const rawId = AgentSession.id(this.session.resource);
-		const sessionUri = AgentSession.uri(this.session.sessionType, rawId);
-		const changesets = createChangesets(sessionUri, this._options, this._isActiveSessionObs, changesetsMetadata);
+		const changesets = createChangesets(this._backendSessionUri, this._options, this._isActiveSessionObs, changesetsMetadata);
 
 		this._changesets.set(changesets, undefined);
 	}
@@ -4609,11 +4604,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	private _handleSessionAdded(summary: SessionSummary): void {
-		const sessionUri = URI.parse(summary.resource);
-		const rawId = AgentSession.id(sessionUri);
 		const workingDirs = summary.workingDirectories?.map(d => this.mapWorkingDirectoryUri(URI.parse(d)));
-		const meta: IAgentSessionMetadata = {
-			session: sessionUri,
+		const rawMeta: IAgentSessionMetadata = {
+			session: URI.parse(summary.resource),
 			startTime: Date.parse(summary.createdAt),
 			modifiedTime: Date.parse(summary.modifiedAt),
 			summary: summary.title,
@@ -4631,6 +4624,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			// existing one can be promoted by it.
 			...(summary._meta !== undefined ? { _meta: summary._meta } : {}),
 		};
+
+		// Adopt before deriving the cache key so a host that addresses sessions under a different
+		// scheme routes to the agent provider, as the refresh and persistence paths do.
+		const meta = this._adoptSessionMeta(rawMeta);
+		const rawId = AgentSession.id(meta.session);
 
 		const existing = this._sessionCache.get(rawId);
 		if (existing) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -277,6 +277,11 @@ export interface IAgentHostAdapterOptions {
 	readonly getConnection: () => IAgentConnection | undefined;
 	/** Agent capability lookup shared by every adapter owned by this provider. */
 	readonly agentCapabilities: IObservable<ReadonlyMap<string, AgentCapabilities | undefined> | undefined>;
+	/**
+	 * The scheme the host addresses this session under, when it differs from the agent provider
+	 * (cloud sandbox: provider `copilot`, sessions `ahp-session:/<id>`). Defaults to the provider.
+	 */
+	readonly backendSessionScheme?: string;
 }
 
 /**
@@ -513,6 +518,12 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	private readonly _resourceScheme: string;
 
 	readonly agentProvider: string;
+	/**
+	 * This session's URI as the host's registry is keyed by it, which may use a different scheme
+	 * than {@link agentProvider} (cloud sandbox: provider `copilot`, backend `ahp-session:/<id>`).
+	 * Every backend call must address the session by this URI.
+	 */
+	readonly backendUri: URI;
 
 	// Retained so we can rebuild `workspace` when only `_meta` changes via
 	// a `SessionMetaChanged` action dispatched on session open (without a full
@@ -595,6 +606,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			throw new Error(`Agent session URI has no provider scheme: ${metadata.session.toString()}`);
 		}
 		this.agentProvider = agentProvider;
+		this.backendUri = AgentSession.uri(_options.backendSessionScheme ?? agentProvider, rawId);
 		this.resource = URI.from({ scheme: resourceScheme, path: `/${rawId}` });
 		this._rawId = rawId;
 		this._resourceScheme = resourceScheme;
@@ -1334,6 +1346,14 @@ interface INewSessionConstructionContext {
 	readonly providerId: string;
 	readonly icon: ThemeIcon;
 	readonly resourceScheme: string;
+	/**
+	 * The URI scheme used to reconstruct this draft's backend (wire) session URI,
+	 * when it differs from the agent provider ({@link sessionType}.id). Defaults to
+	 * the agent provider. Cloud sandbox creates sessions under `ahp-session:/<id>`
+	 * while the agent provider is `copilot`; the eager backend `createSession`/
+	 * subscribe must use this scheme so it matches the handler's create path.
+	 */
+	readonly backendSessionScheme?: string;
 	readonly authenticationPending: IObservable<boolean>;
 	readonly logService: ILogService;
 	/**
@@ -1397,6 +1417,8 @@ class NewSession extends Disposable {
 	readonly session: ISession;
 	readonly sessionId: string;
 	readonly agentProvider: string;
+	/** This draft's URI as the host's registry would key it. See {@link AgentHostSessionAdapter.backendUri}. */
+	private readonly _backendSessionUri: URI;
 	readonly workspaceUri: URI | undefined;
 	readonly requiresWorkspaceTrust: boolean;
 	/** `true` when this is a workspace-less quick chat. */
@@ -1484,6 +1506,9 @@ class NewSession extends Disposable {
 
 		const resource = URI.from({ scheme: ctx.resourceScheme, path: `/${generateUuid()}` });
 		this._isActiveSessionObs = derived(this, reader => isEqual(sessionsService.activeSession.read(reader)?.resource, resource));
+		// Defaults to scheme == provider; only hosts that address sessions under a different
+		// scheme (cloud sandbox: provider `copilot`, scheme `ahp-session`) override it.
+		this._backendSessionUri = AgentSession.uri(ctx.backendSessionScheme ?? this.agentProvider, AgentSession.id(resource));
 		this._status = observableValue<SessionStatus>(this, SessionStatus.Untitled);
 		this._title = observableValue<string>(this, '');
 		const title = this._title;
@@ -1702,7 +1727,7 @@ class NewSession extends Disposable {
 	 * no session state exists at send time.
 	 */
 	eagerCreate(connection: IAgentConnection): void {
-		const backendUri = AgentSession.uri(this.agentProvider, this.session.resource.path.substring(1));
+		const backendUri = this._backendSessionUri;
 		if (this._backendUri?.toString() === backendUri.toString() || this._subscription) {
 			return;
 		}
@@ -2140,6 +2165,32 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 */
 	protected abstract _adapterOptions(): Pick<IAgentHostAdapterOptions, 'buildWorkspace'>;
 
+	/**
+	 * Hook to normalize a session's metadata before it is cached, keyed, or
+	 * persisted. The default is identity. Subclasses override this when the host
+	 * addresses sessions under a scheme that differs from the agent provider
+	 * (e.g. a cloud sandbox host that lists sessions as `ahp-session:/<id>` while
+	 * its agent provider is `copilot`), so that routing, persistence, and content
+	 * resolution all agree on a single scheme. Must preserve the raw session id
+	 * (URI path) so cache keys remain stable.
+	 */
+	protected _adoptSessionMeta(meta: IAgentSessionMetadata): IAgentSessionMetadata {
+		return meta;
+	}
+
+	/**
+	 * The backend (wire) session URI scheme for a given agent provider. Default is
+	 * identity (scheme == provider), which holds for every host except the Copilot
+	 * host used by cloud sandbox, whose sessions are addressed under
+	 * `ahp-session:/<id>` while the agent provider is `copilot`. Subclasses
+	 * override this so all backend `AgentSession.uri(...)` reconstructions on the
+	 * adapter and provider use the host's real scheme. Must be a stable per-provider
+	 * mapping.
+	 */
+	protected _backendSessionScheme(agentProvider: string): string {
+		return agentProvider;
+	}
+
 	/** Build an adapter for the given metadata. */
 	protected createAdapter(meta: IAgentSessionMetadata): AgentHostSessionAdapter {
 		const provider = AgentSession.provider(meta.session);
@@ -2156,6 +2207,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			instantiationService: this._instantiationService,
 			getConnection: () => this.connection,
 			agentCapabilities: this._agentCapabilities,
+			backendSessionScheme: this._backendSessionScheme(provider),
 			...this._adapterOptions(),
 		} satisfies IAgentHostAdapterOptions;
 
@@ -2453,6 +2505,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			providerId: this.id,
 			icon: sessionType.icon,
 			resourceScheme,
+			backendSessionScheme: this._backendSessionScheme(sessionType.id),
 			authenticationPending: this.authenticationPending,
 			logService: this._logService,
 			initialConfigValues: this._initialNewSessionConfig(workspace),
@@ -2800,7 +2853,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const rawId = this._rawIdFromChatId(sessionId);
 		const cached = rawId ? this._sessionCache.get(rawId) : undefined;
 		if (cached && rawId) {
-			const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+			const sessionUri = cached.backendUri;
 			const action = { type: ActionType.SessionConfigChanged as const, config: { [property]: normalizedValue } };
 			connection.dispatch(sessionUri.toString(), action);
 			void this._resolveRunningSessionConfig(sessionId, cached, nextValues);
@@ -2847,7 +2900,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const rawId = this._rawIdFromChatId(sessionId);
 		const cached = rawId ? this._sessionCache.get(rawId) : undefined;
 		if (cached && rawId) {
-			const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+			const sessionUri = cached.backendUri;
 			const action = {
 				type: ActionType.SessionConfigChanged as const,
 				config: nextValues,
@@ -3204,7 +3257,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!cached || !rawId) {
 			return [];
 		}
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		return (sessionState.customizations ?? [])
 			.flatMap(c => c.type === CustomizationType.McpServer
 				? [c]
@@ -3261,7 +3314,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!cached || !rawId) {
 			return undefined;
 		}
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const annotationsUri = URI.parse(buildAnnotationsUri(sessionUri.toString()));
 		return { connection, annotationsUri };
 	}
@@ -3276,7 +3329,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 			const connection = this.connection;
 			if (connection) {
-				const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+				const sessionUri = cached.backendUri;
 				const action = { type: ActionType.SessionIsArchivedChanged as const, isArchived: true };
 				connection.dispatch(sessionUri.toString(), action);
 			}
@@ -3291,7 +3344,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 			const connection = this.connection;
 			if (connection) {
-				const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+				const sessionUri = cached.backendUri;
 				const action = { type: ActionType.SessionIsArchivedChanged as const, isArchived: false };
 				connection.dispatch(sessionUri.toString(), action);
 			}
@@ -3306,7 +3359,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 			const connection = this.connection;
 			if (connection) {
-				const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+				const sessionUri = cached.backendUri;
 				const action = { type: ActionType.SessionIsReadChanged as const, isRead };
 				connection.dispatch(sessionUri.toString(), action);
 			}
@@ -3334,7 +3387,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return;
 		}
 		for (const { rawId, sessionId, cached } of targets) {
-			await connection.disposeSession(AgentSession.uri(cached.agentProvider, rawId));
+			await connection.disposeSession(cached.backendUri);
 			this._sessionCache.delete(rawId);
 			this._runningSessionConfigs.delete(sessionId);
 			this._runningSessionConfigResolveSeq.delete(sessionId);
@@ -3353,7 +3406,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!cached || !rawId || !connection) {
 			return;
 		}
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const chatId = chatUri.fragment;
 		const action = { type: ActionType.SessionTitleChanged as const, title };
 		if (chatId) {
@@ -3377,7 +3430,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (cached && rawId && connection) {
 			cached.title.set(title, undefined);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
-			const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+			const sessionUri = cached.backendUri;
 			const action = { type: ActionType.SessionTitleChanged as const, title };
 			connection.dispatch(sessionUri.toString(), action);
 		}
@@ -3396,7 +3449,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!rawId || !cached || !connection) {
 			return false;
 		}
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const ahpChatUri = URI.parse(buildChatUri(sessionUri, chatId));
 
 		if (!options?.skipConfirmation) {
@@ -3447,7 +3500,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(`Session '${chatId}' does not support multiple chats`);
 		}
 
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const newChatId = generateUuid();
 		const chatUri = URI.parse(buildChatUri(sessionUri, newChatId));
 		const selectedModelId = cached.modelId.get() ?? (cached.modelSelection ? `${cached.resource.scheme}:${cached.modelSelection.id}` : undefined);
@@ -3490,7 +3543,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(`Session '${sessionId}' does not support multiple chats`);
 		}
 
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const newChatId = generateUuid();
 		const chatUri = URI.parse(buildChatUri(sessionUri, newChatId));
 		const sourceBackendUri = this._resolveBackendSourceChatUri(cached.sessionId, sessionUri, sourceChat);
@@ -3975,7 +4028,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!cached) {
 			return;
 		}
-		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const sessionUri = cached.backendUri;
 		const ref = connection.getSubscription(StateComponents.Session, sessionUri, 'BaseAgentHostSessionsProvider.summary');
 		const store = new DisposableStore();
 		store.add(ref);
@@ -4273,10 +4326,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return;
 		}
 		for (const entry of parsed as readonly ISerializedSessionMetadata[]) {
-			const meta = deserializeMetadata(entry);
-			if (!meta) {
+			const deserialized = deserializeMetadata(entry);
+			if (!deserialized) {
 				continue;
 			}
+			const meta = this._adoptSessionMeta(deserialized);
 			const rawId = AgentSession.id(meta.session);
 			if (this._sessionCache.has(rawId)) {
 				continue;
@@ -4361,7 +4415,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			const added: ISession[] = [];
 			const changed: ISession[] = [];
 
-			for (const meta of sessions) {
+			for (const rawMeta of sessions) {
+				const meta = this._adoptSessionMeta(rawMeta);
 				const rawId = AgentSession.id(meta.session);
 				currentKeys.add(rawId);
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHost.contribution.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { ICloudSandboxAgentHostService, ICloudSandboxCredentialsService } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { CloudSandboxAgentHostService } from './cloudSandboxAgentHostService.js';
+import { CloudSandboxAgentHostContribution } from './cloudSandboxAgentHostContribution.js';
+import { CloudSandboxCredentialsService } from './cloudSandboxCredentialsService.js';
+
+registerSingleton(ICloudSandboxCredentialsService, CloudSandboxCredentialsService, InstantiationType.Delayed);
+registerSingleton(ICloudSandboxAgentHostService, CloudSandboxAgentHostService, InstantiationType.Delayed);
+
+registerWorkbenchContribution2(CloudSandboxAgentHostContribution.ID, CloudSandboxAgentHostContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
@@ -1,0 +1,403 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Surfaces Copilot cloud sandbox (copilot-developer-cli) sessions as native agent-host sessions.
+// Owns a RemoteAgentHostSessionsProvider per sandbox environment, connects on demand via
+// CloudSandboxAgentHostService, and wires the live connection to the provider so the native session
+// machinery can enumerate and render the host's sessions.
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import {
+	CLOUD_SANDBOX_AGENT_PROVIDER,
+	CLOUD_SANDBOX_SESSION_SCHEME,
+	CloudSandboxEnabledSettingId,
+	CloudSandboxEnvironmentOfflineError,
+	cloudSandboxAddress,
+	ICloudSandboxAgentHostService,
+	ICloudSandboxCredentialsService,
+	type ICloudSandboxConnectOptions,
+	type ICloudSandboxDiscoveredSession,
+} from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { AgentSession, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
+import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { findRemoteAgentHostSessionTypeAuthority, remoteAgentHostSessionTypeId } from '../../../../../platform/agentHost/common/agentHostSessionType.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IWorkbenchContribution } from '../../../../../workbench/common/contributions.js';
+import { ChatSessionsExtensions, IAsyncChatSessionActivationRegistry } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionSchemeAlias, RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
+import { IRemoteAgentHostConnectionCustomizationService } from './remoteAgentHostConnectionCustomization.js';
+import { createCloudSandboxConnectionCustomization, isCloudSandboxConnectionAddress } from './cloudSandboxConnectionCustomization.js';
+import { watchForIncompatibleNotifications } from './remoteHostOptions.js';
+
+const LOG_PREFIX = '[CloudSandboxAgentHost]';
+
+/**
+ * Mission Control creates every sandbox session as `ahp-session:/<id>` while the host advertises the
+ * `copilot` agent, so the two schemes name the same session.
+ */
+const SANDBOX_SESSION_SCHEME_ALIAS: ISessionSchemeAlias = {
+	ui: CLOUD_SANDBOX_AGENT_PROVIDER,
+	backend: CLOUD_SANDBOX_SESSION_SCHEME,
+};
+
+/** A discovered sandbox environment we can create a provider for. */
+interface ICloudSandboxEnvironment {
+	readonly environmentId: string;
+	readonly sessionId?: string;
+	readonly name: string;
+}
+
+export class CloudSandboxAgentHostContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.cloudSandboxAgentHost';
+
+	/** Provider instances keyed by connection address (`cloudsandbox:<envId>`). */
+	private readonly _providerInstances = new Map<string, RemoteAgentHostSessionsProvider>();
+	private readonly _providerStores = this._register(new DisposableMap<string>());
+	/** Environment metadata keyed by connection address, for on-demand reconnect. */
+	private readonly _environments = new Map<string, ICloudSandboxEnvironment>();
+	/** In-flight connects keyed by address, so concurrent opens share one attempt. */
+	private readonly _pendingConnects = new Map<string, Promise<string>>();
+	/** Serializes discovery so overlapping triggers can't interleave reconciliation. */
+	private _discoveryInFlight: Promise<void> | undefined;
+	private _discoveryQueued: Promise<void> | undefined;
+	/** Whether discovery has completed at least once, used to stop the auth-driven retry. */
+	private _hasDiscovered = false;
+
+	constructor(
+		@ICloudSandboxAgentHostService private readonly _cloudSandboxService: ICloudSandboxAgentHostService,
+		@ICloudSandboxCredentialsService private readonly _credentialsService: ICloudSandboxCredentialsService,
+		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
+		@IRemoteAgentHostConnectionCustomizationService private readonly _connectionCustomizations: IRemoteAgentHostConnectionCustomizationService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@INotificationService private readonly _notificationService: INotificationService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		// Supply the generic remote-agent-host contribution with the sandbox host's per-connection
+		// deviations (sealed-token auth + `ahp-session` backend scheme) without leaking sandbox
+		// specifics into that shared code path.
+		this._register(this._connectionCustomizations.register(
+			isCloudSandboxConnectionAddress,
+			address => createCloudSandboxConnectionCustomization(address, this._cloudSandboxService)!,
+		));
+
+		// Keep providers wired to their live connections and their status fresh.
+		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
+			this._wireConnections();
+			this._updateConnectionStatuses();
+		}));
+
+		// React to the feature toggles at runtime: (re)discover when enabled, tear everything down
+		// when disabled, so enabling the setting doesn't require a reload and disabling it doesn't
+		// leave stale providers, connections, or credential refreshers behind.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(CloudSandboxEnabledSettingId) || e.affectsConfiguration(RemoteAgentHostsEnabledSettingId)) {
+				if (this._isEnabled()) {
+					void this._discoverAndSeed();
+				} else {
+					this._teardownAll();
+				}
+			}
+		}));
+
+		// Lazy discovery: surface environment-bound sandbox sessions in the list
+		// without connecting. Runs when the Agents window (re)discovers hosts and
+		// once now so sessions appear on startup. Connecting happens on open via
+		// the sandbox async activator.
+		this._register(this._agentHostFilterService.registerDiscoveryHandler(() => this._discoverAndSeed()));
+		void this._discoverAndSeed();
+
+		// Discovery needs a GitHub session, and the auth provider is contributed by an extension that
+		// may not be registered yet at startup. Retry as sessions become available, until the first
+		// success; from then on the discovery handler above drives refreshes.
+		const retryUntilFirstSuccess = this._register(new DisposableStore());
+		const retry = () => {
+			if (this._hasDiscovered) {
+				retryUntilFirstSuccess.clear();
+				return;
+			}
+			void this._discoverAndSeed();
+		};
+		retryUntilFirstSuccess.add(this._authenticationService.onDidChangeSessions(retry));
+		retryUntilFirstSuccess.add(this._authenticationService.onDidRegisterAuthenticationProvider(retry));
+
+		// Connect-on-open: when a seeded sandbox session is opened, the chat
+		// service resolves it through this async activator, which establishes the
+		// relay connection and waits for the host to advertise the session's agent
+		// (so its content provider registers) before the chat loads. Scoped to our
+		// sandbox authorities so it never intercepts other remote-agent-host types.
+		this._register(Registry.as<IAsyncChatSessionActivationRegistry>(ChatSessionsExtensions.AsyncActivation).register({
+			matchSessionType: sessionType => this._findAddressForSessionType(sessionType) !== undefined,
+			waitForActivation: (_accessor, sessionType) => this._waitForActivation(sessionType),
+		}));
+	}
+
+	/**
+	 * Discover environment-bound sandbox sessions and seed them into per-environment providers so
+	 * they appear in the sessions list **without** connecting. Reconciles against the result:
+	 * environments that have vanished from discovery (e.g. their task was archived) and are not
+	 * currently connected are torn down, so stale providers/sessions don't linger. Best-effort:
+	 * a failed discovery is logged and leaves existing state untouched.
+	 *
+	 * Runs are serialized, with at most one follow-up queued, so overlapping triggers can't
+	 * interleave their reconciliation passes.
+	 */
+	private _discoverAndSeed(): Promise<void> {
+		if (this._discoveryInFlight) {
+			this._discoveryQueued ??= this._discoveryInFlight.then(() => {
+				this._discoveryQueued = undefined;
+				return this._discoverAndSeed();
+			});
+			return this._discoveryQueued;
+		}
+		this._discoveryInFlight = this._doDiscoverAndSeed().finally(() => {
+			this._discoveryInFlight = undefined;
+		});
+		return this._discoveryInFlight;
+	}
+
+	private async _doDiscoverAndSeed(): Promise<void> {
+		if (!this._isEnabled()) {
+			return;
+		}
+		let discovered: readonly ICloudSandboxDiscoveredSession[] | undefined;
+		try {
+			discovered = await this._credentialsService.listSessions(CancellationToken.None);
+		} catch (error) {
+			// Discovery failed (not "empty") — keep existing state; don't reconcile on a transient error.
+			this._logService.warn(`${LOG_PREFIX} Discovery failed: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
+		this._hasDiscovered = true;
+		const present = new Set<string>();
+		for (const session of discovered ?? []) {
+			if (!session.environmentId || !session.sessionId) {
+				continue;
+			}
+			const address = cloudSandboxAddress(session.environmentId);
+			present.add(address);
+			this._ensureProvider({ environmentId: session.environmentId, sessionId: session.sessionId, name: session.name });
+			const provider = this._providerInstances.get(address);
+			const parsed = session.updatedAt ? Date.parse(session.updatedAt) : Number.NaN;
+			const modifiedTime = Number.isNaN(parsed) ? Date.now() : parsed;
+			const meta: IAgentSessionMetadata = {
+				// Seed under the agent-provider (UI) scheme, preserving the session id. Mission Control
+				// issues each session as `ahp-session:/<id>` (the id it also returns here), and the
+				// Copilot host lists that same id back, so the seed reconciles deterministically with
+				// the live `listSessions()` result on connect. See copilot-host session-identity docs.
+				session: AgentSession.uri(CLOUD_SANDBOX_AGENT_PROVIDER, session.sessionId),
+				startTime: modifiedTime,
+				modifiedTime,
+				summary: session.name,
+			};
+			provider?.seedSessions([meta]);
+		}
+
+		// Negative reconciliation: drop environments that are no longer discoverable and aren't
+		// currently connected (an open/connected session is kept so active use isn't disrupted).
+		for (const address of [...this._environments.keys()]) {
+			if (present.has(address)) {
+				continue;
+			}
+			const connected = this._remoteAgentHostService.connections.some(c => c.address === address);
+			if (!connected) {
+				this._teardownEnvironment(address);
+			}
+		}
+
+		this._logService.info(`${LOG_PREFIX} Seeded ${present.size} discovered sandbox environment(s).`);
+	}
+
+	/**
+	 * Remove the connection (and its credential refresher) for an environment while keeping the
+	 * provider and its cached sessions visible in a disconnected state. Disposing the protocol
+	 * client stops the soft-reconnect loop; the {@link CloudSandboxAgentHostService} prunes the
+	 * refresher via `onDidChangeConnections`.
+	 */
+	private async _disconnectEnvironment(address: string): Promise<void> {
+		try {
+			await this._remoteAgentHostService.removeRemoteAgentHost(address);
+		} catch (error) {
+			this._logService.warn(`${LOG_PREFIX} Failed to disconnect ${address}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	/**
+	 * Fully tear down an environment: dispose its provider (unregistering it and its sessions) and
+	 * remove its connection + credential refresher. Used when an environment vanishes from discovery
+	 * or the feature is disabled.
+	 */
+	private _teardownEnvironment(address: string): void {
+		this._environments.delete(address);
+		this._pendingConnects.delete(address);
+		this._providerStores.deleteAndDispose(address);
+		void this._disconnectEnvironment(address);
+	}
+
+	/** Tear down every known sandbox environment (feature disabled). */
+	private _teardownAll(): void {
+		for (const address of [...this._environments.keys()]) {
+			this._teardownEnvironment(address);
+		}
+	}
+
+	/** Map each known sandbox connection authority to its address (`cloudsandbox:<envId>`). */
+	private _authoritiesByAddress(): Map<string, string> {
+		const byAuthority = new Map<string, string>();
+		for (const address of this._environments.keys()) {
+			byAuthority.set(agentHostAuthority(address), address);
+		}
+		return byAuthority;
+	}
+
+	/** Resolve the sandbox address owning a remote-agent-host session type, if any. */
+	private _findAddressForSessionType(sessionType: string): string | undefined {
+		const byAuthority = this._authoritiesByAddress();
+		const authority = findRemoteAgentHostSessionTypeAuthority(sessionType, byAuthority.keys());
+		return authority ? byAuthority.get(authority) : undefined;
+	}
+
+	/**
+	 * Async-activation hook for a sandbox session type: establish the relay connection on demand,
+	 * then resolve once the host advertises the agent backing this session type (its content
+	 * provider is registered), so the chat can load. Returns false if the environment is unknown,
+	 * the connection fails, or the agent never appears.
+	 */
+	private async _waitForActivation(sessionType: string): Promise<boolean> {
+		const address = this._findAddressForSessionType(sessionType);
+		const env = address ? this._environments.get(address) : undefined;
+		if (!address || !env) {
+			return false;
+		}
+		try {
+			await this.connect({ environmentId: env.environmentId, sessionId: env.sessionId, name: env.name });
+		} catch (error) {
+			this._logService.warn(`${LOG_PREFIX} connect-on-open failed for ${address}: ${error instanceof Error ? error.message : String(error)}`);
+			// TODO: render the session's history read-only and queue follow-ups instead of refusing to
+			// open it. Needs a history source that does not depend on the relay.
+			if (error instanceof CloudSandboxEnvironmentOfflineError) {
+				this._notificationService.warn(error.message);
+			}
+			return false;
+		}
+		const authority = agentHostAuthority(address);
+		while (true) {
+			const connection = this._remoteAgentHostService.getConnection(address);
+			if (!connection) {
+				return false;
+			}
+			const rootState = connection.rootState.value;
+			if (rootState instanceof Error) {
+				return false;
+			}
+			if (rootState) {
+				return rootState.agents.some(agent => remoteAgentHostSessionTypeId(authority, agent.provider) === sessionType);
+			}
+			await Event.toPromise(connection.rootState.onDidChange);
+		}
+	}
+
+	/**
+	 * Ensure a provider exists for the environment and establish (or reuse) the
+	 * connection. Resolves with the connection's display address.
+	 */
+	async connect(options: ICloudSandboxConnectOptions): Promise<string> {
+		if (!this._isEnabled()) {
+			throw new Error('Copilot cloud sandbox connections are not enabled.');
+		}
+		const address = cloudSandboxAddress(options.environmentId);
+		this._ensureProvider({ environmentId: options.environmentId, sessionId: options.sessionId, name: options.name });
+
+		const pending = this._pendingConnects.get(address);
+		if (pending) {
+			return pending;
+		}
+		const attempt = (async () => {
+			try {
+				this._providerInstances.get(address)?.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
+				const result = await this._cloudSandboxService.connect(options, CancellationToken.None);
+				// `onDidChangeConnections` fires from addManagedConnection and wires the
+				// provider; call _wireConnections directly too in case it already fired.
+				this._wireConnections();
+				return result;
+			} finally {
+				this._pendingConnects.delete(address);
+			}
+		})();
+		this._pendingConnects.set(address, attempt);
+		return attempt;
+	}
+
+	private _isEnabled(): boolean {
+		return this._configurationService.getValue<boolean>(CloudSandboxEnabledSettingId)
+			&& this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
+	}
+
+	/** Create the sessions provider for an environment if it doesn't exist yet. */
+	private _ensureProvider(env: ICloudSandboxEnvironment): void {
+		const address = cloudSandboxAddress(env.environmentId);
+		this._environments.set(address, env);
+		if (this._providerStores.has(address)) {
+			return;
+		}
+		const store = new DisposableStore();
+		const provider = this._instantiationService.createInstance(
+			RemoteAgentHostSessionsProvider, {
+			address,
+			name: env.name,
+			connectOnDemand: () => this.connect({ environmentId: env.environmentId, sessionId: env.sessionId, name: env.name }).then(() => { }),
+			sessionSchemeAlias: SANDBOX_SESSION_SCHEME_ALIAS,
+		});
+		store.add(provider);
+		store.add(this._sessionsProvidersService.registerProvider(provider));
+		store.add(watchForIncompatibleNotifications(provider, this._instantiationService, this._notificationService));
+		this._providerInstances.set(address, provider);
+		store.add(toDisposable(() => this._providerInstances.delete(address)));
+		this._providerStores.set(address, store);
+		this._logService.info(`${LOG_PREFIX} Registered sessions provider for ${address}`);
+	}
+
+	/** Wire each live connection to its provider so session enumeration runs. */
+	private _wireConnections(): void {
+		for (const [address, provider] of this._providerInstances) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(
+				c => c.address === address && RemoteAgentHostConnectionStatus.isConnected(c.status),
+			);
+			if (connectionInfo) {
+				const connection = this._remoteAgentHostService.getConnection(address);
+				if (connection) {
+					provider.setConnection(connection, connectionInfo.defaultDirectory);
+				}
+			}
+		}
+	}
+
+	/** Push the service's authoritative connection status onto each provider. */
+	private _updateConnectionStatuses(): void {
+		for (const [address, provider] of this._providerInstances) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo) {
+				provider.setConnectionStatus(connectionInfo.status);
+			} else if (!RemoteAgentHostConnectionStatus.isIncompatible(provider.connectionStatus.get())) {
+				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.disconnected);
+			}
+		}
+	}
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
@@ -8,7 +8,8 @@
 // CloudSandboxAgentHostService, and wires the live connection to the provider so the native session
 // machinery can enumerate and render the host's sessions.
 
-import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { CancellationError } from '../../../../../base/common/errors.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
@@ -21,7 +22,7 @@ import {
 	ICloudSandboxAgentHostService,
 	ICloudSandboxCredentialsService,
 	type ICloudSandboxConnectOptions,
-	type ICloudSandboxDiscoveredSession,
+	type ICloudSandboxDiscoveryResult,
 } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
@@ -69,6 +70,11 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 	private readonly _environments = new Map<string, ICloudSandboxEnvironment>();
 	/** In-flight connects keyed by address, so concurrent opens share one attempt. */
 	private readonly _pendingConnects = new Map<string, Promise<string>>();
+	/**
+	 * Cancelled when the feature is disabled (or the contribution is disposed), so in-flight
+	 * discovery and connects abort instead of committing state after teardown has run.
+	 */
+	private _enabledCts = new CancellationTokenSource();
 	/** Serializes discovery so overlapping triggers can't interleave reconciliation. */
 	private _discoveryInFlight: Promise<void> | undefined;
 	private _discoveryQueued: Promise<void> | undefined;
@@ -143,6 +149,12 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 		// relay connection and waits for the host to advertise the session's agent
 		// (so its content provider registers) before the chat loads. Scoped to our
 		// sandbox authorities so it never intercepts other remote-agent-host types.
+		// The source is swapped out by `_teardownAll`, so cancel whichever one is current on dispose.
+		this._register(toDisposable(() => {
+			this._enabledCts.cancel();
+			this._enabledCts.dispose();
+		}));
+
 		this._register(Registry.as<IAsyncChatSessionActivationRegistry>(ChatSessionsExtensions.AsyncActivation).register({
 			matchSessionType: sessionType => this._findAddressForSessionType(sessionType) !== undefined,
 			waitForActivation: (_accessor, sessionType) => this._waitForActivation(sessionType),
@@ -177,17 +189,26 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 		if (!this._isEnabled()) {
 			return;
 		}
-		let discovered: readonly ICloudSandboxDiscoveredSession[] | undefined;
+		const token = this._enabledCts.token;
+		let result: ICloudSandboxDiscoveryResult;
 		try {
-			discovered = await this._credentialsService.listSessions(CancellationToken.None);
+			result = await this._credentialsService.listSessions(token);
 		} catch (error) {
-			// Discovery failed (not "empty") — keep existing state; don't reconcile on a transient error.
-			this._logService.warn(`${LOG_PREFIX} Discovery failed: ${error instanceof Error ? error.message : String(error)}`);
+			result = { kind: 'failed', reason: error instanceof Error ? error.message : String(error) };
+		}
+		if (result.kind === 'failed') {
+			// Not "no sessions" — leave existing state alone, and stay eligible for the auth retry.
+			this._logService.warn(`${LOG_PREFIX} Discovery failed: ${result.reason}`);
+			return;
+		}
+		// The feature may have been disabled while the scan was in flight.
+		if (token.isCancellationRequested || !this._isEnabled()) {
 			return;
 		}
 		this._hasDiscovered = true;
+
 		const present = new Set<string>();
-		for (const session of discovered ?? []) {
+		for (const session of result.sessions) {
 			if (!session.environmentId || !session.sessionId) {
 				continue;
 			}
@@ -212,17 +233,20 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 
 		// Negative reconciliation: drop environments that are no longer discoverable and aren't
 		// currently connected (an open/connected session is kept so active use isn't disrupted).
-		for (const address of [...this._environments.keys()]) {
-			if (present.has(address)) {
-				continue;
-			}
-			const connected = this._remoteAgentHostService.connections.some(c => c.address === address);
-			if (!connected) {
-				this._teardownEnvironment(address);
+		// Only a complete scan is authoritative — a partial one is missing entries that still exist.
+		if (result.kind === 'complete') {
+			for (const address of [...this._environments.keys()]) {
+				if (present.has(address)) {
+					continue;
+				}
+				const connected = this._remoteAgentHostService.connections.some(c => c.address === address);
+				if (!connected) {
+					this._teardownEnvironment(address);
+				}
 			}
 		}
 
-		this._logService.info(`${LOG_PREFIX} Seeded ${present.size} discovered sandbox environment(s).`);
+		this._logService.info(`${LOG_PREFIX} Seeded ${present.size} discovered sandbox environment(s)${result.kind === 'partial' ? ' (partial scan; kept existing entries)' : ''}.`);
 	}
 
 	/**
@@ -253,6 +277,10 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 
 	/** Tear down every known sandbox environment (feature disabled). */
 	private _teardownAll(): void {
+		// Abort in-flight discovery/connects first so nothing commits state after this runs.
+		this._enabledCts.cancel();
+		this._enabledCts.dispose();
+		this._enabledCts = new CancellationTokenSource();
 		for (const address of [...this._environments.keys()]) {
 			this._teardownEnvironment(address);
 		}
@@ -329,10 +357,17 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 		if (pending) {
 			return pending;
 		}
+		const token = this._enabledCts.token;
 		const attempt = (async () => {
 			try {
 				this._providerInstances.get(address)?.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
-				const result = await this._cloudSandboxService.connect(options, CancellationToken.None);
+				const result = await this._cloudSandboxService.connect(options, token);
+				// The feature may have been disabled while connecting; drop the connection rather
+				// than leaving a live relay open after teardown.
+				if (token.isCancellationRequested || !this._isEnabled()) {
+					void this._disconnectEnvironment(address);
+					throw new CancellationError();
+				}
 				// `onDidChangeConnections` fires from addManagedConnection and wires the
 				// provider; call _wireConnections directly too in case it already fired.
 				this._wireConnections();

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostService.ts
@@ -1,0 +1,363 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationError, isCancellationError } from '../../../../../base/common/errors.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { disposableTimeout, timeout } from '../../../../../base/common/async.js';
+import { IProtocolTransport } from '../../../../../platform/agentHost/common/state/sessionTransport.js';
+import { RemoteAgentHostProtocolClient } from '../../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
+import { editorWindowAgentHostClientInfo } from '../../../../../platform/agentHost/common/agentHostClientInfo.js';
+import { WebPubSubRelayTransport } from '../../../../../platform/agentHost/browser/webPubSubRelayTransport.js';
+import { GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../../../../platform/agentHost/common/agentService.js';
+import {
+	buildWpsUrl,
+	cloudSandboxAddress,
+	CloudSandboxEnabledSettingId,
+	ICloudSandboxAgentHostService,
+	ICloudSandboxConnectOptions,
+	CloudSandboxEnvironmentOfflineError,
+	ICloudSandboxCredentialsService,
+	isCloudSandboxSealedToken,
+	type ICloudSandboxClientToken,
+	type ICloudSandboxEnvironment,
+} from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+
+const LOG_PREFIX = '[CloudSandboxAgentHost]';
+
+/** Maximum number of `/connect` "waking" retries before giving up. */
+const MAX_WAKING_RETRIES = 20;
+
+/** Upper bound on a single waking Retry-After wait (ms), guarding against a hostile header. */
+const MAX_WAKING_DELAY_MS = 30_000;
+
+/** Refresh the Web PubSub credentials this long before the access token's `expires_at`. */
+const CREDENTIAL_REFRESH_LEAD_MS = 60_000;
+
+/** Floor / ceiling for the scheduled credential-refresh delay. */
+const MIN_CREDENTIAL_REFRESH_DELAY_MS = 5_000;
+const MAX_CREDENTIAL_REFRESH_DELAY_MS = 55 * 60_000;
+
+/** Backoff delay after a failed credential refresh before retrying. */
+const CREDENTIAL_REFRESH_RETRY_MS = 30_000;
+
+/** Maximum time to wait for a sandbox environment to report `online` before giving up. */
+const ENVIRONMENT_READY_TIMEOUT_MS = 120_000;
+
+/** Delay between environment status polls while waiting for `online`. */
+const ENVIRONMENT_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * How many full establish attempts (each minting a fresh client id via `/connect`, which is the
+ * only call that publishes a new daemon spawn) before giving up.
+ */
+const MAX_ESTABLISH_ATTEMPTS = 3;
+
+/** Delay between establish attempts. */
+const ESTABLISH_RETRY_DELAY_MS = 2_000;
+
+/** Mutable holder for the current Web PubSub credentials, read by the transport factory. */
+interface ICloudSandboxCreds {
+	token: ICloudSandboxClientToken;
+}
+
+/**
+ * Delay (ms) until credentials should be refreshed, computed as `expires_at` minus a lead time and
+ * clamped to a sane range. Falls back to the minimum when `expires_at` is missing/unparseable.
+ */
+function credentialRefreshDelayMs(expiresAt: string | undefined): number {
+	const expiryMs = expiresAt ? Date.parse(expiresAt) : NaN;
+	if (Number.isNaN(expiryMs)) {
+		return MIN_CREDENTIAL_REFRESH_DELAY_MS;
+	}
+	const delay = expiryMs - Date.now() - CREDENTIAL_REFRESH_LEAD_MS;
+	return Math.min(MAX_CREDENTIAL_REFRESH_DELAY_MS, Math.max(MIN_CREDENTIAL_REFRESH_DELAY_MS, delay));
+}
+
+/**
+ * Renderer-side coordinator for Copilot cloud sandbox connections.
+ *
+ * Mirrors {@link WebTunnelAgentHostService}: establishes a connection
+ * out-of-band (mint creds → open a {@link WebPubSubRelayTransport} → drive the
+ * AHP handshake) and hands the pre-connected {@link RemoteAgentHostProtocolClient}
+ * to {@link IRemoteAgentHostService.addManagedConnection}, so the existing
+ * remote-agent-host contribution surfaces it as a native, interactive session.
+ */
+export class CloudSandboxAgentHostService extends Disposable implements ICloudSandboxAgentHostService {
+	declare readonly _serviceBrand: undefined;
+
+	/** Credential-refresh scheduler per connection address, disposed when the connection is gone. */
+	private readonly _managed = this._register(new DisposableMap<string>());
+
+	/** Current Web PubSub credentials per connection address, including the sealed GitHub token. */
+	private readonly _creds = new Map<string, ICloudSandboxCreds>();
+
+	constructor(
+		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
+		@ICloudSandboxCredentialsService private readonly _credentialsService: ICloudSandboxCredentialsService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		// Stop refreshing credentials once a connection is gone.
+		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
+			for (const address of [...this._managed.keys()]) {
+				if (!this._remoteAgentHostService.connections.some(c => c.address === address)) {
+					this._managed.deleteAndDispose(address);
+					this._creds.delete(address);
+				}
+			}
+		}));
+	}
+
+	getSealedGitHubToken(environmentId: string): string | undefined {
+		return this._creds.get(cloudSandboxAddress(environmentId))?.token.encrypted_github_token;
+	}
+
+	async connect(options: ICloudSandboxConnectOptions, token: CancellationToken): Promise<string> {
+		if (!this._configurationService.getValue<boolean>(CloudSandboxEnabledSettingId)) {
+			throw new Error('Copilot cloud sandbox connections are not enabled.');
+		}
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
+
+		const address = cloudSandboxAddress(options.environmentId);
+
+		// Reuse an existing live connection for this environment.
+		const existing = this._remoteAgentHostService.getConnection(address);
+		if (existing) {
+			this._logService.trace(`${LOG_PREFIX} Reusing existing connection for ${address}`);
+			return address;
+		}
+
+		this._logService.info(`${LOG_PREFIX} Connecting to sandbox environment ${options.environmentId}`);
+
+		// Each attempt mints a fresh client id via `/connect`; only that call republishes the daemon
+		// spawn, so a failed attempt cannot be recovered by reusing the same id.
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= MAX_ESTABLISH_ATTEMPTS; attempt++) {
+			if (token.isCancellationRequested) {
+				throw new CancellationError();
+			}
+			try {
+				return await this._establish(options, address, token);
+			} catch (err) {
+				if (isCancellationError(err) || err instanceof CancellationError) {
+					throw err;
+				}
+				// Retrying re-mints credentials and wakes the sandbox again, which cannot help here.
+				if (err instanceof CloudSandboxEnvironmentOfflineError) {
+					throw err;
+				}
+				lastError = err;
+				if (attempt >= MAX_ESTABLISH_ATTEMPTS) {
+					break;
+				}
+				this._logService.warn(`${LOG_PREFIX} Establish attempt ${attempt}/${MAX_ESTABLISH_ATTEMPTS} failed for ${address}; retrying with a fresh connect`, err);
+				await timeout(ESTABLISH_RETRY_DELAY_MS, token);
+			}
+		}
+		this._logService.error(`${LOG_PREFIX} Connection setup failed`, lastError);
+		throw lastError;
+	}
+
+	/**
+	 * One establish attempt: mint credentials, wait for the environment to be online, open the relay,
+	 * drive the AHP handshake, and register the connection.
+	 */
+	private async _establish(options: ICloudSandboxConnectOptions, address: string, token: CancellationToken): Promise<string> {
+		const clientToken = await this._mintWithWaking(options, token);
+
+		// Credentials can be issued before the daemon is listening, which would leave `initialize`
+		// unanswered, so wait for the environment to report `online`.
+		await this._waitForEnvironmentOnline(options.environmentId, token);
+
+		// Mutable holder read by the transport factory: the protocol client re-invokes the factory to
+		// soft-reconnect, picking up whatever credentials the refresh scheduler last wrote.
+		const creds: ICloudSandboxCreds = { token: clientToken };
+		// Three per-client relay lanes: publish to `to_host`; receive replies on `to_client` and
+		// unsolicited session state on `broadcast`. `groupValidation` drops inbound frames whose
+		// group name doesn't carry our own client id.
+		const transportFactory = (): IProtocolTransport => new WebPubSubRelayTransport({
+			url: buildWpsUrl(creds.token),
+			toHostGroup: creds.token.groups.to_host,
+			joinGroups: [creds.token.groups.broadcast, creds.token.groups.to_client],
+			groupValidation: { expected: { cid: creds.token.client_id } },
+		});
+
+		// Mission Control mints the client id and binds the relay lane to it, so the AHP identity
+		// must match or the host rejects requests on that lane.
+		const protocolClient = this._instantiationService.createInstance(
+			RemoteAgentHostProtocolClient, address, transportFactory, undefined, clientToken.client_id, editorWindowAgentHostClientInfo,
+		);
+
+		let status: RemoteAgentHostConnectionStatus = RemoteAgentHostConnectionStatus.connected;
+		let connectError: unknown;
+		try {
+			await protocolClient.connect();
+			this._logService.info(`${LOG_PREFIX} Protocol handshake completed with ${address}`);
+		} catch (err) {
+			const incompatible = RemoteAgentHostConnectionStatus.fromConnectError(err, [PROTOCOL_VERSION]);
+			if (!RemoteAgentHostConnectionStatus.isIncompatible(incompatible)) {
+				protocolClient.dispose();
+				throw err;
+			}
+			this._logService.warn(`${LOG_PREFIX} Incompatible with ${address}: ${incompatible.message}`);
+			status = incompatible;
+			connectError = err;
+		}
+
+		// Push the sealed GitHub token so the host can call api.github.com on the agent's behalf.
+		// Only a `copilot-sealed.v1.` envelope is forwarded; a plaintext bearer is refused.
+		if (!connectError && clientToken.encrypted_github_token) {
+			if (!isCloudSandboxSealedToken(clientToken.encrypted_github_token)) {
+				this._logService.error(`${LOG_PREFIX} Refusing to forward a non-sealed token to ${address}; Mission Control did not return a copilot-sealed envelope.`);
+			} else {
+				try {
+					await protocolClient.authenticate({
+						resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
+						token: clientToken.encrypted_github_token,
+					});
+				} catch (err) {
+					this._logService.warn(`${LOG_PREFIX} Sealed-token authenticate failed for ${address}`, err);
+				}
+			}
+		}
+
+		try {
+			await this._remoteAgentHostService.addManagedConnection({
+				name: options.name,
+				connection: {
+					type: RemoteAgentHostEntryType.CloudSandbox,
+					address,
+					environmentId: options.environmentId,
+					sessionId: options.sessionId,
+				},
+			}, protocolClient, undefined, status);
+		} catch (err) {
+			protocolClient.dispose();
+			this._logService.error(`${LOG_PREFIX} addManagedConnection failed`, err);
+			throw err;
+		}
+
+		// Keep credentials fresh for the life of the connection so reconnects have a valid token.
+		const store = new DisposableStore();
+		this._scheduleCredentialRefresh(store, address, options, clientToken.client_id, creds);
+		this._managed.set(address, store);
+		// Expose the sealed GitHub token so the AHP `authenticate` pass can present it to the host.
+		this._creds.set(address, creds);
+
+		if (connectError) {
+			throw connectError;
+		}
+		return address;
+	}
+
+	/**
+	 * Poll until the environment reports `online`. Proceeds without gating when the environment
+	 * cannot be read. Protocol compatibility is settled by the `initialize` handshake.
+	 *
+	 * Credentials are minted first, and Mission Control answers `202 waking` until the environment
+	 * is up — so a token in hand means the wake already completed. A state that cannot recover from
+	 * there is reported immediately rather than waited out.
+	 *
+	 * TODO: when the environment is unreachable, render the session's history read-only and queue
+	 * follow-ups until the host reconnects, as github-ui does. That needs a history source that does
+	 * not depend on the relay, which we do not have yet.
+	 */
+	private async _waitForEnvironmentOnline(environmentId: string, token: CancellationToken): Promise<void> {
+		const deadline = Date.now() + ENVIRONMENT_READY_TIMEOUT_MS;
+		let lastStatus: string | undefined;
+		while (true) {
+			if (token.isCancellationRequested) {
+				throw new CancellationError();
+			}
+			let environment: ICloudSandboxEnvironment;
+			try {
+				environment = await this._credentialsService.getEnvironment(environmentId, token);
+			} catch (err) {
+				this._logService.warn(`${LOG_PREFIX} Could not read environment ${environmentId}; connecting without a readiness gate`, err);
+				return;
+			}
+
+			if (environment.status === 'online') {
+				if (lastStatus) {
+					this._logService.info(`${LOG_PREFIX} Environment ${environmentId} is online.`);
+				}
+				return;
+			}
+			if (environment.status === 'offline' || environment.status === 'draining') {
+				throw new CloudSandboxEnvironmentOfflineError(environment.status);
+			}
+			if (environment.status !== lastStatus) {
+				lastStatus = environment.status;
+				this._logService.info(`${LOG_PREFIX} Environment ${environmentId} is '${environment.status}'; waiting for it to come online.`);
+			}
+			if (Date.now() >= deadline) {
+				// Not fatal: an environment may be reachable without reporting `online`, so fall
+				// through and let the handshake decide.
+				this._logService.warn(`${LOG_PREFIX} Environment ${environmentId} still '${environment.status}' after ${Math.round(ENVIRONMENT_READY_TIMEOUT_MS / 1000)}s; attempting to connect anyway.`);
+				return;
+			}
+			await timeout(ENVIRONMENT_POLL_INTERVAL_MS, token);
+		}
+	}
+
+	/**
+	 * Re-mint Web PubSub credentials shortly before they expire and write them into {@link creds}.
+	 * The open socket is untouched; the new token is used the next time the transport is rebuilt.
+	 */
+	private _scheduleCredentialRefresh(store: DisposableStore, address: string, options: ICloudSandboxConnectOptions, clientId: string, creds: ICloudSandboxCreds): void {
+		const timer = store.add(new MutableDisposable());
+		const arm = (delayMs: number) => {
+			timer.value = disposableTimeout(() => void refresh(), Math.max(MIN_CREDENTIAL_REFRESH_DELAY_MS, delayMs));
+		};
+		const refresh = async () => {
+			try {
+				const result = await this._credentialsService.reconnect(
+					{ environmentId: options.environmentId, sessionId: options.sessionId }, clientId, CancellationToken.None,
+				);
+				if (result.kind === 'waking') {
+					arm(Math.min(result.waking.retryAfterSeconds * 1000, MAX_WAKING_DELAY_MS));
+					return;
+				}
+				// Keep the previous sealed token when a refresh omits it.
+				creds.token = result.token.encrypted_github_token
+					? result.token
+					: { ...result.token, encrypted_github_token: creds.token.encrypted_github_token, host_encryption_key: creds.token.host_encryption_key };
+				this._logService.trace(`${LOG_PREFIX} Refreshed Web PubSub credentials for ${address}`);
+				arm(credentialRefreshDelayMs(result.token.expires_at));
+			} catch (err) {
+				this._logService.warn(`${LOG_PREFIX} Credential refresh failed for ${address}; retrying`, err);
+				arm(CREDENTIAL_REFRESH_RETRY_MS);
+			}
+		};
+		arm(credentialRefreshDelayMs(creds.token.expires_at));
+	}
+
+	/** Mint client creds, retrying (bounded) while the environment is waking. */
+	private async _mintWithWaking(options: ICloudSandboxConnectOptions, token: CancellationToken): Promise<ICloudSandboxClientToken> {
+		for (let attempt = 0; attempt < MAX_WAKING_RETRIES; attempt++) {
+			if (token.isCancellationRequested) {
+				throw new CancellationError();
+			}
+			const result = await this._credentialsService.connect({ environmentId: options.environmentId, sessionId: options.sessionId }, token);
+			if (result.kind === 'token') {
+				return result.token;
+			}
+			const delayMs = Math.min(result.waking.retryAfterSeconds * 1000, MAX_WAKING_DELAY_MS);
+			this._logService.info(`${LOG_PREFIX} Environment ${options.environmentId} waking; retrying in ${delayMs}ms (attempt ${attempt + 1}/${MAX_WAKING_RETRIES})`);
+			await timeout(delayMs, token);
+		}
+		throw new Error(`Timed out waiting for sandbox environment ${options.environmentId} to wake.`);
+	}
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxConnectionCustomization.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxConnectionCustomization.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	CLOUD_SANDBOX_ADDRESS_PREFIX,
+	CLOUD_SANDBOX_AGENT_PROVIDER,
+	CLOUD_SANDBOX_SESSION_SCHEME,
+	cloudSandboxEnvironmentId,
+	ICloudSandboxAgentHostService,
+	isCloudSandboxSealedToken,
+} from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { IAgentHostAuthenticateRequest } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+import { IRemoteAgentHostConnectionCustomization } from './remoteAgentHostConnectionCustomization.js';
+
+/** Hosts whose protected resources may receive the user's GitHub identity token. */
+function isGitHubResource(resource: string): boolean {
+	let host: string;
+	try {
+		host = new URL(resource).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	return host === 'github.com'
+		|| host.endsWith('.github.com')
+		|| host === 'githubcopilot.com'
+		|| host.endsWith('.githubcopilot.com')
+		|| host.endsWith('.ghe.com');
+}
+
+/**
+ * The {@link IRemoteAgentHostConnectionCustomization} for a cloud sandbox address, supplying the two
+ * ways the sandbox host deviates from the generic path:
+ *
+ *  - **Auth**: the host only accepts a sealed envelope, so the connection's `encrypted_github_token`
+ *    is presented instead of the resolved bearer. Fails closed if no sealed token is available.
+ *  - **Scheme**: the host advertises provider `copilot` but addresses sessions as `ahp-session`.
+ *
+ * Returns `undefined` for non-sandbox addresses.
+ */
+export function createCloudSandboxConnectionCustomization(
+	address: string,
+	sandboxService: ICloudSandboxAgentHostService,
+): IRemoteAgentHostConnectionCustomization | undefined {
+	const environmentId = cloudSandboxEnvironmentId(address);
+	if (environmentId === undefined) {
+		return undefined;
+	}
+	return {
+		authenticate: async (request: IAgentHostAuthenticateRequest): Promise<IAgentHostAuthenticateRequest> => {
+			// Already sealed (e.g. re-sending a cached envelope) — forward as-is.
+			if (isCloudSandboxSealedToken(request.token)) {
+				return request;
+			}
+			// The sandbox host only accepts the sealed GitHub token for GitHub resources; there is no
+			// per-resource sealing for other hosts over the sandbox relay today.
+			if (!isGitHubResource(request.resource)) {
+				throw new Error(`Cloud sandbox cannot authenticate the non-GitHub resource '${request.resource}'.`);
+			}
+			const sealed = sandboxService.getSealedGitHubToken(environmentId);
+			if (!sealed || !isCloudSandboxSealedToken(sealed)) {
+				throw new Error(`No sealed GitHub token is available for cloud sandbox ${address}; refusing to forward a plaintext bearer.`);
+			}
+			return { resource: request.resource, scopes: request.scopes, token: sealed };
+		},
+		backendSessionScheme: (provider: string): string | undefined =>
+			provider === CLOUD_SANDBOX_AGENT_PROVIDER ? CLOUD_SANDBOX_SESSION_SCHEME : undefined,
+	};
+}
+
+/** Whether a remote-agent-host connection address identifies a cloud sandbox environment. */
+export function isCloudSandboxConnectionAddress(address: string): boolean {
+	return address.startsWith(CLOUD_SANDBOX_ADDRESS_PREFIX);
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
@@ -1,0 +1,356 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import {
+	CLOUD_SANDBOX_AGENT_SLUG,
+	CloudSandboxAuthenticationRequiredError,
+	CloudSandboxConnectResult,
+	ICloudSandboxClientToken,
+	ICloudSandboxConnectionRequest,
+	ICloudSandboxCredentialsService,
+	ICloudSandboxDiscoveredSession,
+	ICloudSandboxEnvironment,
+} from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { COPILOT_INTEGRATION_ID } from '../../../../../platform/endpoint/common/licenseAgreement.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IRequestContext } from '../../../../../base/parts/request/common/request.js';
+import { asText, IRequestService } from '../../../../../platform/request/common/request.js';
+import { AuthenticationSession, IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+
+/** The agent-environment endpoints Mission Control exposes. */
+type CloudSandboxEnvironmentAction = 'get' | 'connect' | 'reconnect';
+
+/** The subset of a Mission Control task the sandbox discovery path reads. */
+interface ITaskSummary {
+	readonly id: string;
+	readonly name?: string;
+	readonly html_url?: string;
+	readonly archived_at?: string | null;
+	readonly updated_at?: string;
+	readonly agent_collaborators?: readonly { readonly slug?: string }[];
+	readonly compute?: { readonly provider?: string };
+}
+
+/** A full task, which additionally carries the sessions bound to sandbox environments. */
+interface ITaskDetail extends ITaskSummary {
+	readonly sessions?: readonly { readonly id: string; readonly environment_id?: string }[];
+}
+
+const LOG_PREFIX = '[CloudSandboxCredentials]';
+
+/** Per-request timeout (ms) for credential and environment calls. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Per-request timeout (ms) for discovery, whose task list is far larger than a credential mint. */
+const DISCOVERY_TIMEOUT_MS = 30_000;
+
+/** Default Retry-After (seconds) when a 202 "waking" response omits the header. */
+const DEFAULT_WAKING_RETRY_AFTER_SECONDS = 5;
+
+/** How many recent tasks to scan for sandbox sessions during discovery. */
+const DISCOVERY_TASK_SCAN_LIMIT = 100;
+
+/** Fallback scopes when the product does not configure `defaultChatAgent.providerScopes`. */
+const FALLBACK_SCOPES = ['read:user', 'user:email', 'repo', 'workflow'];
+
+/**
+ * Copilot API host serving the agent-environment endpoints. Enterprise installs can override this
+ * per user via the Copilot token's `endpoints.api`, which is not yet available in the renderer.
+ */
+const COPILOT_API_BASE_URI = 'https://api.githubcopilot.com';
+
+/**
+ * Mission Control client for cloud sandbox sessions: mints (`connect`) and refreshes (`reconnect`)
+ * Web PubSub credentials, reads an environment's status, and discovers sandbox-backed sessions.
+ *
+ * Runs in the renderer so the sandbox path works in VS Code Web, where no Copilot extension host is
+ * available.
+ */
+export class CloudSandboxCredentialsService extends Disposable implements ICloudSandboxCredentialsService {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IRequestService private readonly _requestService: IRequestService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@IProductService private readonly _productService: IProductService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	async connect(request: ICloudSandboxConnectionRequest, token: CancellationToken): Promise<CloudSandboxConnectResult> {
+		return this._connectRequest('connect', request.environmentId, token, {
+			...(request.sessionId && { session_id: request.sessionId }),
+		});
+	}
+
+	async reconnect(request: ICloudSandboxConnectionRequest, clientId: string, token: CancellationToken): Promise<CloudSandboxConnectResult> {
+		return this._connectRequest('reconnect', request.environmentId, token, {
+			client_id: clientId,
+			...(request.sessionId && { session_id: request.sessionId }),
+		});
+	}
+
+	async getEnvironment(environmentId: string, token: CancellationToken): Promise<ICloudSandboxEnvironment> {
+		const context = await this._sendEnvironment('get', environmentId, token);
+		if (!isSuccess(context)) {
+			await this._throwForStatus('get', context);
+		}
+		const environment = await this._readJson<ICloudSandboxEnvironment>(context);
+		if (!environment?.status) {
+			throw new Error('Mission Control get returned an incomplete environment response');
+		}
+		return environment;
+	}
+
+	/**
+	 * Enumerate sandbox-backed cloud sessions by scanning recent tasks and resolving each one's
+	 * Mission Control environment binding. Individual failures are logged and skipped.
+	 */
+	async listSessions(token: CancellationToken): Promise<readonly ICloudSandboxDiscoveredSession[]> {
+		let tasks: readonly ITaskSummary[];
+		try {
+			const context = await this._sendTask(`${this._tasksBaseUrl()}/tasks?per_page=${DISCOVERY_TASK_SCAN_LIMIT}`, 'list', token);
+			const response = await this._readJson<{ tasks?: readonly ITaskSummary[] }>(context);
+			if (!response?.tasks) {
+				this._logService.warn(`${LOG_PREFIX} Discovery listTasks returned no 'tasks' array`);
+				return [];
+			}
+			tasks = response.tasks;
+		} catch (error) {
+			this._logService.warn(`${LOG_PREFIX} Discovery listTasks failed: ${toErrorMessage(error)}`);
+			return [];
+		}
+
+		const sandboxTasks = tasks.filter(task => !task.archived_at && isCloudSandboxTask(task));
+		const discovered = await Promise.all(sandboxTasks.map(async (task): Promise<ICloudSandboxDiscoveredSession | undefined> => {
+			try {
+				const context = await this._sendTask(`${this._tasksBaseUrl()}/tasks/${encodeURIComponent(task.id)}`, 'get', token);
+				const full = await this._readJson<ITaskDetail>(context);
+				const binding = full && getTaskEnvironmentBinding(full);
+				if (!full || !binding) {
+					return undefined;
+				}
+				const repo = parseRepoFromTaskUrl(full.html_url);
+				return {
+					environmentId: binding.environmentId,
+					sessionId: binding.sessionId,
+					name: full.name ?? task.name ?? `Sandbox ${task.id}`,
+					repoName: repo ? `${repo.owner}/${repo.name}` : undefined,
+					updatedAt: full.updated_at ?? task.updated_at,
+				};
+			} catch (error) {
+				this._logService.warn(`${LOG_PREFIX} Discovery getTask ${task.id} failed: ${toErrorMessage(error)}`);
+				return undefined;
+			}
+		}));
+
+		const sessions = discovered.filter((session): session is ICloudSandboxDiscoveredSession => session !== undefined);
+		this._logService.info(`${LOG_PREFIX} Discovery found ${sessions.length} sandbox session(s) from ${sandboxTasks.length} sandbox task(s) out of ${tasks.length} task(s) scanned.`);
+		return sessions;
+	}
+
+	/** Shared handler for the `connect`/`reconnect` endpoints (200 token or 202 waking). */
+	private async _connectRequest(
+		action: CloudSandboxEnvironmentAction,
+		environmentId: string,
+		token: CancellationToken,
+		searchParams: Record<string, string>,
+	): Promise<CloudSandboxConnectResult> {
+		const context = await this._sendEnvironment(action, environmentId, token, searchParams);
+
+		if (context.res.statusCode === 202) {
+			const retryAfterSeconds = parseRetryAfter(context.res.headers?.['retry-after']);
+			this._logService.debug(`${LOG_PREFIX} ${action}: environment waking, retry after ${retryAfterSeconds}s`);
+			return { kind: 'waking', waking: { retryAfterSeconds } };
+		}
+		if (!isSuccess(context)) {
+			await this._throwForStatus(action, context);
+		}
+		const clientToken = await this._readJson<ICloudSandboxClientToken>(context);
+		if (!clientToken?.access_token || !clientToken?.wps_endpoint || !clientToken?.client_id || !clientToken?.groups) {
+			throw new Error(`Mission Control ${action} returned an incomplete token response`);
+		}
+		return { kind: 'token', token: clientToken };
+	}
+
+	/**
+	 * Issue an agent-environment request and return the raw response. The caller owns status
+	 * handling, since the meaning of a status is endpoint-specific (notably HTTP 202 = "waking",
+	 * which is neither an error nor a result).
+	 */
+	private async _sendEnvironment(
+		action: CloudSandboxEnvironmentAction,
+		environmentId: string,
+		token: CancellationToken,
+		searchParams?: Record<string, string>,
+	): Promise<IRequestContext> {
+		const path = action === 'get' ? '' : `/${action}`;
+		const url = `${COPILOT_API_BASE_URI}/agents/environments/${encodeURIComponent(environmentId)}${path}${toQuery(searchParams)}`;
+		return this._request(url, `mc.environmentClient.${action}`, {
+			'Copilot-Integration-Id': COPILOT_INTEGRATION_ID,
+		}, token);
+	}
+
+	/** Issue a task API request, throwing on a non-success status. */
+	private async _sendTask(url: string, action: string, token: CancellationToken): Promise<IRequestContext> {
+		const context = await this._request(url, `mc.taskClient.${action}`, {
+			'Accept': 'application/json',
+			'Copilot-Integration-Id': COPILOT_INTEGRATION_ID,
+		}, token, DISCOVERY_TIMEOUT_MS);
+		if (!isSuccess(context)) {
+			await this._throwForStatus(`task ${action}`, context);
+		}
+		return context;
+	}
+
+	private async _request(url: string, callSite: string, headers: Record<string, string>, token: CancellationToken, timeout: number = REQUEST_TIMEOUT_MS): Promise<IRequestContext> {
+		const accessToken = await this._resolveGitHubToken();
+		if (!accessToken) {
+			throw new CloudSandboxAuthenticationRequiredError();
+		}
+		try {
+			return await this._requestService.request({
+				type: 'GET',
+				url,
+				headers: { ...headers, ['Authorization']: `Bearer ${accessToken}` },
+				timeout,
+				callSite,
+			}, token);
+		} catch (error) {
+			this._logService.error(`${LOG_PREFIX} GET ${url} failed: ${toErrorMessage(error)}`);
+			throw error;
+		}
+	}
+
+	/**
+	 * Mission Control task API base. Uses the Copilot API host: `api.github.com/agents/*` omits
+	 * CORS headers on authenticated responses, so a renderer `fetch` receives the reply and discards it.
+	 */
+	private _tasksBaseUrl(): string {
+		return `${COPILOT_API_BASE_URI}/agents`;
+	}
+
+	private async _readJson<T>(context: IRequestContext): Promise<T | undefined> {
+		const body = await asText(context);
+		if (!body) {
+			return undefined;
+		}
+		try {
+			return JSON.parse(body) as T;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/** Throw a diagnosable error for a non-success response, including the body when readable. */
+	private async _throwForStatus(action: string, context: IRequestContext): Promise<never> {
+		const body = await asText(context).catch(() => '');
+		throw new Error(`Mission Control ${action} failed: HTTP ${context.res.statusCode ?? 'unknown'} - ${(body ?? '').slice(0, 200)}`);
+	}
+
+	/** A GitHub session carrying at least the configured chat provider scopes. */
+	private async _resolveGitHubToken(): Promise<string | undefined> {
+		const providerId = this._productService.defaultChatAgent?.provider?.default?.id ?? 'github';
+		const scopes = this._productService.defaultChatAgent?.providerScopes?.[0] ?? FALLBACK_SCOPES;
+
+		let exact: readonly AuthenticationSession[];
+		try {
+			exact = await this._authenticationService.getSessions(providerId, [...scopes], undefined, true);
+		} catch (error) {
+			// Throws when the auth provider extension has not registered yet.
+			this._logService.warn(`${LOG_PREFIX} getSessions('${providerId}') failed: ${toErrorMessage(error)}`);
+			return undefined;
+		}
+		if (exact.length > 0) {
+			return exact[0].accessToken;
+		}
+
+		// Fall back to the narrowest session whose scopes are a superset of what we need.
+		const all = await this._authenticationService.getSessions(providerId, undefined, undefined, true);
+		const required = new Set(scopes);
+		let best: { token: string; extra: number } | undefined;
+		for (const session of all) {
+			const granted = new Set(session.scopes);
+			if ([...required].every(scope => granted.has(scope))) {
+				const extra = granted.size - required.size;
+				if (!best || extra < best.extra) {
+					best = { token: session.accessToken, extra };
+				}
+			}
+		}
+		if (!best) {
+			this._logService.warn(`${LOG_PREFIX} No '${providerId}' session with scopes [${scopes.join(', ')}]`);
+		}
+		return best?.token;
+	}
+}
+
+function isSuccess(context: IRequestContext): boolean {
+	const status = context.res.statusCode ?? 0;
+	return status >= 200 && status < 300;
+}
+
+function toQuery(searchParams: Record<string, string> | undefined): string {
+	if (!searchParams) {
+		return '';
+	}
+	const search = new URLSearchParams(searchParams).toString();
+	return search ? `?${search}` : '';
+}
+
+/** Parse a `Retry-After` header (delta-seconds); fall back to a small default. */
+function parseRetryAfter(value: string | string[] | undefined): number {
+	const raw = Array.isArray(value) ? value[0] : value;
+	if (raw) {
+		const seconds = Number.parseInt(raw, 10);
+		if (Number.isFinite(seconds) && seconds > 0) {
+			return seconds;
+		}
+	}
+	return DEFAULT_WAKING_RETRY_AFTER_SECONDS;
+}
+
+/**
+ * Whether a task is a cloud sandbox task: owned by {@link CLOUD_SANDBOX_AGENT_SLUG} and running on
+ * the `sandboxes` compute provider. Reads list-level fields only.
+ */
+function isCloudSandboxTask(task: ITaskSummary): boolean {
+	const isCloudCodingAgent = task.agent_collaborators?.some(c => c.slug === CLOUD_SANDBOX_AGENT_SLUG) ?? false;
+	return isCloudCodingAgent && task.compute?.provider === 'sandboxes';
+}
+
+/**
+ * The Mission Control environment a sandbox task runs in, read from the full task's nested
+ * `sessions[]`. Undefined when no session is bound to an environment yet.
+ */
+function getTaskEnvironmentBinding(task: ITaskDetail): { environmentId: string; sessionId: string } | undefined {
+	for (const session of task.sessions ?? []) {
+		if (session.environment_id && session.environment_id.length > 0 && session.id.length > 0) {
+			return { environmentId: session.environment_id, sessionId: session.id };
+		}
+	}
+	return undefined;
+}
+
+/** The `owner/name` repository encoded in a task's `html_url`, when parseable. */
+function parseRepoFromTaskUrl(htmlUrl: string | undefined): { owner: string; name: string } | undefined {
+	if (!htmlUrl) {
+		return undefined;
+	}
+	try {
+		const match = new URL(htmlUrl).pathname.match(/^\/([^/]+)\/([^/]+)\//);
+		if (match) {
+			return { owner: match[1], name: match[2] };
+		}
+	} catch {
+		// not a parseable URL
+	}
+	return undefined;
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
@@ -14,6 +14,7 @@ import {
 	ICloudSandboxConnectionRequest,
 	ICloudSandboxCredentialsService,
 	ICloudSandboxDiscoveredSession,
+	ICloudSandboxDiscoveryResult,
 	ICloudSandboxEnvironment,
 } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
 import { COPILOT_INTEGRATION_ID } from '../../../../../platform/endpoint/common/licenseAgreement.js';
@@ -111,30 +112,38 @@ export class CloudSandboxCredentialsService extends Disposable implements ICloud
 
 	/**
 	 * Enumerate sandbox-backed cloud sessions by scanning recent tasks and resolving each one's
-	 * Mission Control environment binding. Individual failures are logged and skipped.
+	 * Mission Control environment binding.
+	 *
+	 * The result distinguishes a full scan from a partial or failed one: a caller that reconciles
+	 * against this list would otherwise treat a transient request failure as "these sessions no
+	 * longer exist" and tear down live providers.
 	 */
-	async listSessions(token: CancellationToken): Promise<readonly ICloudSandboxDiscoveredSession[]> {
+	async listSessions(token: CancellationToken): Promise<ICloudSandboxDiscoveryResult> {
 		let tasks: readonly ITaskSummary[];
 		try {
 			const context = await this._sendTask(`${this._tasksBaseUrl()}/tasks?per_page=${DISCOVERY_TASK_SCAN_LIMIT}`, 'list', token);
 			const response = await this._readJson<{ tasks?: readonly ITaskSummary[] }>(context);
 			if (!response?.tasks) {
-				this._logService.warn(`${LOG_PREFIX} Discovery listTasks returned no 'tasks' array`);
-				return [];
+				return { kind: 'failed', reason: `listTasks returned no 'tasks' array` };
 			}
 			tasks = response.tasks;
 		} catch (error) {
-			this._logService.warn(`${LOG_PREFIX} Discovery listTasks failed: ${toErrorMessage(error)}`);
-			return [];
+			return { kind: 'failed', reason: `listTasks failed: ${toErrorMessage(error)}` };
 		}
 
 		const sandboxTasks = tasks.filter(task => !task.archived_at && isCloudSandboxTask(task));
+		let unresolved = 0;
 		const discovered = await Promise.all(sandboxTasks.map(async (task): Promise<ICloudSandboxDiscoveredSession | undefined> => {
 			try {
 				const context = await this._sendTask(`${this._tasksBaseUrl()}/tasks/${encodeURIComponent(task.id)}`, 'get', token);
 				const full = await this._readJson<ITaskDetail>(context);
-				const binding = full && getTaskEnvironmentBinding(full);
-				if (!full || !binding) {
+				if (!full) {
+					unresolved++;
+					return undefined;
+				}
+				const binding = getTaskEnvironmentBinding(full);
+				if (!binding) {
+					// No environment bound yet — a real state, not a failure to resolve.
 					return undefined;
 				}
 				const repo = parseRepoFromTaskUrl(full.html_url);
@@ -147,13 +156,14 @@ export class CloudSandboxCredentialsService extends Disposable implements ICloud
 				};
 			} catch (error) {
 				this._logService.warn(`${LOG_PREFIX} Discovery getTask ${task.id} failed: ${toErrorMessage(error)}`);
+				unresolved++;
 				return undefined;
 			}
 		}));
 
 		const sessions = discovered.filter((session): session is ICloudSandboxDiscoveredSession => session !== undefined);
-		this._logService.info(`${LOG_PREFIX} Discovery found ${sessions.length} sandbox session(s) from ${sandboxTasks.length} sandbox task(s) out of ${tasks.length} task(s) scanned.`);
-		return sessions;
+		this._logService.info(`${LOG_PREFIX} Discovery found ${sessions.length} sandbox session(s) from ${sandboxTasks.length} sandbox task(s) out of ${tasks.length} scanned${unresolved > 0 ? `; ${unresolved} unresolved` : ''}.`);
+		return { kind: unresolved > 0 ? 'partial' : 'complete', sessions };
 	}
 
 	/** Shared handler for the `connect`/`reconnect` endpoints (200 token or 202 waking). */

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxCredentialsService.ts
@@ -17,6 +17,7 @@ import {
 	ICloudSandboxDiscoveryResult,
 	ICloudSandboxEnvironment,
 } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { GITHUB_DOT_COM_COPILOT_API_BASE_URI } from '../../../../../platform/agentHost/common/githubEndpoints.js';
 import { COPILOT_INTEGRATION_ID } from '../../../../../platform/endpoint/common/licenseAgreement.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -59,12 +60,6 @@ const DISCOVERY_TASK_SCAN_LIMIT = 100;
 
 /** Fallback scopes when the product does not configure `defaultChatAgent.providerScopes`. */
 const FALLBACK_SCOPES = ['read:user', 'user:email', 'repo', 'workflow'];
-
-/**
- * Copilot API host serving the agent-environment endpoints. Enterprise installs can override this
- * per user via the Copilot token's `endpoints.api`, which is not yet available in the renderer.
- */
-const COPILOT_API_BASE_URI = 'https://api.githubcopilot.com';
 
 /**
  * Mission Control client for cloud sandbox sessions: mints (`connect`) and refreshes (`reconnect`)
@@ -202,7 +197,7 @@ export class CloudSandboxCredentialsService extends Disposable implements ICloud
 		searchParams?: Record<string, string>,
 	): Promise<IRequestContext> {
 		const path = action === 'get' ? '' : `/${action}`;
-		const url = `${COPILOT_API_BASE_URI}/agents/environments/${encodeURIComponent(environmentId)}${path}${toQuery(searchParams)}`;
+		const url = `${GITHUB_DOT_COM_COPILOT_API_BASE_URI}/agents/environments/${encodeURIComponent(environmentId)}${path}${toQuery(searchParams)}`;
 		return this._request(url, `mc.environmentClient.${action}`, {
 			'Copilot-Integration-Id': COPILOT_INTEGRATION_ID,
 		}, token);
@@ -244,7 +239,7 @@ export class CloudSandboxCredentialsService extends Disposable implements ICloud
 	 * CORS headers on authenticated responses, so a renderer `fetch` receives the reply and discards it.
 	 */
 	private _tasksBaseUrl(): string {
-		return `${COPILOT_API_BASE_URI}/agents`;
+		return `${GITHUB_DOT_COM_COPILOT_API_BASE_URI}/agents`;
 	}
 
 	private async _readJson<T>(context: IRequestContext): Promise<T | undefined> {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -11,9 +11,10 @@ import { URI } from '../../../../../base/common/uri.js';
 import * as nls from '../../../../../nls.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { RemoteAgentHostProtocolClient } from '../../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
-import { type AgentProvider, type IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
+import { type AgentProvider, type AuthenticateParams, type AuthenticateResult, type IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, type IRemoteAgentHostSSHConnection, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TunnelAgentHostsSettingId } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { CloudSandboxEnabledSettingId } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
 import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
 import { AgentHostLocalFilePermissionsSettingId } from '../../../../../platform/agentHost/common/agentHostResourceService.js';
 import { type ProtectedResourceMetadata } from '../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -43,6 +44,8 @@ import { findRemoteAgentHostSessionTypeAuthority, isRemoteAgentHostSessionType, 
 import { createRemoteAgentHarnessDescriptor, RemoteAgentPluginController } from './remoteAgentHostCustomizationHarness.js';
 import { RemoteAgentHostLogForwarder } from './remoteAgentHostLogForwarder.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
+import { IRemoteAgentHostConnectionCustomizationService, RemoteAgentHostConnectionCustomizationService } from './remoteAgentHostConnectionCustomization.js';
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { watchForIncompatibleNotifications } from './remoteHostOptions.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { IAgentHostTerminalService } from '../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
@@ -280,6 +283,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		@IAgentHostTerminalService private readonly _agentHostTerminalService: IAgentHostTerminalService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IAgentHostActiveClientService private readonly _activeClientService: IAgentHostActiveClientService,
+		@IRemoteAgentHostConnectionCustomizationService private readonly _connectionCustomizations: IRemoteAgentHostConnectionCustomizationService,
 	) {
 		super();
 
@@ -918,6 +922,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		const sessionHandler = agentStore.add(this._instantiationService.createInstance(
 			AgentHostSessionHandler, {
 			provider: agent.provider,
+			backendSessionScheme: this._connectionCustomizations.get(address)?.backendSessionScheme?.(agent.provider),
 			agentId,
 			sessionType,
 			fullName: displayName,
@@ -972,7 +977,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			await this._instantiationService.invokeFunction(authenticateProtectedResources, agents, {
 				authTokenCache,
 				logPrefix: '[RemoteAgentHost]',
-				authenticate: request => connection.authenticate(request),
+				authenticate: this._authenticateCallback(address, connection),
 			});
 		} catch (err) {
 			this._logService.error('[RemoteAgentHost] Failed to authenticate with connection', err);
@@ -982,18 +987,43 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
+	 * Build the `authenticate` callback for a connection. Host-agnostic by default (forwards the
+	 * request unchanged); a connection kind may inject a token transform via
+	 * {@link IRemoteAgentHostConnectionCustomizationService} — e.g. cloud sandbox connections, whose
+	 * host rejects plaintext bearers over the relay (`-32602`) and requires a Mission-Control-sealed
+	 * envelope. The transform owns fail-closed validation, so a raw token can never reach the host.
+	 */
+	private _authenticateCallback(address: string, connection: IAgentConnection): (request: AuthenticateParams) => Promise<AuthenticateResult> {
+		const transform = this._connectionCustomizations.get(address)?.authenticate;
+		if (!transform) {
+			return request => connection.authenticate(request);
+		}
+		return async request => connection.authenticate(await transform(request));
+	}
+
+	/**
 	 * Interactively prompt the user to authenticate when the server requires it.
 	 * Returns true if authentication succeeded.
 	 */
 	private async _resolveAuthenticationInteractively(address: string, connection: IAgentConnection, protectedResources: readonly ProtectedResourceMetadata[]): Promise<boolean> {
 		const authTokenCache = this._connections.get(address)?.authTokenCache;
+		// When the connection transforms the outgoing token (e.g. sealing), the resolved plaintext
+		// is not the identity that was actually sent, and the sealed envelope has its own lifetime.
+		// A host-requested re-auth (this path) must therefore send a fresh transformed token, so drop
+		// the plaintext-keyed dedupe first — otherwise an unchanged plaintext would be suppressed and
+		// the host would never receive a fresh envelope.
+		if (authTokenCache && this._connectionCustomizations.get(address)?.authenticate) {
+			authTokenCache.clear();
+		}
 		return this._instantiationService.invokeFunction(resolveAuthenticationInteractively, protectedResources, {
 			authTokenCache,
 			logPrefix: '[RemoteAgentHost]',
-			authenticate: request => connection.authenticate(request),
+			authenticate: this._authenticateCallback(address, connection),
 		});
 	}
 }
+
+registerSingleton(IRemoteAgentHostConnectionCustomizationService, RemoteAgentHostConnectionCustomizationService, InstantiationType.Delayed);
 
 registerWorkbenchContribution2(RemoteAgentHostContribution.ID, RemoteAgentHostContribution, WorkbenchPhase.AfterRestored);
 
@@ -1012,6 +1042,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			description: nls.localize('chat.remoteAgentHosts.autoConnect', "Automatically connect to online dev tunnel and SSH-configured remote agent hosts on startup. When disabled, cached sessions are still shown but connections are established only on demand."),
 			default: true,
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['experimental', 'advanced'],
+		},
+		[CloudSandboxEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot CLI cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs."),
+			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -1045,6 +1045,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},
+		// Off by default: sandbox tasks currently carry the `copilot-developer-cli` slug, which the
+		// Copilot extension's cloud provider does not list, so the two do not overlap. That slug is
+		// expected to change, at which point both providers would list the same task — see
+		// `CLOUD_SANDBOX_AGENT_SLUG`.
 		[CloudSandboxEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot CLI cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs."),

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostConnectionCustomization.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostConnectionCustomization.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IAgentHostAuthenticateRequest } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+
+/**
+ * Per-connection behavior a specific remote-agent-host kind can inject into the otherwise
+ * host-agnostic remote-agent-host contribution. Connections with no customization are unaffected.
+ */
+export interface IRemoteAgentHostConnectionCustomization {
+	/**
+	 * Transform the outgoing `authenticate` request before it is sent. Must fail closed: throw rather
+	 * than forward a value that does not meet the host's contract. Omit to forward it unchanged.
+	 */
+	readonly authenticate?: (request: IAgentHostAuthenticateRequest) => Promise<IAgentHostAuthenticateRequest>;
+
+	/**
+	 * The backend session URI scheme for an agent provider when it differs from the provider itself.
+	 * Return `undefined` to keep scheme == provider.
+	 */
+	readonly backendSessionScheme?: (provider: string) => string | undefined;
+}
+
+/** Builds a {@link IRemoteAgentHostConnectionCustomization} for a concrete connection address. */
+export type RemoteAgentHostConnectionCustomizationFactory = (address: string) => IRemoteAgentHostConnectionCustomization;
+
+export const IRemoteAgentHostConnectionCustomizationService = createDecorator<IRemoteAgentHostConnectionCustomizationService>('remoteAgentHostConnectionCustomizationService');
+
+/**
+ * Registry that lets a host-kind contribution (e.g. cloud sandbox) inject per-connection behavior
+ * into the generic remote-agent-host contribution, keyed by an address matcher. Inversion of
+ * control: the generic contribution *consults* this registry, the specific contribution *populates*
+ * it — so no host-specific dependency leaks into the shared code path.
+ */
+export interface IRemoteAgentHostConnectionCustomizationService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Register a customization for every connection address matched by {@link match}. The
+	 * {@link factory} is invoked per address so the customization can close over address-derived
+	 * state (e.g. the sandbox environment id).
+	 */
+	register(match: (address: string) => boolean, factory: RemoteAgentHostConnectionCustomizationFactory): IDisposable;
+
+	/** The customization for a connection address, or `undefined` when none is registered. */
+	get(address: string): IRemoteAgentHostConnectionCustomization | undefined;
+}
+
+export class RemoteAgentHostConnectionCustomizationService implements IRemoteAgentHostConnectionCustomizationService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _entries = new Set<{ readonly match: (address: string) => boolean; readonly factory: RemoteAgentHostConnectionCustomizationFactory }>();
+
+	register(match: (address: string) => boolean, factory: RemoteAgentHostConnectionCustomizationFactory): IDisposable {
+		const entry = { match, factory };
+		this._entries.add(entry);
+		return toDisposable(() => this._entries.delete(entry));
+	}
+
+	get(address: string): IRemoteAgentHostConnectionCustomization | undefined {
+		for (const entry of this._entries) {
+			if (entry.match(address)) {
+				return entry.factory(address);
+			}
+		}
+		return undefined;
+	}
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { agentHostUri } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
-import { type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
+import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import type { ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -58,6 +58,23 @@ export interface IRemoteAgentHostSessionsProviderConfig {
 	readonly disconnectOnDemand?: () => Promise<void>;
 	/** Optional progress messages during on-demand connect. */
 	readonly onDidReportConnectProgress?: Event<IAgentHostConnectProgress>;
+	/**
+	 * Set when the host addresses sessions under a scheme that differs from its agent provider, as
+	 * the cloud sandbox host does (sessions are `ahp-session:/<id>` while the agent is `copilot`).
+	 * The provider derives both directions from this pair, so they cannot drift apart.
+	 */
+	readonly sessionSchemeAlias?: ISessionSchemeAlias;
+}
+
+/**
+ * The two names a session goes by when the host's session scheme differs from its agent provider.
+ * The raw session id is shared, so only the scheme is translated.
+ */
+export interface ISessionSchemeAlias {
+	/** Scheme the UI routes by — the agent provider (e.g. `copilot`). */
+	readonly ui: string;
+	/** Scheme the host's session registry is keyed by (e.g. `ahp-session`). */
+	readonly backend: string;
 }
 
 /**
@@ -117,6 +134,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	private readonly _connectionAuthority: string;
 	private readonly _connectOnDemand: (() => Promise<void>) | undefined;
 	private readonly _disconnectOnDemand: (() => Promise<void>) | undefined;
+	private readonly _sessionSchemeAlias: ISessionSchemeAlias | undefined;
 	/** Storage key used for persisting {@link _sessionCache} snapshots. */
 	private readonly _storageKey: string;
 	/**
@@ -154,6 +172,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		this._connectionAuthority = agentHostAuthority(config.address);
 		this._connectOnDemand = config.connectOnDemand;
 		this._disconnectOnDemand = config.disconnectOnDemand;
+		this._sessionSchemeAlias = config.sessionSchemeAlias;
 		this.onDidReportConnectProgress = config.onDidReportConnectProgress;
 		this.canConnectOnDemand = !!config.connectOnDemand;
 		const displayName = config.name || config.address;
@@ -272,6 +291,53 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	/** Update the connection status for this provider. */
 	setConnectionStatus(status: RemoteAgentHostConnectionStatus): void {
 		this._connectionStatus.set(status, undefined);
+	}
+
+	/**
+	 * Seed discovered session summaries into the cache so they surface in the
+	 * sessions list **before** a connection is established (lazy discovery). Each
+	 * summary becomes a cached adapter keyed by its raw session id; entries that
+	 * already exist (e.g. from a prior live `listSessions()` or persistence) are
+	 * left untouched so the live refresh stays authoritative. Opening a seeded
+	 * session triggers `connectOnDemand` via the async activation registry, after
+	 * which `_refreshSessions` reconciles the seed with the host's real state.
+	 */
+	seedSessions(metas: readonly IAgentSessionMetadata[]): void {
+		const added: ISession[] = [];
+		for (const rawMeta of metas) {
+			const meta = this._adoptSessionMeta(rawMeta);
+			const rawId = AgentSession.id(meta.session);
+			if (this._sessionCache.has(rawId)) {
+				continue;
+			}
+			const adapter = this.createAdapter(meta);
+			this._sessionCache.set(rawId, adapter);
+			added.push(adapter);
+		}
+		if (added.length > 0) {
+			this._onDidChangeSessions.fire({ added, removed: [], changed: [] });
+		}
+	}
+
+	/**
+	 * Map a host-reported session URI onto the UI scheme, so the session routes to the agent's
+	 * content provider. The raw id is preserved, so cache keys are unaffected.
+	 */
+	protected override _adoptSessionMeta(meta: IAgentSessionMetadata): IAgentSessionMetadata {
+		const alias = this._sessionSchemeAlias;
+		if (!alias || meta.session.scheme !== alias.backend) {
+			return meta;
+		}
+		return { ...meta, session: meta.session.with({ scheme: alias.ui }) };
+	}
+
+	/**
+	 * Inverse of {@link _adoptSessionMeta}: map the UI scheme back to the one the host's session
+	 * registry is keyed by, so backend calls address the URI the host knows.
+	 */
+	protected override _backendSessionScheme(agentProvider: string): string {
+		const alias = this._sessionSchemeAlias;
+		return alias && agentProvider === alias.ui ? alias.backend : agentProvider;
 	}
 
 	setAuthenticationPending(pending: boolean): void {

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -227,6 +227,8 @@ import './contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution.js';
 import './contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.js';
 import './contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.js';
+// Copilot cloud sandbox connections (copilot-developer-cli) over a Web PubSub AHP relay
+import './contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHost.contribution.js';
 // Chat
 import './contrib/agentFeedback/browser/agentFeedback.contribution.js';
 import './contrib/chat/electron-browser/chat.contribution.js';

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -167,6 +167,8 @@ import './contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.cont
 // Remote agent host session provider — discovers agents and registers sessions
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.js';
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.js';
+// Copilot cloud sandbox connections (copilot-developer-cli) over a Web PubSub AHP relay
+import './contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHost.contribution.js';
 import './contrib/providers/agentHost/browser/agentSessionSettings.contribution.js';
 import './contrib/providers/agentHost/browser/agentHostSettings.contribution.js';
 import './contrib/providers/agentHost/browser/agentHostSessionBranchActions.js';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -678,6 +678,17 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 
 export interface IAgentHostSessionHandlerConfig {
 	readonly provider: AgentProvider;
+	/**
+	 * The URI scheme the host addresses sessions under, when it differs from
+	 * {@link provider}. Defaults to {@link provider}.
+	 *
+	 * Session URIs are client-chosen. For agents core spawns, core picks the URI and
+	 * uses the provider as the scheme. For sessions core *joins* rather than creates
+	 * (cloud sandbox, where Mission Control created the session as `ahp-session:/<id>`),
+	 * the creator's scheme must be used because the host's registry is keyed by the
+	 * exact URI — while the UI still routes the session to the `copilot` provider.
+	 */
+	readonly backendSessionScheme?: string;
 	readonly agentId: string;
 	readonly sessionType: string;
 	readonly fullName: string;
@@ -3987,7 +3998,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	/** Maps a UI session resource to a backend provider URI. */
 	private _resolveSessionUri(sessionResource: URI): URI {
 		const rawId = sessionResource.path.substring(1);
-		return AgentSession.uri(this._config.provider, rawId);
+		return AgentSession.uri(this._config.backendSessionScheme ?? this._config.provider, rawId);
 	}
 
 	private _isNewSessionResource(sessionResource: URI): boolean {


### PR DESCRIPTION
Copilot cloud sessions whose tasks run in a Mission Control **sandbox** (agent slug `copilot-developer-cli`) are rendered today by polling REST logs. That means no slash commands, no steering, and a delay before anything appears.

`copilotd` runs *inside* that sandbox and already speaks the Agent Host Protocol — the same protocol VS Code uses for local agents. So instead of polling, connect to it and let the existing agent-host stack render the session natively: history, live output, steering and slash commands.

### How the connection works

The sandbox isn't directly addressable, so both sides connect **outward** to an Azure Web PubSub relay brokered by Mission Control.

Opening a session:

1. **Mint credentials** — Mission Control answers `202 waking` until the sandbox is up.
2. **Wait for `online`** — credentials can be issued before the daemon is listening, which would leave the AHP `initialize` unanswered.
3. **Open the relay** — a browser `WebSocket`, three per-client lanes.
4. **Handshake**, then present the sealed GitHub token.
5. **Register** the connection so it surfaces as a normal agent-host session.

If an attempt fails, the whole thing retries with a **fresh** `/connect`: Mission Control only spawns the daemon on `/connect`, never on `/reconnect`, so reusing a client id can't recover.

Listing sessions needs no connection at all — tasks are scanned and seeded, and the relay only opens when you click one.

### Notes for reviewers

**It runs entirely in the renderer.** An earlier revision put the Mission Control calls in the Copilot extension and had core call in over `vscode.commands`. That was removed: core would have depended on hardcoded command IDs duplicated across two repos, and — more importantly — the Copilot extension has no web build, so sandbox sessions could never have worked on `vscode.dev/agents`. Core resolves the GitHub token via `IAuthenticationService` and makes requests via `IRequestService`.

**Mission Control is reached over the Copilot API host.** `api.github.com/agents/*` returns CORS headers on *error* responses but omits them on authenticated *success* ones, so a renderer `fetch` receives the reply and then discards it as a bare `TypeError: Failed to fetch`. The extension never hit this because it ran in Node. This deliberately differs from `@vscode/copilot-api`'s `copilotAgentTasksURL`, which is correct for its Node consumers — noted in a comment at the call site.

**The GitHub token is only ever forwarded sealed.** Mission Control encrypts it to the sandbox's public key, so the relay can't read it. A plaintext bearer is refused.

**Suggested read order:** `cloudSandboxCredentialsService.ts` (where data comes from) → `cloudSandboxAgentHostContribution.ts` (what triggers it) → `cloudSandboxAgentHostService.ts` (how the connection is built) → `webPubSubRelayTransport.ts` + `common/webPubSub/*` (the wire).

### Known gaps

- **Enterprise** — the Copilot API host is pinned to dotcom; the per-user `endpoints.api` override isn't discoverable in the renderer yet.
- **Offline environments** — we fast-fail with a message rather than rendering history read-only as github-ui does. That needs a history source independent of the relay. `TODO` in place.
- **Sealed-token validation** is a prefix check; GitHub's client also cross-checks the envelope's `key_id` against trusted keys.
- **No unit tests yet** for the credentials service (202-waking, error paths, scope fallback). The transport, framing, chunking and group layers are covered.

### vscode.dev

The contribution is already registered in the web build and the whole path passes `valid-layers-check` including `tsconfig.browser.json`. It needs one line in vscode-dev's `agents-main.ts` to switch on, since the setting defaults to off.

### Validation

`typecheck-client` 0 errors · `valid-layers-check` pass · ESLint 0 errors/0 warnings · unit tests pass · verified end-to-end against real sandbox sessions.

Gated behind `chat.agentHost.cloudSandbox.enabled`, **off by default**.
