### PR TITLE
agent host pwsh tool should use pwsh grammar for terminal auto-approval 

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1360,7 +1360,10 @@ export interface IAgentToolPendingConfirmationSignal {
 	 * `sandbox.allowBypass`).
 	 */
 	readonly requestSandboxBypass?: boolean;
-	/** Host-only shell language for terminal auto-approval; `unknown` disables terminal rules. */
+	/**
+	 * Host-only shell language for terminal auto-approval.
+	 * Missing preserves the Bash fallback; `unknown` requires confirmation.
+	 */
 	readonly shellLanguage?: 'bash' | 'powershell' | 'unknown';
 	/**
 	 * If set, the tool call belongs to the subagent rooted at this

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1360,12 +1360,7 @@ export interface IAgentToolPendingConfirmationSignal {
 	 * `sandbox.allowBypass`).
 	 */
 	readonly requestSandboxBypass?: boolean;
-	/**
-	 * Host-only shell grammar hint for terminal auto-approval. Set by shell tools
-	 * so PowerShell commands are parsed with the PowerShell grammar instead of
-	 * bash. `unknown` means the shell request could not be correlated with its
-	 * tool and must not be auto-approved by terminal rules.
-	 */
+	/** Host-only shell language for terminal auto-approval; `unknown` disables terminal rules. */
 	readonly shellLanguage?: 'bash' | 'powershell' | 'unknown';
 	/**
 	 * If set, the tool call belongs to the subagent rooted at this

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1362,9 +1362,10 @@ export interface IAgentToolPendingConfirmationSignal {
 	readonly requestSandboxBypass?: boolean;
 	/**
 	 * Host-only shell language for terminal auto-approval.
-	 * Missing preserves the Bash fallback; `unknown` requires confirmation.
+	 * Only `bash` and `powershell` are eligible for terminal-rule analysis;
+	 * missing requires explicit confirmation.
 	 */
-	readonly shellLanguage?: 'bash' | 'powershell' | 'unknown';
+	readonly shellLanguage?: 'bash' | 'powershell';
 	/**
 	 * If set, the tool call belongs to the subagent rooted at this
 	 * parent tool call. Used by the host to route the resulting

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1363,9 +1363,10 @@ export interface IAgentToolPendingConfirmationSignal {
 	/**
 	 * Host-only shell grammar hint for terminal auto-approval (not part of the
 	 * dispatched action). Set by shell tools so PowerShell commands are parsed
-	 * with the PowerShell grammar instead of bash.
+	 * with the PowerShell grammar instead of bash. `unknown` means the shell
+	 * request could not be correlated with its tool and must not be auto-approved.
 	 */
-	readonly shellLanguage?: 'bash' | 'powershell';
+	readonly shellLanguage?: 'bash' | 'powershell' | 'unknown';
 	/**
 	 * If set, the tool call belongs to the subagent rooted at this
 	 * parent tool call. Used by the host to route the resulting

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1361,10 +1361,10 @@ export interface IAgentToolPendingConfirmationSignal {
 	 */
 	readonly requestSandboxBypass?: boolean;
 	/**
-	 * Host-only shell grammar hint for terminal auto-approval (not part of the
-	 * dispatched action). Set by shell tools so PowerShell commands are parsed
-	 * with the PowerShell grammar instead of bash. `unknown` means the shell
-	 * request could not be correlated with its tool and must not be auto-approved.
+	 * Host-only shell grammar hint for terminal auto-approval. Set by shell tools
+	 * so PowerShell commands are parsed with the PowerShell grammar instead of
+	 * bash. `unknown` means the shell request could not be correlated with its
+	 * tool and must not be auto-approved by terminal rules.
 	 */
 	readonly shellLanguage?: 'bash' | 'powershell' | 'unknown';
 	/**

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1361,6 +1361,12 @@ export interface IAgentToolPendingConfirmationSignal {
 	 */
 	readonly requestSandboxBypass?: boolean;
 	/**
+	 * Host-only shell grammar hint for terminal auto-approval (not part of the
+	 * dispatched action). Set by shell tools so PowerShell commands are parsed
+	 * with the PowerShell grammar instead of bash.
+	 */
+	readonly shellLanguage?: 'bash' | 'powershell';
+	/**
 	 * If set, the tool call belongs to the subagent rooted at this
 	 * parent tool call. Used by the host to route the resulting
 	 * `ChatToolCallReady` to the subagent session — otherwise the

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1113,6 +1113,7 @@ export class AgentSideEffects extends Disposable {
 			permissionPath: e.permissionPath,
 			toolInput: e.state.toolInput,
 			requestSandboxBypass: e.requestSandboxBypass,
+			shellLanguage: e.shellLanguage,
 		};
 		const autoApproval = e.managedApprovalRequired
 			? undefined

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -30,7 +30,7 @@ const SAFE_REDIRECT_TARGETS: ReadonlySet<string> = new Set([
  * either a known-safe /dev sink or a file-descriptor duplication target
  * like `&1` (used in `2>&1`).
  */
-function isSafeRedirectDestination(dest: string): boolean {
+function isSafeRedirectDestination(dest: string, isPowerShell?: boolean): boolean {
 	let cleaned = dest.trim();
 	if (cleaned.length === 0) {
 		return false;
@@ -41,6 +41,11 @@ function isSafeRedirectDestination(dest: string): boolean {
 	}
 	// File-descriptor duplication: `&N`, optionally followed by `-` to close.
 	if (/^&[0-9]+-?$/.test(cleaned)) {
+		return true;
+	}
+	// `$null` discards output in PowerShell like /dev/null; variable names are
+	// case-insensitive.
+	if (isPowerShell && cleaned.toLowerCase() === '$null') {
 		return true;
 	}
 	return SAFE_REDIRECT_TARGETS.has(cleaned);
@@ -59,16 +64,16 @@ type FileRedirectClassification =
 	| { kind: 'safeWrite' }
 	| { kind: 'unsafeWrite'; dest: string | undefined };
 
-function classifyFileRedirect(redirectText: string): FileRedirectClassification {
+function classifyFileRedirect(redirectText: string, isPowerShell?: boolean): FileRedirectClassification {
 	if (!redirectText.includes('>')) {
 		return { kind: 'read' };
 	}
-	const destMatch = redirectText.match(/(?:[0-9]+|&)?>>?\|?\s*(.+)$/);
+	const destMatch = redirectText.match(/(?:[0-9]+|&|\*)?>>?\|?\s*(.+)$/);
 	if (!destMatch) {
 		return { kind: 'unsafeWrite', dest: undefined };
 	}
 	const rawDest = destMatch[1].trim();
-	if (isSafeRedirectDestination(rawDest)) {
+	if (isSafeRedirectDestination(rawDest, isPowerShell)) {
 		return { kind: 'safeWrite' };
 	}
 	let dest = rawDest;
@@ -78,6 +83,31 @@ function classifyFileRedirect(redirectText: string): FileRedirectClassification 
 	}
 	return { kind: 'unsafeWrite', dest };
 }
+
+/**
+ * Matches a PowerShell command token of the form `-flag=` or `--flag=` at the
+ * start of input or following whitespace. Used to work around a tree-sitter
+ * PowerShell grammar limitation where POSIX-style `--flag=value` arguments
+ * (e.g. `git log --format="a|b"`) are parsed as assignment expressions and
+ * truncate the surrounding command. Mirrors the workbench's
+ * `TreeSitterCommandParser` workaround.
+ *
+ * See https://github.com/microsoft/vscode/issues/294010
+ * TODO: Remove once upstream tree-sitter PowerShell grammar is updated.
+ */
+const pwshFlagEqualsRegex = /(^|\s)(-{1,2}[\w-]+)=/g;
+
+// TODO: Remove once upstream tree-sitter PowerShell grammar is updated.
+function maskPwshFlagEquals(commandLine: string): string {
+	return commandLine.replace(pwshFlagEqualsRegex, (_, pre, flag) => `${pre}${flag} `);
+}
+
+/**
+ * Matches PowerShell redirects glued to their target (`2>$null`, `>out.txt`,
+ * `*>>log.txt`). The grammar parses these as `generic_token` command arguments
+ * rather than `redirection` nodes, which only cover the spaced form.
+ */
+const pwshNoSpaceRedirectRegex = /^[0-9*]?>>?/;
 
 /**
  * Result of a command auto-approval check.
@@ -114,10 +144,18 @@ export interface IShouldAutoApproveOptions {
 	 * default rules for compatibility with older clients.
 	 */
 	readonly autoApproveRules?: AgentHostTerminalAutoApproveRules;
+	/**
+	 * Shell grammar to parse the command line with. PowerShell commands are
+	 * parsed with the PowerShell grammar and matched against rules
+	 * case-insensitively, like PowerShell itself. Defaults to `bash`.
+	 */
+	readonly language?: 'bash' | 'powershell';
 }
 
 interface IAutoApproveRule {
 	readonly regex: RegExp;
+	/** Case-insensitive variant of {@link regex}, used for PowerShell matching. */
+	readonly regexCaseInsensitive: RegExp;
 }
 
 interface IAutoApproveRules {
@@ -152,6 +190,7 @@ export class CommandAutoApprover extends Disposable {
 	private _cachedRules: IAutoApproveRules | undefined;
 	private _parser: Parser | undefined;
 	private _bashLanguage: Language | undefined;
+	private _powershellLanguage: Language | undefined;
 	private _queryClass: typeof Query | undefined;
 	private readonly _initPromise: Promise<void>;
 
@@ -191,8 +230,9 @@ export class CommandAutoApprover extends Disposable {
 		}
 
 		const rules = this._compileRules(options?.autoApproveRules);
+		const isPowerShell = options?.language === 'powershell';
 
-		const parsed = this._extractSubCommands(trimmed);
+		const parsed = this._extractSubCommands(trimmed, isPowerShell);
 		if (!parsed) {
 			this._logService.trace('[CommandAutoApprover] Tree-sitter unavailable, requiring confirmation');
 			return { result: 'noMatch', autoApproveRuleResolvable: false };
@@ -204,7 +244,7 @@ export class CommandAutoApprover extends Disposable {
 
 		const hasUnapprovedRedirect = () => parsed.unsafeWriteDests.some(dest => dest === undefined || !options?.isWriteDestApproved?.(dest));
 
-		let result = this._matchSubCommands(parsed.subCommands, rules);
+		let result = this._matchSubCommands(parsed.subCommands, rules, isPowerShell);
 		if (result !== 'denied' && this._matchesRule(trimmed, rules.allowCommandLineRules)) {
 			result = 'approved';
 		}
@@ -215,7 +255,7 @@ export class CommandAutoApprover extends Disposable {
 		return { result, autoApproveRuleResolvable: result === 'noMatch' && !hasUnapprovedRedirect() };
 	}
 
-	private _matchSubCommands(subCommands: string[], rules: IAutoApproveRules): CommandApprovalResult {
+	private _matchSubCommands(subCommands: string[], rules: IAutoApproveRules, isPowerShell: boolean): CommandApprovalResult {
 		let allApproved = true;
 		for (const subCommand of subCommands) {
 			// Deny transient env var assignments
@@ -223,7 +263,7 @@ export class CommandAutoApprover extends Disposable {
 				return 'denied';
 			}
 
-			const result = this._matchSingleCommand(subCommand, rules);
+			const result = this._matchSingleCommand(subCommand, rules, isPowerShell);
 			if (result === 'denied') {
 				return 'denied';
 			}
@@ -234,23 +274,29 @@ export class CommandAutoApprover extends Disposable {
 		return allApproved ? 'approved' : 'noMatch';
 	}
 
-	private _matchSingleCommand(command: string, rules: IAutoApproveRules): CommandApprovalResult {
+	private _matchSingleCommand(command: string, rules: IAutoApproveRules, isPowerShell: boolean): CommandApprovalResult {
 		// Check deny rules first
-		if (this._matchesRule(command, rules.denyRules)) {
+		if (this._matchesRule(command, rules.denyRules, isPowerShell)) {
 			return 'denied';
 		}
 
 		// Then check allow rules
-		if (this._matchesRule(command, rules.allowRules)) {
+		if (this._matchesRule(command, rules.allowRules, isPowerShell)) {
 			return 'approved';
 		}
 
 		return 'noMatch';
 	}
 
-	private _matchesRule(command: string, rules: readonly IAutoApproveRule[]): boolean {
+	private _matchesRule(command: string, rules: readonly IAutoApproveRule[], isPowerShell?: boolean): boolean {
 		for (const rule of rules) {
-			if (rule.regex.test(command)) {
+			// PowerShell rule matching is case-insensitive, like the shell itself.
+			if ((isPowerShell ? rule.regexCaseInsensitive : rule.regex).test(command)) {
+				return true;
+			}
+			// Ignore a leading ( for PowerShell commands: it's a command pattern
+			// operating on the output of a command, e.g. `(Get-Content README.md) ...`.
+			if (isPowerShell && command.startsWith('(') && rule.regexCaseInsensitive.test(command.slice(1))) {
 				return true;
 			}
 		}
@@ -259,30 +305,48 @@ export class CommandAutoApprover extends Disposable {
 
 	// ---- Tree-sitter --------------------------------------------------------
 
-	private _extractSubCommands(commandLine: string): { subCommands: string[]; unsafeWriteDests: (string | undefined)[] } | undefined {
-		if (!this._parser || !this._bashLanguage || !this._queryClass) {
+	private _extractSubCommands(commandLine: string, isPowerShell: boolean): { subCommands: string[]; unsafeWriteDests: (string | undefined)[] } | undefined {
+		const language = isPowerShell ? this._powershellLanguage : this._bashLanguage;
+		if (!this._parser || !language || !this._queryClass) {
 			return undefined;
 		}
 
 		try {
-			this._parser.setLanguage(this._bashLanguage);
-			const tree = this._parser.parse(commandLine);
+			this._parser.setLanguage(language);
+			// The PowerShell grammar truncates commands around `--flag=value`
+			// arguments, so they are masked before parsing (positions are
+			// preserved) and capture text is sliced from the original.
+			const masked = isPowerShell ? maskPwshFlagEquals(commandLine) : commandLine;
+			const tree = this._parser.parse(masked);
 			if (!tree) {
 				return undefined;
 			}
 
 			try {
-				const query = new this._queryClass(this._bashLanguage, '(command) @command (file_redirect) @file_redirect (heredoc_redirect) @heredoc_redirect (herestring_redirect) @herestring_redirect');
+				if (isPowerShell && tree.rootNode.hasError) {
+					// An erroring parse can produce truncated captures that hide
+					// part of the command line from rule matching, so require
+					// confirmation instead of judging the partial parse.
+					this._logService.trace('[CommandAutoApprover] PowerShell parse contains errors, requiring confirmation');
+					return undefined;
+				}
+				// No-space PowerShell redirects (`2>$null`) parse as generic_token
+				// command arguments rather than redirection nodes, so both are
+				// captured and filtered by shape below.
+				const query = new this._queryClass(language, isPowerShell
+					? '(command) @command (redirection) @redirection (generic_token) @generic_token'
+					: '(command) @command (file_redirect) @file_redirect (heredoc_redirect) @heredoc_redirect (herestring_redirect) @herestring_redirect');
 				const captures: QueryCapture[] = query.captures(tree.rootNode);
 				const subCommands: string[] = [];
 				const unsafeWriteDests: (string | undefined)[] = [];
 				for (const capture of captures) {
+					const text = masked === commandLine ? capture.node.text : commandLine.substring(capture.node.startIndex, capture.node.endIndex);
 					if (capture.name === 'command') {
-						subCommands.push(capture.node.text);
-					} else if (capture.name === 'file_redirect') {
-						// Writes to known-safe sinks (e.g. `> /dev/null`) and
-						// file-descriptor duplications (e.g. `2>&1`) are allowed.
-						const cls = classifyFileRedirect(capture.node.text);
+						subCommands.push(text);
+					} else if (capture.name === 'file_redirect' || capture.name === 'redirection' || (capture.name === 'generic_token' && pwshNoSpaceRedirectRegex.test(text))) {
+						// Writes to known-safe sinks (e.g. `> /dev/null`, `2>$null`)
+						// and file-descriptor duplications (e.g. `2>&1`) are allowed.
+						const cls = classifyFileRedirect(text, isPowerShell);
 						if (cls.kind === 'unsafeWrite') {
 							unsafeWriteDests.push(cls.dest);
 						}
@@ -336,15 +400,15 @@ export class CommandAutoApprover extends Disposable {
 				}
 			}));
 
-			// Load bash grammar
-			const bashWasmPath = URI.joinPath(moduleRoot, 'tree-sitter-bash.wasm').fsPath;
-			const bashWasm = await fs.promises.readFile(bashWasmPath);
-
-			if (this._store.isDisposed) {
-				return;
-			}
-
-			const bashLanguage = await TreeSitter.Language.load(new Uint8Array(bashWasm.buffer, bashWasm.byteOffset, bashWasm.byteLength));
+			// Load the bash and PowerShell grammars
+			const loadGrammar = async (fileName: string) => {
+				const grammarWasm = await fs.promises.readFile(URI.joinPath(moduleRoot, fileName).fsPath);
+				return TreeSitter.Language.load(new Uint8Array(grammarWasm.buffer, grammarWasm.byteOffset, grammarWasm.byteLength));
+			};
+			const [bashLanguage, powershellLanguage] = await Promise.all([
+				loadGrammar('tree-sitter-bash.wasm'),
+				loadGrammar('tree-sitter-powershell.wasm'),
+			]);
 
 			if (this._store.isDisposed) {
 				return;
@@ -352,6 +416,7 @@ export class CommandAutoApprover extends Disposable {
 
 			this._parser = parser;
 			this._bashLanguage = bashLanguage;
+			this._powershellLanguage = powershellLanguage;
 			this._queryClass = TreeSitter.Query;
 			this._logService.info('[CommandAutoApprover] Tree-sitter initialized successfully');
 		} catch (err) {
@@ -385,23 +450,23 @@ export class CommandAutoApprover extends Disposable {
 		const denyCommandLineRules: IAutoApproveRule[] = [];
 
 		for (const [key, value] of Object.entries(ruleConfig)) {
-			const regex = convertAutoApproveEntryToRegex(key);
+			const rule = convertAutoApproveEntryToRule(key);
 			if (value === true) {
-				allowRules.push({ regex });
+				allowRules.push(rule);
 			} else if (value === false) {
-				denyRules.push({ regex });
+				denyRules.push(rule);
 			} else if (value && typeof value === 'object' && typeof value.approve === 'boolean') {
 				if (value.approve) {
 					if (value.matchCommandLine === true) {
-						allowCommandLineRules.push({ regex });
+						allowCommandLineRules.push(rule);
 					} else {
-						allowRules.push({ regex });
+						allowRules.push(rule);
 					}
 				} else {
 					if (value.matchCommandLine === true) {
-						denyCommandLineRules.push({ regex });
+						denyCommandLineRules.push(rule);
 					} else {
-						denyRules.push({ regex });
+						denyRules.push(rule);
 					}
 				}
 			}
@@ -412,6 +477,14 @@ export class CommandAutoApprover extends Disposable {
 }
 
 // ---- Regex conversion -------------------------------------------------------
+
+function convertAutoApproveEntryToRule(value: string): IAutoApproveRule {
+	const regex = convertAutoApproveEntryToRegex(value);
+	if (regex.flags.includes('i')) {
+		return { regex, regexCaseInsensitive: regex };
+	}
+	return { regex, regexCaseInsensitive: new RegExp(regex.source, regex.flags + 'i') };
+}
 
 function convertAutoApproveEntryToRegex(value: string): RegExp {
 	// If wrapped in `/`, treat as regex

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -146,8 +146,9 @@ export interface IShouldAutoApproveOptions {
 	readonly autoApproveRules?: AgentHostTerminalAutoApproveRules;
 	/**
 	 * Shell grammar to parse the command line with. PowerShell commands are
-	 * parsed with the PowerShell grammar and matched against rules
-	 * case-insensitively, like PowerShell itself. Defaults to `bash`.
+	 * parsed with the PowerShell grammar. Sub-command rules and full-command
+	 * deny rules are matched case-insensitively, like PowerShell itself;
+	 * full-command allow rules retain their configured casing. Defaults to `bash`.
 	 */
 	readonly language?: 'bash' | 'powershell';
 }
@@ -232,7 +233,7 @@ export class CommandAutoApprover extends Disposable {
 		const rules = this._compileRules(options?.autoApproveRules);
 		const isPowerShell = options?.language === 'powershell';
 
-		if (this._matchesRule(trimmed, rules.denyCommandLineRules)) {
+		if (this._matchesCommandLineRule(trimmed, rules.denyCommandLineRules, isPowerShell)) {
 			return { result: 'denied', autoApproveRuleResolvable: false };
 		}
 
@@ -245,7 +246,7 @@ export class CommandAutoApprover extends Disposable {
 		const hasUnapprovedRedirect = () => parsed.unsafeWriteDests.some(dest => dest === undefined || !options?.isWriteDestApproved?.(dest));
 
 		let result = this._matchSubCommands(parsed.subCommands, rules, isPowerShell);
-		if (result !== 'denied' && this._matchesRule(trimmed, rules.allowCommandLineRules)) {
+		if (result !== 'denied' && this._matchesCommandLineRule(trimmed, rules.allowCommandLineRules)) {
 			result = 'approved';
 		}
 		if (result === 'approved' && hasUnapprovedRedirect()) {
@@ -286,6 +287,15 @@ export class CommandAutoApprover extends Disposable {
 		}
 
 		return 'noMatch';
+	}
+
+	private _matchesCommandLineRule(commandLine: string, rules: readonly IAutoApproveRule[], caseInsensitive = false): boolean {
+		for (const rule of rules) {
+			if ((caseInsensitive ? rule.regexCaseInsensitive : rule.regex).test(commandLine)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private _matchesRule(command: string, rules: readonly IAutoApproveRule[], isPowerShell?: boolean): boolean {

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -18,7 +18,7 @@ import type { AgentHostTerminalAutoApproveRuleValue, AgentHostTerminalAutoApprov
  * on disk: the /dev sinks that discard output (`/dev/null`) or write back to
  * the same terminal (`/dev/stdout`, `/dev/stderr`, `/dev/tty`).
  */
-const SAFE_REDIRECT_TARGETS: ReadonlySet<string> = new Set([
+const SAFE_POSIX_REDIRECT_TARGETS: ReadonlySet<string> = new Set([
 	'/dev/null',
 	'/dev/stdout',
 	'/dev/stderr',
@@ -27,13 +27,18 @@ const SAFE_REDIRECT_TARGETS: ReadonlySet<string> = new Set([
 
 /**
  * Returns true when the given redirection destination is known to be safe:
- * either a known-safe /dev sink or a file-descriptor duplication target
+ * either the shell's null/output sink or a file-descriptor duplication target
  * like `&1` (used in `2>&1`).
  */
 function isSafeRedirectDestination(dest: string, isPowerShell?: boolean): boolean {
 	let cleaned = dest.trim();
 	if (cleaned.length === 0) {
 		return false;
+	}
+	// `$null` discards output in PowerShell like /dev/null; variable names are
+	// case-insensitive. Quoted forms are strings rather than the null sink.
+	if (isPowerShell && cleaned.toLowerCase() === '$null') {
+		return true;
 	}
 	if ((cleaned.startsWith(`'`) && cleaned.endsWith(`'`)) ||
 		(cleaned.startsWith('"') && cleaned.endsWith('"'))) {
@@ -43,12 +48,9 @@ function isSafeRedirectDestination(dest: string, isPowerShell?: boolean): boolea
 	if (/^&[0-9]+-?$/.test(cleaned)) {
 		return true;
 	}
-	// `$null` discards output in PowerShell like /dev/null; variable names are
-	// case-insensitive.
-	if (isPowerShell && cleaned.toLowerCase() === '$null') {
-		return true;
-	}
-	return SAFE_REDIRECT_TARGETS.has(cleaned);
+	// PowerShell uses `$null` as its null sink. In particular, `/dev/null`
+	// resolves as a filesystem path on Windows.
+	return !isPowerShell && SAFE_POSIX_REDIRECT_TARGETS.has(cleaned);
 }
 
 /**

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -148,9 +148,9 @@ export interface IShouldAutoApproveOptions {
 	readonly autoApproveRules?: AgentHostTerminalAutoApproveRules;
 	/**
 	 * Shell grammar to parse the command line with. PowerShell commands are
-	 * parsed with the PowerShell grammar. Sub-command rules and full-command
-	 * deny rules are matched case-insensitively, like PowerShell itself;
-	 * full-command allow rules retain their configured casing. Defaults to `bash`.
+	 * parsed with the PowerShell grammar. Sub-command rules are matched
+	 * case-insensitively, like PowerShell itself; full-command rules retain
+	 * their configured casing. Defaults to `bash`.
 	 */
 	readonly language?: 'bash' | 'powershell';
 }
@@ -235,7 +235,7 @@ export class CommandAutoApprover extends Disposable {
 		const rules = this._compileRules(options?.autoApproveRules);
 		const isPowerShell = options?.language === 'powershell';
 
-		if (this._matchesCommandLineRule(trimmed, rules.denyCommandLineRules, isPowerShell)) {
+		if (this._matchesCommandLineRule(trimmed, rules.denyCommandLineRules)) {
 			return { result: 'denied', autoApproveRuleResolvable: false };
 		}
 
@@ -291,13 +291,8 @@ export class CommandAutoApprover extends Disposable {
 		return 'noMatch';
 	}
 
-	private _matchesCommandLineRule(commandLine: string, rules: readonly IAutoApproveRule[], caseInsensitive = false): boolean {
-		for (const rule of rules) {
-			if ((caseInsensitive ? rule.regexCaseInsensitive : rule.regex).test(commandLine)) {
-				return true;
-			}
-		}
-		return false;
+	private _matchesCommandLineRule(commandLine: string, rules: readonly IAutoApproveRule[]): boolean {
+		return rules.some(rule => rule.regex.test(commandLine));
 	}
 
 	private _matchesRule(command: string, rules: readonly IAutoApproveRule[], isPowerShell?: boolean): boolean {

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -485,7 +485,11 @@ export class CommandAutoApprover extends Disposable {
 		const denyCommandLineRules: IAutoApproveRule[] = [];
 
 		for (const [key, value] of Object.entries(ruleConfig)) {
-			const rule = convertAutoApproveEntryToRule(key);
+			const regex = convertAutoApproveEntryToRegex(key);
+			const rule = {
+				regex,
+				regexCaseInsensitive: regex.flags.includes('i') ? regex : new RegExp(regex.source, regex.flags + 'i'),
+			};
 			if (value === true) {
 				allowRules.push(rule);
 			} else if (value === false) {
@@ -512,14 +516,6 @@ export class CommandAutoApprover extends Disposable {
 }
 
 // ---- Regex conversion -------------------------------------------------------
-
-function convertAutoApproveEntryToRule(value: string): IAutoApproveRule {
-	const regex = convertAutoApproveEntryToRegex(value);
-	if (regex.flags.includes('i')) {
-		return { regex, regexCaseInsensitive: regex };
-	}
-	return { regex, regexCaseInsensitive: new RegExp(regex.source, regex.flags + 'i') };
-}
 
 function convertAutoApproveEntryToRegex(value: string): RegExp {
 	// If wrapped in `/`, treat as regex

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -232,14 +232,14 @@ export class CommandAutoApprover extends Disposable {
 		const rules = this._compileRules(options?.autoApproveRules);
 		const isPowerShell = options?.language === 'powershell';
 
-		const parsed = this._extractSubCommands(trimmed, isPowerShell);
-		if (!parsed) {
-			this._logService.trace('[CommandAutoApprover] Tree-sitter unavailable, requiring confirmation');
-			return { result: 'noMatch', autoApproveRuleResolvable: false };
-		}
-
 		if (this._matchesRule(trimmed, rules.denyCommandLineRules)) {
 			return { result: 'denied', autoApproveRuleResolvable: false };
+		}
+
+		const parsed = this._extractSubCommands(trimmed, isPowerShell);
+		if (!parsed) {
+			this._logService.trace('[CommandAutoApprover] Command line could not be analyzed, requiring confirmation');
+			return { result: 'noMatch', autoApproveRuleResolvable: false };
 		}
 
 		const hasUnapprovedRedirect = () => parsed.unsafeWriteDests.some(dest => dest === undefined || !options?.isWriteDestApproved?.(dest));
@@ -332,17 +332,22 @@ export class CommandAutoApprover extends Disposable {
 				}
 				// No-space PowerShell redirects (`2>$null`) parse as generic_token
 				// command arguments rather than redirection nodes, so both are
-				// captured and filtered by shape below.
+				// captured and filtered by shape below. Assignments and method
+				// invocations are captured so the command line can fail closed
+				// when it contains code the rules cannot see.
 				const query = new this._queryClass(language, isPowerShell
-					? '(command) @command (redirection) @redirection (generic_token) @generic_token'
+					? '(command) @command (redirection) @redirection (generic_token) @generic_token (assignment_expression) @unanalyzable (invokation_expression) @unanalyzable'
 					: '(command) @command (file_redirect) @file_redirect (heredoc_redirect) @heredoc_redirect (herestring_redirect) @herestring_redirect');
 				const captures: QueryCapture[] = query.captures(tree.rootNode);
 				const subCommands: string[] = [];
 				const unsafeWriteDests: (string | undefined)[] = [];
+				let unanalyzableType: string | undefined;
 				for (const capture of captures) {
 					const text = masked === commandLine ? capture.node.text : commandLine.substring(capture.node.startIndex, capture.node.endIndex);
 					if (capture.name === 'command') {
 						subCommands.push(text);
+					} else if (capture.name === 'unanalyzable') {
+						unanalyzableType ??= capture.node.type;
 					} else if (capture.name === 'file_redirect' || capture.name === 'redirection' || (capture.name === 'generic_token' && pwshNoSpaceRedirectRegex.test(text))) {
 						// Writes to known-safe sinks (e.g. `> /dev/null`, `2>$null`)
 						// and file-descriptor duplications (e.g. `2>&1`) are allowed.
@@ -356,6 +361,11 @@ export class CommandAutoApprover extends Disposable {
 					}
 				}
 				query.delete();
+
+				if (unanalyzableType) {
+					this._logService.trace(`[CommandAutoApprover] Command line contains an unanalyzable ${unanalyzableType}, requiring confirmation`);
+					return undefined;
+				}
 				return subCommands.length > 0 || unsafeWriteDests.length > 0 ? { subCommands, unsafeWriteDests } : undefined;
 			} finally {
 				tree.delete();
@@ -400,12 +410,14 @@ export class CommandAutoApprover extends Disposable {
 				}
 			}));
 
-			// Load the bash and PowerShell grammars
+			// Load the bash and PowerShell grammars. A failure to load one must
+			// not disable auto-approval for the other, so each is settled
+			// independently and assigned only if it resolved.
 			const loadGrammar = async (fileName: string) => {
 				const grammarWasm = await fs.promises.readFile(URI.joinPath(moduleRoot, fileName).fsPath);
 				return TreeSitter.Language.load(new Uint8Array(grammarWasm.buffer, grammarWasm.byteOffset, grammarWasm.byteLength));
 			};
-			const [bashLanguage, powershellLanguage] = await Promise.all([
+			const [bashLanguage, powershellLanguage] = await Promise.allSettled([
 				loadGrammar('tree-sitter-bash.wasm'),
 				loadGrammar('tree-sitter-powershell.wasm'),
 			]);
@@ -415,10 +427,21 @@ export class CommandAutoApprover extends Disposable {
 			}
 
 			this._parser = parser;
-			this._bashLanguage = bashLanguage;
-			this._powershellLanguage = powershellLanguage;
 			this._queryClass = TreeSitter.Query;
-			this._logService.info('[CommandAutoApprover] Tree-sitter initialized successfully');
+			// A grammar that fails to load leaves its language undefined, so
+			// commands for that shell fall back to `noMatch` and require
+			// confirmation rather than auto-approving.
+			if (bashLanguage.status === 'fulfilled') {
+				this._bashLanguage = bashLanguage.value;
+			} else {
+				this._logService.warn('[CommandAutoApprover] Failed to load the bash grammar; bash commands will require confirmation', bashLanguage.reason);
+			}
+			if (powershellLanguage.status === 'fulfilled') {
+				this._powershellLanguage = powershellLanguage.value;
+			} else {
+				this._logService.warn('[CommandAutoApprover] Failed to load the PowerShell grammar; PowerShell commands will require confirmation', powershellLanguage.reason);
+			}
+			this._logService.info(`[CommandAutoApprover] Tree-sitter initialized (bash=${this._bashLanguage ? 'available' : 'unavailable'}, powershell=${this._powershellLanguage ? 'available' : 'unavailable'})`);
 		} catch (err) {
 			this._logService.warn('[CommandAutoApprover] Failed to initialize tree-sitter', err);
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2505,12 +2505,13 @@ export class CopilotAgentSession extends Disposable {
 			const shellToolName = request.kind === 'shell'
 				? trackedToolName
 				: customShellToolName;
-			const shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'] = !isShellRequest
-				? undefined
-				: shellToolName === 'bash' || shellToolName === 'powershell'
+			// Only emit a language when the executing shell tool is known.
+			// Missing language fails closed in SessionPermissionManager.
+			const shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'] =
+				isShellRequest && (shellToolName === 'bash' || shellToolName === 'powershell')
 					? shellToolName
-					: 'unknown';
-			if (shellLanguage === 'unknown') {
+					: undefined;
+			if (isShellRequest && shellLanguage === undefined) {
 				this._logService.warn(`[Copilot:${this.sessionId}] Shell permission request has no recognized shell tool name; requiring confirmation: toolCallId=${toolCallId}, toolName=${shellToolName ?? '(missing)'}`);
 			}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2492,14 +2492,19 @@ export class CopilotAgentSession extends Disposable {
 				return { kind: 'approve-once' };
 			}
 
-			const isShellRequest = request.kind === 'shell'
-				|| (request.kind === 'custom-tool' && typeof request.toolName === 'string' && isShellTool(request.toolName));
+			// The SDK's built-in terminal reports `kind: 'shell'`. The Agent Host's
+			// terminal override is registered as an SDK custom tool named `bash` or
+			// `powershell`, so it reports `kind: 'custom-tool'` instead.
+			const customShellToolName = request.kind === 'custom-tool'
+				&& typeof request.toolName === 'string'
+				&& isShellTool(request.toolName)
+				? request.toolName
+				: undefined;
+			const isShellRequest = request.kind === 'shell' || customShellToolName !== undefined;
 			const trackedToolName = this._activeToolCalls.get(toolCallId)?.toolName;
 			const shellToolName = request.kind === 'shell'
 				? trackedToolName
-				: request.kind === 'custom-tool'
-					? request.toolName
-					: undefined;
+				: customShellToolName;
 			const shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'] = !isShellRequest
 				? undefined
 				: shellToolName === 'bash' || shellToolName === 'powershell'

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -32,7 +32,7 @@ import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from 
 import { gitHubMcpServerUrl } from '../../common/githubEndpoints.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, platformRootSchema, platformSessionSchema } from '../../common/agentHostSchema.js';
-import { AgentSession, AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle } from '../../common/agentService.js';
+import { AgentSession, AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import { META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta, type IToolSearchCandidate } from '../../common/meta/agentToolCallMeta.js';
@@ -2494,13 +2494,24 @@ export class CopilotAgentSession extends Disposable {
 
 			const isShellRequest = request.kind === 'shell'
 				|| (request.kind === 'custom-tool' && typeof request.toolName === 'string' && isShellTool(request.toolName));
-			// Tell the auto-approver which grammar the command is written in.
-			// `shell` requests carry no tool name, so fall back to the tracked
-			// tool call's SDK tool name.
-			const shellToolName = typeof request.toolName === 'string' ? request.toolName : this._activeToolCalls.get(toolCallId)?.toolName;
-			const shellLanguage = isShellRequest
-				? (shellToolName && getShellLanguage(shellToolName) === 'powershell' ? 'powershell' as const : 'bash' as const)
-				: undefined;
+			const trackedToolName = this._activeToolCalls.get(toolCallId)?.toolName;
+			const shellToolName = typeof request.toolName === 'string' ? request.toolName : trackedToolName;
+			let shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'];
+			if (isShellRequest) {
+				switch (shellToolName) {
+					case 'bash':
+						shellLanguage = 'bash';
+						break;
+					case 'powershell':
+						shellLanguage = 'powershell';
+						break;
+					default:
+						shellLanguage = 'unknown';
+				}
+			}
+			if (shellLanguage === 'unknown') {
+				this._logService.warn(`[Copilot:${this.sessionId}] Shell permission request has no recognized shell tool name; requiring confirmation: toolCallId=${toolCallId}, toolName=${shellToolName ?? '(missing)'}`);
+			}
 
 			if (!managedApprovalRequired && request.kind === 'custom-tool'
 				&& typeof request.toolName === 'string'

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2494,6 +2494,13 @@ export class CopilotAgentSession extends Disposable {
 
 			const isShellRequest = request.kind === 'shell'
 				|| (request.kind === 'custom-tool' && typeof request.toolName === 'string' && isShellTool(request.toolName));
+			// Tell the auto-approver which grammar the command is written in.
+			// `shell` requests carry no tool name, so fall back to the tracked
+			// tool call's SDK tool name.
+			const shellToolName = typeof request.toolName === 'string' ? request.toolName : this._activeToolCalls.get(toolCallId)?.toolName;
+			const shellLanguage = isShellRequest
+				? (shellToolName && getShellLanguage(shellToolName) === 'powershell' ? 'powershell' as const : 'bash' as const)
+				: undefined;
 
 			if (!managedApprovalRequired && request.kind === 'custom-tool'
 				&& typeof request.toolName === 'string'
@@ -2576,6 +2583,7 @@ export class CopilotAgentSession extends Disposable {
 				permissionPath,
 				managedApprovalRequired,
 				requestSandboxBypass: request.requestSandboxBypass,
+				shellLanguage,
 				parentToolCallId,
 			});
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2495,20 +2495,16 @@ export class CopilotAgentSession extends Disposable {
 			const isShellRequest = request.kind === 'shell'
 				|| (request.kind === 'custom-tool' && typeof request.toolName === 'string' && isShellTool(request.toolName));
 			const trackedToolName = this._activeToolCalls.get(toolCallId)?.toolName;
-			const shellToolName = typeof request.toolName === 'string' ? request.toolName : trackedToolName;
-			let shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'];
-			if (isShellRequest) {
-				switch (shellToolName) {
-					case 'bash':
-						shellLanguage = 'bash';
-						break;
-					case 'powershell':
-						shellLanguage = 'powershell';
-						break;
-					default:
-						shellLanguage = 'unknown';
-				}
-			}
+			const shellToolName = request.kind === 'shell'
+				? trackedToolName
+				: request.kind === 'custom-tool'
+					? request.toolName
+					: undefined;
+			const shellLanguage: IAgentToolPendingConfirmationSignal['shellLanguage'] = !isShellRequest
+				? undefined
+				: shellToolName === 'bash' || shellToolName === 'powershell'
+					? shellToolName
+					: 'unknown';
 			if (shellLanguage === 'unknown') {
 				this._logService.warn(`[Copilot:${this.sessionId}] Shell permission request has no recognized shell tool name; requiring confirmation: toolCallId=${toolCallId}, toolName=${shellToolName ?? '(missing)'}`);
 			}

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -308,6 +308,10 @@ export class SessionPermissionManager extends Disposable {
 
 		// 6. Shell auto-approval
 		if (e.permissionKind === 'shell' && e.toolInput) {
+			if (e.shellLanguage === 'unknown') {
+				this._logService.trace('[SessionPermissionManager] Shell language is unknown, requiring confirmation');
+				return undefined;
+			}
 			if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {
 				return undefined;
 			}
@@ -331,7 +335,7 @@ export class SessionPermissionManager extends Disposable {
 
 	/** Whether adding a persistent terminal auto-approve rule can suppress future prompts for this shell event. */
 	isAutoApproveRuleResolvable(e: IToolApprovalEvent, sessionKey: ProtocolURI): boolean {
-		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass) {
+		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass || e.shellLanguage === 'unknown') {
 			return false;
 		}
 		if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {
@@ -488,15 +492,35 @@ export class SessionPermissionManager extends Disposable {
 	}
 
 	/**
+	 * Matches redirect destinations whose final path is decided by the shell
+	 * rather than by the text: variable expansions (`$HOME/x`, `$env:TEMP/x`,
+	 * `%APPDATA%\x`), command substitutions (`$(pwd)/x`, `` `pwd`/x ``), brace
+	 * expansions, and `~` in a position {@link untildify} does not handle.
+	 * Mirrors the workbench's file-write analyzer guard.
+	 *
+	 * See https://github.com/microsoft/vscode/issues/274166 and
+	 * https://github.com/microsoft/vscode/issues/274167
+	 */
+	private static readonly _dynamicRedirectDestRegex = /[$(){}`~%]/;
+
+	/**
 	 * Resolves the raw text of a shell redirect destination to an absolute
 	 * filesystem path. `~` is expanded to the user's home directory; the
 	 * downstream working-directory check rejects paths that end up outside
 	 * the workspace. Returns `undefined` when resolution would require a
-	 * working directory that isn't configured.
+	 * working directory that isn't configured, or when the destination expands
+	 * at runtime and therefore cannot be resolved from its text alone.
 	 */
 	private _resolveShellRedirectResource(dest: string, workingDirectory: URI | undefined): URI | undefined {
 		const trimmed = untildify(dest.trim(), homedir());
 		if (!trimmed) {
+			return undefined;
+		}
+		// A destination the shell expands (e.g. `$HOME/x.txt`) would otherwise be
+		// treated as a literal relative path and resolve *inside* the working
+		// directory, auto-approving a write that actually lands elsewhere.
+		if (SessionPermissionManager._dynamicRedirectDestRegex.test(trimmed)) {
+			this._logService.trace(`[SessionPermissionManager] Redirect destination expands at runtime, requiring confirmation: ${dest}`);
 			return undefined;
 		}
 		if (path.isAbsolute(trimmed)) {

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -46,6 +46,7 @@ export interface IToolApprovalEvent {
 	readonly permissionPath?: string;
 	readonly toolInput?: string;
 	readonly requestSandboxBypass?: boolean;
+	readonly shellLanguage?: IAgentToolPendingConfirmationSignal['shellLanguage'];
 }
 
 /** Standard per-tool confirmation options presented to the user. */
@@ -313,6 +314,7 @@ export class SessionPermissionManager extends Disposable {
 			const result = this._commandAutoApprover.shouldAutoApprove(e.toolInput, {
 				autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
 				isWriteDestApproved: dest => this._isShellWriteDestApproved(dest, workingDirectories),
+				language: e.shellLanguage,
 			});
 			if (result === 'approved') {
 				this._logService.trace('[SessionPermissionManager] Auto-approving shell command');
@@ -340,6 +342,7 @@ export class SessionPermissionManager extends Disposable {
 		return this._commandAutoApprover.evaluate(e.toolInput, {
 			autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
 			isWriteDestApproved: dest => this._isShellWriteDestApproved(dest, workingDirectories),
+			language: e.shellLanguage,
 		}).autoApproveRuleResolvable;
 	}
 

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -308,8 +308,10 @@ export class SessionPermissionManager extends Disposable {
 
 		// 6. Shell auto-approval
 		if (e.permissionKind === 'shell' && e.toolInput) {
-			if (e.shellLanguage === 'unknown') {
-				this._logService.trace('[SessionPermissionManager] Shell language is unknown, requiring confirmation');
+			// Terminal-rule analysis needs an explicit shell dialect. Producers
+			// that omit `shellLanguage` (or fail to correlate one) must prompt.
+			if (!e.shellLanguage) {
+				this._logService.trace('[SessionPermissionManager] Shell language is missing, requiring confirmation');
 				return undefined;
 			}
 			if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {
@@ -335,7 +337,7 @@ export class SessionPermissionManager extends Disposable {
 
 	/** Whether adding a persistent terminal auto-approve rule can suppress future prompts for this shell event. */
 	isAutoApproveRuleResolvable(e: IToolApprovalEvent, sessionKey: ProtocolURI): boolean {
-		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass || e.shellLanguage === 'unknown') {
+		if (e.permissionKind !== 'shell' || !e.toolInput || e.requestSandboxBypass || !e.shellLanguage) {
 			return false;
 		}
 		if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2979,6 +2979,54 @@ suite('AgentSideEffects', () => {
 				'only the rule-resolvable shell confirmation is marked; sandbox-bypass and managed confirmations are not');
 		});
 
+		test('tool_ready forwards the signal shell language into shell approval', async () => {
+			setupSession();
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+			await sideEffects.initialize();
+
+			// `get-childitem` only matches the default `Get-ChildItem` allow rule
+			// under PowerShell's case-insensitive matching: the powershell
+			// confirmation auto-approves while the bash one stays rule-resolvable.
+			const cases = [
+				['tc-shell-lang-1', 'powershell'],
+				['tc-shell-lang-2', undefined],
+			] as const;
+			for (const [toolCallId, shellLanguage] of cases) {
+				agent.fireProgress({
+					kind: 'action', resource: URI.parse(defaultChatUri),
+					action: {
+						type: ActionType.ChatToolCallStart, turnId: 'turn-1',
+						toolCallId, toolName: 'shell', displayName: 'Shell', contributor: { kind: ToolCallContributorKind.Client, clientId: 'test-client' },
+						_meta: { toolKind: undefined, language: undefined },
+					},
+				});
+				agent.fireProgress({
+					kind: 'pending_confirmation', chat: URI.parse(defaultChatUri),
+					state: {
+						status: ToolCallStatus.PendingConfirmation,
+						toolCallId, toolName: '', displayName: '',
+						invocationMessage: 'Run command', toolInput: 'get-childitem',
+						confirmationTitle: 'Run in terminal?', edits: undefined,
+					},
+					permissionKind: 'shell', permissionPath: undefined,
+					shellLanguage,
+				});
+			}
+
+			const state = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const parts = s?.activeTurn?.responseParts;
+				return parts?.length === cases.length && parts.every(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation) ? s : undefined;
+			});
+			assert.deepStrictEqual(
+				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall
+					? [p.toolCall._meta?.['autoApproveBySetting'], p.toolCall._meta?.['autoApproveRuleResolvable']]
+					: undefined),
+				[[true, undefined], [undefined, true]],
+				'the powershell confirmation auto-approves by setting; the bash one is only rule-resolvable');
+		});
+
 		test('tool_ready is dropped when the tool completes while permission lookup is pending', async () => {
 			setupSession();
 			startTurn('turn-1');

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -2942,9 +2942,9 @@ suite('AgentSideEffects', () => {
 			await sideEffects.initialize();
 
 			const cases = [
-				['tc-shell-rules-1', { requestSandboxBypass: false }],
-				['tc-shell-rules-2', { requestSandboxBypass: true }],
-				['tc-shell-rules-3', { managedApprovalRequired: true }],
+				['tc-shell-rules-1', { requestSandboxBypass: false, shellLanguage: 'bash' as const }],
+				['tc-shell-rules-2', { requestSandboxBypass: true, shellLanguage: 'bash' as const }],
+				['tc-shell-rules-3', { managedApprovalRequired: true, shellLanguage: 'bash' as const }],
 			] as const;
 			for (const [toolCallId, signalOverrides] of cases) {
 				agent.fireProgress({
@@ -2986,11 +2986,12 @@ suite('AgentSideEffects', () => {
 			await sideEffects.initialize();
 
 			// `get-childitem` only matches the default `Get-ChildItem` allow rule
-			// under PowerShell's case-insensitive matching: the powershell
-			// confirmation auto-approves while the bash one stays rule-resolvable.
+			// under PowerShell's case-insensitive matching. Missing language fails
+			// closed before rule analysis.
 			const cases = [
 				['tc-shell-lang-1', 'powershell'],
-				['tc-shell-lang-2', undefined],
+				['tc-shell-lang-2', 'bash'],
+				['tc-shell-lang-3', undefined],
 			] as const;
 			for (const [toolCallId, shellLanguage] of cases) {
 				agent.fireProgress({
@@ -3023,8 +3024,8 @@ suite('AgentSideEffects', () => {
 				state.activeTurn?.responseParts.map(p => p.kind === ResponsePartKind.ToolCall
 					? [p.toolCall._meta?.['autoApproveBySetting'], p.toolCall._meta?.['autoApproveRuleResolvable']]
 					: undefined),
-				[[true, undefined], [undefined, true]],
-				'the powershell confirmation auto-approves by setting; the bash one is only rule-resolvable');
+				[[true, undefined], [undefined, true], [undefined, undefined]],
+				'powershell auto-approves; bash stays rule-resolvable; missing language is neither');
 		});
 
 		test('tool_ready is dropped when the tool completes while permission lookup is pending', async () => {

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -312,18 +312,21 @@ suite('CommandAutoApprover', () => {
 			], ['denied', 'denied']);
 		});
 
-		// `$null` discards output like /dev/null; both the spaced form (a
+		// An unquoted `$null` discards PowerShell output; both the spaced form (a
 		// `redirection` node) and the no-space form (a `generic_token`) must be
-		// recognized. Real file targets still require confirmation.
-		test('treats $null redirects as safe sinks but blocks file writes', () => {
+		// recognized. POSIX sinks and real file targets still require confirmation.
+		test('treats unquoted $null redirects as safe sinks but blocks file writes', () => {
 			assert.deepStrictEqual([
 				approver.shouldAutoApprove('Get-Content file.txt 2>$null', pwsh),
 				approver.shouldAutoApprove('Get-Content file.txt 2> $null', pwsh),
 				approver.shouldAutoApprove('Write-Host hi >$null', pwsh),
 				approver.shouldAutoApprove('Write-Host hi 2>&1', pwsh),
+				approver.shouldAutoApprove('Write-Host hi > /dev/null', pwsh),
+				approver.shouldAutoApprove('Write-Host hi >/dev/null', pwsh),
+				approver.shouldAutoApprove(`Write-Host hi > '$null'`, pwsh),
 				approver.shouldAutoApprove('Write-Host hi > out.txt', pwsh),
 				approver.shouldAutoApprove('Write-Host hi >out.txt', pwsh),
-			], ['approved', 'approved', 'approved', 'approved', 'noMatch', 'noMatch']);
+			], ['approved', 'approved', 'approved', 'approved', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch']);
 		});
 
 		// The grammar parses `--flag=value` as an assignment expression that

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -332,6 +332,22 @@ suite('CommandAutoApprover', () => {
 			], ['approved', 'approved', 'approved', 'approved', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch']);
 		});
 
+		test('distinguishes embedded greater-than text from a redirect operator', () => {
+			const seen: string[] = [];
+			const options = {
+				...pwsh,
+				isWriteDestApproved: (dest: string) => {
+					seen.push(dest);
+					return false;
+				},
+			};
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Write-Host hi>../../outside.txt', options),
+				approver.shouldAutoApprove('Write-Host hi >../../outside.txt', options),
+			], ['approved', 'noMatch']);
+			assert.deepStrictEqual(seen, ['../../outside.txt']);
+		});
+
 		// The grammar parses `--flag=value` as an assignment expression that
 		// truncates the command (microsoft/vscode#294010). Without masking, the
 		// truncated capture could match an allow rule while the real command
@@ -351,17 +367,21 @@ suite('CommandAutoApprover', () => {
 			], ['approved', 'noMatch']);
 		});
 
-		test('PowerShell matchCommandLine deny rules are case-insensitive', () => {
-			const autoApproveRules = {
+		test('PowerShell matchCommandLine deny rules retain configured casing', () => {
+			const caseSensitiveRules = {
 				'Get-ChildItem': true,
 				'/^Get-ChildItem -Force$/': { approve: false, matchCommandLine: true },
 			};
+			const caseInsensitiveRules = {
+				'Get-ChildItem': true,
+				'/^Get-ChildItem -Force$/i': { approve: false, matchCommandLine: true },
+			};
 			assert.deepStrictEqual([
-				approver.shouldAutoApprove('Get-ChildItem -Force', { language: 'powershell', autoApproveRules }),
-				approver.shouldAutoApprove('get-childitem -Force', { language: 'powershell', autoApproveRules }),
-				approver.shouldAutoApprove('Get-ChildItem -Force', { language: 'bash', autoApproveRules }),
-				approver.shouldAutoApprove('get-childitem -Force', { language: 'bash', autoApproveRules }),
-			], ['denied', 'denied', 'denied', 'noMatch']);
+				approver.shouldAutoApprove('Get-ChildItem -Force', { language: 'powershell', autoApproveRules: caseSensitiveRules }),
+				approver.shouldAutoApprove('get-childitem -Force', { language: 'powershell', autoApproveRules: caseSensitiveRules }),
+				approver.shouldAutoApprove('get-childitem -Force', { language: 'powershell', autoApproveRules: caseInsensitiveRules }),
+				approver.shouldAutoApprove('get-childitem -Force', { language: 'bash', autoApproveRules: caseSensitiveRules }),
+			], ['denied', 'approved', 'denied', 'noMatch']);
 		});
 
 		test('reports rule resolvability', () => {

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -287,7 +287,10 @@ suite('CommandAutoApprover', () => {
 				approver.shouldAutoApprove('Get-ChildItem `\n  -Path .', pwsh),
 				// Expression-style invocations capture the inner command without the parentheses.
 				approver.shouldAutoApprove('(Get-Content README.md).Length', pwsh),
-			], ['approved', 'approved', 'approved', 'approved']);
+				// Subexpressions are traversed so their nested commands are checked.
+				approver.shouldAutoApprove('Write-Host $(Get-Date)', pwsh),
+				approver.shouldAutoApprove('Write-Host $(Remove-Item x)', pwsh),
+			], ['approved', 'approved', 'approved', 'approved', 'approved', 'denied']);
 		});
 
 		test('matches rules case-insensitively like PowerShell itself', () => {

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -274,4 +274,84 @@ suite('CommandAutoApprover', () => {
 			assert.deepStrictEqual(uninitialized.evaluate('ls'), { result: 'noMatch', autoApproveRuleResolvable: false });
 		});
 	});
+
+	suite('PowerShell grammar', () => {
+
+		const pwsh = { language: 'powershell' } as const;
+
+		test('parses PowerShell-specific syntax that the bash grammar mangles', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-ChildItem -Recurse', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem | Select-Object Name', pwsh),
+				// Backtick line continuations are valid PowerShell and parse as a single command.
+				approver.shouldAutoApprove('Get-ChildItem `\n  -Path .', pwsh),
+				// Expression-style invocations capture the inner command without the parentheses.
+				approver.shouldAutoApprove('(Get-Content README.md).Length', pwsh),
+			], ['approved', 'approved', 'approved', 'approved']);
+		});
+
+		test('matches rules case-insensitively like PowerShell itself', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('get-childitem', pwsh),
+				approver.shouldAutoApprove('IEX "bad"', pwsh),
+				// bash rule matching stays case-sensitive.
+				approver.shouldAutoApprove('get-childitem'),
+			], ['approved', 'denied', 'noMatch']);
+		});
+
+		// The PowerShell grammar descends into script blocks, so commands nested
+		// inside `{ ... }` are checked individually. The bash grammar keeps the
+		// block opaque, which would let an allow rule on the outer cmdlet
+		// blanket-approve arbitrary nested commands.
+		test('denies commands nested inside script blocks', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-ChildItem | Where-Object { Remove-Item $_ }', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem | ForEach-Object { Invoke-Expression $_ }', pwsh),
+			], ['denied', 'denied']);
+		});
+
+		// `$null` discards output like /dev/null; both the spaced form (a
+		// `redirection` node) and the no-space form (a `generic_token`) must be
+		// recognized. Real file targets still require confirmation.
+		test('treats $null redirects as safe sinks but blocks file writes', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-Content file.txt 2>$null', pwsh),
+				approver.shouldAutoApprove('Get-Content file.txt 2> $null', pwsh),
+				approver.shouldAutoApprove('Write-Host hi >$null', pwsh),
+				approver.shouldAutoApprove('Write-Host hi 2>&1', pwsh),
+				approver.shouldAutoApprove('Write-Host hi > out.txt', pwsh),
+				approver.shouldAutoApprove('Write-Host hi >out.txt', pwsh),
+			], ['approved', 'approved', 'approved', 'approved', 'noMatch', 'noMatch']);
+		});
+
+		// The grammar parses `--flag=value` as an assignment expression that
+		// truncates the command (microsoft/vscode#294010). Without masking, the
+		// truncated capture could match an allow rule while the real command
+		// line runs.
+		test('masks --flag=value arguments before parsing', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('git log --format="%h|%s" -5', pwsh),
+				approver.shouldAutoApprove('git log --format="a|b"; Remove-Item x', pwsh),
+			], ['approved', 'denied']);
+		});
+
+		test('matchCommandLine rules stay case-sensitive', () => {
+			const autoApproveRules = { '/^Get-ChildItem$/': { approve: true, matchCommandLine: true } };
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-ChildItem', { language: 'powershell', autoApproveRules }),
+				approver.shouldAutoApprove('get-childitem', { language: 'powershell', autoApproveRules }),
+			], ['approved', 'noMatch']);
+		});
+
+		test('reports rule resolvability', () => {
+			const cases: [commandLine: string, expected: ICommandApprovalEvaluation][] = [
+				['My-CustomCmdlet', { result: 'noMatch', autoApproveRuleResolvable: true }],
+				// Unapproved write redirects block regardless of rules.
+				['Write-Host hi > out.txt', { result: 'noMatch', autoApproveRuleResolvable: false }],
+				// Commands the grammar cannot parse are never rule-resolvable.
+				['if ($x -eq', { result: 'noMatch', autoApproveRuleResolvable: false }],
+			];
+			assert.deepStrictEqual(cases.map(([commandLine]) => approver.evaluate(commandLine, pwsh)), cases.map(([, expected]) => expected));
+		});
+	});
 });

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -337,12 +337,25 @@ suite('CommandAutoApprover', () => {
 			], ['approved', 'denied']);
 		});
 
-		test('matchCommandLine rules stay case-sensitive', () => {
+		test('PowerShell matchCommandLine allow rules stay case-sensitive', () => {
 			const autoApproveRules = { '/^Get-ChildItem$/': { approve: true, matchCommandLine: true } };
 			assert.deepStrictEqual([
 				approver.shouldAutoApprove('Get-ChildItem', { language: 'powershell', autoApproveRules }),
 				approver.shouldAutoApprove('get-childitem', { language: 'powershell', autoApproveRules }),
 			], ['approved', 'noMatch']);
+		});
+
+		test('PowerShell matchCommandLine deny rules are case-insensitive', () => {
+			const autoApproveRules = {
+				'Get-ChildItem': true,
+				'/^Get-ChildItem -Force$/': { approve: false, matchCommandLine: true },
+			};
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-ChildItem -Force', { language: 'powershell', autoApproveRules }),
+				approver.shouldAutoApprove('get-childitem -Force', { language: 'powershell', autoApproveRules }),
+				approver.shouldAutoApprove('Get-ChildItem -Force', { language: 'bash', autoApproveRules }),
+				approver.shouldAutoApprove('get-childitem -Force', { language: 'bash', autoApproveRules }),
+			], ['denied', 'denied', 'denied', 'noMatch']);
 		});
 
 		test('reports rule resolvability', () => {

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -302,7 +302,9 @@ suite('CommandAutoApprover', () => {
 		// The PowerShell grammar descends into script blocks, so commands nested
 		// inside `{ ... }` are checked individually. The bash grammar keeps the
 		// block opaque, which would let an allow rule on the outer cmdlet
-		// blanket-approve arbitrary nested commands.
+		// blanket-approve arbitrary nested commands. Nested content that is not
+		// a command (e.g. a .NET invocation) is handled by the fail-closed check
+		// below, not by this traversal.
 		test('denies commands nested inside script blocks', () => {
 			assert.deepStrictEqual([
 				approver.shouldAutoApprove('Get-ChildItem | Where-Object { Remove-Item $_ }', pwsh),
@@ -352,6 +354,45 @@ suite('CommandAutoApprover', () => {
 				['if ($x -eq', { result: 'noMatch', autoApproveRuleResolvable: false }],
 			];
 			assert.deepStrictEqual(cases.map(([commandLine]) => approver.evaluate(commandLine, pwsh)), cases.map(([, expected]) => expected));
+		});
+
+		test('fails closed on PowerShell assignments and invocations', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('$env:GIT_SSH_COMMAND="evil"; git status', pwsh),
+				approver.shouldAutoApprove('Write-Output ($env:FOO="evil"); Get-ChildItem', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem | Where-Object { $env:FOO="evil"; $true }', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem; [System.IO.File]::Delete("x")', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem | Where-Object { [System.IO.File]::Delete($_.FullName) }', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem; $obj.Delete()', pwsh),
+				// Deliberate over-block: an invocation in an argument is usually
+				// harmless, but the rules cannot tell `[math]::Round` from
+				// `[System.IO.File]::Delete`, so both require confirmation.
+				approver.shouldAutoApprove('Write-Output ([math]::Round(1.5))', pwsh),
+				// Property access executes no method, so it stays approved.
+				approver.shouldAutoApprove('(Get-Content README.md).Length', pwsh),
+			], ['noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'approved']);
+		});
+
+		test('exact allow rules require a safely analyzable command line', () => {
+			const parseErrorAllow = { '/^if \\(\\$x -eq$/': { approve: true, matchCommandLine: true } };
+			const parseErrorDeny = { '/^if \\(\\$x -eq$/': { approve: false, matchCommandLine: true } };
+			const invocationAllow = { '/^Write-Output \\(\\[math\\]::Round\\(1\\.5\\)\\)$/': { approve: true, matchCommandLine: true } };
+			const redirectAllow = {
+				Write: true,
+				'/^Write-Host hi >out\\.txt$/': { approve: true, matchCommandLine: true },
+			};
+			const deniedSubCommand = {
+				Get: true,
+				Remove: false,
+				'/^Get-ChildItem; Remove-Item x$/': { approve: true, matchCommandLine: true },
+			};
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('if ($x -eq', { language: 'powershell', autoApproveRules: parseErrorAllow }),
+				approver.shouldAutoApprove('if ($x -eq', { language: 'powershell', autoApproveRules: parseErrorDeny }),
+				approver.shouldAutoApprove('Write-Output ([math]::Round(1.5))', { language: 'powershell', autoApproveRules: invocationAllow }),
+				approver.shouldAutoApprove('Write-Host hi >out.txt', { language: 'powershell', autoApproveRules: redirectAllow }),
+				approver.shouldAutoApprove('Get-ChildItem; Remove-Item x', { language: 'powershell', autoApproveRules: deniedSubCommand }),
+			], ['noMatch', 'denied', 'noMatch', 'noMatch', 'denied']);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2360,6 +2360,43 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(actual, cases.map(({ toolCallId, expected }) => `${toolCallId}=${expected}`));
 		});
 
+		test('custom terminal permissions are normalized for shell auto-approval', async () => {
+			const cases = [
+				{ toolCallId: 'tc-custom-bash', toolName: 'bash', command: 'git status' },
+				{ toolCallId: 'tc-custom-powershell', toolName: 'powershell', command: 'Get-ChildItem' },
+			] as const;
+			const actual: Array<{ permissionKind: string | undefined; toolInput: string | undefined; shellLanguage: string | undefined }> = [];
+
+			for (const { toolCallId, toolName, command } of cases) {
+				const { session, runtime, waitForSignal } = await createAgentSession(disposables);
+				const resultPromise = runtime.handlePermissionRequest({
+					kind: 'custom-tool',
+					toolCallId,
+					toolName,
+					args: { command },
+				});
+				const signal = await waitForSignal(s => s.kind === 'pending_confirmation' && s.state.toolCallId === toolCallId);
+				assert.strictEqual(signal.kind, 'pending_confirmation');
+				if (signal.kind !== 'pending_confirmation') {
+					throw new Error('Expected a pending confirmation');
+				}
+				actual.push({
+					permissionKind: signal.permissionKind,
+					toolInput: signal.state.toolInput,
+					shellLanguage: signal.shellLanguage,
+				});
+				assert.ok(session.respondToPermissionRequest(toolCallId, true));
+				assert.strictEqual((await resultPromise).kind, 'approve-once');
+				disposables.clear();
+			}
+
+			assert.deepStrictEqual(actual, cases.map(({ toolName, command }) => ({
+				permissionKind: 'shell',
+				toolInput: command,
+				shellLanguage: toolName,
+			})));
+		});
+
 		test('auto-approves sandboxed-by-default shell command without prompting', async () => {
 			const { runtime, signals } = await createAgentSession(disposables, {
 				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2322,19 +2322,22 @@ suite('CopilotAgentSession', () => {
 
 		test('shell permissions carry the tracked shell language or unknown', async () => {
 			const cases = [
-				{ toolCallId: 'tc-powershell-language', toolName: 'powershell', expected: 'powershell' },
-				{ toolCallId: 'tc-bash-language', toolName: 'bash', expected: 'bash' },
-				{ toolCallId: 'tc-unrecognized-language', toolName: 'unexpected-shell-tool', expected: 'unknown' },
-				{ toolCallId: 'tc-unknown-language', toolName: undefined, expected: 'unknown' },
+				{ toolCallId: 'tc-powershell-language', trackedToolName: 'powershell', requestToolName: undefined, expected: 'powershell' },
+				{ toolCallId: 'tc-bash-language', trackedToolName: 'bash', requestToolName: undefined, expected: 'bash' },
+				{ toolCallId: 'tc-unrecognized-language', trackedToolName: 'unexpected-shell-tool', requestToolName: undefined, expected: 'unknown' },
+				{ toolCallId: 'tc-unknown-language', trackedToolName: undefined, requestToolName: undefined, expected: 'unknown' },
+				// `PermissionRequestShell` has no toolName. If a loose or synthetic
+				// request includes one anyway, the tracked runtime tool remains authoritative.
+				{ toolCallId: 'tc-conflicting-language', trackedToolName: 'powershell', requestToolName: 'bash', expected: 'powershell' },
 			] as const;
 			const actual: string[] = [];
 
-			for (const { toolCallId, toolName } of cases) {
+			for (const { toolCallId, trackedToolName, requestToolName } of cases) {
 				const { session, runtime, mockSession, waitForSignal } = await createAgentSession(disposables);
-				if (toolName) {
+				if (trackedToolName) {
 					mockSession.fire('tool.execution_start', {
 						toolCallId,
-						toolName,
+						toolName: trackedToolName,
 						arguments: { command: 'Get-ChildItem' },
 					} as SessionEventPayload<'tool.execution_start'>['data']);
 				}
@@ -2342,6 +2345,7 @@ suite('CopilotAgentSession', () => {
 					kind: 'shell',
 					toolCallId,
 					fullCommandText: 'Get-ChildItem',
+					toolName: requestToolName,
 				});
 				const signal = await waitForSignal(s => s.kind === 'pending_confirmation' && s.state.toolCallId === toolCallId);
 				assert.strictEqual(signal.kind, 'pending_confirmation');

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2320,6 +2320,42 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'denied-interactively-by-user');
 		});
 
+		test('shell permissions carry the tracked shell language or unknown', async () => {
+			const cases = [
+				{ toolCallId: 'tc-powershell-language', toolName: 'powershell', expected: 'powershell' },
+				{ toolCallId: 'tc-bash-language', toolName: 'bash', expected: 'bash' },
+				{ toolCallId: 'tc-unrecognized-language', toolName: 'unexpected-shell-tool', expected: 'unknown' },
+				{ toolCallId: 'tc-unknown-language', toolName: undefined, expected: 'unknown' },
+			] as const;
+			const actual: string[] = [];
+
+			for (const { toolCallId, toolName } of cases) {
+				const { session, runtime, mockSession, waitForSignal } = await createAgentSession(disposables);
+				if (toolName) {
+					mockSession.fire('tool.execution_start', {
+						toolCallId,
+						toolName,
+						arguments: { command: 'Get-ChildItem' },
+					} as SessionEventPayload<'tool.execution_start'>['data']);
+				}
+				const resultPromise = runtime.handlePermissionRequest({
+					kind: 'shell',
+					toolCallId,
+					fullCommandText: 'Get-ChildItem',
+				});
+				const signal = await waitForSignal(s => s.kind === 'pending_confirmation' && s.state.toolCallId === toolCallId);
+				assert.strictEqual(signal.kind, 'pending_confirmation');
+				if (signal.kind !== 'pending_confirmation') {
+					throw new Error('Expected a pending confirmation');
+				}
+				actual.push(`${toolCallId}=${signal.shellLanguage}`);
+				assert.ok(session.respondToPermissionRequest(toolCallId, true));
+				assert.strictEqual((await resultPromise).kind, 'approve-once');
+			}
+
+			assert.deepStrictEqual(actual, cases.map(({ toolCallId, expected }) => `${toolCallId}=${expected}`));
+		});
+
 		test('auto-approves sandboxed-by-default shell command without prompting', async () => {
 			const { runtime, signals } = await createAgentSession(disposables, {
 				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2320,12 +2320,12 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'denied-interactively-by-user');
 		});
 
-		test('shell permissions carry the tracked shell language or unknown', async () => {
+		test('shell permissions carry the tracked shell language when known', async () => {
 			const cases = [
 				{ toolCallId: 'tc-powershell-language', trackedToolName: 'powershell', requestToolName: undefined, expected: 'powershell' },
 				{ toolCallId: 'tc-bash-language', trackedToolName: 'bash', requestToolName: undefined, expected: 'bash' },
-				{ toolCallId: 'tc-unrecognized-language', trackedToolName: 'unexpected-shell-tool', requestToolName: undefined, expected: 'unknown' },
-				{ toolCallId: 'tc-unknown-language', trackedToolName: undefined, requestToolName: undefined, expected: 'unknown' },
+				{ toolCallId: 'tc-unrecognized-language', trackedToolName: 'unexpected-shell-tool', requestToolName: undefined, expected: undefined },
+				{ toolCallId: 'tc-missing-language', trackedToolName: undefined, requestToolName: undefined, expected: undefined },
 				// `PermissionRequestShell` has no toolName. If a loose or synthetic
 				// request includes one anyway, the tracked runtime tool remains authoritative.
 				{ toolCallId: 'tc-conflicting-language', trackedToolName: 'powershell', requestToolName: 'bash', expected: 'powershell' },

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -60,6 +60,10 @@ suite('SessionPermissionManager', () => {
 		return { toolCallId: 'tc-shell', session: URI.parse(sessionUri), permissionKind: 'shell', toolInput: commandLine };
 	}
 
+	function powershellEvent(commandLine: string): IToolApprovalEvent {
+		return { ...shellEvent(commandLine), shellLanguage: 'powershell' };
+	}
+
 	setup(async () => {
 		// Prefer the CI runner temp dir (a plain long path) over `os.tmpdir()`,
 		// which on Windows CI is an 8.3 short path (`C:\Users\RUNNER~1\...`) that
@@ -289,13 +293,40 @@ suite('SessionPermissionManager', () => {
 	// PowerShell's case-insensitive matching, so it distinguishes which grammar
 	// the approver used.
 	test('shell approval and rule eligibility respect the event shell language', async () => {
-		const pwshEvent: IToolApprovalEvent = { ...shellEvent('get-childitem'), shellLanguage: 'powershell' };
+		const pwshEvent = powershellEvent('get-childitem');
 		assert.deepStrictEqual([
 			await permissions.getAutoApproval(pwshEvent, sessionUri),
 			await permissions.getAutoApproval(shellEvent('get-childitem'), sessionUri),
 			permissions.isAutoApproveRuleResolvable(pwshEvent, sessionUri),
 			permissions.isAutoApproveRuleResolvable(shellEvent('get-childitem'), sessionUri),
 		], [ToolCallConfirmationReason.NotNeeded, undefined, false, true]);
+	});
+
+	test('PowerShell redirects require a literal approved destination', async () => {
+		const dynamicResults = [];
+		for (const dest of ['$HOME/outside.txt', '$env:TEMP/x.txt', '$(Get-Location)/x.txt', '`pwd`/x.txt', '${HOME}/x.txt', '%APPDATA%/x.txt']) {
+			dynamicResults.push(await permissions.getAutoApproval(powershellEvent(`Write-Host hi >${dest}`), sessionUri));
+		}
+		assert.deepStrictEqual({
+			dynamicResults,
+			literalWorkspaceDestination: await permissions.getAutoApproval(powershellEvent('Write-Host hi >out.txt'), sessionUri),
+			nullSink: await permissions.getAutoApproval(powershellEvent('Write-Host hi >$null'), sessionUri),
+		}, {
+			dynamicResults: [undefined, undefined, undefined, undefined, undefined, undefined],
+			literalWorkspaceDestination: ToolCallConfirmationReason.NotNeeded,
+			nullSink: ToolCallConfirmationReason.NotNeeded,
+		});
+	});
+
+	test('unknown shell language disables terminal rules and rule suggestions', async () => {
+		const event: IToolApprovalEvent = { ...shellEvent('Get-ChildItem'), shellLanguage: 'unknown' };
+		assert.deepStrictEqual({
+			approval: await permissions.getAutoApproval(event, sessionUri),
+			ruleResolvable: permissions.isAutoApproveRuleResolvable(event, sessionUri),
+		}, {
+			approval: undefined,
+			ruleResolvable: false,
+		});
 	});
 
 	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -285,6 +285,19 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(permissions.isAutoApproveRuleResolvable(shellEvent('my-custom-script'), sessionUri), false);
 	});
 
+	// `get-childitem` only matches the default `Get-ChildItem` allow rule under
+	// PowerShell's case-insensitive matching, so it distinguishes which grammar
+	// the approver used.
+	test('shell approval and rule eligibility respect the event shell language', async () => {
+		const pwshEvent: IToolApprovalEvent = { ...shellEvent('get-childitem'), shellLanguage: 'powershell' };
+		assert.deepStrictEqual([
+			await permissions.getAutoApproval(pwshEvent, sessionUri),
+			await permissions.getAutoApproval(shellEvent('get-childitem'), sessionUri),
+			permissions.isAutoApproveRuleResolvable(pwshEvent, sessionUri),
+			permissions.isAutoApproveRuleResolvable(shellEvent('get-childitem'), sessionUri),
+		], [ToolCallConfirmationReason.NotNeeded, undefined, false, true]);
+	});
+
 	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {
 		configService.updateRootConfig({
 			[AgentHostTerminalAutoApproveEnabledConfigKey]: false,

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -56,7 +56,7 @@ suite('SessionPermissionManager', () => {
 		return { toolCallId: 'tc-read', session: URI.parse(resource), permissionKind: 'read', permissionPath };
 	}
 
-	function shellEvent(commandLine: string, shellLanguage: IToolApprovalEvent['shellLanguage'] = 'bash'): IToolApprovalEvent {
+	function shellEvent(commandLine: string, shellLanguage: IToolApprovalEvent['shellLanguage']): IToolApprovalEvent {
 		return { toolCallId: 'tc-shell', session: URI.parse(sessionUri), permissionKind: 'shell', toolInput: commandLine, shellLanguage };
 	}
 
@@ -235,28 +235,28 @@ suite('SessionPermissionManager', () => {
 	});
 
 	test('auto-approves shell commands in default permission mode when terminal auto-approve is enabled', async () => {
-		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('echo hello', 'bash'), sessionUri);
 		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 	});
 
 	test('uses forwarded terminal auto-approve rules as the source of truth over fallback defaults', async () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: {} });
 
-		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('echo hello', 'bash'), sessionUri);
 		assert.strictEqual(result, undefined);
 	});
 
 	test('respects forwarded terminal auto-approve deny rules in default permission mode', async () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: { echo: false } });
 
-		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('echo hello', 'bash'), sessionUri);
 		assert.strictEqual(result, undefined);
 	});
 
 	test('respects forwarded terminal auto-approve allow rules in default permission mode', async () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: { python: true } });
 
-		const result = await permissions.getAutoApproval(shellEvent('python script.py'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('python script.py', 'bash'), sessionUri);
 		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 	});
 
@@ -266,17 +266,17 @@ suite('SessionPermissionManager', () => {
 			[AgentHostTerminalAutoApproveRulesConfigKey]: { echo: true },
 		});
 
-		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('echo hello', 'bash'), sessionUri);
 		assert.strictEqual(result, undefined);
 	});
 
 	test('isAutoApproveRuleResolvable is true only when a missing allow rule is the sole blocker', () => {
 		const cases: [name: string, event: IToolApprovalEvent, expected: boolean][] = [
-			['unknown command', shellEvent('my-custom-script'), true],
-			['already approved', shellEvent('echo hello'), false],
-			['denied', shellEvent('rm file.txt'), false],
-			['unapproved write redirect', shellEvent('my-custom-script > /etc/passwd'), false],
-			['sandbox bypass', { ...shellEvent('my-custom-script'), requestSandboxBypass: true }, false],
+			['unknown command', shellEvent('my-custom-script', 'bash'), true],
+			['already approved', shellEvent('echo hello', 'bash'), false],
+			['denied', shellEvent('rm file.txt', 'bash'), false],
+			['unapproved write redirect', shellEvent('my-custom-script > /etc/passwd', 'bash'), false],
+			['sandbox bypass', { ...shellEvent('my-custom-script', 'bash'), requestSandboxBypass: true }, false],
 			['non-shell', writeEvent('/outside/app.ts'), false],
 		];
 		assert.deepStrictEqual(
@@ -286,7 +286,7 @@ suite('SessionPermissionManager', () => {
 
 	test('isAutoApproveRuleResolvable is false when terminal auto-approve is disabled', () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
-		assert.strictEqual(permissions.isAutoApproveRuleResolvable(shellEvent('my-custom-script'), sessionUri), false);
+		assert.strictEqual(permissions.isAutoApproveRuleResolvable(shellEvent('my-custom-script', 'bash'), sessionUri), false);
 	});
 
 	// `get-childitem` only matches the default `Get-ChildItem` allow rule under
@@ -296,9 +296,9 @@ suite('SessionPermissionManager', () => {
 		const pwshEvent = powershellEvent('get-childitem');
 		assert.deepStrictEqual([
 			await permissions.getAutoApproval(pwshEvent, sessionUri),
-			await permissions.getAutoApproval(shellEvent('get-childitem'), sessionUri),
+			await permissions.getAutoApproval(shellEvent('get-childitem', 'bash'), sessionUri),
 			permissions.isAutoApproveRuleResolvable(pwshEvent, sessionUri),
-			permissions.isAutoApproveRuleResolvable(shellEvent('get-childitem'), sessionUri),
+			permissions.isAutoApproveRuleResolvable(shellEvent('get-childitem', 'bash'), sessionUri),
 		], [ToolCallConfirmationReason.NotNeeded, undefined, false, true]);
 	});
 
@@ -339,7 +339,7 @@ suite('SessionPermissionManager', () => {
 			values: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
 		});
 
-		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('echo hello', 'bash'), sessionUri);
 		assert.strictEqual(result, ToolCallConfirmationReason.Setting);
 	});
 
@@ -359,7 +359,7 @@ suite('SessionPermissionManager', () => {
 		// A command that would otherwise require confirmation (terminal
 		// auto-approve disabled) is approved because global auto-approve is a
 		// superset that short-circuits before the per-kind checks.
-		const result = await permissions.getAutoApproval(shellEvent('rm -rf /tmp/whatever'), sessionUri);
+		const result = await permissions.getAutoApproval(shellEvent('rm -rf /tmp/whatever', 'bash'), sessionUri);
 		assert.strictEqual(result, ToolCallConfirmationReason.Setting);
 	});
 
@@ -411,7 +411,7 @@ suite('SessionPermissionManager', () => {
 		test('a relative shell redirect resolves against the primary root (index 0)', async () => {
 			// `out.txt` resolves against the single process cwd = `workDir`, so it
 			// is contained by the primary root and auto-approves.
-			const result = await permissions.getAutoApproval(shellEvent('echo hi > out.txt'), multiUri);
+			const result = await permissions.getAutoApproval(shellEvent('echo hi > out.txt', 'bash'), multiUri);
 			assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 		});
 
@@ -419,8 +419,8 @@ suite('SessionPermissionManager', () => {
 			// POSIX-only: embedding absolute paths in the command string avoids
 			// Windows backslash/drive-colon parsing pitfalls. The containment rule
 			// itself is platform-agnostic and covered by the read/write test above.
-			const intoPeer = await permissions.getAutoApproval(shellEvent(`echo hi > ${join(workDir2, 'out.txt')}`), multiUri);
-			const outside = await permissions.getAutoApproval(shellEvent(`echo hi > ${join(outsideDir, 'out.txt')}`), multiUri);
+			const intoPeer = await permissions.getAutoApproval(shellEvent(`echo hi > ${join(workDir2, 'out.txt')}`, 'bash'), multiUri);
+			const outside = await permissions.getAutoApproval(shellEvent(`echo hi > ${join(outsideDir, 'out.txt')}`, 'bash'), multiUri);
 			assert.deepStrictEqual([intoPeer, outside], [ToolCallConfirmationReason.NotNeeded, undefined]);
 		});
 

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -56,12 +56,12 @@ suite('SessionPermissionManager', () => {
 		return { toolCallId: 'tc-read', session: URI.parse(resource), permissionKind: 'read', permissionPath };
 	}
 
-	function shellEvent(commandLine: string): IToolApprovalEvent {
-		return { toolCallId: 'tc-shell', session: URI.parse(sessionUri), permissionKind: 'shell', toolInput: commandLine };
+	function shellEvent(commandLine: string, shellLanguage: IToolApprovalEvent['shellLanguage'] = 'bash'): IToolApprovalEvent {
+		return { toolCallId: 'tc-shell', session: URI.parse(sessionUri), permissionKind: 'shell', toolInput: commandLine, shellLanguage };
 	}
 
 	function powershellEvent(commandLine: string): IToolApprovalEvent {
-		return { ...shellEvent(commandLine), shellLanguage: 'powershell' };
+		return shellEvent(commandLine, 'powershell');
 	}
 
 	setup(async () => {
@@ -318,8 +318,8 @@ suite('SessionPermissionManager', () => {
 		});
 	});
 
-	test('unknown shell language disables terminal rules and rule suggestions', async () => {
-		const event: IToolApprovalEvent = { ...shellEvent('Get-ChildItem'), shellLanguage: 'unknown' };
+	test('missing shell language disables terminal rules and rule suggestions', async () => {
+		const event = shellEvent('Get-ChildItem', undefined);
 		assert.deepStrictEqual({
 			approval: await permissions.getAutoApproval(event, sessionUri),
 			ruleResolvable: permissions.isAutoApproveRuleResolvable(event, sessionUri),


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/328052

- Select the terminal grammar from the tool that actually executes the command: correlate SDK `shell` permissions with `tool.execution_start`, and recognize Agent Host terminal overrides reported as `custom-tool` requests named `bash` or `powershell`.
- Carry an explicit `bash` or `powershell` language on Agent Host's internal confirmation signal. Only those values are eligible for terminal-rule auto-approval and rule suggestions; missing language requires confirmation.
- Load the Bash and PowerShell tree-sitter grammars independently so one unavailable grammar does not disable the other.
- Parse PowerShell pipelines, script blocks, subexpressions, backtick continuations, `$null` and no-space redirects, and `--flag=value` arguments with PowerShell-specific handling.
- Match parsed PowerShell subcommands case-insensitively while preserving configured regex casing for full-command rules. Keep full-command deny-before-allow precedence; a full-command allow can approve only with a usable parse, no denied subcommand, and successful redirect validation.
- Require confirmation for PowerShell parse errors, assignments, method/static invocations, runtime-expanded redirect destinations, and other constructs that cannot be analyzed safely. Literal workspace destinations and `$null` remain eligible for auto-approval.
- Keep the shell-language signal internal to Agent Host; no protocol action or public API changes.

-----------------------------------------
Inspirations from:

- Shell-specific grammar selection comes from the workbench run-in-terminal analyzer options in [`runInTerminalTool.ts`](https://github.com/microsoft/vscode/blob/1da4a4235b2e5783f9f4c70b60c0fa2fd0a3fc88/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L477-L485).
- PowerShell subcommand parsing and the `--flag=value` workaround come from [`TreeSitterCommandParser`](https://github.com/microsoft/vscode/blob/1da4a4235b2e5783f9f4c70b60c0fa2fd0a3fc88/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts#L15-L67).
- PowerShell's case-insensitive subcommand matching and leading-parenthesis handling come from [`CommandLineAutoApprover._commandMatchesRule`](https://github.com/microsoft/vscode/blob/1da4a4235b2e5783f9f4c70b60c0fa2fd0a3fc88/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts#L229-L243).
- Full-command rule casing and deny-before-allow precedence come from [`CommandLineAutoApprover.isCommandLineAutoApproved`](https://github.com/microsoft/vscode/blob/1da4a4235b2e5783f9f4c70b60c0fa2fd0a3fc88/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts#L142-L173).
- Runtime-expanded redirect detection comes from the workbench file-write analyzer guard in [`commandLineFileWriteAnalyzer.ts`](https://github.com/microsoft/vscode/blob/1da4a4235b2e5783f9f4c70b60c0fa2fd0a3fc88/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts#L147-L153).