### PR TITLE
docs(extensions): fix GitHub org capitalization in references-view README

### DIFF
--- a/extensions/references-view/README.md
+++ b/extensions/references-view/README.md
@@ -17,7 +17,7 @@ This extension is just an alternative UI for reference search and extensions imp
 
 ## Issues
 
-This extension ships with Visual Studio Code and uses its issue tracker. Please file issue here: https://github.com/Microsoft/vscode/issues
+This extension ships with Visual Studio Code and uses its issue tracker. Please file issue here: https://github.com/microsoft/vscode/issues
 
 # Contributing
 


### PR DESCRIPTION
## Problem

The `references-view` extension README links to `https://github.com/Microsoft/vscode/issues` for filing issues. GitHub org slugs are case-sensitive in URLs; the canonical org is `microsoft` (lowercase).

## Fix

Update the issue tracker URL to `https://github.com/microsoft/vscode/issues` in `extensions/references-view/README.md`.

## Verification

- Preflight against `upstream/main` confirmed the stale `Microsoft` URL is still present
- Docs-only one-line change; no runtime behavior impact

## How to test

Read `extensions/references-view/README.md` and confirm the Issues section URL uses lowercase `microsoft`.
