### PR TITLE
Preserve non-pty shell output across runtime truncation snapshots

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts
@@ -23,8 +23,8 @@ interface INonPtyShellStream {
 	readonly uri: string;
 	readonly title: string;
 	created: boolean;
-	/** The last cumulative snapshot written to the channel. */
-	lastEmitted: string;
+	lastSnapshot: string;
+	sourceTruncated: boolean;
 	finalized: boolean;
 }
 
@@ -44,6 +44,38 @@ function parseCompletedShell(text: string | undefined): TerminalCommandResult | 
 	};
 }
 
+const enum StitchConstants {
+	/** Minimum characters of overlap required to treat a rewritten snapshot as a rolling tail. */
+	MinimumOverlapLength = 8
+}
+
+const partialOutputTruncationMarker = /<output too long - dropped \d+ (?:characters|lines) from the end>\n?$/;
+
+function getTruncatedOutputPrefix(output: string): string | undefined {
+	const match = partialOutputTruncationMarker.exec(output);
+	return match ? output.slice(0, match.index) : undefined;
+}
+
+/**
+ * Finds where `next` overlaps the end of `previous` when the runtime rewrote
+ * its cumulative snapshot as a rolling tail.
+ */
+function findStitchOverlap(previous: string, next: string): number | undefined {
+	const probe = next.slice(0, StitchConstants.MinimumOverlapLength);
+	if (probe.length < StitchConstants.MinimumOverlapLength) {
+		return undefined;
+	}
+	let index = previous.indexOf(probe);
+	while (index !== -1) {
+		const overlapLength = previous.length - index;
+		if (overlapLength <= next.length && next.startsWith(previous.slice(index))) {
+			return overlapLength;
+		}
+		index = previous.indexOf(probe, index + 1);
+	}
+	return undefined;
+}
+
 export interface INonPtyShellToolCompletion {
 	readonly uri: string;
 	readonly result?: TerminalCommandResult;
@@ -56,10 +88,7 @@ export interface INonPtyShellToolCompletion {
  * via `tool.execution_partial_result` as throttled cumulative snapshots that
  * may be rewritten once output is truncated (a trailing truncation marker
  * under the emit cap, a rolling tail past the large-output threshold); this
- * class emits only the unseen suffix as `terminal/data` while the snapshot
- * grows in place, and resets the channel when the snapshot was rewritten, so
- * subscribed clients receive live plain-text output (`isPty: false` — no VT
- * parsing needed).
+ * class preserves the streamed transcript across those lossy rewrites.
  *
  * Created once per session and disposed with it, matching the pty-backed
  * `ShellManager` lifecycle.
@@ -95,7 +124,8 @@ export class NonPtyShellTerminalStreams extends Disposable {
 			this._streams.set(toolCallId, {
 				uri: buildNonPtyShellTerminalUri(this._sessionUri, toolCallId),
 				title,
-				lastEmitted: '',
+				lastSnapshot: '',
+				sourceTruncated: false,
 				finalized: false,
 				created: false,
 			});
@@ -111,19 +141,38 @@ export class NonPtyShellTerminalStreams extends Disposable {
 		if (created) {
 			this._createTerminal(toolCallId, stream);
 		}
-		if (stream.finalized || cumulativeOutput === stream.lastEmitted) {
+		if (stream.finalized || cumulativeOutput === stream.lastSnapshot) {
 			return { uri: stream.uri, created };
 		}
-		if (cumulativeOutput.startsWith(stream.lastEmitted)) {
-			this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput.slice(stream.lastEmitted.length));
+		const truncatedPrefix = getTruncatedOutputPrefix(cumulativeOutput);
+		if (truncatedPrefix !== undefined) {
+			if (!stream.sourceTruncated) {
+				if (cumulativeOutput.startsWith(stream.lastSnapshot)) {
+					this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput.slice(stream.lastSnapshot.length));
+				} else {
+					const overlap = findStitchOverlap(stream.lastSnapshot, cumulativeOutput);
+					this._terminalManager.appendOutputTerminalData(stream.uri, overlap === undefined ? cumulativeOutput.slice(truncatedPrefix.length) : cumulativeOutput.slice(overlap));
+				}
+				stream.sourceTruncated = true;
+			}
+		} else if (cumulativeOutput.startsWith(stream.lastSnapshot)) {
+			this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput.slice(stream.lastSnapshot.length));
 		} else {
-			// The snapshot no longer extends what we emitted — the runtime
-			// rewrote it after truncation (marker under the emit cap, rolling
-			// tail past the large-output threshold). Start the channel over.
-			this._terminalManager.resetOutputTerminal(stream.uri);
-			this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput);
+			const overlap = findStitchOverlap(stream.lastSnapshot, cumulativeOutput);
+			if (overlap !== undefined) {
+				const unseen = cumulativeOutput.slice(overlap);
+				if (unseen) {
+					this._terminalManager.appendOutputTerminalData(stream.uri, unseen);
+				}
+			} else if (stream.sourceTruncated || cumulativeOutput.length < stream.lastSnapshot.length) {
+				this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput);
+				stream.sourceTruncated = true;
+			} else {
+				this._terminalManager.resetOutputTerminal(stream.uri);
+				this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput);
+			}
 		}
-		stream.lastEmitted = cumulativeOutput;
+		stream.lastSnapshot = cumulativeOutput;
 		return { uri: stream.uri, created };
 	}
 
@@ -145,10 +194,11 @@ export class NonPtyShellTerminalStreams extends Disposable {
 			}
 			return { uri: stream.uri, shouldRetire: false };
 		}
-		if (!stream.created) {
+		const created = !stream.created;
+		if (created) {
 			this._createTerminal(toolCallId, stream);
 		}
-		if (result.preview !== undefined) {
+		if (result.preview !== undefined && (!result.truncated || created)) {
 			this.append(toolCallId, result.preview);
 		}
 		if (result.exitCode !== undefined) {

--- a/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts
@@ -158,7 +158,8 @@ export class NonPtyShellTerminalStreams extends Disposable {
 		} else if (cumulativeOutput.startsWith(stream.lastSnapshot)) {
 			this._terminalManager.appendOutputTerminalData(stream.uri, cumulativeOutput.slice(stream.lastSnapshot.length));
 		} else {
-			const overlap = findStitchOverlap(stream.lastSnapshot, cumulativeOutput);
+			const previousSnapshot = getTruncatedOutputPrefix(stream.lastSnapshot) ?? stream.lastSnapshot;
+			const overlap = findStitchOverlap(previousSnapshot, cumulativeOutput);
 			if (overlap !== undefined) {
 				const unseen = cumulativeOutput.slice(overlap);
 				if (unseen) {
@@ -198,8 +199,16 @@ export class NonPtyShellTerminalStreams extends Disposable {
 		if (created) {
 			this._createTerminal(toolCallId, stream);
 		}
-		if (result.preview !== undefined && (!result.truncated || created)) {
-			this.append(toolCallId, result.preview);
+		if (!stream.finalized && result.preview !== undefined) {
+			if (created) {
+				this.append(toolCallId, result.preview);
+			} else if (!result.truncated) {
+				if (stream.sourceTruncated || !result.preview.startsWith(stream.lastSnapshot)) {
+					this._replaceOutput(stream, result.preview);
+				} else {
+					this.append(toolCallId, result.preview);
+				}
+			}
 		}
 		if (result.exitCode !== undefined) {
 			this._finalize(stream, result.exitCode);
@@ -232,6 +241,15 @@ export class NonPtyShellTerminalStreams extends Disposable {
 		}
 		stream.finalized = true;
 		this._terminalManager.finalizeOutputTerminal(stream.uri, exitCode);
+	}
+
+	private _replaceOutput(stream: INonPtyShellStream, output: string): void {
+		this._terminalManager.resetOutputTerminal(stream.uri);
+		if (output) {
+			this._terminalManager.appendOutputTerminalData(stream.uri, output);
+		}
+		stream.lastSnapshot = output;
+		stream.sourceTruncated = false;
 	}
 
 	private _createTerminal(toolCallId: string, stream: INonPtyShellStream): void {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4278,15 +4278,15 @@ suite('CopilotAgentSession', () => {
 			} as SessionEventPayload<'tool.execution_start'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
-				partialOutput: 'line 1\nline 2\n',
+				partialOutput: 'line 1\nline 498\nline 499\n',
 			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
-				partialOutput: 'line 1\nline 2\n<output too long - dropped 42 lines from the end>\n',
+				partialOutput: 'line 1\nline 498\nline 499\n<output too long - dropped 42 lines from the end>\n',
 			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
-				partialOutput: 'line 1\nline 2\n<output too long - dropped 99 lines from the end>\n',
+				partialOutput: 'line 1\nline 498\nline 499\n<output too long - dropped 99 lines from the end>\n',
 			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
@@ -4322,9 +4322,9 @@ suite('CopilotAgentSession', () => {
 				result: terminalResult?.result,
 			}, {
 				data: [
-					{ uri: terminalUri, data: 'line 1\nline 2\n' },
+					{ uri: terminalUri, data: 'line 1\nline 498\nline 499\n' },
 					{ uri: terminalUri, data: '<output too long - dropped 42 lines from the end>\n' },
-					{ uri: terminalUri, data: 'line 498\nline 499\nline 500\n' },
+					{ uri: terminalUri, data: 'line 500\n' },
 					{ uri: terminalUri, data: 'line 501\n' },
 				],
 				resets: [],

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4266,8 +4266,9 @@ suite('CopilotAgentSession', () => {
 			]);
 		});
 
-		test('tool partial results reset the channel when the runtime rewrites its snapshot', async () => {
-			const { mockSession, terminalManager } = await createAgentSession(disposables);
+		test('truncated shell output streams through marker, rolling-tail, and completion transitions', async () => {
+			const { session, mockSession, signals, waitForSignal, terminalManager } = await createAgentSession(disposables);
+			session.resetTurnState('turn-truncated-stream');
 
 			const terminalUri = 'agenthost-terminal://shell/test-session-1/tc-rewrite';
 			mockSession.fire('tool.execution_start', {
@@ -4277,27 +4278,59 @@ suite('CopilotAgentSession', () => {
 			} as SessionEventPayload<'tool.execution_start'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
-				partialOutput: 'tick 1\n',
-			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
-			// Once output is truncated the runtime rewrites its snapshot (a
-			// truncation marker under the emit cap, a rolling tail past the
-			// large-output threshold), so it stops being prefix-stable.
-			mockSession.fire('tool.execution_partial_result', {
-				toolCallId: 'tc-rewrite',
-				partialOutput: 'tick 1\n[...truncated 42 lines...]\n',
+				partialOutput: 'line 1\nline 2\n',
 			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
 			mockSession.fire('tool.execution_partial_result', {
 				toolCallId: 'tc-rewrite',
-				partialOutput: 'tick 1\n[...truncated 99 lines...]\n',
+				partialOutput: 'line 1\nline 2\n<output too long - dropped 42 lines from the end>\n',
 			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-rewrite',
+				partialOutput: 'line 1\nline 2\n<output too long - dropped 99 lines from the end>\n',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-rewrite',
+				partialOutput: 'line 498\nline 499\nline 500\n',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_partial_result', {
+				toolCallId: 'tc-rewrite',
+				partialOutput: 'line 499\nline 500\nline 501\n',
+			} as SessionEventPayload<'tool.execution_partial_result'>['data']);
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-rewrite',
+				success: true,
+				result: {
+					content: 'Output too large',
+					contents: [{
+						type: 'shell_exit',
+						shellId: '0',
+						exitCode: 0,
+						outputPreview: 'line 1\nline 2\n',
+						outputTruncated: true,
+					}],
+				},
+			} as SessionEventPayload<'tool.execution_complete'>['data']);
+			await waitForSignal(signal => isAction(signal, ActionType.ChatToolCallComplete));
 
-			assert.deepStrictEqual({ data: terminalManager.outputTerminalData, resets: terminalManager.outputTerminalResets }, {
+			const completed = getActions(signals).find(action => action.type === ActionType.ChatToolCallComplete) as ChatToolCallCompleteAction;
+			const terminalResult = completed.result.content?.find(content => content.type === ToolResultContentType.Terminal) as ToolResultTerminalContent | undefined;
+			assert.deepStrictEqual({
+				data: terminalManager.outputTerminalData,
+				resets: terminalManager.outputTerminalResets,
+				finalized: terminalManager.outputTerminalsFinalized,
+				disposed: terminalManager.disposedTerminals,
+				result: terminalResult?.result,
+			}, {
 				data: [
-					{ uri: terminalUri, data: 'tick 1\n' },
-					{ uri: terminalUri, data: '[...truncated 42 lines...]\n' },
-					{ uri: terminalUri, data: 'tick 1\n[...truncated 99 lines...]\n' },
+					{ uri: terminalUri, data: 'line 1\nline 2\n' },
+					{ uri: terminalUri, data: '<output too long - dropped 42 lines from the end>\n' },
+					{ uri: terminalUri, data: 'line 498\nline 499\nline 500\n' },
+					{ uri: terminalUri, data: 'line 501\n' },
 				],
-				resets: [terminalUri],
+				resets: [],
+				finalized: [{ uri: terminalUri, exitCode: 0 }],
+				disposed: [terminalUri],
+				result: { exitCode: 0, preview: 'line 1\nline 2\n', truncated: true },
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/copilotNonPtyShellTerminals.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotNonPtyShellTerminals.test.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual, ok, strictEqual } from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NonPtyShellTerminalStreams } from '../../node/copilot/copilotNonPtyShellTerminals.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
+
+suite('NonPtyShellTerminalStreams', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let manager: TestAgentHostTerminalManager;
+	let streams: NonPtyShellTerminalStreams;
+
+	setup(() => {
+		manager = store.add(new TestAgentHostTerminalManager());
+		streams = store.add(new NonPtyShellTerminalStreams(URI.parse('agenthost-session://test/session-1'), manager));
+	});
+
+	function channelContent(): string {
+		return manager.outputTerminalData.map(d => d.data).join('');
+	}
+
+	suite('rolling-tail snapshot stitching', () => {
+		test('appends only the unseen suffix when the snapshot is a rolling tail, without resetting', () => {
+			streams.track('call-1', 'shell');
+			streams.append('call-1', 'line 1\r\nline 2\r\nline 3\r\n');
+			streams.append('call-1', 'line 2\r\nline 3\r\nline 4\r\n');
+			streams.append('call-1', 'line 4\r\nline 5\r\nline 6\r\n');
+
+			deepStrictEqual(manager.outputTerminalResets, [], 'rolling tails must not reset the channel');
+			strictEqual(channelContent(), 'line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\nline 6\r\n');
+		});
+
+		test('truncated completion preview does not discard the streamed transcript', () => {
+			streams.track('call-2', 'shell');
+			streams.append('call-2', 'line 1\r\nline 2\r\nline 3\r\n');
+			streams.append('call-2', 'line 3\r\nline 4\r\nline 5\r\n');
+
+			const completion = streams.completeToolCall('call-2', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: 'line 4\r\nline 5\r\n', truncated: true }
+			});
+
+			ok(completion);
+			deepStrictEqual(manager.outputTerminalResets, []);
+			strictEqual(channelContent(), 'line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\n');
+			deepStrictEqual(manager.outputTerminalsFinalized, [{ uri: completion.uri, exitCode: 0 }]);
+		});
+
+		test('preserves the transcript across truncation marker rewrites and disjoint rolling tails', () => {
+			streams.track('call-3', 'shell');
+			streams.append('call-3', 'line 1\r\nline 2\r\n');
+			streams.append('call-3', 'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n');
+			streams.append('call-3', 'line 1\r\nline 2\r\n<output too long - dropped 99 lines from the end>\n');
+			streams.append('call-3', 'line 498\r\nline 499\r\nline 500\r\n');
+			streams.append('call-3', 'line 499\r\nline 500\r\nline 501\r\n');
+			streams.append('call-3', 'line 700\r\nline 701\r\nline 702\r\n');
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				content: channelContent(),
+			}, {
+				resets: [],
+				content: [
+					'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n',
+					'line 498\r\nline 499\r\nline 500\r\n',
+					'line 501\r\n',
+					'line 700\r\nline 701\r\nline 702\r\n',
+				].join(''),
+			});
+		});
+
+		test('recognizes the single-line character truncation marker', () => {
+			streams.track('call-4', 'shell');
+			streams.append('call-4', 'abcdefghij');
+			streams.append('call-4', 'abcdefghij<output too long - dropped 5 characters from the end>');
+			streams.append('call-4', 'abcdefghij<output too long - dropped 8 characters from the end>');
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				content: channelContent(),
+			}, {
+				resets: [],
+				content: 'abcdefghij<output too long - dropped 5 characters from the end>',
+			});
+		});
+
+		test('preserves a direct transition to disjoint shorter tails', () => {
+			streams.track('call-5', 'shell');
+			streams.append('call-5', 'alpha beta gamma\r\n');
+			streams.append('call-5', 'tail one\r\n');
+			streams.append('call-5', 'tail two\r\n');
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				content: channelContent(),
+			}, {
+				resets: [],
+				content: 'alpha beta gamma\r\ntail one\r\ntail two\r\n',
+			});
+		});
+
+		test('does not append a truncated completion preview after streamed output', () => {
+			streams.track('call-6', 'shell');
+			streams.append('call-6', 'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n');
+			streams.append('call-6', 'line 498\r\nline 499\r\nline 500\r\n');
+
+			streams.completeToolCall('call-6', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: 'line 1\r\nline 2\r\n', truncated: true }
+			});
+
+			strictEqual(channelContent(), [
+				'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n',
+				'line 498\r\nline 499\r\nline 500\r\n',
+			].join(''));
+		});
+
+		test('seeds a zero-partial terminal from its truncated completion preview', () => {
+			streams.track('call-7', 'shell');
+
+			streams.completeToolCall('call-7', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: 'line 1\r\nline 2\r\n', truncated: true }
+			});
+
+			strictEqual(channelContent(), 'line 1\r\nline 2\r\n');
+		});
+
+		test('an unrelated rewrite still resets the channel', () => {
+			streams.track('call-8', 'shell');
+			streams.append('call-8', 'alpha beta gamma\r\n');
+			streams.append('call-8', 'completely different content\r\n');
+
+			strictEqual(manager.outputTerminalResets.length, 1);
+			deepStrictEqual(manager.outputTerminalData.map(d => d.data), ['alpha beta gamma\r\n', 'completely different content\r\n']);
+		});
+	});
+
+	suite('completion and lifecycle', () => {
+		test('parses fallback completion, finalizes once, and ignores later output', () => {
+			streams.track('call-9', 'shell');
+
+			const completion = streams.completeToolCall('call-9', 'fallback output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
+			streams.completeToolCall('call-9', 'different output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
+			streams.append('call-9', 'late output\r\n');
+
+			deepStrictEqual({
+				completion,
+				content: channelContent(),
+				finalized: manager.outputTerminalsFinalized,
+			}, {
+				completion: {
+					uri: 'agenthost-terminal://shell/session-1/call-9',
+					result: { exitCode: -1, preview: 'fallback output\r\n' },
+					shouldRetire: true,
+				},
+				content: 'fallback output\r\n',
+				finalized: [{ uri: 'agenthost-terminal://shell/session-1/call-9', exitCode: -1 }],
+			});
+		});
+
+		test('drops an unstarted stream without completion data', () => {
+			streams.track('call-10', 'shell');
+
+			strictEqual(streams.completeToolCall('call-10', undefined, undefined), undefined);
+			strictEqual(streams.append('call-10', 'late output'), undefined);
+		});
+
+		test('keeps a started stream alive without completion data', () => {
+			streams.track('call-11', 'shell');
+			const appended = streams.append('call-11', 'partial output');
+			ok(appended);
+
+			deepStrictEqual(streams.completeToolCall('call-11', undefined, undefined), {
+				uri: appended.uri,
+				shouldRetire: false,
+			});
+		});
+
+		test('retires a stream exactly once', () => {
+			streams.track('call-12', 'shell');
+			const appended = streams.append('call-12', 'partial output');
+			ok(appended);
+
+			streams.retire('call-12');
+			streams.retire('call-12');
+
+			deepStrictEqual(manager.disposedTerminals, [appended.uri]);
+			strictEqual(streams.append('call-12', 'late output'), undefined);
+		});
+
+		test('ignores append and completion for an untracked tool call', () => {
+			strictEqual(streams.append('missing', 'output'), undefined);
+			strictEqual(streams.completeToolCall('missing', undefined, undefined), undefined);
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/copilotNonPtyShellTerminals.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotNonPtyShellTerminals.test.ts
@@ -53,9 +53,9 @@ suite('NonPtyShellTerminalStreams', () => {
 
 		test('preserves the transcript across truncation marker rewrites and disjoint rolling tails', () => {
 			streams.track('call-3', 'shell');
-			streams.append('call-3', 'line 1\r\nline 2\r\n');
-			streams.append('call-3', 'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n');
-			streams.append('call-3', 'line 1\r\nline 2\r\n<output too long - dropped 99 lines from the end>\n');
+			streams.append('call-3', 'line 1\r\nline 498\r\nline 499\r\n');
+			streams.append('call-3', 'line 1\r\nline 498\r\nline 499\r\n<output too long - dropped 42 lines from the end>\n');
+			streams.append('call-3', 'line 1\r\nline 498\r\nline 499\r\n<output too long - dropped 99 lines from the end>\n');
 			streams.append('call-3', 'line 498\r\nline 499\r\nline 500\r\n');
 			streams.append('call-3', 'line 499\r\nline 500\r\nline 501\r\n');
 			streams.append('call-3', 'line 700\r\nline 701\r\nline 702\r\n');
@@ -66,8 +66,8 @@ suite('NonPtyShellTerminalStreams', () => {
 			}, {
 				resets: [],
 				content: [
-					'line 1\r\nline 2\r\n<output too long - dropped 42 lines from the end>\n',
-					'line 498\r\nline 499\r\nline 500\r\n',
+					'line 1\r\nline 498\r\nline 499\r\n<output too long - dropped 42 lines from the end>\n',
+					'line 500\r\n',
 					'line 501\r\n',
 					'line 700\r\nline 701\r\nline 702\r\n',
 				].join(''),
@@ -131,10 +131,73 @@ suite('NonPtyShellTerminalStreams', () => {
 			strictEqual(channelContent(), 'line 1\r\nline 2\r\n');
 		});
 
-		test('an unrelated rewrite still resets the channel', () => {
+		test('replaces a truncated stream with an authoritative non-truncated completion preview', () => {
 			streams.track('call-8', 'shell');
-			streams.append('call-8', 'alpha beta gamma\r\n');
-			streams.append('call-8', 'completely different content\r\n');
+			const appended = streams.append('call-8', 'head\r\n<output too long - dropped 42 lines from the end>\n');
+			ok(appended);
+
+			streams.completeToolCall('call-8', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: 'complete output\r\n', truncated: false }
+			});
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				data: manager.outputTerminalData,
+			}, {
+				resets: [appended.uri],
+				data: [
+					{ uri: appended.uri, data: 'head\r\n<output too long - dropped 42 lines from the end>\n' },
+					{ uri: appended.uri, data: 'complete output\r\n' },
+				],
+			});
+		});
+
+		test('clears stale streamed output when the authoritative completion preview is empty', () => {
+			streams.track('call-9', 'shell');
+			const appended = streams.append('call-9', 'stale output\r\n');
+			ok(appended);
+
+			streams.completeToolCall('call-9', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: '', truncated: false }
+			});
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				data: manager.outputTerminalData,
+			}, {
+				resets: [appended.uri],
+				data: [{ uri: appended.uri, data: 'stale output\r\n' }],
+			});
+		});
+
+		test('appends a prefix-stable authoritative completion preview', () => {
+			streams.track('call-10', 'shell');
+			const appended = streams.append('call-10', 'line 1\r\n');
+			ok(appended);
+
+			streams.completeToolCall('call-10', undefined, {
+				shellId: 'shell-1',
+				result: { exitCode: 0, preview: 'line 1\r\nline 2\r\n', truncated: false }
+			});
+
+			deepStrictEqual({
+				resets: manager.outputTerminalResets,
+				data: manager.outputTerminalData,
+			}, {
+				resets: [],
+				data: [
+					{ uri: appended.uri, data: 'line 1\r\n' },
+					{ uri: appended.uri, data: 'line 2\r\n' },
+				],
+			});
+		});
+
+		test('an unrelated rewrite still resets the channel', () => {
+			streams.track('call-11', 'shell');
+			streams.append('call-11', 'alpha beta gamma\r\n');
+			streams.append('call-11', 'completely different content\r\n');
 
 			strictEqual(manager.outputTerminalResets.length, 1);
 			deepStrictEqual(manager.outputTerminalData.map(d => d.data), ['alpha beta gamma\r\n', 'completely different content\r\n']);
@@ -143,11 +206,11 @@ suite('NonPtyShellTerminalStreams', () => {
 
 	suite('completion and lifecycle', () => {
 		test('parses fallback completion, finalizes once, and ignores later output', () => {
-			streams.track('call-9', 'shell');
+			streams.track('call-12', 'shell');
 
-			const completion = streams.completeToolCall('call-9', 'fallback output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
-			streams.completeToolCall('call-9', 'different output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
-			streams.append('call-9', 'late output\r\n');
+			const completion = streams.completeToolCall('call-12', 'fallback output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
+			streams.completeToolCall('call-12', 'different output\r\n<shellId: shell-1 completed with exit code -1>', undefined);
+			streams.append('call-12', 'late output\r\n');
 
 			deepStrictEqual({
 				completion,
@@ -155,43 +218,43 @@ suite('NonPtyShellTerminalStreams', () => {
 				finalized: manager.outputTerminalsFinalized,
 			}, {
 				completion: {
-					uri: 'agenthost-terminal://shell/session-1/call-9',
+					uri: 'agenthost-terminal://shell/session-1/call-12',
 					result: { exitCode: -1, preview: 'fallback output\r\n' },
 					shouldRetire: true,
 				},
 				content: 'fallback output\r\n',
-				finalized: [{ uri: 'agenthost-terminal://shell/session-1/call-9', exitCode: -1 }],
+				finalized: [{ uri: 'agenthost-terminal://shell/session-1/call-12', exitCode: -1 }],
 			});
 		});
 
 		test('drops an unstarted stream without completion data', () => {
-			streams.track('call-10', 'shell');
+			streams.track('call-13', 'shell');
 
-			strictEqual(streams.completeToolCall('call-10', undefined, undefined), undefined);
-			strictEqual(streams.append('call-10', 'late output'), undefined);
+			strictEqual(streams.completeToolCall('call-13', undefined, undefined), undefined);
+			strictEqual(streams.append('call-13', 'late output'), undefined);
 		});
 
 		test('keeps a started stream alive without completion data', () => {
-			streams.track('call-11', 'shell');
-			const appended = streams.append('call-11', 'partial output');
+			streams.track('call-14', 'shell');
+			const appended = streams.append('call-14', 'partial output');
 			ok(appended);
 
-			deepStrictEqual(streams.completeToolCall('call-11', undefined, undefined), {
+			deepStrictEqual(streams.completeToolCall('call-14', undefined, undefined), {
 				uri: appended.uri,
 				shouldRetire: false,
 			});
 		});
 
 		test('retires a stream exactly once', () => {
-			streams.track('call-12', 'shell');
-			const appended = streams.append('call-12', 'partial output');
+			streams.track('call-15', 'shell');
+			const appended = streams.append('call-15', 'partial output');
 			ok(appended);
 
-			streams.retire('call-12');
-			streams.retire('call-12');
+			streams.retire('call-15');
+			streams.retire('call-15');
 
 			deepStrictEqual(manager.disposedTerminals, [appended.uri]);
-			strictEqual(streams.append('call-12', 'late output'), undefined);
+			strictEqual(streams.append('call-15', 'late output'), undefined);
 		});
 
 		test('ignores append and completion for an untracked tool call', () => {


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/328299

- Preserve Agent Host non-PTY shell output across lossy `tool.execution_partial_result` rewrites instead of resetting the output channel.
- Keep prefix-stable growth as appends of only the unseen suffix.
- Retain the first `<output too long - dropped … from the end>` marker and ignore later marker-count updates, preventing repeated clears and flicker.
- When output switches to a short rolling tail, stitch overlapping snapshots and retain disjoint tails without resetting an already-truncated stream.
- Continue resetting the channel for unrelated rewrites.
- On completion, apply non-truncated final previews, but do not replace a richer streamed transcript with a truncated preview. Still seed from a truncated preview when no partial output was received.
- Net effect: large commands retain substantially more of what was delivered—initial output, the first truncation marker, and subsequent tails. This does not recover output omitted before reaching Agent Host; it prevents VS Code from additionally discarding received output.
- Add 13 focused tests with 94.1% statement coverage, including a complete Agent Session marker → rolling-tail → completion → retirement scenario.

-----------------------------------------
Inspirations from:

- The original prefix-stable append-versus-rewrite behavior comes from [`NonPtyShellTerminalStreams.append`](https://github.com/microsoft/vscode/blob/c423d6bc458e7bae0c6ba08995fb6b349833aeaa/src/vs/platform/agentHost/node/copilot/copilotNonPtyShellTerminals.ts#L105-L127).
- Output-channel append and reset primitives come from [`appendOutputTerminalData` and `resetOutputTerminal`](https://github.com/microsoft/vscode/blob/c423d6bc458e7bae0c6ba08995fb6b349833aeaa/src/vs/platform/agentHost/node/agentHostTerminalManager.ts#L855-L879).
- Client-side prefix-stable append behavior is mirrored from [`DetachedTerminalSnapshotMirror._render`](https://github.com/microsoft/vscode/blob/c423d6bc458e7bae0c6ba08995fb6b349833aeaa/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts#L874-L878).
- The session scenario extends the existing partial-result harness in [`copilotAgentSession.test.ts`](https://github.com/microsoft/vscode/blob/c423d6bc458e7bae0c6ba08995fb6b349833aeaa/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts#L4200-L4300).