### PR TITLE
Fix Copilot OTel file span serialization

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
@@ -195,6 +195,10 @@ Key methods:
 
 Selection happens in `src/extension/extension/vscode-node/services.ts`: exactly one of `NodeOTelService` or `InMemoryOTelService` is bound to `IOTelService` per extension host based on `resolveOTelConfig().enabled`.
 
+### File Exporter Serialization
+
+The file exporters write one JSON object per line. SDK `ReadableSpan` implementations contain circular internal span-processor state, so `FileSpanExporter` snapshots the public span fields instead of serializing the SDK object directly. Span and link contexts are expanded into plain data, including serialized trace state. If any signal cannot be serialized, the exporter reports a failed export and does not write a placeholder record.
+
 ### Two TracerProviders in Same Process
 
 When the CLI SDK is active with OTel enabled:

--- a/extensions/copilot/src/platform/otel/node/fileExporters.ts
+++ b/extensions/copilot/src/platform/otel/node/fileExporters.ts
@@ -3,18 +3,68 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { SpanContext } from '@opentelemetry/api';
 import { type ExportResult, ExportResultCode } from '@opentelemetry/core';
 import type { LogRecordExporter, ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import { type PushMetricExporter, type ResourceMetrics, AggregationTemporality } from '@opentelemetry/sdk-metrics';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-node';
 import * as fs from 'node:fs';
 
-function safeStringify(data: unknown): string {
-	try {
-		return JSON.stringify(data);
-	} catch {
-		return '{}';
+function stringify(data: unknown): string {
+	const result = JSON.stringify(data);
+	if (result === undefined) {
+		throw new TypeError('Unable to serialize OpenTelemetry data');
 	}
+	return result;
+}
+
+function spanContextToJson(context: SpanContext) {
+	return {
+		traceId: context.traceId,
+		spanId: context.spanId,
+		traceFlags: context.traceFlags,
+		traceState: context.traceState?.serialize(),
+		isRemote: context.isRemote,
+	};
+}
+
+/**
+ * Converts a ReadableSpan into a JSON-safe snapshot of its public data. The SDK
+ * span implementation contains a circular reference through its span processor.
+ */
+function readableSpanToJson(span: ReadableSpan) {
+	const context = span.spanContext();
+	return {
+		resource: {
+			attributes: span.resource.attributes,
+			schemaUrl: span.resource.schemaUrl,
+			asyncAttributesPending: span.resource.asyncAttributesPending,
+		},
+		instrumentationScope: span.instrumentationScope,
+		traceId: context.traceId,
+		spanId: context.spanId,
+		traceFlags: context.traceFlags,
+		traceState: context.traceState?.serialize(),
+		isRemote: context.isRemote,
+		parentSpanContext: span.parentSpanContext ? spanContextToJson(span.parentSpanContext) : undefined,
+		name: span.name,
+		kind: span.kind,
+		startTime: span.startTime,
+		endTime: span.endTime,
+		duration: span.duration,
+		ended: span.ended,
+		attributes: span.attributes,
+		status: span.status,
+		events: span.events,
+		links: span.links.map(link => ({
+			context: spanContextToJson(link.context),
+			attributes: link.attributes,
+			droppedAttributesCount: link.droppedAttributesCount,
+		})),
+		droppedAttributesCount: span.droppedAttributesCount,
+		droppedEventsCount: span.droppedEventsCount,
+		droppedLinksCount: span.droppedLinksCount,
+	};
 }
 
 abstract class BaseFileExporter {
@@ -31,32 +81,37 @@ abstract class BaseFileExporter {
 	forceFlush(): Promise<void> {
 		return Promise.resolve();
 	}
+
+	protected write(dataFactory: () => string, resultCallback: (result: ExportResult) => void): void {
+		let data: string;
+		try {
+			data = dataFactory();
+		} catch (error) {
+			resultCallback({ code: ExportResultCode.FAILED, error: error instanceof Error ? error : new Error(String(error)) });
+			return;
+		}
+
+		this.writeStream.write(data, error => {
+			resultCallback({ code: error ? ExportResultCode.FAILED : ExportResultCode.SUCCESS, error: error ?? undefined });
+		});
+	}
 }
 
 export class FileSpanExporter extends BaseFileExporter implements SpanExporter {
 	export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
-		const data = spans.map(s => safeStringify(s) + '\n').join('');
-		this.writeStream.write(data, err => {
-			resultCallback({ code: err ? ExportResultCode.FAILED : ExportResultCode.SUCCESS, error: err ?? undefined });
-		});
+		this.write(() => spans.map(span => stringify(readableSpanToJson(span)) + '\n').join(''), resultCallback);
 	}
 }
 
 export class FileLogExporter extends BaseFileExporter implements LogRecordExporter {
 	export(logs: ReadableLogRecord[], resultCallback: (result: ExportResult) => void): void {
-		const data = logs.map(l => safeStringify(l) + '\n').join('');
-		this.writeStream.write(data, err => {
-			resultCallback({ code: err ? ExportResultCode.FAILED : ExportResultCode.SUCCESS, error: err ?? undefined });
-		});
+		this.write(() => logs.map(log => stringify(log) + '\n').join(''), resultCallback);
 	}
 }
 
 export class FileMetricExporter extends BaseFileExporter implements PushMetricExporter {
 	export(metrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): void {
-		const data = safeStringify(metrics) + '\n';
-		this.writeStream.write(data, err => {
-			resultCallback({ code: err ? ExportResultCode.FAILED : ExportResultCode.SUCCESS, error: err ?? undefined });
-		});
+		this.write(() => stringify(metrics) + '\n', resultCallback);
 	}
 
 	selectAggregationTemporality(): AggregationTemporality {

--- a/extensions/copilot/src/platform/otel/node/test/fileExporters.spec.ts
+++ b/extensions/copilot/src/platform/otel/node/test/fileExporters.spec.ts
@@ -3,13 +3,45 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExportResultCode } from '@opentelemetry/core';
+import { SpanKind, SpanStatusCode, type Span } from '@opentelemetry/api';
+import { type ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { AggregationTemporality } from '@opentelemetry/sdk-metrics';
+import { InMemorySpanExporter, NodeTracerProvider, type ReadableSpan, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../common/genAiAttributes';
 import { FileLogExporter, FileMetricExporter, FileSpanExporter } from '../fileExporters';
+
+const userPrompt = 'Read every .md file in this project in parallel and summarise each in one line.';
+
+async function createFinishedSpans(names: readonly string[], configure?: (span: Span) => void): Promise<ReadableSpan[]> {
+	const memoryExporter = new InMemorySpanExporter();
+	const provider = new NodeTracerProvider({
+		resource: resourceFromAttributes({
+			'service.name': 'copilot-chat',
+			'session.id': 'test-session',
+		}),
+		spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+	});
+	const tracer = provider.getTracer('copilot-chat', '0.59.0');
+
+	for (const name of names) {
+		const span = tracer.startSpan(name, { kind: SpanKind.INTERNAL });
+		configure?.(span);
+		span.end();
+	}
+
+	const spans = [...memoryExporter.getFinishedSpans()];
+	await provider.shutdown();
+	return spans;
+}
+
+function exportSpans(exporter: FileSpanExporter, spans: ReadableSpan[]): Promise<ExportResult> {
+	return new Promise(resolve => exporter.export(spans, resolve));
+}
 
 describe('FileSpanExporter', () => {
 	let tmpFile: string;
@@ -26,32 +58,71 @@ describe('FileSpanExporter', () => {
 	});
 
 	it('writes span data as JSON lines', async () => {
-		const fakeSpan = { name: 'test-span', kind: 0, attributes: { a: 1 } };
-		await new Promise<void>((resolve, reject) => {
-			exporter.export([fakeSpan as any], result => {
-				result.code === ExportResultCode.SUCCESS ? resolve() : reject(result.error);
+		const [span] = await createFinishedSpans(['invoke_agent'], span => {
+			span.setAttributes({
+				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
+				[GenAiAttr.INPUT_MESSAGES]: JSON.stringify([{ role: 'user', parts: [{ type: 'text', content: userPrompt }] }]),
+				[CopilotChatAttr.USER_REQUEST]: userPrompt,
 			});
+			span.addEvent('user_message', { content: userPrompt });
+			span.setStatus({ code: SpanStatusCode.OK });
 		});
+		const result = await exportSpans(exporter, [span]);
+		expect(result.code).toBe(ExportResultCode.SUCCESS);
 		await exporter.shutdown();
 		const content = fs.readFileSync(tmpFile, 'utf-8');
-		const parsed = JSON.parse(content.trim());
-		expect(parsed.name).toBe('test-span');
-		expect(parsed.attributes).toEqual({ a: 1 });
+		expect(JSON.parse(content.trim())).toMatchObject({
+			resource: {
+				attributes: {
+					'service.name': 'copilot-chat',
+					'session.id': 'test-session',
+				},
+			},
+			instrumentationScope: { name: 'copilot-chat', version: '0.59.0' },
+			traceId: span.spanContext().traceId,
+			spanId: span.spanContext().spanId,
+			name: 'invoke_agent',
+			kind: SpanKind.INTERNAL,
+			ended: true,
+			attributes: {
+				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
+				[GenAiAttr.INPUT_MESSAGES]: JSON.stringify([{ role: 'user', parts: [{ type: 'text', content: userPrompt }] }]),
+				[CopilotChatAttr.USER_REQUEST]: userPrompt,
+			},
+			status: { code: SpanStatusCode.OK },
+			events: [{ name: 'user_message', attributes: { content: userPrompt } }],
+			droppedAttributesCount: 0,
+			droppedEventsCount: 0,
+			droppedLinksCount: 0,
+		});
 	});
 
 	it('appends multiple exports', async () => {
-		for (let i = 0; i < 3; i++) {
-			await new Promise<void>((resolve, reject) => {
-				exporter.export([{ name: `span-${i}` } as any], result => {
-					result.code === ExportResultCode.SUCCESS ? resolve() : reject(result.error);
-				});
-			});
+		const spans = await createFinishedSpans(['span-0', 'span-1', 'span-2']);
+		for (const span of spans) {
+			const result = await exportSpans(exporter, [span]);
+			expect(result.code).toBe(ExportResultCode.SUCCESS);
 		}
 		await exporter.shutdown();
 		const lines = fs.readFileSync(tmpFile, 'utf-8').trim().split('\n');
 		expect(lines).toHaveLength(3);
 		expect(JSON.parse(lines[0]).name).toBe('span-0');
 		expect(JSON.parse(lines[2]).name).toBe('span-2');
+	});
+
+	it('reports serialization failures without writing an empty object', async () => {
+		const serializationError = new Error('span context unavailable');
+		const [span] = await createFinishedSpans(['invoke_agent']);
+		const brokenSpan: ReadableSpan = new Proxy(span, {
+			get: (target, property, receiver) => property === 'spanContext'
+				? () => { throw serializationError; }
+				: Reflect.get(target, property, receiver),
+		});
+
+		const result = await exportSpans(exporter, [brokenSpan]);
+		expect(result).toEqual({ code: ExportResultCode.FAILED, error: serializationError });
+		await exporter.shutdown();
+		expect(fs.readFileSync(tmpFile, 'utf-8')).toBe('');
 	});
 });
 

--- a/extensions/copilot/src/platform/otel/node/test/fileExporters.spec.ts
+++ b/extensions/copilot/src/platform/otel/node/test/fileExporters.spec.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { packageJson } from '../../../env/common/packagejson';
 import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../common/genAiAttributes';
 import { FileLogExporter, FileMetricExporter, FileSpanExporter } from '../fileExporters';
 
@@ -26,7 +27,7 @@ async function createFinishedSpans(names: readonly string[], configure?: (span: 
 		}),
 		spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 	});
-	const tracer = provider.getTracer('copilot-chat', '0.59.0');
+	const tracer = provider.getTracer('copilot-chat', packageJson.version);
 
 	for (const name of names) {
 		const span = tracer.startSpan(name, { kind: SpanKind.INTERNAL });
@@ -78,7 +79,7 @@ describe('FileSpanExporter', () => {
 					'session.id': 'test-session',
 				},
 			},
-			instrumentationScope: { name: 'copilot-chat', version: '0.59.0' },
+			instrumentationScope: { name: 'copilot-chat', version: packageJson.version },
 			traceId: span.spanContext().traceId,
 			spanId: span.spanContext().spanId,
 			name: 'invoke_agent',


### PR DESCRIPTION
Fixes #319993

## Summary

- serialize public `ReadableSpan` data into JSON-safe span records for the file exporter
- report serialization failures instead of silently writing `{}` placeholder records
- cover real SDK spans, content attributes, events, repeated exports, and failure behavior
- document the file exporter serialization boundary

## Root cause

`FileSpanExporter` passed the SDK span implementation directly to `JSON.stringify`. The implementation contains circular span-processor state, so serialization threw and `safeStringify` replaced the entire span with `{}`. Logs and metrics still appeared, which made the file look active while span data and content attributes were absent.

## Validation

- `npm run test:unit -- src/platform/otel/node/test/fileExporters.spec.ts` — 6 tests passed
- `npm run test:unit -- src/platform/otel src/extension/chatSessions/copilotcli/node/test/copilotCliBridgeSpanProcessor.spec.ts` — 259 tests passed
- `npm run typecheck`
- targeted ESLint for the changed TypeScript files
- `npm run compile` — VS Code and Copilot compilation completed with 0 errors
- manual file/SQLite parity check: 4/4 spans, 63/63 attributes, and 4/4 events matched with no missing fields or value mismatches