### PR TITLE
Implement file permission settings after extraction

### DIFF
--- a/.github/skills/agent-host-logs/scripts/extract.py
+++ b/.github/skills/agent-host-logs/scripts/extract.py
@@ -149,7 +149,7 @@ def validate_entries(source: zipfile.ZipFile, root: Path) -> list[tuple[zipfile.
 	return validated
 
 
-def extract_archive(archive: Path) -> Path:
+ def extract_archive(archive: Path) -> Path:
 	preflight_archive(archive)
 	root = Path(tempfile.mkdtemp(prefix='agent-host-logs-')).resolve()
 	try:
@@ -164,12 +164,23 @@ def extract_archive(archive: Path) -> Path:
 				target.parent.mkdir(parents=True, exist_ok=True)
 				with source.open(info) as input_stream, target.open('xb') as output_stream:
 					shutil.copyfileobj(input_stream, output_stream)
+				
+				# Eklenen İyileştirme: Dosya izinlerini güvenli bir şekilde ayarla
+				# (Windows haricindeki sistemler için)
+				try:
+					mode = (info.external_attr >> 16) & 0o777
+					if mode:
+						target.chmod(mode)
+					else:
+						target.chmod(0o644)
+				except OSError:
+					pass
+					
 	except (Exception, KeyboardInterrupt):
 		shutil.rmtree(root)
 		raise
 
 	return root
-
 
 def main() -> None:
 	parser = argparse.ArgumentParser(description='Safely extract an Agent Host debug log zip into a temporary directory.')

--- a/.github/skills/agent-host-logs/scripts/extract.py
+++ b/.github/skills/agent-host-logs/scripts/extract.py
@@ -149,7 +149,12 @@ def validate_entries(source: zipfile.ZipFile, root: Path) -> list[tuple[zipfile.
 	return validated
 
 
- def extract_archive(archive: Path) -> Path:
+import os
+import sys
+
+# ... (diğer importlar ve kodlar aynı kalacak) ...
+
+def extract_archive(archive: Path) -> Path:
 	preflight_archive(archive)
 	root = Path(tempfile.mkdtemp(prefix='agent-host-logs-')).resolve()
 	try:
@@ -165,17 +170,16 @@ def validate_entries(source: zipfile.ZipFile, root: Path) -> list[tuple[zipfile.
 				with source.open(info) as input_stream, target.open('xb') as output_stream:
 					shutil.copyfileobj(input_stream, output_stream)
 				
-				# Eklenen İyileştirme: Dosya izinlerini güvenli bir şekilde ayarla
-				# (Windows haricindeki sistemler için)
-				try:
-					mode = (info.external_attr >> 16) & 0o777
-					if mode:
-						target.chmod(mode)
-					else:
-						target.chmod(0o644)
-				except OSError:
-					pass
-					
+				# Düzeltme: Sadece non-Windows sistemler için dosya izinlerini ayarla
+				if os.name != 'nt':
+					try:
+						mode = (info.external_attr >> 16) & 0o777
+						if mode:
+							target.chmod(mode)
+						else:
+							target.chmod(0o644)
+					except OSError:
+						pass
 	except (Exception, KeyboardInterrupt):
 		shutil.rmtree(root)
 		raise


### PR DESCRIPTION
Added file permission handling for extracted files on non-Windows systems using `info.external_attr`.

### Summary of Changes:
- Preserves original file permissions from the archive where available.
- Falls back to a safe default (`0644`) for standard files.
- Wrapped in a `try-except` block to gracefully handle platform restrictions (like Windows).

### Test Plan:
- Verified that ZIP extraction works correctly without raising exceptions on non-Windows platforms.