### PR TITLE
Unblock Copilot session refresh after SDK shutdown

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2365,7 +2365,7 @@ export class CopilotAgentSession extends Disposable {
 		} catch (error) {
 			this._logService.warn(`[Copilot:${this.sessionId}] Failed to flush edit attribution: ${error}`);
 		}
-		await this._wrapper.session.disconnect();
+		await this._wrapper.disconnect();
 	}
 
 	async setModel(model: string, reasoningEffort?: SessionConfig['reasoningEffort'], contextTier?: SessionConfig['contextTier']): Promise<void> {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { CopilotSession, SessionEvent, SessionEventPayload, SessionEventType } from '@github/copilot-sdk';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 
@@ -17,21 +18,39 @@ export class CopilotSessionWrapper extends Disposable {
 	private readonly _handledEventTypes = new Set<SessionEventType>();
 	private readonly _onUnhandledEvent = this._register(new Emitter<SessionEvent>());
 	readonly onUnhandledEvent = this._onUnhandledEvent.event;
+	private readonly _shutdown = new DeferredPromise<void>();
+	private _disconnectPromise: Promise<void> | undefined;
 
 	constructor(readonly session: CopilotSession) {
 		super();
 		const unsubscribeAll = session.on(event => {
+			if (event.type === 'session.shutdown') {
+				void this._shutdown.complete();
+			}
 			if (!this._handledEventTypes.has(event.type)) {
 				this._onUnhandledEvent.fire(event);
 			}
 		});
 		this._register(toDisposable(unsubscribeAll));
 		this._register(toDisposable(() => {
-			session.disconnect().catch(() => { /* best-effort */ });
+			void this.disconnect().catch(() => { /* best-effort */ });
 		}));
 	}
 
 	get sessionId(): string { return this.session.sessionId; }
+
+	/** Disconnects once the request completes or the SDK reports session shutdown. */
+	disconnect(): Promise<void> {
+		if (this._shutdown.isSettled) {
+			return this._shutdown.p;
+		}
+		this._disconnectPromise ??= this.session.disconnect().catch(error => {
+			if (!this._shutdown.isSettled) {
+				throw error;
+			}
+		});
+		return Promise.race([this._disconnectPromise, this._shutdown.p]);
+	}
 
 	private _onMessageDelta: Event<SessionEventPayload<'assistant.message_delta'>> | undefined;
 	get onMessageDelta(): Event<SessionEventPayload<'assistant.message_delta'>> {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -114,6 +114,9 @@ class MockCopilotSession {
 	usageMetricsCalls = 0;
 	/** Awaited inside `usage.getMetrics` so tests can hold a refresh in flight. */
 	usageMetricsGate: Promise<unknown> | undefined;
+	disconnectCalls = 0;
+	disconnectGate: Promise<void> | undefined;
+	disconnectHook: (() => void) | undefined;
 	/**
 	 * Per-call gates, consumed in call order, for holding individual reads in flight.
 	 * Lets a test make an earlier-issued read resolve after a later one.
@@ -191,7 +194,11 @@ class MockCopilotSession {
 	}
 	async setModel() { }
 	async getEvents(): Promise<SessionEvent[]> { return this.messages; }
-	async disconnect() { }
+	async disconnect() {
+		this.disconnectCalls++;
+		this.disconnectHook?.();
+		await this.disconnectGate;
+	}
 
 	readonly rpc = {
 		mode: {
@@ -732,6 +739,32 @@ suite('CopilotAgentSession', () => {
 
 			assert.deepStrictEqual(events, ['session.compaction_start']);
 		});
+	});
+
+	test('destroySession completes when shutdown arrives before the response', async () => {
+		const disconnectStarted = new DeferredPromise<void>();
+		const disconnectGate = new DeferredPromise<void>();
+		const { session, mockSession } = await createAgentSession(disposables, {
+			configureMockSession: mockSession => {
+				mockSession.disconnectGate = disconnectGate.p;
+				mockSession.disconnectHook = () => { void disconnectStarted.complete(); };
+			},
+		});
+		const destroy = session.destroySession();
+
+		await disconnectStarted.p;
+		try {
+			mockSession.fire('session.shutdown', {
+				shutdownType: 'normal',
+				totalApiDurationMs: 0,
+			} as SessionEventPayload<'session.shutdown'>['data']);
+			await destroy;
+			session.dispose();
+
+			assert.strictEqual(mockSession.disconnectCalls, 1);
+		} finally {
+			disconnectGate.complete();
+		}
 	});
 
 	test('logs SDK events without wrapped handlers', async () => {


### PR DESCRIPTION
Follow-up to #327125 and #327126.

PR #327126 correctly made configuration refresh wait for the previous Copilot SDK session to tear down before resuming the same session ID. In this incident, the runtime emitted `session.shutdown` and completed destruction, but the `disconnect()` RPC promise remained pending while the SDK process drained a large persisted-event/export backlog.

`CopilotAgent._sendMessage` held the per-session sequencer while awaiting that promise. Cancellation updated protocol state, but provider abort, idle release, and subsequent sends all queued behind the same blocked teardown. A later turn therefore reached `chat/turnStarted` but never reached `sendMessage`, leaving the Agents window on **Working…** indefinitely.

This change makes `CopilotSessionWrapper` treat either the disconnect response or the SDK's authoritative `session.shutdown` event as teardown completion. The disconnect request is memoized so later wrapper disposal reuses it instead of sending a duplicate destroy request. `CopilotAgentSession.destroySession()` now goes through that lifecycle-aware wrapper path.

Testing:
- focused `CopilotAgentSession` shutdown-before-response regression test
- existing config-refresh disconnect ordering test
- `npm run typecheck-client`
- `npm run valid-layers-check`
- hygiene checks

[logs](https://vscodeteam.slack.com/archives/D05FFSDD8Q3/p1785498679543509)

cc @connor4312