### PR TITLE
Agent host: track pull requests per branch

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1169,10 +1169,34 @@ export interface ISessionGitHubState {
 	/** The URL of the GitHub pull request. */
 	readonly pullRequestUrl?: string;
 	/**
+<<<<<<< HEAD
 	 * URLs of the GitHub issues referenced by the session's user messages, in
 	 * order of first appearance.
 	 */
 	readonly issueUrls?: readonly string[];
+	/**
+	 * The name of the branch {@link pullRequestUrl} was found (or created) for.
+	 * A pull request always relates to a branch: when the working copy switches
+	 * to a different branch the host keeps reporting the known pull request but
+	 * resumes looking for one that belongs to the newly checked out branch.
+	 */
+	readonly pullRequestBranchName?: string;
+}
+
+/**
+ * Whether the known pull request of `gitHubState` belongs to `branchName`.
+ *
+ * State persisted before pull requests were tracked per branch has no
+ * {@link ISessionGitHubState.pullRequestBranchName}; such a pull request is
+ * optimistically treated as belonging to the given branch so existing sessions
+ * keep their pull request affordances until the host has verified which branch
+ * it actually belongs to.
+ */
+export function hasSessionPullRequestForBranch(gitHubState: ISessionGitHubState | undefined, branchName: string | undefined): boolean {
+	if (!gitHubState?.pullRequestUrl) {
+		return false;
+	}
+	return gitHubState.pullRequestBranchName === undefined || gitHubState.pullRequestBranchName === branchName;
 }
 
 /**
@@ -1254,12 +1278,14 @@ export function readSessionGitHubState(meta: SessionSummaryMeta | undefined): IS
 		repo?: string;
 		pullRequestUrl?: string;
 		issueUrls?: readonly string[];
+		pullRequestBranchName?: string;
 	} = {};
 
 	if (typeof raw['owner'] === 'string') { result.owner = raw['owner']; }
 	if (typeof raw['repo'] === 'string') { result.repo = raw['repo']; }
 	if (typeof raw['pullRequestUrl'] === 'string') { result.pullRequestUrl = raw['pullRequestUrl']; }
 	if (Array.isArray(raw['issueUrls'])) { result.issueUrls = raw['issueUrls'].filter((url): url is string => typeof url === 'string'); }
+	if (typeof raw['pullRequestBranchName'] === 'string') { result.pullRequestBranchName = raw['pullRequestBranchName']; }
 	return result;
 }
 

--- a/src/vs/platform/agentHost/node/agentHostCommitOperationProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostCommitOperationProvider.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore, IDisposable } from '../../../base/common/l
 import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import type { IChangesetOperationContribution, IChangesetOperationContext, IChangesetOperationRegistry } from '../common/agentHostChangesetOperationService.js';
-import { ChangesetOperationScope, ChangesetOperationStatus, type ChangesetOperation } from '../common/state/sessionState.js';
+import { ChangesetOperationScope, ChangesetOperationStatus, hasSessionPullRequestForBranch, type ChangesetOperation } from '../common/state/sessionState.js';
 import { AgentHostCommitOperationHandler } from './agentHostCommitOperationHandler.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 
@@ -37,7 +37,7 @@ export class AgentHostCommitOperationContribution extends Disposable implements 
 			return [];
 		}
 
-		if (!gitHubState?.pullRequestUrl && changesetKind !== 'uncommitted') {
+		if (!hasSessionPullRequestForBranch(gitHubState, gitState?.branchName) && changesetKind !== 'uncommitted') {
 			return [];
 		}
 

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -203,16 +203,17 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 								owner: gitState.githubOwner,
 								repo: gitState.githubRepo
 							} satisfies ISessionGitHubState);
-						}
 
-						// The working copy switched to a different branch: look
-						// for a pull request that belongs to the new branch. The
-						// previously known pull request keeps being reported
-						// until a new one is found. Awaited so the refresh event
-						// below carries the pull request of the new branch
-						// rather than stale GitHub state.
-						if (previousGitState?.branchName !== gitState.branchName) {
-							await this._queuePullRequestLookup(sessionKey);
+							// The working copy switched to a different branch:
+							// look for a pull request that belongs to the new
+							// branch. The previously known pull request keeps
+							// being reported until a new one is found. Awaited
+							// so the refresh event below carries the pull
+							// request of the new branch rather than stale
+							// GitHub state.
+							if (previousGitState?.branchName !== gitState.branchName) {
+								await this._queuePullRequestLookup(sessionKey);
+							}
 						}
 					}
 				}

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -18,7 +18,7 @@ import { IAgentService } from '../common/agentService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
-import { ThrottlerByKey, timeout } from '../../../base/common/async.js';
+import { ThrottlerByKey, SequencerByKey, timeout } from '../../../base/common/async.js';
 import { isCancellationError } from '../../../base/common/errors.js';
 
 export class AgentHostGitStateService extends Disposable implements IAgentHostGitStateService {
@@ -29,6 +29,14 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 	private readonly _gitStateRefreshThrottler = this._register(new ThrottlerByKey<string>());
 	private readonly _gitStateRefreshCancellationTokenSource = new CancellationTokenSource();
+
+	/**
+	 * Serializes pull request lookups per session so overlapping triggers (turn
+	 * completion, session restore, a refresh observing a branch change) issue at
+	 * most one GitHub request at a time and observe each other's writes.
+	 */
+	private readonly _pullRequestSequencer = new SequencerByKey<string>();
+	private readonly _pullRequestAbortController = new AbortController();
 
 	constructor(
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
@@ -42,11 +50,21 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		super();
 
 		this._register(toDisposable(() => this._gitStateRefreshCancellationTokenSource.dispose(true)));
+		this._register(toDisposable(() => this._pullRequestAbortController.abort()));
 	}
 
 	async attachSessionGitHubPullRequest(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {
 		await this.refreshSessionGitState(sessionKey, workingDirectory);
-		await this._attachSessionGitHubPullRequest(sessionKey);
+		await this._queuePullRequestLookup(sessionKey);
+	}
+
+	/**
+	 * Queues a pull request lookup on the session's sequencer so overlapping
+	 * triggers (turn completion, session restore, a refresh observing a branch
+	 * change) issue at most one GitHub request at a time.
+	 */
+	private _queuePullRequestLookup(sessionKey: string): Promise<void> {
+		return this._pullRequestSequencer.queue(sessionKey, () => this._attachSessionGitHubPullRequest(sessionKey));
 	}
 
 	private async _attachSessionGitHubPullRequest(sessionKey: string): Promise<void> {
@@ -62,13 +80,23 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 
 		// GitHub state
 		const gitHubState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
-		if (!gitHubState?.owner || !gitHubState?.repo || gitHubState?.pullRequestUrl) {
+		if (!gitHubState?.owner || !gitHubState?.repo) {
 			return;
 		}
 
 		// Git state
 		const gitState = readSessionGitState(state._meta);
-		if (!gitState?.branchName || (gitState.branchName === gitState.baseBranchName)) {
+		const branchName = gitState?.branchName;
+		if (!branchName || (branchName === gitState?.baseBranchName)) {
+			return;
+		}
+
+		// A pull request is always tied to a branch: only stop looking once we
+		// know a pull request for the branch that is currently checked out.
+		// State persisted before pull requests were tracked per branch records
+		// no branch, so its pull request is verified against the current branch
+		// rather than assumed to belong to it.
+		if (gitHubState.pullRequestBranchName === branchName) {
 			return;
 		}
 
@@ -82,17 +110,28 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				return;
 			}
 
-			const signal = new AbortController().signal;
 			const pr = await this._octoKitService.findPullRequestByHeadBranch(
-				gitHubState.owner, gitHubState.repo, gitState.branchName, authToken, signal, gitState.githubHeadOwner);
+				gitHubState.owner, gitHubState.repo, branchName, authToken, this._pullRequestAbortController.signal, gitState?.githubHeadOwner);
 			if (!pr?.url) {
+				// No pull request for this branch (yet). The previously known
+				// pull request, if any, keeps being reported and the lookup is
+				// retried on the next refresh.
 				return;
 			}
 
-			this.setSessionGitHubState(sessionKey, {
+			// The working copy may have moved to another branch while the
+			// request was in flight; discard the now stale result so it cannot
+			// overwrite the pull request of the branch that is checked out now.
+			const currentBranchName = readSessionGitState(this._stateManager.getSessionState(sessionKey)?._meta)?.branchName;
+			if (currentBranchName !== branchName) {
+				return;
+			}
+
+			await this.setSessionGitHubState(sessionKey, {
 				owner: gitHubState.owner,
 				repo: gitHubState.repo,
-				pullRequestUrl: pr.url
+				pullRequestUrl: pr.url,
+				pullRequestBranchName: branchName
 			} satisfies ISessionGitHubState);
 		} catch (error) {
 			this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Failed to find pull request for ${sessionKey}`, error);
@@ -153,7 +192,8 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				const gitState = await this._gitService.getSessionGitState(workingDirectory);
 				if (gitState) {
 					const currentMeta = this._stateManager.getSessionState(sessionKey)?._meta;
-					if (!objectEquals(readSessionGitState(currentMeta), gitState)) {
+					const previousGitState = readSessionGitState(currentMeta);
+					if (!objectEquals(previousGitState, gitState)) {
 						// Update the session's git state
 						await this._setSessionGitState(sessionKey, gitState);
 
@@ -163,6 +203,16 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 								owner: gitState.githubOwner,
 								repo: gitState.githubRepo
 							} satisfies ISessionGitHubState);
+						}
+
+						// The working copy switched to a different branch: look
+						// for a pull request that belongs to the new branch. The
+						// previously known pull request keeps being reported
+						// until a new one is found. Awaited so the refresh event
+						// below carries the pull request of the new branch
+						// rather than stale GitHub state.
+						if (previousGitState?.branchName !== gitState.branchName) {
+							await this._queuePullRequestLookup(sessionKey);
 						}
 					}
 				}

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -47,6 +47,8 @@ function parseUpstreamBranchName(upstreamBranchName: string | undefined): { remo
 export interface PullRequestCreatedEvent {
 	readonly sessionKey: string;
 	readonly pullRequestUrl: string;
+	/** The head branch the pull request was created (or found) for. */
+	readonly branchName: string;
 }
 
 /**
@@ -197,7 +199,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		const existing = await this._octoKitService.findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, headBranch, authToken, signal, headOwner);
 		if (existing) {
 			this._throwIfCancelled(token);
-			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+			return await this._finalize(existing, true, sessionUri, gitHubState.owner, gitHubState.repo, branchName, authToken, signal, token);
 		}
 		this._throwIfCancelled(token);
 
@@ -231,12 +233,12 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 			}
 			if (foundAfterFailure) {
 				this._throwIfCancelled(token);
-				return await this._finalize(foundAfterFailure, true, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+				return await this._finalize(foundAfterFailure, true, sessionUri, gitHubState.owner, gitHubState.repo, branchName, authToken, signal, token);
 			}
 			throw err;
 		}
 		this._throwIfCancelled(token);
-		return await this._finalize(created, false, sessionUri, gitHubState.owner, gitHubState.repo, authToken, signal, token);
+		return await this._finalize(created, false, sessionUri, gitHubState.owner, gitHubState.repo, branchName, authToken, signal, token);
 	}
 
 	/**
@@ -251,13 +253,14 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		sessionUri: string,
 		owner: string,
 		repo: string,
+		branchName: string,
 		authToken: string,
 		signal: AbortSignal,
 		token: CancellationToken,
 	): Promise<InvokeChangesetOperationResult> {
 		if (!this._autoMergeMethod) {
 			// No auto-merge configured
-			this._onPullRequestCreated({ sessionKey: sessionUri, pullRequestUrl: pr.url });
+			this._onPullRequestCreated({ sessionKey: sessionUri, pullRequestUrl: pr.url, branchName });
 			return this._createResult(pr, this._buildMessage(pr, isExisting, 'none', undefined));
 		}
 
@@ -280,7 +283,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 			this._logService.warn(`[AgentHostPullRequestOperationHandler] Cannot enable auto-merge for ${owner}/${repo}#${pr.number}: missing pull request node id`);
 		}
 
-		this._onPullRequestCreated({ sessionKey: sessionUri, pullRequestUrl: pr.url });
+		this._onPullRequestCreated({ sessionKey: sessionUri, pullRequestUrl: pr.url, branchName });
 		return this._createResult(pr, this._buildMessage(pr, isExisting, autoMergeOutcome, autoMergeError));
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationProvider.ts
@@ -8,7 +8,7 @@ import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import type { IChangesetOperationContribution, IChangesetOperationContext, IChangesetOperationRegistry } from '../common/agentHostChangesetOperationService.js';
 import { IAgentHostGitStateService } from '../common/agentHostGitStateService.js';
-import { ChangesetOperationScope, ChangesetOperationStatus, SessionLifecycle, type ChangesetOperation } from '../common/state/sessionState.js';
+import { ChangesetOperationScope, ChangesetOperationStatus, hasSessionPullRequestForBranch, SessionLifecycle, type ChangesetOperation } from '../common/state/sessionState.js';
 import { AgentHostPullRequestOperationHandler, type PullRequestCreatedEvent } from './agentHostPullRequestOperationHandler.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 
@@ -50,8 +50,8 @@ export class AgentHostPullRequestOperationContribution extends Disposable implem
 			return undefined;
 		}
 
-		// Pull request already exists
-		if (gitHubState?.pullRequestUrl) {
+		// Pull request already exists for the currently checked out branch
+		if (hasSessionPullRequestForBranch(gitHubState, gitState?.branchName)) {
 			return undefined;
 		}
 
@@ -111,7 +111,8 @@ export class AgentHostPullRequestOperationContribution extends Disposable implem
 		this._registry?.refreshSessionGitState(sessionKey);
 
 		this._gitStateService.setSessionGitHubState(sessionKey, {
-			pullRequestUrl: event.pullRequestUrl
+			pullRequestUrl: event.pullRequestUrl,
+			pullRequestBranchName: event.branchName
 		});
 	}
 }

--- a/src/vs/platform/agentHost/test/node/agentHostCommitOperationProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostCommitOperationProvider.test.ts
@@ -53,4 +53,16 @@ suite('AgentHostCommitOperationContribution', () => {
 
 		assert.deepStrictEqual(operations?.map(op => op.id), []);
 	});
+
+	test('advertises commit on the session changeset only for a pull request on the current branch', () => {
+		const provider = createContribution();
+		const sessionChangesetUri = buildSessionChangesetUri(sessionKey);
+
+		const actual = [
+			provider.getOperations({ sessionKey, changesetUri: sessionChangesetUri, changesetKind: ChangesetKind.Session, gitState: gitStateWithUncommittedChanges, gitHubState: { pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature/test' } }),
+			provider.getOperations({ sessionKey, changesetUri: sessionChangesetUri, changesetKind: ChangesetKind.Session, gitState: gitStateWithUncommittedChanges, gitHubState: { pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature/other' } }),
+		];
+
+		assert.deepStrictEqual(actual.map(operations => operations?.map(op => op.id)), [['commit'], []]);
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -10,12 +10,12 @@ import { runWithFakedTimers } from '../../../../base/test/common/timeTravelSched
 import { NullLogService } from '../../../log/common/log.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import type { IAgentService } from '../../common/agentService.js';
-import { readSessionGitHubState, readSessionGitState, withSessionGitState, SessionStatus, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
+import { readSessionGitHubState, readSessionGitState, withSessionGitHubState, withSessionGitState, SessionStatus, type ISessionGitHubState, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
 import { META_GIT_STATE, META_GITHUB_STATE } from '../../common/agentHostGitStateService.js';
 import { AgentHostGitStateService } from '../../node/agentHostGitStateService.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import type { IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
+import type { CreatedPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../common/sessionTestHelpers.js';
 
 const SESSION = 'mock:/session-1';
@@ -44,13 +44,23 @@ suite('AgentHostGitStateService', () => {
 			},
 		};
 
-		// The octokit and agent services are only used by the GitHub
-		// pull-request flow, which `refreshSessionGitState` does not touch.
+		const pullRequestCalls: string[] = [];
+		const pullRequestsByBranch = new Map<string, CreatedPullRequest>();
+		let onPullRequestLookup: ((branch: string) => Promise<void>) | undefined;
+		const octoKitService = {
+			findPullRequestByHeadBranch: async (_owner: string, _repo: string, branch: string) => {
+				pullRequestCalls.push(branch);
+				await onPullRequestLookup?.(branch);
+				return pullRequestsByBranch.get(branch);
+			},
+		} as unknown as IAgentHostOctoKitService;
+		const agentService = { getAuthToken: () => 'token' } as unknown as IAgentService;
+
 		const service = disposables.add(new AgentHostGitStateService(
 			stateManager,
 			gitService,
-			options?.octoKitService ?? {} as unknown as IAgentHostOctoKitService,
-			options?.agentService ?? {} as unknown as IAgentService,
+			options?.octoKitService ?? octoKitService,
+			options?.agentService ?? agentService,
 			createTestGitHubEndpointService(),
 			new NullLogService(),
 			sessionDataService,
@@ -65,12 +75,15 @@ suite('AgentHostGitStateService', () => {
 			service,
 			gitCalls,
 			runEvents,
+			pullRequestCalls,
 			setGitResult: (state: ISessionGitState | undefined) => { gitResult = state; },
 			setGitError: (error: Error) => { gitError = error; },
+			setPullRequest: (branch: string, pullRequest: CreatedPullRequest) => { pullRequestsByBranch.set(branch, pullRequest); },
+			setOnPullRequestLookup: (fn: (branch: string) => Promise<void>) => { onPullRequestLookup = fn; },
 		};
 	}
 
-	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState }): void {
+	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState; gitHubState?: ISessionGitHubState }): void {
 		const summary: SessionSummary = {
 			resource: SESSION,
 			provider: 'mock',
@@ -85,6 +98,9 @@ suite('AgentHostGitStateService', () => {
 		stateManager.restoreSession(summary, []);
 		if (options?.gitState) {
 			stateManager.setSessionMeta(SESSION, withSessionGitState(undefined, options.gitState));
+		}
+		if (options?.gitHubState) {
+			stateManager.setSessionMeta(SESSION, withSessionGitHubState(stateManager.getSessionState(SESSION)?._meta, options.gitHubState));
 		}
 	}
 
@@ -255,6 +271,7 @@ suite('AgentHostGitStateService', () => {
 					owner: 'microsoft',
 					repo: 'vscode',
 					pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1',
+					pullRequestBranchName: 'feature',
 				},
 			});
 		});
@@ -317,6 +334,168 @@ suite('AgentHostGitStateService', () => {
 			]);
 
 			assert.strictEqual(h.gitCalls.length, 2);
+		});
+	});
+
+	test('stops looking for a pull request once one is known for the current branch', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 });
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature'],
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature' },
+			});
+		});
+	});
+
+	test('keeps the known pull request but resumes looking after the branch changed', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const nextGitState: ISessionGitState = { branchName: 'feature-2', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState: { branchName: 'feature', baseBranchName: 'main' },
+				gitHubState: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature' },
+			});
+			h.stateManager.setSessionMeta(SESSION, withSessionGitState(h.stateManager.getSessionState(SESSION)?._meta, nextGitState));
+			h.setGitResult(nextGitState);
+
+			// No pull request exists for the new branch yet
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+			const githubBeforePullRequestExists = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+
+			h.setPullRequest('feature-2', { url: 'https://github.com/microsoft/vscode/pull/2', number: 2 });
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				githubBeforePullRequestExists,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature-2', 'feature-2'],
+				githubBeforePullRequestExists: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature' },
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/2', pullRequestBranchName: 'feature-2' },
+			});
+		});
+	});
+
+	test('verifies a pull request that predates branch tracking against the current branch', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1' },
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 });
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature'],
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature' },
+			});
+		});
+	});
+
+	test('does not bind a pull request that predates branch tracking to a branch without one', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature-2', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1' },
+			});
+			h.setGitResult(gitState);
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature-2', 'feature-2'],
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1' },
+			});
+		});
+	});
+
+	test('discards a pull request lookup whose branch is no longer checked out', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 });
+			// The working copy moves to another branch while the lookup is in flight.
+			h.setOnPullRequestLookup(async () => {
+				h.stateManager.setSessionMeta(SESSION, withSessionGitState(h.stateManager.getSessionState(SESSION)?._meta, { branchName: 'feature-2', baseBranchName: 'main' }));
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature'],
+				github: { owner: 'microsoft', repo: 'vscode' },
+			});
+		});
+	});
+
+	test('looks for a pull request before reporting a refresh that observed a branch change', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState: { branchName: 'feature', baseBranchName: 'main', githubOwner: 'microsoft', githubRepo: 'vscode' },
+				gitHubState: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature' },
+			});
+			h.setGitResult({ branchName: 'feature-2', baseBranchName: 'main', githubOwner: 'microsoft', githubRepo: 'vscode' });
+			h.setPullRequest('feature-2', { url: 'https://github.com/microsoft/vscode/pull/2', number: 2 });
+
+			// The GitHub state is captured when the refresh is reported so the
+			// event carries the pull request of the newly checked out branch.
+			let githubOnRefreshEvent: ISessionGitHubState | undefined;
+			disposables.add(h.service.onDidRefreshSessionGitState(() => {
+				githubOnRefreshEvent = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			}));
+
+			await h.service.refreshSessionGitState(SESSION, undefined);
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				githubOnRefreshEvent,
+			}, {
+				pullRequestCalls: ['feature-2'],
+				githubOnRefreshEvent: { owner: 'microsoft', repo: 'vscode', pullRequestUrl: 'https://github.com/microsoft/vscode/pull/2', pullRequestBranchName: 'feature-2' },
+			});
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
@@ -60,4 +60,15 @@ suite('AgentHostPullRequestOperationContribution', () => {
 
 		assert.deepStrictEqual(actual, [undefined, undefined]);
 	});
+
+	test('advertises PR operations again for a branch whose pull request is unknown', () => {
+		const provider = createContribution();
+
+		const actual = [
+			provider.getOperations({ sessionKey: 'agent:/session', gitState: githubBranchWithUncommittedChanges, gitHubState: { pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature/test' }, changesetKind: ChangesetKind.Session, changesetUri: '' }),
+			provider.getOperations({ sessionKey: 'agent:/session', gitState: githubBranchWithUncommittedChanges, gitHubState: { pullRequestUrl: 'https://github.com/microsoft/vscode/pull/1', pullRequestBranchName: 'feature/other' }, changesetKind: ChangesetKind.Session, changesetUri: '' }),
+		];
+
+		assert.deepStrictEqual(actual.map(operations => operations?.map(op => op.id)), [undefined, ['create-pr', 'create-pr-auto-merge', 'create-pr-auto-squash', 'create-pr-auto-rebase', 'create-draft-pr']]);
+	});
 });


### PR DESCRIPTION
A pull request always relates to a branch, but the agent host latched onto the first pull request it found for a session and never looked again. When the agent switched the branch of the working directory, the session kept reporting the previous branch's pull request forever, and the pull request affordances (`Create Pull Request`, `Commit Changes`) stayed wrong for the new branch.

## Changes

- `ISessionGitHubState` gains `pullRequestBranchName`, recording the branch a pull request was found (or created) for.
- `attachSessionGitHubPullRequest` stops only once a pull request is known **for the branch that is currently checked out**. Lookups are serialized per session, tied to the service lifetime, and stale responses are discarded when the working copy moved on while the request was in flight.
- `refreshSessionGitState` compares the previous branch with the freshly probed one and, on a change, awaits a pull request lookup before firing `onDidRefreshSessionGitState` so consumers recompute operations from self-consistent state.
- The previously known pull request keeps being reported until one is found for the new branch.
- State persisted before this change records no branch; instead of assuming it belongs to whatever branch is checked out now, it is verified against GitHub and only bound once a pull request is actually returned for that branch.
- `AgentHostCommitOperationContribution` now gates on `hasSessionPullRequestForBranch` so it agrees with the pull request provider.

## Validation

- 78 agent host unit tests pass (git state service, pull request + commit operation providers, pull request handler, changeset coordinator/operation service, session server tools), including new coverage for branch switches, stale lookups, legacy state and per-branch operation gating.
- `tsc --noEmit` on `src/tsconfig.json` is clean apart from a pre-existing unrelated error in `copilotSystemNotification.ts`.