### PR TITLE
Improve notification handling to reduce duplicates

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -28,6 +28,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { DEFAULT_CUSTOM_TITLEBAR_HEIGHT } from '../../../../platform/window/common/window.js';
+import { PendingNotificationToasts } from './pendingNotificationToasts.js';
 
 interface INotificationToast {
 	readonly item: INotificationViewItem;
@@ -72,6 +73,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 
 	private readonly mapNotificationToToast = new Map<INotificationViewItem, INotificationToast>();
 	private readonly mapNotificationToDisposable = new Map<INotificationViewItem, IDisposable>();
+	private readonly pendingToasts: PendingNotificationToasts<INotificationViewItem>;
 
 	private readonly notificationsToastsVisibleContextKey: IContextKey<boolean>;
 
@@ -93,6 +95,12 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 		super(themeService);
 
 		this.notificationsToastsVisibleContextKey = NotificationsToastsVisibleContext.bindTo(contextKeyService);
+		this.pendingToasts = this._register(new PendingNotificationToasts(
+			item => this.model.notifications.includes(item),
+			(item, other) => item.equals(other),
+			callback => scheduleAtNextAnimationFrame(getWindow(this.container), callback)
+		));
+		this._register(toDisposable(() => this.removeToasts()));
 
 		this.registerListeners();
 	}
@@ -192,6 +200,10 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 			}
 		}
 
+		if (this.pendingToasts.tryReplace(item)) {
+			return;
+		}
+
 		// Optimization: it is possible that a lot of notifications are being
 		// added in a very short time. To prevent this kind of spam, we protect
 		// against showing too many notifications at once. Since they can always
@@ -202,15 +214,10 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 			return;
 		}
 
-		// Optimization: showing a notification toast can be expensive
-		// because of the associated animation. If the renderer is busy
-		// doing actual work, the animation can cause a lot of slowdown
-		// As such we use `scheduleAtNextAnimationFrame` to push out
-		// the toast until the renderer has time to process it.
-		// (see also https://github.com/microsoft/vscode/issues/107935)
-		const itemDisposables = new DisposableStore();
-		this.mapNotificationToDisposable.set(item, itemDisposables);
-		itemDisposables.add(scheduleAtNextAnimationFrame(getWindow(this.container), () => this.doAddToast(item, itemDisposables)));
+		this.pendingToasts.add(item, (pendingItem, itemDisposables) => {
+			this.mapNotificationToDisposable.set(pendingItem, itemDisposables);
+			this.doAddToast(pendingItem, itemDisposables);
+		});
 	}
 
 	private isElementInNotificationQuarter(element: HTMLElement): boolean {
@@ -395,6 +402,8 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 	private removeToast(item: INotificationViewItem): void {
 		let focusEditor = false;
 
+		this.pendingToasts.remove(item);
+
 		// UI
 		const notificationToast = this.mapNotificationToToast.get(item);
 		if (notificationToast) {
@@ -431,6 +440,9 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 	}
 
 	private removeToasts(): void {
+
+		// Pending
+		this.pendingToasts.clear();
 
 		// Toast
 		this.mapNotificationToToast.clear();

--- a/src/vs/workbench/browser/parts/notifications/pendingNotificationToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/pendingNotificationToasts.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+
+interface IPendingNotificationToast<T> {
+	item: T;
+	readonly disposables: DisposableStore;
+	cleanupScheduled: boolean;
+}
+
+export class PendingNotificationToasts<T> implements IDisposable {
+
+	private readonly pendingToasts = new Set<IPendingNotificationToast<T>>();
+
+	constructor(
+		private readonly isCurrent: (item: T) => boolean,
+		private readonly equals: (item: T, other: T) => boolean,
+		private readonly scheduler: (callback: () => void) => IDisposable
+	) { }
+
+	tryReplace(item: T): boolean {
+		for (const pendingToast of this.pendingToasts) {
+			if (this.equals(pendingToast.item, item)) {
+				pendingToast.item = item;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	add(item: T, render: (item: T, disposables: DisposableStore) => void): void {
+		const disposables = new DisposableStore();
+		const pendingToast: IPendingNotificationToast<T> = { item, disposables, cleanupScheduled: false };
+		this.pendingToasts.add(pendingToast);
+		disposables.add(toDisposable(() => this.pendingToasts.delete(pendingToast)));
+		// Defer toast creation to avoid animation work while the renderer is busy (#107935).
+		disposables.add(this.scheduler(() => {
+			const pendingItem = pendingToast.item;
+			if (!this.isCurrent(pendingItem)) {
+				disposables.dispose();
+				return;
+			}
+
+			this.pendingToasts.delete(pendingToast);
+			render(pendingItem, disposables);
+		}));
+	}
+
+	remove(item: T): void {
+		for (const pendingToast of this.pendingToasts) {
+			if (pendingToast.item === item && !pendingToast.cleanupScheduled) {
+				pendingToast.cleanupScheduled = true;
+				// Allow a synchronous duplicate ADD to retarget the pending toast before cleanup.
+				queueMicrotask(() => {
+					pendingToast.cleanupScheduled = false;
+					if (this.pendingToasts.has(pendingToast) && !this.isCurrent(pendingToast.item)) {
+						pendingToast.disposables.dispose();
+					}
+				});
+				break;
+			}
+		}
+	}
+
+	clear(): void {
+		for (const pendingToast of this.pendingToasts) {
+			pendingToast.disposables.dispose();
+		}
+		this.pendingToasts.clear();
+	}
+
+	dispose(): void {
+		this.clear();
+	}
+}

--- a/src/vs/workbench/test/browser/notificationsToasts.test.ts
+++ b/src/vs/workbench/test/browser/notificationsToasts.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Dimension, getWindow } from '../../../base/browser/dom.js';
+import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { Severity } from '../../../platform/notification/common/notification.js';
+import { NotificationsToasts } from '../../browser/parts/notifications/notificationsToasts.js';
+import { NotificationsModel } from '../../common/notifications.js';
+import { workbenchInstantiationService } from './workbenchTestServices.js';
+
+suite('NotificationsToasts', () => {
+
+	suiteSetup(async () => {
+		const warmupDisposables = new DisposableStore();
+		try {
+			const { model, flushAnimationFrame } = await createToasts(warmupDisposables);
+			model.addNotification({ severity: Severity.Error, message: 'Warmup' });
+			await flushAnimationFrame();
+		} finally {
+			warmupDisposables.dispose();
+		}
+	});
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function createToasts(testDisposables: Pick<DisposableStore, 'add'> = disposables): Promise<{
+		readonly container: HTMLElement;
+		readonly model: NotificationsModel;
+		readonly toasts: NotificationsToasts;
+		readonly flushAnimationFrame: () => Promise<void>;
+	}> {
+		const container = document.createElement('div');
+		const targetWindow = getWindow(container);
+		targetWindow.document.body.appendChild(container);
+		testDisposables.add(toDisposable(() => container.remove()));
+
+		const instantiationService = workbenchInstantiationService(undefined, testDisposables);
+		const model = testDisposables.add(new NotificationsModel());
+		testDisposables.add(toDisposable(() => {
+			for (const notification of [...model.notifications]) {
+				notification.close();
+			}
+		}));
+
+		const toasts = testDisposables.add(instantiationService.createInstance(NotificationsToasts, container, model));
+		toasts.layout(new Dimension(1024, 768));
+		await Promise.resolve();
+
+		return {
+			container,
+			model,
+			toasts,
+			flushAnimationFrame: () => new Promise(resolve => targetWindow.requestAnimationFrame(() => resolve()))
+		};
+	}
+
+	test('shows one toast for rapidly added duplicate notifications', async () => {
+		const { container, model, toasts, flushAnimationFrame } = await createToasts();
+
+		for (let i = 0; i < 15; i++) {
+			model.addNotification({ severity: Severity.Error, message: 'Hello!' });
+		}
+		await Promise.resolve();
+
+		const beforeAnimationFrame = {
+			notifications: model.notifications.length,
+			toasts: container.querySelectorAll('.notification-toast-container').length
+		};
+
+		await flushAnimationFrame();
+
+		assert.deepStrictEqual({
+			beforeAnimationFrame,
+			notifications: model.notifications.length,
+			toasts: container.querySelectorAll('.notification-toast-container').length,
+			visible: toasts.isVisible
+		}, {
+			beforeAnimationFrame: {
+				notifications: 1,
+				toasts: 0
+			},
+			notifications: 1,
+			toasts: 1,
+			visible: true
+		});
+	});
+
+	test('limits rapidly added distinct notification toasts', async () => {
+		const { container, model, toasts, flushAnimationFrame } = await createToasts();
+
+		for (let i = 0; i < 15; i++) {
+			model.addNotification({ severity: Severity.Error, message: `Message ${i}` });
+		}
+
+		await flushAnimationFrame();
+
+		assert.deepStrictEqual({
+			notifications: model.notifications.length,
+			toasts: container.querySelectorAll('.notification-toast-container').length,
+			visible: toasts.isVisible
+		}, {
+			notifications: 15,
+			toasts: 3,
+			visible: true
+		});
+	});
+
+	test('does not show a pending notification removed before rendering', async () => {
+		const { container, model, toasts, flushAnimationFrame } = await createToasts();
+		const handle = model.addNotification({ severity: Severity.Error, message: 'Hello!' });
+
+		handle.close();
+		await Promise.resolve();
+		await flushAnimationFrame();
+
+		assert.deepStrictEqual({
+			notifications: model.notifications.length,
+			toasts: container.querySelectorAll('.notification-toast-container').length,
+			visible: toasts.isVisible
+		}, {
+			notifications: 0,
+			toasts: 0,
+			visible: false
+		});
+	});
+});

--- a/src/vs/workbench/test/browser/notificationsToasts.test.ts
+++ b/src/vs/workbench/test/browser/notificationsToasts.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { Dimension, getWindow } from '../../../base/browser/dom.js';
+import { Event } from '../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import { Severity } from '../../../platform/notification/common/notification.js';
@@ -17,9 +18,10 @@ suite('NotificationsToasts', () => {
 	suiteSetup(async () => {
 		const warmupDisposables = new DisposableStore();
 		try {
-			const { model, flushAnimationFrame } = await createToasts(warmupDisposables);
+			const { model, toasts } = await createToasts(warmupDisposables);
+			const toastVisible = Event.toPromise(toasts.onDidChangeVisibility);
 			model.addNotification({ severity: Severity.Error, message: 'Warmup' });
-			await flushAnimationFrame();
+			await toastVisible;
 		} finally {
 			warmupDisposables.dispose();
 		}
@@ -47,7 +49,8 @@ suite('NotificationsToasts', () => {
 		}));
 
 		const toasts = testDisposables.add(instantiationService.createInstance(NotificationsToasts, container, model));
-		toasts.layout(new Dimension(1024, 768));
+		// Avoid viewport-dependent hiding because these tests assert scheduled toast counts.
+		toasts.layout(new Dimension(1024, Number.MAX_SAFE_INTEGER));
 		await Promise.resolve();
 
 		return {
@@ -59,7 +62,8 @@ suite('NotificationsToasts', () => {
 	}
 
 	test('shows one toast for rapidly added duplicate notifications', async () => {
-		const { container, model, toasts, flushAnimationFrame } = await createToasts();
+		const { container, model, toasts } = await createToasts();
+		const toastVisible = Event.toPromise(toasts.onDidChangeVisibility);
 
 		for (let i = 0; i < 15; i++) {
 			model.addNotification({ severity: Severity.Error, message: 'Hello!' });
@@ -71,8 +75,7 @@ suite('NotificationsToasts', () => {
 			toasts: container.querySelectorAll('.notification-toast-container').length
 		};
 
-		await flushAnimationFrame();
-
+		await toastVisible;
 		assert.deepStrictEqual({
 			beforeAnimationFrame,
 			notifications: model.notifications.length,
@@ -90,13 +93,14 @@ suite('NotificationsToasts', () => {
 	});
 
 	test('limits rapidly added distinct notification toasts', async () => {
-		const { container, model, toasts, flushAnimationFrame } = await createToasts();
+		const { container, model, toasts } = await createToasts();
+		const toastVisible = Event.toPromise(toasts.onDidChangeVisibility);
 
 		for (let i = 0; i < 15; i++) {
 			model.addNotification({ severity: Severity.Error, message: `Message ${i}` });
 		}
 
-		await flushAnimationFrame();
+		await toastVisible;
 
 		assert.deepStrictEqual({
 			notifications: model.notifications.length,


### PR DESCRIPTION
Introduce a new `PendingNotificationToasts` class to manage rapidly added notifications, ensuring that duplicate notifications are consolidated into a single toast. This change optimizes the rendering process and prevents spammy notifications from overwhelming the user interface. Tests validate the new behavior.

fixes https://github.com/microsoft/vscode/issues/328209

