### PR TITLE
chat: stop auto-expanding non-terminal tool failures

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -2026,7 +2026,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.AutoExpandToolFailures]: {
 			type: 'boolean',
 			default: true,
-			markdownDescription: nls.localize('chat.tools.autoExpandFailures', "When enabled, tool failures are automatically expanded in the chat UI to show error details."),
+			markdownDescription: nls.localize('chat.tools.autoExpandFailures', "When enabled, terminal tool failures are automatically expanded in the chat UI to show error details."),
 		},
 		[ChatAIDisabledSettingId]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -12,9 +12,7 @@ import { autorun } from '../../../../../../../base/common/observable.js';
 import { basename } from '../../../../../../../base/common/resources.js';
 import { ILanguageService } from '../../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../../editor/common/services/model.js';
-import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { ChatConfiguration } from '../../../../common/constants.js';
 import { ChatResponseResource } from '../../../../common/model/chatModel.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../../common/chatService/chatService.js';
 import { IToolResultInputOutputDetails } from '../../../../common/tools/languageModelToolsService.js';
@@ -48,7 +46,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IModelService modelService: IModelService,
 		@ILanguageService languageService: ILanguageService,
-		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super(toolInvocation);
 
@@ -112,10 +109,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 				}),
 			} : undefined,
 			isError,
-			// Expand by default when there's an error (if setting enabled),
-			// otherwise use the stored expanded state (defaulting to false)
-			(isError && configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures)) ||
-			(ChatInputOutputMarkdownProgressPart._expandedByDefault.get(toolInvocation) ?? false),
+			ChatInputOutputMarkdownProgressPart._expandedByDefault.get(toolInvocation) ?? false,
 			shouldShimmerForTool(toolInvocation, message),
 		));
 		this._register(toDisposable(() => ChatInputOutputMarkdownProgressPart._expandedByDefault.set(toolInvocation, collapsibleListPart.expanded)));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSimpleToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSimpleToolProgressPart.ts
@@ -10,9 +10,7 @@ import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../../base/common/observable.js';
 import { ILanguageService } from '../../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../../editor/common/services/model.js';
-import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { ChatConfiguration } from '../../../../common/constants.js';
 import { IChatSimpleToolInvocationData, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../../common/chatService/chatService.js';
 import { IChatCodeBlockInfo } from '../../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
@@ -42,7 +40,6 @@ export class ChatSimpleToolProgressPart extends BaseChatToolInvocationSubPart {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IModelService modelService: IModelService,
 		@ILanguageService languageService: ILanguageService,
-		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super(toolInvocation);
 
@@ -80,10 +77,7 @@ export class ChatSimpleToolProgressPart extends BaseChatToolInvocationSubPart {
 			inputPart,
 			outputParts ? { parts: outputParts } : undefined,
 			isError,
-			// Expand by default when there's an error (if setting enabled),
-			// otherwise use the stored expanded state (defaulting to false)
-			(isError && configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures)) ||
-			(ChatSimpleToolProgressPart._expandedByDefault.get(toolInvocation) ?? false),
+			ChatSimpleToolProgressPart._expandedByDefault.get(toolInvocation) ?? false,
 			shouldShimmerForTool(toolInvocation, message),
 		));
 		this._register(toDisposable(() => ChatSimpleToolProgressPart._expandedByDefault.set(toolInvocation, collapsibleListPart.expanded)));


### PR DESCRIPTION
## Summary
- keep failed terminal tool calls expanded
- preserve the collapsed state for failed non-terminal tool calls
- clarify that the auto-expand setting applies to terminal tools

## Validation
- git diff --check
- not run: npm/node are unavailable on PATH