### PR TITLE
agentHost: discover Claude customizations across workspace roots

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -96,6 +96,16 @@ function resolveCurrentPermissionMode(
 	return readClaudePermissionMode(configurationService, sessionUri) ?? permissionModeFallback;
 }
 
+function sameWorkingDirectories(a: readonly URI[] | undefined, b: readonly URI[] | undefined): boolean {
+	if (!a || !b) {
+		return a === b;
+	}
+	if (a.length !== b.length) {
+		return false;
+	}
+	return a.every((directory, index) => isEqual(directory, b[index]));
+}
+
 /**
  * Per-session coordinator. Owns:
  *   • Per-session identity (sessionId / sessionUri / workspace /
@@ -470,6 +480,7 @@ export class ClaudeAgentSession extends Disposable {
 		// roots) takes precedence and also refreshes the additional-directory
 		// tail; the singular `workingDirectory` stays supported for single-root
 		// callers that only resolve the primary.
+		const previousWorkingDirectories = this.workingDirectories;
 		const resolvedPrimary = ctx.workingDirectories?.[0] ?? ctx.workingDirectory;
 		if (resolvedPrimary && !isEqual(resolvedPrimary, this.workingDirectory)) {
 			this._workingDirectory = resolvedPrimary;
@@ -477,7 +488,10 @@ export class ClaudeAgentSession extends Disposable {
 		if (ctx.workingDirectories && ctx.workingDirectories.length > 0) {
 			this._additionalDirectories = ctx.workingDirectories.slice(1);
 		}
-		this._watchCustomizations(this.workingDirectories);
+		const currentWorkingDirectories = this.workingDirectories;
+		if (!sameWorkingDirectories(previousWorkingDirectories, currentWorkingDirectories)) {
+			this._watchCustomizations(currentWorkingDirectories);
+		}
 		if (!this.workingDirectory) {
 			throw new Error(`Cannot materialize Claude session ${this.sessionId}: workingDirectory is required`);
 		}

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -7,7 +7,7 @@ import type { McpSdkServerConfigWithInstance, OnElicitation, Options, Permission
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -36,12 +36,11 @@ import { SessionClientToolsDiff } from './clientTools/claudeSessionClientToolsMo
 import { SessionClientCustomizationsDiff } from './customizations/claudeSessionClientCustomizationsModel.js';
 import { ClaudeCustomizationWatcher, buildDiscoveredCustomizations, resolveClaudeAgentName } from './customizations/claudeSessionCustomizationDiscovery.js';
 import { applyMcpServerEnablement, findMcpChildId, findMcpServerName, getEffectiveMcpServerCustomizations } from '../shared/mcpCustomizationController.js';
-import { scanClaudeDiskCustomizations } from './customizations/scan/claudeAgentSkillScan.js';
 import { scanClaudeHooks } from './customizations/scan/claudeHookScan.js';
 import { scanClaudeMcpServers } from './customizations/scan/claudeMcpScan.js';
-import { scanClaudeNativePlugins } from './customizations/scan/claudeNativePluginScan.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
 import { scanClaudeRules } from './customizations/scan/claudeRuleScan.js';
+import { discoverClaudeMultiRootCustomizations } from './customizations/claudeMultiRootCustomizationDiscovery.js';
 import { resolvePromptToContentBlocks } from './claudePromptResolver.js';
 import type { ClaudeTransport } from './claudeProxyService.js';
 import { ClaudeSdkPipeline, IRematerializer, type ISdkResolvedCustomizations } from './claudeSdkPipeline.js';
@@ -177,7 +176,7 @@ export class ClaudeAgentSession extends Disposable {
 		const primary = this.workingDirectory;
 		return primary ? [primary, ...this._additionalDirectories] : undefined;
 	}
-	private readonly _customizationWatcher = this._register(new DisposableStore());
+	private readonly _customizationWatcher = this._register(new MutableDisposable<DisposableStore>());
 
 	/** Exposed for the materializer's MCP-server build closure. */
 	get pendingClientToolCalls(): PendingRequestRegistry<CallToolResult> { return this._pendingClientToolCalls; }
@@ -385,18 +384,19 @@ export class ClaudeAgentSession extends Disposable {
 		this.toolDiff = this._register(toolDiff);
 		this._register(this.clientCustomizationsDiff.onDidChange(() => this._onDidCustomizationsChange.fire()));
 
-		this._watchCustomizations(this.workspace);
+		this._watchCustomizations(this.workingDirectories);
 	}
 
-	private _watchCustomizations(directory: URI | undefined): void {
-		this._customizationWatcher.clear();
-		const watcher = this._customizationWatcher.add(new ClaudeCustomizationWatcher(
-			directory,
+	private _watchCustomizations(directories: readonly URI[] | undefined): void {
+		const store = new DisposableStore();
+		const watcher = store.add(new ClaudeCustomizationWatcher(
+			directories,
 			this._environmentService.userHome,
 			this._fileService,
 			this._logService,
 		));
-		this._customizationWatcher.add(watcher.onDidChange(() => this._onDidCustomizationsChange.fire()));
+		store.add(watcher.onDidChange(() => this._onDidCustomizationsChange.fire()));
+		this._customizationWatcher.value = store;
 	}
 
 	/**
@@ -473,11 +473,11 @@ export class ClaudeAgentSession extends Disposable {
 		const resolvedPrimary = ctx.workingDirectories?.[0] ?? ctx.workingDirectory;
 		if (resolvedPrimary && !isEqual(resolvedPrimary, this.workingDirectory)) {
 			this._workingDirectory = resolvedPrimary;
-			this._watchCustomizations(resolvedPrimary);
 		}
 		if (ctx.workingDirectories && ctx.workingDirectories.length > 0) {
 			this._additionalDirectories = ctx.workingDirectories.slice(1);
 		}
+		this._watchCustomizations(this.workingDirectories);
 		if (!this.workingDirectory) {
 			throw new Error(`Cannot materialize Claude session ${this.sessionId}: workingDirectory is required`);
 		}
@@ -1057,12 +1057,11 @@ export class ClaudeAgentSession extends Disposable {
 	async getSessionCustomizations(): Promise<readonly Customization[]> {
 		const { synced } = this.clientCustomizationsDiff.model.state.get();
 		const userHome = this._environmentService.userHome;
-		const [discovered, rules, mcpServers, hooks, nativePlugins] = await Promise.all([
-			scanClaudeDiskCustomizations(this.workingDirectory, userHome, this._fileService),
+		const [multiRoot, rules, mcpServers, hooks] = await Promise.all([
+			discoverClaudeMultiRootCustomizations(this.workingDirectories, userHome, this._fileService, this._logService),
 			scanClaudeRules(this.workingDirectory, userHome, this._fileService),
 			scanClaudeMcpServers(this.workingDirectory, userHome, this._fileService),
 			scanClaudeHooks(this.workingDirectory, userHome, this._fileService),
-			scanClaudeNativePlugins(this.workingDirectory, userHome, this._fileService, this._logService),
 		]);
 
 		// Post-materialize, the live SDK snapshot filters the disk set down to
@@ -1082,7 +1081,7 @@ export class ClaudeAgentSession extends Disposable {
 		// `buildDiscoveredCustomizations` also folds in the read-only "Built-in"
 		// surfacing (curated pre-materialize, SDK-derived post-materialize) for
 		// both agents and skills, so the SDK-vs-curated decision lives in one place.
-		const discoveredCustomizations = buildDiscoveredCustomizations([...discovered, ...rules], mcpServers, hooks, nativePlugins, this.workingDirectory, userHome, sdk);
+		const discoveredCustomizations = buildDiscoveredCustomizations([...multiRoot.discovered, ...rules], mcpServers, hooks, multiRoot.nativePlugins, multiRoot.workingDirectories, userHome, sdk);
 
 		// Final projection: the client-pushed tier first, then the discovered
 		// tier, with session MCP enablement applied to both.

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeCustomizationPolicy.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeCustomizationPolicy.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isEqualOrParent } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+
+export function selectFirstClaudeCustomizationByKey<T>(groups: readonly (readonly T[])[], keyOf: (item: T) => string): readonly T[] {
+	const selected = new Map<string, T>();
+	for (const group of groups) {
+		for (const item of group) {
+			const key = keyOf(item);
+			if (!selected.has(key)) {
+				selected.set(key, item);
+			}
+		}
+	}
+	return [...selected.values()];
+}
+
+export function selectEnabledClaudePluginIds(groups: readonly ReadonlyMap<string, boolean>[]): readonly string[] {
+	const selected = new Map<string, boolean>();
+	for (const group of groups) {
+		for (const [id, enabled] of group) {
+			if (!selected.has(id)) {
+				selected.set(id, enabled);
+			}
+		}
+	}
+	return [...selected].filter(([, enabled]) => enabled).map(([id]) => id);
+}
+
+export function findMostSpecificClaudeWorkspaceRoot(resource: URI, workingDirectories: readonly URI[]): URI | undefined {
+	let result: URI | undefined;
+	for (const directory of workingDirectories) {
+		if (resource.scheme === directory.scheme && isEqualOrParent(resource, directory) && (!result || directory.path.length > result.path.length)) {
+			result = directory;
+		}
+	}
+	return result;
+}

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceSet } from '../../../../../base/common/map.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IFileService } from '../../../../files/common/files.js';
+import { ILogService } from '../../../../log/common/log.js';
+import { CustomizationType } from '../../../common/state/protocol/channels-session/state.js';
+import type { IParsedAgent, IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
+import { scanClaudeCustomizationScope } from './scan/claudeAgentSkillScan.js';
+import { scanClaudeNativePluginsForRoots, type IResolvedNativePlugin } from './scan/claudeNativePluginScan.js';
+import { selectFirstClaudeCustomizationByKey } from './claudeCustomizationPolicy.js';
+
+export interface IClaudeMultiRootCustomizations {
+	readonly workingDirectories: readonly URI[];
+	readonly discovered: readonly (IParsedAgent | IParsedSkill)[];
+	readonly nativePlugins: readonly IResolvedNativePlugin[];
+}
+
+export function distinctClaudeWorkingDirectories(workingDirectories: readonly URI[] | undefined): readonly URI[] {
+	const seen = new ResourceSet();
+	const result: URI[] = [];
+	for (const directory of workingDirectories ?? []) {
+		if (!seen.has(directory)) {
+			seen.add(directory);
+			result.push(directory);
+		}
+	}
+	return result;
+}
+
+function isParsedAgent(item: IParsedAgent | IParsedSkill): item is IParsedAgent {
+	return item.customization.type === CustomizationType.Agent;
+}
+
+function isParsedSkill(item: IParsedAgent | IParsedSkill): item is IParsedSkill {
+	return item.customization.type === CustomizationType.Skill;
+}
+
+export async function discoverClaudeMultiRootCustomizations(
+	workingDirectories: readonly URI[] | undefined,
+	userHome: URI,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<IClaudeMultiRootCustomizations> {
+	const roots = distinctClaudeWorkingDirectories(workingDirectories);
+	const scopes = await Promise.all([
+		...roots.map((root, index) => scanClaudeCustomizationScope(root, fileService, index === 0)),
+		scanClaudeCustomizationScope(userHome, fileService),
+	]);
+	const discovered = [
+		...selectFirstClaudeCustomizationByKey(scopes.map(items => items.filter(isParsedAgent)), item => item.name),
+		...selectFirstClaudeCustomizationByKey(scopes.map(items => items.filter(isParsedSkill)), item => item.name),
+	];
+	const nativePlugins = await scanClaudeNativePluginsForRoots(roots, userHome, fileService, logService);
+	return {
+		workingDirectories: roots,
+		discovered,
+		nativePlugins,
+	};
+}

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
@@ -9,8 +9,8 @@ import { IFileService } from '../../../../files/common/files.js';
 import { ILogService } from '../../../../log/common/log.js';
 import { CustomizationType } from '../../../common/state/protocol/channels-session/state.js';
 import type { IParsedAgent, IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
-import { scanClaudeCustomizationScope } from './scan/claudeAgentSkillScan.js';
-import { scanClaudeNativePluginsForRoots, type IResolvedNativePlugin } from './scan/claudeNativePluginScan.js';
+import { scanClaudeCustomizationScope, scanClaudeDiskCustomizations } from './scan/claudeAgentSkillScan.js';
+import { scanClaudeNativePlugins, scanClaudeNativePluginsForRoots, type IResolvedNativePlugin } from './scan/claudeNativePluginScan.js';
 import { selectFirstClaudeCustomizationByKey } from './claudeCustomizationPolicy.js';
 
 export interface IClaudeMultiRootCustomizations {
@@ -46,6 +46,13 @@ export async function discoverClaudeMultiRootCustomizations(
 	logService: ILogService,
 ): Promise<IClaudeMultiRootCustomizations> {
 	const roots = distinctClaudeWorkingDirectories(workingDirectories);
+	if (roots.length <= 1) {
+		const [discovered, nativePlugins] = await Promise.all([
+			scanClaudeDiskCustomizations(roots[0], userHome, fileService),
+			scanClaudeNativePlugins(roots[0], userHome, fileService, logService),
+		]);
+		return { workingDirectories: roots, discovered, nativePlugins };
+	}
 	const [scopes, nativePlugins] = await Promise.all([
 		Promise.all([
 			...roots.map((root, index) => scanClaudeCustomizationScope(root, fileService, index === 0)),

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeMultiRootCustomizationDiscovery.ts
@@ -46,15 +46,17 @@ export async function discoverClaudeMultiRootCustomizations(
 	logService: ILogService,
 ): Promise<IClaudeMultiRootCustomizations> {
 	const roots = distinctClaudeWorkingDirectories(workingDirectories);
-	const scopes = await Promise.all([
-		...roots.map((root, index) => scanClaudeCustomizationScope(root, fileService, index === 0)),
-		scanClaudeCustomizationScope(userHome, fileService),
+	const [scopes, nativePlugins] = await Promise.all([
+		Promise.all([
+			...roots.map((root, index) => scanClaudeCustomizationScope(root, fileService, index === 0)),
+			scanClaudeCustomizationScope(userHome, fileService),
+		]),
+		scanClaudeNativePluginsForRoots(roots, userHome, fileService, logService),
 	]);
 	const discovered = [
 		...selectFirstClaudeCustomizationByKey(scopes.map(items => items.filter(isParsedAgent)), item => item.name),
 		...selectFirstClaudeCustomizationByKey(scopes.map(items => items.filter(isParsedSkill)), item => item.name),
 	];
-	const nativePlugins = await scanClaudeNativePluginsForRoots(roots, userHome, fileService, logService);
 	return {
 		workingDirectories: roots,
 		discovered,

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
+import { isEqualOrParent } from '../../../../../base/common/resources.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IFileService } from '../../../../files/common/files.js';
@@ -105,6 +106,9 @@ function createBucket(base: URI): ICustomizationBucket {
 
 function findCustomizationBucket(uri: URI, workspaceBuckets: readonly ICustomizationBucket[], userBucket: ICustomizationBucket): ICustomizationBucket {
 	const root = findMostSpecificClaudeWorkspaceRoot(uri, workspaceBuckets.map(bucket => bucket.base));
+	if (uri.scheme === userBucket.base.scheme && isEqualOrParent(uri, userBucket.base) && (!root || userBucket.base.path.length > root.path.length)) {
+		return userBucket;
+	}
 	return workspaceBuckets.find(bucket => bucket.base === root) ?? userBucket;
 }
 

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
-import { isEqualOrParent } from '../../../../../base/common/resources.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IFileService } from '../../../../files/common/files.js';
@@ -18,6 +17,8 @@ import { deriveMcpState } from './scan/claudeMcpScan.js';
 import { claudeMemoryFiles } from './scan/claudeRuleScan.js';
 import type { IResolvedNativePlugin } from './scan/claudeNativePluginScan.js';
 import { CLAUDE_BUILTIN_AGENTS, buildClaudeBuiltinSkillsContainer, buildSdkBuiltinSkillsContainer } from './claudeBuiltinCommands.js';
+import { distinctClaudeWorkingDirectories } from './claudeMultiRootCustomizationDiscovery.js';
+import { findMostSpecificClaudeWorkspaceRoot } from './claudeCustomizationPolicy.js';
 
 /**
  * The Claude SDK's built-in default agent. Hidden from the picker:
@@ -90,21 +91,21 @@ function makePlugin(plugin: IResolvedNativePlugin): PluginCustomization {
  * The scope a discovered customization belongs to, derived from which
  * `.claude/` tree contains its source file.
  */
-const enum ClaudeCustomizationScope {
-	Workspace = 'workspace',
-	User = 'user',
+interface ICustomizationBucket {
+	readonly base: URI;
+	readonly agents: AgentCustomization[];
+	readonly skills: SkillCustomization[];
+	readonly rules: RuleCustomization[];
+	readonly hooks: HookCustomization[];
 }
 
-/**
- * Attributes a discovered file to the scope whose `.claude/` directory
- * contains it. SDK-only (`claude-internal:`) and any out-of-tree URIs fall
- * back to the user scope. Drives per-scope grouping so the workbench can
- * label containers "Workspace" vs "User".
- */
-function scopeOf(uri: URI, workingDirectory: URI | undefined): ClaudeCustomizationScope {
-	return workingDirectory && uri.scheme === workingDirectory.scheme && isEqualOrParent(uri, workingDirectory)
-		? ClaudeCustomizationScope.Workspace
-		: ClaudeCustomizationScope.User;
+function createBucket(base: URI): ICustomizationBucket {
+	return { base, agents: [], skills: [], rules: [], hooks: [] };
+}
+
+function findCustomizationBucket(uri: URI, workspaceBuckets: readonly ICustomizationBucket[], userBucket: ICustomizationBucket): ICustomizationBucket {
+	const root = findMostSpecificClaudeWorkspaceRoot(uri, workspaceBuckets.map(bucket => bucket.base));
+	return workspaceBuckets.find(bucket => bucket.base === root) ?? userBucket;
 }
 
 /**
@@ -122,15 +123,14 @@ export function mapDiscoveredCustomizations(
 	mcpServers: readonly McpServerCustomization[],
 	hooks: readonly HookCustomization[],
 	nativePlugins: readonly IResolvedNativePlugin[],
-	workingDirectory: URI | undefined,
+	workingDirectories: readonly URI[] | URI | undefined,
 	userHome: URI,
 ): readonly Customization[] {
-	const buckets = new Map<ClaudeCustomizationScope, { agents: AgentCustomization[]; skills: SkillCustomization[]; rules: RuleCustomization[]; hooks: HookCustomization[] }>([
-		[ClaudeCustomizationScope.Workspace, { agents: [], skills: [], rules: [], hooks: [] }],
-		[ClaudeCustomizationScope.User, { agents: [], skills: [], rules: [], hooks: [] }],
-	]);
+	const roots = distinctClaudeWorkingDirectories(Array.isArray(workingDirectories) ? workingDirectories : workingDirectories ? [workingDirectories] : []);
+	const workspaceBuckets = roots.map(createBucket);
+	const userBucket = createBucket(userHome);
 	for (const d of discovered) {
-		const bucket = buckets.get(scopeOf(d.uri, workingDirectory))!;
+		const bucket = findCustomizationBucket(d.uri, workspaceBuckets, userBucket);
 		if (d.customization.type === CustomizationType.Agent) {
 			bucket.agents.push(d.customization);
 		} else if (d.customization.type === CustomizationType.Skill) {
@@ -143,32 +143,22 @@ export function mapDiscoveredCustomizations(
 	// carry no `IParsed*` wrapper, so attribute them to scope via their source
 	// settings-file uri.
 	for (const hook of hooks) {
-		buckets.get(scopeOf(URI.parse(hook.uri), workingDirectory))!.hooks.push(hook);
+		findCustomizationBucket(URI.parse(hook.uri), workspaceBuckets, userBucket).hooks.push(hook);
 	}
 
 	const result: Customization[] = [];
-	// Workspace containers first (precedence), then user. `base` is the scope
-	// root the container `.claude/<sub>` uri is built from.
-	const orderedScopes: readonly (readonly [ClaudeCustomizationScope, URI | undefined])[] = [
-		[ClaudeCustomizationScope.Workspace, workingDirectory],
-		[ClaudeCustomizationScope.User, userHome],
-	];
-	for (const [scope, base] of orderedScopes) {
-		if (!base) {
-			continue;
-		}
-		const bucket = buckets.get(scope)!;
+	for (const bucket of [...workspaceBuckets, userBucket]) {
 		if (bucket.agents.length > 0) {
-			result.push(makeDirectory(base, 'agents', CustomizationType.Agent, bucket.agents));
+			result.push(makeDirectory(bucket.base, 'agents', CustomizationType.Agent, bucket.agents));
 		}
 		if (bucket.skills.length > 0) {
-			result.push(makeDirectory(base, 'skills', CustomizationType.Skill, bucket.skills));
+			result.push(makeDirectory(bucket.base, 'skills', CustomizationType.Skill, bucket.skills));
 		}
 		if (bucket.rules.length > 0) {
-			result.push(makeDirectory(base, 'rules', CustomizationType.Rule, bucket.rules));
+			result.push(makeDirectory(bucket.base, 'rules', CustomizationType.Rule, bucket.rules));
 		}
 		if (bucket.hooks.length > 0) {
-			result.push(makeDirectory(base, 'hooks', CustomizationType.Hook, bucket.hooks));
+			result.push(makeDirectory(bucket.base, 'hooks', CustomizationType.Hook, bucket.hooks));
 		}
 	}
 
@@ -278,7 +268,7 @@ export function buildDiscoveredCustomizations(
 	mcpServers: readonly McpServerCustomization[],
 	hooks: readonly HookCustomization[],
 	nativePlugins: readonly IResolvedNativePlugin[],
-	workingDirectory: URI | undefined,
+	workingDirectories: readonly URI[] | URI | undefined,
 	userHome: URI,
 	sdk: ISdkResolvedCustomizations | undefined,
 ): readonly Customization[] {
@@ -350,7 +340,7 @@ export function buildDiscoveredCustomizations(
 		const builtinAgents = CLAUDE_BUILTIN_AGENTS
 			.filter(a => a.name !== CLAUDE_SDK_DEFAULT_AGENT_NAME && !diskAgentNames.has(a.name))
 			.map(a => toParsedAgent({ uri: nonEditableUri('agent', a.name), name: a.name, description: a.description() }));
-		return withBuiltinSkills(mapDiscoveredCustomizations([...discovered, ...builtinAgents], mcpServers, hooks, nativePlugins, workingDirectory, userHome));
+		return withBuiltinSkills(mapDiscoveredCustomizations([...discovered, ...builtinAgents], mcpServers, hooks, nativePlugins, workingDirectories, userHome));
 	}
 
 	const agentNames = new Set(sdk.agents.map(a => a.name));
@@ -430,7 +420,7 @@ export function buildDiscoveredCustomizations(
 
 	// Native plugins were matched to the live SDK set at the top of this
 	// function (`visiblePlugins`); surface them as top-level containers.
-	return withBuiltinSkills(mapDiscoveredCustomizations(entries, servers, hooks, visiblePlugins, workingDirectory, userHome));
+	return withBuiltinSkills(mapDiscoveredCustomizations(entries, servers, hooks, visiblePlugins, workingDirectories, userHome));
 }
 
 /**
@@ -479,7 +469,7 @@ export class ClaudeCustomizationWatcher extends Disposable {
 	readonly onDidChange: Event<void>;
 
 	constructor(
-		workingDirectory: URI | undefined,
+		workingDirectories: readonly URI[] | URI | undefined,
 		userHome: URI,
 		fileService: IFileService,
 		logService: ILogService,
@@ -487,9 +477,16 @@ export class ClaudeCustomizationWatcher extends Disposable {
 	) {
 		super();
 
+		const roots = distinctClaudeWorkingDirectories(Array.isArray(workingDirectories) ? workingDirectories : workingDirectories ? [workingDirectories] : []);
 		// URIs whose subtree (or exact file, for `.mcp.json`) signals a re-scan.
 		const triggers: URI[] = [];
+		const watched = new Set<string>();
 		const watch = (uri: URI, recursive: boolean) => {
+			const key = `${recursive}:${uri.toString()}`;
+			if (watched.has(key)) {
+				return;
+			}
+			watched.add(key);
 			try {
 				this._register(fileService.watch(uri, { recursive, excludes: [] }));
 			} catch (err) {
@@ -506,12 +503,23 @@ export class ClaudeCustomizationWatcher extends Disposable {
 			}
 		};
 
-		if (workingDirectory) {
-			const projectClaude = URI.joinPath(workingDirectory, '.claude');
+		const primary = roots[0];
+		if (primary) {
+			const projectClaude = URI.joinPath(primary, '.claude');
 			watch(projectClaude, true);
 			addClaudeTriggers(projectClaude);
-			watch(workingDirectory, false);
-			triggers.push(URI.joinPath(workingDirectory, '.mcp.json'));
+			watch(primary, false);
+			triggers.push(URI.joinPath(primary, '.mcp.json'));
+		}
+		for (const additional of roots.slice(1)) {
+			const projectClaude = URI.joinPath(additional, '.claude');
+			watch(projectClaude, true);
+			triggers.push(
+				URI.joinPath(projectClaude, 'agents'),
+				URI.joinPath(projectClaude, 'skills'),
+				URI.joinPath(projectClaude, 'settings.json'),
+				URI.joinPath(projectClaude, 'settings.local.json'),
+			);
 		}
 		const userClaude = URI.joinPath(userHome, '.claude');
 		watch(userClaude, true);
@@ -521,7 +529,7 @@ export class ClaudeCustomizationWatcher extends Disposable {
 		// canonical list so the watcher never drifts from what it actually
 		// reads. Entries already under a recursively-watched `.claude` root
 		// (e.g. `.claude/CLAUDE.md`) are harmless duplicate triggers.
-		triggers.push(...claudeMemoryFiles(workingDirectory, userHome));
+		triggers.push(...claudeMemoryFiles(primary, userHome));
 
 		// Collapse the raw file-change stream into a single debounced signal.
 		// The `DisposableStore` argument is required because `onDidChange` is a

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -106,7 +106,7 @@ function createBucket(base: URI): ICustomizationBucket {
 
 function findCustomizationBucket(uri: URI, workspaceBuckets: readonly ICustomizationBucket[], userBucket: ICustomizationBucket): ICustomizationBucket {
 	const root = findMostSpecificClaudeWorkspaceRoot(uri, workspaceBuckets.map(bucket => bucket.base));
-	if (uri.scheme === userBucket.base.scheme && isEqualOrParent(uri, userBucket.base) && (!root || userBucket.base.path.length > root.path.length)) {
+	if (workspaceBuckets.length > 1 && uri.scheme === userBucket.base.scheme && isEqualOrParent(uri, userBucket.base) && (!root || userBucket.base.path.length > root.path.length)) {
 		return userBucket;
 	}
 	return workspaceBuckets.find(bucket => bucket.base === root) ?? userBucket;

--- a/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/claudeSessionCustomizationDiscovery.ts
@@ -89,8 +89,8 @@ function makePlugin(plugin: IResolvedNativePlugin): PluginCustomization {
 }
 
 /**
- * The scope a discovered customization belongs to, derived from which
- * `.claude/` tree contains its source file.
+ * A URI-backed scope bucket. The base URI distinguishes workspace A,
+ * workspace B, and user scope without a separate scope enum.
  */
 interface ICustomizationBucket {
 	readonly base: URI;

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
@@ -7,6 +7,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { dirname } from '../../../../../../base/common/resources.js';
 import { IFileService } from '../../../../../files/common/files.js';
 import { detectPluginFormat, readAgentComponents, readSkills, toParsedAgent, toParsedSkill, type INamedPluginResource, type IParsedAgent, type IParsedSkill } from '../../../../../agentPlugins/common/pluginParsers.js';
+import { CustomizationType } from '../../../../common/state/protocol/channels-session/state.js';
 
 /**
  * The `.claude/<sub>` directories one scope (project or user) contributes
@@ -54,6 +55,26 @@ async function excludeNativePluginSkills(skills: readonly INamedPluginResource[]
 	return skills.filter((_, i) => !isPluginDir[i]);
 }
 
+export async function scanClaudeCustomizationScope(
+	scope: URI,
+	fileService: IFileService,
+	includeCommands: boolean = true,
+): Promise<readonly (IParsedAgent | IParsedSkill)[]> {
+	const { agents: agentsDir, skills: skillsDir, commands: commandsDir } = scopeRoots(scope);
+	const [agentResources, skillResources, commandResources] = await Promise.all([
+		readAgentComponents([agentsDir], fileService),
+		readSkills(skillsDir, [skillsDir], fileService),
+		includeCommands ? readAgentComponents([commandsDir], fileService) : [],
+	]);
+	const agents = new Map<string, IParsedAgent>();
+	const skills = new Map<string, IParsedSkill>();
+	collectByName(agents, agentResources.map(toParsedAgent));
+	const standaloneSkills = await excludeNativePluginSkills(skillResources, fileService);
+	collectByName(skills, standaloneSkills.map(toParsedSkill));
+	collectByName(skills, commandResources.map(toParsedSkill));
+	return [...agents.values(), ...skills.values()];
+}
+
 /**
  * Scans a Claude session's `.claude/{agents,skills,commands}` directories
  * (project + user scope) and returns the discovered customizations with
@@ -84,21 +105,9 @@ export async function scanClaudeDiskCustomizations(
 	const skills = new Map<string, IParsedSkill>();
 
 	for (const scope of scopes) {
-		const { agents: agentsDir, skills: skillsDir, commands: commandsDir } = scopeRoots(scope);
-		const [agentRes, skillRes, commandRes] = await Promise.all([
-			readAgentComponents([agentsDir], fileService),
-			// pluginRoot = the skills dir itself, so the readSkills fallback
-			// targets `<skillsDir>/SKILL.md` (a legit single-skill dir), never
-			// an unrelated `<userHome>/SKILL.md`.
-			readSkills(skillsDir, [skillsDir], fileService),
-			readAgentComponents([commandsDir], fileService),
-		]);
-		collectByName(agents, agentRes.map(toParsedAgent));
-		// Skills before commands so a same-named skill wins (spec section 3).
-		// Drop `@skills-dir` plugin dirs first — they surface as plugins (PB-8).
-		const standaloneSkills = await excludeNativePluginSkills(skillRes, fileService);
-		collectByName(skills, standaloneSkills.map(toParsedSkill));
-		collectByName(skills, commandRes.map(toParsedSkill));
+		const discovered = await scanClaudeCustomizationScope(scope, fileService);
+		collectByName(agents, discovered.filter((item): item is IParsedAgent => item.customization.type === CustomizationType.Agent));
+		collectByName(skills, discovered.filter((item): item is IParsedSkill => item.customization.type === CustomizationType.Skill));
 	}
 
 	return [...agents.values(), ...skills.values()];

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
@@ -104,8 +104,8 @@ export async function scanClaudeDiskCustomizations(
 	const agents = new Map<string, IParsedAgent>();
 	const skills = new Map<string, IParsedSkill>();
 
-	const discoveredScopes = await Promise.all(scopes.map(scope => scanClaudeCustomizationScope(scope, fileService)));
-	for (const discovered of discoveredScopes) {
+	for (const scope of scopes) {
+		const discovered = await scanClaudeCustomizationScope(scope, fileService);
 		collectByName(agents, discovered.filter((item): item is IParsedAgent => item.customization.type === CustomizationType.Agent));
 		collectByName(skills, discovered.filter((item): item is IParsedSkill => item.customization.type === CustomizationType.Skill));
 	}

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeAgentSkillScan.ts
@@ -104,8 +104,8 @@ export async function scanClaudeDiskCustomizations(
 	const agents = new Map<string, IParsedAgent>();
 	const skills = new Map<string, IParsedSkill>();
 
-	for (const scope of scopes) {
-		const discovered = await scanClaudeCustomizationScope(scope, fileService);
+	const discoveredScopes = await Promise.all(scopes.map(scope => scanClaudeCustomizationScope(scope, fileService)));
+	for (const discovered of discoveredScopes) {
 		collectByName(agents, discovered.filter((item): item is IParsedAgent => item.customization.type === CustomizationType.Agent));
 		collectByName(skills, discovered.filter((item): item is IParsedSkill => item.customization.type === CustomizationType.Skill));
 	}

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
@@ -248,7 +248,9 @@ async function resolveNativePlugins(
 		}
 		seenRoots.add(root);
 		try {
-			const workspaceRoot = findMostSpecificClaudeWorkspaceRoot(root, workingDirectories);
+			const workspaceRoot = parts.marketplace === SKILLS_DIR_MARKETPLACE
+				? findMostSpecificClaudeWorkspaceRoot(root, workingDirectories)
+				: undefined;
 			const parsed = await parsePlugin(root, fileService, workspaceRoot ?? workingDirectories[0], userHome, root);
 			result.push({ id, root, parsed });
 		} catch (err) {

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
@@ -72,14 +72,16 @@ async function readEnabledPlugins(uri: URI, fileService: IFileService): Promise<
 async function resolveEnabledPluginIds(workingDirectory: URI | undefined, userHome: URI, fileService: IFileService): Promise<string[]> {
 	const effective = new Map<string, boolean>();
 	const seenFiles = new ResourceSet();
-	for (const uri of claudeSettingsFilesByPrecedence(workingDirectory, userHome)) {
+	const settingsFiles = claudeSettingsFilesByPrecedence(workingDirectory, userHome).filter(uri => {
 		if (seenFiles.has(uri)) {
-			// The same settings file can be reached from two scopes (cwd ===
-			// userHome) — read it once. Mirrors the per-scanner dedupe.
-			continue;
+			return false;
 		}
 		seenFiles.add(uri);
-		for (const [id, enabled] of await readEnabledPlugins(uri, fileService)) {
+		return true;
+	});
+	const settings = await Promise.all(settingsFiles.map(uri => readEnabledPlugins(uri, fileService)));
+	for (const enabledPlugins of settings) {
+		for (const [id, enabled] of enabledPlugins) {
 			effective.set(id, enabled);
 		}
 	}

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
@@ -8,6 +8,7 @@ import { ResourceSet } from '../../../../../../base/common/map.js';
 import { IFileService } from '../../../../../files/common/files.js';
 import { ILogService } from '../../../../../log/common/log.js';
 import { detectPluginFormat, parsePlugin, readJsonFile, type IParsedPlugin } from '../../../../../agentPlugins/common/pluginParsers.js';
+import { findMostSpecificClaudeWorkspaceRoot, selectEnabledClaudePluginIds } from '../claudeCustomizationPolicy.js';
 
 /**
  * A Claude-native plugin enabled via `enabledPlugins` and resolved to its
@@ -46,6 +47,22 @@ function claudeSettingsFilesByPrecedence(workingDirectory: URI | undefined, user
 	return files;
 }
 
+async function readEnabledPlugins(uri: URI, fileService: IFileService): Promise<ReadonlyMap<string, boolean>> {
+	const result = new Map<string, boolean>();
+	const raw = await readJsonFile(uri, fileService);
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+		return result;
+	}
+	const enabledPlugins = (raw as Record<string, unknown>)['enabledPlugins'];
+	if (!enabledPlugins || typeof enabledPlugins !== 'object' || Array.isArray(enabledPlugins)) {
+		return result;
+	}
+	for (const [id, value] of Object.entries(enabledPlugins as Record<string, unknown>)) {
+		result.set(id, value !== false);
+	}
+	return result;
+}
+
 /**
  * Computes the effective set of enabled plugin ids across the settings
  * scopes. A plugin's value may be `true`, a `string[]` (version
@@ -62,16 +79,8 @@ async function resolveEnabledPluginIds(workingDirectory: URI | undefined, userHo
 			continue;
 		}
 		seenFiles.add(uri);
-		const raw = await readJsonFile(uri, fileService);
-		if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-			continue;
-		}
-		const enabledPlugins = (raw as Record<string, unknown>)['enabledPlugins'];
-		if (!enabledPlugins || typeof enabledPlugins !== 'object' || Array.isArray(enabledPlugins)) {
-			continue;
-		}
-		for (const [id, value] of Object.entries(enabledPlugins as Record<string, unknown>)) {
-			effective.set(id, value !== false);
+		for (const [id, enabled] of await readEnabledPlugins(uri, fileService)) {
+			effective.set(id, enabled);
 		}
 	}
 	return [...effective].filter(([, enabled]) => enabled).map(([id]) => id);
@@ -114,9 +123,9 @@ async function hasManifest(dir: URI, fileService: IFileService): Promise<boolean
  * workspace scope over the user scope. Accepts a candidate only when it
  * holds a plugin manifest.
  */
-async function resolveSkillsDirRoot(plugin: string, workingDirectory: URI | undefined, userHome: URI, fileService: IFileService): Promise<URI | undefined> {
+async function resolveSkillsDirRoot(plugin: string, workingDirectories: readonly URI[], userHome: URI, fileService: IFileService): Promise<URI | undefined> {
 	const candidates: URI[] = [];
-	if (workingDirectory) {
+	for (const workingDirectory of workingDirectories) {
 		candidates.push(URI.joinPath(workingDirectory, '.claude', 'skills', plugin));
 	}
 	candidates.push(URI.joinPath(userHome, '.claude', 'skills', plugin));
@@ -189,6 +198,34 @@ export async function scanClaudeNativePlugins(
 	logService: ILogService,
 ): Promise<readonly IResolvedNativePlugin[]> {
 	const ids = await resolveEnabledPluginIds(workingDirectory, userHome, fileService);
+	return resolveNativePlugins(ids, workingDirectory ? [workingDirectory] : [], userHome, fileService, logService);
+}
+
+export async function scanClaudeNativePluginsForRoots(
+	workingDirectories: readonly URI[],
+	userHome: URI,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<readonly IResolvedNativePlugin[]> {
+	const settingsFiles: URI[] = [];
+	for (const workingDirectory of workingDirectories) {
+		settingsFiles.push(
+			URI.joinPath(workingDirectory, '.claude', 'settings.local.json'),
+			URI.joinPath(workingDirectory, '.claude', 'settings.json'),
+		);
+	}
+	settingsFiles.push(URI.joinPath(userHome, '.claude', 'settings.json'));
+	const ids = selectEnabledClaudePluginIds(await Promise.all(settingsFiles.map(uri => readEnabledPlugins(uri, fileService))));
+	return resolveNativePlugins(ids, workingDirectories, userHome, fileService, logService);
+}
+
+async function resolveNativePlugins(
+	ids: readonly string[],
+	workingDirectories: readonly URI[],
+	userHome: URI,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<readonly IResolvedNativePlugin[]> {
 	const result: IResolvedNativePlugin[] = [];
 	const seenRoots = new ResourceSet();
 	for (const id of ids) {
@@ -198,7 +235,7 @@ export async function scanClaudeNativePlugins(
 			continue;
 		}
 		const root = parts.marketplace === SKILLS_DIR_MARKETPLACE
-			? await resolveSkillsDirRoot(parts.plugin, workingDirectory, userHome, fileService)
+			? await resolveSkillsDirRoot(parts.plugin, workingDirectories, userHome, fileService)
 			: await resolveMarketplaceCacheRoot(parts.plugin, parts.marketplace, userHome, fileService);
 		if (!root) {
 			logService.warn(`[claudeNativePluginScan] could not resolve an on-disk root for enabled plugin '${id}'`);
@@ -209,7 +246,8 @@ export async function scanClaudeNativePlugins(
 		}
 		seenRoots.add(root);
 		try {
-			const parsed = await parsePlugin(root, fileService, workingDirectory, userHome, root);
+			const workspaceRoot = findMostSpecificClaudeWorkspaceRoot(root, workingDirectories);
+			const parsed = await parsePlugin(root, fileService, workspaceRoot ?? workingDirectories[0], userHome, root);
 			result.push({ id, root, parsed });
 		} catch (err) {
 			logService.warn(`[claudeNativePluginScan] failed to parse plugin '${id}' at '${root.toString()}': ${err instanceof Error ? err.message : String(err)}`);

--- a/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
+++ b/src/vs/platform/agentHost/node/claude/customizations/scan/claudeNativePluginScan.ts
@@ -72,17 +72,21 @@ async function readEnabledPlugins(uri: URI, fileService: IFileService): Promise<
 async function resolveEnabledPluginIds(workingDirectory: URI | undefined, userHome: URI, fileService: IFileService): Promise<string[]> {
 	const effective = new Map<string, boolean>();
 	const seenFiles = new ResourceSet();
-	const settingsFiles = claudeSettingsFilesByPrecedence(workingDirectory, userHome).filter(uri => {
+	for (const uri of claudeSettingsFilesByPrecedence(workingDirectory, userHome)) {
 		if (seenFiles.has(uri)) {
-			return false;
+			continue;
 		}
 		seenFiles.add(uri);
-		return true;
-	});
-	const settings = await Promise.all(settingsFiles.map(uri => readEnabledPlugins(uri, fileService)));
-	for (const enabledPlugins of settings) {
-		for (const [id, enabled] of enabledPlugins) {
-			effective.set(id, enabled);
+		const raw = await readJsonFile(uri, fileService);
+		if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+			continue;
+		}
+		const enabledPlugins = (raw as Record<string, unknown>)['enabledPlugins'];
+		if (!enabledPlugins || typeof enabledPlugins !== 'object' || Array.isArray(enabledPlugins)) {
+			continue;
+		}
+		for (const [id, value] of Object.entries(enabledPlugins as Record<string, unknown>)) {
+			effective.set(id, value !== false);
 		}
 	}
 	return [...effective].filter(([, enabled]) => enabled).map(([id]) => id);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -2273,6 +2273,38 @@ suite('ClaudeAgent', () => {
 		});
 	});
 
+	test('multi-root session discovers and retains customizations from an additional directory', async () => {
+		const { agent, sdk, fileService } = createTestContext(disposables, { rootConfig: { [AgentHostClaudeMultiRootEnabledConfigKey]: true } });
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const repoA = URI.file('/repo-a');
+		const repoB = URI.file('/repo-b');
+		const skillUri = URI.joinPath(repoB, '.claude', 'skills', 'from-b', 'SKILL.md');
+		await fileService.writeFile(skillUri, VSBuffer.fromString('---\nname: from-b\ndescription: Skill from B\n---\nbody'));
+		const created = await agent.createSession({ workingDirectories: [repoA, repoB] });
+		const before = await agent.getSessionCustomizations(created.session);
+		const sessionId = AgentSession.id(created.session);
+		sdk.supportedAgentsResult = [];
+		sdk.supportedCommandsResult = [{ name: 'from-b', description: 'Skill from B', argumentHint: '' }];
+		sdk.mcpServerStatusResult = [];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', [repoA, repoB], undefined, 'turn-1');
+		const after = await agent.getSessionCustomizations(created.session);
+		const skillContainerUri = URI.joinPath(repoB, '.claude', 'skills').toString();
+		const names = (customizations: readonly Customization[]) => {
+			const container = customizations.find(customization => customization.uri === skillContainerUri);
+			return container?.type === CustomizationType.Directory ? container.children?.map(skill => skill.name) : undefined;
+		};
+
+		assert.deepStrictEqual({
+			before: names(before),
+			after: names(after),
+		}, {
+			before: ['from-b'],
+			after: ['from-b'],
+		});
+	});
+
 	test('cold resume recovers the additional directories from the persisted overlay', async () => {
 		const database = new TestSessionDatabase();
 		const repoA = URI.file('/repo-a');

--- a/src/vs/platform/agentHost/test/node/customizations/claudeMultiRootCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeMultiRootCustomizationDiscovery.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IFileService } from '../../../../files/common/files.js';
+import { NullLogService } from '../../../../log/common/log.js';
+import { discoverClaudeMultiRootCustomizations } from '../../../node/claude/customizations/claudeMultiRootCustomizationDiscovery.js';
+import { createInMemoryFileService, seedFile } from './claudeCustomizationTestUtils.js';
+
+suite('claudeMultiRootCustomizationDiscovery', () => {
+	const disposables = new DisposableStore();
+	const rootA = URI.from({ scheme: Schemas.inMemory, path: '/a' });
+	const rootB = URI.from({ scheme: Schemas.inMemory, path: '/b' });
+	const userHome = URI.from({ scheme: Schemas.inMemory, path: '/home' });
+	let fileService: IFileService;
+	const seed = (path: string, content = '') => seedFile(fileService, path, content);
+
+	setup(() => {
+		fileService = createInMemoryFileService(disposables);
+	});
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('combines roots in order and applies first-name-wins precedence', async () => {
+		await Promise.all([
+			seed('/a/.claude/agents/shared.md', '---\nname: shared\ndescription: from a\n---'),
+			seed('/b/.claude/agents/shared.md', '---\nname: shared\ndescription: from b\n---'),
+			seed('/b/.claude/agents/b-only.md', '---\nname: b-only\ndescription: from b\n---'),
+			seed('/b/.claude/skills/shared-skill/SKILL.md', '---\nname: shared-skill\ndescription: from b\n---'),
+			seed('/home/.claude/skills/shared-skill/SKILL.md', '---\nname: shared-skill\ndescription: from user\n---'),
+			seed('/home/.claude/skills/user-only/SKILL.md', '---\nname: user-only\ndescription: from user\n---'),
+			seed('/b/.claude/commands/not-loaded.md', '---\nname: not-loaded\ndescription: added-directory command\n---'),
+		]);
+
+		const result = await discoverClaudeMultiRootCustomizations([rootA, rootB], userHome, fileService, new NullLogService());
+
+		assert.deepStrictEqual({
+			roots: result.workingDirectories.map(root => root.path),
+			items: result.discovered.map(item => ({ name: item.name, description: item.description, path: item.uri.path })),
+		}, {
+			roots: ['/a', '/b'],
+			items: [
+				{ name: 'shared', description: 'from a', path: '/a/.claude/agents/shared.md' },
+				{ name: 'b-only', description: 'from b', path: '/b/.claude/agents/b-only.md' },
+				{ name: 'shared-skill', description: 'from b', path: '/b/.claude/skills/shared-skill/SKILL.md' },
+				{ name: 'user-only', description: 'from user', path: '/home/.claude/skills/user-only/SKILL.md' },
+			],
+		});
+	});
+
+	test('deduplicates equivalent roots without changing precedence', async () => {
+		await seed('/a/.claude/agents/a.md', '---\nname: a\ndescription: A\n---');
+
+		const result = await discoverClaudeMultiRootCustomizations([rootA, rootA], userHome, fileService, new NullLogService());
+
+		assert.deepStrictEqual({
+			roots: result.workingDirectories.map(root => root.path),
+			items: result.discovered.map(item => item.name),
+		}, {
+			roots: ['/a'],
+			items: ['a'],
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/customizations/claudeMultiRootCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeMultiRootCustomizationDiscovery.test.ts
@@ -11,6 +11,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { IFileService } from '../../../../files/common/files.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import { discoverClaudeMultiRootCustomizations } from '../../../node/claude/customizations/claudeMultiRootCustomizationDiscovery.js';
+import { scanClaudeDiskCustomizations } from '../../../node/claude/customizations/scan/claudeAgentSkillScan.js';
+import { scanClaudeNativePlugins } from '../../../node/claude/customizations/scan/claudeNativePluginScan.js';
 import { createInMemoryFileService, seedFile } from './claudeCustomizationTestUtils.js';
 
 suite('claudeMultiRootCustomizationDiscovery', () => {
@@ -27,6 +29,33 @@ suite('claudeMultiRootCustomizationDiscovery', () => {
 
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses the existing single-root discovery path without changing output order', async () => {
+		await Promise.all([
+			seed('/a/.claude/agents/project.md', '---\nname: project\ndescription: project agent\n---'),
+			seed('/home/.claude/agents/user.md', '---\nname: user\ndescription: user agent\n---'),
+			seed('/a/.claude/skills/project-skill/SKILL.md', '---\nname: project-skill\ndescription: project skill\n---'),
+			seed('/home/.claude/skills/user-skill/SKILL.md', '---\nname: user-skill\ndescription: user skill\n---'),
+			seed('/home/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'user-plugin@m': true } })),
+			seed('/a/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'project-plugin@m': true } })),
+			seed('/home/.claude/plugins/cache/m/user-plugin/1.0.0/.claude-plugin/plugin.json', JSON.stringify({ name: 'user-plugin' })),
+			seed('/home/.claude/plugins/cache/m/project-plugin/1.0.0/.claude-plugin/plugin.json', JSON.stringify({ name: 'project-plugin' })),
+		]);
+		const logService = new NullLogService();
+		const [expectedDiscovered, expectedPlugins, actual] = await Promise.all([
+			scanClaudeDiskCustomizations(rootA, userHome, fileService),
+			scanClaudeNativePlugins(rootA, userHome, fileService, logService),
+			discoverClaudeMultiRootCustomizations([rootA], userHome, fileService, logService),
+		]);
+
+		assert.deepStrictEqual({
+			discovered: actual.discovered,
+			plugins: actual.nativePlugins,
+		}, {
+			discovered: expectedDiscovered,
+			plugins: expectedPlugins,
+		});
+	});
 
 	test('combines roots in order and applies first-name-wins precedence', async () => {
 		await Promise.all([

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -88,6 +88,22 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			);
 		});
 
+		test('preserves single-root workspace attribution when the workspace contains userHome', () => {
+			const broadRoot = URI.from({ scheme: Schemas.inMemory, path: '/home' });
+			const userSkill = URI.joinPath(userHome, '.claude', 'skills', 'user-skill', 'SKILL.md');
+			const result = mapDiscoveredCustomizations([
+				toParsedSkill({ uri: userSkill, name: 'user-skill' }),
+			], [], [], [], broadRoot, userHome);
+
+			assert.deepStrictEqual(
+				(result.filter(c => c.type === CustomizationType.Directory) as DirectoryCustomization[])
+					.map(directory => ({ uri: directory.uri, children: directory.children?.map(child => child.name) })),
+				[
+					{ uri: URI.joinPath(broadRoot, '.claude', 'skills').toString(), children: ['user-skill'] },
+				],
+			);
+		});
+
 		test('maps discovered entries into per-scope Directory containers with real child URIs + top-level MCP', () => {
 			const wsAgentUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/agents/wa.md' });
 			const wsSkillUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/skills/ws/SKILL.md' });

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -72,6 +72,22 @@ suite('claudeSessionCustomizationDiscovery', () => {
 			);
 		});
 
+		test('keeps user customizations in the user bucket when an additional root contains userHome', () => {
+			const broadRoot = URI.from({ scheme: Schemas.inMemory, path: '/home' });
+			const userSkill = URI.joinPath(userHome, '.claude', 'skills', 'user-skill', 'SKILL.md');
+			const result = mapDiscoveredCustomizations([
+				toParsedSkill({ uri: userSkill, name: 'user-skill' }),
+			], [], [], [], [workspace, broadRoot], userHome);
+
+			assert.deepStrictEqual(
+				(result.filter(c => c.type === CustomizationType.Directory) as DirectoryCustomization[])
+					.map(directory => ({ uri: directory.uri, children: directory.children?.map(child => child.name) })),
+				[
+					{ uri: URI.joinPath(userHome, '.claude', 'skills').toString(), children: ['user-skill'] },
+				],
+			);
+		});
+
 		test('maps discovered entries into per-scope Directory containers with real child URIs + top-level MCP', () => {
 			const wsAgentUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/agents/wa.md' });
 			const wsSkillUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/skills/ws/SKILL.md' });

--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -53,6 +53,25 @@ suite('claudeSessionCustomizationDiscovery', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	suite('mapDiscoveredCustomizations', () => {
+		test('maps agents and skills into separate ordered workspace-root containers', () => {
+			const workspaceB = URI.from({ scheme: Schemas.inMemory, path: '/workspace/packages/b' });
+			const rootAgent = URI.joinPath(workspace, '.claude', 'agents', 'root.md');
+			const nestedAgent = URI.joinPath(workspaceB, '.claude', 'agents', 'nested.md');
+			const result = mapDiscoveredCustomizations([
+				toParsedAgent({ uri: rootAgent, name: 'root' }),
+				toParsedAgent({ uri: nestedAgent, name: 'nested' }),
+			], [], [], [], [workspace, workspaceB], userHome);
+
+			assert.deepStrictEqual(
+				(result.filter(c => c.type === CustomizationType.Directory) as DirectoryCustomization[])
+					.map(directory => ({ uri: directory.uri, children: directory.children?.map(child => child.name) })),
+				[
+					{ uri: URI.joinPath(workspace, '.claude', 'agents').toString(), children: ['root'] },
+					{ uri: URI.joinPath(workspaceB, '.claude', 'agents').toString(), children: ['nested'] },
+				],
+			);
+		});
+
 		test('maps discovered entries into per-scope Directory containers with real child URIs + top-level MCP', () => {
 			const wsAgentUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/agents/wa.md' });
 			const wsSkillUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/skills/ws/SKILL.md' });
@@ -390,6 +409,25 @@ suite('claudeSessionCustomizationDiscovery', () => {
 				seed('/home/.claude/agents/a.md', 'a'),
 				seed('/workspace/.claude/skills/s/SKILL.md', 's'),
 				seed('/workspace/.mcp.json', '{}'),
+			]);
+			await settle();
+			assert.strictEqual(fires, 1);
+		});
+
+		test('watches agents, skills, and plugin settings under additional roots', async () => {
+			const workspaceB = URI.from({ scheme: Schemas.inMemory, path: '/workspace-b' });
+			const watcher = disposables.add(new ClaudeCustomizationWatcher([workspace, workspaceB], userHome, fileService, new NullLogService(), debounceMs));
+			let fires = 0;
+			disposables.add(watcher.onDidChange(() => { fires++; }));
+
+			await seed('/workspace-b/unrelated.txt', 'x');
+			await settle();
+			assert.strictEqual(fires, 0);
+
+			await Promise.all([
+				seed('/workspace-b/.claude/agents/a.md', 'a'),
+				seed('/workspace-b/.claude/skills/s/SKILL.md', 's'),
+				seed('/workspace-b/.claude/settings.json', '{}'),
 			]);
 			await settle();
 			assert.strictEqual(fires, 1);

--- a/src/vs/platform/agentHost/test/node/customizations/scan/claudeNativePluginScan.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/scan/claudeNativePluginScan.test.ts
@@ -159,6 +159,25 @@ suite('claudeNativePluginScan', () => {
 		]);
 	});
 
+	test('uses the primary root for cached plugin hooks when an additional root contains userHome', async () => {
+		const broadRoot = workspace.with({ path: '/home' });
+		await seed('/home/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'cached@m': true } }));
+		await seed('/home/.claude/plugins/cache/m/cached/1.0.0/.claude-plugin/plugin.json', manifest('cached'));
+		await seed('/home/.claude/plugins/cache/m/cached/1.0.0/hooks/hooks.json', JSON.stringify({
+			hooks: {
+				PreToolUse: [{
+					hooks: [{ type: 'command', command: 'echo cached', cwd: 'scripts' }],
+				}],
+			},
+		}));
+
+		const plugins = await scanClaudeNativePluginsForRoots([workspace, broadRoot], userHome, fileService, logService);
+
+		assert.deepStrictEqual(plugins[0].parsed.hooks.flatMap(group => group.commands).map(hook => hook.cwd?.path), [
+			'/workspace/scripts',
+		]);
+	});
+
 	test('uses ordered root precedence for conflicting plugin enablement', async () => {
 		const workspaceB = workspace.with({ path: '/workspace-b' });
 		await seed('/workspace/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'mine@skills-dir': false } }));

--- a/src/vs/platform/agentHost/test/node/customizations/scan/claudeNativePluginScan.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/scan/claudeNativePluginScan.test.ts
@@ -8,7 +8,7 @@ import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../log/common/log.js';
 import { IFileService } from '../../../../../files/common/files.js';
-import { scanClaudeNativePlugins } from '../../../../node/claude/customizations/scan/claudeNativePluginScan.js';
+import { scanClaudeNativePlugins, scanClaudeNativePluginsForRoots } from '../../../../node/claude/customizations/scan/claudeNativePluginScan.js';
 import { claudeTestUserHome as userHome, claudeTestWorkspace as workspace, createInMemoryFileService, seedFile } from '../claudeCustomizationTestUtils.js';
 
 suite('claudeNativePluginScan', () => {
@@ -126,6 +126,48 @@ suite('claudeNativePluginScan', () => {
 		const plugins = await scanClaudeNativePlugins(workspace, userHome, fileService, logService);
 
 		assert.deepStrictEqual(plugins.map(p => p.root.path), ['/workspace/.claude/skills/mine']);
+	});
+
+	test('discovers an in-place plugin enabled only by an additional workspace root', async () => {
+		const workspaceB = workspace.with({ path: '/workspace-b' });
+		await seed('/workspace-b/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'mine@skills-dir': true } }));
+		await seed('/workspace-b/.claude/skills/mine/.claude-plugin/plugin.json', manifest('mine'));
+
+		const plugins = await scanClaudeNativePluginsForRoots([workspace, workspaceB], userHome, fileService, logService);
+
+		assert.deepStrictEqual(plugins.map(p => ({ id: p.id, root: p.root.path })), [
+			{ id: 'mine@skills-dir', root: '/workspace-b/.claude/skills/mine' },
+		]);
+	});
+
+	test('uses the most-specific nested workspace root when parsing plugin hooks', async () => {
+		const workspaceB = workspace.with({ path: '/workspace/packages/b' });
+		await seed('/workspace/packages/b/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'mine@skills-dir': true } }));
+		await seed('/workspace/packages/b/.claude/skills/mine/.claude-plugin/plugin.json', manifest('mine'));
+		await seed('/workspace/packages/b/.claude/skills/mine/hooks/hooks.json', JSON.stringify({
+			hooks: {
+				PreToolUse: [{
+					hooks: [{ type: 'command', command: 'echo nested', cwd: 'scripts' }],
+				}],
+			},
+		}));
+
+		const plugins = await scanClaudeNativePluginsForRoots([workspace, workspaceB], userHome, fileService, logService);
+
+		assert.deepStrictEqual(plugins[0].parsed.hooks.flatMap(group => group.commands).map(hook => hook.cwd?.path), [
+			'/workspace/packages/b/scripts',
+		]);
+	});
+
+	test('uses ordered root precedence for conflicting plugin enablement', async () => {
+		const workspaceB = workspace.with({ path: '/workspace-b' });
+		await seed('/workspace/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'mine@skills-dir': false } }));
+		await seed('/workspace-b/.claude/settings.json', JSON.stringify({ enabledPlugins: { 'mine@skills-dir': true } }));
+		await seed('/workspace-b/.claude/skills/mine/.claude-plugin/plugin.json', manifest('mine'));
+
+		const plugins = await scanClaudeNativePluginsForRoots([workspace, workspaceB], userHome, fileService, logService);
+
+		assert.deepStrictEqual(plugins, []);
 	});
 
 	test('fail-soft: an enabled plugin with no resolvable root is skipped, not thrown', async () => {

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -140,6 +140,8 @@ The shared plugin discovery pipeline selects format-specific component paths whi
 
 Runtime projection is provider-specific. Copilot receives strict skills and MCP explicitly rather than through legacy SDK plugin-directory discovery. Codex receives strict skill roots plus MCP, with remote transport selected by its existing auto-detection. Claude excludes strict packages from legacy plugin discovery and can project remote MCP through its existing auto-detection, but its current SDK cannot register external skill directories or provide the per-server working directory required by strict stdio MCP, so those components are reported and skipped.
 
+Claude Agent Host multi-root customization discovery is gated by the hidden, default-off `chat.agentHost.claudeAgent.multiRootEnabled` setting. When enabled, the primary working directory and each SDK `additionalDirectories` root contribute standalone `.claude/agents`, `.claude/skills`, and native plugin enablement to the Customizations editor. Roots are processed in session order, followed by user scope; same-named standalone agents or skills use the first visible definition as the display source. This display policy is centralized because the SDK reports standalone entries by name rather than source URI. Native plugin loaded state remains authoritative from the SDK snapshot. Rules, hooks, MCP configuration, commands, and CLAUDE.md remain primary-root/user scoped because Claude additional directories do not load those configuration types. Each contributing root has its own writable directory container, and secondary-root watchers observe only agents, skills, and plugin settings.
+
 ### IHarnessDescriptor
 
 Key properties on the harness descriptor:


### PR DESCRIPTION
## Summary

- discover Claude Agent Host agents, skills, and native plugins from every session working directory
- preserve focused single-root scanners behind ordered multi-root coordination and centralized conflict policies
- project separate writable containers per workspace root and watch supported customization sources in additional roots
- keep plugin loaded state authoritative from the Claude SDK snapshot

The behavior remains gated by the hidden, default-off `chat.agentHost.claudeAgent.multiRootEnabled` setting. Rules, hooks, MCP configuration, commands, and CLAUDE.md remain primary-root/user scoped to match Claude additional-directory behavior.

## Validation

- `npm run typecheck-client`
- `npm run compile-client`
- targeted Claude customization and Claude Agent unit tests (46 passing)
- `npm run valid-layers-check`
- targeted hygiene checks

https://github.com/microsoft/vscode/issues/321651