### PR TITLE
Voice: queue concurrent question forms instead of swapping them

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -92,7 +92,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	// state-change event needs to fire before the timer expires.
 	private _pendingContext: IVoiceSessionContext | undefined;
 	private _lastSentById = new Map<string, Record<string, unknown>>(); // session id → last-sent field values
-	private _lastSentActive = '';
 
 	// --- Events ---
 	private readonly _onTranscription = this._register(new Emitter<IVoiceTranscription>());
@@ -534,7 +533,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		this._lastSessionId = undefined;
 		this._isResuming = false;
 		this._lastSentById.clear();
-		this._lastSentActive = '';
 		this._setConnected(false);
 	}
 
@@ -636,8 +634,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	private _sendDelta(context: IVoiceSessionContext): void {
 		const currentIds = new Set(context.sessions.map(s => s.id));
 		const removes = [...this._lastSentById.keys()].filter(id => !currentIds.has(id));
-		const activeKey = context.active_session ? stableStringify(context.active_session) : '';
-		const activeChanged = activeKey !== this._lastSentActive;
 
 		// Compute per-session field-level patches (JSON Merge Patch style)
 		const upserts: Record<string, unknown>[] = [];
@@ -691,7 +687,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			}
 		}
 
-		if (upserts.length === 0 && removes.length === 0 && !activeChanged) {
+		if (upserts.length === 0 && removes.length === 0) {
 			return;
 		}
 
@@ -704,16 +700,14 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			this._lastSentById.set(session.id, obj);
 		}
 		for (const id of removes) { this._lastSentById.delete(id); }
-		this._lastSentActive = activeKey;
 
 		this._ws!.send(JSON.stringify({
 			type: 'session_context',
 			mode: 'delta',
 			upserts,
 			removes,
-			...(activeChanged && context.active_session ? { active_session: context.active_session } : {}),
 		}));
-		this._logService.trace(`[voice] _sendDelta upserts=[${upserts.map(u => `${String(u.id).slice(-8)}:${u.agent_state ?? '(no-state)'}${Object.prototype.hasOwnProperty.call(u, 'agent_state_detail') ? '+detail' : ''}${Object.prototype.hasOwnProperty.call(u, 'last_response_summary') && u.last_response_summary ? '+summary' : ''}`).join(', ')}] removes=${removes.length} activeChanged=${activeChanged}`);
+		this._logService.trace(`[voice] _sendDelta upserts=[${upserts.map(u => `${String(u.id).slice(-8)}:${u.agent_state ?? '(no-state)'}${Object.prototype.hasOwnProperty.call(u, 'agent_state_detail') ? '+detail' : ''}${Object.prototype.hasOwnProperty.call(u, 'last_response_summary') && u.last_response_summary ? '+summary' : ''}`).join(', ')}] removes=${removes.length}`);
 	}
 
 	private _seedTracking(context: IVoiceSessionContext): void {
@@ -725,7 +719,6 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			}
 			this._lastSentById.set(session.id, obj);
 		}
-		this._lastSentActive = context.active_session ? stableStringify(context.active_session) : '';
 	}
 
 	sendToolResult(callId: string, result: string | IVoiceDispatchResult): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -32,7 +32,7 @@ import { IChatService, IChatToolInvocation, ToolConfirmKind, IChatModelReference
 import { getDisplayedQuestionText, getOptionsWithDefaultsFirst } from '../../common/chatService/chatQuestionCarouselHelpers.js';
 import { formatQuestionPrompt } from '../../common/voiceClient/voicePendingNarration.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
-import { IChatModel } from '../../common/model/chatModel.js';
+import { IChatModel, IChatProgressResponseContent } from '../../common/model/chatModel.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -5550,6 +5550,94 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return stateInfo.state;
 	}
 
+	/**
+	 * The single pending part voice is currently on for a session.
+	 *
+	 * Scans OLDEST-first and returns the first still-open actionable part of the
+	 * last request, matching how the chat model itself decides what a response is
+	 * waiting on (`_pendingInfo` in `chatModel.ts`).
+	 *
+	 * Two callers share this: `_buildPendingPayload`, which decides what a spoken
+	 * answer routes to, and `_getAgentStateInfo`, which produces the prose the
+	 * model hears. They used to pick independently, so a second form arriving
+	 * flipped the prose to the new form while the payload stayed on the old one -
+	 * which reads the old form aloud again as a detail transition.
+	 *
+	 * Oldest-first also gives voice a queue with no stored state: resolved parts
+	 * are skipped, so the oldest still-open part is by construction the one
+	 * already published. A form arriving never takes the turn from the form the
+	 * user is part-way through answering.
+	 */
+	private _selectPendingPart(model: IChatModel | undefined | null): { requestId: string; part: IChatProgressResponseContent } | undefined {
+		const lastRequest = model?.getRequests().at(-1);
+		const parts = lastRequest?.response?.response.value;
+		if (!lastRequest || !parts) {
+			return undefined;
+		}
+		for (const part of parts) {
+			if (this._isOpenPendingPart(part)) {
+				return { requestId: lastRequest.id, part };
+			}
+		}
+		return undefined;
+	}
+
+	/** Whether a response part is still waiting on the user. */
+	private _isOpenPendingPart(part: IChatProgressResponseContent): boolean {
+		if (part.kind === 'questionCarousel') {
+			const carousel = part as IChatQuestionCarousel;
+			// A form with no questions can't be answered by voice or by mouse, so
+			// it must not hold the queue.
+			return !carousel.isUsed && !carousel.answeredExternally && carousel.questions.length > 0;
+		}
+		if (part.kind === 'planReview' || part.kind === 'confirmation') {
+			return !(part as { isUsed?: boolean }).isUsed;
+		}
+		if (part.kind === 'elicitation2') {
+			return (part as { state: IObservable<string> }).state.get() === 'pending';
+		}
+		if (part.kind === 'toolInvocation') {
+			return (part as IChatToolInvocation).state.get().type === IChatToolInvocation.StateKind.WaitingForConfirmation;
+		}
+		return false;
+	}
+
+	/** Prose for the selected pending part, for `agent_state_detail`. */
+	private _describePendingPart(part: IChatProgressResponseContent, fallbackDetail: string | undefined): string {
+		if (part.kind === 'questionCarousel') {
+			const carousel = part as IChatQuestionCarousel;
+			const titles = carousel.questions.map(question => question.title).filter(Boolean);
+			if (titles.length > 0) {
+				return `questions: ${titles.join(', ')}`;
+			}
+			return this._plainText(carousel.message) || 'asking clarifying questions';
+		}
+		if (part.kind === 'planReview') {
+			return 'review the plan to continue';
+		}
+		if (part.kind === 'elicitation2') {
+			return this._plainText((part as { title?: string | IMarkdownString }).title) || 'needs input';
+		}
+		if (part.kind === 'confirmation') {
+			return (part as { title?: string }).title ?? 'needs approval';
+		}
+		if (part.kind === 'toolInvocation') {
+			const state = (part as IChatToolInvocation).state.get();
+			if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+				return '';
+			}
+			const params = state.parameters as Record<string, unknown> | undefined;
+			const command = params?.['command'] ?? params?.['input'];
+			const explanation = params?.['explanation'] ?? params?.['goal'];
+			if (typeof command !== 'string' || !command) {
+				return fallbackDetail ?? '';
+			}
+			const reason = typeof explanation === 'string' && explanation ? `\nreason: ${explanation}` : '';
+			return `command: ${command}${reason}`;
+		}
+		return '';
+	}
+
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {
 		if (!model) {
 			return { state: 'unknown' };
@@ -5558,51 +5646,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		const lastRequest = model.getRequests().at(-1);
 		const pendingConfirmation = lastRequest?.response?.isPendingConfirmation.get();
 		if (pendingConfirmation) {
-			// Scan ALL response parts to find the most recent pending item.
-			// We iterate the full list and keep overwriting `confirmDetail` so
-			// the LAST match wins — response parts are ordered chronologically,
-			// so earlier tools (already confirmed) will have left
-			// WaitingForConfirmation while the newest pending item is last.
-			let confirmDetail = '';
-			for (const part of lastRequest?.response?.response.value ?? []) {
-				if (part.kind === 'questionCarousel' && !(part as { isUsed?: boolean }).isUsed) {
-					const carousel = part as { questions?: { title?: string }[]; message?: string | { value: string } };
-					const titles = (carousel.questions ?? []).map(q => q.title).filter(Boolean);
-					if (titles.length > 0) {
-						confirmDetail = `questions: ${titles.join(', ')}`;
-					} else {
-						const msg = carousel.message;
-						confirmDetail = msg ? (typeof msg === 'string' ? msg : msg.value) : 'asking clarifying questions';
-					}
-				} else if (part.kind === 'planReview' && !(part as { isUsed?: boolean }).isUsed) {
-					confirmDetail = 'review the plan to continue';
-				} else if (part.kind === 'elicitation2') {
-					const elicitation = part as { state: IObservable<string>; title?: string | { value: string } };
-					if (elicitation.state.get() === 'pending') {
-						const title = elicitation.title;
-						confirmDetail = title ? (typeof title === 'string' ? title : title.value) : 'needs input';
-					}
-				} else if (part.kind === 'confirmation' && !(part as { isUsed?: boolean }).isUsed) {
-					const conf = part as { title?: string };
-					confirmDetail = conf.title ?? 'needs approval';
-				} else if (part.kind === 'toolInvocation') {
-					const state = part.state.get();
-					if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
-						const params = state.parameters as Record<string, unknown> | undefined;
-						const command = params?.['command'] ?? params?.['input'];
-						const explanation = params?.['explanation'] ?? params?.['goal'];
-						if (typeof command === 'string' && command) {
-							confirmDetail = `command: ${command}`;
-							if (typeof explanation === 'string' && explanation) {
-								confirmDetail += `\nreason: ${explanation}`;
-							}
-						} else {
-							confirmDetail = pendingConfirmation.detail ?? '';
-						}
-					}
-				}
-			}
-
+			// Same part `_buildPendingPayload` publishes, so the prose the model
+			// hears and the form an answer routes to can never name different
+			// forms. See `_selectPendingPart`.
+			const selected = this._selectPendingPart(model);
+			const confirmDetail = selected ? this._describePendingPart(selected.part, pendingConfirmation.detail) : '';
 			return {
 				state: 'waiting_for_confirmation',
 				detail: confirmDetail || pendingConfirmation.detail || '',
@@ -5664,64 +5712,55 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * `questions: <titles>`, losing the options, their values and the ids. This
 	 * returns what the backend needs to route an answer back to the exact part.
 	 *
-	 * Scans newest-first and returns the first still-open part, so an
-	 * already-answered earlier form can't shadow the live one. Plan review is
-	 * deliberately not typed here; it stays on the legacy string path.
+	 * The part is chosen by `_selectPendingPart`, shared with
+	 * `_getAgentStateInfo` so the routable payload and the spoken detail can
+	 * never name different forms. Only carousels and tool confirmations have a
+	 * typed shape; anything else the selector lands on publishes nothing, and the
+	 * session simply has no voice-answerable pending until it is resolved.
 	 */
 	private _buildPendingPayload(model: IChatModel | undefined | null): IVoiceSessionPending | undefined {
-		const lastRequest = model?.getRequests().at(-1);
-		const parts = lastRequest?.response?.response.value;
-		if (!lastRequest || !parts) {
+		const selected = this._selectPendingPart(model);
+		if (!selected) {
 			return undefined;
 		}
+		const { requestId, part } = selected;
+		// Minted lazily: an id is issued only once the part is confirmed to be
+		// a live pending request, so a part the backend can never answer never
+		// gets an identity that a stale id could collide with.
+		const routing = () => ({ pending_id: derivePendingId(requestId, part), request_id: requestId });
 
-		for (let index = parts.length - 1; index >= 0; index--) {
-			const part = parts[index];
-			// Minted lazily: an id is issued only once the part is confirmed to be
-			// a live pending request, so a part the backend can never answer never
-			// gets an identity that a stale id could collide with.
-			const routing = () => ({ pending_id: derivePendingId(lastRequest.id, part), request_id: lastRequest.id });
-
-			if (part.kind === 'questionCarousel') {
-				const carousel = part as IChatQuestionCarousel;
-				if (carousel.isUsed || carousel.answeredExternally || carousel.questions.length === 0) {
-					continue;
-				}
-				return {
-					type: 'questions',
-					...routing(),
-					allow_skip: carousel.allowSkip === true,
-					...(carousel.message ? { message: this._plainText(carousel.message) } : {}),
-					questions: carousel.questions.map((question): IVoicePendingQuestion => ({
-						id: question.id,
-						type: question.type,
-						// The same text the widget shows, so voice reads the question
-						// rather than its header.
-						title: this._plainText(getDisplayedQuestionText(question)),
-						allow_freeform: question.allowFreeformInput !== false,
-						// The ordinal the user hears has to be the one they see, so the
-						// list is in the same order the widget renders, and both sides
-						// number it by position.
-						options: getOptionsWithDefaultsFirst(question).map(({ option }) => ({
-							label: option.label,
-							value: option.value,
-						})),
+		if (part.kind === 'questionCarousel') {
+			const carousel = part as IChatQuestionCarousel;
+			return {
+				type: 'questions',
+				...routing(),
+				allow_skip: carousel.allowSkip === true,
+				...(carousel.message ? { message: this._plainText(carousel.message) } : {}),
+				questions: carousel.questions.map((question): IVoicePendingQuestion => ({
+					id: question.id,
+					type: question.type,
+					// The same text the widget shows, so voice reads the question
+					// rather than its header.
+					title: this._plainText(getDisplayedQuestionText(question)),
+					allow_freeform: question.allowFreeformInput !== false,
+					// The ordinal the user hears has to be the one they see, so the
+					// list is in the same order the widget renders, and both sides
+					// number it by position.
+					options: getOptionsWithDefaultsFirst(question).map(({ option }) => ({
+						label: option.label,
+						value: option.value,
 					})),
-				};
-			}
+				})),
+			};
+		}
 
-			if (part.kind === 'toolInvocation') {
-				const state = (part as IChatToolInvocation).state.get();
-				if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
-					continue;
-				}
-				const message = this._plainText((part as { invocationMessage?: string | IMarkdownString }).invocationMessage);
-				return {
-					type: 'approval',
-					...routing(),
-					...(message ? { message } : {}),
-				};
-			}
+		if (part.kind === 'toolInvocation') {
+			const message = this._plainText((part as { invocationMessage?: string | IMarkdownString }).invocationMessage);
+			return {
+				type: 'approval',
+				...routing(),
+				...(message ? { message } : {}),
+			};
 		}
 
 		return undefined;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -5335,6 +5335,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				const cachedSummary = fallbackState === 'idle' ? this._lastResponseSummaryById.get(sessionIdStr) : undefined;
 				return {
 					id: sessionIdStr,
+					...(s.label ? { label: s.label } : {}),
 					is_active: isActive,
 					agent_state: scoped.state,
 					...(cachedSummary ? { last_response_summary: cachedSummary } : {}),
@@ -5360,6 +5361,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const pending = this._buildPendingPayload(model);
 			return {
 				id: s.resource.toString(),
+				...(s.label ? { label: s.label } : {}),
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
@@ -5386,6 +5388,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const pending = this._buildPendingPayload(chatModel);
 			sessionList.push({
 				id: key,
+				...(chatModel.title ? { label: chatModel.title } : {}),
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
@@ -5394,24 +5397,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			});
 		}
 
-		// Try to get active session from chatViewPane via command
-		let activeSession: { id: string; last_message: string | null } | undefined;
-		try {
-			// This is fire-and-forget; the sync command bridge populates active_session
-			// For now, we omit active_session when called from controller
-			// (the chatViewPane's context already had this, the floating window didn't)
-		} catch {
-			// ignore
-		}
-
-		const context: IVoiceSessionContext = {
+		// `active_session` is not sent: the per-session `is_active` flag already
+		// names the focused session, and the backend keys the marker off it.
+		return {
 			sessions: sessionList,
 			display_locale: this._window?.navigator.language || 'en-US',
 		};
-		if (activeSession) {
-			context.active_session = activeSession;
-		}
-		return context;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -5541,23 +5541,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return stateInfo.state;
 	}
 
-	/**
-	 * The single pending part voice is currently on for a session.
-	 *
-	 * Scans OLDEST-first and returns the first still-open actionable part of the
-	 * last request, matching how the chat model itself decides what a response is
-	 * waiting on (`_pendingInfo` in `chatModel.ts`).
-	 *
-	 * Two callers share this: `_buildPendingPayload`, which decides what a spoken
-	 * answer routes to, and `_getAgentStateInfo`, which produces the prose the
-	 * model hears. They used to pick independently, so a second form arriving
-	 * flipped the prose to the new form while the payload stayed on the old one -
-	 * which reads the old form aloud again as a detail transition.
-	 *
-	 * Oldest-first also gives voice a queue with no stored state: resolved parts
-	 * are skipped, so the oldest still-open part is by construction the one
-	 * already published. A form arriving never takes the turn from the form the
-	 * user is part-way through answering.
+/**
+	 * Returns the oldest open pending part from the last request so narration and answer routing use the same item.
 	 */
 	private _selectPendingPart(model: IChatModel | undefined | null): { requestId: string; part: IChatProgressResponseContent } | undefined {
 		const lastRequest = model?.getRequests().at(-1);

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -5541,8 +5541,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return stateInfo.state;
 	}
 
-/**
-	 * Returns the oldest open pending part from the last request so narration and answer routing use the same item.
+	/**
+	 * Returns the oldest still-open pending part of the last request.
+	 *
+	 * Answer routing and narration prose MUST both come from here, or they can
+	 * name different forms and a spoken answer lands on the wrong one.
 	 */
 	private _selectPendingPart(model: IChatModel | undefined | null): { requestId: string; part: IChatProgressResponseContent } | undefined {
 		const lastRequest = model?.getRequests().at(-1);

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -97,16 +97,14 @@ export function peekPendingId(requestId: string, part: object): string | undefin
 export interface IVoiceSessionContext {
 	sessions: {
 		id: string;
+		/** Human-readable name, so the backend can tell two sessions apart. */
+		label?: string;
 		is_active: boolean;
 		agent_state: string;
 		agent_state_detail?: string;
 		last_response_summary?: string;
 		pending?: IVoiceSessionPending;
 	}[];
-	active_session?: {
-		id: string;
-		last_message: string | null;
-	};
 	display_locale: string;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -25,7 +25,7 @@ import { IAuthenticationService } from '../../../../../services/authentication/c
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { IVoiceTranscriptStore, IVoiceTranscriptTurn } from '../../../../agentsVoice/common/voiceTranscriptStore.js';
-import { IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
+import { AgentSessionStatus, IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
 import { IChatWidgetService } from '../../../browser/chat.js';
 import { IMicCaptureService } from '../../../browser/voiceClient/micCaptureService.js';
@@ -208,22 +208,40 @@ class TestMicCaptureService extends mock<IMicCaptureService>() {
 
 class TestAgentSessionsService extends mock<IAgentSessionsService>() {
 	override readonly onDidChangeSessionArchivedState = Event.None;
-	override readonly model: IAgentSessionsModel = {
-		onWillResolve: Event.None,
-		onDidResolve: Event.None,
-		sessions: [],
-		onDidChangeSessions: Event.None,
-		onDidChangeSessionArchivedState: Event.None,
-		resolved: true,
-		getSession: () => undefined,
-		observeSession: () => observableValue('session', undefined),
-		resolve: async () => { },
+	override readonly model: IAgentSessionsModel;
+
+	constructor(sessions: readonly unknown[] = []) {
+		super();
+		this.model = {
+			onWillResolve: Event.None,
+			onDidResolve: Event.None,
+			sessions: sessions as IAgentSessionsModel['sessions'],
+			onDidChangeSessions: Event.None,
+			onDidChangeSessionArchivedState: Event.None,
+			resolved: true,
+			getSession: () => undefined,
+			observeSession: () => observableValue('session', undefined),
+			resolve: async () => { },
+		};
+	}
+}
+
+/** An agent session entry as `_buildSessionContext` reads it. */
+function agentSessionEntry(id: string, label: string | undefined, status: AgentSessionStatus) {
+	return {
+		resource: URI.parse(id),
+		label,
+		status,
+		isArchived: () => false,
+		timing: { created: Date.now(), lastRequestEnded: Date.now() },
 	};
 }
 
 class TestChatService extends mock<IChatService>() {
 	override readonly chatModels = observableValue('chatModels', []);
 	override getSession(): undefined { return undefined; }
+	/** A session that never loads: the controller eagerly loads models for waiting sessions. */
+	override async acquireOrLoadSession(): Promise<undefined> { return undefined; }
 }
 
 /**
@@ -348,6 +366,7 @@ suite('VoiceSessionController', () => {
 		promptsService: IPromptsService = new class extends mock<IPromptsService>() {
 			override async getVoiceInstructions(): Promise<undefined> { return undefined; }
 		}(),
+		agentSessionsService: IAgentSessionsService = new TestAgentSessionsService(),
 	): IVoiceSessionController {
 		store.add({ dispose: () => voiceClientService.dispose() });
 		store.add(ttsPlaybackService);
@@ -363,7 +382,7 @@ suite('VoiceSessionController', () => {
 				override notifyPlaybackStart(): void { }
 				override notifyPlaybackEnd(): void { }
 			}(),
-			new TestAgentSessionsService(),
+			agentSessionsService,
 			chatService,
 			commandService,
 			new class extends mock<IAuthenticationService>() {
@@ -614,6 +633,63 @@ suite('VoiceSessionController', () => {
 		assert.strictEqual(info.state, 'waiting_for_confirmation');
 		assert.strictEqual(info.detail, 'questions: Which region?');
 		assert.deepStrictEqual(buildPendingPayload.call(controller, model)?.questions?.map(question => question.title), ['Which region?']);
+	});
+
+	test('sends each agent session label so two waiting sessions can be told apart', () => {
+		// The label is the only human-readable handle the backend has. Without it
+		// every session is "Untitled" and naming one out loud cannot disambiguate
+		// which of two open forms an answer is for.
+		const controller = createController(
+			new TestVoiceClientService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+			new TestAgentSessionsService([
+				agentSessionEntry('vscode-chat://a', 'Auth fix', AgentSessionStatus.NeedsInput),
+				agentSessionEntry('vscode-chat://b', 'Billing refactor', AgentSessionStatus.InProgress),
+			]),
+		);
+		const buildSessionContext = Reflect.get(controller, '_buildSessionContext') as () => { sessions: { id: string; label?: string }[] };
+
+		const labels = buildSessionContext.call(controller).sessions.map(session => session.label);
+
+		assert.deepStrictEqual(labels, ['Auth fix', 'Billing refactor']);
+	});
+
+	test('omits the label for an unlabelled agent session rather than sending an empty one', () => {
+		// An empty string would render as a nameless label the model might try to
+		// quote back at the user; absent lets the backend fall back to "Untitled".
+		const controller = createController(
+			new TestVoiceClientService(), undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+			new TestAgentSessionsService([agentSessionEntry('vscode-chat://a', undefined, AgentSessionStatus.NeedsInput)]),
+		);
+		const buildSessionContext = Reflect.get(controller, '_buildSessionContext') as () => { sessions: { id: string; label?: string }[] };
+
+		const [session] = buildSessionContext.call(controller).sessions;
+
+		assert.strictEqual(session.id, 'vscode-chat://a');
+		assert.ok(!Object.hasOwn(session, 'label'));
+	});
+
+	test('sends the agent session label once its model is resident too', () => {
+		// The label is emitted from two branches - model resident or not - and a
+		// session flips between them as VS Code loads and disposes models. Only
+		// covering the unloaded branch would let the loaded one lose the label
+		// silently, which is exactly when a form is on screen to disambiguate.
+		const chatService = new ControllableChatService();
+		const resource = URI.parse('vscode-chat://a');
+		chatService.setModels([pendingConfirmationModel(resource)]);
+		const controller = createController(
+			new TestVoiceClientService(), undefined, undefined, undefined, undefined, undefined, chatService, undefined,
+			new TestAgentSessionsService([agentSessionEntry(resource.toString(), 'Auth fix', AgentSessionStatus.NeedsInput)]),
+		);
+		const buildSessionContext = Reflect.get(controller, '_buildSessionContext') as () => { sessions: { id: string; label?: string; agent_state: string }[] };
+		// Make it the active session: a background confirmation is deliberately
+		// downgraded to `thinking`, which would hide whether the resident branch
+		// ran at all.
+		controller.setTargetSession(resource);
+
+		const [session] = buildSessionContext.call(controller).sessions;
+
+		assert.strictEqual(session.agent_state, 'waiting_for_confirmation');
+		assert.strictEqual(session.label, 'Auth fix');
 	});
 
 	test('an older tool confirmation holds the turn ahead of a newer form', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -32,7 +32,7 @@ import { IMicCaptureService } from '../../../browser/voiceClient/micCaptureServi
 import { ITtsPlaybackService } from '../../../browser/voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController, VoiceSessionController } from '../../../browser/voiceClient/voiceSessionController.js';
 import { IVoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
-import { IChatService } from '../../../common/chatService/chatService.js';
+import { IChatService, IChatToolInvocation } from '../../../common/chatService/chatService.js';
 import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
 import { derivePendingId, IVoiceAudioResponse, IVoiceBargeIn, IVoiceClientService, IVoiceNarrationSignal, IVoiceSpeechStarted, IVoiceToolCall, IVoiceTranscription, VoiceNarrationKind, IVoiceDispatchResult } from '../../../common/voiceClient/voiceClientService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
@@ -244,8 +244,18 @@ class ControllableChatService extends mock<IChatService>() {
 }
 
 /** Minimal chat model whose last request carries one unanswered question form. */
-function questionCarouselModel(part: object, requestId = 'req-1'): IChatModel {
-	const lastRequest = { id: requestId, response: { response: { value: [part] } } };
+function pendingPartsModel(parts: object | object[], requestId = 'req-1', pendingDetail?: string): IChatModel {
+	const value = Array.isArray(parts) ? parts : [parts];
+	const lastRequest = {
+		id: requestId,
+		response: {
+			response: { value },
+			isPendingConfirmation: observableValue<{ detail?: string } | undefined>(
+				'pending',
+				pendingDetail === undefined ? undefined : { detail: pendingDetail },
+			),
+		},
+	};
 	return {
 		getRequests: () => [lastRequest],
 	} as unknown as IChatModel;
@@ -500,7 +510,7 @@ suite('VoiceSessionController', () => {
 			}],
 		};
 
-		const payload = buildPendingPayload.call(controller, questionCarouselModel(part));
+		const payload = buildPendingPayload.call(controller, pendingPartsModel(part));
 
 		assert.deepStrictEqual(payload, {
 			type: 'questions',
@@ -527,9 +537,133 @@ suite('VoiceSessionController', () => {
 		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => unknown;
 		const questions = [{ id: 'region', type: 'singleSelect', title: 'Which region?', options: [{ id: 'west', label: 'West US', value: 'westus' }] }];
 
-		assert.strictEqual(buildPendingPayload.call(controller, questionCarouselModel({ kind: 'questionCarousel', isUsed: true, questions })), undefined);
-		assert.strictEqual(buildPendingPayload.call(controller, questionCarouselModel({ kind: 'questionCarousel', answeredExternally: true, questions })), undefined);
-		assert.strictEqual(buildPendingPayload.call(controller, questionCarouselModel({ kind: 'questionCarousel', questions: [] })), undefined);
+		assert.strictEqual(buildPendingPayload.call(controller, pendingPartsModel({ kind: 'questionCarousel', isUsed: true, questions })), undefined);
+		assert.strictEqual(buildPendingPayload.call(controller, pendingPartsModel({ kind: 'questionCarousel', answeredExternally: true, questions })), undefined);
+		assert.strictEqual(buildPendingPayload.call(controller, pendingPartsModel({ kind: 'questionCarousel', questions: [] })), undefined);
+	});
+
+	test('selects the oldest still-open pending part, not the newest', () => {
+		// Voice is a serial channel: a second form arriving must not take the turn
+		// from the one the user was just read out and is part-way through
+		// answering. Oldest-first is also what the chat model itself does when it
+		// decides what a response is waiting on.
+		const controller = createController(new TestVoiceClientService());
+		const selectPendingPart = Reflect.get(controller, '_selectPendingPart') as (model: IChatModel) => { requestId: string; part: { kind: string } } | undefined;
+		const older = { kind: 'questionCarousel', questions: [{ id: 'a', type: 'singleSelect', title: 'A?', options: [] }] };
+		const newer = { kind: 'questionCarousel', questions: [{ id: 'b', type: 'singleSelect', title: 'B?', options: [] }] };
+
+		const selected = selectPendingPart.call(controller, pendingPartsModel([older, newer]));
+
+		assert.strictEqual(selected?.part, older);
+		assert.strictEqual(selected?.requestId, 'req-1');
+	});
+
+	test('moves on once the oldest pending part is resolved', () => {
+		const controller = createController(new TestVoiceClientService());
+		const selectPendingPart = Reflect.get(controller, '_selectPendingPart') as (model: IChatModel) => { part: { kind: string } } | undefined;
+		const answered = { kind: 'questionCarousel', isUsed: true, questions: [{ id: 'a', type: 'singleSelect', title: 'A?', options: [] }] };
+		const newer = { kind: 'questionCarousel', questions: [{ id: 'b', type: 'singleSelect', title: 'B?', options: [] }] };
+
+		assert.strictEqual(selectPendingPart.call(controller, pendingPartsModel([answered, newer]))?.part, newer);
+		assert.strictEqual(selectPendingPart.call(controller, pendingPartsModel([answered]))?.part, undefined);
+	});
+
+	test('an executing tool does not shadow the form it opened', () => {
+		// askQuestions appends its carousel from inside invoke(), so its own tool
+		// part is always earlier in the list. It declares no confirmationMessages
+		// and therefore sits in Executing, not WaitingForConfirmation - if that
+		// ever changed, oldest-first would publish an approval for a question form
+		// and the form would never reach voice.
+		const controller = createController(new TestVoiceClientService());
+		const selectPendingPart = Reflect.get(controller, '_selectPendingPart') as (model: IChatModel) => { part: { kind: string } } | undefined;
+		const executingTool = {
+			kind: 'toolInvocation',
+			state: observableValue('state', { type: IChatToolInvocation.StateKind.Executing }),
+		};
+		const carousel = { kind: 'questionCarousel', questions: [{ id: 'a', type: 'singleSelect', title: 'A?', options: [] }] };
+
+		assert.strictEqual(selectPendingPart.call(controller, pendingPartsModel([executingTool, carousel]))?.part, carousel);
+	});
+
+	test('keeps publishing the older form when a second one arrives', () => {
+		// Without this the payload flips to the newest form with no narration, so
+		// an answer meant for the first form is applied to the second.
+		const controller = createController(new TestVoiceClientService());
+		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => { pending_id?: string; questions?: { id: string }[] } | undefined;
+		const older = { kind: 'questionCarousel', questions: [{ id: 'region', type: 'singleSelect', title: 'Which region?', options: [{ id: 'w', label: 'West US', value: 'westus' }] }] };
+		const newer = { kind: 'questionCarousel', questions: [{ id: 'tier', type: 'singleSelect', title: 'Which tier?', options: [{ id: 'p', label: 'Premium', value: 'premium' }] }] };
+
+		const payload = buildPendingPayload.call(controller, pendingPartsModel([older, newer]));
+
+		assert.deepStrictEqual(payload?.questions?.map(question => question.id), ['region']);
+		assert.strictEqual(payload?.pending_id, derivePendingId('req-1', older));
+	});
+
+	test('payload and spoken detail name the same form when two are open', () => {
+		// If these two disagree, the newer form flips the detail, that counts as a
+		// transition, and the narration path then reads the OLDER form aloud again.
+		const controller = createController(new TestVoiceClientService());
+		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => { questions?: { title: string }[] } | undefined;
+		const getAgentStateInfo = Reflect.get(controller, '_getAgentStateInfo') as (model: IChatModel) => { state: string; detail?: string };
+		const older = { kind: 'questionCarousel', questions: [{ id: 'region', type: 'singleSelect', title: 'Which region?', options: [] }] };
+		const newer = { kind: 'questionCarousel', questions: [{ id: 'tier', type: 'singleSelect', title: 'Which tier?', options: [] }] };
+		const model = pendingPartsModel([older, newer], 'req-1', 'Answer questions to continue...');
+
+		const info = getAgentStateInfo.call(controller, model);
+
+		assert.strictEqual(info.state, 'waiting_for_confirmation');
+		assert.strictEqual(info.detail, 'questions: Which region?');
+		assert.deepStrictEqual(buildPendingPayload.call(controller, model)?.questions?.map(question => question.title), ['Which region?']);
+	});
+
+	test('an older tool confirmation holds the turn ahead of a newer form', () => {
+		// Queue semantics applied uniformly: approve the command you were asked
+		// about, then answer the questions.
+		const controller = createController(new TestVoiceClientService());
+		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => { type?: string } | undefined;
+		const getAgentStateInfo = Reflect.get(controller, '_getAgentStateInfo') as (model: IChatModel) => { detail?: string };
+		const approval = {
+			kind: 'toolInvocation',
+			invocationMessage: 'Run a command',
+			state: observableValue('state', {
+				type: IChatToolInvocation.StateKind.WaitingForConfirmation,
+				parameters: { command: 'docker push myapp:latest' },
+			}),
+		};
+		const form = { kind: 'questionCarousel', questions: [{ id: 'tier', type: 'singleSelect', title: 'Which tier?', options: [] }] };
+		const model = pendingPartsModel([approval, form], 'req-1', 'Run command?');
+
+		assert.strictEqual(buildPendingPayload.call(controller, model)?.type, 'approval');
+		assert.strictEqual(getAgentStateInfo.call(controller, model).detail, 'command: docker push myapp:latest');
+	});
+
+	test('an older confirmation suppresses a newer form payload but still speaks', () => {
+		// `confirmation` has no typed wire shape, so the queue costs the newer form
+		// its structured payload until the confirmation is resolved. Deliberate.
+		const controller = createController(new TestVoiceClientService());
+		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => unknown;
+		const getAgentStateInfo = Reflect.get(controller, '_getAgentStateInfo') as (model: IChatModel) => { detail?: string };
+		const confirmation = { kind: 'confirmation', title: 'Delete the branch?' };
+		const form = { kind: 'questionCarousel', questions: [{ id: 'tier', type: 'singleSelect', title: 'Which tier?', options: [] }] };
+		const model = pendingPartsModel([confirmation, form], 'req-1', 'Delete the branch?');
+
+		assert.strictEqual(buildPendingPayload.call(controller, model), undefined);
+		assert.strictEqual(getAgentStateInfo.call(controller, model).detail, 'Delete the branch?');
+	});
+
+	test('a newer form answered by mouse leaves the focused form untouched', () => {
+		// Resolving B out of order must not move the turn, and must not change the
+		// detail either - a detail change alone counts as a transition and would
+		// read A aloud a second time.
+		const controller = createController(new TestVoiceClientService());
+		const buildPendingPayload = Reflect.get(controller, '_buildPendingPayload') as (model: IChatModel) => { questions?: { id: string }[] } | undefined;
+		const getAgentStateInfo = Reflect.get(controller, '_getAgentStateInfo') as (model: IChatModel) => { detail?: string };
+		const older = { kind: 'questionCarousel', questions: [{ id: 'region', type: 'singleSelect', title: 'Which region?', options: [] }] };
+		const newerAnswered = { kind: 'questionCarousel', isUsed: true, questions: [{ id: 'tier', type: 'singleSelect', title: 'Which tier?', options: [] }] };
+		const model = pendingPartsModel([older, newerAnswered], 'req-1', 'Answer questions to continue...');
+
+		assert.deepStrictEqual(buildPendingPayload.call(controller, model)?.questions?.map(question => question.id), ['region']);
+		assert.strictEqual(getAgentStateInfo.call(controller, model).detail, 'questions: Which region?');
 	});
 
 	test('fatal disconnect clears routing target and pending confirmations and the tracker cannot repopulate them before reconnect', () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8624

Follow-on to #327899, which made a spoken answer land on the right question form. That fix assumed one form at a time; with two pending in the same session it picks the wrong one.

## The bug

Two functions independently decide which pending part voice is working on, and both took the **last** match: `_getAgentStateInfo` (the spoken `agent_state_detail`) and `_buildPendingPayload` (the structured `pending` an answer is resolved against). A second form arriving silently stole focus, so the user mid-answer on form A had their next utterance resolved against form B.

Fixing only the payload would be worse than the bug: `_getAgentStateInfo` would still hold the newest, its changed detail alone satisfies `isDetailTransition`, and the narration it triggers reads the payload and gets A. Questions aren't text-deduped, so form A would be re-read aloud every time B arrived. Both callers have to agree.

## The fix

One `_selectPendingPart`, used by both, scanning **oldest-first** and returning the first still-open part. A form holds focus until it resolves; a second form waits its turn. This also matches the platform — `chatModel._pendingInfo` scans forward and its value already feeds the fallback `_getAgentStateInfo` uses. Newest-first was the deviation.

Split so the two callers can't drift again: `_selectPendingPart` (which part), `_isOpenPendingPart` (still open, per kind), `_describePendingPart` (the prose, lifted verbatim).

## Also here

Send each session's `label`. The backend renders `[SESSIONS]` for its routing model and refuses to guess between waiting sessions — but every entry we sent was anonymous, so two concurrent forms arrived as two identical lines.

Drop `active_session`. The only place that would assign it is an empty `try {} catch {}`, so it has always been undefined and the delta never carried the field — removal is provably behaviour-preserving. The per-entry `is_active` flag names the focused session.

## Verification

`VoiceSessionController` + `VoiceClientService`: **73 passing**, 11 new — oldest-first selection, moving on once a form resolves, an executing tool not shadowing the form it opened, an older form surviving a newer arrival, payload and spoken detail agreeing, a newer form answered by mouse leaving focus untouched, and the session labels. Compile is clean in `contrib/chat` (the 90 total errors are pre-existing on `main`, in `platform/agentHost`, `localTranscription` and `native`).

Draft until the companion backend change lands and the two-form case has been driven end to end by voice.
