### PR TITLE
Add Markdown diff editing to the Agents window

### DIFF
--- a/extensions/markdown-language-features/src/preview/lineDiff.ts
+++ b/extensions/markdown-language-features/src/preview/lineDiff.ts
@@ -9,6 +9,7 @@ import type { MarkdownPreviewChangeIndicator, MarkdownPreviewInnerChange, Markdo
 interface LineChanges {
 	readonly added: readonly number[];
 	readonly deleted: readonly number[];
+	readonly changedLineRanges: readonly ChangedLineRange[];
 	readonly originalToModified: readonly number[];
 	readonly modifiedToOriginal: readonly number[];
 	readonly originalInnerChanges: readonly MarkdownPreviewInnerChange[];
@@ -21,7 +22,7 @@ interface LineMappings {
 	readonly modifiedToOriginal: number[];
 }
 
-type ChangedLineRange = Pick<vscode.TextDiffChange, 'originalRange' | 'modifiedRange'>;
+export type ChangedLineRange = Pick<vscode.TextDiffChange, 'originalRange' | 'modifiedRange'>;
 
 export class MarkdownPreviewLineDiffProvider {
 
@@ -53,6 +54,10 @@ export class MarkdownPreviewLineDiffProvider {
 		const innerChanges = changes.modifiedInnerChanges;
 		const changeIndicators = options?.includeChangeIndicators === false ? [] : changes.changeIndicators;
 		return added.length || innerChanges.length || changeIndicators.length ? { added, innerChanges, changeIndicators } : undefined;
+	}
+
+	public async getChangedLineRanges(): Promise<readonly ChangedLineRange[]> {
+		return (await this.#getLineChanges()).changedLineRanges;
 	}
 
 	public async translateOriginalLineToModified(line: number): Promise<number> {
@@ -143,7 +148,7 @@ async function computeLineChanges(originalDocument: vscode.TextDocument, modifie
 	const splitChangedLineRanges = splitChangedLineRangesByMarkdownBlocks(changedLineRanges, originalDocument, modifiedDocument);
 	const changeIndicators = createChangeIndicators(splitChangedLineRanges, originalDocument, modifiedDocument, originalInnerChanges, modifiedInnerChanges);
 
-	return { added, deleted, originalInnerChanges, modifiedInnerChanges, changeIndicators, ...mappings };
+	return { added, deleted, changedLineRanges, originalInnerChanges, modifiedInnerChanges, changeIndicators, ...mappings };
 }
 
 function createChangeIndicators(ranges: readonly ChangedLineRange[], originalDocument: vscode.TextDocument, modifiedDocument: vscode.TextDocument, originalInnerChanges: readonly MarkdownPreviewInnerChange[], modifiedInnerChanges: readonly MarkdownPreviewInnerChange[]): MarkdownPreviewChangeIndicator[] {

--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { Disposable } from '../util/dispose';
 import { MdLinkOpener } from '../util/openDocumentLink';
 import { getMarkdownLocalResourceRoots } from '../util/resources';
+import { ChangedLineRange, MarkdownPreviewLineDiffProvider } from './lineDiff';
 
 /**
  * Experimental hybrid (WYSIWYG) Markdown editor backed by the
@@ -43,6 +44,18 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		webviewPanel: vscode.WebviewPanel,
 		token: vscode.CancellationToken,
 	): Promise<void> {
+		await this.#resolveEditor(document, webviewPanel, token);
+	}
+
+	public async resolveCustomTextEditorInlineDiff(
+		documents: vscode.CustomEditorDiffDocuments<vscode.TextDocument>,
+		webviewPanel: vscode.WebviewPanel,
+		token: vscode.CancellationToken,
+	): Promise<void> {
+		await this.#resolveEditor(documents.modified, webviewPanel, token, documents.original);
+	}
+
+	async #resolveEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken, originalDocument?: vscode.TextDocument): Promise<void> {
 		if (!vscode.workspace.isTrusted) {
 			const cancel = { title: vscode.l10n.t("Cancel"), isCloseAffordance: true };
 			const openAnyway = { title: vscode.l10n.t("Open Anyway") };
@@ -61,9 +74,12 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			}
 		}
 
+		if (token.isCancellationRequested) {
+			return;
+		}
 		const webview = webviewPanel.webview;
 		this.#configureWebview(document.uri, webview);
-		this.#wireSingle(document, webviewPanel);
+		this.#wireSingle(document, webviewPanel, originalDocument);
 	}
 
 	#configureWebview(documentUri: vscode.Uri, webview: vscode.Webview): void {
@@ -76,7 +92,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		webview.html = this.#getHtml(documentUri, webview);
 	}
 
-	#wireSingle(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): void {
+	#wireSingle(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, originalDocument?: vscode.TextDocument): void {
 		const webview = webviewPanel.webview;
 		let isUpdatingFromWebview = false;
 		let editQueue = Promise.resolve();
@@ -143,7 +159,9 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		});
 
 		const highlight = this.#wireHighlight(webview);
-		const quickDiff = this.#wireQuickDiff(document, webview);
+		const quickDiff = originalDocument
+			? this.#wireDocumentDiff(originalDocument, document, webview)
+			: this.#wireQuickDiff(document, webview);
 		const comments = this.#wireComments(document, webview);
 		const onDidGrantWorkspaceTrust = vscode.workspace.onDidGrantWorkspaceTrust(() => {
 			this.#configureWebview(document.uri, webview);
@@ -196,6 +214,32 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		});
 
 		return vscode.Disposable.from(diffProvider, onChange, onMessage, onDocumentChange);
+	}
+
+	#wireDocumentDiff(originalDocument: vscode.TextDocument, modifiedDocument: vscode.TextDocument, webview: vscode.Webview): vscode.Disposable {
+		const lineDiffProvider = new MarkdownPreviewLineDiffProvider(originalDocument, modifiedDocument);
+		const postMarkers = async () => {
+			const originalVersion = originalDocument.version;
+			const modifiedVersion = modifiedDocument.version;
+			const changes = await lineDiffProvider.getChangedLineRanges();
+			if (originalVersion !== originalDocument.version || modifiedVersion !== modifiedDocument.version) {
+				return;
+			}
+			webview.postMessage({ type: 'gutterMarkers', markers: lineRangesToGutterMarkers(modifiedDocument, changes) });
+		};
+
+		const onMessage = webview.onDidReceiveMessage(message => {
+			if (message.type === 'ready') {
+				void postMarkers();
+			}
+		});
+		const onDocumentChange = vscode.workspace.onDidChangeTextDocument(event => {
+			if (event.document.uri.toString() === originalDocument.uri.toString() || event.document.uri.toString() === modifiedDocument.uri.toString()) {
+				void postMarkers();
+			}
+		});
+
+		return vscode.Disposable.from(onMessage, onDocumentChange);
 	}
 
 	/**
@@ -350,4 +394,21 @@ function toGutterMarkers(document: vscode.TextDocument, changes: readonly vscode
 		});
 	}
 	return markers;
+}
+
+export function lineRangesToGutterMarkers(document: vscode.TextDocument, changes: readonly ChangedLineRange[]): GutterMarkerMessage[] {
+	return changes.map(change => {
+		if (change.modifiedRange.isEmpty) {
+			const offset = document.offsetAt(change.modifiedRange.start);
+			return { start: offset, endExclusive: offset, type: 'deleted' };
+		}
+
+		const start = document.offsetAt(change.modifiedRange.start);
+		const endExclusive = document.offsetAt(document.lineAt(change.modifiedRange.end.line - 1).range.end);
+		return {
+			start,
+			endExclusive,
+			type: change.originalRange.isEmpty ? 'added' : 'modified',
+		};
+	});
 }

--- a/extensions/markdown-language-features/src/test/markdownEditorProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/markdownEditorProvider.test.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import 'mocha';
+import * as vscode from 'vscode';
+import { lineRangesToGutterMarkers } from '../preview/markdownEditorProvider';
+
+suite('Markdown editor diff', () => {
+	test('maps modified-side line changes to quick diff gutter markers', async () => {
+		const document = await vscode.workspace.openTextDocument({ language: 'markdown', content: 'one\ntwo changed\nthree added\nfour\n' });
+		const changes = [
+			{ originalRange: new vscode.Range(1, 0, 2, 0), modifiedRange: new vscode.Range(1, 0, 2, 0) },
+			{ originalRange: new vscode.Range(2, 0, 2, 0), modifiedRange: new vscode.Range(2, 0, 3, 0) },
+			{ originalRange: new vscode.Range(3, 0, 4, 0), modifiedRange: new vscode.Range(3, 0, 3, 0) },
+		];
+
+		assert.deepStrictEqual(lineRangesToGutterMarkers(document, changes), [
+			{ start: 4, endExclusive: 15, type: 'modified' },
+			{ start: 16, endExclusive: 27, type: 'added' },
+			{ start: 28, endExclusive: 28, type: 'deleted' },
+		]);
+	});
+});

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -127,7 +127,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			description: localize('enabled', "Enable/disable navigation breadcrumbs."),
 			type: 'boolean',
 			default: true,
-			agentsWindow: { default: false },
+			agentsWindow: { default: true },
 		},
 		'breadcrumbs.filePath': {
 			description: localize('filepath', "Controls whether and how file paths are shown in the breadcrumbs view."),
@@ -172,6 +172,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			markdownDescription: localize('showEditorType', "Controls whether the breadcrumbs bar shows a dropdown to switch between the editors that can open the current file (for example the text editor and a custom editor). The dropdown only appears when a more specialized editor is available."),
 			type: 'boolean',
 			default: false,
+			agentsWindow: { default: true },
 			tags: ['experimental']
 		},
 		'breadcrumbs.symbolPathSeparator': {

--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -9,7 +9,7 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationNode, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
-import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, markdownDefaultEditorAgentsWindowSettingId, RegisteredEditorInfo, RegisteredEditorPriority, toRegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
+import { diffEditorsAssociationsAgentsWindowDefault, diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, markdownDefaultEditorAgentsWindowSettingId, RegisteredEditorInfo, RegisteredEditorPriority, toRegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
 import { IJSONSchemaMap } from '../../../../base/common/jsonSchema.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { coalesce } from '../../../../base/common/arrays.js';
@@ -192,6 +192,9 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 							type: 'string',
 							enum: binaryEditorCandidates,
 						}
+					},
+					agentsWindow: {
+						default: diffEditorsAssociationsAgentsWindowDefault({ markdownDefaultEditor: markdownDefaultEditorEnabled })
 					}
 				}
 			}

--- a/src/vs/workbench/browser/parts/editor/editorTypePicker.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTypePicker.ts
@@ -8,7 +8,7 @@ import { extUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { DEFAULT_EDITOR_ASSOCIATION, EditorResourceAccessor, SideBySideEditor, isDiffEditorInput } from '../../../common/editor.js';
+import { DEFAULT_EDITOR_ASSOCIATION, EditorResourceAccessor, SideBySideEditor, isDiffEditorInput, isEditorInputWithDiffResources } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority, priorityToRank } from '../../../services/editor/common/editorResolverService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -33,7 +33,12 @@ export interface IAvailableEditorTypes {
  * exclusive editor (e.g. the hex editor, for which `getEditors` returns an empty list).
  */
 export function getAvailableEditorTypes(activeEditor: EditorInput | null | undefined, editorResolverService: IEditorResolverService): IAvailableEditorTypes | undefined {
-	const resource = EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+	const standardDiffResources = isDiffEditorInput(activeEditor) ? {
+		original: activeEditor.original.resource,
+		modified: activeEditor.modified.resource,
+	} : undefined;
+	const diffResources = standardDiffResources ?? (isEditorInputWithDiffResources(activeEditor) ? activeEditor.diffResources : undefined);
+	const resource = diffResources?.modified ?? EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
 	if (!resource) {
 		return undefined;
 	}
@@ -41,12 +46,11 @@ export function getAvailableEditorTypes(activeEditor: EditorInput | null | undef
 	if (editors.length <= 1) {
 		return undefined;
 	}
-	const isDiffEditor = isDiffEditorInput(activeEditor);
 	return {
 		resource,
-		isDiffEditor,
-		originalResource: isDiffEditor ? activeEditor.original.resource : undefined,
-		modifiedResource: isDiffEditor ? activeEditor.modified.resource : undefined,
+		isDiffEditor: !!diffResources,
+		originalResource: diffResources?.original,
+		modifiedResource: diffResources?.modified,
 		currentId: activeEditor?.editorId ?? DEFAULT_EDITOR_ASSOCIATION.id,
 		editors
 	};

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -966,6 +966,19 @@ export function isDiffEditorInput(editor: unknown): editor is IDiffEditorInput {
 	return isEditorInput(candidate?.modified) && isEditorInput(candidate?.original);
 }
 
+export interface IEditorInputWithDiffResources extends EditorInput {
+	readonly diffResources: {
+		readonly original: URI;
+		readonly modified: URI;
+	};
+}
+
+export function isEditorInputWithDiffResources(editor: unknown): editor is IEditorInputWithDiffResources {
+	const candidate = editor as IEditorInputWithDiffResources | undefined;
+
+	return URI.isUri(candidate?.diffResources?.original) && URI.isUri(candidate.diffResources.modified);
+}
+
 export interface IUntypedFileEditorInput extends ITextResourceEditorInput {
 
 	/**

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorDiffInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorDiffInput.ts
@@ -12,7 +12,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IUndoRedoService } from '../../../../platform/undoRedo/common/undoRedo.js';
-import { EditorInputCapabilities, GroupIdentifier, IResourceDiffEditorInput, IRevertOptions, ISaveOptions, IUntypedEditorInput, isEditorInput, isResourceEditorInput, isResourceDiffEditorInput, Verbosity } from '../../../common/editor.js';
+import { EditorInputCapabilities, GroupIdentifier, IEditorInputWithDiffResources, IResourceDiffEditorInput, IRevertOptions, ISaveOptions, IUntypedEditorInput, isEditorInput, isResourceEditorInput, isResourceDiffEditorInput, Verbosity } from '../../../common/editor.js';
 import { EditorInput, IUntypedEditorOptions } from '../../../common/editor/editorInput.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { IFilesConfigurationService } from '../../../services/filesConfiguration/common/filesConfigurationService.js';
@@ -41,7 +41,7 @@ function getCustomEditorSideBySideDiffInputResource(init: CustomEditorSideBySide
 	return init.side === 'original' ? init.originalResource : init.modifiedResource;
 }
 
-export class CustomEditorDiffInput extends LazilyResolvedWebviewEditorInput {
+export class CustomEditorDiffInput extends LazilyResolvedWebviewEditorInput implements IEditorInputWithDiffResources {
 
 	private readonly _modelRef = this._register(new MutableDisposable<IReference<ICustomEditorModel>>());
 
@@ -111,6 +111,13 @@ export class CustomEditorDiffInput extends LazilyResolvedWebviewEditorInput {
 
 	get modifiedResource(): URI {
 		return this.init.modifiedResource;
+	}
+
+	get diffResources(): IEditorInputWithDiffResources['diffResources'] {
+		return {
+			original: this.originalResource,
+			modified: this.modifiedResource,
+		};
 	}
 
 	override getName(): string {

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -59,6 +59,10 @@ export function editorsAssociationsAgentsWindowDefault(options?: { markdownDefau
 	};
 }
 
+export function diffEditorsAssociationsAgentsWindowDefault(options?: { markdownDefaultEditor?: boolean }): Record<string, string> {
+	return editorsAssociationsAgentsWindowDefault(options);
+}
+
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
 const editorAssociationsConfigurationNode: IConfigurationNode = {
@@ -86,6 +90,9 @@ const editorAssociationsConfigurationNode: IConfigurationNode = {
 			markdownDescription: localize('editor.diffEditorAssociations', "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for diff views (for example `\"*.md\": \"vscode.markdown.preview.editor\"`). These override `workbench.editorAssociations` for diffs."),
 			additionalProperties: {
 				type: 'string'
+			},
+			agentsWindow: {
+				default: diffEditorsAssociationsAgentsWindowDefault()
 			}
 		}
 	}

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -12,11 +12,21 @@ import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { EditorResolverService } from '../../browser/editorResolverService.js';
 import { IEditorGroupsService } from '../../common/editorGroupsService.js';
-import { IEditorResolverService, ResolvedStatus, RegisteredEditorPriority, diffEditorsAssociationsSettingId, editorsAssociationsSettingId } from '../../common/editorResolverService.js';
+import { diffEditorsAssociationsAgentsWindowDefault, IEditorResolverService, ResolvedStatus, RegisteredEditorPriority, diffEditorsAssociationsSettingId, editorsAssociationsSettingId } from '../../common/editorResolverService.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { createEditorPart, ITestInstantiationService, TestFileEditorInput, TestServiceAccessor, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('EditorResolverService', () => {
+	test('Agents window diff editor default follows the Markdown editor setting', () => {
+		assert.deepStrictEqual({
+			enabled: diffEditorsAssociationsAgentsWindowDefault({ markdownDefaultEditor: true }),
+			disabled: diffEditorsAssociationsAgentsWindowDefault({ markdownDefaultEditor: false }),
+		}, {
+			enabled: { '*.md': 'vscode.markdown.editor' },
+			disabled: { '*.md': 'vscode.markdown.preview.editor' },
+		});
+	});
+
 
 	const TEST_EDITOR_INPUT_ID = 'testEditorInputForEditorResolverService';
 	const disposables = new DisposableStore();

--- a/src/vs/workbench/test/browser/parts/editor/editorTypePicker.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorTypePicker.test.ts
@@ -4,15 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { DEFAULT_EDITOR_ASSOCIATION } from '../../../../common/editor.js';
-import { IAvailableEditorTypes, hasDefaultEditorAssociation } from '../../../../browser/parts/editor/editorTypePicker.js';
-import { RegisteredEditorInfo, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
+import { DEFAULT_EDITOR_ASSOCIATION, IEditorInputWithDiffResources } from '../../../../common/editor.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { getAvailableEditorTypes, IAvailableEditorTypes, hasDefaultEditorAssociation } from '../../../../browser/parts/editor/editorTypePicker.js';
+import { IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
 
 suite('Editor Type Picker', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	function editor(id: string, editorPriority: RegisteredEditorPriority, diffPriority = editorPriority): RegisteredEditorInfo {
 		return {
@@ -60,6 +62,45 @@ suite('Editor Type Picker', () => {
 			defaultEditorOverriddenWithText: true,
 			builtinEditor: true,
 			diffDefaultEditor: true,
+		});
+	});
+
+	test('inline custom diff editor is classified as a diff editor', () => {
+		const original = URI.file('/original/test.md');
+		const modified = URI.file('/modified/test.md');
+		const registeredEditors = [
+			editor(DEFAULT_EDITOR_ASSOCIATION.id, RegisteredEditorPriority.builtin),
+			editor('test.markdownEditor', RegisteredEditorPriority.option, RegisteredEditorPriority.never),
+		];
+		const input = disposables.add(new class extends EditorInput implements IEditorInputWithDiffResources {
+			override get typeId(): string { return 'test.inlineCustomDiffEditor'; }
+			override get editorId(): string { return 'test.markdownEditor'; }
+			override get resource(): URI { return modified; }
+			get diffResources(): IEditorInputWithDiffResources['diffResources'] { return { original, modified }; }
+			override getName(): string { return 'test'; }
+		}());
+		const requestedResources: URI[] = [];
+		const editorResolverService = new class extends mock<IEditorResolverService>() {
+			override getEditors(resource?: URI): RegisteredEditorInfo[] {
+				if (resource) {
+					requestedResources.push(resource);
+				}
+				return registeredEditors;
+			}
+		};
+
+		const result = getAvailableEditorTypes(input, editorResolverService);
+
+		assert.deepStrictEqual({ requestedResources, result }, {
+			requestedResources: [modified],
+			result: {
+				resource: modified,
+				isDiffEditor: true,
+				originalResource: original,
+				modifiedResource: modified,
+				currentId: 'test.markdownEditor',
+				editors: registeredEditors,
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- enable breadcrumbs and the editor type picker by default in the Agents window
- apply the Agents Markdown editor preference to both regular and diff editor associations
- render Markdown diffs in the normal Markdown editor with quick-diff gutter markers, without rendering the original document
- classify inline custom editor diffs correctly in the editor type picker

## Testing

- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused editor resolver and editor type picker unit tests
- `\.\scripts\test-integration.bat --suite markdown`
- file-scoped hygiene checks