### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: 'actions/setup-node@v6'
         with:
-          node-version: 'lts/*'
+          node-version: '24'
 
       - name: 'Run vscode-telemetry-extractor'
         run: 'npx --package=@vscode/telemetry-extractor@1.14.0 --yes vscode-telemetry-extractor -s .'


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `24` (using `24` where a concrete pin is needed).

- `.github/workflows/telemetry.yml`
  - `node-version: 'lts/*'` → `node-version: '24'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
