### PR TITLE
Close deinitialized Git submodules

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -784,6 +784,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			.get<number>('detectWorktreesLimit') as number;
 
 		let submoduleCheckSequence = 0;
+		let submoduleLimitWarningShown = false;
+		let worktreesLimitWarningShown = false;
+		const submoduleStatLimiter = new Limiter<string | undefined>(10);
 		const checkForSubmodules = async () => {
 			const sequence = ++submoduleCheckSequence;
 
@@ -792,34 +795,43 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				return;
 			}
 
-			if (repository.submodules.length > submodulesLimit) {
+			if (repository.submodules.length > submodulesLimit && !submoduleLimitWarningShown) {
+				submoduleLimitWarningShown = true;
 				window.showWarningMessage(l10n.t('The "{0}" repository has {1} submodules which won\'t be opened automatically. You can still open each one individually by opening a file within.', path.basename(repository.root), repository.submodules.length));
-				statusListener.dispose();
 			}
 
 			const submodulePaths = repository.submodules.map(r => path.join(repository.root, r.path));
-			const initializedSubmodulePaths = (await Promise.all(submodulePaths.map(async submodulePath => {
+			const submodulePathsToCheck = submodulePaths.slice(0, submodulesLimit);
+			for (const openRepository of this.openRepositories) {
+				const submodulePath = submodulePaths.find(submodulePath => pathEquals(submodulePath, openRepository.repository.root));
+				if (submodulePath && !submodulePathsToCheck.some(pathToCheck => pathEquals(pathToCheck, submodulePath))) {
+					submodulePathsToCheck.push(submodulePath);
+				}
+			}
+
+			const initializedSubmodulePaths = (await Promise.all(submodulePathsToCheck.map(submodulePath => submoduleStatLimiter.queue(async () => {
 				try {
 					await fs.promises.stat(path.join(submodulePath, '.git'));
 					return submodulePath;
 				} catch {
 					return undefined;
 				}
-			}))).filter(submodulePath => submodulePath !== undefined);
+			})))).filter(submodulePath => submodulePath !== undefined);
 			if (sequence !== submoduleCheckSequence) {
 				return;
 			}
 
 			for (const openRepository of [...this.openRepositories]) {
-				if (submodulePaths.some(submodulePath => pathEquals(submodulePath, openRepository.repository.root))
+				if (submodulePathsToCheck.some(submodulePath => pathEquals(submodulePath, openRepository.repository.root))
 					&& !initializedSubmodulePaths.some(submodulePath => pathEquals(submodulePath, openRepository.repository.root))) {
 					this.logger.trace(`[Model][open] Closing deinitialized submodule: '${openRepository.repository.root}'`);
 					openRepository.dispose();
 				}
 			}
 
-			initializedSubmodulePaths
+			submodulePaths
 				.slice(0, submodulesLimit)
+				.filter(submodulePath => initializedSubmodulePaths.some(initializedPath => pathEquals(initializedPath, submodulePath)))
 				.forEach(p => {
 					this.logger.trace(`[Model][open] Opening submodule: '${p}'`);
 					this.eventuallyScanPossibleGitRepository(p);
@@ -837,9 +849,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				return;
 			}
 
-			if (repository.worktrees.length > worktreesLimit) {
+			if (repository.worktrees.length > worktreesLimit && !worktreesLimitWarningShown) {
+				worktreesLimitWarningShown = true;
 				window.showWarningMessage(l10n.t('The "{0}" repository has {1} worktrees which won\'t be opened automatically. You can still open each one individually by opening a file within.', path.basename(repository.root), repository.worktrees.length));
-				statusListener.dispose();
 			}
 
 			repository.worktrees
@@ -887,6 +899,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		updateOperationInProgressContext();
 
 		const dispose = () => {
+			submoduleCheckSequence++;
 			disappearListener.dispose();
 			disposeParentListener.dispose();
 			changeListener.dispose();

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -783,7 +783,10 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			.getConfiguration('git', Uri.file(repository.root))
 			.get<number>('detectWorktreesLimit') as number;
 
-		const checkForSubmodules = () => {
+		let submoduleCheckSequence = 0;
+		const checkForSubmodules = async () => {
+			const sequence = ++submoduleCheckSequence;
+
 			if (!shouldDetectSubmodules) {
 				this.logger.trace('[Model][open] Automatic detection of git submodules is not enabled.');
 				return;
@@ -794,9 +797,29 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				statusListener.dispose();
 			}
 
-			repository.submodules
+			const submodulePaths = repository.submodules.map(r => path.join(repository.root, r.path));
+			const initializedSubmodulePaths = (await Promise.all(submodulePaths.map(async submodulePath => {
+				try {
+					await fs.promises.stat(path.join(submodulePath, '.git'));
+					return submodulePath;
+				} catch {
+					return undefined;
+				}
+			}))).filter(submodulePath => submodulePath !== undefined);
+			if (sequence !== submoduleCheckSequence) {
+				return;
+			}
+
+			for (const openRepository of [...this.openRepositories]) {
+				if (submodulePaths.some(submodulePath => pathEquals(submodulePath, openRepository.repository.root))
+					&& !initializedSubmodulePaths.some(submodulePath => pathEquals(submodulePath, openRepository.repository.root))) {
+					this.logger.trace(`[Model][open] Closing deinitialized submodule: '${openRepository.repository.root}'`);
+					openRepository.dispose();
+				}
+			}
+
+			initializedSubmodulePaths
 				.slice(0, submodulesLimit)
-				.map(r => path.join(repository.root, r.path))
 				.forEach(p => {
 					this.logger.trace(`[Model][open] Opening submodule: '${p}'`);
 					this.eventuallyScanPossibleGitRepository(p);
@@ -839,12 +862,12 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		};
 
 		const statusListener = repository.onDidRunGitStatus(() => {
-			checkForSubmodules();
+			void checkForSubmodules();
 			checkForWorktrees();
 			updateMergeChanges();
 			this.onDidChangeActiveTextEditor();
 		});
-		checkForSubmodules();
+		void checkForSubmodules();
 		checkForWorktrees();
 		this.onDidChangeActiveTextEditor();
 

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -8,6 +8,7 @@ import assert from 'assert';
 import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, extensions, TabInputTextDiff, TabInputNotebook, TabInputNotebookDiff } from 'vscode';
 import * as cp from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { GitExtension, API, Repository } from '../api/git';
 import { Status } from '../api/git.constants';
@@ -145,6 +146,38 @@ suite('git smoke test', function () {
 
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
+	});
+
+	test('closes a deinitialized submodule repository', async function () {
+		const submoduleSource = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-git-submodule-'));
+		const submodulePath = file('submodule');
+
+		try {
+			cp.execFileSync('git', ['init', '-b', 'main'], { cwd: submoduleSource });
+			cp.execFileSync('git', ['config', 'user.name', 'testuser'], { cwd: submoduleSource });
+			cp.execFileSync('git', ['config', 'user.email', 'monacotools@example.com'], { cwd: submoduleSource });
+			cp.execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: submoduleSource });
+			fs.writeFileSync(path.join(submoduleSource, 'README.md'), 'submodule');
+			cp.execFileSync('git', ['add', '.'], { cwd: submoduleSource });
+			cp.execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: submoduleSource });
+
+			cp.execFileSync('git', ['-c', 'protocol.file.allow=always', 'submodule', 'add', submoduleSource, 'submodule'], { cwd });
+			await commands.executeCommand('git.openRepository', submodulePath);
+			assert(git.repositories.some(repository => repository.rootUri.fsPath === submodulePath));
+
+			const onDidCloseSubmodule = eventToPromise(git.onDidCloseRepository);
+
+			cp.execFileSync('git', ['submodule', 'deinit', '-f', '--', 'submodule'], { cwd });
+			await repository.status();
+			const closedRepository = await onDidCloseSubmodule;
+
+			assert.strictEqual(closedRepository.rootUri.fsPath, submodulePath);
+			assert(!git.repositories.some(repository => repository.rootUri.fsPath === submodulePath));
+		} finally {
+			cp.execFileSync('git', ['reset', '--hard', 'HEAD'], { cwd });
+			fs.rmSync(submodulePath, { recursive: true, force: true });
+			fs.rmSync(submoduleSource, { recursive: true, force: true });
+		}
 	});
 
 	// diabled because of https://github.com/microsoft/vscode/issues/327142


### PR DESCRIPTION
Fixes #168662

Submodule discovery used every path declared in `.gitmodules`, so a deinitialized submodule was continually treated as available and its existing Source Control repository was never closed.

This distinguishes initialized submodules by their worktree `.git` entry, closes open repositories for paths that have been deinitialized, and only schedules initialized paths for discovery. A sequence guard prevents an older asynchronous status refresh from winning a race with a newer one.

Tests run:

- `npm run gulp compile-extension:git` (0 errors)
- Focused real-repository deinit regression test (1 passing)
- Full Git extension test suite (57 passing, 2 pre-existing pending)
- Targeted ESLint, pre-commit hygiene, and diff checks

The repository-wide ESLint command also inspected generated Markdown editor output in this linked dependency setup and reported pre-existing generated-file violations; ESLint on the two changed files passed.
