### PR TITLE
Cascade code actions on save by provider

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -104,6 +104,7 @@ export async function getCodeActions(
 	trigger: CodeActionTrigger,
 	progress: IProgress<languages.CodeActionProvider>,
 	token: CancellationToken,
+	onlyProvider?: languages.CodeActionProvider,
 ): Promise<CodeActionSet> {
 	const filter = trigger.filter || {};
 	const notebookFilter: CodeActionFilter = {
@@ -119,7 +120,8 @@ export async function getCodeActions(
 	const cts = new TextModelCancellationTokenSource(model, token);
 	// if the trigger is auto (autosave, lightbulb, etc), we should exclude notebook codeActions
 	const excludeNotebookCodeActions = (trigger.type === languages.CodeActionTriggerType.Auto);
-	const providers = getCodeActionProviders(registry, model, (excludeNotebookCodeActions) ? notebookFilter : filter);
+	const providers = getCodeActionProviders(registry, model, (excludeNotebookCodeActions) ? notebookFilter : filter)
+		.filter(provider => !onlyProvider || provider === onlyProvider);
 
 	const disposables = new DisposableStore();
 	const promises = providers.map(async provider => {

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -270,7 +270,7 @@ class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 	}
 }
 
-class CodeActionOnSaveParticipant extends Disposable implements ITextFileSaveParticipant {
+export class CodeActionOnSaveParticipant extends Disposable implements ITextFileSaveParticipant {
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -409,35 +409,38 @@ class CodeActionOnSaveParticipant extends Disposable implements ITextFileSavePar
 		};
 
 		for (const codeActionKind of codeActionsOnSave) {
-			const actionsToRun = await this.getActionsToRun(model, codeActionKind, excludes, getActionProgress, token);
+			const providers = this.languageFeaturesService.codeActionProvider.all(model);
+			for (const provider of providers) {
+				const actionsToRun = await this.getActionsToRun(model, codeActionKind, excludes, getActionProgress, token, provider);
 
-			if (token.isCancellationRequested) {
-				actionsToRun.dispose();
-				return;
-			}
-
-			try {
-				for (const action of actionsToRun.validActions) {
-					progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.action.title) });
-					await this.instantiationService.invokeFunction(applyCodeAction, action, ApplyCodeActionReason.OnSave, {}, token);
-					if (token.isCancellationRequested) {
-						return;
-					}
+				if (token.isCancellationRequested) {
+					actionsToRun.dispose();
+					return;
 				}
-			} catch {
-				// Failure to apply a code action should not block other on save actions
-			} finally {
-				actionsToRun.dispose();
+
+				try {
+					for (const action of actionsToRun.validActions) {
+						progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.action.title) });
+						await this.instantiationService.invokeFunction(applyCodeAction, action, ApplyCodeActionReason.OnSave, {}, token);
+						if (token.isCancellationRequested) {
+							return;
+						}
+					}
+				} catch {
+					// Failure to apply a code action should not block other on save actions
+				} finally {
+					actionsToRun.dispose();
+				}
 			}
 		}
 	}
 
-	private getActionsToRun(model: ITextModel, codeActionKind: HierarchicalKind, excludes: readonly HierarchicalKind[], progress: IProgress<CodeActionProvider>, token: CancellationToken) {
+	private getActionsToRun(model: ITextModel, codeActionKind: HierarchicalKind, excludes: readonly HierarchicalKind[], progress: IProgress<CodeActionProvider>, token: CancellationToken, provider: CodeActionProvider) {
 		return getCodeActions(this.languageFeaturesService.codeActionProvider, model, model.getFullModelRange(), {
 			type: CodeActionTriggerType.Auto,
 			triggerAction: CodeActionTriggerSource.OnSave,
 			filter: { include: codeActionKind, excludes: excludes, includeSourceActions: true },
-		}, progress, token);
+		}, progress, token, provider);
 	}
 }
 

--- a/src/vs/workbench/contrib/codeEditor/test/browser/saveParticipant.test.ts
+++ b/src/vs/workbench/contrib/codeEditor/test/browser/saveParticipant.test.ts
@@ -4,23 +4,31 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { FinalNewLineParticipant, TrimFinalNewLinesParticipant, TrimWhitespaceParticipant } from '../../browser/saveParticipants.js';
-import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { workbenchInstantiationService, TestServiceAccessor } from '../../../../test/browser/workbenchTestServices.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite, toResource } from '../../../../../base/test/common/utils.js';
+import { IBulkEditService, ResourceEdit, ResourceTextEdit } from '../../../../../editor/browser/services/bulkEditService.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { Selection } from '../../../../../editor/common/core/selection.js';
+import * as languages from '../../../../../editor/common/languages.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
+import { CodeActionKind } from '../../../../../editor/contrib/codeAction/common/types.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { Progress } from '../../../../../platform/progress/common/progress.js';
+import { SaveReason } from '../../../../common/editor.js';
 import { TextFileEditorModel } from '../../../../services/textfile/common/textFileEditorModel.js';
 import { IResolvedTextFileEditorModel, snapshotToString } from '../../../../services/textfile/common/textfiles.js';
-import { SaveReason } from '../../../../common/editor.js';
 import { TextFileEditorModelManager } from '../../../../services/textfile/common/textFileEditorModelManager.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { workbenchInstantiationService, TestServiceAccessor } from '../../../../test/browser/workbenchTestServices.js';
+import { CodeActionOnSaveParticipant, FinalNewLineParticipant, TrimFinalNewLinesParticipant, TrimWhitespaceParticipant } from '../../browser/saveParticipants.js';
 
 suite('Save Participants', function () {
 
 	const disposables = new DisposableStore();
-	let instantiationService: IInstantiationService;
+	let instantiationService: TestInstantiationService;
 	let accessor: TestServiceAccessor;
 
 	setup(() => {
@@ -173,6 +181,72 @@ suite('Save Participants', function () {
 
 		// confirm trimming
 		assert.strictEqual(snapshotToString(model.createSnapshot()!), `${textContent}`);
+	});
+
+	test('code actions on save cascade between providers, #174295', async function () {
+		const model: IResolvedTextFileEditorModel = disposables.add(instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/organize_imports.py'), 'utf8', undefined) as IResolvedTextFileEditorModel);
+		await model.resolve();
+		model.textEditorModel.setValue('import os,sys\nlast');
+		instantiationService.stub(IBulkEditService, new class extends mock<IBulkEditService>() {
+			override async apply(edit: ResourceEdit[] | languages.WorkspaceEdit) {
+				const edits = Array.isArray(edit) ? edit : ResourceEdit.convert(edit);
+				for (const resourceEdit of edits) {
+					if (resourceEdit instanceof ResourceTextEdit) {
+						assert.strictEqual(resourceEdit.resource.toString(), model.resource.toString());
+						model.textEditorModel.applyEdits([resourceEdit.textEdit]);
+					}
+				}
+				return { ariaSummary: '', isApplied: true };
+			}
+		});
+
+		accessor.testConfigurationService.setUserConfiguration('editor', {
+			codeActionsOnSave: {
+				[CodeActionKind.SourceOrganizeImports.value]: 'explicit'
+			}
+		});
+
+		const providerInputs: string[] = [];
+		const createProvider = (name: string, getEdit: (textModel: ITextModel) => languages.WorkspaceEdit | undefined): languages.CodeActionProvider => ({
+			providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports.value],
+			provideCodeActions: (textModel: ITextModel): languages.CodeActionList => {
+				providerInputs.push(`${name}: ${textModel.getValue()}`);
+				const edit = getEdit(textModel);
+				return {
+					actions: edit ? [{ title: `${name} organizer`, kind: CodeActionKind.SourceOrganizeImports.value, edit }] : [],
+					dispose: () => { }
+				};
+			}
+		});
+		const languageFeaturesService = instantiationService.invokeFunction(accessor => accessor.get(ILanguageFeaturesService));
+		disposables.add(languageFeaturesService.codeActionProvider.register('*', createProvider('second', textModel => textModel.getValue().startsWith('import os,sys') ? {
+			edits: [{
+				resource: textModel.uri,
+				textEdit: { range: new Range(1, 1, 1, 14), text: 'import os\nimport sys' },
+				versionId: undefined
+			}]
+		} : undefined)));
+		disposables.add(languageFeaturesService.codeActionProvider.register('*', createProvider('first', textModel => textModel.getValue().startsWith('import os,sys') ? {
+			edits: [{
+				resource: textModel.uri,
+				textEdit: { range: new Range(1, 10, 1, 11), text: '\nimport ' },
+				versionId: undefined
+			}]
+		} : undefined)));
+
+		const participant = disposables.add(instantiationService.createInstance(CodeActionOnSaveParticipant));
+		await participant.participate(model, { reason: SaveReason.EXPLICIT }, Progress.None, CancellationToken.None);
+
+		assert.deepStrictEqual({
+			providerInputs,
+			value: model.textEditorModel.getValue()
+		}, {
+			providerInputs: [
+				'first: import os,sys\nlast',
+				'second: import os\nimport sys\nlast'
+			],
+			value: 'import os\nimport sys\nlast'
+		});
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -524,42 +524,45 @@ export class CodeActionParticipantUtils {
 		};
 
 		for (const codeActionKind of codeActionsOnSave) {
-			const actionsToRun = await CodeActionParticipantUtils.getActionsToRun(model, codeActionKind, excludes, languageFeaturesService, getActionProgress, token);
-			if (token.isCancellationRequested) {
-				actionsToRun.dispose();
-				return;
-			}
+			const providers = languageFeaturesService.codeActionProvider.all(model);
+			for (const provider of providers) {
+				const actionsToRun = await CodeActionParticipantUtils.getActionsToRun(model, codeActionKind, excludes, languageFeaturesService, getActionProgress, token, provider);
+				if (token.isCancellationRequested) {
+					actionsToRun.dispose();
+					return;
+				}
 
-			try {
-				for (const action of actionsToRun.validActions) {
-					const codeActionEdits = action.action.edit?.edits;
-					let breakFlag = false;
-					if (!action.action.kind?.startsWith('notebook')) {
-						for (const edit of codeActionEdits ?? []) {
-							const workspaceTextEdit = edit as IWorkspaceTextEdit;
-							if (workspaceTextEdit.resource && isEqual(workspaceTextEdit.resource, model.uri)) {
-								continue;
-							} else {
-								// error -> applied to multiple resources
-								breakFlag = true;
-								break;
+				try {
+					for (const action of actionsToRun.validActions) {
+						const codeActionEdits = action.action.edit?.edits;
+						let breakFlag = false;
+						if (!action.action.kind?.startsWith('notebook')) {
+							for (const edit of codeActionEdits ?? []) {
+								const workspaceTextEdit = edit as IWorkspaceTextEdit;
+								if (workspaceTextEdit.resource && isEqual(workspaceTextEdit.resource, model.uri)) {
+									continue;
+								} else {
+									// error -> applied to multiple resources
+									breakFlag = true;
+									break;
+								}
 							}
 						}
+						if (breakFlag) {
+							logService.warn('Failed to apply code action on save, applied to multiple resources.');
+							continue;
+						}
+						progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.action.title) });
+						await instantiationService.invokeFunction(applyCodeAction, action, ApplyCodeActionReason.OnSave, {}, token);
+						if (token.isCancellationRequested) {
+							return;
+						}
 					}
-					if (breakFlag) {
-						logService.warn('Failed to apply code action on save, applied to multiple resources.');
-						continue;
-					}
-					progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.action.title) });
-					await instantiationService.invokeFunction(applyCodeAction, action, ApplyCodeActionReason.OnSave, {}, token);
-					if (token.isCancellationRequested) {
-						return;
-					}
+				} catch {
+					// Failure to apply a code action should not block other on save actions
+				} finally {
+					actionsToRun.dispose();
 				}
-			} catch {
-				// Failure to apply a code action should not block other on save actions
-			} finally {
-				actionsToRun.dispose();
 			}
 		}
 	}
@@ -629,12 +632,12 @@ export class CodeActionParticipantUtils {
 	}
 
 	// @Yoyokrazy this could likely be modified to leverage the extensionID, therefore not getting actions from providers unnecessarily -- future work
-	static getActionsToRun(model: ITextModel, codeActionKind: HierarchicalKind, excludes: readonly HierarchicalKind[], languageFeaturesService: ILanguageFeaturesService, progress: IProgress<CodeActionProvider>, token: CancellationToken) {
+	static getActionsToRun(model: ITextModel, codeActionKind: HierarchicalKind, excludes: readonly HierarchicalKind[], languageFeaturesService: ILanguageFeaturesService, progress: IProgress<CodeActionProvider>, token: CancellationToken, provider?: CodeActionProvider) {
 		return getCodeActions(languageFeaturesService.codeActionProvider, model, model.getFullModelRange(), {
 			type: CodeActionTriggerType.Invoke,
 			triggerAction: CodeActionTriggerSource.OnSave,
 			filter: { include: codeActionKind, excludes: excludes, includeSourceActions: true },
-		}, progress, token);
+		}, progress, token, provider);
 	}
 
 }

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/saveParticipants.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/saveParticipants.test.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite, toResource } from '../../../../../../base/test/common/utils.js';
+import { IBulkEditService, ResourceEdit, ResourceTextEdit } from '../../../../../../editor/browser/services/bulkEditService.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import * as languages from '../../../../../../editor/common/languages.js';
+import { ITextModel } from '../../../../../../editor/common/model.js';
+import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
+import { CodeActionKind } from '../../../../../../editor/contrib/codeAction/common/types.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { Progress } from '../../../../../../platform/progress/common/progress.js';
+import { TextFileEditorModel } from '../../../../../services/textfile/common/textFileEditorModel.js';
+import { IResolvedTextFileEditorModel } from '../../../../../services/textfile/common/textfiles.js';
+import { TextFileEditorModelManager } from '../../../../../services/textfile/common/textFileEditorModelManager.js';
+import { workbenchInstantiationService, TestServiceAccessor } from '../../../../../test/browser/workbenchTestServices.js';
+import { CodeActionParticipantUtils } from '../../../browser/contrib/saveParticipants/saveParticipants.js';
+
+suite('Notebook Save Participants', function () {
+	const disposables = new DisposableStore();
+	let instantiationService: TestInstantiationService;
+	let accessor: TestServiceAccessor;
+
+	setup(() => {
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+		accessor = instantiationService.createInstance(TestServiceAccessor);
+		disposables.add(<TextFileEditorModelManager>accessor.textFileService.files);
+	});
+
+	teardown(() => disposables.clear());
+
+	test('code actions on save cascade between providers, #174295', async function () {
+		const model = disposables.add(instantiationService.createInstance(
+			TextFileEditorModel,
+			toResource.call(this, '/path/notebook_organize_imports.py'),
+			'utf8',
+			undefined
+		) as IResolvedTextFileEditorModel);
+		await model.resolve();
+		model.textEditorModel.setValue('import os,sys\nlast');
+
+		instantiationService.stub(IBulkEditService, new class extends mock<IBulkEditService>() {
+			override async apply(edit: ResourceEdit[] | languages.WorkspaceEdit) {
+				const edits = Array.isArray(edit) ? edit : ResourceEdit.convert(edit);
+				for (const resourceEdit of edits) {
+					if (resourceEdit instanceof ResourceTextEdit) {
+						assert.strictEqual(resourceEdit.resource.toString(), model.resource.toString());
+						model.textEditorModel.applyEdits([resourceEdit.textEdit]);
+					}
+				}
+				return { ariaSummary: '', isApplied: true };
+			}
+		});
+
+		const providerInputs: string[] = [];
+		const createProvider = (name: string, getEdit: (textModel: ITextModel) => languages.WorkspaceEdit | undefined): languages.CodeActionProvider => ({
+			providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports.value],
+			provideCodeActions: (textModel: ITextModel): languages.CodeActionList => {
+				providerInputs.push(`${name}: ${textModel.getValue()}`);
+				const edit = getEdit(textModel);
+				return {
+					actions: edit ? [{ title: `${name} organizer`, kind: CodeActionKind.SourceOrganizeImports.value, edit }] : [],
+					dispose: () => { }
+				};
+			}
+		});
+		const languageFeaturesService = instantiationService.invokeFunction(accessor => accessor.get(ILanguageFeaturesService));
+		disposables.add(languageFeaturesService.codeActionProvider.register('*', createProvider('second', textModel => textModel.getValue().startsWith('import os,sys') ? {
+			edits: [{
+				resource: textModel.uri,
+				textEdit: { range: new Range(1, 1, 1, 14), text: 'import os\nimport sys' },
+				versionId: undefined
+			}]
+		} : undefined)));
+		disposables.add(languageFeaturesService.codeActionProvider.register('*', createProvider('first', textModel => textModel.getValue().startsWith('import os,sys') ? {
+			edits: [{
+				resource: textModel.uri,
+				textEdit: { range: new Range(1, 10, 1, 11), text: '\nimport ' },
+				versionId: undefined
+			}]
+		} : undefined)));
+
+		await instantiationService.invokeFunction(
+			CodeActionParticipantUtils.applyOnSaveGenericCodeActions,
+			model.textEditorModel,
+			[CodeActionKind.SourceOrganizeImports],
+			[],
+			Progress.None,
+			CancellationToken.None
+		);
+
+		assert.deepStrictEqual({
+			providerInputs,
+			value: model.textEditorModel.getValue()
+		}, {
+			providerInputs: [
+				'first: import os,sys\nlast',
+				'second: import os\nimport sys\nlast'
+			],
+			value: 'import os\nimport sys\nlast'
+		});
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
Fixes #174295

Code action providers used for save participants were queried concurrently against the same document version, but their edits were then applied sequentially. When multiple import organizers returned edits, the later provider could apply stale offsets and duplicate or corrupt imports.

This queries and applies providers sequentially in the registry's deterministic order. Each provider therefore sees the document after the preceding provider's edits, while action ordering within a provider remains unchanged.

Tests run:

- `npm run typecheck-client`
- `npm run gulp compile` (0 errors)
- Save Participants suite (6 passing), including a regression that reproduced the duplicate import before the fix
- CodeAction suite (7 passing)
- Targeted ESLint, pre-commit hygiene, and diff checks
