### PR TITLE
nes: preserve ghost-text state for speculative reuse

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -701,7 +701,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				telemetryBuilder.setStatelessNextEditTelemetry(nextEditResult.telemetry);
 				if (speculativeRequest) {
 					const firstEdit = await requestToReuse.firstEdit.p;
-					return firstEdit.map(val => ({ ...val, isFromSpeculativeRequest: true }));
+					return firstEdit.map(val => ({ ...val, isFromSpeculativeRequest: true, baseCacheEntry: val.baseCacheEntry ?? val }));
 				}
 				return nextEditResult.nextEdit.isError() ? nextEditResult.nextEdit : requestToReuse.firstEdit.p;
 			} else {

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditCacheRebase.spec.ts
@@ -170,6 +170,7 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
 
 		assert(cachedEdit !== undefined, 'setKthNextEdit should return the cached edit');
 		assert(cachedEdit.userEditSince !== undefined, 'userEditSince should be set');
+		cachedEdit.wasRenderedAsInlineSuggestion = true;
 
 		const rebaseResult = cache.tryRebaseCacheEntry(
 			cachedEdit,
@@ -180,6 +181,64 @@ describe('NextEditCache rebase — Fibonacci scenario', () => {
 		assert(rebaseResult.edit !== undefined, 'should rebase successfully');
 		assert(rebaseResult.edit.rebasedEdit !== undefined, 'should have a rebased edit for the class body');
 		assert.strictEqual(rebaseResult.edit.modelTelemetry, testModelTelemetry, 'should preserve model attribution on the rebased edit');
+		const baseCacheEntry = rebaseResult.edit.baseCacheEntry;
+		assert(baseCacheEntry, 'should reference the stable cache entry');
+		assert.strictEqual(baseCacheEntry, cachedEdit);
+		assert.strictEqual(baseCacheEntry.wasRenderedAsInlineSuggestion, true, 'should preserve inline-rendered state on the stable cache entry');
+	});
+});
+
+describe('NextEditCache ghost-text presentation state', () => {
+
+	const document = new StringText('const value = 1;\n');
+	const docId = DocumentId.create(URI.file('/test/cache-presentation-state.ts').toString());
+
+	function makeSource(): NextEditFetchRequest {
+		const logContext = new InlineEditRequestLogContext('test', 0, undefined);
+		return new NextEditFetchRequest(generateUuid(), logContext, undefined, false);
+	}
+
+	it('does not carry inline-rendered state to a replacement cache entry', () => {
+		const workspace = new MutableObservableWorkspace();
+		workspace.addDocument({ id: docId, initialValue: document.value });
+		const cache = new NextEditCache(workspace, new LogServiceImpl([]), new DefaultsOnlyConfigurationService(), new NullExperimentationService());
+
+		const first = cache.setKthNextEdit(
+			docId,
+			document,
+			undefined,
+			StringReplacement.insert(document.value.length, 'first'),
+			0,
+			undefined,
+			undefined,
+			makeSource(),
+			{ isFromCursorJump: false, modelTelemetry: testModelTelemetry },
+		);
+		assert(first);
+		first.wasRenderedAsInlineSuggestion = true;
+
+		const replacement = cache.setKthNextEdit(
+			docId,
+			document,
+			undefined,
+			StringReplacement.insert(document.value.length, 'replacement'),
+			0,
+			undefined,
+			undefined,
+			makeSource(),
+			{ isFromCursorJump: false, modelTelemetry: testModelTelemetry },
+		);
+		const result = cache.lookupNextEdit(docId, document, [OffsetRange.emptyAt(document.value.length)]);
+
+		assert.deepStrictEqual({
+			isReplacementEntry: result === replacement,
+			newText: result?.edit?.newText,
+			wasRenderedAsInlineSuggestion: result?.wasRenderedAsInlineSuggestion,
+		}, {
+			isReplacementEntry: true,
+			newText: 'replacement',
+			wasRenderedAsInlineSuggestion: undefined,
+		});
 	});
 });
 

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
@@ -627,6 +627,46 @@ describe('NextEditProvider speculative requests', () => {
 			await statelessProvider.calls[1].completed.p;
 		});
 
+		it('reused speculative request preserves inline-rendered state on the cached entry', async () => {
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);
+
+			const statelessProvider = new TestStatelessNextEditProvider();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenNoSuggestions', edit: lineReplacement(1, 'const value = 2;') });
+			const specContinue = new DeferredPromise<void>();
+			statelessProvider.enqueueBehavior({ kind: 'yieldEditThenWait', edit: lineReplacement(2, 'console.log(value + 1);'), continueSignal: specContinue });
+			const { nextEditProvider, workspace } = createProviderAndWorkspace(statelessProvider);
+
+			const doc = workspace.addDocument({
+				id: DocumentId.create(URI.file('/test/spec-cache-entry-identity.ts').toString()),
+				initialValue: 'const value = 1;\nconsole.log(value);',
+			});
+			doc.setSelection([new OffsetRange(0, 0)], undefined);
+
+			const firstSuggestion = await getNextEdit(nextEditProvider, doc.id);
+			assert(firstSuggestion.result?.edit);
+			nextEditProvider.handleShown(firstSuggestion);
+			await statelessProvider.waitForCall(2);
+			nextEditProvider.handleAcceptance(doc.id, firstSuggestion);
+			doc.applyEdit(firstSuggestion.result.edit.toEdit());
+
+			const speculativeSuggestion = await getNextEdit(nextEditProvider, doc.id);
+			assert(speculativeSuggestion.result?.cacheEntry);
+			speculativeSuggestion.result.cacheEntry.wasRenderedAsInlineSuggestion = true;
+
+			specContinue.complete();
+			await statelessProvider.calls[1].completed.p;
+
+			const cachedSuggestion = await getNextEdit(nextEditProvider, doc.id);
+			assert(cachedSuggestion.result?.cacheEntry);
+			expect({
+				isSameCacheEntry: cachedSuggestion.result.cacheEntry === speculativeSuggestion.result.cacheEntry,
+				wasRenderedAsInlineSuggestion: cachedSuggestion.result.cacheEntry.wasRenderedAsInlineSuggestion,
+			}).toEqual({
+				isSameCacheEntry: true,
+				wasRenderedAsInlineSuggestion: true,
+			});
+		});
+
 		it('skips cache delay for edits from speculative requests even when enforceCacheDelay is true', async () => {
 			const CACHE_DELAY_MS = 5_000;
 			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, SpeculativeRequestsEnablement.On);


### PR DESCRIPTION
## Summary

- keep speculative NES results linked to their stable cache entry
- preserve the `wasRenderedAsInlineSuggestion` marker across speculative reuse and rebasing
- verify replacement cache entries do not inherit stale presentation state

This closes an adversarial gap in `chat.advanced.inlineEdits.nesMimicGhostTextBehavior`: without the stable reference, a speculative result could be shown as ghost text, write the marker to a transient copy, and later resurface from cache as a more prominent inline-edit view.

Related to microsoft/vscode-internalbacklog#8648.

## Validation

- live Code OSS reproduction with the July 3-in-1 `XtabProvider` configuration
  - flag off: cached ghost text resurfaced as an inline edit
  - flag on: cached non-inline reshow was suppressed
  - returning to the original cursor reused the cache as ghost text
  - fresh non-inline suggestions remained visible
- `npm run compile` in `extensions/copilot`
- `npm run typecheck` in `extensions/copilot`
- targeted Vitest suite: 115 passed, 2 skipped
- hygiene checks passed