### PR TITLE
sessions: fix: put agent-created sessions in correct repository

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Sequencer } from '../../../base/common/async.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
+import { LRUCache } from '../../../base/common/map.js';
 import { URI } from '../../../base/common/uri.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ISessionFileDiff, ISessionGitState } from './state/sessionState.js';
@@ -91,6 +93,54 @@ export interface IPullOptions {
 
 export const IAgentHostGitService = createDecorator<IAgentHostGitService>('agentHostGitService');
 
+/**
+ * Resolves linked checkouts to their primary worktree and caches successful mappings for every worktree reported by Git.
+ * Resolution is serialized so concurrent requests across linked checkouts share one probe, while empty results remain retryable.
+ */
+class PrimaryWorktreeRootResolver {
+	private readonly _roots = new LRUCache<string, URI>(100);
+	private readonly _sequencer = new Sequencer();
+
+	constructor(private readonly _gitService: IAgentHostGitService) { }
+
+	async resolve(checkoutRoot: URI): Promise<URI | undefined> {
+		const key = checkoutRoot.toString();
+		const cached = this._roots.get(key);
+		if (cached) {
+			return cached;
+		}
+		return this._sequencer.queue(async () => {
+			const cached = this._roots.get(key);
+			if (cached) {
+				return cached;
+			}
+			const roots = await this._gitService.getWorktreeRoots(checkoutRoot);
+			const primaryRoot = roots[0];
+			if (!primaryRoot) {
+				return undefined;
+			}
+			this._roots.set(key, primaryRoot);
+			for (const root of roots) {
+				this._roots.set(root.toString(), primaryRoot);
+			}
+			return primaryRoot;
+		});
+	}
+}
+
+/** Resolver lifetime follows the injected Git service; each resolver owns a bounded path cache. */
+const primaryWorktreeRootResolvers = new WeakMap<IAgentHostGitService, PrimaryWorktreeRootResolver>();
+
+/** Resolves the primary worktree root when Git reports a worktree listing. */
+export function tryResolvePrimaryWorktreeRoot(gitService: IAgentHostGitService, checkoutRoot: URI): Promise<URI | undefined> {
+	let resolver = primaryWorktreeRootResolvers.get(gitService);
+	if (!resolver) {
+		resolver = new PrimaryWorktreeRootResolver(gitService);
+		primaryWorktreeRootResolvers.set(gitService, resolver);
+	}
+	return resolver.resolve(checkoutRoot);
+}
+
 export interface IRefQuery {
 	readonly count?: number;
 	readonly pattern?: string | string[];
@@ -156,6 +206,7 @@ export interface IAgentHostGitService {
 	getBranches(workingDirectory: URI, query?: IRefQuery): Promise<Branch[]>;
 	getBranch(workingDirectory: URI, name: string): Promise<Branch | undefined>;
 	getRepositoryRoot(workingDirectory: URI): Promise<URI | undefined>;
+	/** Returns worktree roots in Git's porcelain order, with the primary worktree first. */
 	getWorktreeRoots(workingDirectory: URI): Promise<URI[]>;
 	/**
 	 * Creates a worktree for a new branch. `onProgress` receives every checkout

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -837,7 +837,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const sessionStr = session.session.toString();
 		let primaryRoot = this._normalizedWorktreeRepositoryRoots.get(sessionStr);
 		if (!primaryRoot) {
-			const checkoutRoot = session.workingDirectories?.[0] ?? persistedRoot;
+			const workingDirectory = session.workingDirectories?.[0];
+			const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
 			try {
 				primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
 					?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -9,7 +9,7 @@ import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { ResourceMap } from '../../../base/common/map.js';
+import { LRUCache, ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
 import { IObservable, observableValue } from '../../../base/common/observable.js';
@@ -23,7 +23,7 @@ import { InstantiationService } from '../../instantiation/common/instantiationSe
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateChatSideChatSelection, IAgentCreateChatSideChatSource, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
-import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
+import { type ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, parseEditAttributionResource } from '../common/fileEditAttribution.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
@@ -43,7 +43,7 @@ import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHost
 import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
-import { IAgentHostGitService } from '../common/agentHostGitService.js';
+import { IAgentHostGitService, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
@@ -295,6 +295,8 @@ export class AgentService extends Disposable implements IAgentService {
 	 * agents stay unaware of the folder-vs-worktree distinction.
 	 */
 	private _worktree: WorktreeIsolation | undefined;
+	/** Successful list-time repository-root resolutions; eviction only causes safe re-resolution. */
+	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(100);
 	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
 	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */
@@ -825,6 +827,40 @@ export class AgentService extends Disposable implements IAgentService {
 		};
 	}
 
+	/**
+	 * Repairs repository roots written by older builds that treated a parent linked checkout as the repository.
+	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
+	 */
+	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string): Promise<string> {
+		const storedRepositoryRootRaw = repositoryRootRaw;
+		const persistedRoot = URI.parse(repositoryRootRaw);
+		const sessionStr = session.session.toString();
+		let primaryRoot = this._normalizedWorktreeRepositoryRoots.get(sessionStr);
+		if (!primaryRoot) {
+			const checkoutRoot = session.workingDirectories?.[0] ?? persistedRoot;
+			try {
+				primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
+					?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
+				if (primaryRoot) {
+					this._normalizedWorktreeRepositoryRoots.set(sessionStr, primaryRoot);
+				}
+			} catch (error) {
+				this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
+			}
+		}
+		if (primaryRoot) {
+			repositoryRootRaw = primaryRoot.toString();
+		}
+		if (repositoryRootRaw !== storedRepositoryRootRaw) {
+			try {
+				await database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, repositoryRootRaw);
+			} catch (error) {
+				this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
+			}
+		}
+		return repositoryRootRaw;
+	}
+
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
 		const results = await Promise.all(
@@ -893,12 +929,11 @@ export class AgentService extends Disposable implements IAgentService {
 						updated = { ...updated, _meta: withSessionWorkspaceless(updated._meta, m[AH_META_WORKSPACELESS_DB_KEY] === 'true') };
 					}
 
-					// Worktree-isolated sessions run out of `<repo>.worktrees/<name>` but
-					// must group under the repository in the sessions UI. Merge the repo
-					// project persisted alongside the worktree metadata so a list refresh
-					// doesn't revert the workspace name to the worktree directory. No-op
-					// for folder sessions (key absent).
-					const worktreeProject = worktreeProjectFromRepositoryRoot(m[WORKTREE_META_REPOSITORY_ROOT]);
+					let repositoryRootRaw = m[WORKTREE_META_REPOSITORY_ROOT];
+					if (repositoryRootRaw) {
+						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw);
+					}
+					const worktreeProject = worktreeProjectFromRepositoryRoot(repositoryRootRaw);
 					if (worktreeProject) {
 						updated = { ...updated, project: worktreeProject };
 					}

--- a/src/vs/platform/agentHost/node/copilot/copilotGitProject.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitProject.ts
@@ -7,7 +7,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import type { IAgentSessionProjectInfo } from '../../common/agentService.js';
-import type { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { tryResolvePrimaryWorktreeRoot, type IAgentHostGitService } from '../../common/agentHostGitService.js';
 
 export interface ICopilotSessionContext {
 	readonly cwd?: string;
@@ -25,10 +25,7 @@ export async function resolveGitProject(workingDirectory: URI | undefined, gitSe
 		return undefined;
 	}
 
-	const uri = (await gitService.getWorktreeRoots(workingDirectory))[0] ?? repositoryRoot;
-	if (!uri) {
-		return undefined;
-	}
+	const uri = await tryResolvePrimaryWorktreeRoot(gitService, repositoryRoot) ?? repositoryRoot;
 	return { uri, displayName: basename(uri.fsPath) || uri.toString() };
 }
 

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -14,7 +14,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IAgentSessionProjectInfo } from '../../common/agentService.js';
-import { getBranchCompletions, IAgentHostGitService, IDefaultBranch, IWorktreeFileProgress, META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
+import { getBranchCompletions, IAgentHostGitService, IDefaultBranch, IWorktreeFileProgress, META_DIFF_BASE_BRANCH, tryResolvePrimaryWorktreeRoot } from '../../common/agentHostGitService.js';
 import { ISchemaProperty, schemaProperty } from '../../common/agentHostSchema.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
@@ -518,11 +518,12 @@ export class WorktreeIsolation extends Disposable {
 
 		onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.Starting));
 
-		const repositoryRoot = await this._gitService.getRepositoryRoot(workingDirectory);
-		if (!repositoryRoot) {
+		const checkoutRoot = await this._gitService.getRepositoryRoot(workingDirectory);
+		if (!checkoutRoot) {
 			return workingDirectory;
 		}
 
+		const repositoryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
 		const worktreesRoot = getWorktreesRoot(repositoryRoot);
 		// Prefix (e.g. the user's `git.branchPrefix`) the client forwards for
 		// worktree-isolated sessions. Prepended ahead of the built-in `agents/`
@@ -568,7 +569,7 @@ export class WorktreeIsolation extends Disposable {
 			try {
 				onProgress?.(buildWorktreeProgressText(WorktreeCreationPhase.CopyingIncludeFiles));
 				await withPercentProgress(WorktreeCreationPhase.CopyingIncludeFiles, onProgress, progress =>
-					this._gitService.copyWorktreeIncludeFiles(repositoryRoot, worktree, worktreeIncludeFiles, progress));
+					this._gitService.copyWorktreeIncludeFiles(checkoutRoot, worktree, worktreeIncludeFiles, progress));
 			} catch (error) {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to copy worktree include files: ${errorMessage(error)}`);
 			}
@@ -818,6 +819,15 @@ export class WorktreeIsolation extends Disposable {
 		return meta?.repositoryRoot ? projectFromRepositoryRoot(meta.repositoryRoot) : undefined;
 	}
 
+	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<URI> {
+		try {
+			return await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot) ?? fallbackRoot;
+		} catch (error) {
+			this._logService.warn(`[${this._logLabel}] Failed to resolve primary worktree for '${checkoutRoot.fsPath}': ${errorMessage(error)}`);
+			return fallbackRoot;
+		}
+	}
+
 	/**
 	 * Synchronous companion to {@link resolveWorktreeProject} for the
 	 * materialize-event path: the repository project for a worktree this agent
@@ -872,6 +882,10 @@ export class WorktreeIsolation extends Disposable {
 		}
 	}
 
+	/**
+	 * Reads worktree metadata and migrates repository roots written before linked checkouts were canonicalized.
+	 * It probes an existing worktree when available and otherwise falls back to the persisted root for archived sessions.
+	 */
 	private async _readWorktreeMetadata(sessionUri: URI): Promise<{ branchName: string; worktreePath?: URI; repositoryRoot?: URI } | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);
 		if (!ref) {
@@ -887,7 +901,19 @@ export class WorktreeIsolation extends Disposable {
 				return undefined;
 			}
 			const worktreePath = worktreePathRaw ? URI.parse(worktreePathRaw) : undefined;
-			const repositoryRoot = repositoryRootRaw ? URI.parse(repositoryRootRaw) : undefined;
+			let repositoryRoot = repositoryRootRaw ? URI.parse(repositoryRootRaw) : undefined;
+			if (repositoryRoot) {
+				const checkoutRoot = worktreePath && await fileExists(worktreePath.fsPath) ? worktreePath : repositoryRoot;
+				const primaryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
+				if (primaryRoot.toString() !== repositoryRoot.toString()) {
+					repositoryRoot = primaryRoot;
+					try {
+						await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString());
+					} catch (error) {
+						this._logService.warn(`[${this._logLabel}] Failed to normalize worktree repository metadata for '${sessionUri.toString()}': ${errorMessage(error)}`);
+					}
+				}
+			}
 			return { branchName, worktreePath, repositoryRoot };
 		} finally {
 			ref.dispose();

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -39,7 +39,7 @@ import { createNoopGitService, createSessionDataService, TestSessionDatabase } f
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { WorktreeIsolation } from '../../node/shared/worktreeIsolation.js';
+import { WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 
@@ -1297,6 +1297,51 @@ suite('AgentService (node dispatcher)', () => {
 			const sessions = await svc.listSessions();
 			assert.strictEqual(sessions.length, 1);
 			assert.deepStrictEqual(sessions[0]._meta, { workspaceless: true });
+		});
+
+		test('listSessions normalizes a persisted linked-worktree project', async () => {
+			const db = disposables.add(new TestSessionDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			const sessionWorktree = URI.file('/workspace/vscode.worktrees/parent.worktrees/child');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			const sessionId = 'test-session-linked-worktree';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = {
+				workingDirectories: [sessionWorktree],
+				project: { uri: linkedCheckout, displayName: 'parent' },
+			};
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			let resolvedFrom: URI | undefined;
+			let resolutionCount = 0;
+			gitService.getWorktreeRoots = async workingDirectory => {
+				resolvedFrom = workingDirectory;
+				resolutionCount++;
+				if (workingDirectory.toString() === sessionWorktree.toString()) {
+					return [];
+				}
+				return [primaryRoot, linkedCheckout, sessionWorktree];
+			};
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			const sessions = await svc.listSessions();
+			await svc.listSessions();
+
+			assert.deepStrictEqual({
+				resolutionCount,
+				resolvedFrom: resolvedFrom?.toString(),
+				project: sessions[0].project && { uri: sessions[0].project.uri.toString(), displayName: sessions[0].project.displayName },
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+			}, {
+				resolutionCount: 2,
+				resolvedFrom: linkedCheckout.toString(),
+				project: { uri: primaryRoot.toString(), displayName: 'vscode' },
+				persistedRepositoryRoot: primaryRoot.toString(),
+			});
 		});
 
 		test('listSessions uses SDK title when no custom title exists', async () => {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1299,7 +1299,7 @@ suite('AgentService (node dispatcher)', () => {
 			assert.deepStrictEqual(sessions[0]._meta, { workspaceless: true });
 		});
 
-		test('listSessions normalizes a persisted linked-worktree project', async () => {
+		test('listSessions normalizes a persisted linked-worktree project without probing a missing session worktree', async () => {
 			const db = disposables.add(new TestSessionDatabase());
 			const primaryRoot = URI.file('/workspace/vscode');
 			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
@@ -1315,14 +1315,9 @@ suite('AgentService (node dispatcher)', () => {
 			};
 			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
 			const gitService = createNoopGitService();
-			let resolvedFrom: URI | undefined;
-			let resolutionCount = 0;
+			const resolvedFrom: URI[] = [];
 			gitService.getWorktreeRoots = async workingDirectory => {
-				resolvedFrom = workingDirectory;
-				resolutionCount++;
-				if (workingDirectory.toString() === sessionWorktree.toString()) {
-					return [];
-				}
+				resolvedFrom.push(workingDirectory);
 				return [primaryRoot, linkedCheckout, sessionWorktree];
 			};
 			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
@@ -1332,13 +1327,11 @@ suite('AgentService (node dispatcher)', () => {
 			await svc.listSessions();
 
 			assert.deepStrictEqual({
-				resolutionCount,
-				resolvedFrom: resolvedFrom?.toString(),
+				resolvedFrom: resolvedFrom.map(uri => uri.toString()),
 				project: sessions[0].project && { uri: sessions[0].project.uri.toString(), displayName: sessions[0].project.displayName },
 				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
 			}, {
-				resolutionCount: 2,
-				resolvedFrom: linkedCheckout.toString(),
+				resolvedFrom: [linkedCheckout.toString()],
 				project: { uri: primaryRoot.toString(), displayName: 'vscode' },
 				persistedRepositoryRoot: primaryRoot.toString(),
 			});

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import type { IAgentHostGitService, IBranch, IDefaultBranch } from '../../common/agentHostGitService.js';
+import { tryResolvePrimaryWorktreeRoot, type IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../common/agentHostGitService.js';
 import { projectFromCopilotContext, projectFromRepository, resolveGitProject } from '../../node/copilot/copilotGitProject.js';
 
 class TestAgentHostGitService implements IAgentHostGitService {
@@ -14,6 +14,7 @@ class TestAgentHostGitService implements IAgentHostGitService {
 
 	repositoryRoot: URI | undefined;
 	worktreeRoots: URI[] = [];
+	worktreeRootCalls = 0;
 
 	async getCurrentBranch(): Promise<string | undefined> { return undefined; }
 	async getDefaultBranch(): Promise<IDefaultBranch | undefined> { return undefined; }
@@ -21,7 +22,10 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	async getRefs(): Promise<IBranch[]> { return []; }
 	async getBranches(): Promise<IBranch[]> { return []; }
 	async getRepositoryRoot(): Promise<URI | undefined> { return this.repositoryRoot; }
-	async getWorktreeRoots(): Promise<URI[]> { return this.worktreeRoots; }
+	async getWorktreeRoots(): Promise<URI[]> {
+		this.worktreeRootCalls++;
+		return this.worktreeRoots;
+	}
 	async addWorktree(): Promise<void> { }
 	async copyWorktreeIncludeFiles(): Promise<void> { }
 	async addExistingWorktree(): Promise<void> { }
@@ -86,6 +90,26 @@ suite('Copilot Git Project', () => {
 		}, {
 			uri: URI.file('/workspace/normal-repo').toString(),
 			displayName: 'normal-repo',
+		});
+	});
+
+	test('deduplicates concurrent resolution across linked worktrees', async () => {
+		const primaryRoot = URI.file('/workspace/source-repo');
+		const checkoutA = URI.file('/workspace/source-repo.worktrees/a');
+		const checkoutB = URI.file('/workspace/source-repo.worktrees/b');
+		gitService.worktreeRoots = [primaryRoot, checkoutA, checkoutB];
+
+		const roots = await Promise.all([
+			tryResolvePrimaryWorktreeRoot(gitService, checkoutA),
+			tryResolvePrimaryWorktreeRoot(gitService, checkoutB),
+		]);
+
+		assert.deepStrictEqual({
+			worktreeRootCalls: gitService.worktreeRootCalls,
+			roots: roots.map(root => root?.toString()),
+		}, {
+			worktreeRootCalls: 1,
+			roots: [primaryRoot.toString(), primaryRoot.toString()],
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -240,6 +240,73 @@ suite('WorktreeIsolation', () => {
 		});
 	});
 
+	test('resolveWorkingDirectory creates from the primary worktree while copying include files from the selected checkout', async () => {
+		const checkoutRoot = URI.joinPath(repoRoot, 'linked-checkout');
+		const gitService = createGitService();
+		let addWorktreeRoot: URI | undefined;
+		gitService.getRepositoryRoot = async () => checkoutRoot;
+		gitService.getWorktreeRoots = async () => [repoRoot, checkoutRoot];
+		gitService.addWorktree = async (repositoryRoot, worktree, branch, startPoint, track) => {
+			addWorktreeRoot = repositoryRoot;
+			addWorktreeCalls.push({ worktree, branchName: branch, startPoint, track });
+			mkdirSync(worktree.fsPath, { recursive: true });
+		};
+		const isolation = createIsolation(disposables, { gitService });
+		const includeFiles = ['.env'];
+
+		const worktree = await isolation.resolveWorkingDirectory({
+			sessionUri,
+			sessionId,
+			workingDirectory: checkoutRoot,
+			config: {
+				[SessionConfigKey.Isolation]: 'worktree',
+				[SessionConfigKey.Branch]: 'main',
+				[SessionConfigKey.WorktreeIncludeFiles]: includeFiles,
+			},
+		});
+		const meta = await isolation.readWorktreeMetadata(sessionUri);
+		const project = isolation.createdWorktreeProject(sessionId);
+
+		assert.deepStrictEqual({
+			worktree: worktree?.toString(),
+			addWorktreeRoot: addWorktreeRoot?.toString(),
+			includeFileRoot: copyIncludeCalls[0]?.repositoryRoot.toString(),
+			metaRepositoryRoot: meta?.repositoryRoot?.toString(),
+			project: project && { uri: project.uri.toString(), displayName: project.displayName },
+		}, {
+			worktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
+			addWorktreeRoot: repoRoot.toString(),
+			includeFileRoot: checkoutRoot.toString(),
+			metaRepositoryRoot: repoRoot.toString(),
+			project: { uri: repoRoot.toString(), displayName: basename(repoRoot) },
+		});
+	});
+
+	test('resolveWorkingDirectory falls back to the selected checkout when primary worktree resolution fails', async () => {
+		const checkoutRoot = URI.joinPath(repoRoot, 'linked-checkout');
+		const gitService = createGitService();
+		gitService.getRepositoryRoot = async () => checkoutRoot;
+		gitService.getWorktreeRoots = async () => { throw new Error('worktree enumeration failed'); };
+		const isolation = createIsolation(disposables, { gitService });
+
+		const worktree = await isolation.resolveWorkingDirectory({
+			sessionUri,
+			sessionId,
+			workingDirectory: checkoutRoot,
+			config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+		});
+		const meta = await isolation.readWorktreeMetadata(sessionUri);
+		const fallbackWorktreesRoot = getWorktreesRoot(checkoutRoot);
+
+		assert.deepStrictEqual({
+			worktree: worktree?.toString(),
+			metaRepositoryRoot: meta?.repositoryRoot?.toString(),
+		}, {
+			worktree: URI.joinPath(fallbackWorktreesRoot, getWorktreeName(branchName)).toString(),
+			metaRepositoryRoot: checkoutRoot.toString(),
+		});
+	});
+
 	test('resolveWorkingDirectory names each creation phase, rounding percentages down and debouncing updates', async () => {
 		const gitService = createGitService();
 		gitService.addWorktree = async (_root, worktree, branch, startPoint, track, onProgress) => {
@@ -346,9 +413,13 @@ suite('WorktreeIsolation', () => {
 
 	test('resolveWorkingDirectory serializes concurrent creation in the same repository', async () => {
 		const gitService = createGitService();
+		const checkoutRootA = URI.joinPath(repoRoot, 'linked-checkout-a');
+		const checkoutRootB = URI.joinPath(repoRoot, 'linked-checkout-b');
 		const existingBranches = new Set<string>();
 		let activeAddWorktrees = 0;
 		let maxActiveAddWorktrees = 0;
+		gitService.getRepositoryRoot = async workingDirectory => workingDirectory;
+		gitService.getWorktreeRoots = async () => [repoRoot, checkoutRootA, checkoutRootB];
 		gitService.branchExists = async (_repositoryRoot, candidate) => existingBranches.has(candidate);
 		gitService.addWorktree = async (_repositoryRoot, worktree, candidate, startPoint, track) => {
 			activeAddWorktrees++;
@@ -366,8 +437,8 @@ suite('WorktreeIsolation', () => {
 		const config = { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' };
 
 		const worktrees = await Promise.all([
-			isolation.resolveWorkingDirectory({ sessionUri: URI.parse('agent-session://test/12345678-aaaa-bbbb-cccc-123456789abc'), sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', workingDirectory: repoRoot, config, prompt: 'Add feature' }),
-			isolation.resolveWorkingDirectory({ sessionUri: URI.parse('agent-session://test/87654321-aaaa-bbbb-cccc-123456789abc'), sessionId: '87654321-aaaa-bbbb-cccc-123456789abc', workingDirectory: repoRoot, config, prompt: 'Add feature' }),
+			isolation.resolveWorkingDirectory({ sessionUri: URI.parse('agent-session://test/12345678-aaaa-bbbb-cccc-123456789abc'), sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', workingDirectory: checkoutRootA, config, prompt: 'Add feature' }),
+			isolation.resolveWorkingDirectory({ sessionUri: URI.parse('agent-session://test/87654321-aaaa-bbbb-cccc-123456789abc'), sessionId: '87654321-aaaa-bbbb-cccc-123456789abc', workingDirectory: checkoutRootB, config, prompt: 'Add feature' }),
 		]);
 
 		assert.deepStrictEqual({
@@ -570,6 +641,41 @@ suite('WorktreeIsolation', () => {
 			afterAsync: { uri: repoRoot.toString(), displayName: expectedDisplayName },
 			afterSync: { uri: repoRoot.toString(), displayName: expectedDisplayName },
 			unknownSession: undefined,
+		});
+	});
+
+	test('resolveWorktreeProject normalizes persisted linked-checkout metadata', async () => {
+		const checkoutRoot = URI.joinPath(repoRoot, 'linked-checkout');
+		const existingWorktree = URI.joinPath(repoRoot, 'existing-worktree');
+		mkdirSync(existingWorktree.fsPath, { recursive: true });
+		await Promise.all([
+			db.setMetadata('copilot.worktree.branchName', 'feature/x'),
+			db.setMetadata('copilot.worktree.path', existingWorktree.toString()),
+			db.setMetadata('copilot.worktree.repositoryRoot', checkoutRoot.toString()),
+		]);
+		const gitService = createGitService();
+		let resolvedFrom: URI | undefined;
+		let resolutionCount = 0;
+		gitService.getWorktreeRoots = async workingDirectory => {
+			resolvedFrom = workingDirectory;
+			resolutionCount++;
+			return [repoRoot, checkoutRoot, existingWorktree];
+		};
+		const isolation = createIsolation(disposables, { gitService });
+
+		const project = await isolation.resolveWorktreeProject(sessionUri);
+		await isolation.resolveWorktreeProject(sessionUri);
+
+		assert.deepStrictEqual({
+			resolutionCount,
+			resolvedFrom: resolvedFrom?.toString(),
+			project: project && { uri: project.uri.toString(), displayName: project.displayName },
+			persistedRepositoryRoot: await db.getMetadata('copilot.worktree.repositoryRoot'),
+		}, {
+			resolutionCount: 1,
+			resolvedFrom: existingWorktree.toString(),
+			project: { uri: repoRoot.toString(), displayName: basename(repoRoot) },
+			persistedRepositoryRoot: repoRoot.toString(),
 		});
 	});
 


### PR DESCRIPTION
Fixes #328374

## Summary

Agent-created sessions now retain the underlying repository as their project identity when creation starts from a linked Git worktree.

Previously, creating a session from a checkout such as `markdown-editor-undo-redo-core` caused the child session to appear under a `markdown-editor-undo-redo-core` section in the Sessions view instead of under `vscode`. The child worktree was also placed beneath `<parent-checkout>.worktrees`.

## Root cause

The Sessions view was behaving correctly: it groups sessions using the project/workspace label supplied by Agent Host.

The incorrect label originated in worktree isolation. `git rev-parse --show-toplevel` returns the root of the current checkout. For a normal checkout that is also the primary repository worktree, but for a linked worktree it is only the linked checkout path.

Worktree isolation treated that checkout root as the canonical repository root. It consequently:

1. Created the child worktree beneath `<linked-checkout>.worktrees`.
2. Performed repository operations and serialization against that checkout.
3. Persisted the checkout as `copilot.worktree.repositoryRoot`.
4. Reported the checkout basename as the session project.

The faulty assumption was that the selected checkout root and canonical repository root are always the same path.

## The model after this change

The implementation now keeps three identities distinct:

- **Selected checkout root:** where session creation was requested.
- **Primary repository root:** the first worktree returned by `git worktree list --porcelain`.
- **Child session worktree:** the isolated checkout where the new agent executes.

The selected checkout remains important: ignored dependencies, environment files, generated files, and other include-file content may differ between linked worktrees. Those files therefore continue to be copied from the selected checkout.

The canonical primary root is used for repository identity and repository-wide operations.

## Changes

- Added a shared primary-worktree resolver that:
  - Resolves linked checkouts through `git worktree list --porcelain`.
  - Maps every returned checkout to the primary worktree.
  - Serializes uncached probes so concurrent requests from sibling worktrees share one Git call.
  - Caches only successful results in a bounded LRU, leaving failures retryable.
- Changed worktree isolation to use the primary repository root for:
  - Child worktree placement.
  - Branch collision and start-point resolution.
  - `git worktree add`.
  - Creation serialization.
  - Persisted repository metadata.
  - Session project identity.
- Kept worktree include-file copying rooted at the selected checkout.
- Reused the same primary-root resolution for Copilot project discovery.
- Migrated existing session metadata written before this fix:
  - Direct worktree metadata reads repair the persisted repository root.
  - Session listing also repairs it because archived sessions may never resume through the normal worktree lifecycle.
  - Successful list-time resolutions use a bounded cache.

The Sessions view itself remains unchanged; it now receives the correct canonical project metadata.

The resolution is scoped to the repository containing the requested workspace. A session created from a different local repository, such as `vscode-packages`, resolves and groups under that repository rather than inheriting the parent session's `vscode` identity.

## Validation

- `npm run compile-client`
- 184 focused Agent Host tests passed
- `npm run valid-layers-check`
- Direct hygiene checks for all seven changed files
- `git diff --check`

cc @sandy081
