### PR TITLE
agentHost: emit ask questions telemetry

### DIFF
--- a/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
@@ -393,6 +393,17 @@ export type ChatInputQuestion = ChatInputTextQuestion
 	| ChatInputMultiSelectQuestion;
 
 /**
+ * Why the agent requested chat input.
+ *
+ * @category Chat Input Types
+ */
+export const enum ChatInputRequestPurpose {
+	AskUser = 'askUser',
+	Elicitation = 'elicitation',
+	PlanReview = 'planReview',
+}
+
+/**
  * The request payload carried by an {@link InputRequestResponsePart}.
  *
  * The server creates or replaces the containing response part with
@@ -404,6 +415,8 @@ export type ChatInputQuestion = ChatInputTextQuestion
 export interface ChatInputRequest {
 	/** Stable request identifier */
 	id: string;
+	/** Input lifecycle classification. Missing for requests from older clients or persisted sessions. */
+	purpose?: ChatInputRequestPurpose;
 	/** Display message for the request as a whole */
 	message?: string;
 	/** URL the user should review or open, for URL-style elicitations */

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -58,6 +58,7 @@ export {
 	ChatInputAnswerState as SessionInputAnswerState,
 	ChatInputAnswerValueKind as SessionInputAnswerValueKind,
 	ChatInputQuestionKind as SessionInputQuestionKind,
+	ChatInputRequestPurpose,
 	ChatInputResponseKind as SessionInputResponseKind,
 	ChatInteractivity,
 	ChatOriginKind,

--- a/src/vs/platform/agentHost/node/agentHostInputRequestTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostInputRequestTracker.ts
@@ -97,6 +97,14 @@ export class AgentHostInputRequestTracker {
 		}
 	}
 
+	clearChat(session: string): void {
+		for (const [key, timing] of this._pending) {
+			if (timing.session === session) {
+				this._pending.delete(key);
+			}
+		}
+	}
+
 	clearAgentSession(session: string): void {
 		for (const [key, timing] of this._pending) {
 			const owningSession = isAhpChatChannel(timing.session) ? parseRequiredSessionUriFromChatUri(timing.session) : timing.session;

--- a/src/vs/platform/agentHost/node/agentHostInputRequestTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostInputRequestTracker.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { StopWatch } from '../../../base/common/stopwatch.js';
+import type { ChatInputCompletedAction } from '../common/state/sessionActions.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, ResponsePartKind, isAhpChatChannel, parseRequiredSessionUriFromChatUri, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest, type ChatState } from '../common/state/sessionState.js';
+import type { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+
+interface IInputRequestTiming {
+	readonly stopWatch: Pick<StopWatch, 'elapsed'>;
+	readonly provider: string;
+	readonly session: string;
+	readonly turnId: string;
+	request: ChatInputRequest;
+}
+
+/**
+ * Tracks live ask-user requests through completion and emits legacy-compatible telemetry.
+ */
+export class AgentHostInputRequestTracker {
+
+	private readonly _pending = new Map<string, IInputRequestTiming>();
+
+	constructor(
+		private readonly _reporter: AgentHostTelemetryReporter,
+		private readonly _stopWatchFactory: () => Pick<StopWatch, 'elapsed'> = () => StopWatch.create(true),
+	) { }
+
+	inputRequested(provider: string, session: string, turnId: string, request: ChatInputRequest): void {
+		const key = this._key(session, request.id);
+		if (request.purpose !== ChatInputRequestPurpose.AskUser) {
+			this._pending.delete(key);
+			return;
+		}
+
+		const existing = this._pending.get(key);
+		if (existing) {
+			existing.request = request;
+			return;
+		}
+
+		this._pending.set(key, {
+			stopWatch: this._stopWatchFactory(),
+			provider,
+			session,
+			turnId,
+			request,
+		});
+	}
+
+	inputCompleted(session: string, action: ChatInputCompletedAction, state: ChatState | undefined): void {
+		const key = this._key(session, action.requestId);
+		const timing = this._pending.get(key);
+		if (!timing) {
+			return;
+		}
+		this._pending.delete(key);
+
+		if (action.response !== ChatInputResponseKind.Accept || state?.activeTurn?.id !== timing.turnId) {
+			return;
+		}
+
+		const part = state.activeTurn.responseParts.find(part =>
+			part.kind === ResponsePartKind.InputRequest
+			&& part.request.id === action.requestId
+			&& part.response === ChatInputResponseKind.Accept
+		);
+		if (!part || part.kind !== ResponsePartKind.InputRequest || part.request.purpose !== ChatInputRequestPurpose.AskUser) {
+			return;
+		}
+
+		const questions = part.request.questions ?? timing.request.questions ?? [];
+		const answers = part.request.answers ?? {};
+		const answeredCount = questions.filter(question => this._isAnswered(answers[question.id])).length;
+
+		this._reporter.askQuestionsToolInvoked({
+			provider: timing.provider,
+			session: timing.session,
+			requestId: timing.turnId,
+			questionCount: questions.length,
+			answeredCount,
+			skippedCount: questions.length - answeredCount,
+			freeTextCount: questions.filter(question => this._isFreeTextAnswer(answers[question.id])).length,
+			recommendedAvailableCount: questions.filter(question => this._recommendedOptions(question).length > 0).length,
+			recommendedSelectedCount: questions.filter(question => this._isRecommendedSelected(question, answers[question.id])).length,
+			duration: timing.stopWatch.elapsed(),
+		});
+	}
+
+	clearTurn(session: string, turnId: string): void {
+		for (const [key, timing] of this._pending) {
+			if (timing.session === session && timing.turnId === turnId) {
+				this._pending.delete(key);
+			}
+		}
+	}
+
+	clearAgentSession(session: string): void {
+		for (const [key, timing] of this._pending) {
+			const owningSession = isAhpChatChannel(timing.session) ? parseRequiredSessionUriFromChatUri(timing.session) : timing.session;
+			if (owningSession === session) {
+				this._pending.delete(key);
+			}
+		}
+	}
+
+	clear(): void {
+		this._pending.clear();
+	}
+
+	private _isAnswered(answer: ChatInputAnswer | undefined): answer is Exclude<ChatInputAnswer, { state: ChatInputAnswerState.Skipped }> {
+		return answer !== undefined && answer.state !== ChatInputAnswerState.Skipped;
+	}
+
+	private _isFreeTextAnswer(answer: ChatInputAnswer | undefined): boolean {
+		if (!this._isAnswered(answer)) {
+			return false;
+		}
+		if (answer.value.kind === ChatInputAnswerValueKind.Text) {
+			return true;
+		}
+		return (answer.value.kind === ChatInputAnswerValueKind.Selected || answer.value.kind === ChatInputAnswerValueKind.SelectedMany)
+			&& answer.value.freeformValues?.some(value => value.length > 0) === true;
+	}
+
+	private _recommendedOptions(question: ChatInputQuestion): readonly string[] {
+		if (question.kind !== ChatInputQuestionKind.SingleSelect && question.kind !== ChatInputQuestionKind.MultiSelect) {
+			return [];
+		}
+		return question.options.filter(option => option.recommended).map(option => option.id);
+	}
+
+	private _isRecommendedSelected(question: ChatInputQuestion, answer: ChatInputAnswer | undefined): boolean {
+		if (!this._isAnswered(answer)) {
+			return false;
+		}
+		const recommended = this._recommendedOptions(question);
+		if (answer.value.kind === ChatInputAnswerValueKind.Selected) {
+			return recommended.includes(answer.value.value);
+		}
+		if (answer.value.kind === ChatInputAnswerValueKind.SelectedMany) {
+			return answer.value.value.some(value => recommended.includes(value));
+		}
+		return false;
+	}
+
+	private _key(session: string, requestId: string): string {
+		return `${session}\0${requestId}`;
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -135,6 +135,49 @@ export interface IAgentHostToolInvokedReport {
 	invocationTimeMs?: number;
 }
 
+export interface IAgentHostAskQuestionsToolInvokedEvent {
+	requestId: string;
+	questionCount: number;
+	answeredCount: number;
+	skippedCount: number;
+	freeTextCount: number;
+	recommendedAvailableCount: number;
+	recommendedSelectedCount: number;
+	duration: number;
+	provider: string;
+	agentSessionId: string;
+	isSubagentSession: boolean;
+}
+
+export type IAgentHostAskQuestionsToolInvokedClassification = {
+	requestId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The id of the current request turn.' };
+	questionCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The total number of questions asked' };
+	answeredCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions that were answered' };
+	skippedCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions that were skipped' };
+	freeTextCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions answered with free text input' };
+	recommendedAvailableCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions that had a recommended option' };
+	recommendedSelectedCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions where the user selected the recommended option' };
+	duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The total time in milliseconds to complete all questions' };
+	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the questions belong to a subagent session.' };
+	owner: 'digitarald';
+	comment: 'Tracks usage of the AskQuestions tool for agent clarifications';
+};
+
+export interface IAgentHostAskQuestionsToolInvokedReport {
+	provider: string;
+	session: string;
+	requestId: string;
+	questionCount: number;
+	answeredCount: number;
+	skippedCount: number;
+	freeTextCount: number;
+	recommendedAvailableCount: number;
+	recommendedSelectedCount: number;
+	duration: number;
+}
+
 type AgentHostToolCallResponseType = 'success' | 'cancelled' | 'failed';
 
 export interface IAgentHostToolCallDetailsEvent {
@@ -719,6 +762,23 @@ export class AgentHostTelemetryReporter {
 			toolSourceKind: report.toolSourceKind,
 			invocationTimeMs: report.invocationTimeMs,
 			provider: report.provider,
+		});
+	}
+
+	askQuestionsToolInvoked(report: IAgentHostAskQuestionsToolInvokedReport): void {
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<IAgentHostAskQuestionsToolInvokedEvent, IAgentHostAskQuestionsToolInvokedClassification>('askQuestionsToolInvoked', {
+			requestId: report.requestId,
+			questionCount: report.questionCount,
+			answeredCount: report.answeredCount,
+			skippedCount: report.skippedCount,
+			freeTextCount: report.freeTextCount,
+			recommendedAvailableCount: report.recommendedAvailableCount,
+			recommendedSelectedCount: report.recommendedSelectedCount,
+			duration: report.duration,
+			provider: report.provider,
+			agentSessionId: AgentSession.id(session),
+			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2017,6 +2017,7 @@ export class AgentService extends Disposable implements IAgentService {
 		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {
 			this._sideEffects.clearQueuedMessageSenders(chat.resource);
 		}
+		this._sideEffects.clearInputRequestsForSession(session.toString());
 		// Remove all subagent sessions for this parent
 		this._sideEffects.removeSubagentSessions(session.toString());
 		this._stateManager.deleteSession(session.toString());

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -62,6 +62,7 @@ import {
 	type Turn
 } from '../common/state/sessionState.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
+import { AgentHostInputRequestTracker } from './agentHostInputRequestTracker.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
 import { AgentHostStateManager, resolveChatStateForUri } from './agentHostStateManager.js';
 import { AgentHostTelemetryReporter, type AgentHostModelTelemetryKind, type AgentHostTurnFailureStage, type IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
@@ -179,6 +180,7 @@ export class AgentSideEffects extends Disposable {
 	private readonly _telemetryReporter: AgentHostTelemetryReporter;
 	private readonly _turnTracker: AgentHostTurnTracker;
 	private readonly _toolCallTracker: AgentHostToolCallTracker;
+	private readonly _inputRequestTracker: AgentHostInputRequestTracker;
 	private readonly _titleController: AgentHostSessionTitleController;
 	/** Host-owned worktree isolation controller; injected post-construction. */
 	private _worktree: WorktreeIsolation | undefined;
@@ -197,6 +199,7 @@ export class AgentSideEffects extends Disposable {
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
 		this._toolCallTracker = this._register(new AgentHostToolCallTracker(this._telemetryReporter));
+		this._inputRequestTracker = new AgentHostInputRequestTracker(this._telemetryReporter);
 		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager, {}));
 		this._localCommands = this._register(instantiationService.createInstance(
 			AgentHostLocalCommands,
@@ -223,6 +226,26 @@ export class AgentSideEffects extends Disposable {
 		// actions, which bypass handleAction.
 		this._register(this._stateManager.onDidEmitEnvelope(envelope => {
 			if (isAhpChatChannel(envelope.channel) && isChatAction(envelope.action)) {
+				const chatState = this._stateManager.getChatState(envelope.channel);
+				const action = envelope.action;
+				switch (action.type) {
+					case ActionType.ChatInputRequested: {
+						const turnId = chatState?.activeTurn?.id;
+						const provider = this._options.getAgent(parseRequiredSessionUriFromChatUri(envelope.channel))?.id;
+						if (turnId && provider) {
+							this._inputRequestTracker.inputRequested(provider, envelope.channel, turnId, action.request);
+						}
+						break;
+					}
+					case ActionType.ChatInputCompleted:
+						this._inputRequestTracker.inputCompleted(envelope.channel, action, chatState);
+						break;
+					case ActionType.ChatTurnComplete:
+					case ActionType.ChatTurnCancelled:
+					case ActionType.ChatError:
+						this._inputRequestTracker.clearTurn(envelope.channel, action.turnId);
+						break;
+				}
 				if (envelope.action.type === ActionType.ChatTurnCancelled) {
 					let turnIds = this._cancelledTurnIds.get(envelope.channel);
 					if (!turnIds) {
@@ -1087,6 +1110,10 @@ export class AgentSideEffects extends Disposable {
 		}
 	}
 
+	clearInputRequestsForSession(session: ProtocolURI): void {
+		this._inputRequestTracker.clearAgentSession(session);
+	}
+
 	/**
 	 * Finds the subagent session that owns a given tool call by checking
 	 * whether the tool call was previously registered under a subagent
@@ -1878,6 +1905,7 @@ export class AgentSideEffects extends Disposable {
 		this._toolCallAgents.clear();
 		this._managedApprovalToolCalls.clear();
 		this._toolCallTracker.clear();
+		this._inputRequestTracker.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -245,6 +245,9 @@ export class AgentSideEffects extends Disposable {
 					case ActionType.ChatError:
 						this._inputRequestTracker.clearTurn(envelope.channel, action.turnId);
 						break;
+					case ActionType.ChatTruncated:
+						this._inputRequestTracker.clearChat(envelope.channel);
+						break;
 				}
 				if (envelope.action.type === ActionType.ChatTurnCancelled) {
 					let turnIds = this._cancelledTurnIds.get(envelope.channel);

--- a/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
@@ -5,7 +5,7 @@
 
 import type { PermissionResult, PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
 import { ClaudePermissionMode, ClaudeSessionConfigKey } from '../../common/claudeSessionConfigKeys.js';
-import { ChatInputResponseKind, ToolCallPendingConfirmationState, ToolCallStatus } from '../../common/state/protocol/state.js';
+import { ChatInputRequestPurpose, ChatInputResponseKind, ToolCallPendingConfirmationState, ToolCallStatus } from '../../common/state/protocol/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
 import { buildAskUserSessionInputQuestions, buildExitPlanModeConfirmationState, flattenAskUserAnswers, parseAskUserQuestionInput } from './claudeInteractiveTools.js';
@@ -263,6 +263,7 @@ async function handleAskUserQuestion(
 	const parentToolCallId = resolveSubagentParent(session, options);
 	const answer = await session.requestUserInput({
 		id: toolUseID,
+		purpose: ChatInputRequestPurpose.AskUser,
 		questions: buildAskUserSessionInputQuestions(askInput),
 	}, parentToolCallId);
 	if (answer.response !== ChatInputResponseKind.Accept || !answer.answers) {

--- a/src/vs/platform/agentHost/node/claude/claudeElicitation.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeElicitation.ts
@@ -7,7 +7,7 @@ import type { ElicitationRequest, ElicitationResult } from '@anthropic-ai/claude
 import type { PrimitiveSchemaDefinition } from '@modelcontextprotocol/sdk/types.js';
 import { isObject, isString } from '../../../../base/common/types.js';
 import { vArray, vNumber, vObj, vOptionalProp, vString, vUnknown, type ValidatorType } from '../../../../base/common/validation.js';
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
 
 /**
  * Pure projections between the Claude SDK's MCP elicitation request/response
@@ -135,7 +135,7 @@ function parseElicitationSchema(schema: unknown): IParsedElicitationSchema | und
  */
 export function buildElicitationRequest(requestId: string, request: ElicitationRequest): ChatInputRequest {
 	if (request.mode === 'url') {
-		const result: ChatInputRequest = { id: requestId, message: request.message };
+		const result: ChatInputRequest = { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: request.message };
 		if (request.url) {
 			result.url = request.url;
 		}
@@ -143,10 +143,10 @@ export function buildElicitationRequest(requestId: string, request: ElicitationR
 	}
 	const schema = parseElicitationSchema(request.requestedSchema);
 	if (!schema || schema.fields.length === 0) {
-		return { id: requestId, message: request.message };
+		return { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: request.message };
 	}
 	const questions = schema.fields.map(([name, field]) => elicitationFieldToQuestion(name, field, schema.required.has(name)));
-	return { id: requestId, message: request.message, questions };
+	return { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: request.message, questions };
 }
 
 /**

--- a/src/vs/platform/agentHost/node/claude/claudeElicitationBridge.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeElicitationBridge.ts
@@ -5,7 +5,7 @@
 
 import type { ElicitationRequest, ElicitationResult } from '@anthropic-ai/claude-agent-sdk';
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { ChatInputResponseKind } from '../../common/state/sessionState.js';
+import { ChatInputRequestPurpose, ChatInputResponseKind } from '../../common/state/sessionState.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
 import { buildElicitationRequest, cancelledElicitationResult, elicitationResultFromAnswers } from './claudeElicitation.js';
 
@@ -56,7 +56,10 @@ export async function handleElicitation(
 	// yielded no representable fields. The workbench would inject a required
 	// generic text question whose answer this translator then discards — falsely
 	// reporting the elicitation as accepted. Cancel instead of surfacing it.
-	const chatRequest = buildElicitationRequest(requestId, request);
+	const chatRequest = {
+		...buildElicitationRequest(requestId, request),
+		purpose: ChatInputRequestPurpose.Elicitation,
+	};
 	if (!chatRequest.url && !chatRequest.questions?.length) {
 		return cancelledElicitationResult();
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeElicitationBridge.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeElicitationBridge.ts
@@ -5,7 +5,7 @@
 
 import type { ElicitationRequest, ElicitationResult } from '@anthropic-ai/claude-agent-sdk';
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { ChatInputRequestPurpose, ChatInputResponseKind } from '../../common/state/sessionState.js';
+import { ChatInputResponseKind } from '../../common/state/sessionState.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
 import { buildElicitationRequest, cancelledElicitationResult, elicitationResultFromAnswers } from './claudeElicitation.js';
 
@@ -56,10 +56,7 @@ export async function handleElicitation(
 	// yielded no representable fields. The workbench would inject a required
 	// generic text question whose answer this translator then discards — falsely
 	// reporting the elicitation as accepted. Cancel instead of surfacing it.
-	const chatRequest = {
-		...buildElicitationRequest(requestId, request),
-		purpose: ChatInputRequestPurpose.Elicitation,
-	};
+	const chatRequest = buildElicitationRequest(requestId, request);
 	if (!chatRequest.url && !chatRequest.questions?.length) {
 		return cancelledElicitationResult();
 	}

--- a/src/vs/platform/agentHost/node/codex/codexElicitationMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexElicitationMapper.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { hasKey } from '../../../../base/common/types.js';
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
 import type { JsonValue } from './protocol/generated/serde_json/JsonValue.js';
 import type { McpElicitationPrimitiveSchema } from './protocol/generated/v2/McpElicitationPrimitiveSchema.js';
 import type { McpServerElicitationRequestParams } from './protocol/generated/v2/McpServerElicitationRequestParams.js';
@@ -30,7 +30,7 @@ import type { McpServerElicitationRequestResponse } from './protocol/generated/v
  */
 export function buildElicitationRequest(requestId: string, params: McpServerElicitationRequestParams): ChatInputRequest {
 	if (params.mode === 'url') {
-		const request: ChatInputRequest = { id: requestId, message: params.message };
+		const request: ChatInputRequest = { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: params.message };
 		if (params.url) {
 			request.url = params.url;
 		}
@@ -40,7 +40,7 @@ export function buildElicitationRequest(requestId: string, params: McpServerElic
 		// `openai/form` carries an opaque, OpenAI-specific schema we cannot
 		// project into typed questions; surface the message only so the user
 		// can still accept or decline.
-		return { id: requestId, message: params.message };
+		return { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: params.message };
 	}
 	const required = new Set(params.requestedSchema.required ?? []);
 	const questions: ChatInputQuestion[] = [];
@@ -50,8 +50,8 @@ export function buildElicitationRequest(requestId: string, params: McpServerElic
 		}
 	}
 	return questions.length > 0
-		? { id: requestId, message: params.message, questions }
-		: { id: requestId, message: params.message };
+		? { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: params.message, questions }
+		: { id: requestId, purpose: ChatInputRequestPurpose.Elicitation, message: params.message };
 }
 
 /**

--- a/src/vs/platform/agentHost/node/codex/codexUserInputMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexUserInputMapper.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest } from '../../common/state/sessionState.js';
 import type { ToolRequestUserInputAnswer } from './protocol/generated/v2/ToolRequestUserInputAnswer.js';
 import type { ToolRequestUserInputQuestion } from './protocol/generated/v2/ToolRequestUserInputQuestion.js';
 import type { ToolRequestUserInputResponse } from './protocol/generated/v2/ToolRequestUserInputResponse.js';
@@ -18,6 +18,7 @@ import type { ToolRequestUserInputResponse } from './protocol/generated/v2/ToolR
 export function buildUserInputRequest(requestId: string, questions: readonly ToolRequestUserInputQuestion[]): ChatInputRequest {
 	return {
 		id: requestId,
+		purpose: ChatInputRequestPurpose.AskUser,
 		questions: questions.map((q): ChatInputQuestion => {
 			if (q.options && q.options.length > 0) {
 				return {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -45,7 +45,7 @@ import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAtt
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment, type ToolCallContributor } from '../../common/state/protocol/state.js';
 import { ActionType, isChatAction, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
-import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, isDefaultChatUri, isSubagentSession, readSessionPromptCacheState, withSessionPromptCacheState, type Message, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type ToolResultTerminalContent, type Turn, type UsageInfo, type UsageInfoMeta, type IContextAttributionData, type ISessionPromptCacheState } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, isDefaultChatUri, isSubagentSession, readSessionPromptCacheState, withSessionPromptCacheState, type Message, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type ToolResultTerminalContent, type Turn, type UsageInfo, type UsageInfoMeta, type IContextAttributionData, type ISessionPromptCacheState } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
@@ -3195,7 +3195,7 @@ export class CopilotAgentSession extends Disposable {
 
 			this._emitAction({
 				type: ActionType.ChatInputRequested,
-				request: inputRequest,
+				request: { ...inputRequest, purpose: ChatInputRequestPurpose.AskUser },
 			});
 
 			const result = await pendingInput;
@@ -3267,6 +3267,7 @@ export class CopilotAgentSession extends Disposable {
 
 			const inputRequest: ChatInputRequest = {
 				id: requestId,
+				purpose: ChatInputRequestPurpose.Elicitation,
 				message: context.message,
 				...(context.mode === 'url' && context.url ? { url: context.url } : {}),
 				...(questions && questions.length > 0 ? { questions } : {}),
@@ -4790,6 +4791,7 @@ export class CopilotAgentSession extends Disposable {
 
 		const inputRequest: ChatInputRequestWithPlanReview = {
 			id: requestId,
+			purpose: ChatInputRequestPurpose.PlanReview,
 			planReview: {
 				title: localize('agentHost.planReview.title', "Review Plan"),
 				content: data.summary || localize('agentHost.planReview.fallbackSummary', "A plan is ready for review."),

--- a/src/vs/platform/agentHost/test/node/agentHostInputRequestTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostInputRequestTracker.test.ts
@@ -193,13 +193,17 @@ suite('AgentHostInputRequestTracker', () => {
 		tracker.clearTurn(rootChat, 'turn-1');
 		tracker.inputCompleted(rootChat, accept(request.id), completedState(rootChat, 'turn-1', request));
 
-		tracker.inputRequested('mock', subagentChat, 'turn-2', { ...request, id: 'request-2' });
-		tracker.clearAgentSession(rootSession);
-		tracker.inputCompleted(subagentChat, accept('request-2'), completedState(subagentChat, 'turn-2', { ...request, id: 'request-2' }));
+		tracker.inputRequested('mock', rootChat, 'turn-2', { ...request, id: 'request-2' });
+		tracker.clearChat(rootChat);
+		tracker.inputCompleted(rootChat, accept('request-2'), completedState(rootChat, 'turn-2', { ...request, id: 'request-2' }));
 
-		tracker.inputRequested('mock', rootChat, 'turn-3', { ...request, id: 'request-3' });
+		tracker.inputRequested('mock', subagentChat, 'turn-3', { ...request, id: 'request-3' });
+		tracker.clearAgentSession(rootSession);
+		tracker.inputCompleted(subagentChat, accept('request-3'), completedState(subagentChat, 'turn-3', { ...request, id: 'request-3' }));
+
+		tracker.inputRequested('mock', rootChat, 'turn-4', { ...request, id: 'request-4' });
 		tracker.clear();
-		tracker.inputCompleted(rootChat, accept('request-3'), completedState(rootChat, 'turn-3', { ...request, id: 'request-3' }));
+		tracker.inputCompleted(rootChat, accept('request-4'), completedState(rootChat, 'turn-4', { ...request, id: 'request-4' }));
 
 		assert.deepStrictEqual(telemetry.events, []);
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostInputRequestTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostInputRequestTracker.test.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
+import { ActionType, type ChatInputCompletedAction } from '../../common/state/sessionActions.js';
+import { buildDefaultChatUri, buildSubagentChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, ChatOriginKind, MessageKind, ResponsePartKind, SessionStatus, type ChatInputAnswer, type ChatInputRequest, type ChatState } from '../../common/state/sessionState.js';
+import { AgentHostInputRequestTracker } from '../../node/agentHostInputRequestTracker.js';
+import { AgentHostTelemetryReporter } from '../../node/agentHostTelemetryReporter.js';
+
+class CapturingTelemetryService implements ITelemetryService {
+	declare readonly _serviceBrand: undefined;
+	readonly telemetryLevel = TelemetryLevel.USAGE;
+	readonly sessionId = 'test-session';
+	readonly machineId = 'test-machine';
+	readonly sqmId = 'test-sqm';
+	readonly devDeviceId = 'test-dev-device';
+	readonly firstSessionDate = 'test-first-session-date';
+	readonly sendErrorTelemetry = false;
+	readonly events: { eventName: string; data: unknown }[] = [];
+
+	publicLog(): void { }
+	publicLog2(eventName: string, data?: unknown): void {
+		this.events.push({ eventName, data });
+	}
+	publicLogError(): void { }
+	publicLogError2(): void { }
+	setExperimentProperty(): void { }
+	setCommonProperty(): void { }
+}
+
+suite('AgentHostInputRequestTracker', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const rootSession = AgentSession.uri('mock', 'root-session').toString();
+	const rootChat = buildDefaultChatUri(rootSession);
+	const subagentChat = buildSubagentChatUri(rootSession, 'subagent-tool');
+
+	function createTracker(): { telemetry: CapturingTelemetryService; tracker: AgentHostInputRequestTracker } {
+		const telemetry = new CapturingTelemetryService();
+		return {
+			telemetry,
+			tracker: new AgentHostInputRequestTracker(new AgentHostTelemetryReporter(telemetry), () => ({ elapsed: () => 25 })),
+		};
+	}
+
+	function completedState(session: string, turnId: string, request: ChatInputRequest, answers: Record<string, ChatInputAnswer> = {}): ChatState {
+		return {
+			resource: session,
+			title: 'Test',
+			status: SessionStatus.InProgress,
+			modifiedAt: new Date().toISOString(),
+			origin: { kind: ChatOriginKind.User },
+			turns: [],
+			activeTurn: {
+				id: turnId,
+				startedAt: new Date().toISOString(),
+				message: { text: 'question', origin: { kind: MessageKind.User } },
+				responseParts: [{
+					kind: ResponsePartKind.InputRequest,
+					request: { ...request, answers },
+					response: ChatInputResponseKind.Accept,
+				}],
+				usage: undefined,
+			},
+		};
+	}
+
+	function accept(requestId: string): ChatInputCompletedAction {
+		return { type: ActionType.ChatInputCompleted, requestId, response: ChatInputResponseKind.Accept };
+	}
+
+	test('emits accepted metrics from reduced state with standard root identifiers', () => {
+		const { telemetry, tracker } = createTracker();
+		const request: ChatInputRequest = {
+			id: 'request-1',
+			purpose: ChatInputRequestPurpose.AskUser,
+			questions: [
+				{ id: 'text', kind: ChatInputQuestionKind.Text, message: 'Text?' },
+				{ id: 'selected', kind: ChatInputQuestionKind.SingleSelect, message: 'Select?', options: [{ id: 'recommended', label: 'Recommended', recommended: true }] },
+				{ id: 'multi', kind: ChatInputQuestionKind.MultiSelect, message: 'Many?', options: [{ id: 'recommended-many', label: 'Recommended', recommended: true }, { id: 'other', label: 'Other' }] },
+				{ id: 'number', kind: ChatInputQuestionKind.Number, message: 'Number?' },
+				{ id: 'boolean', kind: ChatInputQuestionKind.Boolean, message: 'Boolean?' },
+				{ id: 'skipped', kind: ChatInputQuestionKind.Text, message: 'Skip?' },
+				{ id: 'missing', kind: ChatInputQuestionKind.Text, message: 'Missing?' },
+			],
+		};
+		const answers: Record<string, ChatInputAnswer> = {
+			text: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Text, value: 'value' } },
+			selected: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Selected, value: 'recommended' } },
+			multi: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.SelectedMany, value: ['other'], freeformValues: ['', 'custom'] } },
+			number: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Number, value: 3 } },
+			boolean: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Boolean, value: false } },
+			skipped: { state: ChatInputAnswerState.Skipped },
+		};
+
+		tracker.inputRequested('mock', rootChat, 'turn-1', request);
+		tracker.inputCompleted(rootChat, accept(request.id), completedState(rootChat, 'turn-1', request, answers));
+
+		assert.deepStrictEqual(telemetry.events.map(event => ({ eventName: event.eventName, data: event.data })), [{
+			eventName: 'askQuestionsToolInvoked',
+			data: {
+				requestId: 'turn-1',
+				questionCount: 7,
+				answeredCount: 5,
+				skippedCount: 2,
+				freeTextCount: 2,
+				recommendedAvailableCount: 2,
+				recommendedSelectedCount: 1,
+				duration: 25,
+				provider: 'mock',
+				agentSessionId: 'root-session',
+				isSubagentSession: false,
+			},
+		}]);
+	});
+
+	test('replacement preserves timing and turn correlation while updating questions', () => {
+		let now = 0;
+		const telemetry = new CapturingTelemetryService();
+		const tracker = new AgentHostInputRequestTracker(new AgentHostTelemetryReporter(telemetry), () => {
+			const startedAt = now;
+			return { elapsed: () => now - startedAt };
+		});
+		const initial: ChatInputRequest = {
+			id: 'request-1',
+			purpose: ChatInputRequestPurpose.AskUser,
+			questions: [{ id: 'old', kind: ChatInputQuestionKind.Text, message: 'Old?' }],
+		};
+		const replacement: ChatInputRequest = {
+			id: 'request-1',
+			purpose: ChatInputRequestPurpose.AskUser,
+			questions: [
+				{ id: 'new-1', kind: ChatInputQuestionKind.Text, message: 'New?' },
+				{ id: 'new-2', kind: ChatInputQuestionKind.Text, message: 'Another?' },
+			],
+		};
+
+		tracker.inputRequested('mock', rootChat, 'turn-1', initial);
+		now = 5;
+		tracker.inputRequested('other-provider', rootChat, 'turn-2', replacement);
+		now = 12;
+		tracker.inputCompleted(rootChat, accept(replacement.id), completedState(rootChat, 'turn-1', replacement));
+
+		assert.deepStrictEqual(telemetry.events, [{
+			eventName: 'askQuestionsToolInvoked',
+			data: {
+				requestId: 'turn-1',
+				questionCount: 2,
+				answeredCount: 0,
+				skippedCount: 2,
+				freeTextCount: 0,
+				recommendedAvailableCount: 0,
+				recommendedSelectedCount: 0,
+				duration: 12,
+				provider: 'mock',
+				agentSessionId: 'root-session',
+				isSubagentSession: false,
+			},
+		}]);
+	});
+
+	test('decline, cancellation, non-ask purposes, missing active turns, and duplicate completion do not emit', () => {
+		const { telemetry, tracker } = createTracker();
+		const ask: ChatInputRequest = { id: 'ask', purpose: ChatInputRequestPurpose.AskUser, questions: [] };
+		const state = completedState(rootChat, 'turn-1', ask);
+
+		tracker.inputRequested('mock', rootChat, 'turn-1', ask);
+		tracker.inputCompleted(rootChat, { ...accept(ask.id), response: ChatInputResponseKind.Decline }, state);
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'cancel' });
+		tracker.inputCompleted(rootChat, { ...accept('cancel'), response: ChatInputResponseKind.Cancel }, state);
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'elicitation', purpose: ChatInputRequestPurpose.Elicitation });
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'plan', purpose: ChatInputRequestPurpose.PlanReview });
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'legacy', purpose: undefined });
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'missing-turn' });
+		tracker.inputCompleted(rootChat, accept('missing-turn'), { ...state, activeTurn: undefined });
+		tracker.inputRequested('mock', rootChat, 'turn-1', { ...ask, id: 'duplicate' });
+		tracker.inputCompleted(rootChat, accept('duplicate'), completedState(rootChat, 'turn-1', { ...ask, id: 'duplicate' }));
+		tracker.inputCompleted(rootChat, accept('duplicate'), completedState(rootChat, 'turn-1', { ...ask, id: 'duplicate' }));
+
+		assert.strictEqual(telemetry.events.length, 1);
+	});
+
+	test('turn, session, and tracker cleanup drop pending requests', () => {
+		const { telemetry, tracker } = createTracker();
+		const request: ChatInputRequest = { id: 'request-1', purpose: ChatInputRequestPurpose.AskUser, questions: [] };
+
+		tracker.inputRequested('mock', rootChat, 'turn-1', request);
+		tracker.clearTurn(rootChat, 'turn-1');
+		tracker.inputCompleted(rootChat, accept(request.id), completedState(rootChat, 'turn-1', request));
+
+		tracker.inputRequested('mock', subagentChat, 'turn-2', { ...request, id: 'request-2' });
+		tracker.clearAgentSession(rootSession);
+		tracker.inputCompleted(subagentChat, accept('request-2'), completedState(subagentChat, 'turn-2', { ...request, id: 'request-2' }));
+
+		tracker.inputRequested('mock', rootChat, 'turn-3', { ...request, id: 'request-3' });
+		tracker.clear();
+		tracker.inputCompleted(rootChat, accept('request-3'), completedState(rootChat, 'turn-3', { ...request, id: 'request-3' }));
+
+		assert.deepStrictEqual(telemetry.events, []);
+	});
+
+	test('emits subagent identifiers', () => {
+		const { telemetry, tracker } = createTracker();
+		const request: ChatInputRequest = { id: 'request-1', purpose: ChatInputRequestPurpose.AskUser, questions: [] };
+
+		tracker.inputRequested('mock', subagentChat, 'turn-1', request);
+		tracker.inputCompleted(subagentChat, accept(request.id), completedState(subagentChat, 'turn-1', request));
+
+		assert.deepStrictEqual(telemetry.events.map(event => {
+			const data = event.data as { agentSessionId: string; isSubagentSession: boolean };
+			return { agentSessionId: data.agentSessionId, isSubagentSession: data.isSubagentSession };
+		}), [{ agentSessionId: 'root-session', isSubagentSession: true }]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -26,7 +26,7 @@ import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import type { RootConfigChangedAction } from '../../common/state/protocol/actions.js';
 import { ChangesSummary, ChatOriginKind, CustomizationType, McpAuthRequiredReason, SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, ActionEnvelope, type ChatAction, type INotification, type SessionAction } from '../../common/state/sessionActions.js';
-import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInteractivity, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
+import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInteractivity, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
@@ -40,6 +40,7 @@ import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentService } from '../../node/agentService.js';
 import { AgentSideEffects, IAgentSideEffectsOptions } from '../../node/agentSideEffects.js';
 import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
+import type { IAgentHostAskQuestionsToolInvokedEvent } from '../../node/agentHostTelemetryReporter.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
@@ -4960,6 +4961,59 @@ suite('AgentSideEffects', () => {
 			});
 
 			assert.deepStrictEqual(sessionInputNeeded(), []);
+		});
+
+		test('accepted ask-user input emits telemetry from synchronized answer state', () => {
+			setupSession();
+			startTurn('turn-1');
+
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatInputRequested,
+				request: {
+					id: 'req-1',
+					purpose: ChatInputRequestPurpose.AskUser,
+					questions: [{ kind: ChatInputQuestionKind.Text, id: 'question-1', message: 'Which value?' }],
+				},
+			});
+			stateManager.dispatchClientAction(defaultChatUri, {
+				type: ActionType.ChatInputAnswerChanged,
+				requestId: 'req-1',
+				questionId: 'question-1',
+				answer: {
+					state: ChatInputAnswerState.Submitted,
+					value: { kind: ChatInputAnswerValueKind.Text, value: 'answer' },
+				},
+			}, { clientId: 'test', clientSeq: 2 });
+			stateManager.dispatchClientAction(defaultChatUri, {
+				type: ActionType.ChatInputCompleted,
+				requestId: 'req-1',
+				response: SessionInputResponseKind.Accept,
+			}, { clientId: 'test', clientSeq: 3 });
+
+			const event = telemetryService.events.find(event => event.eventName === 'askQuestionsToolInvoked');
+			const data = event?.data as IAgentHostAskQuestionsToolInvokedEvent | undefined;
+			assert.deepStrictEqual(event && {
+				eventName: event.eventName,
+				data: {
+					...data,
+					duration: typeof data?.duration,
+				},
+			}, {
+				eventName: 'askQuestionsToolInvoked',
+				data: {
+					requestId: 'turn-1',
+					questionCount: 1,
+					answeredCount: 1,
+					skippedCount: 0,
+					freeTextCount: 1,
+					recommendedAvailableCount: 0,
+					recommendedSelectedCount: 0,
+					duration: 'number',
+					provider: agent.id,
+					agentSessionId: AgentSession.id(sessionUri),
+					isSubagentSession: false,
+				},
+			});
 		});
 
 		test('chat input request without an active turn is not mirrored', () => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -26,7 +26,7 @@ import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import type { RootConfigChangedAction } from '../../common/state/protocol/actions.js';
 import { ChangesSummary, ChatOriginKind, CustomizationType, McpAuthRequiredReason, SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, ActionEnvelope, type ChatAction, type INotification, type SessionAction } from '../../common/state/sessionActions.js';
-import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInteractivity, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
+import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInteractivity, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ChatInputRequest, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
@@ -5014,6 +5014,38 @@ suite('AgentSideEffects', () => {
 					isSubagentSession: false,
 				},
 			});
+		});
+
+		test('chat truncation clears pending ask-user telemetry', () => {
+			setupSession();
+			startTurn('turn-1');
+
+			const request: ChatInputRequest = {
+				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
+				questions: [{ kind: ChatInputQuestionKind.Text, id: 'question-1', message: 'Which value?' }],
+			};
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatInputRequested,
+				request,
+			});
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatTruncated,
+			});
+
+			startTurn('turn-2');
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatInputRequested,
+				request,
+			});
+			stateManager.dispatchServerAction(defaultChatUri, {
+				type: ActionType.ChatInputCompleted,
+				requestId: request.id,
+				response: SessionInputResponseKind.Accept,
+			});
+
+			const events = telemetryService.events.filter(event => event.eventName === 'askQuestionsToolInvoked');
+			assert.deepStrictEqual(events.map(event => (event.data as IAgentHostAskQuestionsToolInvokedEvent).requestId), ['turn-2']);
 		});
 
 		test('chat input request without an active turn is not mirrored', () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -51,7 +51,7 @@ import { ActionType, type AuthRequiredParams } from '../../common/state/sessionA
 import { CustomizationLoadStatus, CustomizationType, MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputResponseKind, SessionStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, parseChatUri, parseDefaultChatUri, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
-import { ProtectedResourceMetadata, ChatInputAnswerState, ChatInputAnswerValueKind, ToolCallStatus, type SessionConfigState, type ChatInputRequest, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { ProtectedResourceMetadata, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputRequestPurpose, ToolCallStatus, type SessionConfigState, type ChatInputRequest, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../../node/agentHostStateManager.js';
@@ -5370,6 +5370,7 @@ suite('ClaudeAgent (Phase 7 §3.5 — INTERACTIVE_CLAUDE_TOOLS)', () => {
 		await tick();
 
 		const inputRequest = inputRequests.at(-1)!;
+		assert.strictEqual(inputRequest.purpose, ChatInputRequestPurpose.AskUser);
 		ctx.agent.respondToUserInputRequest('tu_ask', ChatInputResponseKind.Accept, {
 			q1: {
 				state: ChatInputAnswerState.Submitted,
@@ -5668,6 +5669,7 @@ suite('ClaudeAgent (Phase 10.6 — MCP elicitation translation)', () => {
 		await tick();
 
 		const inputRequest = inputRequests.at(-1)!;
+		assert.strictEqual(inputRequest.purpose, ChatInputRequestPurpose.Elicitation);
 		ctx.agent.respondToUserInputRequest(inputRequest.id, ChatInputResponseKind.Accept, {
 			side: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Text, value: 'left' } },
 		});

--- a/src/vs/platform/agentHost/test/node/claudeElicitation.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeElicitation.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import type { ElicitationRequest } from '@anthropic-ai/claude-agent-sdk';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer } from '../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer } from '../../common/state/sessionState.js';
 import { buildElicitationRequest, cancelledElicitationResult, elicitationResultFromAnswers } from '../../node/claude/claudeElicitation.js';
 import { handleElicitation } from '../../node/claude/claudeElicitationBridge.js';
 
@@ -43,6 +43,7 @@ suite('claudeElicitation', () => {
 	test('buildElicitationRequest (form) projects every primitive field kind', () => {
 		assert.deepStrictEqual(buildElicitationRequest('req-1', formRequest), {
 			id: 'req-1',
+			purpose: ChatInputRequestPurpose.Elicitation,
 			message: 'Please configure',
 			questions: [
 				{ kind: ChatInputQuestionKind.Text, id: 'name', title: 'Name', message: 'Your name', required: true, format: undefined, min: 1, max: undefined, defaultValue: undefined },
@@ -58,6 +59,7 @@ suite('claudeElicitation', () => {
 	test('buildElicitationRequest (url) surfaces the url with no questions', () => {
 		assert.deepStrictEqual(buildElicitationRequest('req-2', urlRequest), {
 			id: 'req-2',
+			purpose: ChatInputRequestPurpose.Elicitation,
 			message: 'Authorize',
 			url: 'https://example.com/auth',
 		});
@@ -70,7 +72,7 @@ suite('claudeElicitation', () => {
 			mode: 'form',
 			requestedSchema: { type: 'object', properties: 'not-an-object' as unknown as Record<string, unknown> },
 		};
-		assert.deepStrictEqual(buildElicitationRequest('req-3', malformed), { id: 'req-3', message: 'Broken' });
+		assert.deepStrictEqual(buildElicitationRequest('req-3', malformed), { id: 'req-3', purpose: ChatInputRequestPurpose.Elicitation, message: 'Broken' });
 	});
 
 	test('buildElicitationRequest drops a field that fails validation but keeps valid siblings', () => {
@@ -90,6 +92,7 @@ suite('claudeElicitation', () => {
 		};
 		assert.deepStrictEqual(buildElicitationRequest('req-4', mixed), {
 			id: 'req-4',
+			purpose: ChatInputRequestPurpose.Elicitation,
 			message: 'Mixed',
 			questions: [
 				{ kind: ChatInputQuestionKind.Text, id: 'ok', title: 'Ok', message: 'Ok', required: false, format: undefined, min: undefined, max: undefined, defaultValue: undefined },
@@ -120,6 +123,7 @@ suite('claudeElicitation', () => {
 		};
 		assert.deepStrictEqual(buildElicitationRequest('req-5', variants), {
 			id: 'req-5',
+			purpose: ChatInputRequestPurpose.Elicitation,
 			message: 'Variants',
 			questions: [
 				{ kind: ChatInputQuestionKind.Number, id: 'ratio', title: 'Ratio', message: 'Ratio', required: false, min: 0, max: 1, defaultValue: 0.5 },
@@ -144,10 +148,10 @@ suite('claudeElicitation', () => {
 			formAllInvalid: buildElicitationRequest('d', { serverName: 'srv', message: 'AllBad', mode: 'form', requestedSchema: { type: 'object', properties: { a: { type: 'string', enum: 123 }, b: { minimum: 'nope' } } } }),
 		};
 		assert.deepStrictEqual(cases, {
-			urlNoUrl: { id: 'a', message: 'NoUrl' },
-			formNoSchema: { id: 'b', message: 'NoSchema' },
-			formEmptyProps: { id: 'c', message: 'Empty' },
-			formAllInvalid: { id: 'd', message: 'AllBad' },
+			urlNoUrl: { id: 'a', purpose: ChatInputRequestPurpose.Elicitation, message: 'NoUrl' },
+			formNoSchema: { id: 'b', purpose: ChatInputRequestPurpose.Elicitation, message: 'NoSchema' },
+			formEmptyProps: { id: 'c', purpose: ChatInputRequestPurpose.Elicitation, message: 'Empty' },
+			formAllInvalid: { id: 'd', purpose: ChatInputRequestPurpose.Elicitation, message: 'AllBad' },
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexElicitationMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexElicitationMapper.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer } from '../../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer } from '../../../common/state/sessionState.js';
 import { buildElicitationRequest, elicitationResponseFromAnswers } from '../../../node/codex/codexElicitationMapper.js';
 import type { McpServerElicitationRequestParams } from '../../../node/codex/protocol/generated/v2/McpServerElicitationRequestParams.js';
 
@@ -38,6 +38,7 @@ suite('codexElicitationMapper', () => {
 	test('buildElicitationRequest (form) projects every primitive field kind', () => {
 		assert.deepStrictEqual(buildElicitationRequest('req-1', formParams), {
 			id: 'req-1',
+			purpose: ChatInputRequestPurpose.Elicitation,
 			message: 'Please configure',
 			questions: [
 				{ kind: ChatInputQuestionKind.Text, id: 'name', title: 'Name', message: 'Your name', required: true, format: undefined, min: 1, max: undefined, defaultValue: undefined },
@@ -52,7 +53,7 @@ suite('codexElicitationMapper', () => {
 
 	test('buildElicitationRequest (url) surfaces the url with no questions', () => {
 		assert.deepStrictEqual(buildElicitationRequest('req-2', urlParams), {
-			id: 'req-2', message: 'Authorize', url: 'https://example.com/auth',
+			id: 'req-2', purpose: ChatInputRequestPurpose.Elicitation, message: 'Authorize', url: 'https://example.com/auth',
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexUserInputMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexUserInputMapper.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, type ChatInputAnswer } from '../../../common/state/sessionState.js';
+import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, type ChatInputAnswer } from '../../../common/state/sessionState.js';
 import { answerStrings, buildUserInputRequest, emptyUserInputResponse, userInputResponseFromAnswers } from '../../../node/codex/codexUserInputMapper.js';
 import type { ToolRequestUserInputQuestion } from '../../../node/codex/protocol/generated/v2/ToolRequestUserInputQuestion.js';
 
@@ -24,6 +24,7 @@ suite('codexUserInputMapper', () => {
 	test('buildUserInputRequest maps select and text questions', () => {
 		assert.deepStrictEqual(buildUserInputRequest('req-1', [selectQuestion, textQuestion]), {
 			id: 'req-1',
+			purpose: ChatInputRequestPurpose.AskUser,
 			questions: [
 				{
 					kind: ChatInputQuestionKind.SingleSelect,

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -30,7 +30,7 @@ import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService, type ISessionDatabase } from '../../common/sessionDataService.js';
 import { ActionType, type ChatDeltaAction, type ChatErrorAction, type ChatInputRequestedAction, type ChatResponsePartAction, type ChatToolCallCompleteAction, type ChatToolCallDeltaAction, type ChatToolCallReadyAction, type ChatToolCallStartAction, type ChatTurnCompleteAction, type ChatUsageAction, type SessionAction, type StateAction } from '../../common/state/sessionActions.js';
-import { MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildChatUri, buildDefaultChatUri, createSessionState, mergeSessionWithDefaultChat, readSessionPromptCacheState, readUsageInfoMeta, SessionStatus, withSessionPromptCacheState, type ToolDefinition, type ToolResultContent, type ToolResultFileEditContent, type ToolResultTerminalContent, type UsageInfoMeta } from '../../common/state/sessionState.js';
+import { MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildChatUri, buildDefaultChatUri, createSessionState, mergeSessionWithDefaultChat, readSessionPromptCacheState, readUsageInfoMeta, SessionStatus, withSessionPromptCacheState, type ToolDefinition, type ToolResultContent, type ToolResultFileEditContent, type ToolResultTerminalContent, type UsageInfoMeta } from '../../common/state/sessionState.js';
 import { TerminalClaimKind } from '../../common/state/protocol/state.js';
 import { STREAMING_TOOL_DISPLAY_INTERVAL_MS } from '../../common/streamingToolCallDisplay.js';
 import { CustomizationType, McpAuthRequiredReason, McpServerStatus, type Customization } from '../../common/state/protocol/channels-session/state.js';
@@ -5843,6 +5843,7 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(signals.length, 1);
 			const request = getInputRequest(signals[0]);
 			const requestId = request.id;
+			assert.strictEqual(request.purpose, ChatInputRequestPurpose.AskUser);
 			assert.ok(request.questions);
 			assert.strictEqual(request.questions[0].message, 'What is your name?');
 			const questionId = request.questions[0].id;
@@ -5985,6 +5986,8 @@ suite('CopilotAgentSession', () => {
 				ActionType.ChatInputRequested,
 				ActionType.ChatInputCompleted,
 			]);
+			const requested = getActions(signals)[0];
+			assert.strictEqual(requested.type === ActionType.ChatInputRequested ? requested.request.purpose : undefined, undefined);
 			const completed = getActions(signals)[1];
 			assert.deepStrictEqual(completed.type === ActionType.ChatInputCompleted ? Object.values(completed.answers ?? {}) : [], [{
 				state: ChatInputAnswerState.Submitted,
@@ -6034,6 +6037,8 @@ suite('CopilotAgentSession', () => {
 				ActionType.ChatInputRequested,
 				ActionType.ChatInputCompleted,
 			]);
+			const requested = getActions(signals)[0];
+			assert.strictEqual(requested.type === ActionType.ChatInputRequested ? requested.request.purpose : undefined, undefined);
 			const completed = getActions(signals)[1];
 			assert.deepStrictEqual(completed.type === ActionType.ChatInputCompleted ? Object.values(completed.answers ?? {}) : [], [{
 				state: ChatInputAnswerState.Submitted,
@@ -6072,6 +6077,7 @@ suite('CopilotAgentSession', () => {
 
 			assert.strictEqual(signals.length, 1);
 			const request = getInputRequest(signals[0]);
+			assert.strictEqual(request.purpose, ChatInputRequestPurpose.Elicitation);
 			assert.strictEqual(request.message, 'Configure deployment');
 			assert.ok(request.questions);
 			assert.deepStrictEqual(request.questions.map(q => ({ id: q.id, kind: q.kind, required: q.required })), [
@@ -7305,6 +7311,7 @@ suite('CopilotAgentSession', () => {
 
 			const signal = await waitForSignal(s => isAction(s, ActionType.ChatInputRequested));
 			const request = getInputRequest(signal);
+			assert.strictEqual(request.purpose, ChatInputRequestPurpose.PlanReview);
 
 			const planReview = (request as ChatInputRequestWithPlanReview).planReview;
 			assert.deepStrictEqual(planReview, {

--- a/src/vs/platform/agentHost/test/node/reducers.test.ts
+++ b/src/vs/platform/agentHost/test/node/reducers.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { changesetReducer, chatReducer, sessionReducer } from '../../common/state/protocol/reducers.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, ChangesetOperationStatus, CustomizationLoadStatus, MessageKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ChatOriginKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ResponsePartKind, ToolCallStatus, TurnState, type AgentCustomization, type ChangesetState, type Customization, type PluginCustomization, type ChatState, type SessionState } from '../../common/state/sessionState.js';
+import { ChangesetStatus, ChangesetOperationStatus, CustomizationLoadStatus, MessageKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputRequestPurpose, ChatInputResponseKind, ChatOriginKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ResponsePartKind, ToolCallStatus, TurnState, type AgentCustomization, type ChangesetState, type Customization, type PluginCustomization, type ChatState, type SessionState } from '../../common/state/sessionState.js';
 import { CustomizationType, ToolCallContributorKind, type ToolCallContributor } from '../../common/state/protocol/state.js';
 
 function makeSession(): SessionState {
@@ -181,6 +181,7 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 			type: ActionType.ChatInputRequested,
 			request: {
 				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
 				message: 'What is your name?',
 				questions: [{
 					kind: ChatInputQuestionKind.Text,
@@ -200,6 +201,7 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 				kind: ResponsePartKind.InputRequest,
 				request: {
 					id: 'req-1',
+					purpose: ChatInputRequestPurpose.AskUser,
 					message: 'What is your name?',
 					questions: [{
 						kind: ChatInputQuestionKind.Text,
@@ -209,6 +211,50 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 					}],
 				},
 			},
+		});
+	});
+
+	test('ChatInputRequested replacement preserves purpose and synchronized answers through completion', () => {
+		let state = withActiveTurnAndToolCall(makeChat());
+		state = chatReducer(state, {
+			type: ActionType.ChatInputRequested,
+			request: {
+				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
+				questions: [{ kind: ChatInputQuestionKind.Text, id: 'q-1', message: 'First?' }],
+			},
+		});
+		state = chatReducer(state, {
+			type: ActionType.ChatInputAnswerChanged,
+			requestId: 'req-1',
+			questionId: 'q-1',
+			answer: { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Text, value: 'answer' } },
+		});
+		state = chatReducer(state, {
+			type: ActionType.ChatInputRequested,
+			request: {
+				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
+				questions: [{ kind: ChatInputQuestionKind.Text, id: 'q-1', message: 'Updated?' }],
+			},
+		});
+		state = chatReducer(state, {
+			type: ActionType.ChatInputCompleted,
+			requestId: 'req-1',
+			response: ChatInputResponseKind.Accept,
+		});
+
+		assert.deepStrictEqual(state.activeTurn?.responseParts.at(-1), {
+			kind: ResponsePartKind.InputRequest,
+			request: {
+				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
+				questions: [{ kind: ChatInputQuestionKind.Text, id: 'q-1', message: 'Updated?' }],
+				answers: {
+					'q-1': { state: ChatInputAnswerState.Submitted, value: { kind: ChatInputAnswerValueKind.Text, value: 'answer' } },
+				},
+			},
+			response: ChatInputResponseKind.Accept,
 		});
 	});
 
@@ -235,6 +281,7 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 			type: ActionType.ChatInputRequested,
 			request: {
 				id: 'req-1',
+				purpose: ChatInputRequestPurpose.AskUser,
 				message: 'What is your name?',
 				questions: [{
 					kind: ChatInputQuestionKind.Text,
@@ -263,6 +310,7 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 				kind: ResponsePartKind.InputRequest,
 				request: {
 					id: 'req-1',
+					purpose: ChatInputRequestPurpose.AskUser,
 					message: 'What is your name?',
 					questions: [{
 						kind: ChatInputQuestionKind.Text,


### PR DESCRIPTION
## Summary

Adds Agent Host parity for the existing local `askQuestionsToolInvoked` telemetry event by observing the shared chat-input lifecycle.

- classifies chat input requests as ask-user, MCP elicitation, or plan review
- tags Copilot, Claude, and Codex producers explicitly instead of inferring intent from payload shape
- tracks live ask-user requests centrally from `ChatInputRequested` through `ChatInputCompleted`
- emits only accepted human responses and clears pending state on turn/session termination
- resolves final answers from reduced chat state so answers synchronized through `ChatInputAnswerChanged` are included

## Local telemetry parity

Agent Host emits the same `askQuestionsToolInvoked` event and preserves the local fields:

| Local field | Agent Host source |
|---|---|
| `requestId` | owning Agent Host turn ID |
| `questionCount` | request question count |
| `answeredCount` | present, non-skipped answers |
| `skippedCount` | skipped or missing answers |
| `freeTextCount` | text answers or selections with non-empty free-form values |
| `recommendedAvailableCount` | questions containing a recommended option |
| `recommendedSelectedCount` | answers selecting a recommended option |
| `duration` | elapsed time from request to completion |

Agent Host rows additionally include the standard discriminators:

- `provider`
- `agentSessionId`
- `isSubagentSession`

Local rows remain unchanged. No question text, option text, or answer content is emitted.

## Behavioral scope

Telemetry is emitted only for explicitly classified `AskUser` requests accepted by a user. It is not emitted for:

- MCP elicitation
- plan review
- decline or cancellation
- failed or cancelled turns
- restored history
- missing active turns
- autopilot or auto-reply completions
- duplicate completion actions

Request replacement updates the tracked payload while preserving the original start time and turn correlation.

## Validation

- 41 tracker, reducer, and Codex mapping tests passed
- 8 AgentSideEffects, Copilot, and Claude lifecycle/provider tests passed
- hygiene passed