### PR TITLE
Fix double tooltip on the chat turn preview pill

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -202,9 +202,6 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		const button = container.appendChild(document.createElement('button'));
 		button.classList.add('chat-turn-preview-action');
 		button.type = 'button';
-		// The resource label owns the hover for this action so that the whole button
-		// has a single (custom) hover instead of one for the label and a native
-		// `title` for the button.
 		const label = this._register(resourceLabels.create(button, { hoverTargetOverride: button }));
 
 		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -18,6 +18,7 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { FileKind } from '../../../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
@@ -61,6 +62,7 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		@IConfigurationService configurationService: IConfigurationService,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ILabelService private readonly _labelService: ILabelService,
 	) {
 		super();
 
@@ -200,7 +202,10 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		const button = container.appendChild(document.createElement('button'));
 		button.classList.add('chat-turn-preview-action');
 		button.type = 'button';
-		const label = this._register(resourceLabels.create(button));
+		// The resource label owns the hover for this action so that the whole button
+		// has a single (custom) hover instead of one for the label and a native
+		// `title` for the button.
+		const label = this._register(resourceLabels.create(button, { hoverTargetOverride: button }));
 
 		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {
 			this._openPrimaryPreview(previewFiles.get());
@@ -211,13 +216,15 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 			const files = previewFiles.read(reader);
 			const primaryFile = files.at(0);
 			if (primaryFile) {
+				const name = basename(primaryFile.uri);
 				label.setResource(
-					{ resource: primaryFile.uri, name: basename(primaryFile.uri) },
-					{ fileKind: FileKind.FILE },
+					{ resource: primaryFile.uri, name },
+					{
+						fileKind: FileKind.FILE,
+						title: localize('chat.turnPreview.tooltip', "{0} • Open Preview", this._labelService.getUriLabel(primaryFile.uri)),
+					},
 				);
-				const tooltip = localize('chat.turnPreview.tooltip', 'Open Preview: {0}', basename(primaryFile.uri));
-				button.setAttribute('aria-label', tooltip);
-				button.title = tooltip;
+				button.setAttribute('aria-label', localize('chat.turnPreview.ariaLabel', "Open Preview: {0}", name));
 			}
 			container.classList.toggle('hidden', !showPreview.read(reader));
 		}));

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3113,15 +3113,17 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* The pill header already spaces its children with `gap`, so the label's own
 	margin-right (needed in the standalone checkpoint summary) is redundant here
-	and leaves unwanted trailing space. */
+	and leaves unwanted trailing space. The counts label also keeps its intrinsic
+	width so the preview action is the part that shrinks when space runs out. */
 .interactive-session .chat-turn-pills-part .checkpoint-file-changes-summary-header .chat-file-changes-label {
 	margin-right: 0;
+	flex: none;
 }
 
 .interactive-session .chat-turn-pills-part .chat-turn-preview {
 	display: flex;
 	align-items: center;
-	flex: none;
+	flex: 0 1 auto;
 	gap: var(--vscode-spacing-size40);
 	min-width: 0;
 	overflow: hidden;
@@ -3147,12 +3149,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: none;
 }
 
+/* The file name is only ellipsized when the header actually runs out of room, so
+	the action shrinks with the available width instead of at a fixed cap. */
 .interactive-session .chat-turn-pills-part .chat-turn-preview-action {
 	display: inline-flex;
 	align-items: center;
 	gap: var(--vscode-spacing-size40);
 	min-width: 0;
-	max-width: 200px;
 	padding: var(--vscode-spacing-sizeNone) var(--vscode-spacing-size40) var(--vscode-spacing-sizeNone) var(--vscode-spacing-size20);
 	border: none;
 	border-radius: var(--vscode-cornerRadius-small);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/328076

The preview pill in the turn status pills showed **two tooltips** when hovering: a custom hover coming from the resource label (the file path), plus a native `title` attribute on the surrounding button (`Open Preview: <name>`).

### Changes

- The resource label now owns the single hover for the whole pill via `hoverTargetOverride`, and its `title` option carries both the file path and the "Open Preview" hint — so exactly one custom hover shows and the native `title` attribute is gone.
- The button keeps a dedicated `aria-label` for screen readers.
- Dropped the fixed `max-width: 200px` on the pill so the file name is only ellipsized when the header actually runs out of horizontal space (the counts label no longer shrinks, the preview pill does).
