### PR TITLE
Fix session PR association for fork branches

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitStateService.ts
@@ -41,10 +41,11 @@ export interface IAgentHostGitStateService {
 	setSessionGitHubState(sessionKey: string, state: ISessionGitHubState): Promise<void>;
 
 	/**
-	 * Find a GitHub pull request for the given session and save it to the session state.
+	 * Refresh git state, then find and save a GitHub pull request for the current branch.
 	 * @param sessionKey The key of the session for which to check the GitHub pull request.
+	 * @param workingDirectory Optional working directory override; when omitted, the session summary's working directory is used.
 	 */
-	attachSessionGitHubPullRequest(sessionKey: string): Promise<void>;
+	attachSessionGitHubPullRequest(sessionKey: string, workingDirectory?: URI): Promise<void>;
 
 	/**
 	 * Detect GitHub issues referenced in a user message and add them to the

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1146,6 +1146,8 @@ export interface ISessionGitState {
 	readonly uncommittedChanges?: number;
 	/** GitHub repository owner parsed from the working copy's GitHub remote (preferring `origin`, falling back to the first GitHub remote). */
 	readonly githubOwner?: string;
+	/** GitHub owner parsed from the current branch's upstream remote. */
+	readonly githubHeadOwner?: string;
 	/** GitHub repository name parsed from the working copy's GitHub remote (preferring `origin`, falling back to the first GitHub remote). */
 	readonly githubRepo?: string;
 }
@@ -1199,6 +1201,7 @@ export function readSessionGitState(meta: SessionMeta | undefined): ISessionGitS
 		outgoingChanges?: number;
 		uncommittedChanges?: number;
 		githubOwner?: string;
+		githubHeadOwner?: string;
 		githubRepo?: string;
 	} = {};
 	if (typeof raw['hasGitHubRemote'] === 'boolean') { result.hasGitHubRemote = raw['hasGitHubRemote']; }
@@ -1209,6 +1212,7 @@ export function readSessionGitState(meta: SessionMeta | undefined): ISessionGitS
 	if (typeof raw['outgoingChanges'] === 'number') { result.outgoingChanges = raw['outgoingChanges']; }
 	if (typeof raw['uncommittedChanges'] === 'number') { result.uncommittedChanges = raw['uncommittedChanges']; }
 	if (typeof raw['githubOwner'] === 'string') { result.githubOwner = raw['githubOwner']; }
+	if (typeof raw['githubHeadOwner'] === 'string') { result.githubHeadOwner = raw['githubHeadOwner']; }
 	if (typeof raw['githubRepo'] === 'string') { result.githubRepo = raw['githubRepo']; }
 	return result;
 }

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -760,6 +760,8 @@ export class AgentHostGitService implements IAgentHostGitService {
 		const hasGitHubRemote = parseHasGitHubRemote(remotesOutput);
 		const baseBranchName = parseDefaultBranchRef(defaultBranchRef);
 		const githubRepo = parseGitHubRepoFromRemote(remotesOutput);
+		const upstreamRemote = status.upstreamBranchName?.split('/')[0];
+		const githubHeadRepo = upstreamRemote ? parseGitHubRepoFromRemote(remotesOutput, upstreamRemote) : undefined;
 
 		// `git status -b --porcelain=v2` only emits ahead/behind counts when the
 		// branch has an upstream tracking ref. For agent-host worktrees the
@@ -786,6 +788,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 			outgoingChanges,
 			uncommittedChanges: status.uncommittedChanges,
 			githubOwner: githubRepo?.owner,
+			githubHeadOwner: githubHeadRepo?.owner,
 			githubRepo: githubRepo?.repo,
 		};
 		// Strip undefined fields so the resulting object is the same regardless
@@ -1303,15 +1306,13 @@ export function parseFetchRemoteUrls(remotesOutput: string | undefined, preferre
 }
 
 /**
- * Parse `owner` and `repo` from `git remote -v` output. Prefers the `origin`
- * remote; falls back to the first GitHub remote so worktrees that renamed
- * the remote still surface PR state. Returns `undefined` if no GitHub
- * remote is present or the URL doesn't match a GitHub repo shape.
+ * Parse `owner` and `repo` from `git remote -v` output. Prefers the requested
+ * remote, then `origin`, and finally the first GitHub remote.
  *
  * Exported for tests.
  */
-export function parseGitHubRepoFromRemote(remotesOutput: string | undefined): { owner: string; repo: string } | undefined {
-	const candidates = parseFetchRemoteUrls(remotesOutput);
+export function parseGitHubRepoFromRemote(remotesOutput: string | undefined, preferredRemote?: string): { owner: string; repo: string } | undefined {
+	const candidates = parseFetchRemoteUrls(remotesOutput, preferredRemote);
 	if (!candidates) {
 		return undefined;
 	}

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -1286,15 +1286,9 @@ export function parseHasGitHubRemote(remotesOutput: string | undefined): boolean
 
 /** Returns fetch remote URLs with the preferred remote, then `origin`, first. */
 export function parseFetchRemoteUrls(remotesOutput: string | undefined, preferredRemote?: string): string[] | undefined {
-	if (remotesOutput === undefined) {
+	const candidates = parseFetchRemotes(remotesOutput);
+	if (!candidates) {
 		return undefined;
-	}
-	const candidates: { name: string; url: string }[] = [];
-	for (const rawLine of remotesOutput.split(/\r?\n/)) {
-		const match = /^(\S+)\s+(\S+)\s+\(fetch\)$/.exec(rawLine.trim());
-		if (match) {
-			candidates.push({ name: match[1], url: match[2] });
-		}
 	}
 	const preferredNames = new Set([preferredRemote, 'origin'].filter((name): name is string => Boolean(name)));
 	const ordered = [
@@ -1305,14 +1299,30 @@ export function parseFetchRemoteUrls(remotesOutput: string | undefined, preferre
 	return [...new Set(ordered.map(candidate => candidate.url))];
 }
 
+function parseFetchRemotes(remotesOutput: string | undefined): { name: string; url: string }[] | undefined {
+	if (remotesOutput === undefined) {
+		return undefined;
+	}
+	const candidates: { name: string; url: string }[] = [];
+	for (const rawLine of remotesOutput.split(/\r?\n/)) {
+		const match = /^(\S+)\s+(\S+)\s+\(fetch\)$/.exec(rawLine.trim());
+		if (match) {
+			candidates.push({ name: match[1], url: match[2] });
+		}
+	}
+	return candidates;
+}
+
 /**
- * Parse `owner` and `repo` from `git remote -v` output. Prefers the requested
- * remote, then `origin`, and finally the first GitHub remote.
+ * Parse `owner` and `repo` from `git remote -v` output. When `remoteName` is
+ * provided, only that remote is considered. Otherwise, `origin` is preferred.
  *
  * Exported for tests.
  */
-export function parseGitHubRepoFromRemote(remotesOutput: string | undefined, preferredRemote?: string): { owner: string; repo: string } | undefined {
-	const candidates = parseFetchRemoteUrls(remotesOutput, preferredRemote);
+export function parseGitHubRepoFromRemote(remotesOutput: string | undefined, remoteName?: string): { owner: string; repo: string } | undefined {
+	const candidates = remoteName === undefined
+		? parseFetchRemoteUrls(remotesOutput)
+		: parseFetchRemotes(remotesOutput)?.filter(candidate => candidate.name === remoteName).map(candidate => candidate.url);
 	if (!candidates) {
 		return undefined;
 	}

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -44,7 +44,11 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		this._register(toDisposable(() => this._gitStateRefreshCancellationTokenSource.dispose(true)));
 	}
 
-	async attachSessionGitHubPullRequest(sessionKey: string): Promise<void> {
+	async attachSessionGitHubPullRequest(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
+		await this._refreshSessionGitState(sessionKey, workingDirectory, true);
+	}
+
+	private async _attachSessionGitHubPullRequest(sessionKey: string): Promise<void> {
 		const state = this._stateManager.getSessionState(sessionKey);
 		if (!state) {
 			return;
@@ -79,7 +83,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 			const signal = new AbortController().signal;
 			const pr = await this._octoKitService.findPullRequestByHeadBranch(
-				gitHubState.owner, gitHubState.repo, gitState.branchName, authToken, signal);
+				gitHubState.owner, gitHubState.repo, gitState.branchName, authToken, signal, gitState.githubHeadOwner);
 			if (!pr?.url) {
 				return;
 			}
@@ -125,6 +129,10 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 	}
 
 	async refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
+		await this._refreshSessionGitState(sessionKey, workingDirectory, false);
+	}
+
+	private async _refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined, attachPullRequest: boolean): Promise<void> {
 		const sessionState = this._stateManager.getSessionState(sessionKey);
 		if (sessionState?.lifecycle === SessionLifecycle.CreationFailed) {
 			return;
@@ -138,6 +146,9 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		}
 
 		if (!workingDirectory) {
+			if (attachPullRequest) {
+				await this._attachSessionGitHubPullRequest(sessionKey);
+			}
 			return;
 		}
 
@@ -163,6 +174,9 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				}
 
 				this._onDidRefreshSessionGitState.fire(sessionKey);
+				if (attachPullRequest) {
+					await this._attachSessionGitHubPullRequest(sessionKey);
+				}
 
 				// We want to ensure that we refresh the git state at
 				// most every 5 seconds in order to avoid excessive git

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -45,7 +45,8 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 	}
 
 	async attachSessionGitHubPullRequest(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
-		await this._refreshSessionGitState(sessionKey, workingDirectory, true);
+		await this.refreshSessionGitState(sessionKey, workingDirectory);
+		await this._attachSessionGitHubPullRequest(sessionKey);
 	}
 
 	private async _attachSessionGitHubPullRequest(sessionKey: string): Promise<void> {
@@ -129,10 +130,6 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 	}
 
 	async refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
-		await this._refreshSessionGitState(sessionKey, workingDirectory, false);
-	}
-
-	private async _refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined, attachPullRequest: boolean): Promise<void> {
 		const sessionState = this._stateManager.getSessionState(sessionKey);
 		if (sessionState?.lifecycle === SessionLifecycle.CreationFailed) {
 			return;
@@ -146,9 +143,6 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		}
 
 		if (!workingDirectory) {
-			if (attachPullRequest) {
-				await this._attachSessionGitHubPullRequest(sessionKey);
-			}
 			return;
 		}
 
@@ -174,9 +168,6 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				}
 
 				this._onDidRefreshSessionGitState.fire(sessionKey);
-				if (attachPullRequest) {
-					await this._attachSessionGitHubPullRequest(sessionKey);
-				}
 
 				// We want to ensure that we refresh the git state at
 				// most every 5 seconds in order to avoid excessive git

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -176,7 +176,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		}
 		this._throwIfCancelled(token);
 
-		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal);
+		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, gitState?.githubHeadOwner);
 		if (existing) {
 			this._throwIfCancelled(token);
 			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
@@ -206,7 +206,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 			this._throwIfCancelled(token);
 			let foundAfterFailure: CreatedPullRequest | undefined;
 			try {
-				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal);
+				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, gitState?.githubHeadOwner);
 			} catch {
 				this._throwIfCancelled(token);
 				throw err;

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -33,6 +33,17 @@ const MAX_PR_CONVERSATION_CONTEXT_CHARS = 12_000;
  */
 const MAX_PR_CHANGE_SUMMARY_CHARS = 4_000;
 
+function parseUpstreamBranchName(upstreamBranchName: string | undefined): { remote: string; branch: string } | undefined {
+	const separatorIndex = upstreamBranchName?.indexOf('/') ?? -1;
+	if (!upstreamBranchName || separatorIndex <= 0 || separatorIndex === upstreamBranchName.length - 1) {
+		return undefined;
+	}
+	return {
+		remote: upstreamBranchName.substring(0, separatorIndex),
+		branch: upstreamBranchName.substring(separatorIndex + 1),
+	};
+}
+
 export interface PullRequestCreatedEvent {
 	readonly sessionKey: string;
 	readonly pullRequestUrl: string;
@@ -50,7 +61,7 @@ export interface PullRequestCreatedEvent {
  * 1. Resolve session → working directory + current/base branch from
  *    {@link ISessionGitState}.
  * 2. Commit any uncommitted working-tree changes.
- * 3. Push the current branch to `origin` (with `--set-upstream` when missing).
+ * 3. Push the current branch to its GitHub upstream remote (with `--set-upstream` when missing).
  * 4. Resolve `owner` / `repo` from {@link ISessionGitState.githubOwner}
  *    / {@link ISessionGitState.githubRepo} (populated by the git probe).
  * 5. Reuse an existing PR for the branch, or POST `/repos/{owner}/{repo}/pulls`
@@ -118,7 +129,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		}
 
 		const workingDirectory = URI.parse(workingDirectoryStr);
-		const gitState = readSessionGitState(sessionState._meta);
+		const gitState = await this._gitService.getSessionGitState(workingDirectory) ?? readSessionGitState(sessionState._meta);
 		const branchName = gitState?.branchName ?? await this._gitService.getCurrentBranch(workingDirectory);
 		if (!branchName) {
 			throw new ProtocolError(JsonRpcErrorCodes.InternalError, `Could not determine current branch for ${workingDirectory}`);
@@ -165,18 +176,25 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		}
 		this._throwIfCancelled(token);
 
-		this._logService.info(`[AgentHostPullRequestOperationHandler] Pushing branch ${branchName} for session ${sessionUri}`);
+		const githubHeadOwner = gitState?.githubHeadOwner;
+		const upstreamBranch = githubHeadOwner ? parseUpstreamBranchName(gitState.upstreamBranchName) : undefined;
+		const headOwner = upstreamBranch && githubHeadOwner ? githubHeadOwner : gitHubState.owner;
+		const headBranch = upstreamBranch?.branch ?? branchName;
+		const pushRef = headBranch === branchName ? branchName : `${branchName}:${headBranch}`;
+		const createHead = headOwner === gitHubState.owner ? headBranch : `${headOwner}:${headBranch}`;
+
+		this._logService.info(`[AgentHostPullRequestOperationHandler] Pushing branch ${branchName} to ${upstreamBranch?.remote ?? 'origin'} for session ${sessionUri}`);
 		const upstreamPresent = await this._gitService.hasUpstream(workingDirectory, branchName);
 		this._throwIfCancelled(token);
 		try {
-			await this._gitService.push(workingDirectory, { ref: branchName, setUpstream: !upstreamPresent });
+			await this._gitService.push(workingDirectory, { remote: upstreamBranch?.remote, ref: pushRef, setUpstream: !upstreamPresent });
 		} catch (err) {
 			this._throwIfCancelled(token);
 			throw new ProtocolError(JsonRpcErrorCodes.InternalError, `Failed to push branch '${branchName}': ${err instanceof Error ? err.message : String(err)}`);
 		}
 		this._throwIfCancelled(token);
 
-		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, gitState?.githubHeadOwner);
+		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, headBranch, authToken, signal, headOwner);
 		if (existing) {
 			this._throwIfCancelled(token);
 			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
@@ -188,7 +206,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		const title = generated?.title ?? this._formatTitle(branchName);
 		const body = generated?.description ?? this._formatBody(branchName, base);
 
-		this._logService.info(`[AgentHostPullRequestOperationHandler] Creating ${this._draft ? 'draft ' : ''}PR ${gitHubState.owner}/${gitHubState.repo} ${branchName} -> ${base}`);
+		this._logService.info(`[AgentHostPullRequestOperationHandler] Creating ${this._draft ? 'draft ' : ''}PR ${gitHubState.owner}/${gitHubState.repo} ${createHead} -> ${base}`);
 		let created: CreatedPullRequest;
 		try {
 			created = await this._octoKitService.createPullRequest(
@@ -196,7 +214,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 				gitHubState.repo,
 				title,
 				body,
-				branchName,
+				createHead,
 				base,
 				this._draft,
 				authToken,
@@ -206,7 +224,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 			this._throwIfCancelled(token);
 			let foundAfterFailure: CreatedPullRequest | undefined;
 			try {
-				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, authToken, signal, gitState?.githubHeadOwner);
+				foundAfterFailure = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, headBranch, authToken, signal, headOwner);
 			} catch {
 				this._throwIfCancelled(token);
 				throw err;

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -531,13 +531,9 @@ export class AgentService extends Disposable implements IAgentService {
 			},
 			resolveWorkingDirectoryBeforeSend: params => this._resolveWorkingDirectoryBeforeSend(params),
 			resolveChatAttachmentTurns: resource => this._resolveChatAttachmentTurns(resource),
-			onTurnComplete: async session => {
-				// Refresh the git state for the session.
+			onTurnComplete: session => {
 				const workingDirStr = this._stateManager.getSessionState(session)?.workingDirectories?.[0];
-				void this._gitStateService.refreshSessionGitState(session, workingDirStr ? URI.parse(workingDirStr) : undefined);
-
-				// Check for a GitHub pull request associated with the session's branch.
-				void this._gitStateService.attachSessionGitHubPullRequest(session.toString());
+				void this._gitStateService.attachSessionGitHubPullRequest(session, workingDirStr ? URI.parse(workingDirStr) : undefined);
 			},
 			onUserMessage: (session, text) => {
 				// Record the GitHub issues the message references on the session.
@@ -2848,11 +2844,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 		this._logService.info(`[AgentService] Restored session ${sessionStr} with ${turns.length} turns`);
 
-		// Refresh the git state for the session.
-		void this._gitStateService.refreshSessionGitState(sessionStr, meta.workingDirectories?.[0]);
-
-		// Check for a GitHub pull request associated with the session's branch.
-		void this._gitStateService.attachSessionGitHubPullRequest(sessionStr);
+		void this._gitStateService.attachSessionGitHubPullRequest(sessionStr, meta.workingDirectories?.[0]);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -78,8 +78,8 @@ export interface IAgentHostOctoKitService {
 		signal: AbortSignal,
 	): Promise<CreatedPullRequest>;
 
-	/** Finds the most recently updated pull request for `owner:branch`, if any. */
-	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined>;
+	/** Finds the most recently updated pull request for `headOwner:branch`, if any. */
+	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, headOwner?: string): Promise<CreatedPullRequest | undefined>;
 
 	/**
 	 * Enables auto-merge on a pull request so GitHub merges it automatically
@@ -153,8 +153,8 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		return { url: html_url, number, nodeId: typeof node_id === 'string' ? node_id : undefined };
 	}
 
-	async findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined> {
-		const routeSlug = `repos/${owner}/${repo}/pulls?head=${encodeURIComponent(`${owner}:${branch}`)}&state=all&sort=updated&direction=desc&per_page=1`;
+	async findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, headOwner = owner): Promise<CreatedPullRequest | undefined> {
+		const routeSlug = `repos/${owner}/${repo}/pulls?head=${encodeURIComponent(`${headOwner}:${branch}`)}&state=all&sort=updated&direction=desc&per_page=1`;
 
 		const etag = this.pullRequestSearchEtags.get(routeSlug);
 		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, etag);

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -96,6 +96,28 @@ suite('AgentHostGitService - getSessionGitState (real git)', () => {
 		assert.strictEqual(result.incomingChanges, undefined);
 	});
 
+	(hasGit ? test : test.skip)('reports the GitHub owner of the branch upstream remote', async () => {
+		const dir = initRepo({ remote: 'https://github.com/base-owner/repo.git' });
+		cp.execFileSync('git', ['remote', 'add', 'fork', 'https://github.com/fork-owner/repo.git'], { cwd: dir, stdio: 'pipe' });
+		cp.execFileSync('git', ['checkout', '-q', '-b', 'feature'], { cwd: dir, stdio: 'pipe' });
+		cp.execFileSync('git', ['update-ref', 'refs/remotes/fork/feature', 'HEAD'], { cwd: dir, stdio: 'pipe' });
+		cp.execFileSync('git', ['branch', '--set-upstream-to', 'fork/feature'], { cwd: dir, stdio: 'pipe' });
+
+		const result = await svc!.getSessionGitState(URI.file(dir));
+
+		assert.deepStrictEqual({
+			githubOwner: result?.githubOwner,
+			githubHeadOwner: result?.githubHeadOwner,
+			githubRepo: result?.githubRepo,
+			upstreamBranchName: result?.upstreamBranchName,
+		}, {
+			githubOwner: 'base-owner',
+			githubHeadOwner: 'fork-owner',
+			githubRepo: 'repo',
+			upstreamBranchName: 'fork/feature',
+		});
+	});
+
 	(hasGit ? test : test.skip)('resolves the default branch name and remote-tracking start point', async () => {
 		const dir = initRepo();
 		cp.execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'refs/heads/main'], { cwd: dir, stdio: 'pipe' });

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -161,12 +161,20 @@ suite('AgentHostGitService', () => {
 	});
 
 	suite('parseGitHubRepoFromRemote', () => {
-		test('prefers the requested fork remote over origin', () => {
+		test('parses only the requested fork remote', () => {
 			const out = [
-				'origin\tgit@github.com:microsoft/vscode.git (fetch)',
-				'benibenj\thttps://github.com/benibenj/vscode.git (fetch)',
+				'origin\tgit@github.com:base-owner/repo.git (fetch)',
+				'fork\thttps://github.com/fork-owner/repo.git (fetch)',
 			].join('\n');
-			assert.deepStrictEqual(parseGitHubRepoFromRemote(out, 'benibenj'), { owner: 'benibenj', repo: 'vscode' });
+			assert.deepStrictEqual(parseGitHubRepoFromRemote(out, 'fork'), { owner: 'fork-owner', repo: 'repo' });
+		});
+
+		test('does not fall back when the requested remote is not GitHub', () => {
+			const out = [
+				'origin\tgit@github.com:base-owner/repo.git (fetch)',
+				'fork\thttps://gitlab.com/fork-owner/repo.git (fetch)',
+			].join('\n');
+			assert.strictEqual(parseGitHubRepoFromRemote(out, 'fork'), undefined);
 		});
 
 		test('parses ssh (scp-like) origin remote', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -161,6 +161,14 @@ suite('AgentHostGitService', () => {
 	});
 
 	suite('parseGitHubRepoFromRemote', () => {
+		test('prefers the requested fork remote over origin', () => {
+			const out = [
+				'origin\tgit@github.com:microsoft/vscode.git (fetch)',
+				'benibenj\thttps://github.com/benibenj/vscode.git (fetch)',
+			].join('\n');
+			assert.deepStrictEqual(parseGitHubRepoFromRemote(out, 'benibenj'), { owner: 'benibenj', repo: 'vscode' });
+		});
+
 		test('parses ssh (scp-like) origin remote', () => {
 			const out = 'origin\tgit@github.com:microsoft/vscode.git (fetch)\norigin\tgit@github.com:microsoft/vscode.git (push)\n';
 			assert.deepStrictEqual(parseGitHubRepoFromRemote(out), { owner: 'microsoft', repo: 'vscode' });

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -209,7 +209,7 @@ suite('AgentHostGitStateService', () => {
 		});
 	});
 
-	test('refreshes the fork owner before attaching a pull request after a turn', async () => {
+	test('preserves pull request attachment when a later refresh replaces its queued refresh', async () => {
 		await runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const calls: { owner: string; repo: string; branch: string; headOwner: string | undefined }[] = [];
 			const octoKitService = {
@@ -232,19 +232,25 @@ suite('AgentHostGitStateService', () => {
 			h.setGitResult({
 				branchName: 'feature',
 				baseBranchName: 'main',
-				upstreamBranchName: 'benibenj/feature',
+				upstreamBranchName: 'fork/feature',
 				githubOwner: 'microsoft',
-				githubHeadOwner: 'benibenj',
+				githubHeadOwner: 'fork-owner',
 				githubRepo: 'vscode',
 			});
 
-			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+			await Promise.all([
+				h.service.refreshSessionGitState(SESSION, URI.parse(WORKING_DIRECTORY)),
+				h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY)),
+				h.service.refreshSessionGitState(SESSION, URI.parse(WORKING_DIRECTORY)),
+			]);
 
 			assert.deepStrictEqual({
+				gitCalls: h.gitCalls.length,
 				calls,
 				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
 			}, {
-				calls: [{ owner: 'microsoft', repo: 'vscode', branch: 'feature', headOwner: 'benibenj' }],
+				gitCalls: 2,
+				calls: [{ owner: 'microsoft', repo: 'vscode', branch: 'feature', headOwner: 'fork-owner' }],
 				github: {
 					owner: 'microsoft',
 					repo: 'vscode',

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -25,7 +25,7 @@ suite('AgentHostGitStateService', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createHarness() {
+	function createHarness(options?: { octoKitService?: IAgentHostOctoKitService; agentService?: IAgentService }) {
 		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		const db = new TestSessionDatabase();
 		const sessionDataService = createSessionDataService(db);
@@ -49,8 +49,8 @@ suite('AgentHostGitStateService', () => {
 		const service = disposables.add(new AgentHostGitStateService(
 			stateManager,
 			gitService,
-			{} as unknown as IAgentHostOctoKitService,
-			{} as unknown as IAgentService,
+			options?.octoKitService ?? {} as unknown as IAgentHostOctoKitService,
+			options?.agentService ?? {} as unknown as IAgentService,
 			createTestGitHubEndpointService(),
 			new NullLogService(),
 			sessionDataService,
@@ -205,6 +205,51 @@ suite('AgentHostGitStateService', () => {
 			}, {
 				github: { owner: 'microsoft', repo: 'vscode' },
 				persistedGit: JSON.stringify(next),
+			});
+		});
+	});
+
+	test('refreshes the fork owner before attaching a pull request after a turn', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const calls: { owner: string; repo: string; branch: string; headOwner: string | undefined }[] = [];
+			const octoKitService = {
+				findPullRequestByHeadBranch: async (owner: string, repo: string, branch: string, _token: string, _signal: AbortSignal, headOwner?: string) => {
+					calls.push({ owner, repo, branch, headOwner });
+					return { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 };
+				},
+			} as unknown as IAgentHostOctoKitService;
+			const agentService = { getAuthToken: () => 'token' } as unknown as IAgentService;
+			const h = createHarness({ octoKitService, agentService });
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState: {
+					branchName: 'feature',
+					baseBranchName: 'main',
+					githubOwner: 'microsoft',
+					githubRepo: 'vscode',
+				},
+			});
+			h.setGitResult({
+				branchName: 'feature',
+				baseBranchName: 'main',
+				upstreamBranchName: 'benibenj/feature',
+				githubOwner: 'microsoft',
+				githubHeadOwner: 'benibenj',
+				githubRepo: 'vscode',
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				calls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				calls: [{ owner: 'microsoft', repo: 'vscode', branch: 'feature', headOwner: 'benibenj' }],
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1',
+				},
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, type IAgentService } from '../../common/agentService.js';
 import { buildSessionChangesetUri } from '../../common/changesetUri.js';
-import { withSessionGitHubState, withSessionGitState, type ISessionFileDiff, MessageKind, ResponsePartKind, SessionStatus, TurnState, type Turn } from '../../common/state/sessionState.js';
+import { withSessionGitHubState, withSessionGitState, type ISessionFileDiff, type ISessionGitState, MessageKind, ResponsePartKind, SessionStatus, TurnState, type Turn } from '../../common/state/sessionState.js';
 import type { IAgentHostGitService, IBranch, IDefaultBranch, IPushOptions } from '../../common/agentHostGitService.js';
 import { AgentHostPullRequestOperationHandler } from '../../node/agentHostPullRequestOperationHandler.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
@@ -51,8 +51,10 @@ class TestGitService implements IAgentHostGitService {
 	declare readonly _serviceBrand: undefined;
 
 	readonly calls: string[] = [];
+	readonly pushOptions: IPushOptions[] = [];
 	uncommitted = false;
 	upstream = false;
+	gitState: ISessionGitState | undefined;
 	branchChanges: readonly ISessionFileDiff[] | undefined = [{ after: { uri: 'file:///repo/file.ts', content: { uri: 'file:///repo/file.ts' } } }];
 
 	async getCurrentBranch(): Promise<string | undefined> { return 'feature/test'; }
@@ -83,8 +85,9 @@ class TestGitService implements IAgentHostGitService {
 	async pull(): Promise<void> { }
 	async push(_workingDirectory: URI, options: IPushOptions): Promise<void> {
 		this.calls.push(`push:${options.ref}:${options.setUpstream}`);
+		this.pushOptions.push(options);
 	}
-	async getSessionGitState(): Promise<undefined> { return undefined; }
+	async getSessionGitState(): Promise<ISessionGitState | undefined> { return this.gitState; }
 	async computeSessionFileDiffs(): Promise<readonly ISessionFileDiff[] | undefined> {
 		this.calls.push('computeSessionFileDiffs');
 		return this.branchChanges;
@@ -117,18 +120,22 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 	created: CreatedPullRequest = { url: 'https://github.com/microsoft/vscode/pull/123', number: 123, nodeId: 'PR_node_123' };
 	lastTitle: string | undefined;
 	lastBody: string | undefined;
+	lastHead: string | undefined;
+	readonly findRequests: { branch: string; headOwner: string | undefined }[] = [];
 
-	async createPullRequest(_owner: string, _repo: string, title: string, body: string, _head: string, _base: string, draft: boolean, _token: string, _signal: AbortSignal): Promise<CreatedPullRequest> {
+	async createPullRequest(_owner: string, _repo: string, title: string, body: string, head: string, _base: string, draft: boolean, _token: string, _signal: AbortSignal): Promise<CreatedPullRequest> {
 		this.calls.push(`createPullRequest:${draft}`);
 		this.lastTitle = title;
 		this.lastBody = body;
+		this.lastHead = head;
 		if (this.createError) {
 			throw this.createError;
 		}
 		return this.created;
 	}
-	async findPullRequestByHeadBranch(_owner: string, _repo: string, branch: string, _token: string, _signal: AbortSignal): Promise<CreatedPullRequest | undefined> {
+	async findPullRequestByHeadBranch(_owner: string, _repo: string, branch: string, _token: string, _signal: AbortSignal, headOwner?: string): Promise<CreatedPullRequest | undefined> {
 		this.calls.push(`findPullRequestByHeadBranch:${branch}`);
+		this.findRequests.push({ branch, headOwner });
 		if (this.calls.some(call => call.startsWith('createPullRequest:'))) {
 			if (this.findAfterCreateError) {
 				throw this.findAfterCreateError;
@@ -237,6 +244,33 @@ suite('AgentHostPullRequestOperationHandler', () => {
 				'createPullRequest:false',
 			],
 			createdEvents: ['agent:/session:https://github.com/microsoft/vscode/pull/123'],
+		});
+	});
+
+	test('pushes, finds, and creates with the same fork upstream', async () => {
+		const gitService = new TestGitService();
+		gitService.upstream = true;
+		gitService.gitState = {
+			branchName: 'feature/test',
+			baseBranchName: 'main',
+			upstreamBranchName: 'fork/published-feature',
+			githubOwner: 'microsoft',
+			githubHeadOwner: 'fork-owner',
+			githubRepo: 'vscode',
+		};
+		const octoKitService = new TestOctoKitService();
+		const { handler, session } = setup(disposables, gitService, octoKitService);
+
+		await handler.invoke({ channel: buildSessionChangesetUri(session.toString()), operationId: AgentHostPullRequestOperationHandler.OPERATION_CREATE_PR }, CancellationToken.None);
+
+		assert.deepStrictEqual({
+			pushOptions: gitService.pushOptions,
+			findRequests: octoKitService.findRequests,
+			createHead: octoKitService.lastHead,
+		}, {
+			pushOptions: [{ remote: 'fork', ref: 'feature/test:published-feature', setUpstream: false }],
+			findRequests: [{ branch: 'published-feature', headOwner: 'fork-owner' }],
+			createHead: 'fork-owner:published-feature',
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -107,6 +107,15 @@ suite('AgentHostOctoKitService', () => {
 		});
 	});
 
+	test('findPullRequestByHeadBranch qualifies a fork branch with its head owner', async () => {
+		const { fetch, captured } = capturingFetch(jsonResponse([{ html_url: 'https://github.com/o/r/pull/9', number: 9 }]));
+		const service = makeService(fetch);
+
+		await service.findPullRequestByHeadBranch('o', 'r', 'feature/test', 'tok', signal(), 'fork-owner');
+
+		assert.strictEqual(captured().url, 'https://api.github.com/repos/o/r/pulls?head=fork-owner%3Afeature%2Ftest&state=all&sort=updated&direction=desc&per_page=1');
+	});
+
 	test('createPullRequest throws on non-OK response', async () => {
 		const service = makeService(capturingFetch(new Response('{"message":"Validation Failed"}', { status: 422, statusText: 'Unprocessable Entity' })).fetch);
 


### PR DESCRIPTION
## Summary
- track the GitHub owner of the current branch's upstream remote
- refresh session git state before looking up a PR and query GitHub with the fork-qualified head branch
- add unit and real-git regression coverage for fork-based pull requests

## Testing
- affected Agent Host unit suites: 28 passed
- focused `agentHostGitService.integrationTest.ts`: 1 passed
- `npm run precommit`
- `npm run typecheck-client` (blocked by the pre-existing `copilotSystemNotification.ts` `unclassified` TS2678 error)