### PR TITLE
refactor(webview): flatten inner keydown prevent/return logic

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-FFQoOVVa2tOE3uqUvirwaMNT20TZmrHcL2aaOjJ8BUo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-E+xFrJh8n1SMMtlrX4+1NFsewbPXVmoCZWHS4vCMJxA=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -588,21 +588,19 @@
 		 * @param {KeyboardEvent} e
 		 */
 		const handleInnerKeydown = (e) => {
-			// If the keypress would trigger a browser event, such as copy or paste,
-			// make sure we block the browser from dispatching it. Instead VS Code
-			// handles these events and will dispatch a copy/paste back to the webview
-			// if needed
-			if (isUndoRedo(e) || isPrint(e) || isFindEvent(e) || isSaveEvent(e)) {
-				e.preventDefault();
-			} else if (isCopyPasteOrCut(e)) {
-				if (onElectron) {
-					e.preventDefault();
-				} else {
-					return; // let the browser handle this
-				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e))) {
-				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
-				// (No effect in a regular browser tab.)
+			// On web, let the browser handle copy/paste/cut natively; on desktop the
+			// host owns them. Everything else the host owns is blocked here so the
+			// platform does not also act on it.
+			if (isCopyPasteOrCut(e) && !onElectron) {
+				return;
+			}
+
+			if (
+				isUndoRedo(e) || isPrint(e) || isFindEvent(e) || isSaveEvent(e) ||
+				isCopyPasteOrCut(e) ||
+				// Ctrl+W / Ctrl+N / F1 / F5 only matter in a PWA (no effect in a tab).
+				(!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e)))
+			) {
 				e.preventDefault();
 			}
 

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-E+xFrJh8n1SMMtlrX4+1NFsewbPXVmoCZWHS4vCMJxA=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-G40+3vu/ZpVWp/n0uD0wcIguNgbWdooqEEQZVMDoVAE=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -588,9 +588,7 @@
 		 * @param {KeyboardEvent} e
 		 */
 		const handleInnerKeydown = (e) => {
-			// On web, let the browser handle copy/paste/cut natively; on desktop the
-			// host owns them. Everything else the host owns is blocked here so the
-			// platform does not also act on it.
+			// On web the browser handles copy/paste/cut natively; on desktop the host owns them.
 			if (isCopyPasteOrCut(e) && !onElectron) {
 				return;
 			}


### PR DESCRIPTION
## Description

Flattens the `if/else` chain in `handleInnerKeydown` (in `src/vs/workbench/contrib/webview/browser/pre/index.html`) into a single early return followed by one `preventDefault` condition.

The original structure nested the copy/paste/cut case inside an `if (onElectron)` and was the only branch with an early `return`, which made the prevent-vs-return-vs-fallthrough decision spread across four branches. The new shape reads as two flat steps:

1. On web, let the browser handle copy/paste/cut natively (`return`).
2. Everything else the host owns is blocked with `preventDefault`.

Behavior is unchanged across all cases (undo/redo, print, find, save, copy/paste/cut on desktop vs web, Ctrl+W / Ctrl+N / F1 / F5 in a PWA, and plain keys that fall through to `did-keydown`). The inline `script-src` CSP `sha256` in the `<meta>` tag is refreshed to match the new script content.

Pure readability refactor, no behavior change.

## 🤖 Agent context

This PR was created with the help of an AI agent (PostHog Code). The agent:
- Read the existing `handleInnerKeydown` logic and confirmed the refactor preserves behavior for every branch.
- Recomputed the CSP `script-src` `sha256` from the updated inline script and updated the `<meta>` tag (verified the new hash round-trips against the file).
- Did not add or change any tests, since this is a behavior-preserving refactor of existing logic already covered by the webview keydown tests.