### PR TITLE
Rewording in Data agent: measurements->measures

### DIFF
--- a/.github/agents/data.md
+++ b/.github/agents/data.md
@@ -33,7 +33,7 @@ When writing Kusto queries, follow these best practices:
 	- Default to a rolling 28-day window (standard practice in VS Code telemetry)
    - Use full day boundaries to avoid partial day data
    - Follow the time filtering patterns from the telemetry documentation
-- **Correctly map names and keys.** EventName is the prefix (`monacoworkbench/` for vscode) and lowercase event name. Properties/Measurements keys are lowercase. Any properties marked `isMeasurement` are in the Measurements bag.
+- **Correctly map names and keys.** EventName is the prefix (`monacoworkbench/` for vscode) and lowercase event name. Properties/Measures keys are lowercase. Any properties marked `isMeasurement` land in the `Measures` column.
 - **Parallelize queries when possible.** Run multiple independent queries as parallel tool calls to speed up analysis.
 
 # Output Format


### PR DESCRIPTION
Prevents the agent from thinking there's a Measurements column