### PR TITLE
Preserve active clients across partial unsubscribe

### DIFF
--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1571,13 +1571,18 @@ export class ProtocolServerHandler extends Disposable {
 				return;
 			}
 			this._agentService.unsubscribe(URI.parse(sub.uri), client.clientId);
-			const session = isAhpChatChannel(sub.uri)
-				? parseRequiredSessionUriFromChatUri(sub.uri)
-				: this._stateManager.getSessionState(sub.uri) ? sub.uri : undefined;
-			if (session && !this._hasSubscriptionForSession(record, session)) {
-				const state = this._stateManager.getSessionState(session);
+			if (isAhpChatChannel(sub.uri)) {
+				const session = parseRequiredSessionUriFromChatUri(sub.uri);
+				if (!this._hasSubscriptionForSession(record, session)) {
+					const state = this._stateManager.getSessionState(session);
+					for (const chat of state?.chats ?? []) {
+						this._releaseActiveClientForSession(session, client.clientId, chat.resource);
+					}
+				}
+			} else {
+				const state = this._stateManager.getSessionState(sub.uri);
 				for (const chat of state?.chats ?? []) {
-					this._releaseActiveClientForSession(session, client.clientId, chat.resource);
+					this._releaseActiveClientForSession(sub.uri, client.clientId, chat.resource);
 				}
 			}
 		} else if (sub.kind === ChannelKind.ResourceWatch) {

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1042,6 +1042,23 @@ export class ProtocolServerHandler extends Disposable {
 		return false;
 	}
 
+	private _hasSubscriptionForSession(record: IClientRecord | undefined, session: string): boolean {
+		if (record?.state !== 'active') {
+			return false;
+		}
+		for (const connection of record.connections) {
+			for (const subscription of connection.subscriptions.values()) {
+				if (subscription.kind !== ChannelKind.State) {
+					continue;
+				}
+				if (subscription.uri === session || (isAhpChatChannel(subscription.uri) && parseRequiredSessionUriFromChatUri(subscription.uri) === session)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	/** Number of clients that currently have a live connection. */
 	private get _connectedClientCount(): number {
 		let count = 0;
@@ -1554,12 +1571,13 @@ export class ProtocolServerHandler extends Disposable {
 				return;
 			}
 			this._agentService.unsubscribe(URI.parse(sub.uri), client.clientId);
-			if (isAhpChatChannel(sub.uri)) {
-				this._releaseActiveClientForSession(parseRequiredSessionUriFromChatUri(sub.uri), client.clientId, sub.uri);
-			} else {
-				const state = this._stateManager.getSessionState(sub.uri);
+			const session = isAhpChatChannel(sub.uri)
+				? parseRequiredSessionUriFromChatUri(sub.uri)
+				: this._stateManager.getSessionState(sub.uri) ? sub.uri : undefined;
+			if (session && !this._hasSubscriptionForSession(record, session)) {
+				const state = this._stateManager.getSessionState(session);
 				for (const chat of state?.chats ?? []) {
-					this._releaseActiveClientForSession(sub.uri, client.clientId, chat.resource);
+					this._releaseActiveClientForSession(session, client.clientId, chat.resource);
 				}
 			}
 		} else if (sub.kind === ChannelKind.ResourceWatch) {

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -1866,6 +1866,27 @@ suite('ProtocolServerHandler', () => {
 		transport.simulateClose();
 	});
 
+	test('unsubscribe keeps the active client while another session channel remains subscribed', () => {
+		stateManager.createSession(makeSessionSummary());
+		stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady });
+		stateManager.dispatchServerAction(sessionUri, {
+			type: ActionType.SessionActiveClientSet,
+			activeClient: {
+				clientId: 'client-tools',
+				tools: [{ name: 'runTask', description: 'Runs a task' }]
+			},
+		});
+
+		const transport = connectClient('client-tools', [sessionUri, defaultChatUri]);
+		transport.simulateMessage(notification('unsubscribe', { channel: defaultChatUri }));
+		assert.deepStrictEqual(stateManager.getSessionState(sessionUri)?.activeClients.map(client => client.clientId), ['client-tools']);
+
+		transport.simulateMessage(notification('unsubscribe', { channel: sessionUri }));
+		assert.deepStrictEqual(stateManager.getSessionState(sessionUri)?.activeClients, []);
+
+		transport.simulateClose();
+	});
+
 	test('reconnect without resubscription removes the active client and fails its owned tool calls', async () => {
 		stateManager.createSession(makeSessionSummary());
 		stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });


### PR DESCRIPTION
## Summary
- retain a client's active-session membership while any session or chat subscription remains
- prevent temporary child-chat subscription cleanup from removing the parent session's active client
- preserve existing cleanup after the client leaves the entire session

## Validation
- targeted ProtocolServerHandler unsubscribe tests
- npm run typecheck-client
- npm run valid-layers-check
- hygiene checks

(Written by Copilot)