### PR TITLE
Propagate agent session hydration cancellation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -6,7 +6,7 @@
 import { Delayer, disposableTimeout, raceCancellation } from '../../../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
-import { getErrorCode, isCancellationError } from '../../../../../../base/common/errors.js';
+import { CancellationError, getErrorCode, isCancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { getChatErrorDetailsFromMeta, getCopilotPlanFromEntitlement, IChatErrorContext } from '../../../common/chatErrorMessages.js';
@@ -1160,6 +1160,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						}
 					}
 				} catch (err) {
+					if (isCancellationError(err)) {
+						throw err;
+					}
 					this._logService.warn(`[AgentHost] Failed to subscribe to existing session: ${resolvedSession.toString()}`, err);
 					// Surface a hard load failure as a visible chat error instead of
 					// a silently empty session. Only when nothing else rendered, so a
@@ -5224,23 +5227,30 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	/**
 	 * Resolves once a subscription has received its first snapshot (its
 	 * `value` is no longer `undefined`) — i.e. it has hydrated with state or
-	 * an error. Resolves immediately if already hydrated or if cancellation
-	 * is requested.
+	 * an error. Rejects with a cancellation error if cancellation is requested.
 	 */
 	private _whenSubscriptionHydrated<T>(sub: IAgentSubscription<T>, token: CancellationToken): Promise<void> {
-		if (sub.value !== undefined || token.isCancellationRequested) {
+		if (sub.value !== undefined) {
 			return Promise.resolve();
 		}
-		return new Promise<void>(resolve => {
+		if (token.isCancellationRequested) {
+			return Promise.reject(new CancellationError());
+		}
+		return new Promise<void>((resolve, reject) => {
 			const store = new DisposableStore();
 			const settle = () => { store.dispose(); resolve(); };
+			const cancel = () => { store.dispose(); reject(new CancellationError()); };
 			store.add(sub.onDidChange(() => { if (sub.value !== undefined) { settle(); } }));
 			const onDidError = sub.onDidError;
 			if (onDidError) {
 				store.add(onDidError(settle));
 			}
-			store.add(token.onCancellationRequested(settle));
-			if (sub.value !== undefined) { settle(); }
+			store.add(token.onCancellationRequested(cancel));
+			if (sub.value !== undefined) {
+				settle();
+			} else if (token.isCancellationRequested) {
+				cancel();
+			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1064,6 +1064,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					// separate chat channel, so reading them before the chat
 					// subscription lands would yield an empty history.
 					await this._whenSubscriptionHydrated(sub, token);
+					if (token.isCancellationRequested) {
+						throw new CancellationError();
+					}
 					// A failed subscription surfaces as an `Error` value; rethrow it
 					// so the real reason (e.g. the working directory no longer
 					// exists) is logged and rendered instead of a generic message.
@@ -5227,30 +5230,23 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	/**
 	 * Resolves once a subscription has received its first snapshot (its
 	 * `value` is no longer `undefined`) — i.e. it has hydrated with state or
-	 * an error. Rejects with a cancellation error if cancellation is requested.
+	 * an error. Resolves immediately if already hydrated or if cancellation
+	 * is requested.
 	 */
 	private _whenSubscriptionHydrated<T>(sub: IAgentSubscription<T>, token: CancellationToken): Promise<void> {
-		if (sub.value !== undefined) {
+		if (sub.value !== undefined || token.isCancellationRequested) {
 			return Promise.resolve();
 		}
-		if (token.isCancellationRequested) {
-			return Promise.reject(new CancellationError());
-		}
-		return new Promise<void>((resolve, reject) => {
+		return new Promise<void>(resolve => {
 			const store = new DisposableStore();
 			const settle = () => { store.dispose(); resolve(); };
-			const cancel = () => { store.dispose(); reject(new CancellationError()); };
 			store.add(sub.onDidChange(() => { if (sub.value !== undefined) { settle(); } }));
 			const onDidError = sub.onDidError;
 			if (onDidError) {
 				store.add(onDidError(settle));
 			}
-			store.add(token.onCancellationRequested(cancel));
-			if (sub.value !== undefined) {
-				settle();
-			} else if (token.isCancellationRequested) {
-				cancel();
-			}
+			store.add(token.onCancellationRequested(settle));
+			if (sub.value !== undefined) { settle(); }
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -8,6 +8,7 @@ import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js'
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { isCancellationError } from '../../../../../../base/common/errors.js';
 import { DisposableStore, IDisposable, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -3582,6 +3583,24 @@ suite('AgentHostChatContribution', () => {
 
 			assert.deepStrictEqual(agentHostService.turnActions.map(d => (d.action as ITurnStartedAction).message.text), ['Hello']);
 		}));
+
+		test('cancelling session hydration rejects without creating an empty session', async () => {
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/cancelled-hydration' });
+			const backendSession = AgentSession.uri('copilot', 'cancelled-hydration');
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+			agentHostService.makePendingErrorSub(backendSession.toString());
+
+			const cancellation = disposables.add(new CancellationTokenSource());
+			const loadPromise = sessionHandler.provideChatSessionContent(sessionResource, cancellation.token);
+			cancellation.cancel();
+
+			await assert.rejects(loadPromise, isCancellationError);
+
+			agentHostService.firePendingSubError(backendSession.toString(), new Error('Delayed subscription failed'));
+			const retriedSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => retriedSession.dispose()));
+			assert.deepStrictEqual(retriedSession.history, []);
+		});
 
 		test('rejects generic contributed-chat untitled resource', async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);


### PR DESCRIPTION
## Summary
- reject session hydration waits when their cancellation token is cancelled
- avoid converting cancelled loads into empty contributed chat sessions
- add regression coverage for cancellation followed by a clean retry

## Validation
- targeted AgentHostChatContribution tests
- npm run typecheck-client
- npm run valid-layers-check
- hygiene checks

(Written by Copilot)