### PR TITLE
Fix Mangler TS compilation errors in ClaudeAgent and XaaAuthProvider

### DIFF
--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5578,7 +5578,7 @@ suite('ClaudeAgent (Phase 7 §3.4 — _handleCanUseTool)', () => {
 		// with `deny` and clears the entry.
 		const { ctx, canUseTool, sessionUri } = await materialize();
 
-		const session = ctx.agent['_sessions'].get(AgentSession.id(sessionUri))?.defaultChat;
+		const session = (ctx.agent as ClaudeAgent).getSessionForTesting(sessionUri);
 		assert.ok(session, 'session is materialized');
 
 		const ac = new AbortController();

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -209,19 +209,19 @@ async function assertPrewarmEvictedOnSend(disposables: Pick<DisposableStore, 'ad
 	const agent = await createAgent(disposables);
 	const peer = disposables.add(createTestPeer());
 	const client = new CodexAppServerClient(peer.transport);
-	agent['_connection'] = {
+	(agent as unknown as { _connection: unknown })['_connection'] = {
 		kind: 'ready',
 		client,
 		usageSource: 'github',
 		child: { kill: () => true },
 	} as never;
-	agent['_refreshSkillHookCustomizations'] = async () => { };
-	agent['_refreshSkillExtraRoots'] = async () => { };
+	(agent as unknown as { _refreshSkillHookCustomizations: () => Promise<void> })['_refreshSkillHookCustomizations'] = async () => { };
+	(agent as unknown as { _refreshSkillExtraRoots: () => Promise<void> })['_refreshSkillExtraRoots'] = async () => { };
 
 	const folder = URI.file('/repo/folder');
 	const worktree = URI.file('/repo/worktree');
 	const { session } = await agent.createSession({ workingDirectories: [folder], model: { id: COPILOT_TEST_MODEL } });
-	const entry = agent['_sessions'].get(AgentSession.id(session))!;
+	const entry = (agent as unknown as { _sessions: { get(id: string): { defaultChat: unknown, materializePromise: unknown, threadId: string, workingDirectory: { fsPath: string } | undefined } | undefined } })['_sessions'].get(AgentSession.id(session))!;
 	const folderStart = await readNextRequest(peer.outbound);
 
 	try {
@@ -258,8 +258,8 @@ async function assertPrewarmEvictedOnSend(disposables: Pick<DisposableStore, 'ad
 			],
 			threadId: entry.threadId,
 			workingDirectory: entry.workingDirectory?.fsPath,
-			folderThreadRouted: agent['_sessionIdByThreadId'].has('thread-folder'),
-			worktreeThreadRouted: agent['_sessionIdByThreadId'].has('thread-worktree'),
+			folderThreadRouted: (agent as unknown as { _sessionIdByThreadId: { has(id: string): boolean } })['_sessionIdByThreadId'].has('thread-folder'),
+			worktreeThreadRouted: (agent as unknown as { _sessionIdByThreadId: { has(id: string): boolean } })['_sessionIdByThreadId'].has('thread-worktree'),
 		}, {
 			requests: [
 				{ method: 'thread/start', cwd: folder.fsPath },

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -372,6 +372,7 @@ export class MockAgent implements IAgent {
  */
 export const PRE_EXISTING_SESSION_URI = AgentSession.uri('mock', 'pre-existing-session');
 
+/** @skipMangle */
 export class ScriptedMockAgent implements IAgent {
 	readonly id: AgentProvider = 'mock';
 

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -455,14 +455,14 @@ class ChangesetReviewActionViewItem extends CheckboxActionViewItem {
 		container.classList.add('changeset-review-action');
 	}
 
-	override updateChecked(): void {
+	protected override updateChecked(): void {
 		super.updateChecked();
 
 		this.updateAriaLabel();
 		this.updateTooltip();
 	}
 
-	override getTooltip(): string {
+	protected override getTooltip(): string {
 		return this.action.checked
 			? localize('changeset.viewed.tooltip', "Mark as Not Viewed")
 			: localize('changeset.notViewed.tooltip', "Mark as Viewed");

--- a/src/vs/workbench/api/common/extHostXaaAuthProvider.ts
+++ b/src/vs/workbench/api/common/extHostXaaAuthProvider.ts
@@ -81,17 +81,17 @@ export function isExpired(entry: { token: { expires_in?: number }; created_at: n
  */
 export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base: TBase): TBase {
 	return class XaaAuthenticationProvider extends Base {
-		private readonly _resourceTokens = new Map<string, IResourceCacheEntry>();
+		readonly _resourceTokens = new Map<string, IResourceCacheEntry>();
 		/**
 		 * Per-(resource, client_id) client secrets. Lazily populated via the main-thread
 		 * prompt. Keyed by both the resource indicator and the client_id because two
 		 * different resources may legitimately share a client_id but require different
 		 * secrets — keying by client_id alone could send the wrong secret to the wrong AS.
 		 */
-		private readonly _resourceClientSecrets = new Map<string, string>();
+		readonly _resourceClientSecrets = new Map<string, string>();
 
 		/** Compound key for {@link _resourceClientSecrets}, matching main-thread secret storage scoping. */
-		private _resourceClientSecretKey(resource: string, clientId: string): string {
+		_resourceClientSecretKey(resource: string, clientId: string): string {
 			return `${resource}|${clientId}`;
 		}
 
@@ -193,7 +193,7 @@ export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base
 		 *
 		 * Caches the resulting token in `_resourceTokens` so subsequent getSessions are O(1).
 		 */
-		private async _mintResourceToken(
+		async _mintResourceToken(
 			idpSession: vscode.AuthenticationSession,
 			scopes: string[],
 			audience: string,
@@ -289,13 +289,13 @@ export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base
 		 * `undefined`. Critically does NOT call `super.createSession`, so this is safe to use
 		 * from {@link getSessions}.
 		 */
-		private async _tryGetSilentIdpSession(): Promise<vscode.AuthenticationSession | undefined> {
+		async _tryGetSilentIdpSession(): Promise<vscode.AuthenticationSession | undefined> {
 			const cleanOptions: vscode.AuthenticationProviderSessionOptions = {};
 			const existing = await super.getSessions(IDP_SCOPES as string[], cleanOptions);
 			return existing.length ? existing[0] : undefined;
 		}
 
-		private async _ensureIdpSession(): Promise<vscode.AuthenticationSession> {
+		async _ensureIdpSession(): Promise<vscode.AuthenticationSession> {
 			this._logger.trace(`[XAA] _ensureIdpSession: scopes=[${IDP_SCOPES.join(' ')}] authorization_endpoint=${this._serverMetadata.authorization_endpoint}`);
 			const silent = await this._tryGetSilentIdpSession();
 			if (silent?.idToken) {
@@ -306,7 +306,7 @@ export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base
 			return super.createSession([...IDP_SCOPES], {});
 		}
 
-		private async _exchangeForIdJag(idToken: string, audience: string, resource: string, scopes: string[]): Promise<string> {
+		async _exchangeForIdJag(idToken: string, audience: string, resource: string, scopes: string[]): Promise<string> {
 			const tokenEndpoint = this._serverMetadata.token_endpoint;
 			if (!tokenEndpoint) {
 				throw new Error('Issuer metadata is missing token_endpoint; cannot perform XAA token exchange.');
@@ -334,7 +334,7 @@ export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base
 			return issued;
 		}
 
-		private async _discoverResourceTokenEndpoint(audience: string): Promise<string> {
+		async _discoverResourceTokenEndpoint(audience: string): Promise<string> {
 			const { metadata, errors } = await fetchAuthorizationServerMetadata(audience);
 			if (!metadata?.token_endpoint) {
 				throw new Error(`Failed to discover resource authorization server metadata for '${audience}': ${errors.map(e => e.message).join('; ') || 'no token_endpoint in metadata'}`);
@@ -342,7 +342,7 @@ export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base
 			return metadata.token_endpoint;
 		}
 
-		private async _redeemAtResource(tokenEndpoint: string, idJag: string, resource: string, scopes: string[], resourceClientId: string, resourceClientSecret: string | undefined): Promise<IAuthorizationTokenResponse> {
+		async _redeemAtResource(tokenEndpoint: string, idJag: string, resource: string, scopes: string[], resourceClientId: string, resourceClientSecret: string | undefined): Promise<IAuthorizationTokenResponse> {
 			const body = buildResourceRedemptionBody(resourceClientId, resourceClientSecret, idJag, resource, scopes);
 			this._logger.trace(`[XAA] POST ${tokenEndpoint} (ID-JAG redemption) client_id=${resourceClientId} resource=${resource} scope=${scopes.join(' ')}`);
 			const response = await fetch(tokenEndpoint, {

--- a/src/vs/workbench/contrib/chat/browser/chatGoalSummaryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatGoalSummaryService.ts
@@ -145,7 +145,7 @@ export function cleanGoalSummary(raw: string): string | undefined {
 	}
 	// Strip surrounding quotes and any leading "Goal:" the model may have added.
 	s = s.replace(/^["'`]+|["'`]+$/g, '');
-	s = s.replace(/^\s*goal\s*[:\-—]\s*/i, '');
+	s = s.replace(/^\s*goal\s*[:\-\u2014]\s*/i, '');
 	s = s.replace(/\s+/g, ' ').trim();
 	// The summary model occasionally declines to summarize (e.g. content
 	// filtering) and replies with a refusal like "Sorry, I can't assist with
@@ -155,7 +155,7 @@ export function cleanGoalSummary(raw: string): string | undefined {
 		return undefined;
 	}
 	if (s.length > MAX_SUMMARY_CHARS) {
-		s = s.slice(0, MAX_SUMMARY_CHARS - 1).replace(/\s+\S*$/, '') + '…';
+		s = s.slice(0, MAX_SUMMARY_CHARS - 1).replace(/\s+\S*$/, '') + '\u2026';
 	}
 	return s || undefined;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -4754,22 +4754,22 @@ suite('VoiceSessionController live transcription', () => {
 		});
 
 		const controller = store.add(instantiationService.createInstance(VoiceSessionController));
-		controller['_isConnected'].set(true, undefined);
-		controller['_userLogin'] = 'test-user';
+		(controller as unknown as { _isConnected: { set(v: boolean, e: undefined): void } })['_isConnected'].set(true, undefined);
+		(controller as unknown as { _userLogin: string })['_userLogin'] = 'test-user';
 		return { controller, persisted };
 	}
 
 	function beginTurn(controller: VoiceSessionController): string {
 		controller.pttDown();
-		return controller['_pttCurrentTurnId'];
+		return (controller as unknown as { _pttCurrentTurnId: string })['_pttCurrentTurnId'];
 	}
 
 	function finishTurn(controller: VoiceSessionController): void {
-		controller['_finishPtt']('local');
+		(controller as unknown as { _finishPtt(ctx: string): void })['_finishPtt']('local');
 	}
 
 	function transcribe(controller: VoiceSessionController, event: IVoiceTranscription): void {
-		controller['_handleTranscription'](event);
+		(controller as unknown as { _handleTranscription(e: IVoiceTranscription): void })['_handleTranscription'](event);
 	}
 
 	test('replaces cumulative partials and final exactly once', () => {
@@ -4820,7 +4820,7 @@ suite('VoiceSessionController live transcription', () => {
 		const turnId = beginTurn(controller);
 
 		transcribe(controller, { text: 'run the tests', committed: 'run ', status: 'partial', turnId, revision: 1 });
-		controller['_handleTurnAutoEnded']({ reason: 'vad_silence', turnId });
+		(controller as unknown as { _handleTurnAutoEnded(e: unknown): void })['_handleTurnAutoEnded']({ reason: 'vad_silence', turnId });
 		transcribe(controller, { text: 'run the focused tests', status: 'final', turnId, revision: 2 });
 
 		assert.deepStrictEqual({
@@ -4867,13 +4867,13 @@ suite('VoiceSessionController live transcription', () => {
 		const { controller, persisted } = createController();
 		const bargeInTurnId = beginTurn(controller);
 		finishTurn(controller);
-		controller['_handleBargeIn']({ turnId: 'new-turn', interruptedTurnId: bargeInTurnId });
+		(controller as unknown as { _handleBargeIn(e: unknown): void })['_handleBargeIn']({ turnId: 'new-turn', interruptedTurnId: bargeInTurnId });
 		transcribe(controller, { text: 'after barge-in', status: 'final', turnId: bargeInTurnId, revision: 1 });
 
-		controller['_isConnected'].set(true, undefined);
+		(controller as unknown as { _isConnected: { set(v: boolean, e: undefined): void } })['_isConnected'].set(true, undefined);
 		const reconnectTurnId = beginTurn(controller);
 		finishTurn(controller);
-		controller['_onConnectionLost']();
+		(controller as unknown as { _onConnectionLost(): void })['_onConnectionLost']();
 		transcribe(controller, { text: 'after reconnect', status: 'final', turnId: reconnectTurnId, revision: 1 });
 
 		assert.deepStrictEqual(persisted, []);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -13,6 +13,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { ResultKind } from '../../../../../platform/keybinding/common/keybindingResolver.js';
 import { TerminalCapability, type ICwdDetectionCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
@@ -275,7 +276,7 @@ suite('Workbench - TerminalInstance', () => {
 
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
-			const keybindingService = instance['_keybindingService'];
+			const { _keybindingService: keybindingService } = instance as unknown as { _keybindingService: IKeybindingService };
 			const originalSoftDispatch = keybindingService.softDispatch;
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'workbench.action.zoomIn', commandArgs: undefined, isBubble: false });
 
@@ -300,7 +301,7 @@ suite('Workbench - TerminalInstance', () => {
 
 		test('custom key event handler should intercept Meta-modified keys that resolve to a command when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
-			const keybindingService = instance['_keybindingService'];
+			const { _keybindingService: keybindingService } = instance as unknown as { _keybindingService: IKeybindingService };
 			const originalSoftDispatch = keybindingService.softDispatch;
 			strictEqual(DEFAULT_COMMANDS_TO_SKIP_SHELL.includes('test.metaKeyInterceptCommand'), false);
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'test.metaKeyInterceptCommand', commandArgs: undefined, isBubble: false });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -703,7 +703,7 @@ export function detectsHighConfidenceInputPattern(cursorLine: string): boolean {
 		//   "? Do you want to install jsdom? <chevron>"  (prompts)
 		//   "? Pick a color <chevron> "                  (enquirer)
 		// allow-any-unicode-next-line
-		/^(?:\s|\x1b\[[0-9;]*m)*\?.*[›❯▸▶]\s*$/,
+		/^(?:\s|\x1b\[[0-9;]*m)*\?.*[\u203A\u276F\u25B8\u25B6]\s*$/,
 	].some(e => e.test(cursorLine));
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
@@ -72,6 +72,7 @@ export const ConfirmTerminalCommandToolData: IToolData = {
 	}
 };
 
+/** @skipMangle */
 export class ConfirmTerminalCommandTool extends RunInTerminalTool {
 	protected override get _enableCommandLineSandboxRewriting() {
 		return false;


### PR DESCRIPTION
Fixes #328113

This PR unblocks the `vscode-reh-web-*-min` build targets, which are currently crashing in `main` during both the AST Mangler phase and the tail-end esbuild optimizer check.

Fixes:

- **String Indexing (Test Mangler Aliasing)**: Bypassed test failures caused by the AST Mangler strictly renaming private test properties (`_sessions`, `_keybindingService`, etc.) in `terminalInstance.test.ts`, `voiceSessionController.test.ts`, and `codexPrewarmEviction.test.ts`.
- **Testing Encapsulation**: Refactored string-hack inside `claudeAgent.test.ts` to correctly utilize the public `getSessionForTesting(sessionUri)` helper method.
- **Dynamic Imports**: Added `/** @skipMangle */` to `ConfirmTerminalCommandTool` and `ScriptedMockAgent` because they are imported via dynamic string paths, escaping the Mangler's internal export-compression dictionary.
- **Mixin Inheritance**: Converted the private variables on the inline Generic Mixin `XaaAuthenticationProvider` to public. The AST mangler physically cannot calculate inheritance limits on dynamic anonymous Mixins, causing its properties to falsely collide with mangled parent variables during compilation.
- **Protected Inheritance Mangling**: Shifted `updateChecked` and `getTooltip` in `sessionChangesEditor.ts` to `protected` to properly constrain the AST inheritance mangler and bypass collision errors.
- **Esbuild Unicode Crashes**: Translated raw terminal chevron characters `[›❯▸▶]` to their standard Unicode escape-sequences `[\u203A\u276F\u25B8\u25B6]` in `outputMonitor.ts`. Did the same for unescaped Em-Dashes (`—`) and Ellipses (`…`) rendering as `\u2014` and `\u2026` in `chatGoalSummaryService.ts`. Unescaped non-ASCII characters inside strings and RegEx blocks violently crash the minifier.
- **Wiring**: Added missing mocked dependency injections for `NewChatVoiceTargetService` in `voiceBridge.test.ts`.