### PR TITLE
sessions: propagate visibility to hidden chat transcripts

### DIFF
--- a/src/vs/sessions/browser/parts/chatView.ts
+++ b/src/vs/sessions/browser/parts/chatView.ts
@@ -130,12 +130,8 @@ export abstract class AbstractChatView extends Disposable implements ISerializab
 	}
 
 	/**
-	 * Notifies the view whether it is currently visible, i.e. whether both the
-	 * sessions part and this view's grid leaf are shown. Hidden views live under
-	 * a `display:none` ancestor, so they must pause DOM rendering (measuring
-	 * rows there yields `0px`) and catch up once shown again. Note that this is
-	 * independent of {@link setActive}: inactive side-by-side sessions are still
-	 * visible. The default implementation is a no-op.
+	 * Notifies the view whether it is currently shown. Unlike {@link setActive},
+	 * inactive sessions displayed side by side are still visible.
 	 */
 	setVisible(_visible: boolean): void {
 		// no-op by default

--- a/src/vs/sessions/browser/parts/chatView.ts
+++ b/src/vs/sessions/browser/parts/chatView.ts
@@ -130,6 +130,18 @@ export abstract class AbstractChatView extends Disposable implements ISerializab
 	}
 
 	/**
+	 * Notifies the view whether it is currently visible, i.e. whether both the
+	 * sessions part and this view's grid leaf are shown. Hidden views live under
+	 * a `display:none` ancestor, so they must pause DOM rendering (measuring
+	 * rows there yields `0px`) and catch up once shown again. Note that this is
+	 * independent of {@link setActive}: inactive side-by-side sessions are still
+	 * visible. The default implementation is a no-op.
+	 */
+	setVisible(_visible: boolean): void {
+		// no-op by default
+	}
+
+	/**
 	 * Shows an indeterminate progress bar at the top of this leaf while the
 	 * given promise is pending, mirroring how each editor group surfaces
 	 * progress on its own {@link ProgressBar} (see `EditorGroupView` /

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -85,6 +85,18 @@ export class SessionView extends Disposable implements ISerializableView {
 	/** Whether this view currently hosts the active session in the grid. */
 	private _isActive = true;
 
+	/**
+	 * Whether the owning {@link SessionsPart} is visible in the workbench grid.
+	 * Pushed in by the part via {@link setPartVisible}.
+	 */
+	private _isPartVisible = true;
+
+	/**
+	 * Whether this leaf is visible within the part's internal grid. Pushed in by
+	 * the grid via {@link setVisible} when a sibling leaf is maximized.
+	 */
+	private _isLeafVisible = true;
+
 	private readonly _sessionObs = observableValue<IActiveSession | undefined>(this, undefined);
 
 	constructor(
@@ -214,6 +226,7 @@ export class SessionView extends Disposable implements ISerializableView {
 				this._contentContainer.replaceChildren(view.element);
 				this._currentView.value = view;
 				view.setActive(this._isActive);
+				view.setVisible(this._isVisible);
 			}
 
 			if (session) {
@@ -246,7 +259,16 @@ export class SessionView extends Disposable implements ISerializableView {
 		if (!this._lastLayout) {
 			return;
 		}
+
+		// A hidden leaf sits under a `display:none` ancestor and is laid out at
+		// zero size by the split view, so forwarding those dimensions would make
+		// the chat widget measure and cache bogus geometry. The split view lays
+		// the leaf out again right after it becomes visible, and `setVisible`
+		// re-runs this pass, so no layout is lost.
 		const { width, height, top, left } = this._lastLayout;
+		if (!this._isVisible || width === 0 || height === 0) {
+			return;
+		}
 
 		// Apply the centered band's width first so the header and tabs wrap to
 		// their final layout before we measure their combined height. Measuring
@@ -324,6 +346,54 @@ export class SessionView extends Disposable implements ISerializableView {
 		this._isActive = active;
 		this._applyActiveSessionStyles();
 		this._currentView.value?.setActive(active);
+	}
+
+	/**
+	 * Grid hook invoked by the part's internal split view when this leaf is
+	 * hidden or shown (e.g. when a sibling session is maximized).
+	 */
+	setVisible(visible: boolean): void {
+		if (this._isLeafVisible === visible) {
+			return;
+		}
+		const wasVisible = this._isVisible;
+		this._isLeafVisible = visible;
+		this._updateVisibility(wasVisible);
+	}
+
+	/**
+	 * Called by the owning {@link SessionsPart} when the part itself is hidden or
+	 * shown in the workbench grid. Combined with this leaf's own visibility to
+	 * form the view's effective visibility.
+	 */
+	setPartVisible(visible: boolean): void {
+		if (this._isPartVisible === visible) {
+			return;
+		}
+		const wasVisible = this._isVisible;
+		this._isPartVisible = visible;
+		this._updateVisibility(wasVisible);
+	}
+
+	/**
+	 * Whether this view is actually shown, i.e. neither the part nor this leaf is
+	 * hidden. Note this is unrelated to {@link setActive}: inactive sessions shown
+	 * side by side are still visible.
+	 */
+	private get _isVisible(): boolean {
+		return this._isPartVisible && this._isLeafVisible;
+	}
+
+	private _updateVisibility(wasVisible: boolean): void {
+		const visible = this._isVisible;
+		if (visible === wasVisible) {
+			return;
+		}
+		this._currentView.value?.setVisible(visible);
+		if (visible) {
+			// Catch up on the layout passes that were skipped while hidden.
+			this._layoutChildren();
+		}
 	}
 
 	private _applyActiveSessionStyles(): void {

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -85,16 +85,10 @@ export class SessionView extends Disposable implements ISerializableView {
 	/** Whether this view currently hosts the active session in the grid. */
 	private _isActive = true;
 
-	/**
-	 * Whether the owning {@link SessionsPart} is visible in the workbench grid.
-	 * Pushed in by the part via {@link setPartVisible}.
-	 */
+	/** Whether the owning {@link SessionsPart} is visible in the workbench grid. */
 	private _isPartVisible = true;
 
-	/**
-	 * Whether this leaf is visible within the part's internal grid. Pushed in by
-	 * the grid via {@link setVisible} when a sibling leaf is maximized.
-	 */
+	/** Whether this leaf is visible within the part's internal grid. */
 	private _isLeafVisible = true;
 
 	private readonly _sessionObs = observableValue<IActiveSession | undefined>(this, undefined);
@@ -260,11 +254,7 @@ export class SessionView extends Disposable implements ISerializableView {
 			return;
 		}
 
-		// A hidden leaf sits under a `display:none` ancestor and is laid out at
-		// zero size by the split view, so forwarding those dimensions would make
-		// the chat widget measure and cache bogus geometry. The split view lays
-		// the leaf out again right after it becomes visible, and `setVisible`
-		// re-runs this pass, so no layout is lost.
+		// A hidden or zero-sized leaf would report invalid geometry to the chat widget.
 		const { width, height, top, left } = this._lastLayout;
 		if (!this._isVisible || width === 0 || height === 0) {
 			return;
@@ -376,9 +366,8 @@ export class SessionView extends Disposable implements ISerializableView {
 	}
 
 	/**
-	 * Whether this view is actually shown, i.e. neither the part nor this leaf is
-	 * hidden. Note this is unrelated to {@link setActive}: inactive sessions shown
-	 * side by side are still visible.
+	 * Whether this view is actually shown. Unrelated to {@link setActive}:
+	 * inactive sessions shown side by side are still visible.
 	 */
 	private get _isVisible(): boolean {
 		return this._isPartVisible && this._isLeafVisible;

--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -93,9 +93,8 @@ export class SessionsPart extends Part {
 	private readonly _sessionsFocusKey: IContextKey<boolean>;
 
 	/**
-	 * Whether the part itself is visible in the workbench grid. Pushed into every
-	 * {@link SessionView} so hidden session views can pause rendering. Starts
-	 * `true` because the workbench grid only calls {@link setVisible} on change.
+	 * Whether the part itself is visible in the workbench grid. Starts `true`
+	 * because the workbench grid only calls {@link setVisible} on change.
 	 */
 	private _isPartVisible = true;
 
@@ -425,11 +424,7 @@ export class SessionsPart extends Part {
 
 	override setVisible(visible: boolean): void {
 		if (this._isPartVisible !== visible) {
-			// Forward the part's visibility to each session view so hidden chats
-			// stop rendering into a `display:none` subtree, where dynamic row
-			// measurement reads a height of zero. Updated before the base class
-			// raises its visibility event, which re-enters this method via the
-			// layout's part-visibility handling.
+			// Update before `super`, whose event re-enters this method.
 			this._isPartVisible = visible;
 			for (const slot of this._slots) {
 				slot.view.setPartVisible(visible);

--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -93,6 +93,13 @@ export class SessionsPart extends Part {
 	private readonly _sessionsFocusKey: IContextKey<boolean>;
 
 	/**
+	 * Whether the part itself is visible in the workbench grid. Pushed into every
+	 * {@link SessionView} so hidden session views can pause rendering. Starts
+	 * `true` because the workbench grid only calls {@link setVisible} on change.
+	 */
+	private _isPartVisible = true;
+
+	/**
 	 * Whether the session type ("harness") picker should be rendered below the
 	 * input (in the controls) instead of next to the workspace picker. Backed
 	 * by the {@link HARNESS_PICKER_IN_CONTROLS_TREATMENT} A/B experiment, which
@@ -381,6 +388,7 @@ export class SessionsPart extends Part {
 	private _createSlot(): IGridSlot {
 		const disposables = new DisposableStore();
 		const view = disposables.add(this.instantiationService.createInstance(SessionView));
+		view.setPartVisible(this._isPartVisible);
 		const slot: IGridSlot = { view, disposables, boundSessionId: undefined };
 		// Promote a visible session to the active session when its view receives
 		// focus or is clicked. Pointer-down covers clicks on non-focusable chrome
@@ -413,6 +421,22 @@ export class SessionsPart extends Part {
 		container.style.backgroundColor = this.getColor(agentsPanelBackground) || '';
 
 		this._gridWidget?.style({ separatorBorder: this._gridSeparatorBorder });
+	}
+
+	override setVisible(visible: boolean): void {
+		if (this._isPartVisible !== visible) {
+			// Forward the part's visibility to each session view so hidden chats
+			// stop rendering into a `display:none` subtree, where dynamic row
+			// measurement reads a height of zero. Updated before the base class
+			// raises its visibility event, which re-enters this method via the
+			// layout's part-visibility handling.
+			this._isPartVisible = visible;
+			for (const slot of this._slots) {
+				slot.view.setPartVisible(visible);
+			}
+		}
+
+		super.setVisible(visible);
 	}
 
 	override layout(width: number, height: number, top: number, left: number): void {

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -145,11 +145,7 @@ export class ChatView extends AbstractChatView {
 	/** Observable mirror of {@link _isActive} so the voice overlay can react. */
 	private readonly _isActiveObs = observableValue<boolean>(this, true);
 
-	/**
-	 * Whether this view is currently visible. `undefined` until the hosting
-	 * `SessionView` pushes the effective visibility right after creating the
-	 * view, so that initial value always reaches the widget.
-	 */
+	/** Whether this view is currently visible. `undefined` so the first push always reaches the widget. */
 	private _isVisible: boolean | undefined;
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -146,6 +146,13 @@ export class ChatView extends AbstractChatView {
 	private readonly _isActiveObs = observableValue<boolean>(this, true);
 
 	/**
+	 * Whether this view is currently visible. `undefined` until the hosting
+	 * `SessionView` pushes the effective visibility right after creating the
+	 * view, so that initial value always reaches the widget.
+	 */
+	private _isVisible: boolean | undefined;
+
+	/**
 	 * Per-view mirror of `agentsVoiceInitiatedHere`, scoped above the chat widget.
 	 * Keeps post-connect voice controls anchored to the active session view.
 	 */
@@ -198,7 +205,6 @@ export class ChatView extends AbstractChatView {
 			this._buildStyles(this._isActive)
 		));
 		this._widget.render(this.element);
-		this._widget.setVisible(true);
 
 		this._selectionSideChatController = this._register(scopedInstantiationService.createInstance(ResponseSelectionSideChatController, this._widget));
 
@@ -417,6 +423,14 @@ export class ChatView extends AbstractChatView {
 		this._isActiveObs.set(active, undefined);
 		this._banners.setActive(active);
 		this._widget.setStyles(this._buildStyles(active));
+	}
+
+	override setVisible(visible: boolean): void {
+		if (this._isVisible === visible) {
+			return;
+		}
+		this._isVisible = visible;
+		this._widget.setVisible(visible);
 	}
 }
 

--- a/src/vs/sessions/test/browser/sessionView.test.ts
+++ b/src/vs/sessions/test/browser/sessionView.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { SessionView } from '../../browser/parts/sessionView.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+
+suite('Sessions - Session View', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('forwards effective visibility (part and grid leaf) to the hosted chat view', () => {
+		const forwarded: boolean[] = [];
+		const view = {
+			_isPartVisible: true,
+			_isLeafVisible: true,
+			_lastLayout: undefined,
+			_currentView: { value: { setVisible: (visible: boolean) => forwarded.push(visible) } },
+		} as unknown as SessionView;
+
+		// A sibling session is maximized, hiding this leaf.
+		SessionView.prototype.setVisible.call(view, false);
+		// The whole sessions part is hidden while the leaf is still hidden.
+		SessionView.prototype.setPartVisible.call(view, false);
+		// Leaving the maximized state must not reveal the chat while the part is hidden.
+		SessionView.prototype.setVisible.call(view, true);
+		// Showing the part again reveals the chat.
+		SessionView.prototype.setPartVisible.call(view, true);
+
+		assert.deepStrictEqual(forwarded, [false, true]);
+	});
+});

--- a/src/vs/sessions/test/browser/sessionView.test.ts
+++ b/src/vs/sessions/test/browser/sessionView.test.ts
@@ -12,21 +12,22 @@ suite('Sessions - Session View', () => {
 
 	test('forwards effective visibility (part and grid leaf) to the hosted chat view', () => {
 		const forwarded: boolean[] = [];
-		const view = {
+		// Created from the prototype so the internal visibility helpers are present.
+		const view: SessionView = Object.assign(Object.create(SessionView.prototype), {
 			_isPartVisible: true,
 			_isLeafVisible: true,
 			_lastLayout: undefined,
 			_currentView: { value: { setVisible: (visible: boolean) => forwarded.push(visible) } },
-		} as unknown as SessionView;
+		});
 
 		// A sibling session is maximized, hiding this leaf.
-		SessionView.prototype.setVisible.call(view, false);
+		view.setVisible(false);
 		// The whole sessions part is hidden while the leaf is still hidden.
-		SessionView.prototype.setPartVisible.call(view, false);
+		view.setPartVisible(false);
 		// Leaving the maximized state must not reveal the chat while the part is hidden.
-		SessionView.prototype.setVisible.call(view, true);
+		view.setVisible(true);
 		// Showing the part again reveals the chat.
-		SessionView.prototype.setPartVisible.call(view, true);
+		view.setPartVisible(true);
 
 		assert.deepStrictEqual(forwarded, [false, true]);
 	});


### PR DESCRIPTION
Fixes #328200

## What was wrong

Hidden chat transcripts in the Agents window kept updating their dynamic-height list as though they were visible. While a response was streaming this produced many copies of:

```
Measured item node at 0px- ensure that ListView is not display:none before measuring row height!
```

`ChatWidget._visible` was pinned to `true` for the entire life of a sessions chat view:

- `ChatView` called `this._widget.setVisible(true)` in its constructor and never sent `false`.
- `SessionView` is a leaf of the Sessions part's internal `SerializableGrid`, but did not implement the optional `IView.setVisible` hook that `SplitView`/`GridView` invoke when a leaf is hidden (e.g. when a sibling session is maximized). `SplitView` removes the `.visible` class before calling that hook, and its CSS gives non-visible leaves `display: none`.
- `SessionsPart` received outer workbench-grid visibility through `Part.setVisible`, but never propagated it to its internal session views.

So model updates kept flowing into `ChatListWidget.refresh`, where dynamic row measurement reads `offsetHeight === 0` under a `display:none` ancestor.

## What changed

Combine the outer Sessions-part visibility with each internal grid leaf's visibility into a single effective value, seed it when views are created, and forward it down to `ChatWidget.setVisible`.

- **`browser/parts/chatView.ts`** — new `AbstractChatView.setVisible()` hook (no-op default), documented as independent of `setActive`.
- **`contrib/chat/browser/chatView.ts`** — `ChatView` overrides `setVisible` and forwards to `ChatWidget.setVisible`. The eager `setVisible(true)` in the constructor is removed; the initial state is pushed by the host instead. Tracked as `boolean | undefined` so the first push always reaches the widget, including an initial `false`.
- **`browser/parts/sessionView.ts`** — implements the grid's `setVisible` hook plus a new `setPartVisible`, ANDs them into an effective visibility, seeds it into each chat view in `openSession`, and forwards only on real transitions. `_layoutChildren` is skipped while hidden or zero-sized (so bogus geometry is never fed to the widget) and re-runs on reveal so nothing is lost.
- **`browser/parts/sessionsPart.ts`** — overrides `Part.setVisible` to push part visibility into every slot, and seeds newly created slots in `_createSlot`.

Active-session state stays separate on purpose: inactive sessions shown side by side are still visible, so `setActive` and `setVisible` are independent.

## Notes for reviewers

- In `SessionsPart.setVisible`, the internal state is updated **before** `super.setVisible(visible)`. The base class raises the visibility event, which re-enters this path through the layout's part-visibility handling, so updating first keeps that re-entrancy a no-op.
- Both hide paths from the issue are covered: maximizing a different session (inner grid leaf) and hiding the Sessions part (outer workbench grid).
- This should also fix the secondary symptoms called out in the issue — hidden chats performing visibility-gated actions such as scrolling to a new request, and a completed hidden session being marked read because `ChatWidget.visible` incorrectly stayed `true`.

## Validation

- `tsc --project ./src/tsconfig.json --noEmit` — clean.
- `build/hygiene.ts` on all changed files — clean.
- Added `src/vs/sessions/test/browser/sessionView.test.ts` covering the AND-combination, in particular that un-maximizing while the part is hidden must **not** reveal the chat. It follows the same prototype-`call` stub pattern as the existing `mobileSessionsPart.test.ts`. My worktree had no build output or Electron, so I could not run the unit-test harness locally — leaving that to CI.

The regression was introduced by the Sessions Grid change in 6dfc9e40fbf801efd2e471c25021075ba44d161a. The warning itself predates it and was added to diagnose exactly this class of measurement-under-hidden-ancestor bug.
