### PR TITLE
fix: guard notebook match selection against unmaterialized tree element

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchTreeSelection.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeSelection.ts
@@ -6,18 +6,18 @@
 /**
  * Minimal async-tree surface used when focusing/selecting a search result.
  */
-export interface ISearchTreeSelectionTarget {
-	hasNode(element: unknown): boolean;
-	getFocus(): readonly unknown[];
-	getSelection(): readonly unknown[];
-	setSelection(elements: unknown[], browserEvent?: UIEvent): void;
-	setFocus(elements: unknown[], browserEvent?: UIEvent): void;
+export interface ISearchTreeSelectionTarget<T> {
+	hasNode(element: T): boolean;
+	getFocus(): readonly T[];
+	getSelection(): readonly T[];
+	setSelection(elements: T[], browserEvent?: UIEvent): void;
+	setFocus(elements: T[], browserEvent?: UIEvent): void;
 }
 
 /** Select/focus only when the async tree has materialized `element` (#328427). */
-export function selectSearchTreeElementIfPresent(
-	tree: ISearchTreeSelectionTarget,
-	element: unknown,
+export function selectSearchTreeElementIfPresent<T>(
+	tree: ISearchTreeSelectionTarget<T>,
+	element: T,
 	browserEvent?: UIEvent
 ): boolean {
 	if (!tree.hasNode(element)) {
@@ -25,7 +25,7 @@ export function selectSearchTreeElementIfPresent(
 	}
 	if (!tree.getFocus().includes(element) || !tree.getSelection().includes(element)) {
 		tree.setSelection([element], browserEvent);
-		tree.setFocus([element]);
+		tree.setFocus([element], browserEvent);
 	}
 	return true;
 }

--- a/src/vs/workbench/contrib/search/browser/searchTreeSelection.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeSelection.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Minimal async-tree surface used when focusing/selecting a search result.
+ */
+export interface ISearchTreeSelectionTarget {
+	hasNode(element: unknown): boolean;
+	getFocus(): readonly unknown[];
+	getSelection(): readonly unknown[];
+	setSelection(elements: unknown[], browserEvent?: UIEvent): void;
+	setFocus(elements: unknown[], browserEvent?: UIEvent): void;
+}
+
+/** Select/focus only when the async tree has materialized `element` (#328427). */
+export function selectSearchTreeElementIfPresent(
+	tree: ISearchTreeSelectionTarget,
+	element: unknown,
+	browserEvent?: UIEvent
+): boolean {
+	if (!tree.hasNode(element)) {
+		return false;
+	}
+	if (!tree.getFocus().includes(element) || !tree.getSelection().includes(element)) {
+		tree.setSelection([element], browserEvent);
+		tree.setFocus([element]);
+	}
+	return true;
+}

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -61,6 +61,7 @@ import { IFindInFilesArgs } from './searchActionsBase.js';
 import { searchDetailsIcon } from './searchIcons.js';
 import { renderSearchMessage } from './searchMessage.js';
 import { FileMatchRenderer, FolderMatchRenderer, MatchRenderer, SearchAccessibilityProvider, SearchDelegate, TextSearchResultRenderer } from './searchResultsView.js';
+import { selectSearchTreeElementIfPresent } from './searchTreeSelection.js';
 import { SearchWidget } from './searchWidget.js';
 import * as Constants from '../common/constants.js';
 import { IReplaceService } from './replace.js';
@@ -2288,10 +2289,8 @@ export class SearchView extends ViewPane {
 
 						if (isIMatchInNotebook(match)) {
 							elemParent.showMatch(match);
-							if (!this.tree.getFocus().includes(match) || !this.tree.getSelection().includes(match)) {
-								this.tree.setSelection([match], getSelectionKeyboardEvent());
-								this.tree.setFocus([match]);
-							}
+							// Remapped match may not be in the async tree yet (#328427).
+							selectSearchTreeElementIfPresent(this.tree, match, getSelectionKeyboardEvent());
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
+++ b/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
@@ -36,11 +36,11 @@ export class MockObjectTree<T, TRef> implements IDisposable {
 	get onDidDispose() { return someEvent; }
 	get lastVisibleElement() { return this.elements[this.elements.length - 1]; }
 
-	private readonly _nodes = new Set<unknown>();
-	private _focus: unknown[] = [];
-	private _selection: unknown[] = [];
+	private readonly _nodes = new Set<T>();
+	private _focus: T[] = [];
+	private _selection: T[] = [];
 
-	constructor(private elements: any[]) {
+	constructor(private elements: T[]) {
 		for (const element of elements) {
 			this._nodes.add(element);
 		}
@@ -48,26 +48,26 @@ export class MockObjectTree<T, TRef> implements IDisposable {
 
 	domFocus(): void { }
 
-	hasNode(element: unknown): boolean {
+	hasNode(element: T): boolean {
 		return this._nodes.has(element);
 	}
 
-	getFocus(): unknown[] {
+	getFocus(): T[] {
 		return this._focus;
 	}
 
-	getSelection(): unknown[] {
+	getSelection(): T[] {
 		return this._selection;
 	}
 
-	setFocus(elements: unknown[]): void {
+	setFocus(elements: T[], _browserEvent?: UIEvent): void {
 		if (!elements.every(e => this.hasNode(e))) {
 			throw new Error('Tree element not found');
 		}
 		this._focus = elements;
 	}
 
-	setSelection(elements: unknown[], _browserEvent?: UIEvent): void {
+	setSelection(elements: T[], _browserEvent?: UIEvent): void {
 		if (!elements.every(e => this.hasNode(e))) {
 			throw new Error('Tree element not found');
 		}

--- a/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
+++ b/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
@@ -52,12 +52,6 @@ export class MockObjectTree<T, TRef> implements IDisposable {
 		return this._nodes.has(element);
 	}
 
-	materialize(...elements: unknown[]): void {
-		for (const element of elements) {
-			this._nodes.add(element);
-		}
-	}
-
 	getFocus(): unknown[] {
 		return this._focus;
 	}

--- a/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
+++ b/src/vs/workbench/contrib/search/test/browser/mockSearchTree.ts
@@ -36,9 +36,49 @@ export class MockObjectTree<T, TRef> implements IDisposable {
 	get onDidDispose() { return someEvent; }
 	get lastVisibleElement() { return this.elements[this.elements.length - 1]; }
 
-	constructor(private elements: any[]) { }
+	private readonly _nodes = new Set<unknown>();
+	private _focus: unknown[] = [];
+	private _selection: unknown[] = [];
+
+	constructor(private elements: any[]) {
+		for (const element of elements) {
+			this._nodes.add(element);
+		}
+	}
 
 	domFocus(): void { }
+
+	hasNode(element: unknown): boolean {
+		return this._nodes.has(element);
+	}
+
+	materialize(...elements: unknown[]): void {
+		for (const element of elements) {
+			this._nodes.add(element);
+		}
+	}
+
+	getFocus(): unknown[] {
+		return this._focus;
+	}
+
+	getSelection(): unknown[] {
+		return this._selection;
+	}
+
+	setFocus(elements: unknown[]): void {
+		if (!elements.every(e => this.hasNode(e))) {
+			throw new Error('Tree element not found');
+		}
+		this._focus = elements;
+	}
+
+	setSelection(elements: unknown[], _browserEvent?: UIEvent): void {
+		if (!elements.every(e => this.hasNode(e))) {
+			throw new Error('Tree element not found');
+		}
+		this._selection = elements;
+	}
 
 	collapse(location: TRef, recursive: boolean = false): boolean {
 		return true;

--- a/src/vs/workbench/contrib/search/test/browser/searchTreeSelection.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchTreeSelection.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { selectSearchTreeElementIfPresent } from '../../browser/searchTreeSelection.js';
+import { MockObjectTree } from './mockSearchTree.js';
+
+suite('selectSearchTreeElementIfPresent (#328427)', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('skips setSelection/setFocus when the element is not materialized', () => {
+		const tree = new MockObjectTree<object, object>([]);
+		const match = { id: 'remapped-match' };
+
+		assert.strictEqual(selectSearchTreeElementIfPresent(tree, match), false);
+		assert.deepStrictEqual(tree.getSelection(), []);
+		assert.deepStrictEqual(tree.getFocus(), []);
+	});
+
+	test('does not throw Tree element not found for unmaterialized elements', () => {
+		const tree = new MockObjectTree<object, object>([]);
+		const match = { id: 'remapped-match' };
+
+		assert.doesNotThrow(() => selectSearchTreeElementIfPresent(tree, match));
+		assert.throws(() => tree.setSelection([match]), /Tree element not found/);
+	});
+
+	test('selects and focuses when the element is materialized', () => {
+		const match = { id: 'notebook-match' };
+		const tree = new MockObjectTree<object, object>([match]);
+
+		assert.strictEqual(selectSearchTreeElementIfPresent(tree, match), true);
+		assert.deepStrictEqual(tree.getSelection(), [match]);
+		assert.deepStrictEqual(tree.getFocus(), [match]);
+	});
+
+	test('skips redundant setSelection/setFocus when already selected and focused', () => {
+		const match = { id: 'notebook-match' };
+		const tree = new MockObjectTree<object, object>([match]);
+		tree.setSelection([match]);
+		tree.setFocus([match]);
+
+		let setSelectionCalls = 0;
+		let setFocusCalls = 0;
+		const originalSetSelection = tree.setSelection.bind(tree);
+		const originalSetFocus = tree.setFocus.bind(tree);
+		tree.setSelection = ((elements: unknown[], browserEvent?: UIEvent) => {
+			setSelectionCalls++;
+			return originalSetSelection(elements, browserEvent);
+		}) as typeof tree.setSelection;
+		tree.setFocus = ((elements: unknown[]) => {
+			setFocusCalls++;
+			return originalSetFocus(elements);
+		}) as typeof tree.setFocus;
+
+		assert.strictEqual(selectSearchTreeElementIfPresent(tree, match), true);
+		assert.strictEqual(setSelectionCalls, 0);
+		assert.strictEqual(setFocusCalls, 0);
+	});
+});

--- a/src/vs/workbench/contrib/search/test/browser/searchTreeSelection.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchTreeSelection.test.ts
@@ -45,16 +45,8 @@ suite('selectSearchTreeElementIfPresent (#328427)', () => {
 
 		let setSelectionCalls = 0;
 		let setFocusCalls = 0;
-		const originalSetSelection = tree.setSelection.bind(tree);
-		const originalSetFocus = tree.setFocus.bind(tree);
-		tree.setSelection = ((elements: unknown[], browserEvent?: UIEvent) => {
-			setSelectionCalls++;
-			return originalSetSelection(elements, browserEvent);
-		}) as typeof tree.setSelection;
-		tree.setFocus = ((elements: unknown[]) => {
-			setFocusCalls++;
-			return originalSetFocus(elements);
-		}) as typeof tree.setFocus;
+		tree.setSelection = () => { setSelectionCalls++; };
+		tree.setFocus = () => { setFocusCalls++; };
 
 		assert.strictEqual(selectSearchTreeElementIfPresent(tree, match), true);
 		assert.strictEqual(setSelectionCalls, 0);


### PR DESCRIPTION
## Summary
- Fixes #328427 — opening a Search result inside a notebook could throw `TreeError [SearchView] Tree element not found` (telemetry spike; same family as #326646).
- After `updateMatchesForEditorWidget()` rebuilds notebook matches, `open()` called `setSelection`/`setFocus` on a remapped object that the lazy async tree may not have materialized yet.
- Select/focus only when `tree.hasNode(match)` — same approach as #326652 for Quick Search. `showMatch` still runs so the notebook highlight is unchanged.

## Test plan
- [x] Unit: `selectSearchTreeElementIfPresent (#328427)` — unmaterialized skip / no throw / materialized select / already-selected skip
- [x] Existing `Search Actions` suite still passes
- [ ] Search in a workspace with notebooks → open a match under a collapsed notebook file match → no TreeError; editor still highlights
- [ ] Open an already-expanded notebook match → tree selection/focus still updates when the node is present