### PR TITLE
agentHost: route repetition telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitHubTelemetryRouter.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitHubTelemetryRouter.ts
@@ -14,6 +14,7 @@ const enum TelemetryDestination {
 const targetDestinations = new Map<string, TelemetryDestination>([
 	['engine.messages', TelemetryDestination.EnhancedGH],
 	['engine.messages.length', TelemetryDestination.EnhancedGH | TelemetryDestination.InternalMSFT],
+	['conversation.repetition.detected', TelemetryDestination.EnhancedGH],
 	['model.message.added', TelemetryDestination.InternalMSFT],
 	['model.modelCall.input', TelemetryDestination.InternalMSFT],
 	['model.modelCall.output', TelemetryDestination.InternalMSFT],

--- a/src/vs/platform/agentHost/test/node/agentHostGitHubTelemetryRouter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitHubTelemetryRouter.test.ts
@@ -71,6 +71,7 @@ suite('AgentHostGitHubTelemetryRouter', () => {
 		const handled = await Promise.all([
 			'engine.messages',
 			'engine.messages.length',
+			'conversation.repetition.detected',
 			'model.message.added',
 			'model.modelCall.input',
 			'model.modelCall.output',
@@ -82,11 +83,12 @@ suite('AgentHostGitHubTelemetryRouter', () => {
 			handled,
 			events: telemetry.events.map(({ destination, eventName }) => ({ destination, eventName })),
 		}, {
-			handled: [true, true, true, true, true, true, true],
+			handled: [true, true, true, true, true, true, true, true],
 			events: [
 				{ destination: 'enhancedGH', eventName: 'engine.messages' },
 				{ destination: 'enhancedGH', eventName: 'engine.messages.length' },
 				{ destination: 'internalMSFT', eventName: 'engine.messages.length' },
+				{ destination: 'enhancedGH', eventName: 'conversation.repetition.detected' },
 				{ destination: 'internalMSFT', eventName: 'model.message.added' },
 				{ destination: 'internalMSFT', eventName: 'model.modelCall.input' },
 				{ destination: 'internalMSFT', eventName: 'model.modelCall.output' },


### PR DESCRIPTION
## Overview

Route the restricted, host-only `conversation.repetition.detected` compatibility event from [github/copilot-agent-runtime#14210](https://github.com/github/copilot-agent-runtime/pull/14210) to the existing Enhanced GitHub telemetry sink.

This is receiver-only and safe to merge before runtime adoption: no event is emitted until VS Code adopts a runtime containing the producer.

Validation:

- repository pre-commit hygiene
- targeted ESLint for the router and its test
- router allowlist/sink expectations updated

Full local compilation is currently blocked by unrelated existing dependency/type mismatches in the checkout (`VsCodeV2CommentsView.revealComment` and Claude SDK test types).
