### PR TITLE
Tighten agent host reconnect E2E test

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/protocolContractsSuite.ts
@@ -115,13 +115,14 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 	conformanceTest(context, 'reconnect replays only the actions a dropped client missed', async function () {
 		const { sessionUri } = await createSession('reconnect');
 		const chatUri = buildDefaultChatUri(sessionUri);
+		const droppedClientId = `reconnect-dropped-${config.provider}`;
 
 		// The cutoff comes from the subscribe response rather than from watching
 		// this client receive its own dispatch: a subscription is not guaranteed
 		// to be installed before a dispatch sent immediately after it is handled,
 		// so waiting for that echo races. `fromSeq` is the same boundary and the
 		// response itself guarantees it.
-		const { carried: seenThrough, revived } = await afterConnectionDrop(`reconnect-${config.provider}`, async first => {
+		const { carried: seenThrough, revived } = await afterConnectionDrop(droppedClientId, async first => {
 			const subscribed = await first.call<SubscribeResult>('subscribe', { channel: chatUri });
 			return subscribed.snapshot!.fromSeq;
 		});
@@ -133,7 +134,7 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 
 			const result = await revived.call<ReconnectResult>('reconnect', {
 				channel: ROOT_STATE_URI,
-				clientId: `reconnect-${config.provider}`,
+				clientId: droppedClientId,
 				lastSeenServerSeq: seenThrough,
 				subscriptions: [chatUri],
 			});
@@ -160,12 +161,13 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 	conformanceTest(context, 'reconnect reports a subscription it cannot resume as missing', async function () {
 		const { sessionUri } = await createSession('reconnect-missing');
 		const chatUri = buildDefaultChatUri(sessionUri);
+		const droppedClientId = `reconnect-missing-dropped-${config.provider}`;
 		// A channel that never existed stands in for one disposed while the client
 		// was away: either way the server cannot resume it, and the client has to
 		// be told rather than left waiting on a dead channel.
 		const goneUri = URI.from({ scheme: 'agenthost-terminal', authority: 'e2e', path: '/never-existed' }).toString();
 
-		const { carried: seenThrough, revived } = await afterConnectionDrop(`reconnect-missing-${config.provider}`, async first => {
+		const { carried: seenThrough, revived } = await afterConnectionDrop(droppedClientId, async first => {
 			const subscribed = await first.call<SubscribeResult>('subscribe', { channel: chatUri });
 			return subscribed.snapshot!.fromSeq;
 		});
@@ -173,7 +175,7 @@ export function defineProtocolContractTests(context: IAgentHostE2ETestContext): 
 		try {
 			const result = await revived.call<ReconnectResult>('reconnect', {
 				channel: ROOT_STATE_URI,
-				clientId: `reconnect-missing-${config.provider}`,
+				clientId: droppedClientId,
 				lastSeenServerSeq: seenThrough,
 				subscriptions: [chatUri, goneUri],
 			});


### PR DESCRIPTION
## Summary
- give reconnect test transports a distinct logical client ID
- prevent a closing secondary socket from intercepting the shared client's synchronization notification

## Validation
- `npm run typecheck-client`
- targeted hygiene check
- reconnect conformance tests repeated 5 times
- full Agent Host conformance suite (79 passing)

(Written by Copilot)