### PR TITLE
Add Agents window startup A/A experiment trigger

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -845,6 +845,8 @@ Editor entry points pass an `AgentsWindowOpenSource` through `INativeHostService
 
 On the first handoff in a window, `SelectAgentsFolderContribution` starts `SessionsWindowOpenTelemetry` only when the application-scoped `TOTAL_SESSIONS_KEY` counter is still zero. The collector freezes whether the settled initial view is a workspace-preselected new-session view (or records `undefined` when a created session is visible), reads whether the initial setup flow showed its sign-in dialog, and emits `agents/firstTimeWindowOpen` once. A close within three minutes includes `windowCloseDurationMs`; otherwise the event emits at the three-minute boundary with that field undefined.
 
+`SessionsWindowStartupExperiment` reads the `agentsWindowStartupAA` treatment at `WorkbenchPhase.BlockStartup`. Both A/A variants use the same treatment value, so the read records experiment exposure without changing the Agents window experience.
+
 ### Automation Run Lifecycle
 
 `AutomationRunner` exposes separate dispatch and lifecycle promises. It resolves

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -26,6 +26,7 @@ import { IStorageService, StorageScope } from '../../../../platform/storage/comm
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTracker.js';
 import { ISessionsWindowOpenViewState, SessionsWindowOpenTelemetry } from '../../sessions/browser/sessionsWindowOpenTelemetry.js';
+import { SessionsWindowStartupExperiment } from '../../sessions/browser/sessionsWindowStartupExperiment.js';
 
 class SelectAgentsFolderContribution extends Disposable implements IWorkbenchContribution {
 
@@ -211,6 +212,7 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 }
 
 registerWorkbenchContribution2(SelectAgentsFolderContribution.ID, SelectAgentsFolderContribution, WorkbenchPhase.BlockStartup);
+registerWorkbenchContribution2(SessionsWindowStartupExperiment.ID, SessionsWindowStartupExperiment, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(SessionsCopilotConfigSlashSubmitHandlerContribution.ID, SessionsCopilotConfigSlashSubmitHandlerContribution, WorkbenchPhase.AfterRestored);
 
 // Renderer-side BYOK language-model handler that backs the node agent host's

--- a/src/vs/sessions/contrib/sessions/browser/sessionsWindowStartupExperiment.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsWindowStartupExperiment.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { IWorkbenchAssignmentService } from '../../../../workbench/services/assignment/common/assignmentService.js';
+
+export const AGENTS_WINDOW_STARTUP_AA_EXPERIMENT = 'agentsWindowStartupAA';
+
+export class SessionsWindowStartupExperiment implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.windowStartupExperiment';
+
+	constructor(
+		@IWorkbenchAssignmentService assignmentService: IWorkbenchAssignmentService,
+	) {
+		void assignmentService.getTreatment<boolean>(AGENTS_WINDOW_STARTUP_AA_EXPERIMENT);
+	}
+}

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowStartupExperiment.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowStartupExperiment.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { NullWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/test/common/nullAssignmentService.js';
+import { AGENTS_WINDOW_STARTUP_AA_EXPERIMENT, SessionsWindowStartupExperiment } from '../../browser/sessionsWindowStartupExperiment.js';
+
+class TestAssignmentService extends NullWorkbenchAssignmentService {
+	readonly treatments: string[] = [];
+
+	override async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
+		this.treatments.push(name);
+		return true as T;
+	}
+}
+
+suite('SessionsWindowStartupExperiment', () => {
+
+	test('reads the A/A treatment when the contribution starts', () => {
+		const assignmentService = new TestAssignmentService();
+
+		new SessionsWindowStartupExperiment(assignmentService);
+
+		assert.deepStrictEqual(assignmentService.treatments, [AGENTS_WINDOW_STARTUP_AA_EXPERIMENT]);
+	});
+});

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowStartupExperiment.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsWindowStartupExperiment.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/test/common/nullAssignmentService.js';
 import { AGENTS_WINDOW_STARTUP_AA_EXPERIMENT, SessionsWindowStartupExperiment } from '../../browser/sessionsWindowStartupExperiment.js';
 
@@ -17,6 +18,8 @@ class TestAssignmentService extends NullWorkbenchAssignmentService {
 }
 
 suite('SessionsWindowStartupExperiment', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('reads the A/A treatment when the contribution starts', () => {
 		const assignmentService = new TestAssignmentService();


### PR DESCRIPTION
## Summary
- Adds a BlockStartup treatment read for `agentsWindowStartupAA` when the Agents window first starts.
- A/A: control and variant both expose the same flag/UX; assignment is for measurement only.
- Unit test + short SESSIONS.md note.

## Experiment
- Workspace: `dbd12384-5001-4e90-a863-526321eaf233` / `vscodeexpws~agentswindowtest`
- Feature: Agents Window Startup A/A (`agentsWindowStartupAA`)

## Test plan
- [x] Real Codespace Electron proof for control and treatment (HEVC 1600x1000)
- [x] Telemetry: `tasClientReadTreatmentComplete` with `treatmentName=agentsWindowStartupAA` and assignment context tokens for each arm
- [x] Unit test for startup experiment contribution

## Product-ready proof videos (visible cohort assignment)

A/A arms are UX-identical; proof is the **cohort allocation token** visible in **Developer: Show Telemetry** (Find + full-window HEVC recording).

### Treatment
- Cohort token: `agents-window-startup-aa-variant:31559566`
- Video: https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/treatment-cohort-proof-full-window.mp4
- Telemetry Find screenshot: https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/treatment-cohort-token.png

![Treatment cohort token in Telemetry](https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/treatment-cohort-token.png)

### Control
- Cohort token: `agents-window-startup-aa-control:31559570`
- Video: https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/control-cohort-proof-full-window.mp4
- Telemetry Find screenshot: https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/control-cohort-token.png

![Control cohort token in Telemetry](https://github.com/rfeltis/vscode/releases/download/agents-window-aa-proof-videos/control-cohort-token.png)

### Notes
- Videos: HEVC (hvc1), 1600×1000, ~61s
- Release bundle: https://github.com/rfeltis/vscode/releases/tag/agents-window-aa-proof-videos
- Experiment remains **stopped** pending version/targeting before any 50/50 start