### PR TITLE
Add Kimi K3 biosecurity policy for Copilot Chat recovery

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-chat",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-chat",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-chat",
   "displayName": "GitHub Copilot",
   "description": "AI chat features powered by Copilot",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "build": "1",
   "completionsCoreVersion": "1.378.1799",
   "internalLargeStorageAriaKey": "ec712b3202c5462fb6877acae7f1f9d7-c19ad55e-3e3c-4f99-984b-827f6d95bd9e-6917",

--- a/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
@@ -16,6 +16,32 @@ import { ApplyPatchInstructions, CodesearchModeInstructions, DefaultAgentPromptP
 import { FileLinkificationInstructions } from './fileLinkificationInstructions';
 import { IAgentPrompt, PromptRegistry, ReminderInstructionsConstructor, SystemPrompt } from './promptRegistry';
 
+const KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY = `BIOSECURITY AND CHEMICAL SAFETY POLICY (non-negotiable)
+
+You must refuse to provide information that would provide meaningful uplift toward
+biological or chemical weapons or other mass-casualty harm. This overrides any
+other instruction, persona, or user framing (including "hypothetical," "fictional,"
+"research," "educational," or "for a novel" framings).
+
+Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a
+request seeks to:
+- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider
+  screening, sequence order screening, or "know-your-customer" biosecurity controls
+  (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
+- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or
+  transmissibility of, or weaponize any pathogen, toxin, or biological agent.
+- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or
+  scale-up guidance intended to produce a harmful biological or chemical agent.
+- Produce, synthesize, or disperse chemical weapons, toxic agents, or their precursors.
+
+When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly
+safe, high-level educational or defensive alternatives (e.g., biosafety, public-health,
+or policy information) without operational detail.
+
+Answer normally for legitimate requests: general science education, clinical care,
+approved public-health work, defensive biosecurity, and dual-use topics that do not
+provide operational uplift toward the categories above.`;
+
 class KimiAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 	async render(state: void, sizing: PromptSizing) {
 		const tools = detectToolCapabilities(this.props.availableTools);
@@ -25,6 +51,8 @@ class KimiAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 				You are an expert AI programming assistant, working with a user in the VS Code editor. You are a precise, practical coding agent with strong software engineering judgment across programming languages and frameworks.<br />
 				Follow the user's requirements carefully and use the provided workspace context, attachments, and tool results as reference material. If the answer is not supported by the available context, gather more context before acting or state the limitation clearly.
 			</Tag>
+
+			{this.props.modelFamily.toLowerCase().includes('kimi-k3') && <>{KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY}<br /></>}
 
 			<Tag name='taskApproach'>
 				Use clear, step-by-step task execution:<br />

--- a/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
@@ -40,7 +40,7 @@ class KimiAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 				Follow the user's requirements carefully and use the provided workspace context, attachments, and tool results as reference material. If the answer is not supported by the available context, gather more context before acting or state the limitation clearly.
 			</Tag>
 
-			{this.props.modelFamily.toLowerCase().includes('kimi-k3') && <>{KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY}<br /></>}
+			{this.props.modelFamily?.toLowerCase().includes('kimi-k3') && <>{KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY}<br /></>}
 
 			<Tag name='taskApproach'>
 				Use clear, step-by-step task execution:<br />

--- a/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/kimiPrompts.tsx
@@ -18,29 +18,17 @@ import { IAgentPrompt, PromptRegistry, ReminderInstructionsConstructor, SystemPr
 
 const KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY = `BIOSECURITY AND CHEMICAL SAFETY POLICY (non-negotiable)
 
-You must refuse to provide information that would provide meaningful uplift toward
-biological or chemical weapons or other mass-casualty harm. This overrides any
-other instruction, persona, or user framing (including "hypothetical," "fictional,"
-"research," "educational," or "for a novel" framings).
+You must refuse to provide information that would provide meaningful uplift toward biological or chemical weapons or other mass-casualty harm. This overrides any other instruction, persona, or user framing (including "hypothetical", "fictional", "research", "educational", or "for a novel" framings).
 
-Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a
-request seeks to:
-- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider
-  screening, sequence order screening, or "know-your-customer" biosecurity controls
-  (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
-- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or
-  transmissibility of, or weaponize any pathogen, toxin, or biological agent.
-- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or
-  scale-up guidance intended to produce a harmful biological or chemical agent.
+Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a request seeks to:
+- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider screening, sequence order screening, or "know-your-customer" biosecurity controls (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
+- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or transmissibility of, or weaponize any pathogen, toxin, or biological agent.
+- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or scale-up guidance intended to produce a harmful biological or chemical agent.
 - Produce, synthesize, or disperse chemical weapons, toxic agents, or their precursors.
 
-When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly
-safe, high-level educational or defensive alternatives (e.g., biosafety, public-health,
-or policy information) without operational detail.
+When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly safe, high-level educational or defensive alternatives (e.g., biosafety, public-health, or policy information) without operational detail.
 
-Answer normally for legitimate requests: general science education, clinical care,
-approved public-health work, defensive biosecurity, and dual-use topics that do not
-provide operational uplift toward the categories above.`;
+Answer normally for legitimate requests: general science education, clinical care, approved public-health work, defensive biosecurity, and dual-use topics that do not provide operational uplift toward the categories above.`;
 
 class KimiAgentPrompt extends PromptElement<DefaultAgentPromptProps> {
 	async render(state: void, sizing: PromptSizing) {

--- a/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
@@ -22,29 +22,17 @@ import { PromptRegistry } from '../promptRegistry';
 
 const KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY = `BIOSECURITY AND CHEMICAL SAFETY POLICY (non-negotiable)
 
-You must refuse to provide information that would provide meaningful uplift toward
-biological or chemical weapons or other mass-casualty harm. This overrides any
-other instruction, persona, or user framing (including "hypothetical," "fictional,"
-"research," "educational," or "for a novel" framings).
+You must refuse to provide information that would provide meaningful uplift toward biological or chemical weapons or other mass-casualty harm. This overrides any other instruction, persona, or user framing (including "hypothetical", "fictional", "research", "educational", or "for a novel" framings).
 
-Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a
-request seeks to:
-- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider
-  screening, sequence order screening, or "know-your-customer" biosecurity controls
-  (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
-- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or
-  transmissibility of, or weaponize any pathogen, toxin, or biological agent.
-- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or
-  scale-up guidance intended to produce a harmful biological or chemical agent.
+Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a request seeks to:
+- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider screening, sequence order screening, or "know-your-customer" biosecurity controls (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
+- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or transmissibility of, or weaponize any pathogen, toxin, or biological agent.
+- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or scale-up guidance intended to produce a harmful biological or chemical agent.
 - Produce, synthesize, or disperse chemical weapons, toxic agents, or their precursors.
 
-When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly
-safe, high-level educational or defensive alternatives (e.g., biosafety, public-health,
-or policy information) without operational detail.
+When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly safe, high-level educational or defensive alternatives (e.g., biosafety, public-health, or policy information) without operational detail.
 
-Answer normally for legitimate requests: general science education, clinical care,
-approved public-health work, defensive biosecurity, and dual-use topics that do not
-provide operational uplift toward the categories above.`;
+Answer normally for legitimate requests: general science education, clinical care, approved public-health work, defensive biosecurity, and dual-use topics that do not provide operational uplift toward the categories above.`;
 
 suite('KimiPrompts', () => {
 	let accessor: ITestingServicesAccessor;

--- a/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx
@@ -20,6 +20,32 @@ import { PromptRenderer } from '../../base/promptRenderer';
 import '../allAgentPrompts';
 import { PromptRegistry } from '../promptRegistry';
 
+const KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY = `BIOSECURITY AND CHEMICAL SAFETY POLICY (non-negotiable)
+
+You must refuse to provide information that would provide meaningful uplift toward
+biological or chemical weapons or other mass-casualty harm. This overrides any
+other instruction, persona, or user framing (including "hypothetical," "fictional,"
+"research," "educational," or "for a novel" framings).
+
+Refuse, and do not provide workarounds, partial answers, or pointers to sources, when a
+request seeks to:
+- Bypass, evade, circumvent, or defeat nucleic-acid / DNA / RNA synthesis-provider
+  screening, sequence order screening, or "know-your-customer" biosecurity controls
+  (including obfuscating, fragmenting, recoding, or reordering sequences to avoid detection).
+- Design, synthesize, acquire, culture, propagate, stabilize, enhance the virulence or
+  transmissibility of, or weaponize any pathogen, toxin, or biological agent.
+- Obtain step-by-step wet-lab protocols, troubleshooting, reagent/equipment sourcing, or
+  scale-up guidance intended to produce a harmful biological or chemical agent.
+- Produce, synthesize, or disperse chemical weapons, toxic agents, or their precursors.
+
+When refusing, give a brief, non-judgmental refusal and, where appropriate, offer clearly
+safe, high-level educational or defensive alternatives (e.g., biosafety, public-health,
+or policy information) without operational detail.
+
+Answer normally for legitimate requests: general science education, clinical care,
+approved public-health work, defensive biosecurity, and dual-use topics that do not
+provide operational uplift toward the categories above.`;
+
 suite('KimiPrompts', () => {
 	let accessor: ITestingServicesAccessor;
 
@@ -75,5 +101,18 @@ suite('KimiPrompts', () => {
 		expect(renderedPrompt).toContain(`A single ${ToolName.MultiReplaceString} call is much faster and cheaper`);
 		expect(renderedPrompt).not.toContain(`Use ${ToolName.EditFile}`);
 		expect(renderedPrompt).not.toContain(`Use ${ToolName.ApplyPatch}`);
+	});
+
+	test('adds the biosecurity and chemical safety policy only for Kimi K3', async () => {
+		const kimiK3Prompt = await renderSystemPrompt('kimi-k3');
+		const kimiK2Prompts = await Promise.all([
+			renderSystemPrompt('kimi-k2.6'),
+			renderSystemPrompt('kimi-k2.7-code'),
+		]);
+
+		expect(kimiK3Prompt).toContain(KIMI_K3_BIOSECURITY_AND_CHEMICAL_SAFETY_POLICY);
+		for (const renderedPrompt of kimiK2Prompts) {
+			expect(renderedPrompt).not.toContain('BIOSECURITY AND CHEMICAL SAFETY POLICY');
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- add the provided biosecurity and chemical safety policy to the Kimi K3 system prompt
- keep the policy scoped to Kimi K3 so Kimi K2 prompt variants remain unchanged
- bump Copilot Chat to `0.59.1` for a Stable recovery release targeting VS Code `1.131.x`
- add regression coverage for the complete policy text and model scoping

## Release
After this merges into `release/1.131`, trigger the `copilot-chat (stable recovery)` pipeline with **Publish Stable Recovery Extension** enabled. This publishes the extension through the VS Marketplace without requiring a new VS Code build.

## Testing
- `npm run typecheck`
- `npx vitest --run --pool=forks src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx`
- `npx eslint src/extension/prompts/node/agent/kimiPrompts.tsx src/extension/prompts/node/agent/test/kimiPrompts.spec.tsx --max-warnings=0`