### PR TITLE
Fix input box warnings not adjusting on resize

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -117,6 +117,7 @@ export class InputBox extends Widget {
 	private maxHeight: number = Number.POSITIVE_INFINITY;
 	private scrollableElement: ScrollableElement | undefined;
 	private readonly hover: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+	private readonly messageResizeObserver: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 
 	private _onDidChange = this._register(new Emitter<string>());
 	public get onDidChange(): Event<string> { return this._onDidChange.event; }
@@ -527,9 +528,12 @@ export class InputBox extends Widget {
 			},
 			onHide: () => {
 				this.state = 'closed';
+				this.messageResizeObserver.clear();
 			},
 			layout: layout
 		});
+
+		this.observeElementResize();
 
 		// ARIA Support
 		let alertText: string;
@@ -555,7 +559,25 @@ export class InputBox extends Widget {
 			this.contextViewProvider.hideContextView();
 		}
 
+		this.messageResizeObserver.clear();
 		this.state = 'idle';
+	}
+
+	/**
+	 * Keeps the validation message sized and anchored to the input while the
+	 * message is showing and the input itself is resized, e.g. because the
+	 * containing view was resized.
+	 */
+	private observeElementResize(): void {
+		const observer = new dom.DisposableResizeObserver('InputBox.validationMessage', () => {
+			// Ignore notifications for a hidden or detached input, laying out
+			// against a degenerate anchor would move the message to the corner.
+			if (this.element.isConnected && dom.getTotalWidth(this.element) > 0) {
+				this.layoutMessage();
+			}
+		}, dom.getWindow(this.element));
+		observer.observe(this.element);
+		this.messageResizeObserver.value = observer;
 	}
 
 	private layoutMessage(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fix https://github.com/microsoft/vscode/issues/328286