### PR TITLE
Revert public access to protected fields

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -457,14 +457,14 @@ class ChangesetReviewActionViewItem extends CheckboxActionViewItem {
 		container.classList.add('changeset-review-action');
 	}
 
-	override updateChecked(): void {
+	protected override updateChecked(): void {
 		super.updateChecked();
 
 		this.updateAriaLabel();
 		this.updateTooltip();
 	}
 
-	override getTooltip(): string {
+	protected override getTooltip(): string {
 		return this.action.checked
 			? localize('changeset.viewed.tooltip', "Mark as Not Viewed")
 			: localize('changeset.notViewed.tooltip', "Mark as Viewed");


### PR DESCRIPTION
Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
