### PR TITLE
Let endpoints declare native PDF support instead of a hardcoded family allowlist

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -62,6 +62,13 @@ export interface BYOKModelCapabilities {
 	contextWindow?: number;
 	toolCalling: boolean;
 	vision: boolean;
+	/**
+	 * Whether the model accepts native PDF document content parts. When unset,
+	 * falls back to the family-based `modelSupportsPDFDocuments` heuristic, so
+	 * a compatible custom endpoint no longer needs to masquerade as an
+	 * allowlisted model family just to unlock PDF attachments.
+	 */
+	pdfInput?: boolean;
 	thinking?: boolean;
 	adaptiveThinking?: boolean;
 	streaming?: boolean;
@@ -154,6 +161,7 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 				streaming: knownModelInfo?.streaming ?? true,
 				tool_calls: !!knownModelInfo?.toolCalling,
 				vision: !!knownModelInfo?.vision,
+				pdf_documents: knownModelInfo?.pdfInput,
 				thinking: !!knownModelInfo?.thinking,
 				adaptive_thinking: !!knownModelInfo?.adaptiveThinking,
 				reasoning_effort: knownModelInfo?.supportsReasoningEffort

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -134,6 +134,26 @@ describe('resolveModelInfo', () => {
 
 		expect(info.capabilities.limits?.max_context_window_tokens).toBe(128000);
 	});
+
+	it('propagates an explicit pdfInput declaration into capabilities.supports.pdf_documents', () => {
+		const supportsPdf = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			pdfInput: true,
+		});
+		const rejectsPdf = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			pdfInput: false,
+		});
+
+		expect(supportsPdf.capabilities.supports.pdf_documents).toBe(true);
+		expect(rejectsPdf.capabilities.supports.pdf_documents).toBe(false);
+	});
+
+	it('leaves pdf_documents undefined when the model does not declare PDF support, so the family heuristic decides', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, baseCapabilities);
+
+		expect(info.capabilities.supports.pdf_documents).toBeUndefined();
+	});
 });
 
 describe('resolveModelTokenLimits', () => {

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -97,6 +97,8 @@ interface _CustomEndpointModelConfig {
 	contextWindow?: number;
 	toolCalling: boolean;
 	vision: boolean;
+	/** Whether the endpoint accepts native PDF document content parts. */
+	pdfInput?: boolean;
 	thinking?: boolean;
 	streaming?: boolean;
 	editTools?: EndpointEditToolName[];
@@ -159,6 +161,7 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			contextWindow: modelConfiguration?.contextWindow,
 			toolCalling: !!model.capabilities?.toolCalling || false,
 			vision: !!model.capabilities?.imageInput || false,
+			pdfInput: modelConfiguration?.pdfInput,
 			name: model.name,
 			url,
 			thinking: modelConfiguration?.thinking ?? false,

--- a/extensions/copilot/src/extension/prompts/node/panel/fileVariable.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/fileVariable.tsx
@@ -9,7 +9,6 @@ import { UserMessage } from '@vscode/prompt-tsx/dist/base/promptElements';
 import { AbstractDocumentWithLanguageId } from '../../../../platform/editing/common/abstractText';
 import { NotebookDocumentSnapshot } from '../../../../platform/editing/common/notebookDocumentSnapshot';
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
-import { modelSupportsPDFDocuments } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { IFileSystemService } from '../../../../platform/filesystem/common/fileSystemService';
 import { IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
 import { IAlternativeNotebookContentService } from '../../../../platform/notebook/common/alternativeContent';
@@ -119,7 +118,7 @@ export class FileVariable extends PromptElement<FileVariableProps, unknown> {
 		}
 
 		if (/\.pdf$/i.test(uri.path)) {
-			if (!this.promptEndpoint.supportsVision || !modelSupportsPDFDocuments(this.promptEndpoint)) {
+			if (!this.promptEndpoint.supportsVision || !this.promptEndpoint.supportsPDFDocuments) {
 				if (this.props.omitReferences) {
 					return;
 				}

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -61,6 +61,14 @@ export type IChatModelCapabilities = {
 		reasoning_effort?: string[];
 		tool_search?: boolean;
 		context_editing?: boolean;
+		/**
+		 * Whether the model accepts native PDF document content parts (as
+		 * opposed to being sent as image blocks). Lets an endpoint (in
+		 * particular a BYOK/custom endpoint) declare PDF support explicitly
+		 * instead of relying solely on the family-based heuristic in
+		 * `modelSupportsPDFDocuments`.
+		 */
+		pdf_documents?: boolean;
 	};
 };
 

--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -29,7 +29,7 @@ import { ITelemetryService, TelemetryProperties } from '../../telemetry/common/t
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { ITokenizerProvider } from '../../tokenizer/node/tokenizer';
 import { ICAPIClientService } from '../common/capiClient';
-import { getModelCapabilityOverride, isAnthropicFamily, isGeminiFamily, isKimiFamily, modelSupportsContextEditing, modelSupportsToolSearch } from '../common/chatModelCapabilities';
+import { getModelCapabilityOverride, isAnthropicFamily, isGeminiFamily, isKimiFamily, modelSupportsContextEditing, modelSupportsPDFDocuments, modelSupportsToolSearch } from '../common/chatModelCapabilities';
 import { IDomainService } from '../common/domainService';
 import { CustomModel, IChatModelInformation, ModelSupportedEndpoint } from '../common/endpointProvider';
 import { normalizeTokenPrices } from '../../../extension/conversation/common/languageModelAccess';
@@ -172,6 +172,7 @@ export class ChatEndpoint implements IChatEndpoint {
 	public readonly supportsReasoningEffort?: string[];
 	public readonly supportsToolSearch?: boolean;
 	public readonly supportsContextEditing?: boolean;
+	public readonly supportsPDFDocuments?: boolean;
 	public readonly isPremium?: boolean | undefined;
 	public readonly multiplier?: number | undefined;
 	public readonly restrictedToSkus?: string[] | undefined;
@@ -228,6 +229,7 @@ export class ChatEndpoint implements IChatEndpoint {
 		this.supportsReasoningEffort = modelMetadata.capabilities.supports.reasoning_effort;
 		this.supportsToolSearch = modelMetadata.capabilities.supports.tool_search ?? modelSupportsToolSearch(this);
 		this.supportsContextEditing = modelMetadata.capabilities.supports.context_editing ?? modelSupportsContextEditing(this);
+		this.supportsPDFDocuments = modelMetadata.capabilities.supports.pdf_documents ?? modelSupportsPDFDocuments(this);
 		this._supportsStreaming = !!modelMetadata.capabilities.supports.streaming;
 		this.customModel = modelMetadata.custom_model;
 		this.maxPromptImages = modelMetadata.capabilities.limits?.vision?.max_prompt_images;

--- a/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
@@ -455,6 +455,55 @@ describe('ChatEndpoint - Image Count Validation', () => {
 	});
 });
 
+describe('ChatEndpoint - supportsPDFDocuments', () => {
+	let mockServices: ReturnType<typeof createMockServices>;
+
+	beforeEach(() => {
+		mockServices = createMockServices();
+	});
+
+	const createEndpoint = (metadata: IChatModelInformation) =>
+		new ChatEndpoint(
+			metadata,
+			mockServices.domainService,
+			mockServices.chatMLFetcher,
+			mockServices.tokenizerProvider,
+			mockServices.instantiationService,
+			mockServices.configurationService,
+			mockServices.expService,
+			mockServices.chatWebSocketService,
+			mockServices.logService
+		);
+
+	it('falls back to the family heuristic when the endpoint does not declare pdf_documents', () => {
+		expect(createEndpoint(createNonAnthropicModelMetadata('claude-sonnet-4')).supportsPDFDocuments).toBe(true);
+		expect(createEndpoint(createNonAnthropicModelMetadata('llama-3')).supportsPDFDocuments).toBe(false);
+	});
+
+	it('honors an explicit pdf_documents declaration, e.g. for a BYOK/custom endpoint using a non-allowlisted family', () => {
+		const baseMetadata = createNonAnthropicModelMetadata('my-custom-proxy-model');
+		const withPdfSupport: IChatModelInformation = {
+			...baseMetadata,
+			capabilities: {
+				...baseMetadata.capabilities,
+				supports: { ...baseMetadata.capabilities.supports, pdf_documents: true }
+			}
+		};
+		const withoutPdfSupport: IChatModelInformation = {
+			...baseMetadata,
+			capabilities: {
+				...baseMetadata.capabilities,
+				supports: { ...baseMetadata.capabilities.supports, pdf_documents: false }
+			}
+		};
+
+		expect(createEndpoint(withPdfSupport).supportsPDFDocuments).toBe(true);
+		expect(createEndpoint(withoutPdfSupport).supportsPDFDocuments).toBe(false);
+		// Without the declaration, the same non-allowlisted family would be denied.
+		expect(createEndpoint(baseMetadata).supportsPDFDocuments).toBe(false);
+	});
+});
+
 describe('ChatEndpoint - Kimi CAPI customization', () => {
 	let mockServices: ReturnType<typeof createMockServices>;
 

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -334,6 +334,13 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly supportsReasoningEffort?: string[];
 	readonly supportsToolSearch?: boolean;
 	readonly supportsContextEditing?: boolean;
+	/**
+	 * Whether the model accepts native PDF document content parts. Resolved
+	 * from the endpoint's declared capabilities, falling back to the
+	 * family-based `modelSupportsPDFDocuments` heuristic when undeclared —
+	 * see `ChatEndpoint`.
+	 */
+	readonly supportsPDFDocuments?: boolean;
 	readonly supportsToolCalls: boolean;
 	readonly supportsVision: boolean;
 	readonly supportsPrediction: boolean;


### PR DESCRIPTION
Fixes #324961

## Issue

`modelSupportsPDFDocuments()` (extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts) gates whether a PDF attachment is even attempted, based purely on a hardcoded allowlist of Anthropic/GPT model family name prefixes:

    export function modelSupportsPDFDocuments(model: LanguageModelChat | IChatEndpoint): boolean {
    	return isAnthropicFamily(model) || isGpt5PlusFamily(model) || isGpt56(model);
    }

A BYOK or custom endpoint that genuinely accepts PDF documents but doesn't happen to report one of those family names is blocked from ever reaching the point where a PDF could be sent, or has to alias its family to an allowlisted name — which then pulls in every other family-based behavior tied to that name, not just PDF handling.

PRs #324960 and #325833 fixed related but separate bugs in the wire-format converters (PDFs being sent as image blocks, and PDFs being dropped during Anthropic message parsing). Neither touches this gate, so the underlying request in this issue was still open.

## Fix

Added an explicit, declarable capability alongside the existing heuristic, following the same pattern already used for `tool_search` and `context_editing` in this file:

- `IChatModelCapabilities.supports.pdf_documents?: boolean` — an endpoint's declared capability.
- `IChatEndpoint.supportsPDFDocuments`, resolved once in `ChatEndpoint`'s constructor as `modelMetadata.capabilities.supports.pdf_documents ?? modelSupportsPDFDocuments(this)`. An explicit declaration wins; the family heuristic is only consulted when nothing is declared.
- `fileVariable.tsx` (the actual PDF-attachment gate) now reads `endpoint.supportsPDFDocuments` instead of calling the heuristic directly.
- A `pdfInput` toggle threaded through `BYOKModelCapabilities` and the Custom Endpoint JSON config, so a compatible proxy can set `"pdfInput": true` directly instead of spoofing an allowlisted family name.

The capability is intentionally boolean, matching every other flag in `supports` (`vision`, `tool_calls`, `tool_search`, `context_editing`) and the stable `LanguageModelChatCapabilities.imageInput` boolean in vscode.d.ts, rather than a mime-type list — there's no consumer today that would act on more than a single PDF yes/no answer.

## Testing

- `chatModelCapabilities.spec.ts` — existing family-heuristic coverage unchanged.
- `copilotChatEndpoint.spec.ts` — new `ChatEndpoint - supportsPDFDocuments` suite covering both the heuristic fallback and an explicit override on a non-allowlisted family.
- `byokProvider.spec.ts` — new cases verifying `pdfInput` propagates into `capabilities.supports.pdf_documents` and is left undefined when undeclared.
- `npm run typecheck` passes.
- `npx vitest --run --pool=forks` on the four affected suites: 94 tests passing.