### PR TITLE
Enable Agent Host migration settings by default

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6832,7 +6832,7 @@
         "inputPlaceholder": "Run local tasks with Claude, type `#` for adding context",
         "order": 3,
         "description": "%github.copilot.session.providerDescription.claude%",
-        "when": "config.github.copilot.chat.claudeAgent.enabled && ((isSessionsWindow && !config.chat.agents.claude.preferAgentHost) || (!isSessionsWindow && !config.chat.editor.claude.preferAgentHost))",
+        "when": "config.github.copilot.chat.claudeAgent.enabled && (!agentHostEnabled || (isSessionsWindow && !config.chat.agents.claude.preferAgentHost) || (!isSessionsWindow && !config.chat.editor.claude.preferAgentHost))",
         "canDelegate": true,
         "requiresCustomModels": true,
         "supportsAutoModel": false,

--- a/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
@@ -61,7 +61,7 @@ export class AgentHostEnablementService extends Disposable implements IAgentHost
 	readonly enabled: IObservable<boolean>;
 
 	constructor(
-		private readonly _isWebRuntime: boolean,
+		private readonly _isAgentHostRuntimeAvailable: boolean,
 		configurationService: IConfigurationService,
 		contextKeyService: IContextKeyService,
 	) {
@@ -82,7 +82,7 @@ export class AgentHostEnablementService extends Disposable implements IAgentHost
 	}
 
 	private _readEnabled(configurationService: IConfigurationService): boolean {
-		return !this._isWebRuntime
+		return this._isAgentHostRuntimeAvailable
 			&& (configurationService.getValue<boolean>(agentHostEnabledSettingId) ?? false)
 			&& configurationService.getValue<boolean>(ChatAIDisabledSettingId) !== true;
 	}
@@ -103,7 +103,7 @@ class BrowserAgentHostEnablementService extends AgentHostEnablementService {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
-		super(isWeb, configurationService, contextKeyService);
+		super(!isWeb, configurationService, contextKeyService);
 	}
 }
 

--- a/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
@@ -43,7 +43,7 @@ const newNode: IConfigurationNode = {
 				localization: {
 					description: {
 						key: 'chat.agentHost.enabled',
-						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process. In web, a remote extension host is required.")
 					}
 				},
 			}

--- a/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/browser/agentHostEnablementService.ts
@@ -43,7 +43,7 @@ const newNode: IConfigurationNode = {
 				localization: {
 					description: {
 						key: 'chat.agentHost.enabled',
-						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process. In web, a remote extension host is required.")
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
 					}
 				},
 			}

--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -4,12 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IObservable } from '../../../base/common/observable.js';
-import { isWeb } from '../../../base/common/platform.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import { RawContextKey } from '../../contextkey/common/contextkey.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
-import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 
 /** @internal Only the enablement service may read this configuration value at runtime. */
@@ -43,14 +41,14 @@ configurationRegistry.registerConfiguration({
 		[agentHostEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
-			default: !isWeb && product.quality !== 'stable',
+			default: true,
 			tags: ['experimental', 'advanced'],
 			experiment: { mode: 'startup' },
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.agents.copilotCli.hideExtensionHost', "When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker. Requires `#chat.agentHost.enabled#`.", agentHostEnabledSettingId),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
@@ -78,7 +76,7 @@ configurationRegistry.registerConfiguration({
 		'chat.editor.copilotCli.hideExtensionHost': {
 			type: 'boolean',
 			description: nls.localize('chat.editor.copilotCli.hideExtensionHost', "When enabled, hides the Extension Host Copilot CLI entry from the editor window chat picker."),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},

--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -40,7 +40,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[agentHostEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process. In web, a remote extension host is required."),
+			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: true,
 			tags: ['experimental', 'advanced'],
 			experiment: { mode: 'startup' },

--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -40,7 +40,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[agentHostEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
+			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process. In web, a remote extension host is required."),
 			default: true,
 			tags: ['experimental', 'advanced'],
 			experiment: { mode: 'startup' },

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -201,15 +201,13 @@ export const AgentHostSdkSandboxEnabledSettingId = 'chat.agentHost.sdkSandbox.en
 /**
  * Selects which Claude integration fulfills Claude sessions opened from the
  * **Agents Window**:
- *  - `true` — Claude is provided by the agent host process.
- *  - `false` (default) — Claude is provided by the GitHub Copilot Chat extension.
+ *  - `true` (default) — Claude is provided by the agent host process.
+ *  - `false` — Claude is provided by the GitHub Copilot Chat extension.
  *
- * The agent host always registers Claude when its SDK is reachable; this
- * setting only controls whether the per-window bridge in
- * `AgentHostContribution` actually surfaces the AH provider in the Agents
- * Window. The extension's `chatSessions` contribution mirrors the rule
- * declaratively (its `when` clause hides the EH provider when this is `true`),
- * so flipping the setting takes effect live without a window reload.
+ * When Agent Host is enabled, this controls whether the per-window bridge in
+ * `AgentHostContribution` surfaces the AH provider in the Agents Window. The
+ * extension's `chatSessions` contribution mirrors the rule declaratively and
+ * remains visible when Agent Host is unavailable.
  *
  * Paired with {@link ClaudePreferAgentHostEditorSettingId} which governs the
  * regular workbench (sidebar). EXP-backed (`experiment: { mode: 'startup' }`).

--- a/src/vs/platform/agentHost/test/browser/agentHostEnablementService.test.ts
+++ b/src/vs/platform/agentHost/test/browser/agentHostEnablementService.test.ts
@@ -42,7 +42,7 @@ class AgentHostTestConfigurationService extends TestConfigurationService {
 suite('AgentHostEnablementService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createService(enabled: boolean, aiDisabled = false): {
+	function createService(enabled: boolean, aiDisabled = false, runtimeAvailable = true): {
 		readonly service: AgentHostEnablementService;
 		readonly configurationService: AgentHostTestConfigurationService;
 		readonly contextKeyService: MockContextKeyService;
@@ -50,7 +50,7 @@ suite('AgentHostEnablementService', () => {
 		const configurationService = new AgentHostTestConfigurationService(enabled, aiDisabled);
 		disposables.add(configurationService.onDidChangeConfigurationEmitter);
 		const contextKeyService = disposables.add(new MockContextKeyService());
-		const service = disposables.add(new AgentHostEnablementService(false, configurationService, contextKeyService));
+		const service = disposables.add(new AgentHostEnablementService(runtimeAvailable, configurationService, contextKeyService));
 		return { service, configurationService, contextKeyService };
 	}
 
@@ -67,6 +67,17 @@ suite('AgentHostEnablementService', () => {
 
 	test('is disabled when AI features are disabled', () => {
 		const { service, contextKeyService } = createService(true, true);
+		assert.deepStrictEqual({
+			enabled: service.enabled.get(),
+			contextKey: contextKeyService.getContextKeyValue(AGENT_HOST_ENABLED_CONTEXT_KEY.key),
+		}, {
+			enabled: false,
+			contextKey: false,
+		});
+	});
+
+	test('is disabled when the runtime is unavailable', () => {
+		const { service, contextKeyService } = createService(true, false, false);
 		assert.deepStrictEqual({
 			enabled: service.enabled.get(),
 			contextKey: contextKeyService.getContextKeyValue(AGENT_HOST_ENABLED_CONTEXT_KEY.key),

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -225,7 +225,7 @@ export const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
  * Experimental setting id controlling whether the local agent host acts as the
  * default sessions provider. When enabled (and `chat.agentHost.enabled` is
  * true), the local agent host's session types are surfaced before those of
- * other providers. Defaults to `false`.
+ * other providers. Defaults to `true`.
  */
 export const LocalAgentHostDefaultProviderSettingId = 'chat.agentHost.defaultSessionsProvider';
 

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -26,6 +26,7 @@ Agent host providers implement `IAgentHostSessionsProvider` (defined in sessions
 Registered by `LocalAgentHostContribution` in `browser/localAgentHost.contribution.ts`:
 
 - **Gated on `chat.agentHost.enabled`** (`AgentHostEnabledSettingId`). If the setting is off the contribution returns early and registers nothing.
+- In web, Agent Host enablement additionally requires a remote authority. Web windows with a remote extension host use that server's Agent Host; serverless web keeps Agent Host disabled.
 - The local Codex session type is additionally gated directly on `chat.agentHost.codexAgent.enabled`. The Agents window does not register the OpenAI extension's Codex session type, so it has no separate Codex `preferAgentHost` setting.
 - The enablement bit is read once through the sessions-layer `AgentHostEnablementService`; the contribution does not subscribe to config changes.
 - Creates `LocalAgentHostSessionsProvider` via `IInstantiationService` and registers it through `ISessionsProvidersService.registerProvider`.
@@ -34,7 +35,7 @@ Registered by `LocalAgentHostContribution` in `browser/localAgentHost.contributi
   - `AgentHostContribution` — agent discovery, session-handler registration, language-model providers, customization harness (via `IChatSessionsService`).
   - `AgentHostTerminalContribution` — terminal integration for agent host sessions.
   - The classic chat sidebar item controller is registered separately in the editor window only; the Agents window does not load or register `AgentHostSessionListController`.
-- Registers the experimental `chat.agentHost.defaultSessionsProvider` setting (`LocalAgentHostDefaultProviderSettingId`, default `false`, startup experiment).
+- Registers the experimental `chat.agentHost.defaultSessionsProvider` setting (`LocalAgentHostDefaultProviderSettingId`, default `true`, startup experiment).
 
 The Electron-only `electron-browser/agentHost.contribution.ts` adds desktop-only wiring on top.
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
@@ -25,7 +25,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	properties: {
 		[LocalAgentHostDefaultProviderSettingId]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 			markdownDescription: localize('sessions.chat.agentHost.defaultSessionsProvider', "When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#chat.agentHost.enabled#`."),

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -114,6 +114,7 @@ import { IWSLRemoteAgentHostService } from '../platform/agentHost/common/wslRemo
 import { NullWSLRemoteAgentHostService } from '../platform/agentHost/browser/nullWslRemoteAgentHostService.js';
 import { IAgentHostService } from '../platform/agentHost/common/agentService.js';
 import { EditorRemoteAgentHostServiceClient } from '../workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.js';
+import '../workbench/services/agentHost/browser/webAgentHostEnablementService.js';
 import { BrowserAgentHostDebugLogsExportService, IAgentHostDebugLogsExportService } from '../workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.js';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -868,14 +868,14 @@ configurationRegistry.registerConfiguration({
 		[ClaudePreferAgentHostAgentsSettingId]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires `#chat.agentHost.enabled#`."),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
 		[ClaudePreferAgentHostEditorSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.editor.claude.preferAgentHost', "When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window."),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},

--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -79,7 +79,7 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 		this._logService.info(`${LOG_PREFIX} Initializing (enabled=${enabled}, remoteAuthority=${connection?.remoteAuthority ?? 'none'})`);
 
 		if (!enabled) {
-			this._logService.info(`${LOG_PREFIX} Disabled via "chat.agentHost.enabled" or web runtime. Not connecting.`);
+			this._logService.info(`${LOG_PREFIX} Disabled via configuration, policy, or runtime availability. Not connecting.`);
 			this.setAuthenticationPending(false);
 			return;
 		}

--- a/src/vs/workbench/services/agentHost/browser/webAgentHostEnablementService.ts
+++ b/src/vs/workbench/services/agentHost/browser/webAgentHostEnablementService.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AgentHostEnablementService } from '../../../../platform/agentHost/browser/agentHostEnablementService.js';
+import { IAgentHostEnablementService } from '../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
+
+export class WebAgentHostEnablementService extends AgentHostEnablementService {
+	constructor(
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+	) {
+		super(!!environmentService.remoteAuthority, configurationService, contextKeyService);
+	}
+}
+
+registerSingleton(IAgentHostEnablementService, WebAgentHostEnablementService, InstantiationType.Eager);

--- a/src/vs/workbench/services/agentHost/test/browser/webAgentHostEnablementService.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/webAgentHostEnablementService.test.ts
@@ -18,19 +18,23 @@ import { WebAgentHostEnablementService } from '../../browser/webAgentHostEnablem
 suite('WebAgentHostEnablementService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function getEnablement(remoteAuthority: string | undefined): {
+	function getEnablement(options: {
+		readonly remoteAuthority?: string;
+		readonly configured?: boolean;
+		readonly aiDisabled?: boolean;
+	}): {
 		readonly enabled: boolean;
 		readonly contextKey: boolean | undefined;
 	} {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		const configurationService = new TestConfigurationService({
-			'chat.agentHost.enabled': true,
-			[ChatAIDisabledSettingId]: false,
+			'chat.agentHost.enabled': options.configured ?? true,
+			[ChatAIDisabledSettingId]: options.aiDisabled ?? false,
 		});
 		const contextKeyService = disposables.add(new MockContextKeyService());
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IContextKeyService, contextKeyService);
-		instantiationService.stub(IWorkbenchEnvironmentService, { remoteAuthority });
+		instantiationService.stub(IWorkbenchEnvironmentService, { remoteAuthority: options.remoteAuthority });
 
 		const service = disposables.add(instantiationService.createInstance(WebAgentHostEnablementService));
 		return {
@@ -40,16 +44,26 @@ suite('WebAgentHostEnablementService', () => {
 	}
 
 	test('enables Agent Host for web with a remote extension host', () => {
-		assert.deepStrictEqual(getEnablement('ssh-remote+test'), {
+		assert.deepStrictEqual(getEnablement({ remoteAuthority: 'ssh-remote+test' }), {
 			enabled: true,
 			contextKey: true,
 		});
 	});
 
 	test('disables Agent Host for serverless web', () => {
-		assert.deepStrictEqual(getEnablement(undefined), {
+		assert.deepStrictEqual(getEnablement({}), {
 			enabled: false,
 			contextKey: false,
+		});
+	});
+
+	test('respects configuration and AI disablement in web with a remote extension host', () => {
+		assert.deepStrictEqual({
+			configuredOff: getEnablement({ remoteAuthority: 'ssh-remote+test', configured: false }),
+			aiDisabled: getEnablement({ remoteAuthority: 'ssh-remote+test', aiDisabled: true }),
+		}, {
+			configuredOff: { enabled: false, contextKey: false },
+			aiDisabled: { enabled: false, contextKey: false },
 		});
 	});
 });

--- a/src/vs/workbench/services/agentHost/test/browser/webAgentHostEnablementService.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/webAgentHostEnablementService.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { AGENT_HOST_ENABLED_CONTEXT_KEY } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { ChatAIDisabledSettingId } from '../../../../../platform/chat/common/chatSettings.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+import { WebAgentHostEnablementService } from '../../browser/webAgentHostEnablementService.js';
+
+suite('WebAgentHostEnablementService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function getEnablement(remoteAuthority: string | undefined): {
+		readonly enabled: boolean;
+		readonly contextKey: boolean | undefined;
+	} {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		const configurationService = new TestConfigurationService({
+			'chat.agentHost.enabled': true,
+			[ChatAIDisabledSettingId]: false,
+		});
+		const contextKeyService = disposables.add(new MockContextKeyService());
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(IContextKeyService, contextKeyService);
+		instantiationService.stub(IWorkbenchEnvironmentService, { remoteAuthority });
+
+		const service = disposables.add(instantiationService.createInstance(WebAgentHostEnablementService));
+		return {
+			enabled: service.enabled.get(),
+			contextKey: contextKeyService.getContextKeyValue(AGENT_HOST_ENABLED_CONTEXT_KEY.key),
+		};
+	}
+
+	test('enables Agent Host for web with a remote extension host', () => {
+		assert.deepStrictEqual(getEnablement('ssh-remote+test'), {
+			enabled: true,
+			contextKey: true,
+		});
+	});
+
+	test('disables Agent Host for serverless web', () => {
+		assert.deepStrictEqual(getEnablement(undefined), {
+			enabled: false,
+			contextKey: false,
+		});
+	});
+});

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -106,7 +106,7 @@ import { IAgentHostService } from '../platform/agentHost/common/agentService.js'
 import { EditorRemoteAgentHostServiceClient } from './services/agentHost/browser/editorRemoteAgentHostServiceClient.js';
 import { IRemoteAgentHostService, NullRemoteAgentHostService } from '../platform/agentHost/common/remoteAgentHostService.js';
 import { BrowserAgentHostDebugLogsExportService, IAgentHostDebugLogsExportService } from './contrib/chat/browser/actions/exportAgentHostDebugLogsAction.js';
-import '../platform/agentHost/browser/agentHostEnablementService.js';
+import './services/agentHost/browser/webAgentHostEnablementService.js';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService, InstantiationType.Delayed);
 registerSingleton(IAccessibilityService, AccessibilityService, InstantiationType.Delayed);

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -8,7 +8,7 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Application, ApplicationOptions, Logger } from '../../../../automation';
-import { createApp, dumpFailureDiagnostics, getCopilotSmokeTestEnv, getMockLlmServerPath, getMockLlmServerUrl, installAppAfterHandler, installDiagnosticsHandler, installAllHandlers, MockLlmServer, suiteCrashPath, suiteLogsPath } from '../../utils';
+import { createApp, dumpFailureDiagnostics, getCopilotSmokeTestEnv, getMockLlmServerPath, getMockLlmServerUrl, installAppAfterHandler, installDiagnosticsHandler, installAllHandlers, MockLlmServer, preseedChatExtensionEnablement, suiteCrashPath, suiteLogsPath } from '../../utils';
 import { shellEchoResponseMatcher, shellEchoScenario } from '../chat/shellScenarios';
 
 // Selector for the send button in the Agents Window new-session homepage.
@@ -116,6 +116,36 @@ interface CapturedRequest {
 	readonly path: string;
 	readonly method: string;
 	readonly body: any;
+}
+
+async function preseedExtensionHostAgentsProfiles(userDataDir: string | undefined, mockServerUrl: string): Promise<void> {
+	if (!userDataDir) {
+		throw new Error('Cannot pre-seed Agents Window profiles without a user data directory');
+	}
+
+	const settings = JSON.stringify({
+		'github.copilot.advanced.debug.overrideProxyUrl': mockServerUrl,
+		'github.copilot.advanced.debug.overrideAuthType': 'token',
+		'chat.allowAnonymousAccess': true,
+		'github.copilot.chat.githubMcpServer.enabled': false,
+		// This suite exercises the extension-host session providers directly.
+		'chat.agentHost.enabled': false,
+		'sessions.chat.localAgent.enabled': true,
+		'github.copilot.chat.cli.sandbox.enabled': 'on',
+		'github.copilot.chat.cli.sessionEventLogging.enabled': true,
+		// Keep follow-up turns in the same chat so the test flow is deterministic.
+		'sessions.github.copilot.multiChatSessions': false,
+		// Capture enough runtime detail to diagnose CI hangs.
+		'chat.agentHost.copilotSdk.logLevel': 'trace',
+	}, null, 2);
+	for (const settingsPath of [
+		path.join(userDataDir, 'User', 'settings.json'),
+		path.join(userDataDir, 'User', 'profiles', 'builtin', 'agents', 'settings.json'),
+	]) {
+		fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+		fs.writeFileSync(settingsPath, settings);
+	}
+	await preseedChatExtensionEnablement(userDataDir);
 }
 
 /**
@@ -352,7 +382,7 @@ export function setup(logger: Logger) {
 					...copilotEnv,
 				},
 			};
-		});
+		}, app => preseedExtensionHostAgentsProfiles(app.userDataPath, getMockLlmServerUrl(mockServer)));
 
 		before(async function () {
 			// One-time setup: write VS Code settings and open the Agents Window
@@ -367,46 +397,6 @@ export function setup(logger: Logger) {
 			// "uncommitted changes" confirmation flow which aborts the session.
 			cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder });
 			logger.log(`[Agents Window] reset workspace via 'git checkout .'`);
-
-			// overrideProxyUrl redirects all Copilot SDK traffic to our mock server
-			// and enables HMAC auth — no real GitHub token required.
-			// allowAnonymousAccess skips the token-validation gate in the
-			// extension-host copilotTokenManager when there is no real GitHub session.
-			// githubMcpServer is disabled to prevent a real-network MCP connection
-			// to the GitHub MCP server during the test.
-			// sessions.chat.localAgent.enabled exposes the "Local" session type.
-			await app.workbench.settingsEditor.addUserSettings([
-				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(getMockLlmServerUrl(mockServer))],
-				// Use token auth (not HMAC) so the SDK can call /models and
-				// /models/session against the mock server without HMAC validation.
-				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
-				['chat.allowAnonymousAccess', 'true'],
-				['github.copilot.chat.githubMcpServer.enabled', 'false'],
-				['sessions.chat.localAgent.enabled', 'true'],
-				['github.copilot.chat.cli.sandbox.enabled', '"on"'],
-				['github.copilot.chat.cli.sessionEventLogging.enabled', 'true'],
-				// Disable multi-chat per Copilot CLI session for this smoke
-				// test. With multi-chat enabled (default), each follow-up
-				// turn creates a *new sub-chat* with its own SDK session
-				// nested under the parent session: the workbench
-				// auto-swaps the active slot to a fresh new-session
-				// homepage right after the previous turn commits, and
-				// each turn ends up in its own isolated worktree
-				// (`isolationEnabled: true, worktreePath: agents-...`).
-				// That interferes with the smoke test driver's
-				// activate/send sequence and makes msg2 land in a
-				// different VS Code session than the assertion expects.
-				// With this setting off, `supportsMultipleChats` is
-				// false for Copilot CLI and turns share a workspace
-				// (`isolationEnabled: false, worktreePath: undefined`),
-				// which keeps the test flow deterministic.
-				['sessions.github.copilot.multiChatSessions', 'false'],
-				// Force the Copilot runtime to verbose logging so the captured
-				// `process-*.log` (see dumpFailureDiagnostics) has enough detail
-				// to diagnose a hang/timeout in CI.
-				['chat.agentHost.copilotSdk.logLevel', '"trace"'],
-			]);
-			logger.log(`[Agents Window] user settings written; requestCount=${mockServer.requestCount()}`);
 
 			// `--enable-smoke-test-driver` (set by the runner) skips the auth dialog.
 			const windowsBefore = app.code.driver.getAllWindows().length;
@@ -883,7 +873,7 @@ export function setup(logger: Logger) {
 			try {
 				await app.workbench.agentsWindow.startNewSession();
 				await app.workbench.agentsWindow.waitForNewSessionView();
-				await app.workbench.agentsWindow.selectSessionType('Local Agent Host');
+				await app.workbench.agentsWindow.selectSessionType('Copilot');
 
 				const requestsBefore = agentHost.mockServer.requestCount();
 				await app.workbench.agentsWindow.submitNewSessionPrompt(`hello world [scenario:${AGENT_HOST_SANDBOX_SCENARIO_ID}]`);
@@ -1165,12 +1155,12 @@ export function setup(logger: Logger) {
  *
  * Assumes the Agents Window is showing a new-session view. Sends a throwaway
  * prompt, ignores its outcome, then leaves a fresh new-session view with
- * 'Local Agent Host' selected so the caller can submit the real prompt
+ * Agent Host Copilot selected so the caller can submit the real prompt
  * against an already-warmed model list.
  */
 async function warmUpAgentHostModel(app: Application, logger: Logger, label: string): Promise<void> {
 	await app.workbench.agentsWindow.waitForNewSessionView();
-	await app.workbench.agentsWindow.selectSessionType('Local Agent Host');
+	await app.workbench.agentsWindow.selectSessionType('Copilot');
 	await app.workbench.agentsWindow.submitNewSessionPrompt(`hello world [scenario:${AGENT_HOST_WARMUP_SCENARIO_ID}]`);
 	try {
 		await app.workbench.agentsWindow.waitForAssistantText(AGENT_HOST_WARMUP_REPLY, 30_000);
@@ -1181,7 +1171,7 @@ async function warmUpAgentHostModel(app: Application, logger: Logger, label: str
 	}
 	await app.workbench.agentsWindow.startNewSession();
 	await app.workbench.agentsWindow.waitForNewSessionView();
-	await app.workbench.agentsWindow.selectSessionType('Local Agent Host');
+	await app.workbench.agentsWindow.selectSessionType('Copilot');
 }
 
 

--- a/test/smoke/src/areas/chat/chatSessions.test.ts
+++ b/test/smoke/src/areas/chat/chatSessions.test.ts
@@ -81,6 +81,8 @@ async function preseedChatSessionProfile(userDataDir: string | undefined, mockSe
 		'chat.mcp.discovery.enabled': false,
 		'chat.mcp.enabled': false,
 		'chat.disableAIFeatures': false,
+		// This suite exercises the extension-host session providers directly.
+		'chat.agentHost.enabled': false,
 		'github.copilot.chat.backgroundAgent.enabled': true,
 		'github.copilot.chat.claudeAgent.enabled': true,
 		'github.copilot.chat.claudeAgent.useSdkExtension': false,


### PR DESCRIPTION
## Summary

- flip the six Agent Host migration settings from the rollout to their enabled defaults
- make web clients use the Agent Host on a connected remote extension host while keeping serverless web disabled
- preserve the extension-host Claude fallback whenever Agent Host is effectively unavailable

Fixes [vscode-internalbacklog#8652](https://github.com/microsoft/vscode-internalbacklog/issues/8652).

## Validation

- `scripts/test.sh` — Agent Host enablement, web-remote enablement, and remote client tests (11 passing)
- `scripts/test.sh` — chat-session visibility tests (20 passing)
- `npm run valid-layers-check`
- `npm run precommit`
- `npm run typecheck-client` reaches three pre-existing `voiceBridge.test.ts` constructor errors unrelated to this change

(Written by Copilot)