### PR TITLE
sessions: wait for the session's chat model to load before submitting feedback

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { DeferredPromise } from '../../../../base/common/async.js';
+import { DeferredPromise, raceTimeout } from '../../../../base/common/async.js';
 import { createSingleCallFunction } from '../../../../base/common/functional.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { derived, IObservable, runOnChange } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -43,6 +43,57 @@ export { AgentFeedbackKind, AgentFeedbackState, type IAgentFeedback };
 
 /** Shared feedback scope for every undefined or uncreated active session. */
 export const AGENT_FEEDBACK_NEW_SESSION_RESOURCE = URI.from({ scheme: 'agent-feedback', path: '/new-session' });
+
+/**
+ * How long submitting feedback waits for the session's chat model to be loaded into a chat widget
+ * before giving up.
+ */
+const WIDGET_LOAD_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolves the chat widget that has the session loaded, waiting for it to appear when the session's
+ * model has not been loaded into a widget yet.
+ *
+ * Feedback can be submitted (e.g. from the Changes editor or the comments input banner) while the
+ * session is still being restored into its chat widget. `getWidgetBySessionResource` matches on the
+ * widget's *loaded* view model, so it returns `undefined` until the model arrives — submitting then
+ * would silently drop the feedback. Resolves `undefined` if no widget loads the session in time.
+ *
+ * Exported for tests.
+ */
+export async function whenWidgetForSession(chatWidgetService: IChatWidgetService, sessionResource: URI, timeoutMs: number = WIDGET_LOAD_TIMEOUT_MS): Promise<IChatWidget | undefined> {
+	const existing = chatWidgetService.getWidgetBySessionResource(sessionResource);
+	if (existing) {
+		return existing;
+	}
+
+	const store = new DisposableStore();
+	try {
+		const loaded = new Promise<IChatWidget>(resolve => {
+			const check = () => {
+				const widget = chatWidgetService.getWidgetBySessionResource(sessionResource);
+				if (widget) {
+					resolve(widget);
+				}
+			};
+
+			const observe = (candidate: IChatWidget) => store.add(candidate.onDidChangeViewModel(check));
+
+			chatWidgetService.getAllWidgets().forEach(observe);
+			store.add(chatWidgetService.onDidAddWidget(added => {
+				observe(added);
+				check();
+			}));
+
+			// A widget may have loaded the session while the listeners were being wired up.
+			check();
+		});
+
+		return await raceTimeout(loaded, timeoutMs);
+	} finally {
+		store.dispose();
+	}
+}
 
 export interface INavigableSessionComment {
 	readonly id: string;
@@ -256,10 +307,10 @@ export interface IAgentFeedbackService {
 
 	/**
 	 * Submit the currently accumulated accepted feedback for the session to the
-	 * agent and mark those items as submitted. Resolves once the request has been
-	 * accepted by the chat widget — which, while another request is in progress,
-	 * means it was queued rather than sent. Returns whether the feedback was
-	 * submitted.
+	 * agent and mark those items as submitted. Waits for the session's chat model to be loaded
+	 * into a chat widget, then resolves once the request has been accepted by that widget — which,
+	 * while another request is in progress, means it was queued rather than sent. Returns whether
+	 * the feedback was submitted.
 	 */
 	submitFeedback(sessionResource: URI): Promise<boolean>;
 
@@ -808,9 +859,9 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 
 		if (!this._isAgentHostSession(sessionResource)) {
 			// Wait for the attachment contribution to update the chat widget's attachment model
-			const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
+			const widget = await whenWidgetForSession(this._chatWidgetService, sessionResource);
 			if (widget) {
-				const attachmentId = 'agentFeedback:' + sessionResource.toString();
+				const attachmentId = ATTACHMENT_ID_PREFIX + sessionResource.toString();
 				const hasAttachment = () => widget.attachmentModel.attachments.some(a => a.id === attachmentId);
 
 				if (!hasAttachment()) {
@@ -820,7 +871,6 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 				}
 			} else {
 				this._logService.error('[AgentFeedback] addFeedbackAndSubmit: no chat widget found for session, feedback may not be submitted correctly', sessionResource.toString());
-				await new Promise(resolve => setTimeout(resolve, 100));
 			}
 		}
 
@@ -840,7 +890,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 			return this._sessionsService.submitNewSessionInput();
 		}
 
-		const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
+		const widget = await whenWidgetForSession(this._chatWidgetService, sessionResource);
 		if (!widget) {
 			this._logService.error('[AgentFeedback] submitFeedback: no chat widget found for session', sessionResource.toString());
 			return false;

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -11,13 +11,13 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { mock } from '../../../../../base/test/common/mock.js';
-import { AGENT_FEEDBACK_NEW_SESSION_RESOURCE, AgentFeedbackKind, AgentFeedbackService, AgentFeedbackState, IAgentFeedbackService } from '../../browser/agentFeedbackService.js';
+import { AGENT_FEEDBACK_NEW_SESSION_RESOURCE, AgentFeedbackKind, AgentFeedbackService, AgentFeedbackState, IAgentFeedbackService, whenWidgetForSession } from '../../browser/agentFeedbackService.js';
 import { getSessionEditorComments } from '../../browser/sessionEditorComments.js';
 import { IChatEditingService } from '../../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
-import { IChatWidget, IChatWidgetService, IChatAcceptInputOptions } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService, IChatAcceptInputOptions, IChatWidgetViewModelChangeEvent } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IAgentFeedbackVariableEntry } from '../../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { DeferredPromise } from '../../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IEditorService, IVisibleEditorsChangeEvent } from '../../../../../workbench/services/editor/common/editorService.js';
@@ -661,12 +661,17 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 	let acceptInputSent: DeferredPromise<void>;
 	/** Whether the widget hands the request over to the chat service. */
 	let acceptsRequest: boolean;
+	/** Whether the widget has the session's chat model loaded. */
+	let sessionLoaded: boolean;
+	/** Simulates the widget loading the session's chat model. */
+	let loadSession: () => void;
 
 	setup(() => {
 		widgetOps = [];
 		addedEntries = [];
 		acceptInputSent = new DeferredPromise<void>();
 		acceptsRequest = true;
+		sessionLoaded = true;
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() { });
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
@@ -685,7 +690,9 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 		});
 		instantiationService.stub(ISessionsService, { activeSession: observableValue<IActiveSession | undefined>('activeSession', undefined) } as unknown as ISessionsService);
 
+		const onDidChangeViewModel = store.add(new Emitter<IChatWidgetViewModelChangeEvent>());
 		const widget = {
+			onDidChangeViewModel: onDidChangeViewModel.event,
 			attachmentModel: {
 				attachments: [],
 				delete: (id: string) => widgetOps.push(`delete:${id}`),
@@ -704,8 +711,16 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 				return undefined;
 			},
 		} as unknown as IChatWidget;
+		loadSession = () => {
+			sessionLoaded = true;
+			onDidChangeViewModel.fire({ previousSessionResource: undefined, currentSessionResource: session });
+		};
 		instantiationService.stub(IChatWidgetService, new class extends mock<IChatWidgetService>() {
-			override getWidgetBySessionResource(_resource: URI): IChatWidget { return widget; }
+			override onDidAddWidget = Event.None;
+			override getAllWidgets(): readonly IChatWidget[] { return [widget]; }
+			override getWidgetBySessionResource(_resource: URI): IChatWidget | undefined {
+				return sessionLoaded ? widget : undefined;
+			}
 		});
 
 		service = store.add(instantiationService.createInstance(AgentFeedbackService));
@@ -774,5 +789,107 @@ suite('AgentFeedbackService - Submit (agent host)', () => {
 			submitted: false,
 			state: AgentFeedbackState.Accepted,
 		});
+	});
+
+	test('waits for the session model to load into the widget before submitting', async () => {
+		sessionLoaded = false;
+		service.addFeedback(session, fileA, r(10), 'Please simplify');
+
+		const pending = service.submitFeedback(session);
+		await timeout(0);
+		const submittedBeforeLoad = widgetOps.length > 0;
+
+		loadSession();
+
+		assert.deepStrictEqual({
+			submittedBeforeLoad,
+			submitted: await pending,
+			state: service.getFeedback(session)[0].state,
+			accepted: widgetOps.includes('accept:/act-on-feedback'),
+		}, {
+			submittedBeforeLoad: false,
+			submitted: true,
+			state: AgentFeedbackState.Submitted,
+			accepted: true,
+		});
+	});
+});
+
+suite('AgentFeedbackService - whenWidgetForSession', () => {
+
+	const store = new DisposableStore();
+	const session = URI.parse('test://session/1');
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Builds a widget service whose single widget only reports the session once `load` is
+	 * called, mirroring a chat widget that has not loaded its model yet.
+	 */
+	function createWidgetHost(): { widget: IChatWidget; service: IChatWidgetService; load: () => void } {
+		const onDidChangeViewModel = store.add(new Emitter<IChatWidgetViewModelChangeEvent>());
+		const widget = { onDidChangeViewModel: onDidChangeViewModel.event } as unknown as IChatWidget;
+		let loaded = false;
+
+		const service = new class extends mock<IChatWidgetService>() {
+			override onDidAddWidget = Event.None;
+			override getAllWidgets(): readonly IChatWidget[] { return [widget]; }
+			override getWidgetBySessionResource(_resource: URI): IChatWidget | undefined {
+				return loaded ? widget : undefined;
+			}
+		};
+
+		return {
+			widget,
+			service,
+			load: () => {
+				loaded = true;
+				onDidChangeViewModel.fire({ previousSessionResource: undefined, currentSessionResource: session });
+			},
+		};
+	}
+
+	test('resolves immediately when the session is already loaded', async () => {
+		const host = createWidgetHost();
+		host.load();
+
+		assert.strictEqual(await whenWidgetForSession(host.service, session, 0), host.widget);
+	});
+
+	test('resolves once a widget loads the session', async () => {
+		const host = createWidgetHost();
+
+		const pending = whenWidgetForSession(host.service, session, 5000);
+		await timeout(0);
+		host.load();
+
+		assert.strictEqual(await pending, host.widget);
+	});
+
+	test('resolves undefined when no widget loads the session in time', async () => {
+		const host = createWidgetHost();
+
+		assert.strictEqual(await whenWidgetForSession(host.service, session, 1), undefined);
+	});
+
+	test('resolves when a widget that already has the session is added later', async () => {
+		const onDidAddWidget = store.add(new Emitter<IChatWidget>());
+		const widget = { onDidChangeViewModel: Event.None } as unknown as IChatWidget;
+		let widgets: IChatWidget[] = [];
+
+		const service = new class extends mock<IChatWidgetService>() {
+			override onDidAddWidget = onDidAddWidget.event;
+			override getAllWidgets(): readonly IChatWidget[] { return widgets; }
+			override getWidgetBySessionResource(_resource: URI): IChatWidget | undefined { return widgets[0]; }
+		};
+
+		const pending = whenWidgetForSession(service, session, 5000);
+		await timeout(0);
+		widgets = [widget];
+		onDidAddWidget.fire(widget);
+
+		assert.strictEqual(await pending, widget);
 	});
 });


### PR DESCRIPTION
## Problem

`IChatWidgetService.getWidgetBySessionResource` matches on the widget's **loaded** view model:

```ts
getWidgetBySessionResource(sessionResource: URI): IChatWidget | undefined {
    return this._widgets.find(w => isEqual(w.viewModel?.sessionResource, sessionResource));
}
```

So while a session is still being restored into its chat widget it returns `undefined`, and `AgentFeedbackService.submitFeedback` bailed out with an error log — the feedback was silently dropped.

This is reachable from the comments input banner. "Address comments" first accepts the created comments and then submits:

```ts
const created = this.feedbackService.getFeedback(sessionResource)
    .filter(item => item.state === AgentFeedbackState.Created && REVIEWABLE_KINDS.has(item.kind));
for (const item of created) {
    this.feedbackService.acceptFeedback(sessionResource, item.id);
}
const submitted = await this.feedbackService.submitFeedback(sessionResource);
```

Accepting moves the items out of `Created`, which is the only state the banner renders — so the banner disappeared immediately, and then the submit failed because no widget had the session loaded yet. Net effect: the banner vanished and nothing was sent.

## Fix

Add a `whenWidgetForSession` helper that resolves the widget once *any* widget loads the session — watching `onDidChangeViewModel` on the currently known widgets plus `onDidAddWidget` for widgets created later — bounded by a timeout so a session that never opens can't hang the caller.

Both agent feedback submit paths (`submitFeedback` and `addFeedbackAndSubmit`) now await it, so every submit entry point benefits: the editor overlay, the Changes toolbar action, and the comments input banner.

This also replaces the arbitrary `await new Promise(resolve => setTimeout(resolve, 100))` in `addFeedbackAndSubmit`'s no-widget fallback, which was papering over the same race.

## Notes for reviewers

- The helper is exported purely so it can be unit tested — `AgentFeedbackService` is registered as a singleton, so a constructor-injected timeout wasn't an option.
- It returns early without subscribing when the widget is already available, which is the common case.
- The listener store is disposed in a `finally`, so listeners are always released (at the latest when the timeout elapses).

## Validation

- `scripts\test.bat --grep "AgentFeedback"` — 83 passing, including a new `whenWidgetForSession` suite (already loaded, loads later, added later, times out) and a service-level test asserting nothing is sent until the model loads.
- Mutation-tested: reverting the helper to the plain synchronous `getWidgetBySessionResource` lookup fails 3 of the new tests.
- `tsc --project src/tsconfig.json --noEmit` clean apart from a pre-existing unrelated error in `copilotSystemNotification.ts`; hygiene and eslint clean.
