### PR TITLE
Expand Agent Host end-to-end coverage

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/coverage/protocol-surface.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/protocol-surface.json
@@ -5,12 +5,10 @@
 		"note": "A symbol is \"covered\" when an E2E test sends or receives it; this does not measure how deeply its semantics are asserted."
 	},
 	"commands": {
-		"covered": 28,
+		"covered": 29,
 		"total": 29,
-		"percentage": 96.55,
-		"uncovered": [
-			"invokeChangesetOperation"
-		]
+		"percentage": 100,
+		"uncovered": []
 	},
 	"notifications": {
 		"covered": 3,
@@ -25,13 +23,12 @@
 		]
 	},
 	"actions": {
-		"covered": 64,
+		"covered": 65,
 		"total": 85,
-		"percentage": 75.29,
+		"percentage": 76.47,
 		"uncovered": [
 			"changeset/fileRemoved",
 			"changeset/fileSet",
-			"changeset/operationStatusChanged",
 			"chat/error",
 			"chat/inputAnswerChanged",
 			"chat/reasoning",

--- a/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
@@ -15,24 +15,24 @@
 	},
 	"total": {
 		"statements": {
-			"covered": 66445,
-			"total": 94575,
-			"percentage": 70.25
+			"covered": 67536,
+			"total": 95415,
+			"percentage": 70.78
 		},
 		"branches": {
-			"covered": 5740,
-			"total": 9095,
-			"percentage": 63.11
+			"covered": 6026,
+			"total": 9510,
+			"percentage": 63.36
 		},
 		"functions": {
-			"covered": 2175,
-			"total": 3583,
-			"percentage": 60.7
+			"covered": 2232,
+			"total": 3618,
+			"percentage": 61.69
 		},
 		"lines": {
-			"covered": 66445,
-			"total": 94575,
-			"percentage": 70.25
+			"covered": 67536,
+			"total": 95415,
+			"percentage": 70.78
 		}
 	},
 	"files": {
@@ -258,14 +258,14 @@
 		},
 		"src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts": {
 			"statements": {
-				"covered": 353,
+				"covered": 351,
 				"total": 649,
-				"percentage": 54.39
+				"percentage": 54.08
 			},
 			"branches": {
-				"covered": 20,
-				"total": 33,
-				"percentage": 60.6
+				"covered": 17,
+				"total": 31,
+				"percentage": 54.83
 			},
 			"functions": {
 				"covered": 10,
@@ -273,9 +273,9 @@
 				"percentage": 41.66
 			},
 			"lines": {
-				"covered": 353,
+				"covered": 351,
 				"total": 649,
-				"percentage": 54.39
+				"percentage": 54.08
 			}
 		},
 		"src/vs/platform/agentHost/common/agentHostFileSystemService.ts": {
@@ -1004,6 +1004,28 @@
 				"percentage": 69.89
 			}
 		},
+		"src/vs/platform/agentHost/common/partialToolInput.ts": {
+			"statements": {
+				"covered": 18,
+				"total": 26,
+				"percentage": 69.23
+			},
+			"branches": {
+				"covered": 1,
+				"total": 3,
+				"percentage": 33.33
+			},
+			"functions": {
+				"covered": 1,
+				"total": 2,
+				"percentage": 50
+			},
+			"lines": {
+				"covered": 18,
+				"total": 26,
+				"percentage": 69.23
+			}
+		},
 		"src/vs/platform/agentHost/common/pendingRequestRegistry.ts": {
 			"statements": {
 				"covered": 144,
@@ -1050,24 +1072,24 @@
 		},
 		"src/vs/platform/agentHost/common/resourceReadLogging.ts": {
 			"statements": {
-				"covered": 11,
+				"covered": 23,
 				"total": 27,
-				"percentage": 40.74
+				"percentage": 85.18
 			},
 			"branches": {
-				"covered": 0,
-				"total": 0,
-				"percentage": 100
+				"covered": 6,
+				"total": 8,
+				"percentage": 75
 			},
 			"functions": {
-				"covered": 0,
+				"covered": 2,
 				"total": 2,
-				"percentage": 0
+				"percentage": 100
 			},
 			"lines": {
-				"covered": 11,
+				"covered": 23,
 				"total": 27,
-				"percentage": 40.74
+				"percentage": 85.18
 			}
 		},
 		"src/vs/platform/agentHost/common/sandboxConfigSchema.ts": {
@@ -1292,14 +1314,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-changeset/reducer.ts": {
 			"statements": {
-				"covered": 72,
+				"covered": 88,
 				"total": 121,
-				"percentage": 59.5
+				"percentage": 72.72
 			},
 			"branches": {
-				"covered": 9,
-				"total": 19,
-				"percentage": 47.36
+				"covered": 11,
+				"total": 23,
+				"percentage": 47.82
 			},
 			"functions": {
 				"covered": 1,
@@ -1307,31 +1329,31 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 72,
+				"covered": 88,
 				"total": 121,
-				"percentage": 59.5
+				"percentage": 72.72
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-chat/reducer.ts": {
 			"statements": {
-				"covered": 601,
-				"total": 833,
-				"percentage": 72.14
+				"covered": 620,
+				"total": 859,
+				"percentage": 72.17
 			},
 			"branches": {
-				"covered": 114,
-				"total": 182,
-				"percentage": 62.63
+				"covered": 123,
+				"total": 192,
+				"percentage": 64.06
 			},
 			"functions": {
-				"covered": 14,
-				"total": 14,
+				"covered": 15,
+				"total": 15,
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 601,
-				"total": 833,
-				"percentage": 72.14
+				"covered": 620,
+				"total": 859,
+				"percentage": 72.17
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-resource-watch/reducer.ts": {
@@ -1666,14 +1688,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/version/negotiation.ts": {
 			"statements": {
-				"covered": 59,
+				"covered": 63,
 				"total": 69,
-				"percentage": 85.5
+				"percentage": 91.3
 			},
 			"branches": {
-				"covered": 3,
-				"total": 9,
-				"percentage": 33.33
+				"covered": 10,
+				"total": 14,
+				"percentage": 71.42
 			},
 			"functions": {
 				"covered": 3,
@@ -1681,9 +1703,9 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 59,
+				"covered": 63,
 				"total": 69,
-				"percentage": 85.5
+				"percentage": 91.3
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/version/registry.ts": {
@@ -1754,9 +1776,9 @@
 		},
 		"src/vs/platform/agentHost/common/state/sessionProtocol.ts": {
 			"statements": {
-				"covered": 146,
-				"total": 148,
-				"percentage": 98.64
+				"covered": 152,
+				"total": 154,
+				"percentage": 98.7
 			},
 			"branches": {
 				"covered": 5,
@@ -1769,9 +1791,9 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 146,
-				"total": 148,
-				"percentage": 98.64
+				"covered": 152,
+				"total": 154,
+				"percentage": 98.7
 			}
 		},
 		"src/vs/platform/agentHost/common/state/sessionReducers.ts": {
@@ -1798,24 +1820,46 @@
 		},
 		"src/vs/platform/agentHost/common/state/sessionState.ts": {
 			"statements": {
-				"covered": 1129,
-				"total": 1458,
-				"percentage": 77.43
+				"covered": 1165,
+				"total": 1471,
+				"percentage": 79.19
 			},
 			"branches": {
-				"covered": 98,
-				"total": 142,
-				"percentage": 69.01
+				"covered": 105,
+				"total": 153,
+				"percentage": 68.62
 			},
 			"functions": {
-				"covered": 39,
+				"covered": 40,
 				"total": 62,
-				"percentage": 62.9
+				"percentage": 64.51
 			},
 			"lines": {
-				"covered": 1129,
-				"total": 1458,
-				"percentage": 77.43
+				"covered": 1165,
+				"total": 1471,
+				"percentage": 79.19
+			}
+		},
+		"src/vs/platform/agentHost/common/streamingToolCallDisplay.ts": {
+			"statements": {
+				"covered": 76,
+				"total": 180,
+				"percentage": 42.22
+			},
+			"branches": {
+				"covered": 11,
+				"total": 19,
+				"percentage": 57.89
+			},
+			"functions": {
+				"covered": 7,
+				"total": 11,
+				"percentage": 63.63
+			},
+			"lines": {
+				"covered": 76,
+				"total": 180,
+				"percentage": 42.22
 			}
 		},
 		"src/vs/platform/agentHost/common/toolSearchConstants.ts": {
@@ -1864,14 +1908,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentConfigurationService.ts": {
 			"statements": {
-				"covered": 366,
+				"covered": 369,
 				"total": 402,
-				"percentage": 91.04
+				"percentage": 91.79
 			},
 			"branches": {
-				"covered": 34,
-				"total": 47,
-				"percentage": 72.34
+				"covered": 39,
+				"total": 52,
+				"percentage": 75
 			},
 			"functions": {
 				"covered": 14,
@@ -1879,9 +1923,9 @@
 				"percentage": 87.5
 			},
 			"lines": {
-				"covered": 366,
+				"covered": 369,
 				"total": 402,
-				"percentage": 91.04
+				"percentage": 91.79
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostAuthenticationService.ts": {
@@ -1974,14 +2018,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts": {
 			"statements": {
-				"covered": 322,
+				"covered": 330,
 				"total": 368,
-				"percentage": 87.5
+				"percentage": 89.67
 			},
 			"branches": {
-				"covered": 60,
-				"total": 76,
-				"percentage": 78.94
+				"covered": 71,
+				"total": 85,
+				"percentage": 83.52
 			},
 			"functions": {
 				"covered": 26,
@@ -1989,31 +2033,31 @@
 				"percentage": 96.29
 			},
 			"lines": {
-				"covered": 322,
+				"covered": 330,
 				"total": 368,
-				"percentage": 87.5
+				"percentage": 89.67
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetOperationService.ts": {
 			"statements": {
-				"covered": 135,
+				"covered": 200,
 				"total": 234,
-				"percentage": 57.69
+				"percentage": 85.47
 			},
 			"branches": {
-				"covered": 26,
-				"total": 30,
-				"percentage": 86.66
+				"covered": 40,
+				"total": 52,
+				"percentage": 76.92
 			},
 			"functions": {
-				"covered": 7,
+				"covered": 9,
 				"total": 12,
-				"percentage": 58.33
+				"percentage": 75
 			},
 			"lines": {
-				"covered": 135,
+				"covered": 200,
 				"total": 234,
-				"percentage": 57.69
+				"percentage": 85.47
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetService.ts": {
@@ -2023,9 +2067,9 @@
 				"percentage": 66.84
 			},
 			"branches": {
-				"covered": 126,
-				"total": 163,
-				"percentage": 77.3
+				"covered": 127,
+				"total": 164,
+				"percentage": 77.43
 			},
 			"functions": {
 				"covered": 34,
@@ -2111,9 +2155,9 @@
 				"percentage": 79.77
 			},
 			"branches": {
-				"covered": 53,
-				"total": 68,
-				"percentage": 77.94
+				"covered": 54,
+				"total": 69,
+				"percentage": 78.26
 			},
 			"functions": {
 				"covered": 11,
@@ -2194,24 +2238,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostDiscardChangesOperationHandler.ts": {
 			"statements": {
-				"covered": 33,
+				"covered": 68,
 				"total": 87,
-				"percentage": 37.93
+				"percentage": 78.16
 			},
 			"branches": {
-				"covered": 1,
-				"total": 1,
-				"percentage": 100
+				"covered": 4,
+				"total": 11,
+				"percentage": 36.36
 			},
 			"functions": {
-				"covered": 1,
+				"covered": 4,
 				"total": 4,
-				"percentage": 25
+				"percentage": 100
 			},
 			"lines": {
-				"covered": 33,
+				"covered": 68,
 				"total": 87,
-				"percentage": 37.93
+				"percentage": 78.16
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostDiscardChangesOperationProvider.ts": {
@@ -2221,14 +2265,14 @@
 				"percentage": 100
 			},
 			"branches": {
-				"covered": 6,
-				"total": 7,
-				"percentage": 85.71
+				"covered": 7,
+				"total": 8,
+				"percentage": 87.5
 			},
 			"functions": {
-				"covered": 3,
+				"covered": 4,
 				"total": 4,
-				"percentage": 75
+				"percentage": 100
 			},
 			"lines": {
 				"covered": 47,
@@ -2326,36 +2370,36 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostGitService.ts": {
 			"statements": {
-				"covered": 840,
+				"covered": 850,
 				"total": 1413,
-				"percentage": 59.44
+				"percentage": 60.15
 			},
 			"branches": {
-				"covered": 152,
-				"total": 226,
-				"percentage": 67.25
+				"covered": 156,
+				"total": 235,
+				"percentage": 66.38
 			},
 			"functions": {
-				"covered": 40,
+				"covered": 41,
 				"total": 67,
-				"percentage": 59.7
+				"percentage": 61.19
 			},
 			"lines": {
-				"covered": 840,
+				"covered": 850,
 				"total": 1413,
-				"percentage": 59.44
+				"percentage": 60.15
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostGitStateService.ts": {
 			"statements": {
-				"covered": 135,
+				"covered": 136,
 				"total": 202,
-				"percentage": 66.83
+				"percentage": 67.32
 			},
 			"branches": {
-				"covered": 28,
-				"total": 44,
-				"percentage": 63.63
+				"covered": 31,
+				"total": 46,
+				"percentage": 67.39
 			},
 			"functions": {
 				"covered": 5,
@@ -2363,9 +2407,9 @@
 				"percentage": 83.33
 			},
 			"lines": {
-				"covered": 135,
+				"covered": 136,
 				"total": 202,
-				"percentage": 66.83
+				"percentage": 67.32
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts": {
@@ -2722,14 +2766,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostStateManager.ts": {
 			"statements": {
-				"covered": 1358,
+				"covered": 1360,
 				"total": 1495,
-				"percentage": 90.83
+				"percentage": 90.96
 			},
 			"branches": {
-				"covered": 196,
-				"total": 235,
-				"percentage": 83.4
+				"covered": 200,
+				"total": 238,
+				"percentage": 84.03
 			},
 			"functions": {
 				"covered": 51,
@@ -2737,9 +2781,9 @@
 				"percentage": 82.25
 			},
 			"lines": {
-				"covered": 1358,
+				"covered": 1360,
 				"total": 1495,
-				"percentage": 90.83
+				"percentage": 90.96
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostSyncOperationHandler.ts": {
@@ -2854,24 +2898,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostToolCallTracker.ts": {
 			"statements": {
-				"covered": 164,
-				"total": 203,
-				"percentage": 80.78
+				"covered": 188,
+				"total": 231,
+				"percentage": 81.38
 			},
 			"branches": {
-				"covered": 23,
-				"total": 30,
-				"percentage": 76.66
+				"covered": 31,
+				"total": 40,
+				"percentage": 77.5
 			},
 			"functions": {
-				"covered": 10,
-				"total": 10,
+				"covered": 13,
+				"total": 13,
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 164,
-				"total": 203,
-				"percentage": 80.78
+				"covered": 188,
+				"total": 231,
+				"percentage": 81.38
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostTurnTracker.ts": {
@@ -2898,24 +2942,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostUpgradeChannel.ts": {
 			"statements": {
-				"covered": 49,
+				"covered": 52,
 				"total": 89,
-				"percentage": 55.05
+				"percentage": 58.42
 			},
 			"branches": {
-				"covered": 0,
-				"total": 0,
-				"percentage": 100
+				"covered": 1,
+				"total": 3,
+				"percentage": 33.33
 			},
 			"functions": {
-				"covered": 0,
+				"covered": 1,
 				"total": 2,
-				"percentage": 0
+				"percentage": 50
 			},
 			"lines": {
-				"covered": 49,
+				"covered": 52,
 				"total": 89,
-				"percentage": 55.05
+				"percentage": 58.42
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostWorkspaceFiles.ts": {
@@ -3030,36 +3074,36 @@
 		},
 		"src/vs/platform/agentHost/node/agentService.ts": {
 			"statements": {
-				"covered": 2523,
+				"covered": 2756,
 				"total": 4118,
-				"percentage": 61.26
+				"percentage": 66.92
 			},
 			"branches": {
-				"covered": 285,
-				"total": 482,
-				"percentage": 59.12
+				"covered": 369,
+				"total": 591,
+				"percentage": 62.43
 			},
 			"functions": {
-				"covered": 93,
-				"total": 149,
-				"percentage": 62.41
+				"covered": 105,
+				"total": 151,
+				"percentage": 69.53
 			},
 			"lines": {
-				"covered": 2523,
+				"covered": 2756,
 				"total": 4118,
-				"percentage": 61.26
+				"percentage": 66.92
 			}
 		},
 		"src/vs/platform/agentHost/node/agentSideEffects.ts": {
 			"statements": {
-				"covered": 1537,
-				"total": 1886,
-				"percentage": 81.49
+				"covered": 1545,
+				"total": 1895,
+				"percentage": 81.53
 			},
 			"branches": {
-				"covered": 262,
-				"total": 351,
-				"percentage": 74.64
+				"covered": 265,
+				"total": 354,
+				"percentage": 74.85
 			},
 			"functions": {
 				"covered": 48,
@@ -3067,9 +3111,9 @@
 				"percentage": 88.88
 			},
 			"lines": {
-				"covered": 1537,
-				"total": 1886,
-				"percentage": 81.49
+				"covered": 1545,
+				"total": 1895,
+				"percentage": 81.53
 			}
 		},
 		"src/vs/platform/agentHost/node/appNodeModules.ts": {
@@ -3299,9 +3343,9 @@
 				"percentage": 93.95
 			},
 			"branches": {
-				"covered": 13,
-				"total": 18,
-				"percentage": 72.22
+				"covered": 12,
+				"total": 17,
+				"percentage": 70.58
 			},
 			"functions": {
 				"covered": 4,
@@ -3338,24 +3382,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts": {
 			"statements": {
-				"covered": 638,
-				"total": 725,
-				"percentage": 88
+				"covered": 669,
+				"total": 763,
+				"percentage": 87.68
 			},
 			"branches": {
-				"covered": 75,
-				"total": 107,
-				"percentage": 70.09
+				"covered": 84,
+				"total": 122,
+				"percentage": 68.85
 			},
 			"functions": {
-				"covered": 22,
-				"total": 22,
+				"covered": 23,
+				"total": 23,
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 638,
-				"total": 725,
-				"percentage": 88
+				"covered": 669,
+				"total": 763,
+				"percentage": 87.68
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeMcpServerNames.ts": {
@@ -3492,14 +3536,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts": {
 			"statements": {
-				"covered": 501,
-				"total": 647,
-				"percentage": 77.43
+				"covered": 504,
+				"total": 652,
+				"percentage": 77.3
 			},
 			"branches": {
 				"covered": 57,
-				"total": 107,
-				"percentage": 53.27
+				"total": 112,
+				"percentage": 50.89
 			},
 			"functions": {
 				"covered": 18,
@@ -3507,9 +3551,9 @@
 				"percentage": 78.26
 			},
 			"lines": {
-				"covered": 501,
-				"total": 647,
-				"percentage": 77.43
+				"covered": 504,
+				"total": 652,
+				"percentage": 77.3
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSdkMessageRouter.ts": {
@@ -3690,14 +3734,14 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeSubagentSignals.ts": {
 			"statements": {
-				"covered": 282,
-				"total": 311,
-				"percentage": 90.67
+				"covered": 287,
+				"total": 316,
+				"percentage": 90.82
 			},
 			"branches": {
 				"covered": 18,
-				"total": 38,
-				"percentage": 47.36
+				"total": 44,
+				"percentage": 40.9
 			},
 			"functions": {
 				"covered": 5,
@@ -3705,31 +3749,31 @@
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 282,
-				"total": 311,
-				"percentage": 90.67
+				"covered": 287,
+				"total": 316,
+				"percentage": 90.82
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeToolCallRegistry.ts": {
 			"statements": {
-				"covered": 180,
-				"total": 195,
-				"percentage": 92.3
+				"covered": 223,
+				"total": 244,
+				"percentage": 91.39
 			},
 			"branches": {
-				"covered": 9,
-				"total": 18,
-				"percentage": 50
+				"covered": 14,
+				"total": 30,
+				"percentage": 46.66
 			},
 			"functions": {
-				"covered": 9,
-				"total": 9,
+				"covered": 10,
+				"total": 10,
 				"percentage": 100
 			},
 			"lines": {
-				"covered": 180,
-				"total": 195,
-				"percentage": 92.3
+				"covered": 223,
+				"total": 244,
+				"percentage": 91.39
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/claudeToolDenial.ts": {
@@ -3756,24 +3800,24 @@
 		},
 		"src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts": {
 			"statements": {
-				"covered": 462,
-				"total": 616,
-				"percentage": 75
+				"covered": 474,
+				"total": 653,
+				"percentage": 72.58
 			},
 			"branches": {
-				"covered": 54,
-				"total": 129,
-				"percentage": 41.86
+				"covered": 55,
+				"total": 134,
+				"percentage": 41.04
 			},
 			"functions": {
-				"covered": 14,
-				"total": 16,
-				"percentage": 87.5
+				"covered": 15,
+				"total": 17,
+				"percentage": 88.23
 			},
 			"lines": {
-				"covered": 462,
-				"total": 616,
-				"percentage": 75
+				"covered": 474,
+				"total": 653,
+				"percentage": 72.58
 			}
 		},
 		"src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolMcpServer.ts": {
@@ -4614,14 +4658,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgent.ts": {
 			"statements": {
-				"covered": 3275,
+				"covered": 3277,
 				"total": 4695,
-				"percentage": 69.75
+				"percentage": 69.79
 			},
 			"branches": {
-				"covered": 355,
-				"total": 594,
-				"percentage": 59.76
+				"covered": 358,
+				"total": 595,
+				"percentage": 60.16
 			},
 			"functions": {
 				"covered": 153,
@@ -4629,31 +4673,31 @@
 				"percentage": 73.91
 			},
 			"lines": {
-				"covered": 3275,
+				"covered": 3277,
 				"total": 4695,
-				"percentage": 69.75
+				"percentage": 69.79
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts": {
 			"statements": {
-				"covered": 3249,
-				"total": 5086,
-				"percentage": 63.88
+				"covered": 3456,
+				"total": 5339,
+				"percentage": 64.73
 			},
 			"branches": {
-				"covered": 429,
-				"total": 705,
-				"percentage": 60.85
+				"covered": 455,
+				"total": 752,
+				"percentage": 60.5
 			},
 			"functions": {
-				"covered": 125,
-				"total": 185,
-				"percentage": 67.56
+				"covered": 133,
+				"total": 193,
+				"percentage": 68.91
 			},
 			"lines": {
-				"covered": 3249,
-				"total": 5086,
-				"percentage": 63.88
+				"covered": 3456,
+				"total": 5339,
+				"percentage": 64.73
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts": {
@@ -4790,23 +4834,23 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts": {
 			"statements": {
-				"covered": 290,
-				"total": 290,
+				"covered": 295,
+				"total": 295,
 				"percentage": 100
 			},
 			"branches": {
-				"covered": 57,
-				"total": 57,
+				"covered": 58,
+				"total": 58,
 				"percentage": 100
 			},
 			"functions": {
-				"covered": 53,
-				"total": 54,
-				"percentage": 98.14
+				"covered": 54,
+				"total": 55,
+				"percentage": 98.18
 			},
 			"lines": {
-				"covered": 290,
-				"total": 290,
+				"covered": 295,
+				"total": 295,
 				"percentage": 100
 			}
 		},
@@ -4879,8 +4923,8 @@
 		"src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts": {
 			"statements": {
 				"covered": 18,
-				"total": 68,
-				"percentage": 26.47
+				"total": 75,
+				"percentage": 24
 			},
 			"branches": {
 				"covered": 0,
@@ -4894,8 +4938,8 @@
 			},
 			"lines": {
 				"covered": 18,
-				"total": 68,
-				"percentage": 26.47
+				"total": 75,
+				"percentage": 24
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts": {
@@ -4922,46 +4966,46 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts": {
 			"statements": {
-				"covered": 910,
-				"total": 1203,
-				"percentage": 75.64
+				"covered": 969,
+				"total": 1323,
+				"percentage": 73.24
 			},
 			"branches": {
-				"covered": 96,
-				"total": 221,
-				"percentage": 43.43
+				"covered": 110,
+				"total": 244,
+				"percentage": 45.08
 			},
 			"functions": {
-				"covered": 21,
-				"total": 31,
-				"percentage": 67.74
+				"covered": 24,
+				"total": 34,
+				"percentage": 70.58
 			},
 			"lines": {
-				"covered": 910,
-				"total": 1203,
-				"percentage": 75.64
+				"covered": 969,
+				"total": 1323,
+				"percentage": 73.24
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts": {
 			"statements": {
-				"covered": 572,
-				"total": 866,
-				"percentage": 66.05
+				"covered": 582,
+				"total": 875,
+				"percentage": 66.51
 			},
 			"branches": {
-				"covered": 60,
-				"total": 134,
-				"percentage": 44.77
+				"covered": 68,
+				"total": 143,
+				"percentage": 47.55
 			},
 			"functions": {
-				"covered": 19,
-				"total": 20,
-				"percentage": 95
+				"covered": 20,
+				"total": 21,
+				"percentage": 95.23
 			},
 			"lines": {
-				"covered": 572,
-				"total": 866,
-				"percentage": 66.05
+				"covered": 582,
+				"total": 875,
+				"percentage": 66.51
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/pendingEditContentStore.ts": {
@@ -5120,24 +5164,24 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts": {
 			"statements": {
-				"covered": 489,
+				"covered": 516,
 				"total": 1222,
-				"percentage": 40.01
+				"percentage": 42.22
 			},
 			"branches": {
-				"covered": 63,
-				"total": 80,
-				"percentage": 78.75
+				"covered": 69,
+				"total": 89,
+				"percentage": 77.52
 			},
 			"functions": {
-				"covered": 15,
+				"covered": 17,
 				"total": 36,
-				"percentage": 41.66
+				"percentage": 47.22
 			},
 			"lines": {
-				"covered": 489,
+				"covered": 516,
 				"total": 1222,
-				"percentage": 40.01
+				"percentage": 42.22
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts": {
@@ -5164,14 +5208,14 @@
 		},
 		"src/vs/platform/agentHost/node/diffComputeService.ts": {
 			"statements": {
-				"covered": 81,
+				"covered": 79,
 				"total": 102,
-				"percentage": 79.41
+				"percentage": 77.45
 			},
 			"branches": {
-				"covered": 11,
+				"covered": 10,
 				"total": 15,
-				"percentage": 73.33
+				"percentage": 66.66
 			},
 			"functions": {
 				"covered": 6,
@@ -5179,21 +5223,21 @@
 				"percentage": 85.71
 			},
 			"lines": {
-				"covered": 81,
+				"covered": 79,
 				"total": 102,
-				"percentage": 79.41
+				"percentage": 77.45
 			}
 		},
 		"src/vs/platform/agentHost/node/diffWorkerMain.ts": {
 			"statements": {
-				"covered": 92,
+				"covered": 94,
 				"total": 174,
-				"percentage": 52.87
+				"percentage": 54.02
 			},
 			"branches": {
-				"covered": 13,
+				"covered": 14,
 				"total": 19,
-				"percentage": 68.42
+				"percentage": 73.68
 			},
 			"functions": {
 				"covered": 4,
@@ -5201,9 +5245,9 @@
 				"percentage": 44.44
 			},
 			"lines": {
-				"covered": 92,
+				"covered": 94,
 				"total": 174,
-				"percentage": 52.87
+				"percentage": 54.02
 			}
 		},
 		"src/vs/platform/agentHost/node/gitDiffContent.ts": {
@@ -5384,24 +5428,24 @@
 		},
 		"src/vs/platform/agentHost/node/protocolServerHandler.ts": {
 			"statements": {
-				"covered": 1283,
+				"covered": 1361,
 				"total": 1638,
-				"percentage": 78.32
+				"percentage": 83.08
 			},
 			"branches": {
-				"covered": 187,
-				"total": 261,
-				"percentage": 71.64
+				"covered": 213,
+				"total": 284,
+				"percentage": 75
 			},
 			"functions": {
-				"covered": 66,
+				"covered": 68,
 				"total": 81,
-				"percentage": 81.48
+				"percentage": 83.95
 			},
 			"lines": {
-				"covered": 1283,
+				"covered": 1361,
 				"total": 1638,
-				"percentage": 78.32
+				"percentage": 83.08
 			}
 		},
 		"src/vs/platform/agentHost/node/serverUrls.ts": {
@@ -5450,14 +5494,14 @@
 		},
 		"src/vs/platform/agentHost/node/sessionDatabase.ts": {
 			"statements": {
-				"covered": 654,
+				"covered": 655,
 				"total": 869,
-				"percentage": 75.25
+				"percentage": 75.37
 			},
 			"branches": {
-				"covered": 104,
-				"total": 125,
-				"percentage": 83.2
+				"covered": 102,
+				"total": 123,
+				"percentage": 82.92
 			},
 			"functions": {
 				"covered": 32,
@@ -5465,9 +5509,9 @@
 				"percentage": 60.37
 			},
 			"lines": {
-				"covered": 654,
+				"covered": 655,
 				"total": 869,
-				"percentage": 75.25
+				"percentage": 75.37
 			}
 		},
 		"src/vs/platform/agentHost/node/sessionDiffAggregator.ts": {
@@ -5494,14 +5538,14 @@
 		},
 		"src/vs/platform/agentHost/node/sessionPermissions.ts": {
 			"statements": {
-				"covered": 521,
-				"total": 687,
-				"percentage": 75.83
+				"covered": 525,
+				"total": 691,
+				"percentage": 75.97
 			},
 			"branches": {
-				"covered": 72,
-				"total": 112,
-				"percentage": 64.28
+				"covered": 77,
+				"total": 118,
+				"percentage": 65.25
 			},
 			"functions": {
 				"covered": 23,
@@ -5509,9 +5553,9 @@
 				"percentage": 82.14
 			},
 			"lines": {
-				"covered": 521,
-				"total": 687,
-				"percentage": 75.83
+				"covered": 525,
+				"total": 691,
+				"percentage": 75.97
 			}
 		},
 		"src/vs/platform/agentHost/node/shared/agentBranchNameGenerator.ts": {
@@ -5538,24 +5582,24 @@
 		},
 		"src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts": {
 			"statements": {
-				"covered": 223,
+				"covered": 236,
 				"total": 990,
-				"percentage": 22.52
+				"percentage": 23.83
 			},
 			"branches": {
-				"covered": 7,
-				"total": 12,
-				"percentage": 58.33
+				"covered": 10,
+				"total": 20,
+				"percentage": 50
 			},
 			"functions": {
-				"covered": 7,
+				"covered": 9,
 				"total": 41,
-				"percentage": 17.07
+				"percentage": 21.95
 			},
 			"lines": {
-				"covered": 223,
+				"covered": 236,
 				"total": 990,
-				"percentage": 22.52
+				"percentage": 23.83
 			}
 		},
 		"src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts": {
@@ -5741,9 +5785,9 @@
 				"percentage": 88.55
 			},
 			"branches": {
-				"covered": 20,
-				"total": 27,
-				"percentage": 74.07
+				"covered": 21,
+				"total": 28,
+				"percentage": 75
 			},
 			"functions": {
 				"covered": 6,
@@ -5934,14 +5978,14 @@
 		},
 		"src/vs/platform/agentHost/node/shared/worktreeIsolation.ts": {
 			"statements": {
-				"covered": 731,
-				"total": 926,
-				"percentage": 78.94
+				"covered": 745,
+				"total": 946,
+				"percentage": 78.75
 			},
 			"branches": {
-				"covered": 76,
-				"total": 115,
-				"percentage": 66.08
+				"covered": 74,
+				"total": 116,
+				"percentage": 63.79
 			},
 			"functions": {
 				"covered": 31,
@@ -5949,9 +5993,9 @@
 				"percentage": 73.8
 			},
 			"lines": {
-				"covered": 731,
-				"total": 926,
-				"percentage": 78.94
+				"covered": 745,
+				"total": 946,
+				"percentage": 78.75
 			}
 		},
 		"src/vs/platform/agentHost/node/webSocketTransport.ts": {

--- a/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
+++ b/src/vs/platform/agentHost/test/node/e2e/coverage/summary.json
@@ -15,24 +15,24 @@
 	},
 	"total": {
 		"statements": {
-			"covered": 67536,
+			"covered": 67562,
 			"total": 95415,
-			"percentage": 70.78
+			"percentage": 70.8
 		},
 		"branches": {
-			"covered": 6026,
-			"total": 9510,
-			"percentage": 63.36
+			"covered": 6032,
+			"total": 9522,
+			"percentage": 63.34
 		},
 		"functions": {
-			"covered": 2232,
+			"covered": 2234,
 			"total": 3618,
-			"percentage": 61.69
+			"percentage": 61.74
 		},
 		"lines": {
-			"covered": 67536,
+			"covered": 67562,
 			"total": 95415,
-			"percentage": 70.78
+			"percentage": 70.8
 		}
 	},
 	"files": {
@@ -258,14 +258,14 @@
 		},
 		"src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts": {
 			"statements": {
-				"covered": 351,
+				"covered": 353,
 				"total": 649,
-				"percentage": 54.08
+				"percentage": 54.39
 			},
 			"branches": {
-				"covered": 17,
-				"total": 31,
-				"percentage": 54.83
+				"covered": 20,
+				"total": 33,
+				"percentage": 60.6
 			},
 			"functions": {
 				"covered": 10,
@@ -273,9 +273,9 @@
 				"percentage": 41.66
 			},
 			"lines": {
-				"covered": 351,
+				"covered": 353,
 				"total": 649,
-				"percentage": 54.08
+				"percentage": 54.39
 			}
 		},
 		"src/vs/platform/agentHost/common/agentHostFileSystemService.ts": {
@@ -1402,14 +1402,14 @@
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-session/reducer.ts": {
 			"statements": {
-				"covered": 212,
+				"covered": 210,
 				"total": 389,
-				"percentage": 54.49
+				"percentage": 53.98
 			},
 			"branches": {
-				"covered": 37,
-				"total": 60,
-				"percentage": 61.66
+				"covered": 34,
+				"total": 59,
+				"percentage": 57.62
 			},
 			"functions": {
 				"covered": 3,
@@ -1417,9 +1417,9 @@
 				"percentage": 75
 			},
 			"lines": {
-				"covered": 212,
+				"covered": 210,
 				"total": 389,
-				"percentage": 54.49
+				"percentage": 53.98
 			}
 		},
 		"src/vs/platform/agentHost/common/state/protocol/channels-terminal/reducer.ts": {
@@ -1820,24 +1820,24 @@
 		},
 		"src/vs/platform/agentHost/common/state/sessionState.ts": {
 			"statements": {
-				"covered": 1165,
+				"covered": 1168,
 				"total": 1471,
-				"percentage": 79.19
+				"percentage": 79.4
 			},
 			"branches": {
-				"covered": 105,
-				"total": 153,
-				"percentage": 68.62
+				"covered": 106,
+				"total": 154,
+				"percentage": 68.83
 			},
 			"functions": {
-				"covered": 40,
+				"covered": 41,
 				"total": 62,
-				"percentage": 64.51
+				"percentage": 66.12
 			},
 			"lines": {
-				"covered": 1165,
+				"covered": 1168,
 				"total": 1471,
-				"percentage": 79.19
+				"percentage": 79.4
 			}
 		},
 		"src/vs/platform/agentHost/common/streamingToolCallDisplay.ts": {
@@ -1908,14 +1908,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentConfigurationService.ts": {
 			"statements": {
-				"covered": 369,
+				"covered": 366,
 				"total": 402,
-				"percentage": 91.79
+				"percentage": 91.04
 			},
 			"branches": {
-				"covered": 39,
-				"total": 52,
-				"percentage": 75
+				"covered": 33,
+				"total": 46,
+				"percentage": 71.73
 			},
 			"functions": {
 				"covered": 14,
@@ -1923,9 +1923,9 @@
 				"percentage": 87.5
 			},
 			"lines": {
-				"covered": 369,
+				"covered": 366,
 				"total": 402,
-				"percentage": 91.79
+				"percentage": 91.04
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostAuthenticationService.ts": {
@@ -2018,14 +2018,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts": {
 			"statements": {
-				"covered": 330,
+				"covered": 324,
 				"total": 368,
-				"percentage": 89.67
+				"percentage": 88.04
 			},
 			"branches": {
-				"covered": 71,
-				"total": 85,
-				"percentage": 83.52
+				"covered": 65,
+				"total": 80,
+				"percentage": 81.25
 			},
 			"functions": {
 				"covered": 26,
@@ -2033,9 +2033,9 @@
 				"percentage": 96.29
 			},
 			"lines": {
-				"covered": 330,
+				"covered": 324,
 				"total": 368,
-				"percentage": 89.67
+				"percentage": 88.04
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostChangesetOperationService.ts": {
@@ -2370,9 +2370,9 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostGitService.ts": {
 			"statements": {
-				"covered": 850,
+				"covered": 852,
 				"total": 1413,
-				"percentage": 60.15
+				"percentage": 60.29
 			},
 			"branches": {
 				"covered": 156,
@@ -2385,21 +2385,21 @@
 				"percentage": 61.19
 			},
 			"lines": {
-				"covered": 850,
+				"covered": 852,
 				"total": 1413,
-				"percentage": 60.15
+				"percentage": 60.29
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostGitStateService.ts": {
 			"statements": {
-				"covered": 136,
+				"covered": 135,
 				"total": 202,
-				"percentage": 67.32
+				"percentage": 66.83
 			},
 			"branches": {
-				"covered": 31,
-				"total": 46,
-				"percentage": 67.39
+				"covered": 26,
+				"total": 42,
+				"percentage": 61.9
 			},
 			"functions": {
 				"covered": 5,
@@ -2407,9 +2407,9 @@
 				"percentage": 83.33
 			},
 			"lines": {
-				"covered": 136,
+				"covered": 135,
 				"total": 202,
-				"percentage": 67.32
+				"percentage": 66.83
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts": {
@@ -2766,24 +2766,24 @@
 		},
 		"src/vs/platform/agentHost/node/agentHostStateManager.ts": {
 			"statements": {
-				"covered": 1360,
+				"covered": 1368,
 				"total": 1495,
-				"percentage": 90.96
+				"percentage": 91.5
 			},
 			"branches": {
-				"covered": 200,
-				"total": 238,
-				"percentage": 84.03
+				"covered": 206,
+				"total": 244,
+				"percentage": 84.42
 			},
 			"functions": {
-				"covered": 51,
+				"covered": 52,
 				"total": 62,
-				"percentage": 82.25
+				"percentage": 83.87
 			},
 			"lines": {
-				"covered": 1360,
+				"covered": 1368,
 				"total": 1495,
-				"percentage": 90.96
+				"percentage": 91.5
 			}
 		},
 		"src/vs/platform/agentHost/node/agentHostSyncOperationHandler.ts": {
@@ -3074,14 +3074,14 @@
 		},
 		"src/vs/platform/agentHost/node/agentService.ts": {
 			"statements": {
-				"covered": 2756,
+				"covered": 2771,
 				"total": 4118,
-				"percentage": 66.92
+				"percentage": 67.28
 			},
 			"branches": {
-				"covered": 369,
-				"total": 591,
-				"percentage": 62.43
+				"covered": 374,
+				"total": 595,
+				"percentage": 62.85
 			},
 			"functions": {
 				"covered": 105,
@@ -3089,21 +3089,21 @@
 				"percentage": 69.53
 			},
 			"lines": {
-				"covered": 2756,
+				"covered": 2771,
 				"total": 4118,
-				"percentage": 66.92
+				"percentage": 67.28
 			}
 		},
 		"src/vs/platform/agentHost/node/agentSideEffects.ts": {
 			"statements": {
-				"covered": 1545,
+				"covered": 1546,
 				"total": 1895,
-				"percentage": 81.53
+				"percentage": 81.58
 			},
 			"branches": {
-				"covered": 265,
-				"total": 354,
-				"percentage": 74.85
+				"covered": 266,
+				"total": 355,
+				"percentage": 74.92
 			},
 			"functions": {
 				"covered": 48,
@@ -3111,9 +3111,9 @@
 				"percentage": 88.88
 			},
 			"lines": {
-				"covered": 1545,
+				"covered": 1546,
 				"total": 1895,
-				"percentage": 81.53
+				"percentage": 81.58
 			}
 		},
 		"src/vs/platform/agentHost/node/appNodeModules.ts": {
@@ -4003,9 +4003,9 @@
 				"percentage": 76.95
 			},
 			"branches": {
-				"covered": 43,
-				"total": 68,
-				"percentage": 63.23
+				"covered": 44,
+				"total": 69,
+				"percentage": 63.76
 			},
 			"functions": {
 				"covered": 12,
@@ -4152,14 +4152,14 @@
 		},
 		"src/vs/platform/agentHost/node/codex/codexAgent.ts": {
 			"statements": {
-				"covered": 2580,
+				"covered": 2571,
 				"total": 4602,
-				"percentage": 56.06
+				"percentage": 55.86
 			},
 			"branches": {
-				"covered": 196,
-				"total": 373,
-				"percentage": 52.54
+				"covered": 192,
+				"total": 371,
+				"percentage": 51.75
 			},
 			"functions": {
 				"covered": 87,
@@ -4167,9 +4167,9 @@
 				"percentage": 51.47
 			},
 			"lines": {
-				"covered": 2580,
+				"covered": 2571,
 				"total": 4602,
-				"percentage": 56.06
+				"percentage": 55.86
 			}
 		},
 		"src/vs/platform/agentHost/node/codex/codexAppServerClient.ts": {
@@ -4465,9 +4465,9 @@
 				"percentage": 87.81
 			},
 			"branches": {
-				"covered": 21,
-				"total": 42,
-				"percentage": 50
+				"covered": 20,
+				"total": 41,
+				"percentage": 48.78
 			},
 			"functions": {
 				"covered": 11,
@@ -4658,14 +4658,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgent.ts": {
 			"statements": {
-				"covered": 3277,
+				"covered": 3292,
 				"total": 4695,
-				"percentage": 69.79
+				"percentage": 70.11
 			},
 			"branches": {
-				"covered": 358,
-				"total": 595,
-				"percentage": 60.16
+				"covered": 363,
+				"total": 603,
+				"percentage": 60.19
 			},
 			"functions": {
 				"covered": 153,
@@ -4673,9 +4673,9 @@
 				"percentage": 73.91
 			},
 			"lines": {
-				"covered": 3277,
+				"covered": 3292,
 				"total": 4695,
-				"percentage": 69.79
+				"percentage": 70.11
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts": {
@@ -5164,14 +5164,14 @@
 		},
 		"src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts": {
 			"statements": {
-				"covered": 516,
+				"covered": 518,
 				"total": 1222,
-				"percentage": 42.22
+				"percentage": 42.38
 			},
 			"branches": {
-				"covered": 69,
-				"total": 89,
-				"percentage": 77.52
+				"covered": 76,
+				"total": 95,
+				"percentage": 80
 			},
 			"functions": {
 				"covered": 17,
@@ -5179,9 +5179,9 @@
 				"percentage": 47.22
 			},
 			"lines": {
-				"covered": 516,
+				"covered": 518,
 				"total": 1222,
-				"percentage": 42.22
+				"percentage": 42.38
 			}
 		},
 		"src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts": {
@@ -5433,9 +5433,9 @@
 				"percentage": 83.08
 			},
 			"branches": {
-				"covered": 213,
-				"total": 284,
-				"percentage": 75
+				"covered": 214,
+				"total": 285,
+				"percentage": 75.08
 			},
 			"functions": {
 				"covered": 68,
@@ -5494,14 +5494,14 @@
 		},
 		"src/vs/platform/agentHost/node/sessionDatabase.ts": {
 			"statements": {
-				"covered": 655,
+				"covered": 654,
 				"total": 869,
-				"percentage": 75.37
+				"percentage": 75.25
 			},
 			"branches": {
-				"covered": 102,
-				"total": 123,
-				"percentage": 82.92
+				"covered": 104,
+				"total": 125,
+				"percentage": 83.2
 			},
 			"functions": {
 				"covered": 32,
@@ -5509,9 +5509,9 @@
 				"percentage": 60.37
 			},
 			"lines": {
-				"covered": 655,
+				"covered": 654,
 				"total": 869,
-				"percentage": 75.37
+				"percentage": 75.25
 			}
 		},
 		"src/vs/platform/agentHost/node/sessionDiffAggregator.ts": {
@@ -6005,9 +6005,9 @@
 				"percentage": 85.71
 			},
 			"branches": {
-				"covered": 15,
-				"total": 23,
-				"percentage": 65.21
+				"covered": 14,
+				"total": 22,
+				"percentage": 63.63
 			},
 			"functions": {
 				"covered": 7,

--- a/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
@@ -24,11 +24,12 @@
 
 import assert from 'assert';
 import { execSync } from 'child_process';
-import { mkdtempSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import type { SubscribeResult } from '../../../../common/state/protocol/commands.js';
+import { ChangesetOperationTargetKind } from '../../../../common/state/protocol/channels-changeset/commands.js';
 import { ActionType } from '../../../../common/state/sessionActions.js';
 import {
 	buildBranchChangesetUri,
@@ -52,7 +53,22 @@ interface IObservedChangesetFile {
 
 interface IContentChangedAction {
 	readonly files: readonly IObservedChangesetFile[];
-	readonly operations?: readonly { readonly id: string; readonly scopes: readonly string[] }[];
+	readonly operations?: readonly IObservedOperation[];
+}
+
+interface IOperationsChangedAction {
+	readonly operations?: readonly IObservedOperation[];
+}
+
+interface IObservedOperation {
+	readonly id: string;
+	readonly scopes: readonly string[];
+	readonly status: string;
+}
+
+interface IOperationStatusChangedAction {
+	readonly operationId: string;
+	readonly status: string;
 }
 
 export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
@@ -117,6 +133,80 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 		}, timeout);
 		const action = getActionEnvelope(notification).action as IContentChangedAction;
 		return action.files.find(file => fileUri(file).endsWith(`/${basename}`))!;
+	}
+
+	async function waitForIdleResourceOnlyOperation(
+		channel: string,
+		operationId: string,
+		initialOperations: readonly IObservedOperation[],
+	): Promise<void> {
+		const operations = new Map(initialOperations.map(operation => [operation.id, operation]));
+		const isReady = () => {
+			const operation = operations.get(operationId);
+			return operation?.status === 'idle'
+				&& operation.scopes.includes('resource')
+				&& !operation.scopes.includes('changeset');
+		};
+		const reduce = (n: Parameters<typeof isActionNotification>[0]): void => {
+			const isContentChanged = isActionNotification(n, 'changeset/contentChanged');
+			const isOperationsChanged = isActionNotification(n, 'changeset/operationsChanged');
+			const isStatusChanged = isActionNotification(n, 'changeset/operationStatusChanged');
+			if ((!isContentChanged && !isOperationsChanged && !isStatusChanged) || getActionEnvelope(n).channel !== channel) {
+				return;
+			}
+			if (isOperationsChanged) {
+				operations.clear();
+				for (const operation of (getActionEnvelope(n).action as IOperationsChangedAction).operations ?? []) {
+					operations.set(operation.id, operation);
+				}
+			} else if (isContentChanged) {
+				const replacement = (getActionEnvelope(n).action as IContentChangedAction).operations;
+				if (replacement) {
+					operations.clear();
+					for (const operation of replacement) {
+						operations.set(operation.id, operation);
+					}
+				}
+			} else {
+				const changed = getActionEnvelope(n).action as IOperationStatusChangedAction;
+				const operation = operations.get(changed.operationId);
+				if (operation) {
+					operations.set(changed.operationId, { ...operation, status: changed.status });
+				}
+			}
+		};
+		const processed = new Set(context.client.receivedNotifications());
+		for (const notification of processed) {
+			reduce(notification);
+		}
+		if (isReady()) {
+			return;
+		}
+		await context.client.waitForNotification(n => {
+			if (processed.has(n)) {
+				return false;
+			}
+			processed.add(n);
+			reduce(n);
+			return isReady();
+		}, 60_000);
+	}
+
+	async function createModifiedUncommittedChangeset(prefix: string): Promise<{
+		readonly workspace: string;
+		readonly changeset: string;
+		readonly file: IObservedChangesetFile;
+	}> {
+		const workspace = createGitWorkspace(`ahp-${prefix}-`);
+		const sessionUri = await createSessionIn(workspace, prefix);
+		const changeset = buildUncommittedChangesetUri(sessionUri);
+		const subscribed = await context.client.call<SubscribeResult>('subscribe', { channel: changeset });
+		const initialOperations = ((subscribed.snapshot!.state as { operations?: readonly IObservedOperation[] }).operations ?? []);
+		context.client.clearReceived();
+		dispatchTurn(context.client, sessionUri, `turn-${prefix}`, writeFileCommand('seed.txt', 'edited'), 1);
+		const file = await waitForFileInChangeset(changeset, 'seed.txt');
+		await waitForIdleResourceOnlyOperation(changeset, 'discard-changes', initialOperations);
+		return { workspace, changeset, file };
 	}
 
 
@@ -254,6 +344,58 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 			{ id: 'commit', scopes: ['changeset'] },
 			{ id: 'discard-changes', scopes: ['resource'] },
 		]);
+	});
+
+	conformanceTest(context, 'discarding a tracked change restores the file and reports operation status', async function () {
+		const { workspace, changeset, file } = await createModifiedUncommittedChangeset('changeset-discard');
+		const resource = file.edit.after?.uri;
+		assert.ok(resource);
+		context.client.clearReceived();
+		const completed = context.client.waitForNotification(n =>
+			isActionNotification(n, 'changeset/operationStatusChanged')
+			&& getActionEnvelope(n).channel === changeset
+			&& (getActionEnvelope(n).action as { operationId: string; status: string }).operationId === 'discard-changes'
+			&& (getActionEnvelope(n).action as { operationId: string; status: string }).status === 'idle',
+		);
+
+		await context.client.call('invokeChangesetOperation', {
+			channel: changeset,
+			operationId: 'discard-changes',
+			target: { kind: ChangesetOperationTargetKind.Resource, resource },
+		});
+		await completed;
+
+		const statuses = context.client.receivedNotifications(n =>
+			isActionNotification(n, 'changeset/operationStatusChanged')
+			&& getActionEnvelope(n).channel === changeset,
+		).map(n => getActionEnvelope(n).action as { operationId: string; status: string })
+			.filter(action => action.operationId === 'discard-changes')
+			.map(action => action.status);
+		assert.deepStrictEqual({
+			contents: readFileSync(join(workspace, 'seed.txt'), 'utf8').replaceAll('\r\n', '\n'),
+			statuses,
+		}, {
+			contents: 'seed\n',
+			statuses: ['running', 'idle'],
+		});
+	});
+
+	conformanceTest(context, 'invoking an unknown changeset operation is rejected', async function () {
+		const { changeset } = await createModifiedUncommittedChangeset('changeset-unknown-operation');
+
+		await assert.rejects(context.client.call('invokeChangesetOperation', {
+			channel: changeset,
+			operationId: 'unknown-operation',
+		}));
+	});
+
+	conformanceTest(context, 'changeset operation rejects a target outside its advertised scopes', async function () {
+		const { changeset } = await createModifiedUncommittedChangeset('changeset-invalid-scope');
+
+		await assert.rejects(context.client.call('invokeChangesetOperation', {
+			channel: changeset,
+			operationId: 'discard-changes',
+		}));
 	});
 
 	conformanceTest(context, 'the session advertises its changeset catalog on separate channels', async function () {

--- a/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
@@ -141,11 +141,20 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 		initialOperations: readonly IObservedOperation[],
 	): Promise<void> {
 		const operations = new Map(initialOperations.map(operation => [operation.id, operation]));
+		const pendingStatuses = new Map<string, string>();
 		const isReady = () => {
 			const operation = operations.get(operationId);
 			return operation?.status === 'idle'
 				&& operation.scopes.includes('resource')
 				&& !operation.scopes.includes('changeset');
+		};
+		const replaceOperations = (replacement: readonly IObservedOperation[]): void => {
+			operations.clear();
+			for (const operation of replacement) {
+				const pendingStatus = pendingStatuses.get(operation.id);
+				operations.set(operation.id, pendingStatus === undefined ? operation : { ...operation, status: pendingStatus });
+				pendingStatuses.delete(operation.id);
+			}
 		};
 		const reduce = (n: Parameters<typeof isActionNotification>[0]): void => {
 			const isContentChanged = isActionNotification(n, 'changeset/contentChanged');
@@ -155,23 +164,19 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 				return;
 			}
 			if (isOperationsChanged) {
-				operations.clear();
-				for (const operation of (getActionEnvelope(n).action as IOperationsChangedAction).operations ?? []) {
-					operations.set(operation.id, operation);
-				}
+				replaceOperations((getActionEnvelope(n).action as IOperationsChangedAction).operations ?? []);
 			} else if (isContentChanged) {
 				const replacement = (getActionEnvelope(n).action as IContentChangedAction).operations;
 				if (replacement) {
-					operations.clear();
-					for (const operation of replacement) {
-						operations.set(operation.id, operation);
-					}
+					replaceOperations(replacement);
 				}
 			} else {
 				const changed = getActionEnvelope(n).action as IOperationStatusChangedAction;
 				const operation = operations.get(changed.operationId);
 				if (operation) {
 					operations.set(changed.operationId, { ...operation, status: changed.status });
+				} else {
+					pendingStatuses.set(changed.operationId, changed.status);
 				}
 			}
 		};

--- a/src/vs/platform/agentHost/test/node/e2e/suites/clientFilesystemSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/clientFilesystemSuite.ts
@@ -20,7 +20,7 @@
  */
 
 import assert from 'assert';
-import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -30,9 +30,12 @@ import type {
 	ResourceListResult,
 	ResourceReadResult,
 	ResourceResolveResult,
+	SubscribeResult,
 } from '../../../../common/state/protocol/commands.js';
-import { ContentEncoding, ResourceType } from '../../../../common/state/protocol/common/commands.js';
+import { ContentEncoding, ResourceType, ResourceWriteMode } from '../../../../common/state/protocol/common/commands.js';
+import type { ResourceWatchState } from '../../../../common/state/protocol/channels-resource-watch/state.js';
 import { ActionType } from '../../../../common/state/sessionActions.js';
+import { AhpErrorCodes } from '../../../../common/state/sessionProtocol.js';
 import { CustomizationLoadStatus, CustomizationType, ROOT_STATE_URI } from '../../../../common/state/sessionState.js';
 import { createRealSession } from '../harness/agentHostE2ETestHarness.js';
 import { getActionEnvelope, isActionNotification } from '../../serverIntegrationTestHelpers.js';
@@ -62,6 +65,21 @@ export function defineClientFilesystemTests(context: IAgentHostE2ETestContext): 
 			channel: ROOT_STATE_URI,
 			protocolVersions: [PROTOCOL_VERSION],
 			clientId: `${purpose}-${config.provider}`,
+		});
+	}
+
+	async function writeText(uri: string, data: string, options: {
+		readonly createOnly?: boolean;
+		readonly ifMatch?: string;
+		readonly mode?: ResourceWriteMode;
+		readonly position?: number;
+	} = {}): Promise<void> {
+		await context.client.call('resourceWrite', {
+			channel: ROOT_STATE_URI,
+			uri,
+			data,
+			encoding: ContentEncoding.Utf8,
+			...options,
 		});
 	}
 
@@ -166,6 +184,406 @@ export function defineClientFilesystemTests(context: IAgentHostE2ETestContext): 
 		});
 
 		assert.strictEqual(URI.parse(watch.channel).scheme, 'ahp-resource-watch');
+	});
+
+	conformanceTest(context, 'resource watch subscription preserves its descriptor', async function () {
+		await initializeClient('resource-watch-descriptor');
+		const root = createWorkspace('ahp-resource-watch-descriptor-');
+		const rootUri = URI.file(root).toString();
+		const watch = await context.client.call<{ channel: string }>('createResourceWatch', {
+			channel: ROOT_STATE_URI,
+			uri: rootUri,
+			recursive: true,
+			excludes: { items: ['**/*.tmp'] },
+			includes: { items: ['**/*.txt'] },
+		});
+
+		const subscribed = await context.client.call<SubscribeResult>('subscribe', { channel: watch.channel });
+
+		assert.deepStrictEqual(subscribed.snapshot!.state as ResourceWatchState, {
+			root: rootUri,
+			recursive: true,
+			excludes: { items: ['**/*.tmp'] },
+			includes: { items: ['**/*.txt'] },
+		});
+	});
+
+	conformanceTest(context, 'creating a resource watch for a missing root is rejected', async function () {
+		await initializeClient('resource-watch-missing');
+		const root = createWorkspace('ahp-resource-watch-missing-');
+
+		await assert.rejects(context.client.call('createResourceWatch', {
+			channel: ROOT_STATE_URI,
+			uri: fileUri(root, 'missing'),
+			recursive: true,
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceWrite appends at the end of a file', async function () {
+		await initializeClient('resource-append');
+		const root = createWorkspace('ahp-resource-append-');
+		const file = fileUri(root, 'append.txt');
+		writeFileSync(join(root, 'append.txt'), 'BEGIN');
+
+		await writeText(file, '-END', { mode: ResourceWriteMode.Append });
+
+		assert.strictEqual(readFileSync(join(root, 'append.txt'), 'utf8'), 'BEGIN-END');
+	});
+
+	conformanceTest(context, 'resourceWrite append position counts backwards from EOF', async function () {
+		await initializeClient('resource-append-offset');
+		const root = createWorkspace('ahp-resource-append-offset-');
+		const file = fileUri(root, 'append-offset.txt');
+		writeFileSync(join(root, 'append-offset.txt'), 'BEGIN-END');
+
+		await writeText(file, '-MIDDLE', { mode: ResourceWriteMode.Append, position: 4 });
+
+		assert.strictEqual(readFileSync(join(root, 'append-offset.txt'), 'utf8'), 'BEGIN-MIDDLE-END');
+	});
+
+	conformanceTest(context, 'resourceWrite inserts without replacing existing bytes', async function () {
+		await initializeClient('resource-insert');
+		const root = createWorkspace('ahp-resource-insert-');
+		const file = fileUri(root, 'insert.txt');
+		writeFileSync(join(root, 'insert.txt'), 'ABCD');
+
+		await writeText(file, '12', { mode: ResourceWriteMode.Insert, position: 2 });
+
+		assert.strictEqual(readFileSync(join(root, 'insert.txt'), 'utf8'), 'AB12CD');
+	});
+
+	conformanceTest(context, 'resourceWrite truncates from the requested position', async function () {
+		await initializeClient('resource-truncate');
+		const root = createWorkspace('ahp-resource-truncate-');
+		const file = fileUri(root, 'truncate.txt');
+		writeFileSync(join(root, 'truncate.txt'), 'PREFIX-OLD-SUFFIX');
+
+		await writeText(file, 'NEW', { mode: ResourceWriteMode.Truncate, position: 7 });
+
+		assert.strictEqual(readFileSync(join(root, 'truncate.txt'), 'utf8'), 'PREFIX-NEW');
+	});
+
+	conformanceTest(context, 'resourceWrite createOnly rejects an existing file', async function () {
+		await initializeClient('resource-create-only');
+		const root = createWorkspace('ahp-resource-create-only-');
+		const file = fileUri(root, 'existing.txt');
+		writeFileSync(join(root, 'existing.txt'), 'original');
+
+		await assert.rejects(writeText(file, 'replacement', { createOnly: true }), { code: AhpErrorCodes.AlreadyExists });
+		assert.strictEqual(readFileSync(join(root, 'existing.txt'), 'utf8'), 'original');
+	});
+
+	conformanceTest(context, 'resourceWrite ifMatch rejects a stale etag', async function () {
+		await initializeClient('resource-if-match');
+		const root = createWorkspace('ahp-resource-if-match-');
+		const file = fileUri(root, 'etag.txt');
+		writeFileSync(join(root, 'etag.txt'), 'before');
+		const resolved = await context.client.call<ResourceResolveResult>('resourceResolve', {
+			channel: ROOT_STATE_URI,
+			uri: file,
+		});
+		if (resolved.etag === undefined) {
+			this.skip();
+		}
+		await writeText(file, 'first', { ifMatch: resolved.etag });
+
+		await assert.rejects(writeText(file, 'stale', { ifMatch: resolved.etag }), { code: AhpErrorCodes.Conflict });
+		assert.strictEqual(readFileSync(join(root, 'etag.txt'), 'utf8'), 'first');
+	});
+
+	conformanceTest(context, 'resourceCopy failIfExists preserves the destination', async function () {
+		await initializeClient('resource-copy-conflict');
+		const root = createWorkspace('ahp-resource-copy-conflict-');
+		writeFileSync(join(root, 'source.txt'), 'source');
+		writeFileSync(join(root, 'destination.txt'), 'destination');
+
+		await assert.rejects(context.client.call('resourceCopy', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source.txt'),
+			destination: fileUri(root, 'destination.txt'),
+			failIfExists: true,
+		}), { code: AhpErrorCodes.AlreadyExists });
+		assert.strictEqual(readFileSync(join(root, 'destination.txt'), 'utf8'), 'destination');
+	});
+
+	conformanceTest(context, 'resourceMove failIfExists preserves both files', async function () {
+		await initializeClient('resource-move-conflict');
+		const root = createWorkspace('ahp-resource-move-conflict-');
+		writeFileSync(join(root, 'source.txt'), 'source');
+		writeFileSync(join(root, 'destination.txt'), 'destination');
+
+		await assert.rejects(context.client.call('resourceMove', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source.txt'),
+			destination: fileUri(root, 'destination.txt'),
+			failIfExists: true,
+		}), { code: AhpErrorCodes.AlreadyExists });
+		assert.deepStrictEqual({
+			source: readFileSync(join(root, 'source.txt'), 'utf8'),
+			destination: readFileSync(join(root, 'destination.txt'), 'utf8'),
+		}, {
+			source: 'source',
+			destination: 'destination',
+		});
+	});
+
+	conformanceTest(context, 'resourceMkdir rejects a path occupied by a file', async function () {
+		await initializeClient('resource-mkdir-file');
+		const root = createWorkspace('ahp-resource-mkdir-file-');
+		const file = fileUri(root, 'occupied');
+		writeFileSync(join(root, 'occupied'), 'file');
+
+		await assert.rejects(context.client.call('resourceMkdir', {
+			channel: ROOT_STATE_URI,
+			uri: file,
+		}), { code: AhpErrorCodes.AlreadyExists });
+	});
+
+	conformanceTest(context, 'resourceDelete recursively removes a directory tree', async function () {
+		await initializeClient('resource-delete-tree');
+		const root = createWorkspace('ahp-resource-delete-tree-');
+		const tree = join(root, 'tree');
+		mkdirSync(join(tree, 'nested'), { recursive: true });
+		writeFileSync(join(tree, 'nested', 'file.txt'), 'delete');
+
+		await context.client.call('resourceDelete', {
+			channel: ROOT_STATE_URI,
+			uri: URI.file(tree).toString(),
+			recursive: true,
+		});
+
+		assert.strictEqual(existsSync(tree), false);
+	});
+
+	conformanceTest(context, 'resourceWrite decodes base64 content', async function () {
+		await initializeClient('resource-base64');
+		const root = createWorkspace('ahp-resource-base64-');
+		const file = fileUri(root, 'base64.txt');
+
+		await context.client.call('resourceWrite', {
+			channel: ROOT_STATE_URI,
+			uri: file,
+			data: Buffer.from('BASE64_CONTENT').toString('base64'),
+			encoding: ContentEncoding.Base64,
+		});
+
+		assert.strictEqual(readFileSync(join(root, 'base64.txt'), 'utf8'), 'BASE64_CONTENT');
+	});
+
+	conformanceTest(context, 'resourceWrite append creates a missing file', async function () {
+		await initializeClient('resource-append-create');
+		const root = createWorkspace('ahp-resource-append-create-');
+		const file = fileUri(root, 'created.txt');
+
+		await writeText(file, 'created', { mode: ResourceWriteMode.Append });
+
+		assert.strictEqual(readFileSync(join(root, 'created.txt'), 'utf8'), 'created');
+	});
+
+	conformanceTest(context, 'resourceWrite insert creates a missing file', async function () {
+		await initializeClient('resource-insert-create');
+		const root = createWorkspace('ahp-resource-insert-create-');
+		const file = fileUri(root, 'created.txt');
+
+		await writeText(file, 'created', { mode: ResourceWriteMode.Insert, position: 0 });
+
+		assert.strictEqual(readFileSync(join(root, 'created.txt'), 'utf8'), 'created');
+	});
+
+	conformanceTest(context, 'resourceWrite accepts the current etag', async function () {
+		await initializeClient('resource-if-match-current');
+		const root = createWorkspace('ahp-resource-if-match-current-');
+		const file = fileUri(root, 'etag.txt');
+		writeFileSync(join(root, 'etag.txt'), 'before');
+		const resolved = await context.client.call<ResourceResolveResult>('resourceResolve', {
+			channel: ROOT_STATE_URI,
+			uri: file,
+		});
+		if (resolved.etag === undefined) {
+			this.skip();
+		}
+
+		await writeText(file, 'after', { ifMatch: resolved.etag });
+
+		assert.strictEqual(readFileSync(join(root, 'etag.txt'), 'utf8'), 'after');
+	});
+
+	conformanceTest(context, 'resourceWrite ifMatch rejects a missing file', async function () {
+		await initializeClient('resource-if-match-missing');
+		const root = createWorkspace('ahp-resource-if-match-missing-');
+
+		await assert.rejects(writeText(fileUri(root, 'missing.txt'), 'content', { ifMatch: 'missing-etag' }), {
+			code: AhpErrorCodes.Conflict,
+		});
+	});
+
+	conformanceTest(context, 'resourceCopy recursively copies a directory', async function () {
+		await initializeClient('resource-copy-directory');
+		const root = createWorkspace('ahp-resource-copy-directory-');
+		mkdirSync(join(root, 'source', 'nested'), { recursive: true });
+		writeFileSync(join(root, 'source', 'nested', 'file.txt'), 'copied');
+
+		await context.client.call('resourceCopy', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source'),
+			destination: fileUri(root, 'destination'),
+		});
+
+		assert.strictEqual(readFileSync(join(root, 'destination', 'nested', 'file.txt'), 'utf8'), 'copied');
+	});
+
+	conformanceTest(context, 'resourceCopy overwrites an existing destination by default', async function () {
+		await initializeClient('resource-copy-overwrite');
+		const root = createWorkspace('ahp-resource-copy-overwrite-');
+		writeFileSync(join(root, 'source.txt'), 'source');
+		writeFileSync(join(root, 'destination.txt'), 'destination');
+
+		await context.client.call('resourceCopy', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source.txt'),
+			destination: fileUri(root, 'destination.txt'),
+		});
+
+		assert.strictEqual(readFileSync(join(root, 'destination.txt'), 'utf8'), 'source');
+	});
+
+	conformanceTest(context, 'resourceCopy reports a missing source', async function () {
+		await initializeClient('resource-copy-missing');
+		const root = createWorkspace('ahp-resource-copy-missing-');
+
+		await assert.rejects(context.client.call('resourceCopy', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'missing.txt'),
+			destination: fileUri(root, 'destination.txt'),
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceMove relocates a directory tree', async function () {
+		await initializeClient('resource-move-directory');
+		const root = createWorkspace('ahp-resource-move-directory-');
+		mkdirSync(join(root, 'source', 'nested'), { recursive: true });
+		writeFileSync(join(root, 'source', 'nested', 'file.txt'), 'moved');
+
+		await context.client.call('resourceMove', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source'),
+			destination: fileUri(root, 'destination'),
+		});
+
+		assert.deepStrictEqual({
+			sourceExists: existsSync(join(root, 'source')),
+			contents: readFileSync(join(root, 'destination', 'nested', 'file.txt'), 'utf8'),
+		}, {
+			sourceExists: false,
+			contents: 'moved',
+		});
+	});
+
+	conformanceTest(context, 'resourceMove overwrites an existing destination by default', async function () {
+		await initializeClient('resource-move-overwrite');
+		const root = createWorkspace('ahp-resource-move-overwrite-');
+		writeFileSync(join(root, 'source.txt'), 'source');
+		writeFileSync(join(root, 'destination.txt'), 'destination');
+
+		await context.client.call('resourceMove', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'source.txt'),
+			destination: fileUri(root, 'destination.txt'),
+		});
+
+		assert.deepStrictEqual({
+			sourceExists: existsSync(join(root, 'source.txt')),
+			contents: readFileSync(join(root, 'destination.txt'), 'utf8'),
+		}, {
+			sourceExists: false,
+			contents: 'source',
+		});
+	});
+
+	conformanceTest(context, 'resourceMove reports a missing source', async function () {
+		await initializeClient('resource-move-missing');
+		const root = createWorkspace('ahp-resource-move-missing-');
+
+		await assert.rejects(context.client.call('resourceMove', {
+			channel: ROOT_STATE_URI,
+			source: fileUri(root, 'missing.txt'),
+			destination: fileUri(root, 'destination.txt'),
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceDelete requires recursive mode for a non-empty directory', async function () {
+		await initializeClient('resource-delete-non-recursive');
+		const root = createWorkspace('ahp-resource-delete-non-recursive-');
+		const directory = join(root, 'directory');
+		mkdirSync(directory);
+		writeFileSync(join(directory, 'file.txt'), 'preserved');
+
+		await assert.rejects(context.client.call('resourceDelete', {
+			channel: ROOT_STATE_URI,
+			uri: URI.file(directory).toString(),
+		}));
+		assert.strictEqual(readFileSync(join(directory, 'file.txt'), 'utf8'), 'preserved');
+	});
+
+	conformanceTest(context, 'resourceDelete reports a missing resource', async function () {
+		await initializeClient('resource-delete-missing');
+		const root = createWorkspace('ahp-resource-delete-missing-');
+
+		await assert.rejects(context.client.call('resourceDelete', {
+			channel: ROOT_STATE_URI,
+			uri: fileUri(root, 'missing.txt'),
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceRead reports a missing file', async function () {
+		await initializeClient('resource-read-missing');
+		const root = createWorkspace('ahp-resource-read-missing-');
+
+		await assert.rejects(context.client.call('resourceRead', {
+			channel: ROOT_STATE_URI,
+			uri: fileUri(root, 'missing.txt'),
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceList reports a missing directory', async function () {
+		await initializeClient('resource-list-missing');
+		const root = createWorkspace('ahp-resource-list-missing-');
+
+		await assert.rejects(context.client.call('resourceList', {
+			channel: ROOT_STATE_URI,
+			uri: fileUri(root, 'missing'),
+		}), { code: AhpErrorCodes.NotFound });
+	});
+
+	conformanceTest(context, 'resourceList rejects a file resource', async function () {
+		await initializeClient('resource-list-file');
+		const root = createWorkspace('ahp-resource-list-file-');
+		const file = fileUri(root, 'file.txt');
+		writeFileSync(join(root, 'file.txt'), 'content');
+
+		await assert.rejects(context.client.call('resourceList', {
+			channel: ROOT_STATE_URI,
+			uri: file,
+		}));
+	});
+
+	conformanceTest(context, 'resourceWrite reports a missing parent directory', async function () {
+		await initializeClient('resource-write-missing-parent');
+		const root = createWorkspace('ahp-resource-write-missing-parent-');
+
+		await assert.rejects(writeText(fileUri(root, 'missing', 'file.txt'), 'content'), {
+			code: AhpErrorCodes.NotFound,
+		});
+	});
+
+	conformanceTest(context, 'resourceResolve reports a missing resource', async function () {
+		await initializeClient('resource-resolve-missing');
+		const root = createWorkspace('ahp-resource-resolve-missing-');
+
+		await assert.rejects(context.client.call('resourceResolve', {
+			channel: ROOT_STATE_URI,
+			uri: fileUri(root, 'missing'),
+		}), { code: AhpErrorCodes.NotFound });
 	});
 
 	conformanceTest(context, 'host reads a client-hosted plugin through reverse resource requests', async function () {

--- a/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
@@ -73,15 +73,6 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 		}
 	});
 
-	conformanceTest(context, 'requests other than ping are rejected before initialize', async function () {
-		const client = await context.connectClient();
-		try {
-			await assert.rejects(client.call('listSessions', { channel: ROOT_STATE_URI }));
-		} finally {
-			client.close();
-		}
-	});
-
 	conformanceTest(context, 'initialize rejects incompatible protocol versions', async function () {
 		const client = await context.connectClient();
 		try {

--- a/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
@@ -16,11 +16,12 @@ import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { ReconnectResultType, type ReconnectResult, type SubscribeResult } from '../../../../common/state/protocol/commands.js';
+import { ReconnectResultType, type InitializeResult, type ListSessionsResult, type ReconnectResult, type SubscribeResult } from '../../../../common/state/protocol/commands.js';
 import { ActionType, type StateAction } from '../../../../common/state/sessionActions.js';
-import { buildDefaultChatUri, MessageKind, ROOT_STATE_URI } from '../../../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, MessageKind, ROOT_STATE_URI, SessionStatus } from '../../../../common/state/sessionState.js';
 import { createRealSession, dispatchTurn } from '../harness/agentHostE2ETestHarness.js';
 import { PROTOCOL_VERSION } from '../../../../common/state/protocol/version/registry.js';
+import { AhpErrorCodes, JsonRpcErrorCodes } from '../../../../common/state/sessionProtocol.js';
 import { getActionEnvelope, isActionNotification, type TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
 import { conformanceTest, type IAgentHostE2ETestContext } from './e2eTestContext.js';
 
@@ -62,6 +63,143 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 		await context.client.call('ping', { channel: ROOT_STATE_URI });
 	});
 
+	conformanceTest(context, 'ping answers before the client initializes', async function () {
+		const client = await context.connectClient();
+		try {
+			const result = await client.call('ping', { channel: ROOT_STATE_URI });
+			assert.strictEqual(result, null);
+		} finally {
+			client.close();
+		}
+	});
+
+	conformanceTest(context, 'requests other than ping are rejected before initialize', async function () {
+		const client = await context.connectClient();
+		try {
+			await assert.rejects(client.call('listSessions', { channel: ROOT_STATE_URI }));
+		} finally {
+			client.close();
+		}
+	});
+
+	conformanceTest(context, 'initialize rejects incompatible protocol versions', async function () {
+		const client = await context.connectClient();
+		try {
+			await assert.rejects(client.call('initialize', {
+				channel: ROOT_STATE_URI,
+				protocolVersions: ['999.0.0'],
+				clientId: `incompatible-version-${config.provider}`,
+			}), { code: AhpErrorCodes.UnsupportedProtocolVersion });
+		} finally {
+			client.close();
+		}
+	});
+
+	conformanceTest(context, 'initialize rejects an empty protocol version list', async function () {
+		const client = await context.connectClient();
+		try {
+			await assert.rejects(client.call('initialize', {
+				channel: ROOT_STATE_URI,
+				protocolVersions: [],
+				clientId: `empty-versions-${config.provider}`,
+			}), { code: AhpErrorCodes.UnsupportedProtocolVersion });
+		} finally {
+			client.close();
+		}
+	});
+
+	conformanceTest(context, 'initialize without subscriptions returns no snapshots', async function () {
+		const client = await context.connectClient();
+		try {
+			const initialized = await client.call<InitializeResult>('initialize', {
+				channel: ROOT_STATE_URI,
+				protocolVersions: [PROTOCOL_VERSION],
+				clientId: `no-initial-subscriptions-${config.provider}`,
+			});
+			assert.deepStrictEqual(initialized.snapshots, []);
+		} finally {
+			client.close();
+		}
+	});
+
+	conformanceTest(context, 'listSessions includes provider-backed session metadata', async function () {
+		const { sessionUri, workspace } = await createSession('list-session-metadata');
+		const chatUri = buildDefaultChatUri(sessionUri);
+		dispatchTurn(context.client, sessionUri, 'turn-list-session-metadata', '/rename Listed Session', nextClientSeq());
+		await context.client.waitForNotification(n =>
+			isActionNotification(n, 'chat/turnComplete')
+			&& getActionEnvelope(n).channel === chatUri
+			&& (getActionEnvelope(n).action as { turnId: string }).turnId === 'turn-list-session-metadata',
+		);
+
+		const result = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		const item = result.items.find(item => item.resource === sessionUri);
+
+		assert.deepStrictEqual({
+			provider: item?.provider,
+			hasTitle: typeof item?.title === 'string' && item.title.length > 0,
+			statusIsNumber: typeof item?.status === 'number',
+			workingDirectories: item?.workingDirectories,
+			hasCreatedAt: item !== undefined && Number.isFinite(Date.parse(item.createdAt)),
+			hasModifiedAt: item !== undefined && Number.isFinite(Date.parse(item.modifiedAt)),
+		}, {
+			provider: config.provider,
+			hasTitle: true,
+			statusIsNumber: true,
+			workingDirectories: [URI.file(workspace).toString()],
+			hasCreatedAt: true,
+			hasModifiedAt: true,
+		});
+	});
+
+	conformanceTest(context, 'listSessions reflects live title and status changes', async function () {
+		const { sessionUri } = await createSession('list-session-live-state');
+		const chatUri = buildDefaultChatUri(sessionUri);
+		dispatchTurn(context.client, sessionUri, 'turn-list-session-live-state', '/rename Catalog Title', nextClientSeq());
+		await context.client.waitForNotification(n =>
+			isActionNotification(n, 'chat/turnComplete')
+			&& getActionEnvelope(n).channel === chatUri
+			&& (getActionEnvelope(n).action as { turnId: string }).turnId === 'turn-list-session-live-state',
+		);
+		await dispatchAndWaitOnShared(sessionUri, { type: ActionType.SessionIsReadChanged, isRead: true });
+		await dispatchAndWaitOnShared(sessionUri, { type: ActionType.SessionIsArchivedChanged, isArchived: true });
+
+		const result = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		const item = result.items.find(item => item.resource === sessionUri);
+
+		assert.deepStrictEqual({
+			title: item?.title,
+			isRead: !!(item?.status && item.status & SessionStatus.IsRead),
+			isArchived: !!(item?.status && item.status & SessionStatus.IsArchived),
+		}, {
+			title: 'Catalog Title',
+			isRead: true,
+			isArchived: true,
+		});
+	});
+
+	conformanceTest(context, 'disposing a session removes it from listSessions', async function () {
+		const { sessionUri } = await createSession('list-session-dispose');
+		const chatUri = buildDefaultChatUri(sessionUri);
+		dispatchTurn(context.client, sessionUri, 'turn-list-session-dispose', '/rename Disposable Session', nextClientSeq());
+		await context.client.waitForNotification(n =>
+			isActionNotification(n, 'chat/turnComplete')
+			&& getActionEnvelope(n).channel === chatUri
+			&& (getActionEnvelope(n).action as { turnId: string }).turnId === 'turn-list-session-dispose',
+		);
+		const before = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		assert.strictEqual(before.items.some(item => item.resource === sessionUri), true);
+
+		await context.client.call('disposeSession', { channel: sessionUri });
+		const trackedIndex = createdSessions.indexOf(sessionUri);
+		if (trackedIndex >= 0) {
+			createdSessions.splice(trackedIndex, 1);
+		}
+		const result = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+
+		assert.strictEqual(result.items.some(item => item.resource === sessionUri), false);
+	});
+
 	conformanceTest(context, 'fetchTurns reports the turns a chat already has', async function () {
 		const { sessionUri } = await createSession('fetch-turns');
 		const chatUri = buildDefaultChatUri(sessionUri);
@@ -89,6 +227,44 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 		);
 
 		assert.strictEqual((getActionEnvelope(loaded).action as { type: string }).type, ActionType.ChatTurnsLoaded);
+	});
+
+	conformanceTest(context, 'fetchTurns rejects a cursor the host did not issue', async function () {
+		const { sessionUri } = await createSession('fetch-turns-cursor');
+		const chatUri = buildDefaultChatUri(sessionUri);
+		await context.client.call<SubscribeResult>('subscribe', { channel: chatUri });
+
+		await assert.rejects(context.client.call('fetchTurns', {
+			channel: chatUri,
+			cursor: 'not-a-host-cursor',
+		}), { code: JsonRpcErrorCodes.InvalidParams });
+	});
+
+	conformanceTest(context, 'fetchTurns rejects an unknown chat channel', async function () {
+		const { sessionUri } = await createSession('fetch-turns-missing');
+		const missingChat = buildChatUri(sessionUri, 'missing');
+
+		await assert.rejects(context.client.call('fetchTurns', {
+			channel: missingChat,
+		}));
+	});
+
+	conformanceTest(context, 'initialize returns snapshots for initial subscriptions', async function () {
+		const { sessionUri } = await createSession('initial-subscriptions');
+		const chatUri = buildDefaultChatUri(sessionUri);
+		const client = await context.connectClient();
+		try {
+			const initialized = await client.call<InitializeResult>('initialize', {
+				channel: ROOT_STATE_URI,
+				protocolVersions: [PROTOCOL_VERSION],
+				clientId: `initial-subscriptions-${config.provider}`,
+				initialSubscriptions: [sessionUri, chatUri],
+			});
+
+			assert.deepStrictEqual(initialized.snapshots.map(snapshot => snapshot.resource).sort(), [sessionUri, chatUri].sort());
+		} finally {
+			client.close();
+		}
 	});
 
 	/**

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -51,6 +51,7 @@ import {
 	isJsonRpcNotification,
 	isJsonRpcRequest,
 	isJsonRpcResponse,
+	ProtocolError,
 	type AhpNotification,
 	type JsonRpcNotification,
 	type JsonRpcRequest,
@@ -169,7 +170,7 @@ export class TestProtocolClient {
 				this._pendingCalls.delete(msg.id);
 				const errResp = msg as JsonRpcErrorResponse;
 				if (errResp.error) {
-					pending.reject(new Error(errResp.error.message));
+					pending.reject(new ProtocolError(errResp.error.code, errResp.error.message, errResp.error.data));
 				} else {
 					pending.resolve((msg as JsonRpcSuccessResponse).result);
 				}


### PR DESCRIPTION
## Summary

- add 44 net-new host-only Agent Host E2E declarations over the public AHP WebSocket boundary
- cover resource mutation/error semantics, changeset operation invocation, handshake/reconnect contracts, and session catalog behavior
- preserve JSON-RPC error codes and data in the E2E protocol client for typed assertions
- refresh implementation and protocol-surface coverage artifacts

## Coverage

Compared with the fresh baseline captured before these rounds:

- lines/statements: 67,012/95,415 (70.23%) -> 67,536/95,415 (70.78%), +524 covered
- functions: 2,203/3,616 (60.92%) -> 2,232/3,618 (61.69%), +29 covered
- branches: 5,857/9,285 (63.08%) -> 6,026/9,510 (63.36%), +169 covered; native V8 branch denominators vary slightly
- AHP commands: 28/29 -> 29/29 (100%)
- AHP actions: 64/85 -> 65/85, adding changeset/operationStatusChanged

## Validation

- `npm run typecheck-client`
- `node build/next/index.ts transpile`
- focused conformance replay for all new declarations
- representative host-only test under `AGENT_HOST_REPLAY_RECORD=1` with no fixture created
- `npm run test-agent-host-e2e-coverage` (224 passing, 56 expected pending)
- `npm run valid-layers-check`
- `npm run precommit`
- `git diff --check`

(Written by Copilot)