### PR TITLE
Fix Agents Window AgentHost smoke flakes from empty session-type picker

### DIFF
--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -6,7 +6,7 @@
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IReference } from '../../../base/common/lifecycle.js';
-import { autorun, constObservable, IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
+import { autorun, IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
 import { mark } from '../../../base/common/performance.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -72,7 +72,17 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	private readonly _clientEventually = new DeferredPromise<MessagePortClient>();
 	private readonly _management: IAgentHostManagementService;
 	private readonly _ahpLogger: AhpJsonlLogger | undefined;
-	private _protocolClient: RemoteAgentHostProtocolClient | undefined;
+	/**
+	 * Created eagerly so callers can subscribe to {@link rootState} /
+	 * {@link onDidAction} before the MessagePort is acquired. A delayed
+	 * transport resolves once `_connect()` completes the client; until then
+	 * subscriptions are live on this object and receive the initialize
+	 * snapshot when it arrives. Creating the client lazily (and returning a
+	 * noop `Event.None` placeholder until then) caused Agents Window smoke
+	 * flakes: providers subscribed to the placeholder, missed later root-
+	 * state updates, and left the session-type picker empty/hidden.
+	 */
+	private readonly _protocolClient: RemoteAgentHostProtocolClient;
 	private _connectStarted = false;
 	private _didStartInitialSessionList = false;
 	private _didCompleteInitialSessionList = false;
@@ -85,13 +95,6 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', true);
 	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
 	private _authenticationSettled = false;
-	private readonly _noopRootState: IAgentSubscription<RootState> = {
-		value: undefined,
-		verifiedValue: undefined,
-		onDidChange: Event.None,
-		onWillApplyAction: Event.None,
-		onDidApplyAction: Event.None,
-	};
 
 	constructor(
 		private readonly _clientInfo: Implementation,
@@ -113,6 +116,20 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			}))
 			: undefined;
 
+		const transport = new AgentHostIpcChannelTransport(
+			getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
+			this._ahpLogger,
+		);
+		this._protocolClient = this._register(this._instantiationService.createInstance(
+			RemoteAgentHostProtocolClient,
+			LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
+			transport,
+			undefined,
+			this.clientId,
+			this._clientInfo,
+		));
+		this._register(this._protocolClient.onDidClose(() => this._onAgentHostExit.fire(0)));
+
 		this._register(autorun(reader => {
 			if (agentHostEnablementService.enabled.read(reader)) {
 				this.startAgentHost();
@@ -121,24 +138,8 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	startAgentHost(): void {
-		if (!this._protocolClient) {
-			const transport = new AgentHostIpcChannelTransport(
-				getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
-				this._ahpLogger,
-			);
-			this._protocolClient = this._register(this._instantiationService.createInstance(
-				RemoteAgentHostProtocolClient,
-				LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
-				transport,
-				undefined,
-				this.clientId,
-				this._clientInfo,
-			));
-			this._register(this._protocolClient.onDidClose(() => this._onAgentHostExit.fire(0)));
-		}
-
 		void this._connect().catch(error => {
-			this._protocolClient?.notifyTransportClosed();
+			this._protocolClient.notifyTransportClosed();
 			this._logService.error(`${LOG_PREFIX} Protocol connection failed`, error);
 		});
 	}
@@ -174,9 +175,6 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	private _requireClient(): RemoteAgentHostProtocolClient {
-		if (!this._protocolClient) {
-			throw new Error('Local agent host is not connected.');
-		}
 		return this._protocolClient;
 	}
 
@@ -191,23 +189,23 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	get initializeResult(): IObservable<InitializeResult | undefined> {
-		return this._protocolClient?.initializeResult ?? constObservable(undefined);
+		return this._protocolClient.initializeResult;
 	}
 
 	get rootState(): IAgentSubscription<RootState> {
-		return this._protocolClient?.rootState ?? this._noopRootState;
+		return this._protocolClient.rootState;
 	}
 
 	get onDidAction(): Event<ActionEnvelope> {
-		return this._protocolClient?.onDidAction ?? Event.None;
+		return this._protocolClient.onDidAction;
 	}
 
 	get onDidNotification(): Event<INotification> {
-		return this._protocolClient?.onDidNotification ?? Event.None;
+		return this._protocolClient.onDidNotification;
 	}
 
 	get onMcpNotification(): Event<IMcpNotification> {
-		return this._protocolClient?.onMcpNotification ?? Event.None;
+		return this._protocolClient.onMcpNotification;
 	}
 
 	getSubscription<T extends StateComponents>(kind: T, resource: URI, owner: string): IReference<IAgentSubscription<ComponentToState[T]>> {
@@ -215,15 +213,15 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {
-		return this._protocolClient?.getSubscriptionUnmanaged<ComponentToState[T]>(kind, resource);
+		return this._protocolClient.getSubscriptionUnmanaged<ComponentToState[T]>(kind, resource);
 	}
 
 	getInflightSessionCreate(resource: URI): Promise<unknown> | undefined {
-		return this._protocolClient?.getInflightSessionCreate(resource);
+		return this._protocolClient.getInflightSessionCreate(resource);
 	}
 
 	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
-		return this._protocolClient?.getActiveSubscriptions() ?? [];
+		return this._protocolClient.getActiveSubscriptions();
 	}
 
 	dispatch(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction): void {

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -323,6 +323,11 @@ when one exists or showing the empty placeholder otherwise. Internal callers
 (restore fallback, archive, background reseed, and the close-session fallback)
 invoke `openNewSession()` the same way.
 
+`NewChatWidget` is reused when a created session returns to the new-session
+view. When its previous draft is cleared and no replacement draft exists, it
+re-seeds one from the workspace picker's selected folder so the session-type and
+model pickers remain available.
+
 The new-session input separately persists its text and attachments in
 workspace-scoped machine storage. `NewChatWidget` saves that draft when it is
 disposed (for example, when navigating to an existing session), and the

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -371,19 +371,19 @@ export class NewChatWidget extends Disposable {
 		// from a new-session draft when navigating back from another session).
 		this._seedWorkspaceDraft();
 
-		// Re-seed the workspace draft when the composer swaps out of quick-chat
-		// mode (e.g. Cmd+N discards a quick chat, leaving the reused composer
-		// session-less): without an active session the session-type picker has no
-		// folder types and hides itself, so restore the last folder to match a
-		// freshly-opened new-session composer.
+		// Re-seed the workspace draft when the reused composer loses its previous
+		// draft (e.g. Cmd+N after sending, or Agents Window smoke warm-up which
+		// returns to the new-session view after a throwaway turn). Without a
+		// draft the session-type picker has no folder types and hides itself.
 		if (!isWeb) {
-			let wasQuickChat = this._isQuickChatComposer.get();
+			let previousSession = this._session.get();
 			this._register(autorun(reader => {
-				const isQuickChat = this._isQuickChatComposer.read(reader);
-				if (wasQuickChat && !isQuickChat && !this._session.read(reader)) {
+				const session = this._session.read(reader);
+				const shouldSeedWorkspaceDraft = !!previousSession && !session;
+				previousSession = session;
+				if (shouldSeedWorkspaceDraft) {
 					this._seedWorkspaceDraft();
 				}
-				wasQuickChat = isQuickChat;
 			}));
 		}
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -115,7 +115,9 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 		this._attachConnectionListeners(this._agentHostService, this._store);
 
-		this._syncRootState(this._agentHostService.rootState.value);
+		// Subscribe before reading the current value so a root-state update that
+		// lands while we are wiring the listener is not missed (the session-type
+		// picker stays empty/hidden until session types hydrate from root state).
 		this._register(this._agentHostService.rootState.onDidChange(() => {
 			this._syncRootState(this._agentHostService.rootState.value);
 		}));
@@ -124,6 +126,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 				this._syncRootState(error);
 			}));
 		}
+		this._syncRootState(this._agentHostService.rootState.value);
 
 		// Eagerly populate the session cache once authentication has settled.
 		// Without this, the sidebar would only call `getSessions()` after some

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -70,6 +70,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	});
 	private readonly _onDidRootStateError = new Emitter<Error>();
 	private _rootStateValue: RootState | Error | undefined = { agents: [{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [], capabilities: { multipleChats: { fork: true } } } as AgentInfo] };
+	private _agentsOnNextRootStateListenerAccess: AgentInfo[] | undefined;
 	override readonly rootState: IAgentSubscription<RootState>;
 
 	override readonly clientId = 'test-local-client';
@@ -96,11 +97,28 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		this.rootState = {
 			get value() { return self._rootStateValue; },
 			get verifiedValue() { return self._rootStateValue instanceof Error ? undefined : self._rootStateValue; },
-			onDidChange: self._onDidRootStateChange.event,
+			get onDidChange() {
+				if (self._agentsOnNextRootStateListenerAccess) {
+					self._rootStateValue = { agents: self._agentsOnNextRootStateListenerAccess };
+					self._agentsOnNextRootStateListenerAccess = undefined;
+				}
+				return self._onDidRootStateChange.event;
+			},
 			onDidError: self._onDidRootStateError.event,
 			onWillApplyAction: Event.None,
 			onDidApplyAction: Event.None,
 		};
+	}
+
+	/**
+	 * Simulate a root-state update that arrives while the provider is reading
+	 * `onDidChange` to subscribe — the value is still undefined when `value` is
+	 * first read, then agents appear before the listener is attached. Used to
+	 * lock the subscribe-then-sync ordering in the provider constructor.
+	 */
+	setAgentsOnNextRootStateListenerAccess(agents: AgentInfo[]): void {
+		this._rootStateValue = undefined;
+		this._agentsOnNextRootStateListenerAccess = agents;
 	}
 
 	nextClientSeq(): number {
@@ -551,6 +569,18 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
 			{ id: 'copilotcli', label: 'Copilot' },
 			{ id: 'openai', label: 'OpenAI' },
+		]);
+	});
+
+	test('session types hydrate when root state changes while the provider subscribes', () => {
+		agentHost.setAgentsOnNextRootStateListenerAccess([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+		]);
+
+		const provider = createProvider(disposables, agentHost);
+
+		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
+			{ id: 'copilotcli', label: 'Copilot' },
 		]);
 	});
 


### PR DESCRIPTION
Two races left the new-session session-type picker empty/hidden after lazy Agent Host startup (#326768):

1. LocalAgentHostServiceClient returned a noop rootState (Event.None) until startAgentHost() created the protocol client. Providers that subscribed early never saw later root-state updates, so session types never hydrated. Create the protocol client eagerly with a delayed transport so subscriptions are stable from construction.

2. After smoke warm-up (or Cmd+N after send), the reused NewChatWidget could lose its workspace draft without reseeding. Without a draft the picker has no folder types and hides itself. Re-seed whenever the reused composer transitions from a session to none.

Also subscribe-then-sync root state in LocalAgentHostSessionsProvider and cover the TOCTOU with a unit test.

Addresses #328281. Combines the approaches from #328172 and #328238.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
