### PR TITLE
Fix large terminal paste corruption

### DIFF
--- a/src/vs/platform/terminal/node/terminalInputBuffer.ts
+++ b/src/vs/platform/terminal/node/terminalInputBuffer.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+
+const enum Constants {
+	InputChunkSize = 256,
+	InputChunkDelay = 5,
+}
+
+const bracketedPasteStartSequence = '\x1b[200~';
+
+/**
+ * Buffers input to avoid overwhelming programs that change terminal modes while consuming lines.
+ */
+export class TerminalInputBuffer extends Disposable {
+	private readonly _queue: (string | Buffer)[] = [];
+	private _writeTimeout: Timeout | undefined;
+
+	constructor(
+		private readonly _write: (data: string | Buffer) => void,
+		private readonly _throttleMultilineInput: boolean,
+	) {
+		super();
+		this._register(toDisposable(() => {
+			if (this._writeTimeout) {
+				clearTimeout(this._writeTimeout);
+				this._writeTimeout = undefined;
+			}
+			this._queue.length = 0;
+		}));
+	}
+
+	write(data: string | Buffer): void {
+		if (typeof data === 'string' && this._shouldThrottle(data)) {
+			const buffer = Buffer.from(data);
+			for (let offset = 0; offset < buffer.length; offset += Constants.InputChunkSize) {
+				this._queue.push(buffer.subarray(offset, offset + Constants.InputChunkSize));
+			}
+		} else if (this._queue.length > 0 || this._writeTimeout) {
+			this._queue.push(data);
+		} else {
+			this._write(data);
+			return;
+		}
+
+		if (!this._writeTimeout) {
+			this._writeNext();
+		}
+	}
+
+	private _shouldThrottle(data: string): boolean {
+		return this._throttleMultilineInput
+			&& Buffer.byteLength(data) > Constants.InputChunkSize
+			&& /[\r\n]/.test(data)
+			&& !data.startsWith(bracketedPasteStartSequence);
+	}
+
+	private _writeNext(): void {
+		const data = this._queue.shift();
+		if (data === undefined) {
+			return;
+		}
+		this._write(data);
+		if (this._queue.length > 0) {
+			this._writeTimeout = setTimeout(() => {
+				this._writeTimeout = undefined;
+				this._writeNext();
+			}, Constants.InputChunkDelay);
+		}
+	}
+}

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -22,6 +22,7 @@ import { WindowsShellHelper } from './windowsShellHelper.js';
 import { IPty, IPtyForkOptions, IWindowsPtyForkOptions, spawn } from 'node-pty';
 import { isNumber } from '../../../base/common/types.js';
 import { getWindowsBuildNumberSync } from '../../../base/node/windowsVersion.js';
+import { TerminalInputBuffer } from './terminalInputBuffer.js';
 
 const enum ShutdownConstants {
 	/**
@@ -104,6 +105,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 	private _exitMessage: string | undefined;
 	private _closeTimeout: Timeout | undefined;
 	private _ptyProcess: IPty | undefined;
+	private _inputBuffer: TerminalInputBuffer | undefined;
 	private _currentTitle: string = '';
 	private _processStartupComplete: Promise<void> | undefined;
 	private _windowsShellHelper: WindowsShellHelper | undefined;
@@ -197,6 +199,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		}));
 		this._register(toDisposable(() => {
 			this._ptyProcess = undefined;
+			this._inputBuffer = undefined;
 			this._processStartupComplete = undefined;
 		}));
 	}
@@ -315,6 +318,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._logService.trace('node-pty.IPty#spawn', shellLaunchConfig.executable, args, sanitizedOptions);
 		const ptyProcess = spawn(shellLaunchConfig.executable!, args, options);
 		this._ptyProcess = ptyProcess;
+		this._inputBuffer = this._register(new TerminalInputBuffer(data => ptyProcess.write(data), isMacintosh));
 		this._childProcessMonitor = this._register(new ChildProcessMonitor(ptyProcess.pid, this._logService));
 		this._register(this._childProcessMonitor.onDidChangeHasChildProcesses(value => this._onDidChangeProperty.fire({ type: ProcessPropertyType.HasChildProcesses, value })));
 		this._processStartupComplete = new Promise<void>(c => {
@@ -485,9 +489,9 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 	input(data: string, isBinary: boolean = false): void {
 		this._logService.trace('node-pty.IPty#write', data, isBinary);
 		if (isBinary) {
-			this._ptyProcess!.write(Buffer.from(data, 'binary'));
+			this._inputBuffer!.write(Buffer.from(data, 'binary'));
 		} else {
-			this._ptyProcess!.write(data);
+			this._inputBuffer!.write(data);
 		}
 		this._childProcessMonitor?.handleInput();
 	}

--- a/src/vs/platform/terminal/test/node/terminalInputBuffer.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalInputBuffer.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { deepStrictEqual } from 'assert';
-import { timeout } from '../../../../base/common/async.js';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { TerminalInputBuffer } from '../../node/terminalInputBuffer.js';
 
@@ -13,13 +13,19 @@ suite('TerminalInputBuffer', () => {
 
 	test('throttles multiline input while preserving bytes and order', async () => {
 		const writes: (string | Buffer)[] = [];
-		const inputBuffer = store.add(new TerminalInputBuffer(data => writes.push(data), true));
-		const multilineInput = `line\r${'x'.repeat(600)}`;
+		const allWritesComplete = new DeferredPromise<void>();
+		const inputBuffer = store.add(new TerminalInputBuffer(data => {
+			writes.push(data);
+			if (writes.length === 4) {
+				allWritesComplete.complete();
+			}
+		}, true));
+		const multilineInput = `line\r${'x'.repeat(250)}😀${'x'.repeat(350)}`;
 
 		inputBuffer.write(multilineInput);
 		const initialWriteCount = writes.length;
 		inputBuffer.write('after');
-		await timeout(50);
+		await allWritesComplete.p;
 
 		deepStrictEqual({
 			initialWriteCount,
@@ -27,7 +33,7 @@ suite('TerminalInputBuffer', () => {
 			data: Buffer.concat(writes.map(data => Buffer.from(data))).toString(),
 		}, {
 			initialWriteCount: 1,
-			writeSizes: [256, 256, 93, 5],
+			writeSizes: [256, 256, 97, 5],
 			data: `${multilineInput}after`,
 		});
 	});

--- a/src/vs/platform/terminal/test/node/terminalInputBuffer.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalInputBuffer.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual } from 'assert';
+import { timeout } from '../../../../base/common/async.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TerminalInputBuffer } from '../../node/terminalInputBuffer.js';
+
+suite('TerminalInputBuffer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('throttles multiline input while preserving bytes and order', async () => {
+		const writes: (string | Buffer)[] = [];
+		const inputBuffer = store.add(new TerminalInputBuffer(data => writes.push(data), true));
+		const multilineInput = `line\r${'x'.repeat(600)}`;
+
+		inputBuffer.write(multilineInput);
+		const initialWriteCount = writes.length;
+		inputBuffer.write('after');
+		await timeout(50);
+
+		deepStrictEqual({
+			initialWriteCount,
+			writeSizes: writes.map(data => Buffer.byteLength(data)),
+			data: Buffer.concat(writes.map(data => Buffer.from(data))).toString(),
+		}, {
+			initialWriteCount: 1,
+			writeSizes: [256, 256, 93, 5],
+			data: `${multilineInput}after`,
+		});
+	});
+
+	test('does not throttle single line, binary, or bracketed paste input', () => {
+		const writes: (string | Buffer)[] = [];
+		const inputBuffer = store.add(new TerminalInputBuffer(data => writes.push(data), true));
+		const singleLineInput = 'x'.repeat(600);
+		const binaryInput = Buffer.from(`line\r${'x'.repeat(600)}`);
+		const bracketedPasteInput = `\x1b[200~line\r${'x'.repeat(600)}\x1b[201~`;
+
+		inputBuffer.write(singleLineInput);
+		inputBuffer.write(binaryInput);
+		inputBuffer.write(bracketedPasteInput);
+
+		deepStrictEqual(writes, [singleLineInput, binaryInput, bracketedPasteInput]);
+	});
+});


### PR DESCRIPTION
Fixes #100225

Large unbracketed multiline writes can overwhelm programs that change terminal modes while consuming input. On macOS, this was reproducible with the system Bash/readline: a 7.7 KB heredoc sent in one `node-pty` write produced a different checksum.

This change paces that input in byte-safe 256-byte chunks while preserving ordering with any writes that arrive behind it. The behavior is limited to macOS and bypasses single-line input, binary input, and bracketed paste sequences.

Tests run:

- `npm run typecheck-client`
- `npm run gulp compile-client`
- Focused `TerminalInputBuffer` unit tests (3 passing)
- Targeted ESLint and pre-commit hygiene
- Manual Bash 3.2 reproduction, repeated successfully with 256-byte/5 ms pacing
