### PR TITLE
sessions: hide aquarium with new chat view

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -337,7 +337,11 @@ visibility preference; `IChatPetService` owns the same persisted pet state used
 by `/vscode-pet`. Context-menu events from inside `.new-chat-widget-content` are
 left untouched so the composer retains its own context-menu behavior. The
 aquarium preference is also keyboard-accessible through the **Developer: Toggle
-Aquarium Action Visibility** command.
+Aquarium Action Visibility** command. `NewChatView` forwards its effective grid
+visibility to the aquarium mount so a hidden composer cannot leave the aquarium
+rendering behind the visible chat surface. Since `NewChatView` also hosts the
+peer-chat composer, aquarium-specific lifecycle calls must first narrow the
+wrapped widget to `NewChatWidget`.
 
 Agent feedback created while the active session is undefined or uncreated uses
 one shared new-session feedback scope, so it follows every undefined/uncreated

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -105,6 +105,12 @@ export class NewChatView extends AbstractChatView {
 	override attach(uris: URI[]): void {
 		this._widget.attach(uris);
 	}
+
+	override setVisible(visible: boolean): void {
+		if (this._widget instanceof NewChatWidget) {
+			this._widget.setHostVisible(visible);
+		}
+	}
 }
 
 /**

--- a/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NewChatView } from '../../browser/chatView.js';
+import { NewChatInSessionWidget } from '../../browser/newChatInSessionWidget.js';
+import { NewChatWidget } from '../../browser/newChatWidget.js';
+
+suite('Sessions - Chat View', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('forwards new chat visibility to the aquarium host', () => {
+		const forwarded: boolean[] = [];
+		const view: NewChatView = Object.assign(Object.create(NewChatView.prototype), {
+			_widget: Object.assign(Object.create(NewChatWidget.prototype), {
+				setHostVisible: (visible: boolean) => forwarded.push(visible),
+			}),
+		});
+
+		view.setVisible(false);
+		view.setVisible(true);
+
+		assert.deepStrictEqual(forwarded, [false, true]);
+	});
+
+	test('does not forward aquarium visibility to the peer chat composer', () => {
+		const view: NewChatView = Object.assign(Object.create(NewChatView.prototype), {
+			_widget: Object.create(NewChatInSessionWidget.prototype),
+		});
+
+		assert.doesNotThrow(() => view.setVisible(false));
+	});
+});


### PR DESCRIPTION
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix regression where aquarium leaked into main agents window view

<img width="1668" height="921" alt="Screenshot 2026-07-30 at 4 04 03 PM" src="https://github.com/user-attachments/assets/d2135f67-0dd8-4479-9466-1d6947084bda" />
