### PR TITLE
chat: preserve symbol references when editing input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatDynamicVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatDynamicVariables.ts
@@ -11,6 +11,8 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IRange, Range } from '../../../../../editor/common/core/range.js';
 import { IDecorationOptions } from '../../../../../editor/common/editorCommon.js';
 import { Command, isLocation } from '../../../../../editor/common/languages.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelContentChange } from '../../../../../editor/common/model/mirrorTextModel.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -48,7 +50,7 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 		return ChatDynamicVariableModel.ID;
 	}
 
-	private decorationData: { id: string; text: string }[] = [];
+	private decorationData: { id: string; text: string; rangeOffset: number }[] = [];
 
 	private readonly _editorListener = this._register(new MutableDisposable());
 
@@ -96,12 +98,23 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 
 				const newText = model.getValueInRange(newRange);
 				if (newText !== data.text) {
+					const replacement = e.changes.find(change =>
+						change.rangeOffset <= data.rangeOffset
+						&& change.rangeOffset + change.rangeLength >= data.rangeOffset + data.text.length
+					);
+					const preservedRange = replacement && this.findReferenceRangeInReplacement(model, e.changes, replacement, data);
+					if (preservedRange) {
+						didChange = true;
+						return { ...ref, range: preservedRange };
+					}
 
-					this.widget.inputEditor.executeEdits(this.id, [{
-						range: newRange,
-						text: '',
-					}]);
-					this.widget.refreshParsedInput();
+					if (!replacement) {
+						this.widget.inputEditor.executeEdits(this.id, [{
+							range: newRange,
+							text: '',
+						}]);
+						this.widget.refreshParsedInput();
+					}
 
 					removed.push(ref);
 					return null;
@@ -127,6 +140,40 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 
 			this.updateDecorations();
 		});
+	}
+
+	private findReferenceRangeInReplacement(
+		model: ITextModel,
+		changes: readonly IModelContentChange[],
+		replacement: IModelContentChange,
+		data: { text: string; rangeOffset: number }
+	): Range | undefined {
+		if (!data.text) {
+			return undefined;
+		}
+
+		const previousRelativeOffset = data.rangeOffset - replacement.rangeOffset;
+		let matchOffset = replacement.text.indexOf(data.text);
+		let closestMatchOffset = matchOffset;
+		while (matchOffset !== -1) {
+			if (Math.abs(matchOffset - previousRelativeOffset) < Math.abs(closestMatchOffset - previousRelativeOffset)) {
+				closestMatchOffset = matchOffset;
+			}
+			matchOffset = replacement.text.indexOf(data.text, matchOffset + data.text.length);
+		}
+
+		if (closestMatchOffset === -1) {
+			return undefined;
+		}
+
+		const precedingChangesDelta = changes.reduce((delta, change) =>
+			change.rangeOffset < replacement.rangeOffset ? delta + change.text.length - change.rangeLength : delta, 0);
+		const startOffset = replacement.rangeOffset + precedingChangesDelta + closestMatchOffset;
+		const range = Range.fromPositions(
+			model.getPositionAt(startOffset),
+			model.getPositionAt(startOffset + data.text.length)
+		);
+		return model.getValueInRange(range) === data.text ? range : undefined;
 	}
 
 	getInputState(contrib: Record<string, unknown>): void {
@@ -183,9 +230,11 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 		this._variables = validVariables.slice(0, decorationIds.length);
 		this.decorationData = [];
 		for (let i = 0; i < decorationIds.length; i++) {
+			const range = this._variables[i].range;
 			this.decorationData.push({
 				id: decorationIds[i],
-				text: model.getValueInRange(this._variables[i].range)
+				text: model.getValueInRange(range),
+				rangeOffset: model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn })
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/attachments/chatVariables.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/attachments/chatVariables.test.ts
@@ -7,12 +7,19 @@ import assert from 'assert';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { ICodeEditorService } from '../../../../../../editor/browser/services/codeEditorService.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
+import { TrackedRangeStickiness } from '../../../../../../editor/common/model.js';
+import { TestCodeEditorService } from '../../../../../../editor/test/browser/editorTestServices.js';
+import { createTestCodeEditor } from '../../../../../../editor/test/browser/testCodeEditor.js';
+import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
+import { ServiceCollection } from '../../../../../../platform/instantiation/common/serviceCollection.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
+import { TestThemeService } from '../../../../../../platform/theme/test/common/testThemeService.js';
 import { IDynamicVariable, toAttachedContextDynamicVariable } from '../../../common/attachments/chatVariables.js';
 import { IChatWidget } from '../../../browser/chat.js';
 import { getDynamicVariablesForWidget, getSelectedToolAndToolSetsForWidget } from '../../../browser/attachments/chatVariables.js';
-import { ChatDynamicVariableModel } from '../../../browser/attachments/chatDynamicVariables.js';
+import { ChatDynamicVariableModel, dynamicVariableDecorationType } from '../../../browser/attachments/chatDynamicVariables.js';
 import { IChatRequestVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { IToolData, ToolDataSource, ToolAndToolSetEnablementMap } from '../../../common/tools/languageModelToolsService.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
@@ -220,6 +227,94 @@ suite('inline attachment references', () => {
 suite('ChatDynamicVariableModel', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
+	function createDynamicVariableModel(text: string): { editor: ReturnType<typeof createTestCodeEditor>; model: ChatDynamicVariableModel } {
+		const textModel = store.add(createTextModel(text));
+		const codeEditorService = store.add(new TestCodeEditorService(new TestThemeService()));
+		store.add(codeEditorService.registerDecorationType('test', dynamicVariableDecorationType, {
+			rangeBehavior: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		}));
+		const editor = store.add(createTestCodeEditor(textModel, {
+			serviceCollection: new ServiceCollection([ICodeEditorService, codeEditorService]),
+		}));
+		const onDidChangeActiveInputEditor = store.add(new Emitter<void>());
+		const onDidChangeAttachments = store.add(new Emitter<{ deleted: readonly string[]; added: readonly IChatRequestVariableEntry[]; updated: readonly IChatRequestVariableEntry[] }>());
+		const widget = {
+			input: {
+				attachmentModel: {
+					attachments: [],
+					onDidChange: onDidChangeAttachments.event,
+				},
+			},
+			inputEditor: editor,
+			onDidChangeActiveInputEditor: onDidChangeActiveInputEditor.event,
+			refreshParsedInput: () => { },
+		} as unknown as IChatWidget;
+		const model = store.add(new ChatDynamicVariableModel(widget, {
+			getUriLabel: () => '',
+		} as unknown as ILabelService));
+		return { editor, model };
+	}
+
+	test('keeps a reference when editing text before it', () => {
+		const { editor, model } = createDynamicVariableModel('explain #sym:example ');
+		model.addReference(createMockVariable({
+			range: new Range(1, 9, 1, 21),
+		}));
+
+		editor.executeEdits('test', [{
+			range: new Range(1, 1, 1, 21),
+			text: 'describe #sym:example',
+		}]);
+
+		assert.deepStrictEqual({
+			text: editor.getValue(),
+			variables: model.variables.map(variable => variable.range),
+		}, {
+			text: 'describe #sym:example ',
+			variables: [new Range(1, 10, 1, 22)],
+		});
+	});
+
+	test('removes a reference without deleting replacement text', () => {
+		const { editor, model } = createDynamicVariableModel('explain #sym:example ');
+		model.addReference(createMockVariable({
+			range: new Range(1, 9, 1, 21),
+		}));
+
+		editor.executeEdits('test', [{
+			range: new Range(1, 1, 1, 21),
+			text: 'describe',
+		}]);
+
+		assert.deepStrictEqual({
+			text: editor.getValue(),
+			variables: model.variables,
+		}, {
+			text: 'describe ',
+			variables: [],
+		});
+	});
+
+	test('removes the whole reference when editing inside it', () => {
+		const { editor, model } = createDynamicVariableModel('explain #sym:example ');
+		model.addReference(createMockVariable({
+			range: new Range(1, 9, 1, 21),
+		}));
+
+		editor.executeEdits('test', [{
+			range: new Range(1, 14, 1, 15),
+			text: 'X',
+		}]);
+
+		assert.deepStrictEqual({
+			text: editor.getValue(),
+			variables: model.variables,
+		}, {
+			text: 'explain  ',
+			variables: [],
+		});
+	});
+
 	test('does not retain attachment payload after the backing attachment is removed', () => {
 		const attachment = createMockAttachment({
 			kind: 'image',
@@ -303,6 +398,7 @@ suite('ChatDynamicVariableModel', () => {
 				getModel: () => ({
 					getValueInRange: () => '#attachment',
 					getDecorationRange: () => new Range(1, 1, 1, 20),
+					getOffsetAt: (position: { column: number }) => position.column - 1,
 				}),
 				setDecorationsByType: (_owner: string, _type: string, decorations: Array<{ hoverMessage?: { value: string } }>) => {
 					for (const decoration of decorations) {


### PR DESCRIPTION
Fixes #328324

Preserves pasted symbol references when an editor replacement changes text before the reference but keeps the reference text intact. The dynamic-variable model now recovers the reference's updated range from the replacement content, while retaining atomic removal when the reference itself is edited or removed.

Adds regression coverage for preserving references across broad edits, removing stale references without deleting replacement text, and deleting references atomically when edited internally.

Validation:
- `npm run typecheck-client`
- `npm run precommit`
- `scripts/test.bat --run src/vs/workbench/contrib/chat/test/browser/attachments/chatVariables.test.ts` (18 passing)