### PR TITLE
Fix Copilot Chat recovery test checkout path

### DIFF
--- a/build/azure-pipelines/product-copilot-recovery.yml
+++ b/build/azure-pipelines/product-copilot-recovery.yml
@@ -97,6 +97,7 @@ extends:
 
     testSteps:
       - checkout: self
+        path: s
         lfs: true
         retryCountOnTaskFailure: 3
       - template: copilot/setup-steps.yml


### PR DESCRIPTION
## Summary
- check out `microsoft/vscode` at `$(Build.SourcesDirectory)` in the Copilot Chat recovery test stage
- keep the test checkout consistent with the successful package-stage checkout
- prevent multi-repository checkout from placing VS Code under `s/vscode` while setup scripts resolve files from `s`

## Failure
Build [460171](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=460171) failed in `Prepare node_modules cache key` because it attempted to load `/mnt/vss/_work/1/s/build/azure-pipelines/common/computeNodeModulesCacheKey.ts`. The repository had instead been checked out under `/mnt/vss/_work/1/s/vscode`.

## Validation
- parsed `build/azure-pipelines/product-copilot-recovery.yml` with Ruby YAML
- `git diff --check`