### PR TITLE
Fix flaky Agent Host smoke startup

### DIFF
--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -6,7 +6,7 @@
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IReference } from '../../../base/common/lifecycle.js';
-import { autorun, constObservable, IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
+import { autorun, IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
 import { mark } from '../../../base/common/performance.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -72,7 +72,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	private readonly _clientEventually = new DeferredPromise<MessagePortClient>();
 	private readonly _management: IAgentHostManagementService;
 	private readonly _ahpLogger: AhpJsonlLogger | undefined;
-	private _protocolClient: RemoteAgentHostProtocolClient | undefined;
+	private readonly _protocolClient: RemoteAgentHostProtocolClient;
 	private _connectStarted = false;
 	private _didStartInitialSessionList = false;
 	private _didCompleteInitialSessionList = false;
@@ -85,13 +85,6 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', true);
 	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
 	private _authenticationSettled = false;
-	private readonly _noopRootState: IAgentSubscription<RootState> = {
-		value: undefined,
-		verifiedValue: undefined,
-		onDidChange: Event.None,
-		onWillApplyAction: Event.None,
-		onDidApplyAction: Event.None,
-	};
 
 	constructor(
 		private readonly _clientInfo: Implementation,
@@ -113,6 +106,20 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			}))
 			: undefined;
 
+		const transport = new AgentHostIpcChannelTransport(
+			getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
+			this._ahpLogger,
+		);
+		this._protocolClient = this._register(this._instantiationService.createInstance(
+			RemoteAgentHostProtocolClient,
+			LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
+			transport,
+			undefined,
+			this.clientId,
+			this._clientInfo,
+		));
+		this._register(this._protocolClient.onDidClose(() => this._onAgentHostExit.fire(0)));
+
 		this._register(autorun(reader => {
 			if (agentHostEnablementService.enabled.read(reader)) {
 				this.startAgentHost();
@@ -121,24 +128,8 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	startAgentHost(): void {
-		if (!this._protocolClient) {
-			const transport = new AgentHostIpcChannelTransport(
-				getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
-				this._ahpLogger,
-			);
-			this._protocolClient = this._register(this._instantiationService.createInstance(
-				RemoteAgentHostProtocolClient,
-				LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
-				transport,
-				undefined,
-				this.clientId,
-				this._clientInfo,
-			));
-			this._register(this._protocolClient.onDidClose(() => this._onAgentHostExit.fire(0)));
-		}
-
 		void this._connect().catch(error => {
-			this._protocolClient?.notifyTransportClosed();
+			this._protocolClient.notifyTransportClosed();
 			this._logService.error(`${LOG_PREFIX} Protocol connection failed`, error);
 		});
 	}
@@ -174,9 +165,6 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	private _requireClient(): RemoteAgentHostProtocolClient {
-		if (!this._protocolClient) {
-			throw new Error('Local agent host is not connected.');
-		}
 		return this._protocolClient;
 	}
 
@@ -191,23 +179,23 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	get initializeResult(): IObservable<InitializeResult | undefined> {
-		return this._protocolClient?.initializeResult ?? constObservable(undefined);
+		return this._protocolClient.initializeResult;
 	}
 
 	get rootState(): IAgentSubscription<RootState> {
-		return this._protocolClient?.rootState ?? this._noopRootState;
+		return this._protocolClient.rootState;
 	}
 
 	get onDidAction(): Event<ActionEnvelope> {
-		return this._protocolClient?.onDidAction ?? Event.None;
+		return this._protocolClient.onDidAction;
 	}
 
 	get onDidNotification(): Event<INotification> {
-		return this._protocolClient?.onDidNotification ?? Event.None;
+		return this._protocolClient.onDidNotification;
 	}
 
 	get onMcpNotification(): Event<IMcpNotification> {
-		return this._protocolClient?.onMcpNotification ?? Event.None;
+		return this._protocolClient.onMcpNotification;
 	}
 
 	getSubscription<T extends StateComponents>(kind: T, resource: URI, owner: string): IReference<IAgentSubscription<ComponentToState[T]>> {
@@ -215,15 +203,15 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {
-		return this._protocolClient?.getSubscriptionUnmanaged<ComponentToState[T]>(kind, resource);
+		return this._protocolClient.getSubscriptionUnmanaged<ComponentToState[T]>(kind, resource);
 	}
 
 	getInflightSessionCreate(resource: URI): Promise<unknown> | undefined {
-		return this._protocolClient?.getInflightSessionCreate(resource);
+		return this._protocolClient.getInflightSessionCreate(resource);
 	}
 
 	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
-		return this._protocolClient?.getActiveSubscriptions() ?? [];
+		return this._protocolClient.getActiveSubscriptions();
 	}
 
 	dispatch(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction): void {

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -71,6 +71,8 @@ open existing:  view.openSession(uri, { preserveFocus })
                   → view arranges visible slot (activeSession = active slot) + focuses    // focus skipped when preserveFocus
 external link:   workbench openSessionByResource(uri)
                   → Agents-window opener participant → view.openSession(uri)
+folder handoff:  Agents-window opener participant → view.openNewSession({ folderUri })
+                  → persists the selected workspace after trust succeeds; retries when the provider registers late
 new session:    composer → view.openNewSession({ folderUri, ... })  // view: management.createNewSession() (model draft) + activates it
                   → view observes activeSession == draft → shows draft slot
 delegate:       command → management.createNewSession({ providerId, sessionTypeId })

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -12,7 +12,6 @@ import { AgentHostByokLmHandler } from '../../../../workbench/contrib/chat/brows
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { ILifecycleService, LifecyclePhase } from '../../../../workbench/services/lifecycle/common/lifecycle.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -20,6 +19,7 @@ import { SessionsView, SessionsViewId as SessionsListViewId } from '../../sessio
 import { ISessionsSetUpService } from '../../../browser/sessionsSetUpService.js';
 import { ISessionsPartService } from '../../../services/sessions/browser/sessionsPartService.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
+import { ISessionsRecentWorkspacesService } from '../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
 import { SessionsCopilotConfigSlashSubmitHandlerContribution } from '../browser/copilotConfigSlashSubmitHandler.js';
 import { AgentsWindowOpenSource, isAgentsWindowOpenSource } from '../../../../platform/window/common/window.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
@@ -36,12 +36,12 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 	constructor(
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
-		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@IViewsService private readonly viewsService: IViewsService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@ISessionsSetUpService private readonly sessionsSetUpService: ISessionsSetUpService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsPartService private readonly sessionsPartService: ISessionsPartService,
+		@ISessionsRecentWorkspacesService private readonly sessionsRecentWorkspacesService: ISessionsRecentWorkspacesService,
 		@IStorageService private readonly storageService: IStorageService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
@@ -175,8 +175,9 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 	private async selectFolder(folderUri: URI): Promise<void> {
 		// Wait for the welcome/setup flow to complete before selecting the folder
 		await this.sessionsSetUpService.whenWelcomeDone();
+		this.logService.info(`[AgentsHandoff] selecting folder: ${folderUri.toString()}`);
 
-		this.sessionsService.openNewSession();
+		await this.sessionsService.openNewSession();
 
 		// Tell the sessions list this folder is the open-window source folder
 		// so it ranks the matching folder section first. Get the view if it
@@ -184,29 +185,36 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 		const sessionsView = this.viewsService.getViewWithId<SessionsView>(SessionsListViewId);
 		sessionsView?.sessionsControl?.setOpenWindowSourceFolder(folderUri);
 
-		if (this.tryResolveAndSelect(folderUri)) {
-			return;
-		}
-
-		// Provider not registered yet — wait for it, but give up at Eventually phase
-		const disposable = this.sessionsProvidersService.onDidChangeProviders(() => {
-			if (this.tryResolveAndSelect(folderUri)) {
-				disposable.dispose();
+		const listener = this._register(new MutableDisposable());
+		let opening = false;
+		const openWhenAvailable = (): Promise<void> | undefined => {
+			const available = this.sessionsManagementService.isNewSessionTargetAvailable(folderUri);
+			this.logService.info(`[AgentsHandoff] folder target check: available=${available}, opening=${opening}`);
+			if (opening || !available) {
+				return undefined;
 			}
+			opening = true;
+			listener.clear();
+			return this.openFolderDraft(folderUri);
+		};
+		listener.value = this.sessionsManagementService.onDidChangeSessionTypes(() => {
+			void openWhenAvailable()?.catch(error => this.logService.error('[AgentsHandoff] failed to open folder draft', error));
 		});
-		this.lifecycleService.when(LifecyclePhase.Eventually).then(() => disposable.dispose());
+		await openWhenAvailable();
 	}
 
-	private tryResolveAndSelect(folderUri: URI): boolean {
-		const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
-		if (!resolved) {
-			return false;
-		}
+	private async openFolderDraft(folderUri: URI): Promise<void> {
 		const activeSession = this.sessionsService.activeSession.get();
-		if (activeSession === undefined || activeSession.status.get() === SessionStatus.Untitled) {
-			this.sessionsPartService.getSessionView(activeSession?.sessionId)?.selectWorkspace(folderUri, resolved.providerId);
+		if (activeSession && activeSession.status.get() !== SessionStatus.Untitled) {
+			return;
 		}
-		return true;
+		const result = await this.sessionsService.openNewSession({ folderUri });
+		this.logService.info(`[AgentsHandoff] folder draft result: session=${result.session?.sessionId ?? '(none)'}, trustDeclined=${result.trustDeclined}`);
+		if (result.trustDeclined) {
+			this.sessionsRecentWorkspacesService.removeRecentWorkspace(folderUri);
+		} else if (result.session) {
+			this.sessionsRecentWorkspacesService.addRecentWorkspace(folderUri, result.session.providerId, true);
+		}
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -175,7 +175,6 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 	private async selectFolder(folderUri: URI): Promise<void> {
 		// Wait for the welcome/setup flow to complete before selecting the folder
 		await this.sessionsSetUpService.whenWelcomeDone();
-		this.logService.info(`[AgentsHandoff] selecting folder: ${folderUri.toString()}`);
 
 		await this.sessionsService.openNewSession();
 
@@ -187,34 +186,47 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 
 		const listener = this._register(new MutableDisposable());
 		let opening = false;
-		const openWhenAvailable = (): Promise<void> | undefined => {
-			const available = this.sessionsManagementService.isNewSessionTargetAvailable(folderUri);
-			this.logService.info(`[AgentsHandoff] folder target check: available=${available}, opening=${opening}`);
-			if (opening || !available) {
-				return undefined;
+		let checkPending = false;
+		const openWhenAvailable = async (): Promise<void> => {
+			if (opening) {
+				checkPending = true;
+				return;
 			}
+			if (!this.sessionsManagementService.isNewSessionTargetAvailable(folderUri)) {
+				return;
+			}
+
 			opening = true;
-			listener.clear();
-			return this.openFolderDraft(folderUri);
+			try {
+				if (await this.openFolderDraft(folderUri)) {
+					listener.clear();
+				}
+			} finally {
+				opening = false;
+				if (checkPending) {
+					checkPending = false;
+					void openWhenAvailable().catch(error => this.logService.error('[AgentsHandoff] failed to open folder draft', error));
+				}
+			}
 		};
 		listener.value = this.sessionsManagementService.onDidChangeSessionTypes(() => {
-			void openWhenAvailable()?.catch(error => this.logService.error('[AgentsHandoff] failed to open folder draft', error));
+			void openWhenAvailable().catch(error => this.logService.error('[AgentsHandoff] failed to open folder draft', error));
 		});
 		await openWhenAvailable();
 	}
 
-	private async openFolderDraft(folderUri: URI): Promise<void> {
+	private async openFolderDraft(folderUri: URI): Promise<boolean> {
 		const activeSession = this.sessionsService.activeSession.get();
 		if (activeSession && activeSession.status.get() !== SessionStatus.Untitled) {
-			return;
+			return true;
 		}
 		const result = await this.sessionsService.openNewSession({ folderUri });
-		this.logService.info(`[AgentsHandoff] folder draft result: session=${result.session?.sessionId ?? '(none)'}, trustDeclined=${result.trustDeclined}`);
 		if (result.trustDeclined) {
 			this.sessionsRecentWorkspacesService.removeRecentWorkspace(folderUri);
 		} else if (result.session) {
 			this.sessionsRecentWorkspacesService.addRecentWorkspace(folderUri, result.session.providerId, true);
 		}
+		return result.trustDeclined || result.session !== undefined;
 	}
 }
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -115,7 +115,6 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 		this._attachConnectionListeners(this._agentHostService, this._store);
 
-		this._syncRootState(this._agentHostService.rootState.value);
 		this._register(this._agentHostService.rootState.onDidChange(() => {
 			this._syncRootState(this._agentHostService.rootState.value);
 		}));
@@ -124,6 +123,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 				this._syncRootState(error);
 			}));
 		}
+		this._syncRootState(this._agentHostService.rootState.value);
 
 		// Eagerly populate the session cache once authentication has settled.
 		// Without this, the sidebar would only call `getSessions()` after some

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -70,6 +70,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	});
 	private readonly _onDidRootStateError = new Emitter<Error>();
 	private _rootStateValue: RootState | Error | undefined = { agents: [{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [], capabilities: { multipleChats: { fork: true } } } as AgentInfo] };
+	private _agentsOnNextRootStateListenerAccess: AgentInfo[] | undefined;
 	override readonly rootState: IAgentSubscription<RootState>;
 
 	override readonly clientId = 'test-local-client';
@@ -96,11 +97,22 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		this.rootState = {
 			get value() { return self._rootStateValue; },
 			get verifiedValue() { return self._rootStateValue instanceof Error ? undefined : self._rootStateValue; },
-			onDidChange: self._onDidRootStateChange.event,
+			get onDidChange() {
+				if (self._agentsOnNextRootStateListenerAccess) {
+					self._rootStateValue = { agents: self._agentsOnNextRootStateListenerAccess };
+					self._agentsOnNextRootStateListenerAccess = undefined;
+				}
+				return self._onDidRootStateChange.event;
+			},
 			onDidError: self._onDidRootStateError.event,
 			onWillApplyAction: Event.None,
 			onDidApplyAction: Event.None,
 		};
+	}
+
+	setAgentsOnNextRootStateListenerAccess(agents: AgentInfo[]): void {
+		this._rootStateValue = undefined;
+		this._agentsOnNextRootStateListenerAccess = agents;
 	}
 
 	nextClientSeq(): number {
@@ -551,6 +563,18 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
 			{ id: 'copilotcli', label: 'Copilot' },
 			{ id: 'openai', label: 'OpenAI' },
+		]);
+	});
+
+	test('session types hydrate when root state changes while the provider subscribes', () => {
+		agentHost.setAgentsOnNextRootStateListenerAccess([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+		]);
+
+		const provider = createProvider(disposables, agentHost);
+
+		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
+			{ id: 'copilotcli', label: 'Copilot' },
 		]);
 	});
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -347,7 +347,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				if (!candidateWorkspace) {
 					continue;
 				}
-				if (options?.sessionTypeId && !candidate.getSessionTypes(folderUri).some(t => t.id === options.sessionTypeId)) {
+				const sessionTypes = candidate.getSessionTypes(folderUri);
+				if (options?.sessionTypeId ? !sessionTypes.some(t => t.id === options.sessionTypeId) : sessionTypes.length === 0) {
 					continue;
 				}
 				provider = candidate;

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -190,7 +190,7 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 function createSessionsManagementService(
 	session: ISession,
 	disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>,
-	provider: ISessionsProvider = new TestSessionsProvider(session),
+	provider: ISessionsProvider | readonly ISessionsProvider[] = new TestSessionsProvider(session),
 	workspaceTrustManagementService = new TestWorkspaceTrustManagementService(),
 ): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
@@ -200,7 +200,7 @@ function createSessionsManagementService(
 	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
 	instantiationService.stub(ILogService, new NullLogService());
 	instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
-	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([provider]));
+	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService(Array.isArray(provider) ? provider : [provider]));
 	instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
 	instantiationService.stub(IProgressService, new TestProgressService());
@@ -1040,6 +1040,44 @@ suite('SessionsManagementService', () => {
 			() => service.createNewSession(URI.parse('test:///folder'), { providerId: 'test', sessionTypeId: 'missing' }),
 			/does not advertise session type 'missing'/,
 		);
+	});
+
+	test('createNewSession skips workspace resolvers without advertised session types', () => {
+		const folderUri = URI.parse('test:///folder');
+		const workspace: ISessionWorkspace = {
+			uri: folderUri,
+			label: 'Folder',
+			icon: Codicon.folder,
+			folders: [],
+			requiresWorkspaceTrust: false,
+			isVirtualWorkspace: false,
+		};
+		const unavailableSession = stubSession({ sessionId: 'unavailable', providerId: 'unavailable' });
+		const unavailable = new class extends TestSessionsProvider {
+			override readonly id = 'unavailable';
+			override readonly order = 0;
+			override resolveWorkspace(): ISessionWorkspace { return workspace; }
+			override getSessionTypes(): ISessionType[] { return []; }
+		}(unavailableSession);
+
+		const availableSession = stubSession({ sessionId: 'available', providerId: 'available', sessionType: 'available-type' });
+		const available = new class extends TestSessionsProvider {
+			override readonly id = 'available';
+			override readonly order = 1;
+			override resolveWorkspace(): ISessionWorkspace { return workspace; }
+			override getSessionTypes(): ISessionType[] { return [{ id: 'available-type', label: 'Available', icon: Codicon.vm }]; }
+		}(availableSession);
+		const { service } = createSessionsManagementService(availableSession, disposables, [unavailable, available]);
+
+		const created = service.createNewSession(folderUri);
+
+		assert.deepStrictEqual({
+			providerId: created.providerId,
+			sessionType: created.sessionType,
+		}, {
+			providerId: 'available',
+			sessionType: 'available-type',
+		});
 	});
 
 	test('inheritableSessionTarget drops a harness the folder no longer offers', () => {


### PR DESCRIPTION
## Summary

Fixes the Agent Host and Codex new-session picker flakes reported in [#328281](https://github.com/microsoft/vscode/issues/328281).

The failing tests all stopped before sending a model request:

- Linux: `Agents Window (local AgentHost)` and its sandbox variants failed 5 times across 3 of 20 iterations.
- Windows: `Agents Window (Codex) > Test Codex session` failed 3 times across 3 of 20 iterations.
- Every failure timed out waiting for `.sessions-chat-session-type-picker .action-label:not(.hidden)`.

The exact task and process logs from [Azure build 460202](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=460202) showed that the Agent Host process and protocol connection eventually started successfully, but the Agents window never received enough session-type state to populate its new-session picker.

## Root causes

### 1. Lazy Agent Host startup exposed unstable protocol subscriptions

[#326768](https://github.com/microsoft/vscode/pull/326768) made the local Agent Host process start lazily from observable enablement. As part of that change, `LocalAgentHostServiceClient` deferred constructing `RemoteAgentHostProtocolClient` until `startAgentHost()`.

Before that client existed, `rootState` returned a dummy subscription backed by `Event.None`, and the notification/event getters returned `Event.None` as well. Consumers such as `LocalAgentHostSessionsProvider` can be constructed before enablement settles. When they subscribed during that window, they subscribed permanently to the dummy event and never observed the real root-state snapshot. The host could later connect normally while the session-type picker stayed empty forever.

This PR constructs the protocol client immediately over the existing delayed transport, while retaining lazy process/MessagePort startup. Consumers now always observe the same root-state subscription and event objects, regardless of when the process starts.

It also changes `LocalAgentHostSessionsProvider` to subscribe before reading the current root state, closing the smaller read-then-subscribe gap where hydration could land between those operations.

The draft fix in [#328172](https://github.com/microsoft/vscode/pull/328172) identified this issue, but its own [Azure build 460205](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=460205) still failed the SDK-sandbox test twice across 14 iterations because of the independent handoff race below.

### 2. The Agents-window folder handoff could silently lose its workspace

The initial folder handoff was added in [#314602](https://github.com/microsoft/vscode/pull/314602). It originally awaited opening the new-session view before selecting the folder.

[#317309](https://github.com/microsoft/vscode/pull/317309) moved the flow to the sessions grid and replaced that awaited view open with:

```ts
sessionsPartService.getSessionView(...)? .selectWorkspace(...)
```

The optional lookup can legitimately return `undefined` while the new-session slot is still mounting. However, the handoff returned success as soon as any provider could resolve the folder, so the workspace selection was silently dropped and never retried. The picker then had no folder-scoped session types and remained hidden.

This PR removes the mounted-view dependency. The handoff now:

1. opens the new-session state through `ISessionsService`;
2. waits for `ISessionsManagementService` to report an advertised session target for the folder;
3. creates and activates the draft directly through `ISessionsService.openNewSession({ folderUri })`;
4. persists the selected workspace only after creation succeeds.

The listener is tied to the contribution's lifetime rather than a timeout or lifecycle phase, because Agent Host session types can arrive arbitrarily late.

### 3. Folder creation could choose a provider that advertised no session types

The provider-selection loop introduced with the provider-spanning workspace picker in [#317525](https://github.com/microsoft/vscode/pull/317525) selected the first provider that could resolve a workspace. Without an explicitly pinned session type, it did not require that provider to advertise any usable session type.

After Agent Host migration defaults changed in [#328127](https://github.com/microsoft/vscode/pull/328127), multiple providers can resolve the same local folder while one of them is still hydrating or intentionally hidden. The handoff could therefore observe that *some* target was available, then `createNewSession` would choose an earlier resolver with zero session types and fall back to an empty composer.

The unpinned selection path now skips resolvers whose `getSessionTypes(folderUri)` result is empty. Explicit provider/type selection keeps its existing validation and failure behavior.

## Why this is low risk

- The protocol client is created eagerly, but its transport still waits on the existing delayed `MessagePortClient`. This does **not** start the Agent Host process early or bypass enablement/AI-disable gating.
- The root-state fix exposes the same `RemoteAgentHostProtocolClient` surfaces already used after startup; it removes temporary dummy objects rather than adding a second proxying layer.
- The provider subscribes before its initial read, a standard subscribe-then-snapshot pattern covered by a regression test that hydrates root state during listener installation.
- Folder handoff now uses the same `ISessionsService.openNewSession` path as normal new-session creation, including the existing workspace-trust gate and provider routing.
- Provider selection only changes the unpinned fallback case where the old candidate could not create a session anyway. Explicit provider and explicit session-type paths are unchanged.
- No timeouts were increased and no failures are hidden. The waits are driven by actual session-type state changes.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- `npm run compile --prefix test/smoke`
- `./scripts/test.sh --run src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts`
  - 162 passing, 11 pending
- `./scripts/test.sh --run src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts`
  - 74 passing, 2 pending
- `npm run smoketest-no-compile -- -g "Agents Window \\(local AgentHost" --tracing`
  - 3 passing:
    - Agent Host
    - Agent Host sandbox
    - Agent Host SDK sandbox

The targeted smoke command reproduced the picker timeout locally before the complete fix. After fixing the advertised-target and provider-selection paths, all three Agent Host smoke tests passed without changing their timeout.

(Written by Copilot)
