### PR TITLE
Refine Voice Mode and dictation context menus

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -113,7 +113,7 @@ export function getDictationContextMenuActions(commandService: ICommandService, 
 function createVoiceModeSettingsAction(commandService: ICommandService): IAction {
 	return toAction({
 		id: VOICE_OPEN_SETTINGS_COMMAND,
-		label: localize('voiceMode.openSettings', "Settings"),
+		label: localize('voiceMode.openSettings', "Open Settings"),
 		run: () => commandService.executeCommand(VOICE_OPEN_SETTINGS_COMMAND),
 	});
 }

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -5,7 +5,7 @@
 
 import { addDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
 import { StandardMouseEvent } from '../../../../../base/browser/mouseEvent.js';
-import { IAction, toAction } from '../../../../../base/common/actions.js';
+import { IAction, Separator, toAction } from '../../../../../base/common/actions.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
 import { createConfigureKeybindingAction } from '../../../../../platform/actions/common/menuService.js';
@@ -24,11 +24,15 @@ const CANCEL_DICTATION_COMMAND = 'workbench.action.chat.cancelSpeechToText';
 const VOICE_DISCONNECT_COMMAND = 'agentsVoice.disconnect';
 /** Command that opens the Voice Mode settings; the affordance that used to live behind the toolbar gear. */
 const VOICE_OPEN_SETTINGS_COMMAND = 'agentsVoice.openSettings';
+/** Command that opens the Settings editor. */
+const OPEN_SETTINGS_COMMAND = 'workbench.action.openSettings';
+/** Narrows the Settings editor to dictation settings. */
+const DICTATION_SETTINGS_QUERY = 'dictation';
 /** Command that shows the Voice Mode onboarding card again. */
 export const SHOW_VOICE_MODE_ONBOARDING_COMMAND = 'agentsVoice.showOnboarding';
-/** Setting that enables dictation; toggled off by "Disable Dictation". */
+/** Setting that enables dictation; toggled off by "Disable". */
 const DICTATION_ENABLED_SETTING = 'dictation.enabled';
-/** Setting that enables Voice Mode; toggled off by "Disable Voice Mode". */
+/** Setting that enables Voice Mode; toggled off by "Disable". */
 const VOICE_ENABLED_SETTING = 'agents.voice.enabled';
 
 /**
@@ -44,14 +48,14 @@ function createSelectMicrophoneAction(commandService: ICommandService): IAction 
 }
 
 /**
- * "Disable Dictation" entry. Cancels any active/preparing dictation first so
+ * "Disable" entry for dictation. Cancels any active/preparing dictation first so
  * disabling the setting doesn't leave the microphone capturing while the toolbar
  * affordance disappears, then turns off the feature setting.
  */
 function createDisableDictationAction(commandService: ICommandService, configurationService: IConfigurationService): IAction {
 	return toAction({
 		id: 'chat.dictation.disable',
-		label: localize('dictation.disable', "Disable Dictation"),
+		label: localize('dictation.disable', "Disable"),
 		run: async () => {
 			await commandService.executeCommand(CANCEL_DICTATION_COMMAND);
 			await configurationService.updateValue(DICTATION_ENABLED_SETTING, false);
@@ -68,14 +72,14 @@ function createShowDictationOnboardingAction(commandService: ICommandService): I
 }
 
 /**
- * "Disable Voice Mode" entry. Tears down any active session first so disabling
+ * "Disable" entry for Voice Mode. Tears down any active session first so disabling
  * the setting doesn't leave the microphone capturing while the toolbar
  * affordance disappears, then turns off the feature setting.
  */
 function createDisableVoiceModeAction(commandService: ICommandService, configurationService: IConfigurationService): IAction {
 	return toAction({
 		id: 'chat.voiceMode.disable',
-		label: localize('voiceMode.disable', "Disable Voice Mode"),
+		label: localize('voiceMode.disable', "Disable"),
 		run: async () => {
 			await commandService.executeCommand(VOICE_DISCONNECT_COMMAND);
 			await configurationService.updateValue(VOICE_ENABLED_SETTING, false);
@@ -84,30 +88,41 @@ function createDisableVoiceModeAction(commandService: ICommandService, configura
 }
 
 /**
- * Actions for the dictation mic button context menu: "Configure Keybinding"
- * (always enabled so a removed binding can be restored), "Select Microphone"
- * and "Disable Dictation". `keybindingCommandId` is the stable command the
- * keybinding entry targets.
+ * Actions for the dictation mic button context menu. Keybinding and feature
+ * disabling are grouped separately from configuration and onboarding.
  */
 export function getDictationContextMenuActions(commandService: ICommandService, configurationService: IConfigurationService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction[] {
-	return [
-		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
-		createConfigureInstructionsAction(commandService, CONFIGURE_DICTATION_INSTRUCTIONS_ACTION_ID, localize('dictation.configureInstructions', "Configure Dictation Instructions")),
-		createShowDictationOnboardingAction(commandService),
-		createSelectMicrophoneAction(commandService),
-		createDisableDictationAction(commandService, configurationService),
-	];
+	return Separator.join(
+		[
+			createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
+			createDisableDictationAction(commandService, configurationService),
+		],
+		[
+			createDictationSettingsAction(commandService),
+			createConfigureInstructionsAction(commandService, CONFIGURE_DICTATION_INSTRUCTIONS_ACTION_ID, localize('dictation.configureInstructions', "Configure Instructions")),
+			createShowDictationOnboardingAction(commandService),
+			createSelectMicrophoneAction(commandService),
+		],
+	);
 }
 
 /**
- * "Voice Mode Settings" entry. Opens the Voice Mode settings — the affordance
+ * "Settings" entry. Opens the Voice Mode settings — the affordance
  * that used to live behind the toolbar gear button.
  */
 function createVoiceModeSettingsAction(commandService: ICommandService): IAction {
 	return toAction({
 		id: VOICE_OPEN_SETTINGS_COMMAND,
-		label: localize('voiceMode.openSettings', "Open Settings"),
+		label: localize('voiceMode.openSettings', "Settings"),
 		run: () => commandService.executeCommand(VOICE_OPEN_SETTINGS_COMMAND),
+	});
+}
+
+function createDictationSettingsAction(commandService: ICommandService): IAction {
+	return toAction({
+		id: 'chat.dictation.openSettings',
+		label: localize('dictation.openSettings', "Settings"),
+		run: () => commandService.executeCommand(OPEN_SETTINGS_COMMAND, { query: DICTATION_SETTINGS_QUERY }),
 	});
 }
 
@@ -128,22 +143,22 @@ function createConfigureInstructionsAction(commandService: ICommandService, comm
 }
 
 /**
- * Actions for the Voice Mode mic button context menu, mirroring
- * {@link getDictationContextMenuActions} but with "Disable Voice Mode". The
- * "Configure Keybinding" entry opens the keybindings editor scoped to the Voice
- * Mode keybinding and "Voice Mode Settings" opens the Voice Mode settings — the
- * affordances that used to live behind the toolbar gear button.
- * `keybindingCommandId` is the stable command the keybinding entry targets.
+ * Actions for the Voice Mode mic button context menu. Keybinding and feature
+ * disabling are grouped separately from configuration and onboarding.
  */
 export function getVoiceModeContextMenuActions(commandService: ICommandService, configurationService: IConfigurationService, keybindingService: IKeybindingService, keybindingCommandId: string): IAction[] {
-	return [
-		createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
-		createVoiceModeSettingsAction(commandService),
-		createConfigureInstructionsAction(commandService, CONFIGURE_VOICE_INSTRUCTIONS_ACTION_ID, localize('voiceMode.configureInstructions', "Configure Voice Mode Instructions")),
-		createShowVoiceModeOnboardingAction(commandService),
-		createSelectMicrophoneAction(commandService),
-		createDisableVoiceModeAction(commandService, configurationService),
-	];
+	return Separator.join(
+		[
+			createConfigureKeybindingAction(commandService, keybindingService, keybindingCommandId),
+			createDisableVoiceModeAction(commandService, configurationService),
+		],
+		[
+			createVoiceModeSettingsAction(commandService),
+			createConfigureInstructionsAction(commandService, CONFIGURE_VOICE_INSTRUCTIONS_ACTION_ID, localize('voiceMode.configureInstructions', "Configure Instructions")),
+			createShowVoiceModeOnboardingAction(commandService),
+			createSelectMicrophoneAction(commandService),
+		],
+	);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions.ts
@@ -121,7 +121,7 @@ function createVoiceModeSettingsAction(commandService: ICommandService): IAction
 function createDictationSettingsAction(commandService: ICommandService): IAction {
 	return toAction({
 		id: 'chat.dictation.openSettings',
-		label: localize('dictation.openSettings', "Settings"),
+		label: localize('dictation.openSettings', "Open Settings"),
 		run: () => commandService.executeCommand(OPEN_SETTINGS_COMMAND, { query: DICTATION_SETTINGS_QUERY }),
 	});
 }

--- a/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { getDictationContextMenuActions, getVoiceModeContextMenuActions } from '../../browser/speechToText/micButtonMenuActions.js';
+
+suite('Mic button menu actions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const commandService = upcastPartial<ICommandService>({});
+	const configurationService = upcastPartial<IConfigurationService>({});
+	const keybindingService = upcastPartial<IKeybindingService>({});
+
+	test('groups and shortens Voice Mode actions', () => {
+		const actions = getVoiceModeContextMenuActions(commandService, configurationService, keybindingService, 'voice.start');
+
+		assert.deepStrictEqual(actions.map(action => action.label), [
+			'Configure Keybinding',
+			'Disable',
+			'',
+			'Settings',
+			'Configure Instructions',
+			'Show Introduction',
+			'Select Microphone',
+		]);
+	});
+
+	test('groups and shortens dictation actions', () => {
+		const actions = getDictationContextMenuActions(commandService, configurationService, keybindingService, 'dictation.start');
+
+		assert.deepStrictEqual(actions.map(action => action.label), [
+			'Configure Keybinding',
+			'Disable',
+			'',
+			'Settings',
+			'Configure Instructions',
+			'Show Introduction',
+			'Select Microphone',
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
@@ -26,7 +26,7 @@ suite('Mic button menu actions', () => {
 			'Configure Keybinding',
 			'Disable',
 			'',
-			'Settings',
+			'Open Settings',
 			'Configure Instructions',
 			'Show Introduction',
 			'Select Microphone',

--- a/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/micButtonMenuActions.test.ts
@@ -40,7 +40,7 @@ suite('Mic button menu actions', () => {
 			'Configure Keybinding',
 			'Disable',
 			'',
-			'Settings',
+			'Open Settings',
 			'Configure Instructions',
 			'Show Introduction',
 			'Select Microphone',


### PR DESCRIPTION
Group the Voice Mode and dictation microphone context menus into primary and configuration sections.

- Place **Configure Keybinding** and **Disable** in the first group
- Add a separator before settings, instructions, introduction, and microphone selection
- Use concise context-menu labels while preserving feature-specific Command Palette titles
- Add a dictation Settings entry and focused ordering/label tests