### PR TITLE
sessions: mark agent feedback as submitted when the request is queued

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { createSingleCallFunction } from '../../../../base/common/functional.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { derived, IObservable, runOnChange } from '../../../../base/common/observable.js';
@@ -20,7 +22,7 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { editingEntriesContainResource } from '../../../../workbench/contrib/chat/browser/sessionResourceMatching.js';
 import { changeMatchesResource, getActiveResourceCandidates, IAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ICodeReviewSuggestion } from '../../codeReview/browser/codeReviewService.js';
 import { ISession, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../services/sessions/common/session.js';
@@ -254,7 +256,10 @@ export interface IAgentFeedbackService {
 
 	/**
 	 * Submit the currently accumulated accepted feedback for the session to the
-	 * agent and mark those items as submitted. Returns whether the feedback was submitted.
+	 * agent and mark those items as submitted. Resolves once the request has been
+	 * accepted by the chat widget — which, while another request is in progress,
+	 * means it was queued rather than sent. Returns whether the feedback was
+	 * submitted.
 	 */
 	submitFeedback(sessionResource: URI): Promise<boolean>;
 
@@ -846,7 +851,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		// submitted via the "Submit Feedback" button). Attach the accepted
 		// items — which are about to become submitted — to this single request
 		// so the agent receives the comments, then remove the transient
-		// attachment again once the request has been sent.
+		// attachment again once the request has been accepted.
 		if (this._isAgentHostSession(sessionResource)) {
 			const acceptedItems = this.getFeedback(sessionResource).filter(item => item.state === AgentFeedbackState.Accepted);
 			const attachmentId = ATTACHMENT_ID_PREFIX + sessionResource.toString();
@@ -856,32 +861,43 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 				widget.attachmentModel.addContext(createAgentFeedbackVariableEntry(sessionResource, acceptedItems, annotationsResource));
 			}
 
-			try {
-				await widget.acceptInput('/act-on-feedback');
-			} catch (err) {
-				this._logService.error('[AgentFeedback] Failed to submit feedback', err);
-				return false;
-			} finally {
-				widget.attachmentModel.delete(attachmentId);
+			return this._sendActOnFeedbackRequest(widget, sessionResource, () => widget.attachmentModel.delete(attachmentId));
+		}
+
+		// For non-agent-host sessions the reactive attachment contribution also
+		// marks submission on send; marking from the helper is idempotent and
+		// covers sessions without that contribution.
+		return this._sendActOnFeedbackRequest(widget, sessionResource);
+	}
+
+	/**
+	 * Sends the `/act-on-feedback` request and marks the accepted feedback as
+	 * submitted as soon as the request has been accepted by the chat widget.
+	 * The request is queued when the agent is still working on another request,
+	 * in which case awaiting {@link IChatWidget.acceptInput} would only resolve
+	 * once that queued request eventually runs — the feedback items must move to
+	 * the submitted state right away.
+	 */
+	private _sendActOnFeedbackRequest(widget: IChatWidget, sessionResource: URI, cleanup?: () => void): Promise<boolean> {
+		const submitted = new DeferredPromise<boolean>();
+		const cleanupOnce = cleanup && createSingleCallFunction(cleanup);
+
+		widget.acceptInput('/act-on-feedback', {
+			onRequestAccepted: () => {
+				cleanupOnce?.();
+				this.markFeedbackSubmitted(sessionResource);
+				submitted.complete(true);
 			}
-
-			this.markFeedbackSubmitted(sessionResource);
-			return true;
-		}
-
-		// Send first so the accepted feedback is still attached to the request,
-		// then mark the items as submitted. For non-agent-host sessions the
-		// attachment contribution also marks submission on send; marking here is
-		// idempotent and covers sessions without that contribution.
-		try {
-			await widget.acceptInput('/act-on-feedback');
-		} catch (err) {
+		}).then(() => {
+			cleanupOnce?.();
+			submitted.complete(false);
+		}, err => {
 			this._logService.error('[AgentFeedback] Failed to submit feedback', err);
-			return false;
-		}
+			cleanupOnce?.();
+			submitted.complete(false);
+		});
 
-		this.markFeedbackSubmitted(sessionResource);
-		return true;
+		return submitted.p;
 	}
 
 	markFeedbackSubmitted(sessionResource: URI): void {

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -14,9 +14,10 @@ import { mock } from '../../../../../base/test/common/mock.js';
 import { AGENT_FEEDBACK_NEW_SESSION_RESOURCE, AgentFeedbackKind, AgentFeedbackService, AgentFeedbackState, IAgentFeedbackService } from '../../browser/agentFeedbackService.js';
 import { getSessionEditorComments } from '../../browser/sessionEditorComments.js';
 import { IChatEditingService } from '../../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
-import { IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService, IChatAcceptInputOptions } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IAgentFeedbackVariableEntry } from '../../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { DeferredPromise } from '../../../../../base/common/async.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IEditorService, IVisibleEditorsChangeEvent } from '../../../../../workbench/services/editor/common/editorService.js';
@@ -656,10 +657,16 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 	let fileA: URI;
 	let widgetOps: string[];
 	let addedEntries: IAgentFeedbackVariableEntry[];
+	/** Resolves when the (possibly queued) request is actually sent, i.e. when `acceptInput` resolves. */
+	let acceptInputSent: DeferredPromise<void>;
+	/** Whether the widget hands the request over to the chat service. */
+	let acceptsRequest: boolean;
 
 	setup(() => {
 		widgetOps = [];
 		addedEntries = [];
+		acceptInputSent = new DeferredPromise<void>();
+		acceptsRequest = true;
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() { });
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
@@ -687,7 +694,15 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 					widgetOps.push(`add:${entries[0]?.id}`);
 				},
 			},
-			acceptInput: async (query: string) => { widgetOps.push(`accept:${query}`); return undefined; },
+			acceptInput: async (query: string, options?: IChatAcceptInputOptions) => {
+				widgetOps.push(`accept:${query}`);
+				if (acceptsRequest) {
+					options?.onRequestAccepted?.();
+				}
+				await acceptInputSent.p;
+				widgetOps.push(`sent:${query}`);
+				return undefined;
+			},
 		} as unknown as IChatWidget;
 		instantiationService.stub(IChatWidgetService, new class extends mock<IChatWidgetService>() {
 			override getWidgetBySessionResource(_resource: URI): IChatWidget { return widget; }
@@ -724,6 +739,40 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 			kind: 'agentFeedback',
 			texts: ['Please simplify'],
 			state: AgentFeedbackState.Submitted,
+		});
+	});
+
+	test('marks feedback as submitted once the request is queued behind an in-progress request', async () => {
+		service.addFeedback(session, fileA, r(10), 'Please simplify');
+
+		// `acceptInputSent` is still pending: the request was queued and only runs
+		// once the in-progress request completes.
+		const submitted = await service.submitFeedback(session);
+
+		assert.deepStrictEqual({
+			submitted,
+			state: service.getFeedback(session)[0].state,
+			sent: widgetOps.includes('sent:/act-on-feedback'),
+		}, {
+			submitted: true,
+			state: AgentFeedbackState.Submitted,
+			sent: false,
+		});
+	});
+
+	test('keeps feedback accepted when the request is not accepted by the widget', async () => {
+		acceptsRequest = false;
+		acceptInputSent.complete();
+		service.addFeedback(session, fileA, r(10), 'Please simplify');
+
+		const submitted = await service.submitFeedback(session);
+
+		assert.deepStrictEqual({
+			submitted,
+			state: service.getFeedback(session)[0].state,
+		}, {
+			submitted: false,
+			state: AgentFeedbackState.Accepted,
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -356,6 +356,13 @@ export interface IChatAcceptInputOptions {
 	preserveFocus?: boolean;
 	/** Keeps the input box contents and attachments after submitting a programmatic query, and omits them from it. The query itself is sent as-is: prompt slash commands in it are not resolved. */
 	preserveInput?: boolean;
+	/**
+	 * Called once the request has been handed over to the chat service, i.e. it was either sent
+	 * right away or queued because another request is in progress. Callers that must not wait for
+	 * a queued request to actually run should use this instead of awaiting `acceptInput`, which
+	 * only resolves once the request has been sent.
+	 */
+	onRequestAccepted?: () => void;
 }
 
 export interface IChatWidgetViewModelChangeEvent {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -59,7 +59,7 @@ import { ChatMode, getModeNameForTelemetry, IChatMode } from '../../common/chatM
 import { chatAgentLeader, ChatRequestAgentPart, ChatRequestDynamicVariablePart, ChatRequestSlashCommandPart, ChatRequestSlashPromptPart, ChatRequestToolPart, ChatRequestToolSetPart, chatSubcommandLeader, formatChatQuestion, IParsedChatRequest } from '../../common/requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../../common/requestParser/chatRequestParser.js';
 import { getDynamicVariablesForWidget, getSelectedToolAndToolSetsForWidget } from '../attachments/chatVariables.js';
-import { ChatRequestQueueKind, ChatSendResult, IChatLocationData, IChatSendRequestOptions, IChatService } from '../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ChatSendResult, ChatSendResultSent, IChatLocationData, IChatSendRequestOptions, IChatService } from '../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
 import { IChatSlashCommandService } from '../../common/participants/chatSlashCommands.js';
 import { IChatTodoListService } from '../../common/tools/chatTodoListService.js';
@@ -150,6 +150,25 @@ export function getImmediateSilentSlashCommandPart(parsedRequest: IParsedChatReq
 		&& part.slashCommand.executeImmediately === true
 		&& part.slashCommand.silent === true
 	);
+}
+
+/**
+ * Settles the outcome of a `IChatService.sendRequest` call.
+ *
+ * A request that could not be handed over to the chat service is never accepted. Anything else is
+ * accepted right away — a queued request is accepted the moment it enters the queue, which is
+ * potentially long before it runs — so {@link onRequestAccepted} fires before the queued request
+ * settles. Resolves with the request once it has actually been sent, or `undefined` if it never was.
+ */
+export async function acceptAndAwaitSentRequest(result: ChatSendResult, onRequestAccepted?: () => void): Promise<ChatSendResultSent | undefined> {
+	if (ChatSendResult.isRejected(result)) {
+		return undefined;
+	}
+
+	onRequestAccepted?.();
+
+	const sent = ChatSendResult.isQueued(result) ? await result.deferred : result;
+	return ChatSendResult.isSent(sent) ? sent : undefined;
 }
 
 type ChatHandoffClickEvent = {
@@ -2933,10 +2952,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this._maybeStartGoalSummary(requestInputs.input);
 		}
 
-		options.onRequestAccepted?.();
-
-		const sent = ChatSendResult.isQueued(result) ? await result.deferred : result;
-		if (!ChatSendResult.isSent(sent)) {
+		const sent = await acceptAndAwaitSentRequest(result, options.onRequestAccepted);
+		if (!sent) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2933,6 +2933,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this._maybeStartGoalSummary(requestInputs.input);
 		}
 
+		options.onRequestAccepted?.();
+
 		const sent = ChatSendResult.isQueued(result) ? await result.deferred : result;
 		if (!ChatSendResult.isSent(sent)) {
 			return;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { OffsetRange } from '../../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
-import { getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight } from '../../../browser/widget/chatWidget.js';
+import { acceptAndAwaitSentRequest, getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight } from '../../../browser/widget/chatWidget.js';
+import { ChatSendResult, ChatSendResultSent, IChatSendRequestData } from '../../../common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
 import { ChatRequestSlashCommandPart, ChatRequestTextPart, IParsedChatRequest } from '../../../common/requestParser/chatParserTypes.js';
 
@@ -82,5 +84,65 @@ suite('ChatWidget', () => {
 			['setInputPartMaxHeightOverride', 600],
 			['layoutForInputHeight', 420, 720],
 		]);
+	});
+});
+
+suite('ChatWidget - acceptAndAwaitSentRequest', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function sentResult(): ChatSendResultSent {
+		return { kind: 'sent', data: {} as IChatSendRequestData };
+	}
+
+	test('an immediately sent request is accepted and returned', async () => {
+		let accepted = 0;
+		const result = sentResult();
+
+		const sent = await acceptAndAwaitSentRequest(result, () => accepted++);
+
+		assert.deepStrictEqual({ accepted, sent }, { accepted: 1, sent: result });
+	});
+
+	test('a queued request is accepted before the queued request settles', async () => {
+		const deferred = new DeferredPromise<ChatSendResult>();
+		let accepted = 0;
+
+		const pending = acceptAndAwaitSentRequest({ kind: 'queued', deferred: deferred.p }, () => accepted++);
+		// The queued request has not run yet, so `pending` is still unresolved here.
+		const acceptedWhileQueued = accepted === 1;
+
+		const result = sentResult();
+		await deferred.complete(result);
+
+		assert.deepStrictEqual({ acceptedWhileQueued, accepted, sent: await pending }, {
+			acceptedWhileQueued: true,
+			accepted: 1,
+			sent: result,
+		});
+	});
+
+	test('a rejected request is never accepted', async () => {
+		let accepted = 0;
+
+		const sent = await acceptAndAwaitSentRequest({ kind: 'rejected', reason: 'Empty message' }, () => accepted++);
+
+		assert.deepStrictEqual({ accepted, sent }, { accepted: 0, sent: undefined });
+	});
+
+	test('a queued request that is rejected when it runs stays accepted but is not sent', async () => {
+		const deferred = new DeferredPromise<ChatSendResult>();
+		let accepted = 0;
+
+		const pending = acceptAndAwaitSentRequest({ kind: 'queued', deferred: deferred.p }, () => accepted++);
+		await deferred.complete({ kind: 'rejected', reason: 'Session is read-only' });
+
+		assert.deepStrictEqual({ accepted, sent: await pending }, { accepted: 1, sent: undefined });
+	});
+
+	test('accepting is optional', async () => {
+		const result = sentResult();
+
+		assert.strictEqual(await acceptAndAwaitSentRequest(result), result);
 	});
 });


### PR DESCRIPTION
## Problem

`AgentFeedbackService.submitFeedback` awaited `widget.acceptInput('/act-on-feedback')` and only marked the feedback items as submitted afterwards. When a request is already in progress, `ChatWidget._acceptInput` queues the message and then awaits `result.deferred`, which does not resolve until the queued request actually runs.

The await therefore stayed pending indefinitely: the feedback items never left the `Accepted` state and the transient agent-host attachment was never cleaned up. The "Submit" button looked dead even though the message had been queued in the chat.

## Fix

- `IChatAcceptInputOptions` gains an optional `onRequestAccepted` callback, invoked once the request has been handed over to the chat service — i.e. it was either sent right away or queued behind an in-progress request.
- `ChatWidget._acceptInput` fires it immediately after `chatService.sendRequest` resolves and before awaiting the queued deferred, so it runs the moment the message enters the queue.
- Both submit paths in `AgentFeedbackService` now go through a shared `_sendActOnFeedbackRequest` helper that marks the feedback submitted and clears the transient agent-host attachment from `onRequestAccepted`.

The queued request keeps the feedback: `queuePendingRequest` snapshots `options.attachedContext` into the `ChatRequestModel` at queue time, so clearing the widget's attachment in the same tick does not strip it from the queued request.

## Notes for reviewers

Previously any early return from `_acceptInput` (rejected/empty message, read-only session) still fell through to `markFeedbackSubmitted`, falsely marking items as submitted. Now `submitFeedback` resolves `false` in that case and leaves the items `Accepted`.

## Validation

- `scripts\test.bat --grep "AgentFeedback"` — 78 passing, including two new tests: items move to `Submitted` (and `submitFeedback` returns `true`) while the underlying `acceptInput` promise is still pending, and items stay `Accepted` when the request is not accepted.
- `scripts\test.bat --grep "ChatWidget"` — 12 passing.
- `tsc --project src/tsconfig.json --noEmit` — clean apart from one pre-existing unrelated error in `copilotSystemNotification.ts`.
- `npm run precommit` (hygiene) — clean.

Fixes #328177
