### PR TITLE
Preserve static MCP OAuth client id in agent host

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1762,10 +1762,10 @@ export class CopilotAgentSession extends Disposable {
 		}
 		const resource = this._protectedResourceFromMcpAuthRequest(request);
 		const requiredScopes = this._scopesFromChallenge(request.wwwAuthenticateParams?.scope);
-		const oauthClient: McpAuthRequirement['oauthClient'] = request.staticClientConfig?.publicClient
-			? { clientId: request.staticClientConfig.clientId }
-			: request.staticClientConfig?.clientSecret
-				? { clientId: request.staticClientConfig.clientId, clientSecret: request.staticClientConfig.clientSecret }
+		const oauthClient: McpAuthRequirement['oauthClient'] = request.staticClientConfig?.clientSecret
+			? { clientId: request.staticClientConfig.clientId, clientSecret: request.staticClientConfig.clientSecret }
+			: request.staticClientConfig && request.staticClientConfig.publicClient !== false
+				? { clientId: request.staticClientConfig.clientId }
 				: undefined;
 		const auth: McpAuthRequirement = {
 			reason: this._mcpAuthRequiredReason(request.reason),

--- a/src/vs/platform/agentHost/node/copilot/copilotPluginConverters.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotPluginConverters.ts
@@ -93,6 +93,9 @@ function toSdkMcpServer(_name: string, config: IMcpServerConfiguration): MCPServ
 		url: config.url,
 		tools: ['*'],
 		...(config.headers && { headers: { ...config.headers } }),
+		...(config.oauth?.clientId && {
+			oauthClientId: config.oauth.clientId,
+		}),
 	};
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -8078,7 +8078,6 @@ suite('CopilotAgentSession', () => {
 				reason: 'initial',
 				staticClientConfig: {
 					clientId: 'public-client-id',
-					publicClient: true,
 				},
 				resourceMetadata: JSON.stringify({
 					resource: 'https://mcp.example.com',

--- a/src/vs/platform/agentHost/test/node/copilotPluginConverters.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotPluginConverters.test.ts
@@ -102,6 +102,28 @@ suite('copilotPluginConverters', () => {
 			assert.deepStrictEqual(result, {});
 		});
 
+		test('converts remote OAuth client configuration', () => {
+			const defs: IMcpServerDefinition[] = [{
+				name: 'slack',
+				uri: URI.file('/plugin'),
+				configuration: {
+					type: McpServerType.REMOTE,
+					url: 'https://mcp.slack.com/mcp',
+					oauth: { clientId: 'public-client-id' },
+				},
+				customization: stubMcpCustomization('slack'),
+			}];
+
+			assert.deepStrictEqual(toSdkMcpServers(defs), {
+				slack: {
+					type: 'http',
+					url: 'https://mcp.slack.com/mcp',
+					tools: ['*'],
+					oauthClientId: 'public-client-id',
+				},
+			});
+		});
+
 		test('omits optional fields when undefined', () => {
 			const defs: IMcpServerDefinition[] = [{
 				name: 'minimal',


### PR DESCRIPTION
Authored by Copilot.

`toSdkMcpServer` rebuilt HTTP MCP server configs from only `type`, `url`, `tools` and `headers`, dropping the configured `oauth.clientId`. MCP servers that cannot use dynamic client registration then fail to authenticate.

Forwards the client id as `oauthClientId` and lets the runtime apply its documented public-client default. Also fixes the static client mapping in `CopilotAgentSession` so a `clientSecret` wins, an omitted `publicClient` stays public, and `publicClient: false` without a secret no longer yields a partial client config.

## Repro

1. Configure a remote MCP server that requires a pre-registered OAuth client and does not support dynamic client registration, e.g. in a plugin `.mcp.json`:
   ```json
   { "servers": { "slack": { "type": "http", "url": "https://mcp.slack.com/mcp", "oauth": { "clientId": "<client-id>" } } } }
   ```
2. Start an agent session so the agent host launches the server.
3. Trigger authentication for that server.

Before: auth fails with `Failed to create MCP auth provider for https://mcp.slack.com/ User did not provide client details` because the client id never reaches the SDK.
After: the configured client id is forwarded and the auth provider is created.

## Validation

- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotPluginConverters.test.ts` (38 passing, incl. new OAuth conversion test)
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts --grep 'impersonating the GitHub MCP name'`
- `npm run compile`, hygiene, diagnostics clean