### PR TITLE
Preserve CRLF during partial staging

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -384,7 +384,7 @@ export interface ICloneOptions {
 	readonly ref?: string;
 }
 
-export class Git {
+export class Git implements IDisposable {
 
 	readonly path: string;
 	readonly userAgent: string;
@@ -392,6 +392,7 @@ export class Git {
 	readonly env: { [key: string]: string };
 
 	private commandsToLog: string[] = [];
+	private disposables: IDisposable[] = [];
 
 	private _onOutput = new EventEmitter();
 	get onOutput(): EventEmitter { return this._onOutput; }
@@ -411,8 +412,12 @@ export class Git {
 			this.commandsToLog = config.get<string[]>('commandsToLog', []);
 		};
 
-		workspace.onDidChangeConfiguration(onConfigurationChanged, this);
+		workspace.onDidChangeConfiguration(onConfigurationChanged, this, this.disposables);
 		onConfigurationChanged();
+	}
+
+	dispose(): void {
+		this.disposables = dispose(this.disposables);
 	}
 
 	compareGitVersionTo(version: string): -1 | 0 | 1 {
@@ -1992,8 +1997,9 @@ export class Repository {
 		const args = ['hash-object', '--stdin', '-w', '--path', relativePath];
 
 		if (this._git.compareGitVersionTo('2.10.0') >= 0) {
-			const { stdout } = await this.exec(['ls-files', '--eol', '--', relativePath]);
-			if (stdout.startsWith('i/crlf')) {
+			const { stdout } = await this.exec(['--literal-pathspecs', 'ls-files', '--eol', '--', relativePath]);
+			const indexEol = stdout.split(/\s/, 1)[0];
+			if (indexEol === 'i/crlf' || indexEol === 'i/mixed') {
 				args.unshift('-c', 'core.autocrlf=false');
 			}
 		}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1989,7 +1989,16 @@ export class Repository {
 
 	async stage(path: string, data: Uint8Array): Promise<void> {
 		const relativePath = this.sanitizeRelativePath(path);
-		const child = this.stream(['hash-object', '--stdin', '-w', '--path', relativePath], { stdio: [null, null, null] });
+		const args = ['hash-object', '--stdin', '-w', '--path', relativePath];
+
+		if (this._git.compareGitVersionTo('2.10.0') >= 0) {
+			const { stdout } = await this.exec(['ls-files', '--eol', '--', relativePath]);
+			if (stdout.startsWith('i/crlf')) {
+				args.unshift('-c', 'core.autocrlf=false');
+			}
+		}
+
+		const child = this.stream(args, { stdio: [null, null, null] });
 
 		if (!child.stdin) {
 			throw new GitError({

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -91,6 +91,7 @@ async function createModel(context: ExtensionContext, logger: LogOutputChannel, 
 		version: info.version,
 		env: environment,
 	});
+	disposables.push(git);
 	const model = new Model(git, askpass, context.globalState, context.workspaceState, logger, telemetryReporter);
 	disposables.push(model);
 	const cloneManager = new CloneManager(model, telemetryReporter, model.repositoryCache);

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { GitExtension, API, Repository } from '../api/git';
 import { Status } from '../api/git.constants';
+import { Git } from '../git';
 import { eventToPromise } from '../util';
 
 suite('git smoke test', function () {
@@ -43,10 +44,12 @@ suite('git smoke test', function () {
 	suiteSetup(async function () {
 		fs.writeFileSync(file('app.js'), 'hello', 'utf8');
 		fs.writeFileSync(file('index.pug'), 'hello', 'utf8');
+		fs.writeFileSync(file('crlf.txt'), 'first\r\nsecond\r\nthird\r\n', 'utf8');
 		cp.execSync('git init -b main', { cwd });
 		cp.execSync('git config user.name testuser', { cwd });
 		cp.execSync('git config user.email monacotools@example.com', { cwd });
 		cp.execSync('git config commit.gpgsign false', { cwd });
+		cp.execSync('git config core.autocrlf false', { cwd });
 		cp.execSync('git add .', { cwd });
 		cp.execSync('git commit -m "initial commit"', { cwd });
 
@@ -65,6 +68,26 @@ suite('git smoke test', function () {
 		assert.strictEqual(git.repositories[0].rootUri.fsPath, cwd);
 
 		repository = git.repositories[0];
+	});
+
+	test('preserves CRLF when staging partial contents', async function () {
+		const version = cp.execFileSync('git', ['--version'], { encoding: 'utf8' }).trim().replace(/^git version /, '');
+		const logger = window.createOutputChannel('Git Test', { log: true });
+		const gitClient = new Git({ gitPath: 'git', userAgent: 'git-test', version });
+		const gitRepository = gitClient.open(cwd, undefined, { path: path.join(cwd, '.git'), isBare: false }, logger);
+		const contents = Buffer.from('first\r\nchanged\r\nthird\r\n');
+
+		try {
+			cp.execSync('git config core.autocrlf true', { cwd });
+			await gitRepository.stage(file('crlf.txt'), contents);
+
+			const stagedContents = cp.execFileSync('git', ['show', ':crlf.txt'], { cwd });
+			assert.deepStrictEqual(stagedContents, contents);
+		} finally {
+			cp.execFileSync('git', ['reset', '--quiet', 'HEAD', '--', 'crlf.txt'], { cwd });
+			cp.execSync('git config core.autocrlf false', { cwd });
+			logger.dispose();
+		}
 	});
 
 	test('reflects working tree changes', async function () {

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -45,6 +45,9 @@ suite('git smoke test', function () {
 		fs.writeFileSync(file('app.js'), 'hello', 'utf8');
 		fs.writeFileSync(file('index.pug'), 'hello', 'utf8');
 		fs.writeFileSync(file('crlf.txt'), 'first\r\nsecond\r\nthird\r\n', 'utf8');
+		fs.writeFileSync(file('crlf[1].txt'), 'first\r\nsecond\r\nthird\r\n', 'utf8');
+		fs.writeFileSync(file('crlf1.txt'), 'first\nsecond\nthird\n', 'utf8');
+		fs.writeFileSync(file('mixed.txt'), 'first\r\nsecond\nthird\r\n', 'utf8');
 		cp.execSync('git init -b main', { cwd });
 		cp.execSync('git config user.name testuser', { cwd });
 		cp.execSync('git config user.email monacotools@example.com', { cwd });
@@ -75,17 +78,23 @@ suite('git smoke test', function () {
 		const logger = window.createOutputChannel('Git Test', { log: true });
 		const gitClient = new Git({ gitPath: 'git', userAgent: 'git-test', version });
 		const gitRepository = gitClient.open(cwd, undefined, { path: path.join(cwd, '.git'), isBare: false }, logger);
-		const contents = Buffer.from('first\r\nchanged\r\nthird\r\n');
+		const cases = [
+			{ path: 'crlf.txt', contents: Buffer.from('first\r\nchanged\r\nthird\r\n') },
+			{ path: 'crlf[1].txt', contents: Buffer.from('first\r\nchanged\r\nthird\r\n') },
+			{ path: 'mixed.txt', contents: Buffer.from('first\r\nchanged\nthird\r\n') },
+		];
 
 		try {
 			cp.execSync('git config core.autocrlf true', { cwd });
-			await gitRepository.stage(file('crlf.txt'), contents);
-
-			const stagedContents = cp.execFileSync('git', ['show', ':crlf.txt'], { cwd });
-			assert.deepStrictEqual(stagedContents, contents);
+			for (const testCase of cases) {
+				await gitRepository.stage(file(testCase.path), testCase.contents);
+				const stagedContents = cp.execFileSync('git', ['show', `:${testCase.path}`], { cwd });
+				assert.deepStrictEqual(stagedContents, testCase.contents);
+			}
 		} finally {
-			cp.execFileSync('git', ['reset', '--quiet', 'HEAD', '--', 'crlf.txt'], { cwd });
+			cp.execFileSync('git', ['reset', '--quiet', 'HEAD', '--', ...cases.map(testCase => testCase.path)], { cwd });
 			cp.execSync('git config core.autocrlf false', { cwd });
+			gitClient.dispose();
 			logger.dispose();
 		}
 	});


### PR DESCRIPTION
Fixes #96104

Partial staging hashes the edited contents with `hash-object --path`. When `core.autocrlf` is enabled, Git applies that setting during hashing and silently converts an indexed CRLF file to LF, including lines outside the selected range.

This checks the indexed line ending with `git ls-files --eol` and disables `core.autocrlf` only while hashing files whose index form is CRLF. Other files and configured clean filters keep their existing behavior.

Tests run:

- `npm run gulp compile-extension:git` (0 errors)
- Focused CRLF partial-staging regression test (1 passing)
- Full Git extension test suite (57 passing, 2 pre-existing pending)
- Pre-commit hygiene and diff checks
