### PR TITLE
Add /vscode-pet command reference to Pet menu label

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -332,16 +332,17 @@ replacement.
 
 The new-session view mounts the aquarium action outside
 `.new-chat-widget-content`. Its surrounding surface has checked **Aquarium** and
-**Pet** context-menu items. `AquariumService` owns the application-scoped action
-visibility preference; `IChatPetService` owns the same persisted pet state used
-by `/vscode-pet`. Context-menu events from inside `.new-chat-widget-content` are
-left untouched so the composer retains its own context-menu behavior. The
-aquarium preference is also keyboard-accessible through the **Developer: Toggle
-Aquarium Action Visibility** command. `NewChatView` forwards its effective grid
-visibility to the aquarium mount so a hidden composer cannot leave the aquarium
-rendering behind the visible chat surface. Since `NewChatView` also hosts the
-peer-chat composer, aquarium-specific lifecycle calls must first narrow the
-wrapped widget to `NewChatWidget`.
+**Pet (/vscode-pet)** context-menu items. `AquariumService` owns the
+application-scoped action visibility preference; `IChatPetService` owns the same
+persisted pet state used by `/vscode-pet`. Context-menu events from inside
+`.new-chat-widget-content` are left untouched so the composer retains its own
+context-menu behavior. The aquarium preference is also keyboard-accessible
+through the **Developer: Toggle Aquarium Action Visibility** command.
+`NewChatView` forwards its effective grid visibility to the aquarium mount so a
+hidden composer cannot leave the aquarium rendering behind the visible chat
+surface. Since `NewChatView` also hosts the peer-chat composer,
+aquarium-specific lifecycle calls must first narrow the wrapped widget to
+`NewChatWidget`.
 
 Agent feedback created while the active session is undefined or uncreated uses
 one shared new-session feedback scope, so it follows every undefined/uncreated

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -287,7 +287,7 @@ export class NewChatWidget extends Disposable {
 		));
 		const petAction = this._register(new Action(
 			'sessions.chatPet.toggle',
-			localize('petAction', "Pet"),
+			localize('petAction', "Pet (/vscode-pet)"),
 			undefined,
 			true,
 			() => this.chatPetService.toggle()


### PR DESCRIPTION
The Pet context-menu item in the new-session view now shows "Pet (/vscode-pet)" to help users discover the command that toggles the feature.

## Changes
- Updated Pet action label to include `/vscode-pet` command reference
- Updated SESSIONS.md specification to document the menu label change

## Discovery
The standard context-menu widget does not support a secondary description field (menus intentionally suppress tooltips to match native menu behavior). The most discoverable approach is to include the command reference directly in the label, following accessibility help documentation that already mentions `/vscode-pet`.

## Testing
- Hygiene check: ✓ (label text localized)
- Updated spec: ✓ (SESSIONS.md documented)