### PR TITLE
Debounce worktree creation progress updates

### DIFF
--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs/promises';
-import { SequencerByKey } from '../../../../base/common/async.js';
+import { RunOnceScheduler, SequencerByKey } from '../../../../base/common/async.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../base/common/htmlContent.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -47,6 +47,7 @@ export class SessionWorkingDirectoryMissingError extends Error {
 
 /** Default upper bound on branch names returned for the branch picker. */
 const BRANCH_COMPLETION_LIMIT = 25;
+const WORKTREE_PROGRESS_DEBOUNCE_MS = 40;
 
 interface ICreatedWorktree {
 	readonly repositoryRoot: URI;
@@ -133,21 +134,32 @@ export function buildWorktreeProgressText(phase: WorktreeCreationPhase, percent?
 	}
 }
 
+/** Debounced percentage progress for one worktree-creation phase. */
+interface IPercentProgressReporter extends IDisposable {
+	readonly report: (progress: IWorktreeFileProgress) => void;
+	flush(): void;
+}
+
 /**
  * Adapts the raw file counts the git service reports into progress labels for
- * a phase. Samples can arrive several times a second, so this rounds down to
- * whole percent and drops anything that doesn't advance it — a consumer never
- * sees two updates that read the same, and never more than 101 per phase.
+ * a phase. Rounds down to whole percentages, drops non-advancing samples, and
+ * debounces updates to avoid overwhelming consumers. Callers flush the latest
+ * percentage when the phase completes.
  */
-function createPercentProgressReporter(phase: WorktreeCreationPhase, onProgress: (activity: string) => void): (progress: IWorktreeFileProgress) => void {
+function createPercentProgressReporter(phase: WorktreeCreationPhase, onProgress: (activity: string) => void): IPercentProgressReporter {
 	let lastPercent = -1;
-	return ({ filesDone, filesTotal }) => {
-		const percent = Math.min(100, Math.floor(filesDone * 100 / filesTotal));
-		if (percent <= lastPercent) {
-			return;
-		}
-		lastPercent = percent;
-		onProgress(buildWorktreeProgressText(phase, percent));
+	const scheduler = new RunOnceScheduler(() => onProgress(buildWorktreeProgressText(phase, lastPercent)), WORKTREE_PROGRESS_DEBOUNCE_MS);
+	return {
+		report: ({ filesDone, filesTotal }) => {
+			const percent = Math.min(100, Math.floor(filesDone * 100 / filesTotal));
+			if (percent <= lastPercent) {
+				return;
+			}
+			lastPercent = percent;
+			scheduler.schedule();
+		},
+		flush: () => scheduler.flush(),
+		dispose: () => scheduler.dispose(),
 	};
 }
 
@@ -538,7 +550,16 @@ export class WorktreeIsolation extends Disposable {
 			onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.CheckingOut));
 
 			const worktreeBranchTrack = config[SessionConfigKey.WorktreeBranchTrack] === true;
-			await this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch, worktreeBranchTrack, onProgress && createPercentProgressReporter(WorktreeCreationPhase.CheckingOut, onProgress));
+			const checkoutProgress = onProgress && createPercentProgressReporter(WorktreeCreationPhase.CheckingOut, onProgress);
+			try {
+				await this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch, worktreeBranchTrack, checkoutProgress?.report);
+			} finally {
+				try {
+					checkoutProgress?.flush();
+				} finally {
+					checkoutProgress?.dispose();
+				}
+			}
 			return { branchName, worktree, baseBranch };
 		});
 		const worktreeIncludeFiles = Array.isArray(config[SessionConfigKey.WorktreeIncludeFiles])
@@ -548,7 +569,16 @@ export class WorktreeIsolation extends Disposable {
 		if (worktreeIncludeFiles?.length) {
 			try {
 				onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.CopyingIncludeFiles));
-				await this._gitService.copyWorktreeIncludeFiles(repositoryRoot, worktree, worktreeIncludeFiles, onProgress && createPercentProgressReporter(WorktreeCreationPhase.CopyingIncludeFiles, onProgress));
+				const copyProgress = onProgress && createPercentProgressReporter(WorktreeCreationPhase.CopyingIncludeFiles, onProgress);
+				try {
+					await this._gitService.copyWorktreeIncludeFiles(repositoryRoot, worktree, worktreeIncludeFiles, copyProgress?.report);
+				} finally {
+					try {
+						copyProgress?.flush();
+					} finally {
+						copyProgress?.dispose();
+					}
+				}
 			} catch (error) {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to copy worktree include files: ${errorMessage(error)}`);
 			}

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs/promises';
 import { RunOnceScheduler, SequencerByKey } from '../../../../base/common/async.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../base/common/htmlContent.js';
-import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -134,33 +134,39 @@ export function buildWorktreeProgressText(phase: WorktreeCreationPhase, percent?
 	}
 }
 
-/** Debounced percentage progress for one worktree-creation phase. */
-interface IPercentProgressReporter extends IDisposable {
-	readonly report: (progress: IWorktreeFileProgress) => void;
-	flush(): void;
-}
-
 /**
  * Adapts the raw file counts the git service reports into progress labels for
  * a phase. Rounds down to whole percentages, drops non-advancing samples, and
- * debounces updates to avoid overwhelming consumers. Callers flush the latest
- * percentage when the phase completes.
+ * debounces updates to avoid overwhelming consumers, flushing the latest
+ * percentage when the operation completes.
  */
-function createPercentProgressReporter(phase: WorktreeCreationPhase, onProgress: (activity: string) => void): IPercentProgressReporter {
+async function withPercentProgress<T>(
+	phase: WorktreeCreationPhase,
+	onProgress: ((activity: string) => void) | undefined,
+	operation: (onProgress: ((progress: IWorktreeFileProgress) => void) | undefined) => Promise<T>,
+): Promise<T> {
+	if (!onProgress) {
+		return operation(undefined);
+	}
+
 	let lastPercent = -1;
 	const scheduler = new RunOnceScheduler(() => onProgress(buildWorktreeProgressText(phase, lastPercent)), WORKTREE_PROGRESS_DEBOUNCE_MS);
-	return {
-		report: ({ filesDone, filesTotal }) => {
+	try {
+		return await operation(({ filesDone, filesTotal }) => {
 			const percent = Math.min(100, Math.floor(filesDone * 100 / filesTotal));
 			if (percent <= lastPercent) {
 				return;
 			}
 			lastPercent = percent;
 			scheduler.schedule();
-		},
-		flush: () => scheduler.flush(),
-		dispose: () => scheduler.dispose(),
-	};
+		});
+	} finally {
+		const shouldFlush = scheduler.isScheduled();
+		scheduler.dispose();
+		if (shouldFlush) {
+			onProgress(buildWorktreeProgressText(phase, lastPercent));
+		}
+	}
 }
 
 /**
@@ -550,16 +556,8 @@ export class WorktreeIsolation extends Disposable {
 			onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.CheckingOut));
 
 			const worktreeBranchTrack = config[SessionConfigKey.WorktreeBranchTrack] === true;
-			const checkoutProgress = onProgress && createPercentProgressReporter(WorktreeCreationPhase.CheckingOut, onProgress);
-			try {
-				await this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch, worktreeBranchTrack, checkoutProgress?.report);
-			} finally {
-				try {
-					checkoutProgress?.flush();
-				} finally {
-					checkoutProgress?.dispose();
-				}
-			}
+			await withPercentProgress(WorktreeCreationPhase.CheckingOut, onProgress, progress =>
+				this._gitService.addWorktree(repositoryRoot, worktree, branchName, baseBranch, worktreeBranchTrack, progress));
 			return { branchName, worktree, baseBranch };
 		});
 		const worktreeIncludeFiles = Array.isArray(config[SessionConfigKey.WorktreeIncludeFiles])
@@ -569,16 +567,8 @@ export class WorktreeIsolation extends Disposable {
 		if (worktreeIncludeFiles?.length) {
 			try {
 				onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.CopyingIncludeFiles));
-				const copyProgress = onProgress && createPercentProgressReporter(WorktreeCreationPhase.CopyingIncludeFiles, onProgress);
-				try {
-					await this._gitService.copyWorktreeIncludeFiles(repositoryRoot, worktree, worktreeIncludeFiles, copyProgress?.report);
-				} finally {
-					try {
-						copyProgress?.flush();
-					} finally {
-						copyProgress?.dispose();
-					}
-				}
+				await withPercentProgress(WorktreeCreationPhase.CopyingIncludeFiles, onProgress, progress =>
+					this._gitService.copyWorktreeIncludeFiles(repositoryRoot, worktree, worktreeIncludeFiles, progress));
 			} catch (error) {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to copy worktree include files: ${errorMessage(error)}`);
 			}

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -240,7 +240,7 @@ suite('WorktreeIsolation', () => {
 		});
 	});
 
-	test('resolveWorkingDirectory names each creation phase, rounding percentages down and skipping repeats', async () => {
+	test('resolveWorkingDirectory names each creation phase, rounding percentages down and debouncing updates', async () => {
 		const gitService = createGitService();
 		gitService.addWorktree = async (_root, worktree, branch, startPoint, track, onProgress) => {
 			addWorktreeCalls.push({ worktree, branchName: branch, startPoint, track });
@@ -248,6 +248,7 @@ suite('WorktreeIsolation', () => {
 			onProgress?.({ filesDone: 7, filesTotal: 800 });
 			onProgress?.({ filesDone: 96, filesTotal: 800 });
 			onProgress?.({ filesDone: 100, filesTotal: 800 });
+			await timeout(50);
 			onProgress?.({ filesDone: 800, filesTotal: 800 });
 		};
 		gitService.copyWorktreeIncludeFiles = async (_root, _worktree, _globs, onProgress) => {
@@ -274,11 +275,9 @@ suite('WorktreeIsolation', () => {
 			'Creating isolated worktree',
 			'Creating isolated worktree (naming branch)',
 			'Creating isolated worktree (checking out files)',
-			'Creating isolated worktree (checking out files, 0%)',
 			'Creating isolated worktree (checking out files, 12%)',
 			'Creating isolated worktree (checking out files, 100%)',
 			'Creating isolated worktree (copying additional files)',
-			'Creating isolated worktree (copying additional files, 25%)',
 			'Creating isolated worktree (copying additional files, 100%)',
 		]);
 	});


### PR DESCRIPTION
## Summary
- debounce worktree percentage progress updates by 40 ms
- flush the latest progress when each creation phase completes
- update worktree isolation coverage for coalesced progress bursts

## Testing
- Not run (per request).