### PR TITLE
agentHost: add multi-root support for Codex sessions

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -18,7 +18,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
-import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
 import { AMBIENT_AGENT_HOST_AUTHORITY } from '../common/agentHostConnectionsService.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
 import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
@@ -38,7 +38,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { Implementation, InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -400,6 +400,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				}
 				this._updateClaudeMultiRootEnabled();
 			}
+			if (e.affectsConfiguration(AgentHostCodexMultiRootEnabledSettingId)) {
+				if (this._state.kind !== AgentHostClientState.Connected) {
+					return;
+				}
+				this._updateCodexMultiRootEnabled();
+			}
 			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID) || e.affectsConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID)) {
 				if (this._state.kind !== AgentHostClientState.Connected) {
 					return;
@@ -714,6 +720,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._updateSystemProxyEnabled();
 		this._updateCopilotMultiRootEnabled();
 		this._updateClaudeMultiRootEnabled();
+		this._updateCodexMultiRootEnabled();
 		this._updateTerminalAutoApproveRules();
 		this._updateCodexEnabled();
 		this._updateDisableRepoInfoTelemetry();
@@ -1578,6 +1585,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostClaudeMultiRootEnabledConfigKey]: enabled },
+		}, this._clientId, 0);
+	}
+
+	private _updateCodexMultiRootEnabled(): void {
+		const enabled = this._configurationService.getValue<boolean>(AgentHostCodexMultiRootEnabledSettingId) === true;
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostCodexMultiRootEnabledConfigKey]: enabled },
 		}, this._clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -482,6 +482,9 @@ export const AgentHostCopilotMultiRootEnabledConfigKey = 'copilotMultiRootEnable
  */
 export const AgentHostClaudeMultiRootEnabledConfigKey = 'claudeMultiRootEnabled';
 
+/** Root config key forwarded from the renderer that gates Codex multiple-working-directory support. */
+export const AgentHostCodexMultiRootEnabledConfigKey = 'codexMultiRootEnabled';
+
 /**
  * Root config key forwarded from the renderer when VS Code's
  * `chat.tools.terminal.autoApprove` setting changes. Holds the effective
@@ -754,6 +757,12 @@ export const platformRootSchema = createSchema({
 		type: 'boolean',
 		title: localize('agentHost.config.claudeMultiRootEnabled.title', "Claude Multiple Working Directories"),
 		description: localize('agentHost.config.claudeMultiRootEnabled.description', "Whether the Claude provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace."),
+		default: false,
+	}),
+	[AgentHostCodexMultiRootEnabledConfigKey]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.codexMultiRootEnabled.title', "Codex Multiple Working Directories"),
+		description: localize('agentHost.config.codexMultiRootEnabled.description', "Whether the Codex provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace."),
 		default: false,
 	}),
 	[AgentHostTerminalAutoApproveRulesConfigKey]: schemaProperty<AgentHostTerminalAutoApproveRules>({

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -16,6 +16,7 @@ import {
 	AgentHostClaudeMultiRootEnabledSettingId,
 	AgentHostCodexAgentBinaryArgsSettingId,
 	AgentHostCodexAgentEnabledSettingId,
+	AgentHostCodexMultiRootEnabledSettingId,
 	AgentHostCodexAgentSdkRootSettingId,
 	AgentHostCodexAgentCodexHomeSettingId,
 	AgentHostCopilotMultiRootEnabledSettingId,
@@ -110,6 +111,12 @@ configurationRegistry.registerConfiguration({
 			// Hidden from the Settings UI while the feature is dogfooded internally.
 			// Still settable via `settings.json`; flip `default` (e.g. to
 			// `product.quality !== 'stable'`) to enable it for a build channel.
+			included: false,
+		},
+		[AgentHostCodexMultiRootEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.codexAgent.multiRootEnabled', "When enabled, Codex agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host."),
+			default: false,
 			included: false,
 		},
 		[AgentHostClaudeAgentEnabledSettingId]: {

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -76,6 +76,13 @@ export const AgentHostCopilotMultiRootEnabledSettingId = 'chat.agentHost.copilot
  */
 export const AgentHostClaudeMultiRootEnabledSettingId = 'chat.agentHost.claudeAgent.multiRootEnabled';
 
+/**
+ * Configuration key gating multiple-working-directory support for the Codex
+ * agent-host provider. Hidden from the Settings UI and off by default while the
+ * feature is dogfooded.
+ */
+export const AgentHostCodexMultiRootEnabledSettingId = 'chat.agentHost.codexAgent.multiRootEnabled';
+
 // The Copilot-CLI-specific setting IDs (`customTerminalTool`, `opus48Prompt`,
 // `reasoningEffortOverride`, `modelCapabilityOverrides`) live with their
 // root-config keys in `copilotCliConfig.ts`.

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -573,6 +573,10 @@ interface ICodexSession {
 	readonly clientCustomizations: CodexClientCustomizationStore;
 }
 
+type ICodexSessionRead = ThreadReadResponse & {
+	readonly persistedWorkingDirectories?: readonly URI[];
+};
+
 /**
  * A live Codex collab-agent (subagent) child thread. Codex runs each spawned
  * subagent as its OWN app-server thread that emits a full item/turn event
@@ -1205,7 +1209,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			return { type: 'readOnly', networkAccess: false };
 		}
 		const additionalDirectories = narrowAdditionalDirectories(config[CodexSessionConfigKey.AdditionalDirectories]) ?? [];
-		const writableRoots = session.multiRootEnabled
+		const writableRoots = this._isMultiRootActive(session)
 			? distinctAbsolutePaths([
 				...this._runtimeWorkspaceRoots(session),
 				...additionalDirectories,
@@ -1227,7 +1231,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		const config = this._readSessionConfig(session);
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
 		const sandboxPolicy = this._sandboxPolicy(session, config, sandboxMode);
-		const runtimeWorkspaceRoots = session.multiRootEnabled
+		const runtimeWorkspaceRoots = this._isMultiRootActive(session)
 			? this._runtimeWorkspaceRoots(session)
 			: (sandboxPolicy.type === 'workspaceWrite' ? sandboxPolicy.writableRoots : undefined);
 		const effort = this._getReasoningEffort(session);
@@ -1259,6 +1263,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		const workingDirectories = session.workingDirectories
 			?? (session.workingDirectory ? [session.workingDirectory] : []);
 		return distinctAbsolutePaths(workingDirectories.map(directory => directory.fsPath));
+	}
+
+	private _isMultiRootActive(session: ICodexSession): boolean {
+		return session.multiRootEnabled && (session.workingDirectories?.length ?? 0) > 1;
 	}
 
 	private async _refreshModels(): Promise<void> {
@@ -2772,7 +2780,9 @@ export class CodexAgent extends Disposable implements IAgent {
 		const sessionId = config.session ? AgentSession.id(config.session) : generateUuid();
 		const sessionUri = config.session ?? AgentSession.uri(this.id, sessionId);
 		const multiRootEnabled = this._isMultiRootEnabled();
-		const workingDirectories = multiRootEnabled ? distinctWorkingDirectories(config.workingDirectories) : undefined;
+		const workingDirectories = multiRootEnabled && (config.workingDirectories?.length ?? 0) > 1
+			? distinctWorkingDirectories(config.workingDirectories)
+			: undefined;
 
 		// If the workbench is rebinding this URI (createSession arriving
 		// after a previous dispose for the same id), reuse the existing
@@ -2851,7 +2861,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sessionUri,
 			workingDirectory,
 			workingDirectories: effectiveWorkingDirectories,
-			multiRootEnabled: multiRootEnabled ?? ((effectiveWorkingDirectories?.length ?? 0) > 1 || this._isMultiRootEnabled()),
+			multiRootEnabled: multiRootEnabled ?? (effectiveWorkingDirectories?.length ?? 0) > 1,
 			managedWorkingDirectory: undefined,
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
@@ -2904,15 +2914,13 @@ export class CodexAgent extends Disposable implements IAgent {
 		const sourceThreadId = sourceRead.thread.id;
 		const sourceTurns = sourceRead.thread.turns ?? [];
 		const sourceSession = this._sessions.get(AgentSession.id(fork.session));
-		const sourceOverlay = sourceSession?.workingDirectories ? undefined : await this._metadataStore.read(fork.session);
 		const sourcePrimary = sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : config.workingDirectories?.[0];
-		const sourceStoredWorkingDirectories = sourceSession?.workingDirectories ?? sourceOverlay?.workingDirectories;
+		const sourceStoredWorkingDirectories = sourceSession?.workingDirectories ?? sourceRead.persistedWorkingDirectories;
 		const inheritedWorkingDirectories = sourcePrimary
 			? distinctWorkingDirectories([sourcePrimary, ...(sourceStoredWorkingDirectories?.slice(1) ?? [])])
 			: undefined;
-		const multiRootEnabled = sourceSession?.multiRootEnabled
-			?? ((inheritedWorkingDirectories?.length ?? 0) > 1 || this._isMultiRootEnabled());
-		const runtimeWorkspaceRoots = multiRootEnabled && inheritedWorkingDirectories
+		const multiRootEnabled = sourceSession?.multiRootEnabled ?? (inheritedWorkingDirectories?.length ?? 0) > 1;
+		const runtimeWorkspaceRoots = multiRootEnabled && inheritedWorkingDirectories && inheritedWorkingDirectories.length > 1
 			? distinctAbsolutePaths(inheritedWorkingDirectories.map(directory => directory.fsPath))
 			: undefined;
 
@@ -3100,7 +3108,8 @@ export class CodexAgent extends Disposable implements IAgent {
 			threadConfig.mcp_servers = mcpServers as JsonValue;
 			this._logService.info(`[Codex] thread/start for session=${session.sessionUri.toString()} with ${mcpServerNames.length} MCP server(s): ${mcpServerNames.join(', ')}`);
 		}
-		const runtimeWorkspaceRoots = session.multiRootEnabled ? this._runtimeWorkspaceRoots(session) : undefined;
+		const multiRootActive = this._isMultiRootActive(session);
+		const runtimeWorkspaceRoots = multiRootActive ? this._runtimeWorkspaceRoots(session) : undefined;
 		const startResult = await conn.client.request<'thread/start', ThreadStartResponse>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
 			...(runtimeWorkspaceRoots?.length ? { runtimeWorkspaceRoots } : {}),
@@ -3112,7 +3121,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			dynamicTools: this._buildDynamicTools(session),
 		});
 		const threadId = startResult.thread.id;
-		if (session.multiRootEnabled && !session.workingDirectories && startResult.runtimeWorkspaceRoots?.length) {
+		if (multiRootActive && !session.workingDirectories && startResult.runtimeWorkspaceRoots?.length) {
 			session.workingDirectories = startResult.runtimeWorkspaceRoots.map(path => URI.file(path));
 			session.workingDirectory = session.workingDirectories[0];
 		}
@@ -3241,16 +3250,19 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		// Persist only once the prewarmed thread is claimed by a turn. This
 		// avoids restoring an expired, never-used prewarm as a live session.
+		const multiRootActive = this._isMultiRootActive(session);
 		const fields = {
 			threadId: session.threadId,
 			cwd: session.workingDirectory,
 			modelId: session.model?.id,
-			workingDirectories: session.multiRootEnabled ? session.workingDirectories : undefined,
+			workingDirectories: multiRootActive ? session.workingDirectories : undefined,
 		};
 		void this._metadataStore.write(session.sessionUri, fields);
-		const canonicalSessionUri = AgentSession.uri(this.id, session.threadId);
-		if (!isEqual(session.sessionUri, canonicalSessionUri)) {
-			void this._metadataStore.write(canonicalSessionUri, fields);
+		if (multiRootActive) {
+			const canonicalSessionUri = AgentSession.uri(this.id, session.threadId);
+			if (!isEqual(session.sessionUri, canonicalSessionUri)) {
+				void this._metadataStore.write(canonicalSessionUri, fields);
+			}
 		}
 	}
 
@@ -3269,7 +3281,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (session.prewarmClaimed) {
 			if (session.threadId === undefined && !session.materializePromise) {
 				session.workingDirectory = workingDirectory;
-				if (session.multiRootEnabled) {
+				if (this._isMultiRootActive(session)) {
 					session.workingDirectories = distinctWorkingDirectories([
 						workingDirectory,
 						...(session.workingDirectories?.slice(1) ?? []),
@@ -3335,7 +3347,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		// assign when the send supplied one, so the resume path keeps emitting the
 		// singular working directory.
 		if (workingDirectories) {
-			session.workingDirectories = session.multiRootEnabled
+			session.workingDirectories = session.multiRootEnabled && workingDirectories.length > 1
 				? distinctWorkingDirectories([
 					session.workingDirectory ?? workingDirectories[0],
 					...workingDirectories.slice(1),
@@ -3396,12 +3408,13 @@ export class CodexAgent extends Disposable implements IAgent {
 				// so a resumed thread reconnects auth-gated servers, matching
 				// the config a fresh `thread/start` would apply.
 				const mcpServers = this._buildSessionMcpServers(session);
-				const runtimeWorkspaceRoots = session.multiRootEnabled ? this._runtimeWorkspaceRoots(session) : undefined;
+				const multiRootActive = this._isMultiRootActive(session);
+				const runtimeWorkspaceRoots = multiRootActive ? this._runtimeWorkspaceRoots(session) : undefined;
 				const resumeResult = await conn.client.request<'thread/resume', ThreadResumeResponse>(
 					'thread/resume',
 					buildCodexResumeParams(this._usageSource, threadId, mcpServers, runtimeWorkspaceRoots),
 				);
-				if (session.multiRootEnabled && !session.workingDirectories && resumeResult.runtimeWorkspaceRoots?.length) {
+				if (multiRootActive && !session.workingDirectories && resumeResult.runtimeWorkspaceRoots?.length) {
 					session.workingDirectories = resumeResult.runtimeWorkspaceRoots.map(path => URI.file(path));
 					session.workingDirectory = session.workingDirectories[0];
 				}
@@ -3785,7 +3798,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		// thread/resume (Decision 8). The threadId came from the metadata
 		// overlay or from `thread/list` (when the session was materialized
 		// in a prior process); `_readSession` returns the resolved id.
-		const metadata = await this._withPersistedWorkingDirectories(session, this._threadToMetadata(read.thread, session));
+		const metadata = this._withWorkingDirectories(
+			this._threadToMetadata(read.thread, session),
+			read.persistedWorkingDirectories,
+		);
 		if (!this._sessions.has(sessionId)) {
 			const workingDirectory = read.thread.cwd ? URI.file(read.thread.cwd) : undefined;
 			const threadId = read.thread.id;
@@ -3806,7 +3822,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		return metadata;
 	}
 
-	private async _readSession(session: URI): Promise<ThreadReadResponse | undefined> {
+	private async _readSession(session: URI): Promise<ICodexSessionRead | undefined> {
 		// Resolve the codex thread id for this session URI. Resolution
 		// order: in-memory session → persisted metadata overlay → URI host
 		// (for sessions materialized in a prior process where sessionId
@@ -3814,9 +3830,11 @@ export class CodexAgent extends Disposable implements IAgent {
 		const sessionId = AgentSession.id(session);
 		const existing = this._sessions.get(sessionId);
 		let threadId = existing?.threadId;
+		let persistedWorkingDirectories = existing?.workingDirectories;
 		if (threadId === undefined) {
 			const overlay = await this._metadataStore.read(session);
 			threadId = overlay.threadId ?? sessionId;
+			persistedWorkingDirectories = overlay.workingDirectories;
 		}
 		try {
 			const conn = await this._ensureConnection();
@@ -3824,7 +3842,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				threadId,
 				includeTurns: true,
 			});
-			return response;
+			return { ...response, persistedWorkingDirectories };
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			// `thread not loaded` is app-server's expected response for any
@@ -3871,10 +3889,11 @@ export class CodexAgent extends Disposable implements IAgent {
 					liveUriByThreadId.set(s.threadId, s.sessionUri);
 				}
 			}
-			return Promise.all(response.data.map(async thread => {
+			return response.data.map(thread => {
 				const sessionUri = liveUriByThreadId.get(thread.id) ?? AgentSession.uri(this.id, thread.id);
-				return this._withPersistedWorkingDirectories(sessionUri, this._threadToMetadata(thread, sessionUri));
-			}));
+				const liveWorkingDirectories = this._sessions.get(AgentSession.id(sessionUri))?.workingDirectories;
+				return this._withWorkingDirectories(this._threadToMetadata(thread, sessionUri), liveWorkingDirectories);
+			});
 		} catch (err) {
 			this._logService.warn(`[Codex] thread/list failed: ${err instanceof Error ? err.message : String(err)}`);
 			return [];
@@ -3892,16 +3911,14 @@ export class CodexAgent extends Disposable implements IAgent {
 		};
 	}
 
-	private async _withPersistedWorkingDirectories(sessionUri: URI, metadata: IAgentSessionMetadata): Promise<IAgentSessionMetadata> {
+	private _withWorkingDirectories(metadata: IAgentSessionMetadata, storedWorkingDirectories: readonly URI[] | undefined): IAgentSessionMetadata {
 		const primary = metadata.workingDirectories?.[0];
-		if (!primary) {
+		if (!primary || !storedWorkingDirectories || storedWorkingDirectories.length <= 1) {
 			return metadata;
 		}
-		const liveWorkingDirectories = this._sessions.get(AgentSession.id(sessionUri))?.workingDirectories;
-		const storedWorkingDirectories = liveWorkingDirectories ?? (await this._metadataStore.read(sessionUri)).workingDirectories;
 		const workingDirectories = distinctWorkingDirectories([
 			primary,
-			...(storedWorkingDirectories?.slice(1) ?? []),
+			...storedWorkingDirectories.slice(1),
 		]);
 		return workingDirectories && workingDirectories.length > 1
 			? { ...metadata, workingDirectories }

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -13,7 +13,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { type IObservable, observableValue } from '../../../../base/common/observable.js';
 import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from '../../../../base/common/path.js';
-import { isEqual } from '../../../../base/common/resources.js';
+import { extUriBiasedIgnorePathCase, isEqual } from '../../../../base/common/resources.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -363,8 +363,9 @@ function distinctAbsolutePaths(paths: readonly string[]): string[] {
 	const result: string[] = [];
 	for (const path of paths) {
 		const normalized = normalize(path);
-		if (isAbsolute(normalized) && !seen.has(normalized)) {
-			seen.add(normalized);
+		const key = filesystemPathComparisonKey(normalized);
+		if (key && !seen.has(key)) {
+			seen.add(key);
 			result.push(normalized);
 		}
 	}
@@ -379,12 +380,21 @@ function distinctWorkingDirectories(directories: readonly URI[] | undefined): re
 	const result: URI[] = [];
 	for (const directory of directories) {
 		const path = normalize(directory.fsPath);
-		if (isAbsolute(path) && !seen.has(path)) {
-			seen.add(path);
+		const key = filesystemPathComparisonKey(path);
+		if (key && !seen.has(key)) {
+			seen.add(key);
 			result.push(directory);
 		}
 	}
 	return result.length > 0 ? result : undefined;
+}
+
+function filesystemPathComparisonKey(path: string): string | undefined {
+	if (!isAbsolute(path)) {
+		return undefined;
+	}
+	const resource = extUriBiasedIgnorePathCase.removeTrailingPathSeparator(URI.file(path));
+	return extUriBiasedIgnorePathCase.getComparisonKey(resource);
 }
 
 const CodexPrewarmTtlMs = 60_000;

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -12,7 +12,7 @@ import { fetchResourceMetadata } from '../../../../base/common/oauth.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { type IObservable, observableValue } from '../../../../base/common/observable.js';
-import { basename, dirname, isAbsolute, join, resolve, sep } from '../../../../base/common/path.js';
+import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from '../../../../base/common/path.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -21,7 +21,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { createSchema, platformRootSchema, platformSessionSchema, schemaProperty, AgentHostMcpServersConfigKey, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
+import { createSchema, platformRootSchema, platformSessionSchema, schemaProperty, AgentHostCodexMultiRootEnabledConfigKey, AgentHostMcpServersConfigKey, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, type CodexUsageSource } from '../../common/agentHostCustomizationConfig.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
@@ -92,6 +92,8 @@ import type { Thread } from './protocol/generated/v2/Thread.js';
 import type { ThreadListResponse } from './protocol/generated/v2/ThreadListResponse.js';
 import type { ThreadReadResponse } from './protocol/generated/v2/ThreadReadResponse.js';
 import type { ThreadForkResponse } from './protocol/generated/v2/ThreadForkResponse.js';
+import type { ThreadStartResponse } from './protocol/generated/v2/ThreadStartResponse.js';
+import type { ThreadResumeResponse } from './protocol/generated/v2/ThreadResumeResponse.js';
 import type { TurnCompletedNotification } from './protocol/generated/v2/TurnCompletedNotification.js';
 import type { TurnStartedNotification } from './protocol/generated/v2/TurnStartedNotification.js';
 import type { ItemStartedNotification } from './protocol/generated/v2/ItemStartedNotification.js';
@@ -356,6 +358,35 @@ const codexSessionConfigDefaults: ICodexSessionConfigDefaults = {
 	[CodexSessionConfigKey.ReasoningSummary]: 'auto',
 };
 
+function distinctAbsolutePaths(paths: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const path of paths) {
+		const normalized = normalize(path);
+		if (isAbsolute(normalized) && !seen.has(normalized)) {
+			seen.add(normalized);
+			result.push(normalized);
+		}
+	}
+	return result;
+}
+
+function distinctWorkingDirectories(directories: readonly URI[] | undefined): readonly URI[] | undefined {
+	if (!directories) {
+		return undefined;
+	}
+	const seen = new Set<string>();
+	const result: URI[] = [];
+	for (const directory of directories) {
+		const path = normalize(directory.fsPath);
+		if (isAbsolute(path) && !seen.has(path)) {
+			seen.add(path);
+			result.push(directory);
+		}
+	}
+	return result.length > 0 ? result : undefined;
+}
+
 const CodexPrewarmTtlMs = 60_000;
 
 /**
@@ -404,6 +435,7 @@ interface ICodexSession {
 	 * `workingDirectory`).
 	 */
 	workingDirectories?: readonly URI[];
+	readonly multiRootEnabled: boolean;
 	/**
 	 * Set to the temp folder created for this session when no working
 	 * directory was supplied, so {@link CodexAgent.disposeSession} can remove
@@ -1162,10 +1194,16 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (mode === 'read-only') {
 			return { type: 'readOnly', networkAccess: false };
 		}
-		const writableRoots = [
-			...(session.workingDirectory ? [session.workingDirectory.fsPath] : []),
-			...(narrowAdditionalDirectories(config[CodexSessionConfigKey.AdditionalDirectories]) ?? []),
-		];
+		const additionalDirectories = narrowAdditionalDirectories(config[CodexSessionConfigKey.AdditionalDirectories]) ?? [];
+		const writableRoots = session.multiRootEnabled
+			? distinctAbsolutePaths([
+				...this._runtimeWorkspaceRoots(session),
+				...additionalDirectories,
+			])
+			: [
+				...(session.workingDirectory ? [session.workingDirectory.fsPath] : []),
+				...additionalDirectories,
+			];
 		return {
 			type: 'workspaceWrite',
 			writableRoots,
@@ -1179,7 +1217,9 @@ export class CodexAgent extends Disposable implements IAgent {
 		const config = this._readSessionConfig(session);
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
 		const sandboxPolicy = this._sandboxPolicy(session, config, sandboxMode);
-		const runtimeWorkspaceRoots = sandboxPolicy.type === 'workspaceWrite' ? sandboxPolicy.writableRoots : undefined;
+		const runtimeWorkspaceRoots = session.multiRootEnabled
+			? this._runtimeWorkspaceRoots(session)
+			: (sandboxPolicy.type === 'workspaceWrite' ? sandboxPolicy.writableRoots : undefined);
 		const effort = this._getReasoningEffort(session);
 		const personality = narrowPersonality(config[CodexSessionConfigKey.Personality]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.Personality];
 		const summary = narrowReasoningSummary(config[CodexSessionConfigKey.ReasoningSummary]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.ReasoningSummary];
@@ -1203,6 +1243,12 @@ export class CodexAgent extends Disposable implements IAgent {
 			collaborationMode,
 			...(runtimeWorkspaceRoots ? { runtimeWorkspaceRoots } : {}),
 		};
+	}
+
+	private _runtimeWorkspaceRoots(session: ICodexSession): string[] {
+		const workingDirectories = session.workingDirectories
+			?? (session.workingDirectory ? [session.workingDirectory] : []);
+		return distinctAbsolutePaths(workingDirectories.map(directory => directory.fsPath));
 	}
 
 	private async _refreshModels(): Promise<void> {
@@ -2197,6 +2243,8 @@ export class CodexAgent extends Disposable implements IAgent {
 			threadId: childThreadId,
 			sessionUri: parent.sessionUri,
 			workingDirectory: parent.workingDirectory,
+			workingDirectories: parent.workingDirectories,
+			multiRootEnabled: parent.multiRootEnabled,
 			managedWorkingDirectory: undefined,
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
@@ -2625,7 +2673,12 @@ export class CodexAgent extends Disposable implements IAgent {
 			description: this._usageSource === 'openai'
 				? localize('codexAgent.description.openai', "Codex agent using your OpenAI account")
 				: localize('codexAgent.description.copilot', "Codex agent using GitHub Copilot"),
+			...(this._isMultiRootEnabled() ? { capabilities: { multipleWorkingDirectories: { immutablePrimary: true } } } : {}),
 		};
+	}
+
+	private _isMultiRootEnabled(): boolean {
+		return this._configurationService.getRootValue(platformRootSchema, AgentHostCodexMultiRootEnabledConfigKey) === true;
 	}
 
 	private _sessionUriFromChat(chat: URI): URI {
@@ -2708,6 +2761,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		const effectiveModel = this._supportedModelOrUndefined(config.model);
 		const sessionId = config.session ? AgentSession.id(config.session) : generateUuid();
 		const sessionUri = config.session ?? AgentSession.uri(this.id, sessionId);
+		const multiRootEnabled = this._isMultiRootEnabled();
+		const workingDirectories = multiRootEnabled ? distinctWorkingDirectories(config.workingDirectories) : undefined;
 
 		// If the workbench is rebinding this URI (createSession arriving
 		// after a previous dispose for the same id), reuse the existing
@@ -2729,6 +2784,8 @@ export class CodexAgent extends Disposable implements IAgent {
 			threadId: undefined,
 			sessionUri,
 			workingDirectory: config.workingDirectories?.[0],
+			workingDirectories,
+			multiRootEnabled,
 			managedWorkingDirectory: undefined,
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
@@ -2775,13 +2832,16 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * `thread/resume` (`needsResume: true`) — so the prewarm/first-turn flags
 	 * are pre-set to their post-materialization values.
 	 */
-	private _createResumedSessionEntry(sessionId: string, threadId: string, sessionUri: URI, workingDirectory: URI | undefined, model: ModelSelection | undefined): ICodexSession {
+	private _createResumedSessionEntry(sessionId: string, threadId: string, sessionUri: URI, workingDirectory: URI | undefined, model: ModelSelection | undefined, workingDirectories?: readonly URI[], multiRootEnabled?: boolean): ICodexSession {
 		const clientToolSet = new ActiveClientToolSet();
+		const effectiveWorkingDirectories = distinctWorkingDirectories(workingDirectories);
 		return {
 			sessionId,
 			threadId,
 			sessionUri,
 			workingDirectory,
+			workingDirectories: effectiveWorkingDirectories,
+			multiRootEnabled: multiRootEnabled ?? ((effectiveWorkingDirectories?.length ?? 0) > 1 || this._isMultiRootEnabled()),
 			managedWorkingDirectory: undefined,
 			mapState: createCodexSessionMapState(new Set(this._serverToolHost?.toolNames ?? []), clientToolSet),
 			pendingCommandApprovals: new PendingRequestRegistry<CommandExecutionApprovalDecision>(),
@@ -2833,12 +2893,23 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		const sourceThreadId = sourceRead.thread.id;
 		const sourceTurns = sourceRead.thread.turns ?? [];
+		const sourceSession = this._sessions.get(AgentSession.id(fork.session));
+		const sourceOverlay = sourceSession?.workingDirectories ? undefined : await this._metadataStore.read(fork.session);
+		const sourcePrimary = sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : config.workingDirectories?.[0];
+		const sourceStoredWorkingDirectories = sourceSession?.workingDirectories ?? sourceOverlay?.workingDirectories;
+		const inheritedWorkingDirectories = sourcePrimary
+			? distinctWorkingDirectories([sourcePrimary, ...(sourceStoredWorkingDirectories?.slice(1) ?? [])])
+			: undefined;
+		const multiRootEnabled = sourceSession?.multiRootEnabled
+			?? ((inheritedWorkingDirectories?.length ?? 0) > 1 || this._isMultiRootEnabled());
+		const runtimeWorkspaceRoots = multiRootEnabled && inheritedWorkingDirectories
+			? distinctAbsolutePaths(inheritedWorkingDirectories.map(directory => directory.fsPath))
+			: undefined;
 
 		// Resolve how many trailing turns to drop so the fork keeps turns up to
 		// and including `fork.turnId`. A live source maps host turn ids to codex
 		// turn ids; a restored source already uses codex ids. Fall back to the
 		// caller-supplied `turnIndex` when the id can't be resolved.
-		const sourceSession = this._sessions.get(AgentSession.id(fork.session));
 		const codexTurnId = sourceSession?.codexTurnIdByHostTurnId.get(fork.turnId) ?? fork.turnId;
 		// Reject an unresolvable fork boundary rather than silently keeping the
 		// full history: if neither the mapped codex turn id nor the caller's
@@ -2867,6 +2938,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		);
 		const forkResult = await conn.client.request<'thread/fork', ThreadForkResponse>('thread/fork', {
 			threadId: sourceThreadId,
+			...(runtimeWorkspaceRoots?.length ? {
+				cwd: runtimeWorkspaceRoots[0],
+				runtimeWorkspaceRoots,
+			} : {}),
 			...(model ? { model: model.id } : {}),
 			approvalPolicy,
 			sandbox: sandboxMode,
@@ -2900,8 +2975,15 @@ export class CodexAgent extends Disposable implements IAgent {
 		const workingDirectory = forkResult.cwd
 			? URI.file(forkResult.cwd)
 			: (sourceRead.thread.cwd ? URI.file(sourceRead.thread.cwd) : config.workingDirectories?.[0]);
+		const forkWorkingDirectories = multiRootEnabled
+			? distinctWorkingDirectories(
+				forkResult.runtimeWorkspaceRoots?.length
+					? forkResult.runtimeWorkspaceRoots.map(path => URI.file(path))
+					: inheritedWorkingDirectories,
+			)
+			: undefined;
 
-		const session = this._createResumedSessionEntry(newThreadId, newThreadId, newSessionUri, workingDirectory, model);
+		const session = this._createResumedSessionEntry(newThreadId, newThreadId, newSessionUri, workingDirectory, model, forkWorkingDirectories, multiRootEnabled);
 		this._sessions.set(newThreadId, session);
 		this._sessionIdByThreadId.set(newThreadId, newThreadId);
 		// Forked threads skip materialization (the thread already exists), so
@@ -3008,8 +3090,10 @@ export class CodexAgent extends Disposable implements IAgent {
 			threadConfig.mcp_servers = mcpServers as JsonValue;
 			this._logService.info(`[Codex] thread/start for session=${session.sessionUri.toString()} with ${mcpServerNames.length} MCP server(s): ${mcpServerNames.join(', ')}`);
 		}
-		const startResult = await conn.client.request<'thread/start', { thread: { id: string } }>('thread/start', {
+		const runtimeWorkspaceRoots = session.multiRootEnabled ? this._runtimeWorkspaceRoots(session) : undefined;
+		const startResult = await conn.client.request<'thread/start', ThreadStartResponse>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
+			...(runtimeWorkspaceRoots?.length ? { runtimeWorkspaceRoots } : {}),
 			model: model.id,
 			approvalPolicy,
 			sandbox: sandboxMode,
@@ -3018,6 +3102,10 @@ export class CodexAgent extends Disposable implements IAgent {
 			dynamicTools: this._buildDynamicTools(session),
 		});
 		const threadId = startResult.thread.id;
+		if (session.multiRootEnabled && !session.workingDirectories && startResult.runtimeWorkspaceRoots?.length) {
+			session.workingDirectories = startResult.runtimeWorkspaceRoots.map(path => URI.file(path));
+			session.workingDirectory = session.workingDirectories[0];
+		}
 		if (session.disposed) {
 			try {
 				await conn.client.request<'thread/unsubscribe'>('thread/unsubscribe', { threadId });
@@ -3143,11 +3231,17 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		// Persist only once the prewarmed thread is claimed by a turn. This
 		// avoids restoring an expired, never-used prewarm as a live session.
-		void this._metadataStore.write(session.sessionUri, {
+		const fields = {
 			threadId: session.threadId,
 			cwd: session.workingDirectory,
 			modelId: session.model?.id,
-		});
+			workingDirectories: session.multiRootEnabled ? session.workingDirectories : undefined,
+		};
+		void this._metadataStore.write(session.sessionUri, fields);
+		const canonicalSessionUri = AgentSession.uri(this.id, session.threadId);
+		if (!isEqual(session.sessionUri, canonicalSessionUri)) {
+			void this._metadataStore.write(canonicalSessionUri, fields);
+		}
 	}
 
 	private _claimPrewarm(session: ICodexSession): void {
@@ -3165,6 +3259,12 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (session.prewarmClaimed) {
 			if (session.threadId === undefined && !session.materializePromise) {
 				session.workingDirectory = workingDirectory;
+				if (session.multiRootEnabled) {
+					session.workingDirectories = distinctWorkingDirectories([
+						workingDirectory,
+						...(session.workingDirectories?.slice(1) ?? []),
+					]);
+				}
 			}
 			return;
 		}
@@ -3225,7 +3325,12 @@ export class CodexAgent extends Disposable implements IAgent {
 		// assign when the send supplied one, so the resume path keeps emitting the
 		// singular working directory.
 		if (workingDirectories) {
-			session.workingDirectories = workingDirectories;
+			session.workingDirectories = session.multiRootEnabled
+				? distinctWorkingDirectories([
+					session.workingDirectory ?? workingDirectories[0],
+					...workingDirectories.slice(1),
+				])
+				: workingDirectories;
 		}
 		const conn = await this._ensureConnection();
 		const effectiveTurnId = turnId ?? generateUuid();
@@ -3281,7 +3386,15 @@ export class CodexAgent extends Disposable implements IAgent {
 				// so a resumed thread reconnects auth-gated servers, matching
 				// the config a fresh `thread/start` would apply.
 				const mcpServers = this._buildSessionMcpServers(session);
-				await conn.client.request<'thread/resume'>('thread/resume', buildCodexResumeParams(this._usageSource, threadId, mcpServers));
+				const runtimeWorkspaceRoots = session.multiRootEnabled ? this._runtimeWorkspaceRoots(session) : undefined;
+				const resumeResult = await conn.client.request<'thread/resume', ThreadResumeResponse>(
+					'thread/resume',
+					buildCodexResumeParams(this._usageSource, threadId, mcpServers, runtimeWorkspaceRoots),
+				);
+				if (session.multiRootEnabled && !session.workingDirectories && resumeResult.runtimeWorkspaceRoots?.length) {
+					session.workingDirectories = resumeResult.runtimeWorkspaceRoots.map(path => URI.file(path));
+					session.workingDirectory = session.workingDirectories[0];
+				}
 				session.materializedMcpSig = mcpServersSignature(mcpServers);
 				session.needsResume = false;
 			} catch (err) {
@@ -3662,10 +3775,11 @@ export class CodexAgent extends Disposable implements IAgent {
 		// thread/resume (Decision 8). The threadId came from the metadata
 		// overlay or from `thread/list` (when the session was materialized
 		// in a prior process); `_readSession` returns the resolved id.
+		const metadata = await this._withPersistedWorkingDirectories(session, this._threadToMetadata(read.thread, session));
 		if (!this._sessions.has(sessionId)) {
 			const workingDirectory = read.thread.cwd ? URI.file(read.thread.cwd) : undefined;
 			const threadId = read.thread.id;
-			const restored = this._createResumedSessionEntry(sessionId, threadId, session, workingDirectory, undefined);
+			const restored = this._createResumedSessionEntry(sessionId, threadId, session, workingDirectory, undefined, metadata.workingDirectories);
 			this._sessions.set(sessionId, restored);
 			this._sessionIdByThreadId.set(threadId, sessionId);
 			if (!isCodexThreadProviderCompatible(this._usageSource, read.thread.modelProvider)) {
@@ -3679,7 +3793,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				this._serverToolHost.advertise(restored.sessionUri.toString());
 			}
 		}
-		return this._threadToMetadata(read.thread, session);
+		return metadata;
 	}
 
 	private async _readSession(session: URI): Promise<ThreadReadResponse | undefined> {
@@ -3747,10 +3861,10 @@ export class CodexAgent extends Disposable implements IAgent {
 					liveUriByThreadId.set(s.threadId, s.sessionUri);
 				}
 			}
-			return response.data.map(t => this._threadToMetadata(
-				t,
-				liveUriByThreadId.get(t.id) ?? AgentSession.uri(this.id, t.id),
-			));
+			return Promise.all(response.data.map(async thread => {
+				const sessionUri = liveUriByThreadId.get(thread.id) ?? AgentSession.uri(this.id, thread.id);
+				return this._withPersistedWorkingDirectories(sessionUri, this._threadToMetadata(thread, sessionUri));
+			}));
 		} catch (err) {
 			this._logService.warn(`[Codex] thread/list failed: ${err instanceof Error ? err.message : String(err)}`);
 			return [];
@@ -3766,6 +3880,22 @@ export class CodexAgent extends Disposable implements IAgent {
 			summary: thread.name ?? thread.preview ?? undefined,
 			workingDirectories: thread.cwd ? [URI.file(thread.cwd)] : undefined,
 		};
+	}
+
+	private async _withPersistedWorkingDirectories(sessionUri: URI, metadata: IAgentSessionMetadata): Promise<IAgentSessionMetadata> {
+		const primary = metadata.workingDirectories?.[0];
+		if (!primary) {
+			return metadata;
+		}
+		const liveWorkingDirectories = this._sessions.get(AgentSession.id(sessionUri))?.workingDirectories;
+		const storedWorkingDirectories = liveWorkingDirectories ?? (await this._metadataStore.read(sessionUri)).workingDirectories;
+		const workingDirectories = distinctWorkingDirectories([
+			primary,
+			...(storedWorkingDirectories?.slice(1) ?? []),
+		]);
+		return workingDirectories && workingDirectories.length > 1
+			? { ...metadata, workingDirectories }
+			: metadata;
 	}
 
 	setServerToolHost(host: IAgentServerToolHost): void {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -23,10 +23,14 @@ export function isCodexThreadProviderCompatible(usageSource: CodexUsageSource, m
 }
 
 /** Explicitly bind a compatible resumed thread to the current global usage source. */
-export function buildCodexResumeParams(usageSource: CodexUsageSource, threadId: string, mcpServers: Readonly<Record<string, unknown>>): ThreadResumeParams {
+export function buildCodexResumeParams(usageSource: CodexUsageSource, threadId: string, mcpServers: Readonly<Record<string, unknown>>, workingDirectories?: readonly string[]): ThreadResumeParams {
 	return {
 		threadId,
 		modelProvider: usageSource === 'copilot' ? 'vscode-proxy' : 'openai',
+		...(workingDirectories?.length ? {
+			cwd: workingDirectories[0],
+			runtimeWorkspaceRoots: [...workingDirectories],
+		} : {}),
 		...(Object.keys(mcpServers).length > 0 ? { config: { mcp_servers: mcpServers as JsonValue } } : {}),
 	};
 }

--- a/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
@@ -21,10 +21,11 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
  *                      materialize time.
  *   `codex.cwd`      — absolute path to the working directory the
  *                      session was created against (URI string).
+ *                      Multi-root sessions store a JSON object in this same
+ *                      field so single-root reads retain their original shape.
  *   `codex.model`    — serialized {@link ModelSelection.id} string,
  *                      remembered for restore so resumed sessions reuse
  *                      the model picked during the prior process.
- *   `codex.workingDirectories` — ordered URI strings for multi-root restore.
  */
 
 export interface ICodexSessionOverlay {
@@ -46,8 +47,6 @@ export class CodexSessionMetadataStore {
 	private static readonly KEY_THREAD_ID = 'codex.threadId';
 	private static readonly KEY_CWD = 'codex.cwd';
 	private static readonly KEY_MODEL = 'codex.model';
-	private static readonly KEY_WORKING_DIRECTORIES = 'codex.workingDirectories';
-
 	constructor(
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@ILogService private readonly _logService: ILogService,
@@ -69,16 +68,13 @@ export class CodexSessionMetadataStore {
 					work.push(db.setMetadata(CodexSessionMetadataStore.KEY_THREAD_ID, fields.threadId));
 				}
 				if (fields.cwd !== undefined) {
-					work.push(db.setMetadata(CodexSessionMetadataStore.KEY_CWD, fields.cwd.toString()));
+					work.push(db.setMetadata(
+						CodexSessionMetadataStore.KEY_CWD,
+						serializeCwd(fields.cwd, fields.workingDirectories),
+					));
 				}
 				if (fields.modelId !== undefined) {
 					work.push(db.setMetadata(CodexSessionMetadataStore.KEY_MODEL, fields.modelId));
-				}
-				if (fields.workingDirectories !== undefined) {
-					work.push(db.setMetadata(
-						CodexSessionMetadataStore.KEY_WORKING_DIRECTORIES,
-						JSON.stringify(fields.workingDirectories.map(directory => directory.toString())),
-					));
 				}
 				await Promise.all(work);
 			} finally {
@@ -101,17 +97,17 @@ export class CodexSessionMetadataStore {
 				return {};
 			}
 			try {
-				const [threadId, cwdRaw, modelId, workingDirectoriesRaw] = await Promise.all([
+				const [threadId, cwdRaw, modelId] = await Promise.all([
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_THREAD_ID),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_CWD),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_MODEL),
-					ref.object.getMetadata(CodexSessionMetadataStore.KEY_WORKING_DIRECTORIES),
 				]);
+				const cwd = parseCwd(cwdRaw);
 				return {
 					threadId: threadId ?? undefined,
-					cwd: cwdRaw ? URI.parse(cwdRaw) : undefined,
+					cwd: cwd.cwd,
 					modelId: modelId ?? undefined,
-					workingDirectories: parseWorkingDirectories(workingDirectoriesRaw),
+					workingDirectories: cwd.workingDirectories,
 				};
 			} finally {
 				ref.dispose();
@@ -124,20 +120,38 @@ export class CodexSessionMetadataStore {
 
 }
 
-function parseWorkingDirectories(raw: string | undefined): readonly URI[] | undefined {
+function serializeCwd(cwd: URI, workingDirectories: readonly URI[] | undefined): string {
+	if (!workingDirectories || workingDirectories.length <= 1) {
+		return cwd.toString();
+	}
+	return JSON.stringify({
+		cwd: cwd.toString(),
+		workingDirectories: workingDirectories.map(directory => directory.toString()),
+	});
+}
+
+function parseCwd(raw: string | undefined): { readonly cwd?: URI; readonly workingDirectories?: readonly URI[] } {
 	if (!raw) {
-		return undefined;
+		return {};
+	}
+	if (!raw.startsWith('{')) {
+		return { cwd: URI.parse(raw) };
 	}
 	try {
-		const value: unknown = JSON.parse(raw);
-		if (Array.isArray(value)) {
-			const directories = value
-				.filter((directory): directory is string => typeof directory === 'string')
-				.map(directory => URI.parse(directory));
-			return directories.length > 0 ? directories : undefined;
+		const value: { cwd?: unknown; workingDirectories?: unknown } = JSON.parse(raw);
+		if (typeof value.cwd !== 'string') {
+			return {};
 		}
+		const workingDirectories = Array.isArray(value.workingDirectories)
+			? value.workingDirectories
+				.filter((directory): directory is string => typeof directory === 'string')
+				.map(directory => URI.parse(directory))
+			: undefined;
+		return {
+			cwd: URI.parse(value.cwd),
+			workingDirectories: workingDirectories && workingDirectories.length > 1 ? workingDirectories : undefined,
+		};
 	} catch {
-		// Invalid optional metadata is ignored.
+		return {};
 	}
-	return undefined;
 }

--- a/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
@@ -24,18 +24,21 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
  *   `codex.model`    — serialized {@link ModelSelection.id} string,
  *                      remembered for restore so resumed sessions reuse
  *                      the model picked during the prior process.
+ *   `codex.workingDirectories` — ordered URI strings for multi-root restore.
  */
 
 export interface ICodexSessionOverlay {
 	readonly threadId?: string;
 	readonly cwd?: URI;
 	readonly modelId?: string;
+	readonly workingDirectories?: readonly URI[];
 }
 
 export interface ICodexSessionOverlayUpdate {
 	readonly threadId?: string;
 	readonly cwd?: URI;
 	readonly modelId?: string;
+	readonly workingDirectories?: readonly URI[];
 }
 
 export class CodexSessionMetadataStore {
@@ -43,6 +46,7 @@ export class CodexSessionMetadataStore {
 	private static readonly KEY_THREAD_ID = 'codex.threadId';
 	private static readonly KEY_CWD = 'codex.cwd';
 	private static readonly KEY_MODEL = 'codex.model';
+	private static readonly KEY_WORKING_DIRECTORIES = 'codex.workingDirectories';
 
 	constructor(
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
@@ -70,6 +74,12 @@ export class CodexSessionMetadataStore {
 				if (fields.modelId !== undefined) {
 					work.push(db.setMetadata(CodexSessionMetadataStore.KEY_MODEL, fields.modelId));
 				}
+				if (fields.workingDirectories !== undefined) {
+					work.push(db.setMetadata(
+						CodexSessionMetadataStore.KEY_WORKING_DIRECTORIES,
+						JSON.stringify(fields.workingDirectories.map(directory => directory.toString())),
+					));
+				}
 				await Promise.all(work);
 			} finally {
 				ref.dispose();
@@ -91,15 +101,17 @@ export class CodexSessionMetadataStore {
 				return {};
 			}
 			try {
-				const [threadId, cwdRaw, modelId] = await Promise.all([
+				const [threadId, cwdRaw, modelId, workingDirectoriesRaw] = await Promise.all([
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_THREAD_ID),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_CWD),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_MODEL),
+					ref.object.getMetadata(CodexSessionMetadataStore.KEY_WORKING_DIRECTORIES),
 				]);
 				return {
 					threadId: threadId ?? undefined,
 					cwd: cwdRaw ? URI.parse(cwdRaw) : undefined,
 					modelId: modelId ?? undefined,
+					workingDirectories: parseWorkingDirectories(workingDirectoriesRaw),
 				};
 			} finally {
 				ref.dispose();
@@ -109,4 +121,23 @@ export class CodexSessionMetadataStore {
 			return {};
 		}
 	}
+
+}
+
+function parseWorkingDirectories(raw: string | undefined): readonly URI[] | undefined {
+	if (!raw) {
+		return undefined;
+	}
+	try {
+		const value: unknown = JSON.parse(raw);
+		if (Array.isArray(value)) {
+			const directories = value
+				.filter((directory): directory is string => typeof directory === 'string')
+				.map(directory => URI.parse(directory));
+			return directories.length > 0 ? directories : undefined;
+		}
+	} catch {
+		// Invalid optional metadata is ignored.
+	}
+	return undefined;
 }

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -29,8 +29,8 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostCodexAgentEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostCodexAgentEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -964,6 +964,23 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostClaudeMultiRootEnabledConfigKey);
 		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostClaudeMultiRootEnabledConfigKey]: false });
+	});
+
+	test('forwards Codex multi-root enablement on connect and when the setting changes', async () => {
+		const configurationService = new TestConfigurationService({ [AgentHostCodexMultiRootEnabledSettingId]: true });
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+
+		await connectClient(client, transport);
+
+		const multiRootEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(multiRootEnabled), { [AgentHostCodexMultiRootEnabledConfigKey]: true });
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(AgentHostCodexMultiRootEnabledSettingId, false);
+		fireConfigurationChange(configurationService, AgentHostCodexMultiRootEnabledSettingId);
+
+		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey);
+		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostCodexMultiRootEnabledConfigKey]: false });
 	});
 
 	test('forwards auto-reply on connect and when the setting changes', async () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -54,5 +54,11 @@ suite('CodexLaunchConfig', () => {
 			modelProvider: 'vscode-proxy',
 			config: { mcp_servers: { GitHub: { url: 'https://api.githubcopilot.com/mcp/' } } },
 		});
+		assert.deepStrictEqual(buildCodexResumeParams('openai', 'thread-c', {}, ['/repo-a', '/repo-b']), {
+			threadId: 'thread-c',
+			modelProvider: 'openai',
+			cwd: '/repo-a',
+			runtimeWorkspaceRoots: ['/repo-a', '/repo-b'],
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -5,7 +5,6 @@
 
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
-import { Event } from '../../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -14,29 +13,31 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
-import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { CodexAgent } from '../../../node/codex/codexAgent.js';
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { ISessionDataService } from '../../../common/sessionDataService.js';
 import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
+import { AgentHostCodexMultiRootEnabledConfigKey } from '../../../common/agentHostSchema.js';
 
-function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Promise<CCAModel[]>): CodexAgent {
+function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Promise<CCAModel[]>, rootConfig: Record<string, boolean> = {}): CodexAgent {
 	const instantiationService = new TestInstantiationService();
+	const logService = new NullLogService();
+	const stateManager = disposables.add(new AgentHostStateManager(logService));
+	const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+	configurationService.updateRootConfig(rootConfig);
 	instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
 	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined, models });
 	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
-	instantiationService.stub(IAgentConfigurationService, {
-		_serviceBrand: undefined,
-		onDidRootConfigChange: Event.None,
-		getRootValue: () => undefined,
-	});
+	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
-	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ILogService, logService);
 	return disposables.add(instantiationService.createInstance(CodexAgent));
 }
 
@@ -61,5 +62,20 @@ suite('CodexAgent model refresh', () => {
 		await agent.refreshModels();
 
 		assert.deepStrictEqual(agent.models.get().map(model => model.id), ['gpt-5.5']);
+	});
+
+	test('advertises multiple working directories only while enabled', () => {
+		const agent = createAgent(disposables, async () => []);
+		const disabledByDefault = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+		agent['_configurationService'].updateRootConfig({ [AgentHostCodexMultiRootEnabledConfigKey]: true });
+		const whenEnabled = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+		agent['_configurationService'].updateRootConfig({ [AgentHostCodexMultiRootEnabledConfigKey]: false });
+		const afterDisabling = agent.getDescriptor().capabilities?.multipleWorkingDirectories;
+
+		assert.deepStrictEqual({ disabledByDefault, whenEnabled, afterDisabling }, {
+			disabledByDefault: undefined,
+			whenEnabled: { immutablePrimary: true },
+			afterDisabling: undefined,
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -9,6 +9,8 @@ import { PassThrough } from 'stream';
 import { Emitter } from '../../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { sep } from '../../../../../base/common/path.js';
+import { isWindows } from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { INativeEnvironmentService } from '../../../../../platform/environment/common/environment.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -236,11 +238,11 @@ suite('CodexAgent prewarm eviction', () => {
 	});
 
 	test('multi-root start and turn separate workspace roots from additional writable directories', async () => {
-		const additionalDirectory = '/manual-write';
+		const additionalDirectory = URI.file('/manual-write').fsPath;
 		const sessionUri = AgentSession.uri('codex', 'multi-root');
 		const agent = await createAgent(disposables, {
 			multiRootEnabled: true,
-			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory] },
+			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory, `${additionalDirectory}${sep}`] },
 		});
 		const peer = disposables.add(createTestPeer());
 		const client = new CodexAppServerClient(peer.transport);
@@ -254,15 +256,18 @@ suite('CodexAgent prewarm eviction', () => {
 		agent['_refreshSkillExtraRoots'] = async () => { };
 		const repoA = URI.file('/repo-a');
 		const repoB = URI.file('/repo-b');
+		const duplicateRepoA = URI.file(`${repoA.fsPath}${sep}`);
+		const caseVariantRepoA = URI.file(repoA.fsPath.toUpperCase());
 
 		try {
-			const { session } = await agent.createSession({ session: sessionUri, workingDirectories: [repoA, repoB], model: { id: 'gpt-test' } });
+			const workingDirectories = [repoA, duplicateRepoA, ...(isWindows ? [caseVariantRepoA] : []), repoB];
+			const { session } = await agent.createSession({ session: sessionUri, workingDirectories, model: { id: 'gpt-test' } });
 			const entry = agent['_sessions'].get(AgentSession.id(session))!;
 			const start = await readNextRequest(peer.outbound);
 			peer.push({ id: start.id, result: { thread: { id: 'thread' }, runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath] } });
 			await entry.materializePromise;
 
-			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', [repoA, repoB], undefined, 'turn-1');
+			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', workingDirectories, undefined, 'turn-1');
 			const turn = await readNextRequest(peer.outbound);
 			peer.push({ id: turn.id, result: {} });
 			await send;
@@ -314,7 +319,7 @@ suite('CodexAgent prewarm eviction', () => {
 	});
 
 	test('disabled multi-root preserves the existing additional-directory payload', async () => {
-		const additionalDirectory = '/manual-write';
+		const additionalDirectory = URI.file('/manual-write').fsPath;
 		const sessionUri = AgentSession.uri('codex', 'single-root');
 		const agent = await createAgent(disposables, {
 			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory] },

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -6,7 +6,7 @@
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import { PassThrough } from 'stream';
-import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Emitter } from '../../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -17,7 +17,8 @@ import { IProductService } from '../../../../../platform/product/common/productS
 import { AgentSession } from '../../../common/agentService.js';
 import { buildDefaultChatUri } from '../../../common/state/sessionState.js';
 import { ISessionDataService } from '../../../common/sessionDataService.js';
-import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { CodexAgent } from '../../../node/codex/codexAgent.js';
@@ -25,6 +26,10 @@ import { CodexAppServerClient, type ICodexAppServerTransport } from '../../../no
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
+import { AgentHostCodexMultiRootEnabledConfigKey } from '../../../common/agentHostSchema.js';
+import { CodexSessionConfigKey } from '../../../common/codexSessionConfigKeys.js';
+import type { SandboxPolicy } from '../../../node/codex/protocol/generated/v2/SandboxPolicy.js';
+import { createSessionDataService, TestSessionDatabase } from '../../common/sessionTestHelpers.js';
 
 interface ITestWireRequest {
 	readonly id: number;
@@ -32,6 +37,8 @@ interface ITestWireRequest {
 	readonly params: {
 		readonly cwd?: string;
 		readonly threadId?: string;
+		readonly runtimeWorkspaceRoots?: readonly string[];
+		readonly sandboxPolicy?: SandboxPolicy;
 	};
 }
 
@@ -98,25 +105,46 @@ function readNextRequest(stream: PassThrough): Promise<ITestWireRequest> {
 	});
 }
 
-async function createAgent(disposables: Pick<DisposableStore, 'add'>): Promise<CodexAgent> {
+interface ICreateAgentOptions {
+	readonly multiRootEnabled?: boolean;
+	readonly sessionConfig?: Readonly<Record<string, boolean | string | readonly string[]>>;
+	readonly database?: TestSessionDatabase;
+}
+
+class TestCodexConfigurationService extends AgentConfigurationService {
+	constructor(
+		stateManager: AgentHostStateManager,
+		logService: NullLogService,
+		private sessionConfig: Readonly<Record<string, boolean | string | readonly string[]>> | undefined,
+	) {
+		super(stateManager, logService);
+	}
+
+	setSessionConfig(sessionConfig: Readonly<Record<string, boolean | string | readonly string[]>>): void {
+		this.sessionConfig = sessionConfig;
+	}
+
+	override getSessionConfigValues(): Record<string, unknown> | undefined {
+		return this.sessionConfig ? { ...this.sessionConfig } : undefined;
+	}
+}
+
+async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: ICreateAgentOptions = {}): Promise<CodexAgent> {
 	const models = [{ id: 'gpt-test', name: 'GPT Test', supported_endpoints: ['/responses'] }] as CCAModel[];
 	const instantiationService = new TestInstantiationService();
-	instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
+	const logService = new NullLogService();
+	const stateManager = disposables.add(new AgentHostStateManager(logService));
+	const configurationService = disposables.add(new TestCodexConfigurationService(stateManager, logService, options.sessionConfig));
+	configurationService.updateRootConfig({ [AgentHostCodexMultiRootEnabledConfigKey]: options.multiRootEnabled });
+	instantiationService.stub(ISessionDataService, createSessionDataService(options.database));
 	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined, models: async () => models });
 	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
-	instantiationService.stub(IAgentConfigurationService, {
-		_serviceBrand: undefined,
-		onDidRootConfigChange: Event.None,
-		getRootValue: () => undefined,
-		getSessionConfigValues: () => undefined,
-		isWorkingDirectoryPending: () => false,
-		updateRootConfig: () => { },
-	});
+	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined, isSdkResolvableWithoutDownload: async () => true });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
-	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ILogService, logService);
 	const agent = disposables.add(instantiationService.createInstance(CodexAgent));
 	await agent.authenticate(agent.getProtectedResources()[0].resource, 'test-token');
 	await agent.refreshModels();
@@ -205,5 +233,291 @@ suite('CodexAgent prewarm eviction', () => {
 
 	test('waits for and evicts an in-flight folder prewarm when the first send resolves to a worktree', async () => {
 		await assertPrewarmEvictedOnSend(disposables, false);
+	});
+
+	test('multi-root start and turn separate workspace roots from additional writable directories', async () => {
+		const additionalDirectory = '/manual-write';
+		const sessionUri = AgentSession.uri('codex', 'multi-root');
+		const agent = await createAgent(disposables, {
+			multiRootEnabled: true,
+			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory] },
+		});
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = {
+			kind: 'ready',
+			client,
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const repoA = URI.file('/repo-a');
+		const repoB = URI.file('/repo-b');
+
+		try {
+			const { session } = await agent.createSession({ session: sessionUri, workingDirectories: [repoA, repoB], model: { id: 'gpt-test' } });
+			const entry = agent['_sessions'].get(AgentSession.id(session))!;
+			const start = await readNextRequest(peer.outbound);
+			peer.push({ id: start.id, result: { thread: { id: 'thread' }, runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath] } });
+			await entry.materializePromise;
+
+			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', [repoA, repoB], undefined, 'turn-1');
+			const turn = await readNextRequest(peer.outbound);
+			peer.push({ id: turn.id, result: {} });
+			await send;
+			const configurationService = agent['_configurationService'];
+			assert.ok(configurationService instanceof TestCodexConfigurationService);
+			configurationService.setSessionConfig({ [CodexSessionConfigKey.PermissionsPreset]: 'full-access' });
+			const fullAccess = agent['_turnStartOptions'](entry, 'gpt-test');
+			configurationService.setSessionConfig({ [CodexSessionConfigKey.SandboxMode]: 'read-only' });
+			const readOnly = agent['_turnStartOptions'](entry, 'gpt-test');
+
+			assert.deepStrictEqual({
+				start: { cwd: start.params.cwd, runtimeWorkspaceRoots: start.params.runtimeWorkspaceRoots },
+				turn: {
+					runtimeWorkspaceRoots: turn.params.runtimeWorkspaceRoots,
+					sandboxPolicy: turn.params.sandboxPolicy,
+				},
+				fullAccess: {
+					runtimeWorkspaceRoots: fullAccess.runtimeWorkspaceRoots,
+					sandboxPolicy: fullAccess.sandboxPolicy,
+				},
+				readOnly: {
+					runtimeWorkspaceRoots: readOnly.runtimeWorkspaceRoots,
+					sandboxPolicy: readOnly.sandboxPolicy,
+				},
+			}, {
+				start: { cwd: repoA.fsPath, runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath] },
+				turn: {
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+					sandboxPolicy: {
+						type: 'workspaceWrite',
+						writableRoots: [repoA.fsPath, repoB.fsPath, additionalDirectory],
+						networkAccess: false,
+						excludeTmpdirEnvVar: false,
+						excludeSlashTmp: false,
+					},
+				},
+				fullAccess: {
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+					sandboxPolicy: { type: 'dangerFullAccess' },
+				},
+				readOnly: {
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+					sandboxPolicy: { type: 'readOnly', networkAccess: false },
+				},
+			});
+		} finally {
+			peer.exit();
+		}
+	});
+
+	test('disabled multi-root preserves the existing additional-directory payload', async () => {
+		const additionalDirectory = '/manual-write';
+		const sessionUri = AgentSession.uri('codex', 'single-root');
+		const agent = await createAgent(disposables, {
+			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory] },
+		});
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = {
+			kind: 'ready',
+			client,
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const repoA = URI.file('/repo-a');
+		const repoB = URI.file('/repo-b');
+
+		try {
+			const { session } = await agent.createSession({ session: sessionUri, workingDirectories: [repoA, repoB], model: { id: 'gpt-test' } });
+			const entry = agent['_sessions'].get(AgentSession.id(session))!;
+			const start = await readNextRequest(peer.outbound);
+			peer.push({ id: start.id, result: { thread: { id: 'thread' } } });
+			await entry.materializePromise;
+
+			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', [repoA], undefined, 'turn-1');
+			const turn = await readNextRequest(peer.outbound);
+			peer.push({ id: turn.id, result: {} });
+			await send;
+
+			assert.deepStrictEqual({
+				startRuntimeWorkspaceRoots: start.params.runtimeWorkspaceRoots,
+				turnRuntimeWorkspaceRoots: turn.params.runtimeWorkspaceRoots,
+				writableRoots: turn.params.sandboxPolicy?.type === 'workspaceWrite' ? turn.params.sandboxPolicy.writableRoots : undefined,
+			}, {
+				startRuntimeWorkspaceRoots: undefined,
+				turnRuntimeWorkspaceRoots: [repoA.fsPath, additionalDirectory],
+				writableRoots: [repoA.fsPath, additionalDirectory],
+			});
+		} finally {
+			peer.exit();
+		}
+	});
+
+	test('fork inherits the source workspace roots instead of requested replacements', async () => {
+		const agent = await createAgent(disposables, { multiRootEnabled: true });
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = {
+			kind: 'ready',
+			client,
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const repoA = URI.file('/repo-a');
+		const repoB = URI.file('/repo-b');
+		const requestedA = URI.file('/requested-a');
+		const requestedB = URI.file('/requested-b');
+
+		try {
+			const source = await agent.createSession({ workingDirectories: [repoA, repoB], model: { id: 'gpt-test' } });
+			const sourceEntry = agent['_sessions'].get(AgentSession.id(source.session))!;
+			const start = await readNextRequest(peer.outbound);
+			peer.push({ id: start.id, result: { thread: { id: 'source-thread' }, cwd: repoA.fsPath, runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath] } });
+			await sourceEntry.materializePromise;
+
+			const forkPromise = agent.createSession({
+				workingDirectories: [requestedA, requestedB],
+				fork: { session: source.session, turnId: 'turn-1', turnIndex: 0 },
+			});
+			const read = await readNextRequest(peer.outbound);
+			peer.push({
+				id: read.id,
+				result: {
+					thread: {
+						id: 'source-thread',
+						cwd: repoA.fsPath,
+						turns: [{ id: 'turn-1' }],
+					},
+				},
+			});
+			const fork = await readNextRequest(peer.outbound);
+			peer.push({
+				id: fork.id,
+				result: {
+					thread: { id: 'fork-thread', cwd: repoA.fsPath },
+					cwd: repoA.fsPath,
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+				},
+			});
+			const forked = await forkPromise;
+			const forkedEntry = agent['_sessions'].get(AgentSession.id(forked.session))!;
+
+			assert.deepStrictEqual({
+				request: {
+					method: fork.method,
+					cwd: fork.params.cwd,
+					runtimeWorkspaceRoots: fork.params.runtimeWorkspaceRoots,
+				},
+				workingDirectories: forkedEntry.workingDirectories?.map(directory => directory.fsPath),
+			}, {
+				request: {
+					method: 'thread/fork',
+					cwd: repoA.fsPath,
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+				},
+				workingDirectories: [repoA.fsPath, repoB.fsPath],
+			});
+		} finally {
+			peer.exit();
+		}
+	});
+
+	test('cold resume restores persisted workspace roots', async () => {
+		const database = new TestSessionDatabase();
+		const repoA = URI.file('/repo-a');
+		const repoB = URI.file('/repo-b');
+		const agentA = await createAgent(disposables, { multiRootEnabled: true, database });
+		const peerA = disposables.add(createTestPeer());
+		agentA['_connection'] = {
+			kind: 'ready',
+			client: new CodexAppServerClient(peerA.transport),
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+		agentA['_refreshSkillHookCustomizations'] = async () => { };
+		agentA['_refreshSkillExtraRoots'] = async () => { };
+		let peerB: ITestPeer | undefined;
+
+		try {
+			const created = await agentA.createSession({ workingDirectories: [repoA, repoB], model: { id: 'gpt-test' } });
+			const entry = agentA['_sessions'].get(AgentSession.id(created.session))!;
+			const start = await readNextRequest(peerA.outbound);
+			peerA.push({ id: start.id, result: { thread: { id: 'thread' }, cwd: repoA.fsPath, runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath] } });
+			await entry.materializePromise;
+			const firstSend = agentA.chats.sendMessage(URI.parse(buildDefaultChatUri(created.session)), 'hello', [repoA, repoB], undefined, 'turn-1');
+			const firstTurn = await readNextRequest(peerA.outbound);
+			peerA.push({ id: firstTurn.id, result: {} });
+			await firstSend;
+			await new Promise(resolve => setImmediate(resolve));
+			const canonicalOverlay = await agentA['_metadataStore'].read(AgentSession.uri('codex', 'thread'));
+
+			const agentB = await createAgent(disposables, { multiRootEnabled: true, database });
+			peerB = disposables.add(createTestPeer());
+			agentB['_connection'] = {
+				kind: 'ready',
+				client: new CodexAppServerClient(peerB.transport),
+				usageSource: 'github',
+				child: { kill: () => true },
+			} as never;
+			agentB['_refreshSkillHookCustomizations'] = async () => { };
+			agentB['_refreshSkillExtraRoots'] = async () => { };
+
+			const metadataPromise = agentB.getSessionMetadata(created.session);
+			const read = await readNextRequest(peerB.outbound);
+			peerB.push({
+				id: read.id,
+				result: {
+					thread: {
+						id: 'thread',
+						cwd: repoA.fsPath,
+						modelProvider: 'vscode-proxy',
+						turns: [],
+					},
+				},
+			});
+			const metadata = await metadataPromise;
+
+			const resumedSend = agentB.chats.sendMessage(URI.parse(buildDefaultChatUri(created.session)), 'again', undefined, undefined, 'turn-2');
+			const resume = await readNextRequest(peerB.outbound);
+			peerB.push({
+				id: resume.id,
+				result: {
+					thread: { id: 'thread', cwd: repoA.fsPath },
+					cwd: repoA.fsPath,
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+				},
+			});
+			const resumedTurn = await readNextRequest(peerB.outbound);
+			peerB.push({ id: resumedTurn.id, result: {} });
+			await resumedSend;
+
+			assert.deepStrictEqual({
+				canonicalOverlay: canonicalOverlay.workingDirectories?.map(directory => directory.fsPath),
+				metadata: metadata?.workingDirectories?.map(directory => directory.fsPath),
+				resume: {
+					cwd: resume.params.cwd,
+					runtimeWorkspaceRoots: resume.params.runtimeWorkspaceRoots,
+				},
+				turnRuntimeWorkspaceRoots: resumedTurn.params.runtimeWorkspaceRoots,
+			}, {
+				canonicalOverlay: [repoA.fsPath, repoB.fsPath],
+				metadata: [repoA.fsPath, repoB.fsPath],
+				resume: {
+					cwd: repoA.fsPath,
+					runtimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+				},
+				turnRuntimeWorkspaceRoots: [repoA.fsPath, repoB.fsPath],
+			});
+		} finally {
+			peerB?.exit();
+			peerA.exit();
+		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -363,6 +363,89 @@ suite('CodexAgent prewarm eviction', () => {
 		}
 	});
 
+	test('enabled multi-root preserves single-folder protocol and sandbox behavior', async () => {
+		const additionalDirectory = `${URI.file('/manual-write').fsPath}${sep}`;
+		const sessionUri = AgentSession.uri('codex', 'enabled-single-root');
+		const agent = await createAgent(disposables, {
+			multiRootEnabled: true,
+			sessionConfig: { [CodexSessionConfigKey.AdditionalDirectories]: [additionalDirectory] },
+		});
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = {
+			kind: 'ready',
+			client,
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const repo = URI.file('/repo');
+
+		try {
+			const { session } = await agent.createSession({ session: sessionUri, workingDirectories: [repo], model: { id: 'gpt-test' } });
+			const entry = agent['_sessions'].get(AgentSession.id(session))!;
+			const start = await readNextRequest(peer.outbound);
+			peer.push({ id: start.id, result: { thread: { id: 'thread' } } });
+			await entry.materializePromise;
+
+			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', [repo], undefined, 'turn-1');
+			const turn = await readNextRequest(peer.outbound);
+			peer.push({ id: turn.id, result: {} });
+			await send;
+			const configurationService = agent['_configurationService'];
+			assert.ok(configurationService instanceof TestCodexConfigurationService);
+			configurationService.setSessionConfig({ [CodexSessionConfigKey.PermissionsPreset]: 'full-access' });
+			const fullAccess = agent['_turnStartOptions'](entry, 'gpt-test');
+			configurationService.setSessionConfig({ [CodexSessionConfigKey.SandboxMode]: 'read-only' });
+			const readOnly = agent['_turnStartOptions'](entry, 'gpt-test');
+
+			assert.deepStrictEqual({
+				start: {
+					cwd: start.params.cwd,
+					runtimeWorkspaceRoots: start.params.runtimeWorkspaceRoots,
+				},
+				turn: {
+					runtimeWorkspaceRoots: turn.params.runtimeWorkspaceRoots,
+					sandboxPolicy: turn.params.sandboxPolicy,
+				},
+				fullAccess: {
+					runtimeWorkspaceRoots: fullAccess.runtimeWorkspaceRoots,
+					sandboxPolicy: fullAccess.sandboxPolicy,
+				},
+				readOnly: {
+					runtimeWorkspaceRoots: readOnly.runtimeWorkspaceRoots,
+					sandboxPolicy: readOnly.sandboxPolicy,
+				},
+			}, {
+				start: {
+					cwd: repo.fsPath,
+					runtimeWorkspaceRoots: undefined,
+				},
+				turn: {
+					runtimeWorkspaceRoots: [repo.fsPath, additionalDirectory],
+					sandboxPolicy: {
+						type: 'workspaceWrite',
+						writableRoots: [repo.fsPath, additionalDirectory],
+						networkAccess: false,
+						excludeTmpdirEnvVar: false,
+						excludeSlashTmp: false,
+					},
+				},
+				fullAccess: {
+					runtimeWorkspaceRoots: undefined,
+					sandboxPolicy: { type: 'dangerFullAccess' },
+				},
+				readOnly: {
+					runtimeWorkspaceRoots: undefined,
+					sandboxPolicy: { type: 'readOnly', networkAccess: false },
+				},
+			});
+		} finally {
+			peer.exit();
+		}
+	});
+
 	test('fork inherits the source workspace roots instead of requested replacements', async () => {
 		const agent = await createAgent(disposables, { multiRootEnabled: true });
 		const peer = disposables.add(createTestPeer());

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { CodexSessionMetadataStore } from '../../../node/codex/codexSessionMetadataStore.js';
+import { createSessionDataService, TestSessionDatabase } from '../../common/sessionTestHelpers.js';
+
+suite('CodexSessionMetadataStore', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('round trips working directories', async () => {
+		const store = new CodexSessionMetadataStore(createSessionDataService(), new NullLogService());
+		const session = URI.parse('codex:/session');
+		const workingDirectories = [URI.file('/repo-a'), URI.file('/repo-b')];
+
+		await store.write(session, { threadId: 'thread', cwd: workingDirectories[0], workingDirectories });
+
+		const overlay = await store.read(session);
+		assert.deepStrictEqual({
+			threadId: overlay.threadId,
+			cwd: overlay.cwd?.toString(),
+			workingDirectories: overlay.workingDirectories?.map(directory => directory.toString()),
+		}, {
+			threadId: 'thread',
+			cwd: workingDirectories[0].toString(),
+			workingDirectories: workingDirectories.map(directory => directory.toString()),
+		});
+	});
+
+	test('ignores malformed working directory metadata', async () => {
+		const database = new TestSessionDatabase();
+		await database.setMetadata('codex.workingDirectories', '{');
+		const store = new CodexSessionMetadataStore(createSessionDataService(database), new NullLogService());
+
+		const overlay = await store.read(URI.parse('codex:/session'));
+
+		assert.strictEqual(overlay.workingDirectories, undefined);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
@@ -34,11 +34,14 @@ suite('CodexSessionMetadataStore', () => {
 
 	test('ignores malformed working directory metadata', async () => {
 		const database = new TestSessionDatabase();
-		await database.setMetadata('codex.workingDirectories', '{');
+		await database.setMetadata('codex.cwd', '{"cwd":');
 		const store = new CodexSessionMetadataStore(createSessionDataService(database), new NullLogService());
 
 		const overlay = await store.read(URI.parse('codex:/session'));
 
-		assert.strictEqual(overlay.workingDirectories, undefined);
+		assert.deepStrictEqual({ cwd: overlay.cwd, workingDirectories: overlay.workingDirectories }, {
+			cwd: undefined,
+			workingDirectories: undefined,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- add a hidden, default-off setting that enables Codex multi-root session support
- forward workspace roots through Codex thread start, turn, resume, and fork operations
- persist ordered working directories for cold resume, session listing, and fork recovery
- keep `codex.additionalDirectories` as an independent workspace-write permission mechanism
- preserve existing behavior while the feature is disabled

Customizations, skill discovery, hooks, and MCP discovery are intentionally unchanged.

## Validation

- `npm run typecheck-client`
- `npm run compile-client`
- targeted Codex and remote agent-host client unit tests (88 passing)
- changed-file hygiene checks
- code review

https://github.com/microsoft/vscode/issues/321651