### PR TITLE
Support offline dictation model install for registry-blocked networks

### DIFF
--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -82,12 +82,13 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 
 	let istream: WriteStream;
 
-	token.onCancellationRequested(() => {
+	const listener = token.onCancellationRequested(() => {
 		istream?.destroy();
 	});
 
 	return Promise.resolve(promises.mkdir(targetDirName, { recursive: true })).then(() => new Promise<void>((c, e) => {
 		if (token.isCancellationRequested) {
+			c();
 			return;
 		}
 
@@ -100,7 +101,7 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 		} catch (error) {
 			e(error);
 		}
-	}));
+	})).finally(() => listener.dispose());
 }
 
 function extractZip(zipfile: ZipFile, targetPath: string, options: IOptions, token: CancellationToken): Promise<void> {

--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -12,6 +12,14 @@ export const ILocalTranscriptionService = createDecorator<ILocalTranscriptionSer
 /** IPC channel name used to reach the transcription service in the utility process. */
 export const localTranscriptionChannelName = 'localTranscription';
 
+/** Default on-device model used for dictation. */
+export const DEFAULT_LOCAL_TRANSCRIPTION_MODEL = 'nemotron-speech-streaming-en-0.6b';
+
+export interface ILocalTranscriptionModelImportResult {
+	readonly model: string;
+	readonly version: number;
+}
+
 /** Lifecycle of the downloaded transcription model. */
 export const enum LocalTranscriptionModelState {
 	/** Model has not been requested yet. */
@@ -93,6 +101,12 @@ export interface ILocalTranscriptionService {
 
 	/** Current model status (e.g. to gate the dictation UI). */
 	getModelStatus(): Promise<ILocalTranscriptionModelStatus>;
+
+	/**
+	 * Imports the default on-device model from an official Foundry Local expansion
+	 * pack or a prepared model directory into `cacheDir`.
+	 */
+	importModel(options: { readonly sourcePath: string; readonly cacheDir: string }): Promise<ILocalTranscriptionModelImportResult>;
 
 	/**
 	 * Ensure the model is downloaded/loaded (idempotent) and begin a new

--- a/src/vs/platform/localTranscription/node/foundryLocalModelImport.ts
+++ b/src/vs/platform/localTranscription/node/foundryLocalModelImport.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { randomUUID } from 'crypto';
-import { promises as fs } from 'fs';
+import { createHash, randomUUID } from 'crypto';
+import { createReadStream, promises as fs } from 'fs';
 import { basename, dirname, join } from '../../../base/common/path.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { extract } from '../../../base/node/zip.js';
@@ -109,7 +109,7 @@ async function materializeOciModel(indexPath: string, workDirectory: string, can
 		throw new Error('The selected dictation model package has no OCI manifest.');
 	}
 	for (const descriptor of index.manifests) {
-		const manifest = JSON.parse((await fs.readFile(resolveOciBlob(ociRoot, descriptor.digest))).toString('utf8')) as IOciManifest;
+		const manifest = JSON.parse((await readVerifiedOciBlob(ociRoot, descriptor.digest)).toString('utf8')) as IOciManifest;
 		const titledLayers = manifest.layers?.filter(layer => layer.annotations?.[OCI_TITLE_ANNOTATION]);
 		if (!titledLayers?.length) {
 			continue;
@@ -140,15 +140,17 @@ async function materializeOciModel(indexPath: string, workDirectory: string, can
 			const target = join(materializedRoot, `v${version}`, ...pathSegments);
 			await fs.mkdir(dirname(target), { recursive: true });
 			const blob = resolveOciBlob(ociRoot, layer.digest);
+			await verifyOciBlob(blob);
 			if (canMove) {
-				await fs.rename(blob, target);
+				await fs.rename(blob.path, target);
 			} else {
-				await fs.copyFile(blob, target);
+				await fs.copyFile(blob.path, target);
 			}
 		}
 
 		if (version !== undefined) {
 			const versionDirectory = join(materializedRoot, `v${version}`);
+			await assertMaterializedIdentity(versionDirectory, version);
 			await writeInferenceModel(versionDirectory, version);
 			return { version, versionDirectory, canMove: true };
 		}
@@ -157,23 +159,80 @@ async function materializeOciModel(indexPath: string, workDirectory: string, can
 	throw new Error('The selected package does not contain a dictation model OCI payload.');
 }
 
-function resolveOciBlob(ociRoot: string, digest: string): string {
+function resolveOciBlob(ociRoot: string, digest: string): { readonly path: string; readonly hash: string } {
 	const match = /^sha256:(?<hash>[a-fA-F0-9]{64})$/.exec(digest);
 	if (!match?.groups?.hash) {
 		throw new Error(`Unsupported OCI digest: ${digest}`);
 	}
-	return join(ociRoot, 'blobs', 'sha256', match.groups.hash.toLowerCase());
+	const hash = match.groups.hash.toLowerCase();
+	return { path: join(ociRoot, 'blobs', 'sha256', hash), hash };
+}
+
+/** Read a (small) OCI blob into memory and verify it against its content digest. */
+async function readVerifiedOciBlob(ociRoot: string, digest: string): Promise<Buffer> {
+	const blob = resolveOciBlob(ociRoot, digest);
+	const contents = await fs.readFile(blob.path);
+	if (createHash('sha256').update(contents).digest('hex') !== blob.hash) {
+		throw new Error('The selected model package is corrupt (checksum mismatch).');
+	}
+	return contents;
+}
+
+/** Verify a blob against its content digest by streaming it (no full buffering). */
+async function verifyOciBlob(blob: { readonly path: string; readonly hash: string }): Promise<void> {
+	const hash = createHash('sha256');
+	for await (const chunk of createReadStream(blob.path)) {
+		hash.update(chunk as Buffer);
+	}
+	if (hash.digest('hex') !== blob.hash) {
+		throw new Error('The selected model package is corrupt (checksum mismatch).');
+	}
+}
+
+/**
+ * Interpret a Foundry Local `inference_model.json` `Name`. Returns the model
+ * version when the name identifies the supported nemotron CPU model, throws when
+ * it names a *different* model, and returns `undefined` when there is no name to
+ * check (a truly unlabeled package we accept on trust).
+ */
+function modelVersionFromName(name: string | undefined): number | undefined {
+	if (!name) {
+		return undefined;
+	}
+	const match = new RegExp(`^${MODEL_VARIANT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(?<version>[1-9]\\d*)$`).exec(name);
+	if (!match?.groups?.version) {
+		throw new Error(`The selected package is not the ${DEFAULT_LOCAL_TRANSCRIPTION_MODEL} CPU model.`);
+	}
+	return Number(match.groups.version);
+}
+
+/**
+ * Guard the OCI path against mislabeling: if the materialized payload already
+ * carries an `inference_model.json`, it must identify the supported model at
+ * this version before we (re)write our own scanner metadata over it. A payload
+ * with no embedded identity is accepted on trust.
+ */
+async function assertMaterializedIdentity(versionDirectory: string, version: number): Promise<void> {
+	let metadata: { Name?: string };
+	try {
+		metadata = JSON.parse(await fs.readFile(join(versionDirectory, INFERENCE_MODEL_FILE), 'utf8'));
+	} catch {
+		return;
+	}
+	const named = modelVersionFromName(metadata.Name);
+	if (named !== undefined && named !== version) {
+		throw new Error('The selected package identifies a different model version than its files.');
+	}
 }
 
 async function findPreparedModel(root: string, canMove: boolean): Promise<IPreparedModel> {
 	const inferenceModel = (await findNamedFiles(root, INFERENCE_MODEL_FILE))[0];
 	if (inferenceModel) {
 		const metadata = JSON.parse(await fs.readFile(inferenceModel, 'utf8')) as { Name?: string };
-		const match = new RegExp(`^${MODEL_VARIANT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(?<version>[1-9]\\d*)$`).exec(metadata.Name ?? '');
-		if (!match?.groups?.version) {
+		const version = modelVersionFromName(metadata.Name);
+		if (version === undefined) {
 			throw new Error(`The selected folder is not the ${DEFAULT_LOCAL_TRANSCRIPTION_MODEL} CPU model.`);
 		}
-		const version = Number(match.groups.version);
 		const versionDirectory = dirname(inferenceModel);
 		if (basename(versionDirectory) !== `v${version}`) {
 			throw new Error(`The model files must be stored in a v${version} folder.`);
@@ -226,10 +285,11 @@ async function installPreparedModel(model: IPreparedModel, cacheDir: string): Pr
 		await writeInferenceModel(stagedVersion, model.version);
 		await replaceDirectory(staged, target, backup);
 	} finally {
-		await Promise.all([
-			fs.rm(staged, { recursive: true, force: true }),
-			fs.rm(backup, { recursive: true, force: true }),
-		]);
+		// Only the staging area is always safe to remove. The backup is owned by
+		// `replaceDirectory`: it is deleted there once the swap succeeds and is
+		// otherwise the sole surviving copy of a previously working model, so it
+		// must never be force-removed here (a failed rollback would lose it).
+		await fs.rm(staged, { recursive: true, force: true });
 	}
 }
 

--- a/src/vs/platform/localTranscription/node/foundryLocalModelImport.ts
+++ b/src/vs/platform/localTranscription/node/foundryLocalModelImport.ts
@@ -1,0 +1,298 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+import { basename, dirname, join } from '../../../base/common/path.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { extract } from '../../../base/node/zip.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL, ILocalTranscriptionModelImportResult } from '../common/localTranscription.js';
+
+const MODEL_PUBLISHER = 'Microsoft';
+const MODEL_VARIANT = `${DEFAULT_LOCAL_TRANSCRIPTION_MODEL}-generic-cpu`;
+const INFERENCE_MODEL_FILE = 'inference_model.json';
+const GENAI_CONFIG_FILE = 'genai_config.json';
+const OCI_TITLE_ANNOTATION = 'org.opencontainers.image.title';
+
+interface IOciDescriptor {
+	readonly digest: string;
+	readonly annotations?: Record<string, string>;
+}
+
+interface IOciIndex {
+	readonly manifests?: readonly IOciDescriptor[];
+}
+
+interface IOciManifest {
+	readonly layers?: readonly IOciDescriptor[];
+}
+
+interface IPreparedModel {
+	readonly version: number;
+	readonly versionDirectory: string;
+	readonly canMove: boolean;
+}
+
+/**
+ * Imports the official Foundry Local expansion pack (ZIP or extracted OCI
+ * layout), or an already prepared model directory, into the model cache.
+ */
+export async function importFoundryLocalModel(sourcePath: string, cacheDir: string): Promise<ILocalTranscriptionModelImportResult> {
+	const sourceStat = await fs.stat(sourcePath);
+	await fs.mkdir(cacheDir, { recursive: true });
+	const workDirectory = await fs.mkdtemp(join(cacheDir, '.dictation-model-import-'));
+
+	try {
+		const prepared = sourceStat.isDirectory()
+			? await prepareModelSource(sourcePath, workDirectory, false)
+			: await prepareModelArchive(sourcePath, workDirectory);
+		await verifyPreparedModel(prepared.versionDirectory);
+		await installPreparedModel(prepared, cacheDir);
+		return { model: DEFAULT_LOCAL_TRANSCRIPTION_MODEL, version: prepared.version };
+	} finally {
+		await fs.rm(workDirectory, { recursive: true, force: true });
+	}
+}
+
+async function prepareModelArchive(sourcePath: string, workDirectory: string): Promise<IPreparedModel> {
+	if (!sourcePath.toLowerCase().endsWith('.zip')) {
+		throw new Error('The selected dictation model package must be a ZIP archive or a folder.');
+	}
+
+	const extracted = join(workDirectory, 'archive');
+	await extract(sourcePath, extracted, {}, CancellationToken.None);
+	return prepareModelSource(extracted, workDirectory, true);
+}
+
+async function prepareModelSource(sourcePath: string, workDirectory: string, canMove: boolean): Promise<IPreparedModel> {
+	const nestedPackage = (await findNamedFiles(sourcePath, 'Package.zip'))[0];
+	if (nestedPackage) {
+		const extractedPackage = join(workDirectory, 'package');
+		await extract(nestedPackage, extractedPackage, {}, CancellationToken.None);
+		if (canMove) {
+			await fs.rm(sourcePath, { recursive: true, force: true });
+		}
+		sourcePath = extractedPackage;
+		canMove = true;
+	}
+
+	const ociIndex = await findOciIndex(sourcePath);
+	if (ociIndex) {
+		return materializeOciModel(ociIndex, workDirectory, canMove);
+	}
+
+	return findPreparedModel(sourcePath, canMove);
+}
+
+async function findOciIndex(root: string): Promise<string | undefined> {
+	for (const candidate of await findNamedFiles(root, 'index.json')) {
+		try {
+			const layout = JSON.parse(await fs.readFile(join(dirname(candidate), 'oci-layout'), 'utf8')) as { imageLayoutVersion?: string };
+			if (layout.imageLayoutVersion) {
+				return candidate;
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+				throw error;
+			}
+		}
+	}
+	return undefined;
+}
+
+async function materializeOciModel(indexPath: string, workDirectory: string, canMove: boolean): Promise<IPreparedModel> {
+	const ociRoot = dirname(indexPath);
+	const index = JSON.parse(await fs.readFile(indexPath, 'utf8')) as IOciIndex;
+	if (!index.manifests?.length) {
+		throw new Error('The selected dictation model package has no OCI manifest.');
+	}
+	for (const descriptor of index.manifests) {
+		const manifest = JSON.parse((await fs.readFile(resolveOciBlob(ociRoot, descriptor.digest))).toString('utf8')) as IOciManifest;
+		const titledLayers = manifest.layers?.filter(layer => layer.annotations?.[OCI_TITLE_ANNOTATION]);
+		if (!titledLayers?.length) {
+			continue;
+		}
+
+		let version: number | undefined;
+		const materializedRoot = join(workDirectory, 'materialized');
+		for (const layer of titledLayers) {
+			const title = layer.annotations?.[OCI_TITLE_ANNOTATION];
+			if (!title) {
+				continue;
+			}
+			const match = /^v(?<version>[1-9]\d*)\/(?<path>.+)$/.exec(title);
+			if (!match?.groups?.version || !match.groups.path) {
+				throw new Error(`Invalid model file path in the OCI package: ${title}`);
+			}
+			const layerVersion = Number(match.groups.version);
+			if (version !== undefined && version !== layerVersion) {
+				throw new Error('The selected dictation model package contains multiple model versions.');
+			}
+			version = layerVersion;
+
+			const pathSegments = match.groups.path.split('/');
+			if (pathSegments.some(segment => !segment || segment === '.' || segment === '..' || segment.includes('\\'))) {
+				throw new Error(`Invalid model file path in the OCI package: ${title}`);
+			}
+
+			const target = join(materializedRoot, `v${version}`, ...pathSegments);
+			await fs.mkdir(dirname(target), { recursive: true });
+			const blob = resolveOciBlob(ociRoot, layer.digest);
+			if (canMove) {
+				await fs.rename(blob, target);
+			} else {
+				await fs.copyFile(blob, target);
+			}
+		}
+
+		if (version !== undefined) {
+			const versionDirectory = join(materializedRoot, `v${version}`);
+			await writeInferenceModel(versionDirectory, version);
+			return { version, versionDirectory, canMove: true };
+		}
+	}
+
+	throw new Error('The selected package does not contain a dictation model OCI payload.');
+}
+
+function resolveOciBlob(ociRoot: string, digest: string): string {
+	const match = /^sha256:(?<hash>[a-fA-F0-9]{64})$/.exec(digest);
+	if (!match?.groups?.hash) {
+		throw new Error(`Unsupported OCI digest: ${digest}`);
+	}
+	return join(ociRoot, 'blobs', 'sha256', match.groups.hash.toLowerCase());
+}
+
+async function findPreparedModel(root: string, canMove: boolean): Promise<IPreparedModel> {
+	const inferenceModel = (await findNamedFiles(root, INFERENCE_MODEL_FILE))[0];
+	if (inferenceModel) {
+		const metadata = JSON.parse(await fs.readFile(inferenceModel, 'utf8')) as { Name?: string };
+		const match = new RegExp(`^${MODEL_VARIANT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(?<version>[1-9]\\d*)$`).exec(metadata.Name ?? '');
+		if (!match?.groups?.version) {
+			throw new Error(`The selected folder is not the ${DEFAULT_LOCAL_TRANSCRIPTION_MODEL} CPU model.`);
+		}
+		const version = Number(match.groups.version);
+		const versionDirectory = dirname(inferenceModel);
+		if (basename(versionDirectory) !== `v${version}`) {
+			throw new Error(`The model files must be stored in a v${version} folder.`);
+		}
+		return { version, versionDirectory, canMove };
+	}
+
+	const genaiConfig = (await findNamedFiles(root, GENAI_CONFIG_FILE))[0];
+	if (genaiConfig) {
+		const versionDirectory = dirname(genaiConfig);
+		const match = /^v(?<version>[1-9]\d*)$/.exec(basename(versionDirectory));
+		if (!match?.groups?.version) {
+			throw new Error('The model files must be stored in a version folder such as v3.');
+		}
+		return { version: Number(match.groups.version), versionDirectory, canMove };
+	}
+
+	throw new Error('The selected package does not contain a supported dictation model.');
+}
+
+async function verifyPreparedModel(versionDirectory: string): Promise<void> {
+	const entries = await fs.readdir(versionDirectory, { withFileTypes: true });
+	const hasOnnxModel = entries.some(entry => entry.isFile() && entry.name.toLowerCase().endsWith('.onnx'));
+	if (!hasOnnxModel) {
+		throw new Error('The selected dictation model is missing its ONNX model files.');
+	}
+	try {
+		JSON.parse(await fs.readFile(join(versionDirectory, GENAI_CONFIG_FILE), 'utf8'));
+	} catch {
+		throw new Error(`The selected dictation model has a missing or invalid ${GENAI_CONFIG_FILE}.`);
+	}
+}
+
+async function installPreparedModel(model: IPreparedModel, cacheDir: string): Promise<void> {
+	const publisherDirectory = join(cacheDir, MODEL_PUBLISHER);
+	await fs.mkdir(publisherDirectory, { recursive: true });
+	const modelDirectoryName = `${MODEL_VARIANT}-${model.version}`;
+	const target = join(publisherDirectory, modelDirectoryName);
+	const staged = join(publisherDirectory, `.${modelDirectoryName}.staged-${randomUUID()}`);
+	const backup = join(publisherDirectory, `.${modelDirectoryName}.backup-${randomUUID()}`);
+	const stagedVersion = join(staged, `v${model.version}`);
+
+	try {
+		if (model.canMove) {
+			await fs.mkdir(staged, { recursive: true });
+			await fs.rename(model.versionDirectory, stagedVersion);
+		} else {
+			await copyDirectory(model.versionDirectory, stagedVersion);
+		}
+		await writeInferenceModel(stagedVersion, model.version);
+		await replaceDirectory(staged, target, backup);
+	} finally {
+		await Promise.all([
+			fs.rm(staged, { recursive: true, force: true }),
+			fs.rm(backup, { recursive: true, force: true }),
+		]);
+	}
+}
+
+async function replaceDirectory(staged: string, target: string, backup: string): Promise<void> {
+	let movedExisting = false;
+	try {
+		await fs.rename(target, backup);
+		movedExisting = true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+			throw error;
+		}
+	}
+
+	try {
+		await fs.rename(staged, target);
+	} catch (error) {
+		if (movedExisting) {
+			await fs.rename(backup, target);
+		}
+		throw error;
+	}
+
+	if (movedExisting) {
+		await fs.rm(backup, { recursive: true, force: true });
+	}
+}
+
+async function copyDirectory(source: string, target: string): Promise<void> {
+	await fs.mkdir(target, { recursive: true });
+	for (const entry of await fs.readdir(source, { withFileTypes: true })) {
+		const sourceEntry = join(source, entry.name);
+		const targetEntry = join(target, entry.name);
+		if (entry.isDirectory()) {
+			await copyDirectory(sourceEntry, targetEntry);
+		} else if (entry.isFile()) {
+			await fs.copyFile(sourceEntry, targetEntry);
+		} else {
+			throw new Error(`Unsupported model package entry: ${entry.name}`);
+		}
+	}
+}
+
+async function writeInferenceModel(versionDirectory: string, version: number): Promise<void> {
+	await fs.writeFile(join(versionDirectory, INFERENCE_MODEL_FILE), JSON.stringify({
+		Name: `${MODEL_VARIANT}:${version}`,
+		PromptTemplate: null,
+	}, undefined, 2));
+}
+
+async function findNamedFiles(root: string, name: string): Promise<string[]> {
+	const matches: string[] = [];
+	const directories = [root];
+	while (directories.length) {
+		const directory = directories.pop()!;
+		for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+			const entryPath = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				directories.push(entryPath);
+			} else if (entry.isFile() && entry.name === name) {
+				matches.push(entryPath);
+			}
+		}
+	}
+	return matches.sort();
+}

--- a/src/vs/platform/localTranscription/node/localTranscriptionService.ts
+++ b/src/vs/platform/localTranscription/node/localTranscriptionService.ts
@@ -13,8 +13,11 @@ import {
 	ILocalTranscriptionModelStatus,
 	ILocalTranscriptionResult,
 	ILocalTranscriptionService,
+	DEFAULT_LOCAL_TRANSCRIPTION_MODEL,
+	ILocalTranscriptionModelImportResult,
 	LocalTranscriptionModelState,
 } from '../common/localTranscription.js';
+import { importFoundryLocalModel } from './foundryLocalModelImport.js';
 
 /** PCM audio format the renderer captures and streams: mono 16 kHz signed 16-bit. */
 const SAMPLE_RATE = 16000;
@@ -26,8 +29,6 @@ const BITS_PER_SAMPLE = 16;
  * Nemotron streaming RNN-T model the GitHub Copilot app ships for dictation; it
  * runs through Foundry Local's native streaming ASR engine (ORT + ORT-GenAI).
  */
-const DEFAULT_MODEL = 'nemotron-speech-streaming-en-0.6b';
-
 /** Application name reported to Foundry Local for logs/telemetry and its data dir. */
 const FOUNDRY_APP_NAME = 'vscode-dictation';
 
@@ -270,6 +271,10 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		return this._status;
 	}
 
+	importModel(options: { sourcePath: string; cacheDir: string }): Promise<ILocalTranscriptionModelImportResult> {
+		return importFoundryLocalModel(options.sourcePath, options.cacheDir);
+	}
+
 	private _setStatus(status: ILocalTranscriptionModelStatus): void {
 		this._status = status;
 		this._onDidChangeModelStatus.fire(status);
@@ -298,7 +303,7 @@ export class LocalTranscriptionService extends Disposable implements ILocalTrans
 		this._pendingChunks = [];
 		this._runtimeError = undefined;
 
-		const model = options.model ?? DEFAULT_MODEL;
+		const model = options.model ?? DEFAULT_LOCAL_TRANSCRIPTION_MODEL;
 		const language = options.language;
 		// Do not block capture on the (possibly first-use) model download/load and
 		// session open; buffer audio until the session is ready, then flush it.

--- a/src/vs/platform/localTranscription/test/node/foundryLocalModelImport.test.ts
+++ b/src/vs/platform/localTranscription/test/node/foundryLocalModelImport.test.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import { createHash } from 'crypto';
+import { tmpdir } from 'os';
+import { join } from '../../../../base/common/path.js';
+import { zip } from '../../../../base/node/zip.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { getRandomTestPath } from '../../../../base/test/node/testUtils.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../common/localTranscription.js';
+import { importFoundryLocalModel } from '../../node/foundryLocalModelImport.js';
+
+suite('FoundryLocalModelImport', () => {
+	let testDirectory: string;
+	let cacheDirectory: string;
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(async () => {
+		testDirectory = getRandomTestPath(tmpdir(), 'vsctests', 'foundry-model-import');
+		cacheDirectory = join(testDirectory, 'cache');
+		await fs.promises.mkdir(testDirectory, { recursive: true });
+	});
+
+	teardown(() => fs.promises.rm(testDirectory, { recursive: true, force: true }));
+
+	test('imports a prepared model directory and creates scanner metadata', async () => {
+		const source = join(testDirectory, 'prepared', 'v4');
+		await fs.promises.mkdir(source, { recursive: true });
+		await fs.promises.writeFile(join(source, 'genai_config.json'), '{}');
+		await fs.promises.writeFile(join(source, 'encoder.onnx'), 'model');
+
+		const staleTarget = modelVersionDirectory(cacheDirectory, 4);
+		await fs.promises.mkdir(staleTarget, { recursive: true });
+		await fs.promises.writeFile(join(staleTarget, 'stale'), 'old');
+
+		const result = await importFoundryLocalModel(source, cacheDirectory);
+		const target = modelVersionDirectory(cacheDirectory, 4);
+		const metadata = JSON.parse(await fs.promises.readFile(join(target, 'inference_model.json'), 'utf8'));
+
+		assert.deepStrictEqual({
+			result,
+			files: (await fs.promises.readdir(target)).sort(),
+			metadata,
+		}, {
+			result: { model: DEFAULT_LOCAL_TRANSCRIPTION_MODEL, version: 4 },
+			files: ['encoder.onnx', 'genai_config.json', 'inference_model.json'],
+			metadata: {
+				Name: `${DEFAULT_LOCAL_TRANSCRIPTION_MODEL}-generic-cpu:4`,
+				PromptTemplate: null,
+			},
+		});
+	});
+
+	test('imports the official nested expansion-pack OCI layout', async () => {
+		const packageZip = join(testDirectory, 'Package.zip');
+		const configContents = '{}';
+		const modelContents = 'model';
+		const configDigest = digest(configContents);
+		const modelDigest = digest(modelContents);
+		const ociPrefix = 'payload/oci/models/foundry-local/nemotron/cpu-onnx';
+		const manifest = {
+			layers: [
+				{ digest: configDigest, annotations: { 'org.opencontainers.image.title': 'v3/genai_config.json' } },
+				{ digest: modelDigest, annotations: { 'org.opencontainers.image.title': 'v3/encoder.onnx' } },
+			],
+		};
+		const manifestContents = JSON.stringify(manifest);
+		const manifestDigest = digest(manifestContents);
+		await zip(packageZip, [
+			{ path: `${ociPrefix}/oci-layout`, contents: JSON.stringify({ imageLayoutVersion: '1.0.0' }) },
+			{ path: `${ociPrefix}/index.json`, contents: JSON.stringify({ manifests: [{ digest: manifestDigest }] }) },
+			{ path: `${ociPrefix}/blobs/sha256/${manifestDigest.slice('sha256:'.length)}`, contents: manifestContents },
+			{ path: `${ociPrefix}/blobs/sha256/${configDigest.slice('sha256:'.length)}`, contents: configContents },
+			{ path: `${ociPrefix}/blobs/sha256/${modelDigest.slice('sha256:'.length)}`, contents: modelContents },
+		]);
+
+		const expansionPack = join(testDirectory, 'model.zip');
+		await zip(expansionPack, [
+			{ path: 'Manifest.xml', contents: '<Package />' },
+			{ path: 'Package.zip', localPath: packageZip },
+		]);
+
+		const result = await importFoundryLocalModel(expansionPack, cacheDirectory);
+		const target = modelVersionDirectory(cacheDirectory, 3);
+
+		assert.deepStrictEqual({
+			result,
+			files: (await fs.promises.readdir(target)).sort(),
+		}, {
+			result: { model: DEFAULT_LOCAL_TRANSCRIPTION_MODEL, version: 3 },
+			files: ['encoder.onnx', 'genai_config.json', 'inference_model.json'],
+		});
+	});
+
+	test('rejects OCI layer paths that escape the model version directory', async () => {
+		const source = join(testDirectory, 'oci');
+		const modelContents = 'model';
+		const modelDigest = digest(modelContents);
+		const manifestContents = JSON.stringify({
+			layers: [{
+				digest: modelDigest,
+				annotations: { 'org.opencontainers.image.title': 'v3/../outside.onnx' },
+			}],
+		});
+		const manifestDigest = digest(manifestContents);
+		await fs.promises.mkdir(join(source, 'blobs', 'sha256'), { recursive: true });
+		await fs.promises.writeFile(join(source, 'oci-layout'), JSON.stringify({ imageLayoutVersion: '1.0.0' }));
+		await fs.promises.writeFile(join(source, 'index.json'), JSON.stringify({ manifests: [{ digest: manifestDigest }] }));
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', manifestDigest.slice('sha256:'.length)), manifestContents);
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', modelDigest.slice('sha256:'.length)), modelContents);
+
+		await assert.rejects(
+			importFoundryLocalModel(source, cacheDirectory),
+			/Invalid model file path/,
+		);
+		assert.strictEqual(fs.existsSync(join(cacheDirectory, 'Microsoft')), false);
+	});
+
+	test('rejects prepared directories for other models', async () => {
+		const source = join(testDirectory, 'prepared', 'v3');
+		await fs.promises.mkdir(source, { recursive: true });
+		await fs.promises.writeFile(join(source, 'genai_config.json'), '{}');
+		await fs.promises.writeFile(join(source, 'encoder.onnx'), 'model');
+		await fs.promises.writeFile(join(source, 'inference_model.json'), JSON.stringify({ Name: 'other-model:3' }));
+
+		await assert.rejects(
+			importFoundryLocalModel(source, cacheDirectory),
+			new RegExp(`not the ${DEFAULT_LOCAL_TRANSCRIPTION_MODEL}`),
+		);
+	});
+});
+
+function modelVersionDirectory(cacheDirectory: string, version: number): string {
+	return join(
+		cacheDirectory,
+		'Microsoft',
+		`${DEFAULT_LOCAL_TRANSCRIPTION_MODEL}-generic-cpu-${version}`,
+		`v${version}`,
+	);
+}
+
+function digest(contents: string): string {
+	return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+}

--- a/src/vs/platform/localTranscription/test/node/foundryLocalModelImport.test.ts
+++ b/src/vs/platform/localTranscription/test/node/foundryLocalModelImport.test.ts
@@ -121,6 +121,61 @@ suite('FoundryLocalModelImport', () => {
 		assert.strictEqual(fs.existsSync(join(cacheDirectory, 'Microsoft')), false);
 	});
 
+	test('rejects an OCI package whose embedded metadata names a different model', async () => {
+		const source = join(testDirectory, 'oci-wrong-model');
+		const configContents = '{}';
+		const inferenceContents = JSON.stringify({ Name: 'some-other-model-generic-cpu:3' });
+		const configDigest = digest(configContents);
+		const inferenceDigest = digest(inferenceContents);
+		const manifestContents = JSON.stringify({
+			layers: [
+				{ digest: configDigest, annotations: { 'org.opencontainers.image.title': 'v3/genai_config.json' } },
+				{ digest: inferenceDigest, annotations: { 'org.opencontainers.image.title': 'v3/inference_model.json' } },
+			],
+		});
+		const manifestDigest = digest(manifestContents);
+		await fs.promises.mkdir(join(source, 'blobs', 'sha256'), { recursive: true });
+		await fs.promises.writeFile(join(source, 'oci-layout'), JSON.stringify({ imageLayoutVersion: '1.0.0' }));
+		await fs.promises.writeFile(join(source, 'index.json'), JSON.stringify({ manifests: [{ digest: manifestDigest }] }));
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', manifestDigest.slice('sha256:'.length)), manifestContents);
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', configDigest.slice('sha256:'.length)), configContents);
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', inferenceDigest.slice('sha256:'.length)), inferenceContents);
+
+		await assert.rejects(
+			importFoundryLocalModel(source, cacheDirectory),
+			new RegExp(`not the ${DEFAULT_LOCAL_TRANSCRIPTION_MODEL}`),
+		);
+		assert.strictEqual(fs.existsSync(join(cacheDirectory, 'Microsoft')), false);
+	});
+
+	test('rejects an OCI package with a blob that fails its checksum', async () => {
+		const source = join(testDirectory, 'oci-corrupt');
+		const configContents = '{}';
+		const modelContents = 'model';
+		const configDigest = digest(configContents);
+		const modelDigest = digest(modelContents);
+		const manifestContents = JSON.stringify({
+			layers: [
+				{ digest: configDigest, annotations: { 'org.opencontainers.image.title': 'v3/genai_config.json' } },
+				{ digest: modelDigest, annotations: { 'org.opencontainers.image.title': 'v3/encoder.onnx' } },
+			],
+		});
+		const manifestDigest = digest(manifestContents);
+		await fs.promises.mkdir(join(source, 'blobs', 'sha256'), { recursive: true });
+		await fs.promises.writeFile(join(source, 'oci-layout'), JSON.stringify({ imageLayoutVersion: '1.0.0' }));
+		await fs.promises.writeFile(join(source, 'index.json'), JSON.stringify({ manifests: [{ digest: manifestDigest }] }));
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', manifestDigest.slice('sha256:'.length)), manifestContents);
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', configDigest.slice('sha256:'.length)), configContents);
+		// Content that does not hash to the digest used as its blob filename.
+		await fs.promises.writeFile(join(source, 'blobs', 'sha256', modelDigest.slice('sha256:'.length)), 'tampered');
+
+		await assert.rejects(
+			importFoundryLocalModel(source, cacheDirectory),
+			/corrupt/,
+		);
+		assert.strictEqual(fs.existsSync(join(cacheDirectory, 'Microsoft')), false);
+	});
+
 	test('rejects prepared directories for other models', async () => {
 		const source = join(testDirectory, 'prepared', 'v3');
 		await fs.promises.mkdir(source, { recursive: true });

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -10,6 +10,8 @@ import { generateUuid } from '../../../../../base/common/uuid.js';
 import { computeLevenshteinDistance } from '../../../../../base/common/diff/diff.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IAction, toAction } from '../../../../../base/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
@@ -34,6 +36,14 @@ import { IPromptsService } from '../../common/promptSyntax/service/promptsServic
 import { createPcmCaptureNode } from '../pcmCaptureWorklet.js';
 
 export const IChatSpeechToTextService = createDecorator<IChatSpeechToTextService>('chatSpeechToTextService');
+
+/**
+ * Command that imports a locally supplied Foundry Local dictation model package
+ * into the model cache. Registered in the desktop layer
+ * (`installDictationModelAction.ts`); referenced here so a failed download in a
+ * registry-blocked environment can offer the offline install as a next step.
+ */
+export const INSTALL_DICTATION_MODEL_COMMAND_ID = 'workbench.action.chat.installDictationModel';
 
 function joinIncrementalDictationText(prefix: string, suffix: string): string {
 	if (!prefix || !suffix) {
@@ -567,6 +577,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IProgressService private readonly _progressService: IProgressService,
 		@ILogService private readonly _logService: ILogService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -1211,7 +1222,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		} else if (status.state === LocalTranscriptionModelState.Error) {
 			this._logModelPrepareTelemetry(status);
 			this._setPreparingModel(false);
-			this._failSession('model', localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? ''));
+			this._failModelSession(status);
 		}
 	}
 
@@ -1287,11 +1298,33 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	/**
+	 * Handle a terminal model-preparation error. A download failure caused by a
+	 * blocked/unreachable model registry (common on locked-down corporate
+	 * networks) is recoverable by importing the model from a locally supplied
+	 * package, so in that case the error surfaces an action that launches the
+	 * offline install flow. Other failures show a plain error.
+	 */
+	private _failModelSession(status: ILocalTranscriptionModelStatus): void {
+		const message = localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? '');
+		const canImport = this._localTranscription.isSupported
+			&& (status.errorCode === 'network' || status.errorCode === 'notFound');
+		const importAction = canImport
+			? toAction({
+				id: INSTALL_DICTATION_MODEL_COMMAND_ID,
+				label: localize('chatStt.installFromPackage', "Install from Local Package..."),
+				run: () => this._commandService.executeCommand(INSTALL_DICTATION_MODEL_COMMAND_ID),
+			})
+			: undefined;
+		this._failSession('model', message, importAction);
+	}
+
+	/**
 	 * Abort the active recording because of an unrecoverable error (e.g. the
 	 * model failed to download/load), surfacing a notification instead of
-	 * silently returning an empty transcript.
+	 * silently returning an empty transcript. An optional recovery action is
+	 * attached to the notification when the failure is actionable.
 	 */
-	private _failSession(errorCode: string, message: string): void {
+	private _failSession(errorCode: string, message: string, action?: IAction): void {
 		if (this._state === ChatSpeechToTextState.Idle) {
 			return;
 		}
@@ -1300,7 +1333,11 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._cancelBackend();
 		this._teardown();
 		this._setState(ChatSpeechToTextState.Idle);
-		this._notificationService.error(message);
+		if (action) {
+			this._notificationService.notify({ severity: Severity.Error, message, actions: { primary: [action] } });
+		} else {
+			this._notificationService.error(message);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -23,7 +23,7 @@ import { localize } from '../../../../../nls.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { ILocalTranscriptionModelStatus, ILocalTranscriptionService, LocalTranscriptionModelState } from '../../../../../platform/localTranscription/common/localTranscription.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL, ILocalTranscriptionModelStatus, ILocalTranscriptionService, LocalTranscriptionModelState } from '../../../../../platform/localTranscription/common/localTranscription.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
 import { IVoiceClientService, IVoiceSessionContext, IVoiceTranscription, IVoiceTurnConfig } from '../../common/voiceClient/voiceClientService.js';
@@ -1305,16 +1305,20 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	 * offline install flow. Other failures show a plain error.
 	 */
 	private _failModelSession(status: ILocalTranscriptionModelStatus): void {
-		const message = localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? '');
 		const canImport = this._localTranscription.isSupported
 			&& (status.errorCode === 'network' || status.errorCode === 'notFound');
-		const importAction = canImport
-			? toAction({
-				id: INSTALL_DICTATION_MODEL_COMMAND_ID,
-				label: localize('chatStt.installFromPackage', "Install from Local Package..."),
-				run: () => this._commandService.executeCommand(INSTALL_DICTATION_MODEL_COMMAND_ID),
-			})
-			: undefined;
+		if (!canImport) {
+			this._failSession('model', localize('chatStt.modelError', "On-device speech-to-text model failed to load: {0}", status.error ?? ''));
+			return;
+		}
+		// Name the specific model so users know exactly which package to obtain
+		// on a machine that can reach the download, then sideload via the command.
+		const message = localize('chatStt.modelErrorOffline', "Could not download the {0} speech-to-text model, which can happen on networks that block the model registry. You can install it from a downloaded package instead.", DEFAULT_LOCAL_TRANSCRIPTION_MODEL);
+		const importAction = toAction({
+			id: INSTALL_DICTATION_MODEL_COMMAND_ID,
+			label: localize('chatStt.installFromPackage', "Install from Local Package..."),
+			run: () => this._commandService.executeCommand(INSTALL_DICTATION_MODEL_COMMAND_ID),
+		});
 		this._failSession('model', message, importAction);
 	}
 

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction.ts
@@ -11,7 +11,7 @@ import { Action2, MenuId, registerAction2 } from '../../../../../platform/action
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { ILocalTranscriptionService } from '../../../../../platform/localTranscription/common/localTranscription.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL, ILocalTranscriptionService } from '../../../../../platform/localTranscription/common/localTranscription.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IProgressService, ProgressLocation } from '../../../../../platform/progress/common/progress.js';
 import { CHAT_CATEGORY } from '../../browser/actions/chatActions.js';
@@ -50,7 +50,7 @@ export function registerInstallDictationModelAction(): void {
 			}
 
 			const sources = await fileDialogService.showOpenDialog({
-				title: localize('chat.installDictationModel.dialogTitle', "Select a Dictation Model Package or Folder"),
+				title: localize('chat.installDictationModel.dialogTitle', "Select the {0} CPU model package (.zip) or folder", DEFAULT_LOCAL_TRANSCRIPTION_MODEL),
 				openLabel: localize('chat.installDictationModel.openLabel', "Install"),
 				canSelectFiles: true,
 				canSelectFolders: true,

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { joinPath } from '../../../../../base/common/resources.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { ILocalTranscriptionService } from '../../../../../platform/localTranscription/common/localTranscription.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IProgressService, ProgressLocation } from '../../../../../platform/progress/common/progress.js';
+import { CHAT_CATEGORY } from '../../browser/actions/chatActions.js';
+import { INSTALL_DICTATION_MODEL_COMMAND_ID } from '../../browser/speechToText/chatSpeechToTextService.js';
+import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+
+export function registerInstallDictationModelAction(): void {
+	const enabled = ContextKeyExpr.and(
+		ChatContextKeys.enabled,
+		ContextKeyExpr.equals('config.dictation.enabled', true),
+	);
+
+	registerAction2(class InstallDictationModelAction extends Action2 {
+		constructor() {
+			super({
+				id: INSTALL_DICTATION_MODEL_COMMAND_ID,
+				category: CHAT_CATEGORY,
+				title: localize2('chat.installDictationModel', "Install Dictation Model from Local Package..."),
+				precondition: enabled,
+				menu: {
+					id: MenuId.CommandPalette,
+					when: enabled,
+				},
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const localTranscriptionService = accessor.get(ILocalTranscriptionService);
+			const notificationService = accessor.get(INotificationService);
+			const fileDialogService = accessor.get(IFileDialogService);
+			const progressService = accessor.get(IProgressService);
+			const environmentService = accessor.get(IEnvironmentService);
+			if (!localTranscriptionService.isSupported) {
+				notificationService.warn(localize('chat.installDictationModel.unsupported', "On-device dictation is not supported on this platform."));
+				return;
+			}
+
+			const sources = await fileDialogService.showOpenDialog({
+				title: localize('chat.installDictationModel.dialogTitle', "Select a Dictation Model Package or Folder"),
+				openLabel: localize('chat.installDictationModel.openLabel', "Install"),
+				canSelectFiles: true,
+				canSelectFolders: true,
+				canSelectMany: false,
+				filters: [{ name: localize('chat.installDictationModel.filter', "Foundry Local Model Package"), extensions: ['zip'] }],
+			});
+			const source = sources?.[0];
+			if (!source) {
+				return;
+			}
+			if (source.scheme !== Schemas.file) {
+				notificationService.error(localize('chat.installDictationModel.localOnly', "The dictation model package must be on the local file system."));
+				return;
+			}
+
+			const cacheDir = joinPath(environmentService.cacheHome, 'chatDictationModels').fsPath;
+			try {
+				const result = await progressService.withProgress({
+					location: ProgressLocation.Notification,
+					title: localize('chat.installDictationModel.progress', "Installing dictation model..."),
+				}, () => localTranscriptionService.importModel({ sourcePath: source.fsPath, cacheDir }));
+				notificationService.info(localize(
+					'chat.installDictationModel.success',
+					"Installed {0} version {1}.",
+					result.model,
+					result.version,
+				));
+			} catch (error) {
+				notificationService.error(localize(
+					'chat.installDictationModel.error',
+					"Failed to install the dictation model: {0}",
+					error instanceof Error ? error.message : String(error),
+				));
+			}
+		}
+	});
+}

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -55,6 +55,7 @@ import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
 import { registerChatExportZipAction } from './actions/chatExportZip.js';
 import { registerExportAgentTracesDbAction } from './actions/exportAgentTracesDb.js';
+import { registerInstallDictationModelAction } from './actions/installDictationModelAction.js';
 import { shouldWarnForSessionShutdown } from './chatLifecycle.js';
 import { HoldToVoiceChatInChatViewAction, InlineVoiceChatAction, KeywordActivationContribution, QuickVoiceChatAction, ReadChatResponseAloud, StartVoiceChatAction, StopListeningAction, StopListeningAndSubmitAction, StopReadAloud, StopReadChatItemAloud, VoiceChatInChatViewAction } from './actions/voiceChatActions.js';
 import { OpenWorkspaceInAgentsWindowAction, OpenWorkspaceInAgentsContribution, OpenAgentsWindowAction, OpenChatSessionInAgentsWindowAction, AgentsHandoffInputTipContribution, ToggleOpenInAgentsWindowTitleBarAction, OpenWorkspaceInAgentsWindowChatTitleAction, OpenWorkspaceInAgentsWindowTitleBarAction } from './agentSessions/agentSessionsActions.js';
@@ -264,6 +265,7 @@ registerAction2(StopReadAloud);
 registerChatDeveloperActions();
 registerChatExportZipAction();
 registerExportAgentTracesDbAction();
+registerInstallDictationModelAction();
 
 registerWorkbenchContribution2(KeywordActivationContribution.ID, KeywordActivationContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(NativeBuiltinToolsContribution.ID, NativeBuiltinToolsContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/services/localTranscription/browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/browser/localTranscriptionService.ts
@@ -26,6 +26,10 @@ export class NullLocalTranscriptionService implements ILocalTranscriptionService
 		return { state: LocalTranscriptionModelState.Error, error: 'unsupported' };
 	}
 
+	async importModel(): Promise<never> {
+		throw new Error('On-device transcription is not supported in this environment.');
+	}
+
 	async start(): Promise<void> {
 		throw new Error('On-device transcription is not supported in this environment.');
 	}

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -82,6 +82,7 @@ export class LocalTranscriptionService {
 	get onDidTranscribe() { return this._getProxy().onDidTranscribe; }
 
 	getModelStatus() { return this._getProxy().getModelStatus(); }
+	importModel(options: Parameters<ILocalTranscriptionService['importModel']>[0]) { return this._getProxy().importModel(options); }
 	start(options: { cacheDir: string; model?: string; language?: string }) {
 		const { proxyUrl, noProxy, proxyStrictSSL, proxyAuthorization } = this._resolveProxyConfig();
 		const runtime = this.productService.dictationRuntime;


### PR DESCRIPTION
Fixes #328154

<img width="514" height="169" alt="Screenshot 2026-07-30 at 10 50 18 AM" src="https://github.com/user-attachments/assets/67646945-ae1c-43e4-942f-42393b92cb9d" />


## Problem

On-device dictation (Foundry Local / Nemotron ASR) provisions its native runtime fine through a corporate proxy, but the **model download** fails. The native downloader first resolves the model through the Azure ML **registry** (`api.catalog.azureml.ms` + per-region registry endpoints) to get a signed blob URI, and only then downloads the bytes. Locked-down networks block those registry endpoints, so it fails with `RegionFallbackException` / TLS errors across all regions before ever reaching the blob CDN. This is endpoint blocking, not a proxy misconfig, so there is no settings-level fix.

The model files themselves are separately published on a reachable Microsoft download CDN as an expansion-pack ZIP. Foundry Local's SDK has a local scanner: if the files exist in the cache in the right layout (with `genai_config.json` + `inference_model.json`), `model.isCached` becomes `true` and `download()` short-circuits, never touching the registry.

## What this PR does

1. **New command** `Chat: Install Dictation Model from Local Package...` — imports the official Foundry Local expansion pack (ZIP or extracted OCI layout) or a prepared model directory into the dictation model cache, writing the scanner metadata that makes Foundry Local treat the model as cached. Gated on `ChatContextKeys.enabled` + `dictation.enabled`.
2. **Discoverable recovery** — when a model download fails with a network/registry error (`errorCode` = `network`/`notFound`), the failure notification surfaces an **"Install from Local Package..."** action that launches the same command, so users find the fix exactly when they hit the wall. Other failures are unchanged.

The importer validates the package (rejects path-traversal in OCI layer titles and wrong-model packages), stages into a temp dir and atomically swaps into place with backup/rollback, and moves (rather than copies) files extracted to temp to avoid transient disk bloat.

## Why not fully auto-download?

The reachable CDN URL isn't a published/stable contract, the blob is large, and stricter lockdowns can block that host too — auto-fetch would just relocate the failure and add downloader bulk. The guided import gets the benefit without the fragility.

## Notes on bulk

No new npm dependencies. Reuses the existing `localTranscription` utility process and `base/node/zip.ts` (yauzl) extractor plus Node built-ins. The importer code loads only when the command runs.

## Validation

- `transpile-client`, `typecheck-client`, `valid-layers-check` — clean
- New importer tests + zip regression — 10/10 passing (prepared dir import, nested OCI expansion-pack import, path-traversal rejection, wrong-model rejection)
- Hygiene — clean

Also fixes a pre-existing disposable leak in `base/node/zip.ts` (the cancellation listener in `extractEntry` was never disposed).
