### PR TITLE
agentHost: use fake timers for Claude mapper tests

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
@@ -55,12 +55,8 @@ export class ClaudeMapperState {
 	 * Public so mapper functions can call its lifecycle methods
 	 * directly without forwarding through this class.
 	 */
-	readonly toolCalls: ClaudeToolCallRegistry;
+	readonly toolCalls = new ClaudeToolCallRegistry();
 	private _currentMessageId: string | undefined;
-
-	constructor(now: () => number = Date.now) {
-		this.toolCalls = new ClaudeToolCallRegistry(now);
-	}
 
 	/**
 	 * Phase 8 — file-edit content pre-staged by

--- a/src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts
@@ -118,7 +118,7 @@ export class ClaudeToolCallRegistry {
 		if (!entry || entry.displayedInputLength === entry.inputBuffer.length) {
 			return undefined;
 		}
-		const now = Date.now();
+		const now = performance.now();
 		if (!force && entry.displayedAt !== undefined && now - entry.displayedAt < STREAMING_TOOL_DISPLAY_INTERVAL_MS) {
 			return undefined;
 		}

--- a/src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts
@@ -74,8 +74,6 @@ export interface IClaudeStreamingToolInputUpdate {
 export class ClaudeToolCallRegistry {
 	private readonly _entries = new Map<string, IRegistryEntry>();
 
-	constructor(private readonly _now: () => number = Date.now) { }
-
 	/**
 	 * Begin tracking a tool call. Called from `content_block_start`
 	 * for a `tool_use` block. Allocates the delta buffer; the
@@ -120,7 +118,7 @@ export class ClaudeToolCallRegistry {
 		if (!entry || entry.displayedInputLength === entry.inputBuffer.length) {
 			return undefined;
 		}
-		const now = this._now();
+		const now = Date.now();
 		if (!force && entry.displayedAt !== undefined && now - entry.displayedAt < STREAMING_TOOL_DISPLAY_INTERVAL_MS) {
 			return undefined;
 		}

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
@@ -50,9 +50,11 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 	const SESSION_STR = SESSION.toString();
 	const SESSION_ID = 'sid-1';
 	const TURN_ID = 'turn-1';
+	let clock: sinon.SinonFakeTimers | undefined;
 
 	teardown(() => {
-		sinon.restore();
+		clock?.restore();
+		clock = undefined;
 	});
 
 	/**
@@ -336,8 +338,8 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 	});
 
 	test('file-edit input deltas emit compact rich invocation messages', () => {
+		clock = sinon.useFakeTimers({ toFake: ['performance'] });
 		const log = new NullLogService();
-		const clock = sinon.useFakeTimers({ now: 1_000 });
 		const state = new ClaudeMapperState();
 		const resolver = r();
 		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_write', 'Write')), SESSION, TURN_ID, state, log, resolver);
@@ -387,8 +389,8 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 	});
 
 	test('content_block_stop flushes the final rich file-edit message held back by the throttle', () => {
+		clock = sinon.useFakeTimers({ toFake: ['performance'] });
 		const log = new NullLogService();
-		sinon.useFakeTimers({ now: 1_000 });
 		const state = new ClaudeMapperState();
 		const resolver = r();
 		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_write', 'Write')), SESSION, TURN_ID, state, log, resolver);

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as sinon from 'sinon';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
@@ -49,6 +50,10 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 	const SESSION_STR = SESSION.toString();
 	const SESSION_ID = 'sid-1';
 	const TURN_ID = 'turn-1';
+
+	teardown(() => {
+		sinon.restore();
+	});
 
 	/**
 	 * Captures `warn` calls so defense-in-depth tests can assert the
@@ -332,8 +337,8 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 
 	test('file-edit input deltas emit compact rich invocation messages', () => {
 		const log = new NullLogService();
-		let now = 1_000;
-		const state = new ClaudeMapperState(() => now);
+		const clock = sinon.useFakeTimers({ now: 1_000 });
+		const state = new ClaudeMapperState();
 		const resolver = r();
 		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_write', 'Write')), SESSION, TURN_ID, state, log, resolver);
 
@@ -345,7 +350,7 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 			log,
 			resolver,
 		);
-		now += STREAMING_TOOL_DISPLAY_INTERVAL_MS;
+		clock.tick(STREAMING_TOOL_DISPLAY_INTERVAL_MS);
 		const second = mapSDKMessageToAgentSignals(
 			makeStreamEvent(SESSION_ID, makeInputJsonDelta(0, '\\nthree\\nfour\\nfive"')),
 			SESSION,
@@ -383,8 +388,8 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 
 	test('content_block_stop flushes the final rich file-edit message held back by the throttle', () => {
 		const log = new NullLogService();
-		const now = 1_000;
-		const state = new ClaudeMapperState(() => now);
+		sinon.useFakeTimers({ now: 1_000 });
+		const state = new ClaudeMapperState();
 		const resolver = r();
 		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_write', 'Write')), SESSION, TURN_ID, state, log, resolver);
 


### PR DESCRIPTION
## Summary

- remove the test-only Date override parameters from Claude mapper product code
- use Sinon fake timers to exercise streaming tool-call throttling deterministically

## Testing

- `npm run typecheck-client`
- targeted hygiene checks
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/claudeToolCallRegistry.test.ts`

Addresses the review feedback on #327765.

(Written by Copilot)