### PR TITLE
Retract top-level MCP customization once its child id resolves

### DIFF
--- a/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
+++ b/src/vs/platform/agentHost/node/shared/mcpCustomizationController.ts
@@ -280,24 +280,31 @@ export class McpCustomizationController extends Disposable {
 		const previous = this._live.get().get(server.name);
 		const state = this._stateForUpdate(previous?.state, server.state);
 		const enabled = server.enabled ?? previous?.enabled ?? true;
-		// Once promoted to a top-level entry, stay top-level for the
-		// session — flipping back to a child mid-stream would orphan the
-		// previously-published top-level id.
-		let topLevelId = previous?.topLevelId;
-		if (topLevelId === undefined) {
-			const childId = this._options.resolveChildId(server.name);
-			if (childId !== undefined) {
-				this._setLiveEntry(server.name, { serverName: server.name, state, enabled, topLevelId: undefined }, tx);
+		// A top-level entry is only a fallback for servers whose child
+		// customization could not be resolved yet — child customizations are
+		// registered asynchronously, so the first state update for a
+		// plugin-derived server can arrive before its child id exists. Once the
+		// child id resolves, retract the previously published top-level entry
+		// and continue as a child, otherwise the same server stays surfaced
+		// twice for the rest of the session.
+		const childId = this._options.resolveChildId(server.name);
+		if (childId !== undefined) {
+			if (previous?.topLevelId !== undefined) {
 				this._options.emit({
-					type: ActionType.SessionMcpServerStateChanged,
-					id: childId,
-					state,
-					channel: this._buildChannel(server.name, state),
+					type: ActionType.SessionCustomizationRemoved,
+					id: previous.topLevelId,
 				});
-				return;
 			}
-			topLevelId = this._mintTopLevelId(server.name);
+			this._setLiveEntry(server.name, { serverName: server.name, state, enabled, topLevelId: undefined }, tx);
+			this._options.emit({
+				type: ActionType.SessionMcpServerStateChanged,
+				id: childId,
+				state,
+				channel: this._buildChannel(server.name, state),
+			});
+			return;
 		}
+		const topLevelId = previous?.topLevelId ?? this._mintTopLevelId(server.name);
 		this._setLiveEntry(server.name, { serverName: server.name, state, enabled, topLevelId }, tx);
 		this._options.emit({
 			type: ActionType.SessionCustomizationUpdated,

--- a/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts
@@ -197,6 +197,39 @@ suite('McpCustomizationController', () => {
 		]);
 	});
 
+	test('top-level entry is retracted once its child customization resolves', () => {
+		// Child customizations register asynchronously, so the first state
+		// update can land before the child id exists.
+		const customizations: Customization[] = [];
+		const { controller, actions } = harness(store, { customizations });
+		store.add(controller);
+
+		controller.applyOne(server('fs', authRequired()));
+		const topLevelId = 'mcp-top-level:copilot:session-1:fs';
+		assert.deepStrictEqual(controller.topLevelCustomizations().map(c => c.id), [topLevelId]);
+
+		actions.length = 0;
+		customizations.push(...PLUGIN_CUSTOMIZATIONS);
+		controller.applyOne(server('fs', ready()));
+
+		assert.deepStrictEqual({ actions, topLevel: controller.topLevelCustomizations(), runtimeStates: [...controller.runtimeStates.get().keys()] }, {
+			actions: [
+				{
+					type: ActionType.SessionCustomizationRemoved,
+					id: topLevelId,
+				},
+				{
+					type: ActionType.SessionMcpServerStateChanged,
+					id: 'mcp-child:demo:fs',
+					state: { kind: McpServerStatus.Ready },
+					channel: 'mcp://copilot/session-1/fs',
+				},
+			],
+			topLevel: [],
+			runtimeStates: ['mcp-child:demo:fs'],
+		});
+	});
+
 	test('removing a bare top-level server emits SessionCustomizationRemoved', () => {
 		const { controller, actions } = harness(store);
 		store.add(controller);


### PR DESCRIPTION
Authored by Copilot.

`McpCustomizationController` publishes a bare top-level customization for MCP servers whose child customization cannot be resolved. Child customizations register asynchronously, so the first state update for a plugin-derived server can arrive before its child id exists.

The controller then kept the server top-level for the rest of the session, so once the child id resolved the same server was surfaced **twice** — under the plugin child id and under the orphaned `mcp-top-level:<provider>:<session>:<name>` id. Acting on the orphan failed with `Cannot start/stop unknown MCP server customization`.

Now the published top-level entry is retracted with `SessionCustomizationRemoved` when the child id resolves. The "stay top-level" rule existed to avoid orphaning the published id, which the explicit removal handles.

## Repro

1. Install an agent plugin that contributes MCP servers via `.mcp.json`.
2. Start an agent session so the agent host reports MCP state while the plugin child customizations are still registering (most reliable with a server that settles into `authRequired` rather than `ready`, so the duplicate stays visible).
3. Open the MCP server list for the session.

Before: the server appears twice, once with a `plugin.file://...` id and once with `mcp-top-level:...`. Start/stop on the second logs `Cannot start unknown MCP server customization mcp-top-level:...`.

After: the top-level entry is retracted and the server appears once.

## Validation

- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/shared/mcpCustomizationController.test.ts` (17 passing, incl. new retraction test)
- `./scripts/test.sh --runGlob "**/agentHost/test/node/**/*.test.js"` (3238 passing, 0 failing)
- `npm run compile`, hygiene, diagnostics clean
