### PR TITLE
fix(extensions): Hide global disable when extension is globally disabled

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,6 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
 				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& !this.extensionEnablementService.isDisabledGlobally(this.extension.local)
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -916,6 +916,29 @@ suite('ExtensionsActions', () => {
 			});
 	});
 
+	test('Test DisableGloballyAction when extension is installed, disabled globally and enabled for workspace', () => {
+		const local = aLocalExtension('a');
+		instantiationService.stub(IExtensionService, {
+			extensions: [toExtensionDescription(local)],
+			onDidChangeExtensions: Event.None,
+			whenInstalledExtensionsRegistered: () => Promise.resolve(true)
+		});
+
+		const enablementService = instantiationService.get(IWorkbenchExtensionEnablementService);
+		return enablementService.setEnablement([local], EnablementState.DisabledGlobally)
+			.then(() => enablementService.setEnablement([local], EnablementState.EnabledWorkspace))
+			.then(() => {
+				instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
+
+				return instantiationService.get(IExtensionsWorkbenchService).queryLocal()
+					.then(extensions => {
+						const testObject: ExtensionsActions.DisableGloballyAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableGloballyAction));
+						testObject.extension = extensions[0];
+						assert.ok(!testObject.enabled);
+					});
+			});
+	});
+
 	test('Test DisableGloballyAction when extension is uninstalled', () => {
 		const gallery = aGalleryExtension('a');
 		instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage(gallery));


### PR DESCRIPTION
Fixes #244138

**What**
Hide the global `Disable` action when the extension is already globally disabled but enabled in a workspace.

**Why**
When an extension is disabled globally and then enabled for a workspace, the `Disable` button is still displayed as a dropdown with both `Disable` and `Disable (Workspace)`. This is confusing since the extension is already globally disabled. Clicking the `Disable` button would also just disable it globally (removing the workspace enablement), which has the exact same effect as `Disable (Workspace)`.

**How it was tested**
Manually verified that the condition correctly hides the action. Tests are run locally.