### PR TITLE
markdown: fix: route undo and redo to the document history

### DIFF
--- a/extensions/markdown-language-features/markdown-editor-src/editor.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/editor.ts
@@ -65,8 +65,12 @@ class Editor extends Disposable {
 					break;
 				}
 				case 'update': {
+					// `replaceSourceText` (not `sourceText.set`) applies authoritative host
+					// text: it maps the selection through the change and clears stale
+					// pending-paragraph state, so the caret stays valid after an undo shrinks
+					// the document. The guard stops this echoing back as a user edit.
 					this.isUpdatingFromExtension = true;
-					this.model.sourceText.set(new StringValue(message.content), undefined);
+					this.model.replaceSourceText(new StringValue(message.content));
 					this.isUpdatingFromExtension = false;
 					break;
 				}
@@ -157,7 +161,16 @@ class Editor extends Disposable {
 			},
 		}));
 
-		this._register(new EditorController(model, view));
+		// Wire history chords (undo/redo) to the extension so they run against the
+		// backing TextDocument's own undo stack. `record` is deliberately omitted:
+		// the TextDocument owns the history, and a second local stack would drift
+		// from the Edit menu, dirty state and hot exit.
+		this._register(new EditorController(model, view, {
+			historyStrategy: {
+				undo: () => this.#vscode.postMessage({ type: 'history', command: 'undo' }),
+				redo: () => this.#vscode.postMessage({ type: 'history', command: 'redo' }),
+			},
+		}));
 		host.appendChild(view.element);
 
 		// Render comments as the VS Code V2 markdown cards. The card colours come

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",
-        "@vscode/markdown-editor": "^0.0.2-37",
+        "@vscode/markdown-editor": "^0.0.2-40",
         "dompurify": "^3.4.10",
         "highlight.js": "^11.8.0",
         "katex": "^0.16.33",
@@ -632,9 +632,9 @@
       "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
     },
     "node_modules/@vscode/markdown-editor": {
-      "version": "0.0.2-37",
-      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-37.tgz",
-      "integrity": "sha512-Glln7RyQ7dIl2v3OwiAGAcD+v3SdWjHRKdPr7XniVgVNOclnZeVsF29B67h4uDYSc2qEaqmAaGKXMG+0d+BQNA==",
+      "version": "0.0.2-40",
+      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-40.tgz",
+      "integrity": "sha512-NPUmKKHDvauUM61SQpruezqVSi5Ly/+zmGZG89MFk0LZDYTklhGEiPhxQHvH6e3m+qaVbY268OkbajGEYRq7OQ==",
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -909,7 +909,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "@vscode/markdown-editor": "^0.0.2-37",
+    "@vscode/markdown-editor": "^0.0.2-40",
     "dompurify": "^3.4.10",
     "highlight.js": "^11.8.0",
     "katex": "^0.16.33",

--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -93,6 +93,20 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 					await this.#globalState.update(MarkdownEditorProvider.#readonlyStateKey, !!message.readonly);
 					break;
 				}
+				case 'history': {
+					// The TextDocument owns undo/redo, so route the chord to the built-in
+					// command; the active custom editor input scopes it to this resource's
+					// history, shared with the Edit menu and Command Palette. Drain any
+					// in-flight edit first and only act while this panel is active, so the
+					// chord cannot race a pending edit or land on a different document.
+					if (message.command === 'undo' || message.command === 'redo') {
+						await editQueue;
+						if (webviewPanel.active) {
+							await vscode.commands.executeCommand(message.command);
+						}
+					}
+					break;
+				}
 				case 'openLink': {
 					await this.#linkOpener.openDocumentLink(message.href as string, document.uri);
 					break;


### PR DESCRIPTION
Wires undo/redo into the core Markdown editor (viewType `vscode.markdown.editor`) so `Cmd+Z` / `Cmd+Shift+Z` work in the Agents window. Closes #327535.

### Problem

The experimental hybrid Markdown editor is a `CustomTextEditorProvider` whose webview embeds `@vscode/markdown-editor` and attaches an `EditContext`. Because of the `EditContext`, the browser keeps no native undo history and the history chords never reach VS Code's command routing, so `Cmd+Z` does nothing today. The `TextDocument` behind the custom editor already has a full undo stack — it just isn't wired up.

### Change

- **`markdown-editor-src/editor.ts`** — pass a `historyStrategy` to `EditorController` that posts `{ type: 'history', command: 'undo' | 'redo' }` to the extension. `record` is intentionally **not** implemented: the `TextDocument` is the single source of truth, and a second local stack would drift from the Edit menu, dirty state and hot exit.
- **`markdownEditorProvider.ts`** — handle the `history` message by executing the built-in `undo`/`redo` command (guarded to just those two). It first `await`s the existing `editQueue` so any in-flight edit lands before history runs, and only acts while `webviewPanel.active`, so a message delivered after an editor switch can't undo a different document. `CustomEditorService` registers priority-105 `UndoCommand`/`RedoCommand` implementations that route to the active custom editor input's resource-scoped `IUndoRedoService`, ahead of the generic webview implementation (priority 100), so the chord hits this document's history. (Verified against `src/vs/workbench/contrib/customEditor/browser/customEditors.ts` and `customEditorInput.ts`.)
- **`markdown-editor-src/editor.ts`** (`update` handler) — apply the authoritative host text with `model.replaceSourceText(...)` instead of `sourceText.set(...)`, so the selection is mapped through the changed span (the caret could otherwise land out of range after an undo shrinks the document) and stale pending-paragraph state is cleared atomically. The existing `isUpdatingFromExtension` guard still prevents the update from echoing back as an edit.
- **`package.json` / `package-lock.json`** — bump `@vscode/markdown-editor` to **`0.0.2-40`**, the published release that ships the `IHistoryStrategy` / `EditorControllerOptions.historyStrategy` and `EditorModel.replaceSourceText` APIs used above.

Result: keyboard, the Edit menu and the Command Palette all share one history — the `TextDocument`'s.

### Dependency

The consumed `@vscode/markdown-editor` APIs were added by **microsoft/vscode-packages#189** and are published as `0.0.2-40`, which this PR pins (rebased on top of `main`, which had bumped to `0.0.2-37`). The dependency set is unchanged and the lockfile integrity matches the published tarball.

### Testing

- Typechecked `markdown-editor-src` and the extension-host `src` against the installed `0.0.2-40` declarations — both clean.
- No unit tests exist for this provider. Manual smoke test: open a `.md` in the Agents window, ensure Editing mode, put the caret after `abc`, type `d`, press `Cmd+Z` (→ `abc`), `Cmd+Shift+Z` (→ `abcd`); confirm **Edit > Undo** does the same and the caret lands sensibly.
