### PR TITLE
Refresh policy.applied GDPR catalog entry

### DIFF
--- a/src/vs/workbench/services/policies/browser/policyTelemetry.contribution.ts
+++ b/src/vs/workbench/services/policies/browser/policyTelemetry.contribution.ts
@@ -42,7 +42,7 @@ type PolicyAppliedEvent = {
 
 type PolicyAppliedClassification = {
 	owner: 'joshspicer';
-	comment: 'Reports which enterprise-managed settings and device policies are applied and their value buckets, to understand managed-configuration adoption. No raw policy values are collected.';
+	comment: 'Reports which enterprise-managed settings and device policies are applied and their value buckets, to understand managed-configuration adoption. The corresponding classified telemetry event is monacoworkbench/policy.applied; every property is a count, boolean flag, or coarse bucket, and no raw policy values are collected.';
 	policyCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of policies with an applied value (the "applied" denominator).' };
 	defaultModelSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the default chat model policy is applied.' };
 	toolsAutoApproveSet: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the tools auto-approve policy is applied.' };


### PR DESCRIPTION
## Summary

Refreshes the typed GDPR classification metadata for `monacoworkbench/policy.applied` so the normal product-build extraction produces a changed catalog entry for inventory republishing.

The source schema already matches all 15 emitted fields; this does not change the runtime event name, payload, classifications, or collection behavior. It addresses a stale/regressed generated Kusto definitions snapshot observed on 1.132.0-insider.

References https://github.com/microsoft/vscode-internalbacklog/issues/8656.

## Validation

- Ran the full core telemetry extractor over the repository with product-build options.
- Confirmed `policy.applied` is present with owner `joshspicer`, the refreshed downstream event name, and all 15 properties classified.
- Ran the repository pre-commit hygiene checks.

## Post-merge verification

After catalog ingestion, verify new 1.132.0-insider events no longer enter `RawEventsVSCodeUnclassified` and regenerate/publish the typed Kusto definition snapshot as applicable.