### PR TITLE
Handle unavailable restored custom editors

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { toAction } from '../../../base/common/actions.js';
 import { multibyteAwareBtoa } from '../../../base/common/strings.js';
 import { CancelablePromise, createCancelablePromise, DeferredPromise } from '../../../base/common/async.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
@@ -25,7 +26,7 @@ import { IUndoRedoService, UndoRedoElementType } from '../../../platform/undoRed
 import { MainThreadWebviewPanels } from './mainThreadWebviewPanels.js';
 import { MainThreadWebviews, reviveWebviewExtension } from './mainThreadWebviews.js';
 import * as extHostProtocol from '../common/extHost.protocol.js';
-import { IRevertOptions, ISaveOptions } from '../../common/editor.js';
+import { createEditorOpenError, DEFAULT_EDITOR_ASSOCIATION, IRevertOptions, ISaveOptions } from '../../common/editor.js';
 import { CustomEditorDiffInput, CustomEditorSideBySideDiffInput } from '../../contrib/customEditor/browser/customEditorDiffInput.js';
 import { CustomEditorInput } from '../../contrib/customEditor/browser/customEditorInput.js';
 import { CustomDocumentBackupData } from '../../contrib/customEditor/browser/customEditorInputFactory.js';
@@ -54,6 +55,10 @@ const enum CustomEditorModelType {
 }
 
 type CustomEditorWebviewInput = CustomEditorInput | CustomEditorDiffInput | CustomEditorSideBySideDiffInput;
+
+function isCustomEditorWebviewInput(input: WebviewInput): input is CustomEditorWebviewInput {
+	return input instanceof CustomEditorInput || input instanceof CustomEditorDiffInput || input instanceof CustomEditorSideBySideDiffInput;
+}
 
 interface CustomEditorDiffInitData {
 	readonly title: string;
@@ -122,15 +127,46 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 			return matchedWorkingCopies;
 		}));
 
-		// This reviver's only job is to activate custom editor extensions.
+		// Activate custom editor extensions before attempting to restore their editors.
 		this._register(_webviewWorkbenchService.registerResolver({
 			canResolve: (webview: WebviewInput) => {
-				if (webview instanceof CustomEditorInput || webview instanceof CustomEditorDiffInput || webview instanceof CustomEditorSideBySideDiffInput) {
-					extensionService.activateByEvent(`onCustomEditor:${webview.viewType}`);
-				}
-				return false;
+				return isCustomEditorWebviewInput(webview) && !this._customEditorService.getCustomEditorCapabilities(webview.viewType);
 			},
-			resolveWebview: () => { throw new Error('not implemented'); }
+			resolveWebview: async (webview, cancellation) => {
+				if (!isCustomEditorWebviewInput(webview)) {
+					return;
+				}
+
+				await extensionService.activateByEvent(`onCustomEditor:${webview.viewType}`);
+				if (cancellation.isCancellationRequested) {
+					return;
+				}
+
+				if (this._customEditorService.getCustomEditorCapabilities(webview.viewType)) {
+					return this._webviewWorkbenchService.resolveWebview(webview, cancellation);
+				}
+
+				throw createEditorOpenError(localize('customEditorUnavailable', "Cannot open resource with custom editor type '{0}'. Make sure its extension is installed and enabled.", webview.viewType), [
+					toAction({
+						id: 'workbench.customEditor.openWithDefault',
+						label: localize('customEditorOpenWithDefault', "Open With Default Editor"),
+						run: async () => {
+							const replacement = webview.toUntyped();
+							if (!replacement || typeof webview.group !== 'number') {
+								return;
+							}
+
+							await this._editorService.replaceEditors([{
+								editor: webview,
+								replacement: {
+									...replacement,
+									options: { ...replacement.options, override: DEFAULT_EDITOR_ASSOCIATION.id }
+								}
+							}], webview.group);
+						}
+					})
+				], { forceMessage: true });
+			}
 		}));
 
 		// Working copy operations

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -149,7 +149,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				throw createEditorOpenError(localize('customEditorUnavailable', "Cannot open resource with custom editor type '{0}'. Make sure its extension is installed and enabled.", webview.viewType), [
 					toAction({
 						id: 'workbench.customEditor.openWithDefault',
-						label: localize('customEditorOpenWithDefault', "Open With Default Editor"),
+						label: localize('customEditorOpenWithDefault', "Open with Default Editor"),
 						run: async () => {
 							const replacement = webview.toUntyped();
 							if (!replacement || typeof webview.group !== 'number') {

--- a/src/vs/workbench/api/test/browser/mainThreadCustomEditors.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadCustomEditors.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IResourceEditorInput } from '../../../../platform/editor/common/editor.js';
+import { GroupIdentifier, isEditorOpenError } from '../../../common/editor.js';
+import { CustomEditorInput } from '../../../contrib/customEditor/browser/customEditorInput.js';
+import { ICustomEditorService } from '../../../contrib/customEditor/common/customEditor.js';
+import { IWebviewWorkbenchService } from '../../../contrib/webviewPanel/browser/webviewWorkbenchService.js';
+import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorService, IUntypedEditorReplacement } from '../../../services/editor/common/editorService.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IUntitledTextEditorService } from '../../../services/untitled/common/untitledTextEditorService.js';
+import { IWorkingCopyFileService } from '../../../services/workingCopy/common/workingCopyFileService.js';
+import { IWorkingCopyService } from '../../../services/workingCopy/common/workingCopyService.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { TestStorageService } from '../../../test/common/workbenchTestServices.js';
+import { MainThreadCustomEditors } from '../../browser/mainThreadCustomEditors.js';
+import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
+
+suite('MainThreadCustomEditors', () => {
+	const store = new DisposableStore();
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('restored editor fails with a recovery action when its provider is unavailable', async () => {
+		type WebviewResolver = Parameters<IWebviewWorkbenchService['registerResolver']>[0];
+
+		let resolver: WebviewResolver | undefined;
+		const webviewWorkbenchService = new class extends mock<IWebviewWorkbenchService>() {
+			override registerResolver(value: WebviewResolver) {
+				resolver = value;
+				return Disposable.None;
+			}
+		};
+
+		const activations: string[] = [];
+		const extensionService = new class extends mock<IExtensionService>() {
+			override activateByEvent(activationEvent: string): Promise<void> {
+				activations.push(activationEvent);
+				return Promise.resolve();
+			}
+		};
+
+		const customEditorService = new class extends mock<ICustomEditorService>() {
+			override getCustomEditorCapabilities() {
+				return undefined;
+			}
+		};
+
+		const replacements: Array<{ replacements: IUntypedEditorReplacement[]; group: IEditorGroup | GroupIdentifier }> = [];
+		const editorService = new class extends mock<IEditorService>() {
+			override replaceEditors(value: IUntypedEditorReplacement[], group: IEditorGroup | GroupIdentifier): Promise<void> {
+				replacements.push({ replacements: value, group });
+				return Promise.resolve();
+			}
+		};
+
+		const workingCopyFileService = new class extends mock<IWorkingCopyFileService>() {
+			override readonly onWillRunWorkingCopyFileOperation = Event.None;
+			override registerWorkingCopyProvider() { return Disposable.None; }
+		};
+
+		const workingCopyService = new class extends mock<IWorkingCopyService>() {
+			override readonly workingCopies = [];
+		};
+
+		store.add(new MainThreadCustomEditors(
+			SingleProxyRPCProtocol(null),
+			undefined!,
+			undefined!,
+			extensionService,
+			store.add(new TestStorageService()),
+			workingCopyService,
+			workingCopyFileService,
+			customEditorService,
+			new class extends mock<IEditorGroupsService>() { },
+			editorService,
+			new class extends mock<IInstantiationService>() { },
+			webviewWorkbenchService,
+			new class extends mock<IUriIdentityService>() { },
+			new class extends mock<IUntitledTextEditorService>() { },
+		));
+
+		assert.ok(resolver);
+		const input = Object.create(CustomEditorInput.prototype) as CustomEditorInput;
+		Object.defineProperties(input, {
+			viewType: { value: 'missing.customEditor' },
+			resource: { value: URI.file('/test.png') },
+			group: { value: 7 },
+		});
+
+		const error = await resolver.resolveWebview(input, CancellationToken.None).then(() => undefined, error => error);
+		assert.ok(isEditorOpenError(error));
+		assert.deepStrictEqual({
+			activations,
+			message: error.message,
+			forceMessage: error.forceMessage,
+			actions: error.actions.map(action => action.label),
+		}, {
+			activations: ['onCustomEditor:missing.customEditor'],
+			message: 'Cannot open resource with custom editor type \'missing.customEditor\'. Make sure its extension is installed and enabled.',
+			forceMessage: true,
+			actions: ['Open With Default Editor'],
+		});
+
+		await error.actions[0].run();
+		const replacement = replacements[0].replacements[0].replacement as IResourceEditorInput;
+		assert.deepStrictEqual({
+			group: replacements[0].group,
+			editor: replacements[0].replacements[0].editor === input,
+			resource: replacement.resource.toString(),
+			override: replacement.options?.override,
+		}, {
+			group: 7,
+			editor: true,
+			resource: 'file:///test.png',
+			override: 'default',
+		});
+	});
+});

--- a/src/vs/workbench/api/test/browser/mainThreadCustomEditors.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadCustomEditors.test.ts
@@ -34,6 +34,16 @@ suite('MainThreadCustomEditors', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	function createCustomEditorInput(viewType: string): CustomEditorInput {
+		const input = Object.create(CustomEditorInput.prototype) as CustomEditorInput;
+		Object.defineProperties(input, {
+			viewType: { value: viewType },
+			resource: { value: URI.file('/test.png') },
+			group: { value: 7 },
+		});
+		return input;
+	}
+
 	test('restored editor fails with a recovery action when its provider is unavailable', async () => {
 		type WebviewResolver = Parameters<IWebviewWorkbenchService['registerResolver']>[0];
 
@@ -94,12 +104,7 @@ suite('MainThreadCustomEditors', () => {
 		));
 
 		assert.ok(resolver);
-		const input = Object.create(CustomEditorInput.prototype) as CustomEditorInput;
-		Object.defineProperties(input, {
-			viewType: { value: 'missing.customEditor' },
-			resource: { value: URI.file('/test.png') },
-			group: { value: 7 },
-		});
+		const input = createCustomEditorInput('missing.customEditor');
 
 		const error = await resolver.resolveWebview(input, CancellationToken.None).then(() => undefined, error => error);
 		assert.ok(isEditorOpenError(error));
@@ -112,7 +117,7 @@ suite('MainThreadCustomEditors', () => {
 			activations: ['onCustomEditor:missing.customEditor'],
 			message: 'Cannot open resource with custom editor type \'missing.customEditor\'. Make sure its extension is installed and enabled.',
 			forceMessage: true,
-			actions: ['Open With Default Editor'],
+			actions: ['Open with Default Editor'],
 		});
 
 		await error.actions[0].run();
@@ -128,5 +133,72 @@ suite('MainThreadCustomEditors', () => {
 			resource: 'file:///test.png',
 			override: 'default',
 		});
+	});
+
+	test('restored editor delegates to a provider registered during activation', async () => {
+		type WebviewResolver = Parameters<IWebviewWorkbenchService['registerResolver']>[0];
+
+		const resolvers: WebviewResolver[] = [];
+		const webviewWorkbenchService = new class extends mock<IWebviewWorkbenchService>() {
+			override registerResolver(resolver: WebviewResolver) {
+				resolvers.push(resolver);
+				return Disposable.None;
+			}
+
+			override async resolveWebview(webview: CustomEditorInput, cancellation: CancellationToken): Promise<void> {
+				const resolver = resolvers.find(resolver => resolver.canResolve(webview));
+				assert.ok(resolver);
+				await resolver.resolveWebview(webview, cancellation);
+			}
+		};
+
+		let capabilitiesAvailable = false;
+		let providerResolveCount = 0;
+		const providerResolver: WebviewResolver = {
+			canResolve: () => capabilitiesAvailable,
+			resolveWebview: async () => { providerResolveCount++; }
+		};
+		const extensionService = new class extends mock<IExtensionService>() {
+			override activateByEvent(): Promise<void> {
+				capabilitiesAvailable = true;
+				webviewWorkbenchService.registerResolver(providerResolver);
+				return Promise.resolve();
+			}
+		};
+		const customEditorService = new class extends mock<ICustomEditorService>() {
+			override getCustomEditorCapabilities() {
+				return capabilitiesAvailable ? {} : undefined;
+			}
+		};
+		const workingCopyFileService = new class extends mock<IWorkingCopyFileService>() {
+			override readonly onWillRunWorkingCopyFileOperation = Event.None;
+			override registerWorkingCopyProvider() { return Disposable.None; }
+		};
+
+		store.add(new MainThreadCustomEditors(
+			SingleProxyRPCProtocol(null),
+			undefined!,
+			undefined!,
+			extensionService,
+			store.add(new TestStorageService()),
+			new class extends mock<IWorkingCopyService>() { override readonly workingCopies = []; },
+			workingCopyFileService,
+			customEditorService,
+			new class extends mock<IEditorGroupsService>() { },
+			new class extends mock<IEditorService>() { },
+			new class extends mock<IInstantiationService>() { },
+			webviewWorkbenchService,
+			new class extends mock<IUriIdentityService>() { },
+			new class extends mock<IUntitledTextEditorService>() { },
+		));
+
+		const activationResolver = resolvers[0];
+		const input = createCustomEditorInput('available.customEditor');
+		assert.ok(activationResolver.canResolve(input));
+
+		await activationResolver.resolveWebview(input, CancellationToken.None);
+
+		assert.strictEqual(providerResolveCount, 1);
+		assert.ok(!activationResolver.canResolve(input));
 	});
 });


### PR DESCRIPTION
Fixes #125582

The custom editor activation resolver always declined restoration after firing the activation event. If the provider extension was uninstalled or disabled, no later resolver claimed the input and it remained in the revival pool indefinitely.

This resolver now waits for activation and delegates to the registered provider when one becomes available. If no provider appears, restoration fails with a visible editor error and an **Open With Default Editor** recovery action instead of hanging forever.

Tests run:

- `npm run typecheck-client`
- `npm run compile-client` (0 errors)
- Targeted MainThreadCustomEditors Electron tests (2 passing)
- Pre-commit hygiene and diff checks
