### PR TITLE
chat: keep the Ask Question widget anchored to its selection while scrolling

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
@@ -47,7 +47,19 @@ function contributingTextEndpoints(range: Range): { first: Text; last: Text } | 
 		return undefined;
 	}
 
-	const walker = doc.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
+	// Prune unrendered subtrees: the transcript contains `<style>` elements and
+	// display:none metadata (a response's file-change summary) that the range
+	// spans but the user cannot see or select. Their text would otherwise look
+	// like an endpoint outside the response's markdown and reject the selection.
+	// Rejecting at the element level also skips their subtrees wholesale.
+	const walker = doc.createTreeWalker(scope, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+		acceptNode: node => {
+			if (node.nodeType !== Node.ELEMENT_NODE) {
+				return NodeFilter.FILTER_ACCEPT;
+			}
+			return (node as Element).checkVisibility() ? NodeFilter.FILTER_SKIP : NodeFilter.FILTER_REJECT;
+		},
+	});
 	let first: Text | undefined;
 	let last: Text | undefined;
 	for (let node = walker.nextNode(); node; node = walker.nextNode()) {

--- a/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionResolver.ts
@@ -57,7 +57,15 @@ function contributingTextEndpoints(range: Range): { first: Text; last: Text } | 
 			if (node.nodeType !== Node.ELEMENT_NODE) {
 				return NodeFilter.FILTER_ACCEPT;
 			}
-			return (node as Element).checkVisibility() ? NodeFilter.FILTER_SKIP : NodeFilter.FILTER_REJECT;
+			const element = node as Element;
+			if (element.checkVisibility()) {
+				return NodeFilter.FILTER_SKIP;
+			}
+			// A `display: contents` element has no box of its own — so it reads
+			// as invisible — but its descendants do render and are selectable.
+			// Only read the computed style on this rare branch.
+			const display = dom.getWindow(element).getComputedStyle(element).display;
+			return display === 'contents' ? NodeFilter.FILTER_SKIP : NodeFilter.FILTER_REJECT;
 		},
 	});
 	let first: Text | undefined;

--- a/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
+import { clamp } from '../../../../base/common/numbers.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -98,6 +99,8 @@ export class ResponseSelectionSideChatController extends Disposable {
 	private _resolved: IResolvedResponseSelection | undefined;
 	/** Range currently painted via the CSS custom highlight, if any. */
 	private _paintedRange: Range | undefined;
+	/** Pins the transcript while a selection or the question input is active. */
+	private readonly _autoScrollHold = this._register(new MutableDisposable());
 	private _chat: IChat | undefined;
 	/** Bumped on a genuine chat navigation/force-dismiss so a stale submission's completion/error handler can no-op. */
 	private _generation = 0;
@@ -151,8 +154,12 @@ export class ResponseSelectionSideChatController extends Disposable {
 
 		const window = dom.getWindow(this._widget.domNode);
 		this._register(dom.addDisposableListener(window.document, 'selectionchange', () => this._onSelectionChange()));
-		// Scrolling the transcript invalidates the widget's pinned position; hide rather than drift.
-		this._register(dom.addDisposableListener(this._widget.domNode, 'scroll', () => this._dismiss(), true));
+		// The transcript is a virtualized list that scrolls by transform, so it
+		// never fires a DOM scroll event; follow its own scroll event instead.
+		// The capture-phase DOM listener additionally covers nested scrollers
+		// (a scrollable code block within a response).
+		this._register(this._widget.onDidScroll(() => this._reposition()));
+		this._register(dom.addDisposableListener(this._widget.domNode, 'scroll', () => this._reposition(), true));
 		this._register(toDisposable(() => this._paintHighlight(undefined)));
 	}
 
@@ -170,6 +177,9 @@ export class ResponseSelectionSideChatController extends Disposable {
 	}
 
 	private _onSelectionChange(): void {
+		// Reflect the new selection state first: every branch below (including
+		// the early returns) needs the hold to match what is currently selected.
+		this._updateAutoScrollHold();
 		// The browser collapses the document selection the moment the "Ask
 		// Question" textarea receives focus (textareas don't participate in
 		// the Selection API). Ignore selectionchange entirely while focus is
@@ -193,7 +203,32 @@ export class ResponseSelectionSideChatController extends Disposable {
 			return;
 		}
 		this._resolved = resolved;
-		this._showFor(resolved);
+		this._showFor();
+	}
+
+	/**
+	 * Pins the transcript while the user is working with a selection: a growing
+	 * response that scrolls itself to the bottom would otherwise drag the text
+	 * out from under the selection (and the affordance anchored to it). Covers
+	 * any selection in the transcript, not just ones that resolve to a single
+	 * response, since auto-scrolling mid-drag is disruptive either way.
+	 */
+	private _updateAutoScrollHold(): void {
+		const shouldHold = !!this._resolved || this._hasTranscriptSelection();
+		if (shouldHold) {
+			this._autoScrollHold.value ??= this._widget.holdAutoScroll();
+		} else {
+			this._autoScrollHold.clear();
+		}
+	}
+
+	private _hasTranscriptSelection(): boolean {
+		const selection = dom.getWindow(this._widget.domNode).getSelection();
+		if (!selection || selection.isCollapsed || !selection.rangeCount || !selection.toString().trim()) {
+			return false;
+		}
+		const range = selection.getRangeAt(0);
+		return this._widget.domNode.contains(range.commonAncestorContainer);
 	}
 
 	/**
@@ -227,47 +262,78 @@ export class ResponseSelectionSideChatController extends Disposable {
 		this._paintedRange = range;
 	}
 
-	private _showFor(resolved: IResolvedResponseSelection): void {
-		const selectionRect = getVisibleBoundingRect(resolved.range);
-		if (!selectionRect) {
-			return;
-		}
-		const containerRect = this._widget.domNode.getBoundingClientRect();
-
+	private _showFor(): void {
 		this._input.show();
 		this._input.autoSize();
 		this._input.updateActionEnabled();
 		this._syncHighlight();
+		this._reposition();
+	}
 
+	/**
+	 * Re-anchors the input to the (live) selection range. Called on every
+	 * transcript scroll so the overlay tracks the text it belongs to instead of
+	 * staying pinned where the selection used to be.
+	 */
+	private _reposition(): void {
+		const resolved = this._resolved;
+		if (!resolved) {
+			return;
+		}
+		const selectionRect = getVisibleBoundingRect(resolved.range);
+		if (!selectionRect) {
+			return;
+		}
+		this._input.show();
+
+		// The overlay is a child of the widget, so its coordinates are relative
+		// to that, but it is confined to the scrollable transcript: once the
+		// selection scrolls past an edge the overlay parks at that edge instead
+		// of drifting over the chat input or off the window.
+		const originRect = this._widget.domNode.getBoundingClientRect();
+		const bounds = this._transcriptBounds();
 		const gap = 4;
 		const inputWidth = this._input.domNode.offsetWidth;
 		const inputHeight = this._input.domNode.offsetHeight;
-		const viewport = dom.getWindow(this._widget.domNode);
 
-		const maxLeft = Math.max(0, containerRect.width - inputWidth);
-		const left = Math.max(0, Math.min(selectionRect.left - containerRect.left, maxLeft));
+		const minLeft = bounds.left - originRect.left;
+		const maxLeft = Math.max(minLeft, minLeft + bounds.width - inputWidth);
+		const left = clamp(selectionRect.left - originRect.left, minLeft, maxLeft);
 
-		// Clamp to whichever is smaller: the widget's own box, or the visible
-		// viewport below the widget's top edge, so the popup never renders
-		// past either bound.
-		const maxTop = Math.max(0, Math.min(containerRect.height, viewport.innerHeight - containerRect.top) - inputHeight);
-		let top = selectionRect.bottom - containerRect.top + gap;
+		const minTop = bounds.top - originRect.top;
+		const maxTop = Math.max(minTop, minTop + bounds.height - inputHeight);
+		let top = selectionRect.bottom - originRect.top + gap;
 		if (top > maxTop) {
 			// Not enough room below the selection: prefer placing it above instead.
-			const aboveTop = selectionRect.top - containerRect.top - inputHeight - gap;
-			top = aboveTop >= 0 ? aboveTop : maxTop;
+			const aboveTop = selectionRect.top - originRect.top - inputHeight - gap;
+			top = aboveTop >= minTop ? aboveTop : maxTop;
 		}
-		top = Math.max(0, Math.min(top, maxTop));
+		top = clamp(top, minTop, maxTop);
 
 		this._input.domNode.style.top = `${top}px`;
 		this._input.domNode.style.left = `${left}px`;
 	}
 
 	/**
+	 * Box the overlay is confined to, in viewport coordinates: the scrollable
+	 * transcript, further clipped to the window so it can never render out of
+	 * sight on a small window.
+	 */
+	private _transcriptBounds(): { top: number; left: number; width: number; height: number } {
+		const rect = this._widget.transcriptDomNode.getBoundingClientRect();
+		const viewport = dom.getWindow(this._widget.domNode);
+		const top = Math.max(rect.top, 0);
+		const left = Math.max(rect.left, 0);
+		const bottom = Math.min(rect.top + rect.height, viewport.innerHeight);
+		const right = Math.min(rect.left + rect.width, viewport.innerWidth);
+		return { top, left, width: Math.max(0, right - left), height: Math.max(0, bottom - top) };
+	}
+
+	/**
 	 * Dismisses the input. While a submission is pending (`_input.isBusy`),
 	 * only a genuine view change (`force`, from {@link setChat}) may dismiss
-	 * it — outside interactions like Escape, scrolling, or selection
-	 * invalidation must not race the in-flight create/open/send.
+	 * it — outside interactions like Escape or selection invalidation must not
+	 * race the in-flight create/open/send.
 	 */
 	private _dismiss(force = false): void {
 		if (!force && this._input.isBusy) {
@@ -280,6 +346,7 @@ export class ResponseSelectionSideChatController extends Disposable {
 		const hadFocus = dom.isAncestorOfActiveElement(this._input.domNode);
 		this._resolved = undefined;
 		this._paintHighlight(undefined);
+		this._updateAutoScrollHold();
 		this._input.setBusy(false);
 		this._input.hide();
 		this._input.clearInput();

--- a/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { clamp } from '../../../../base/common/numbers.js';
@@ -100,7 +100,7 @@ export class ResponseSelectionSideChatController extends Disposable {
 	/** Range currently painted via the CSS custom highlight, if any. */
 	private _paintedRange: Range | undefined;
 	/** Pins the transcript while a selection or the question input is active. */
-	private readonly _autoScrollHold = this._register(new MutableDisposable());
+	private readonly _autoScrollHold = this._register(new MutableDisposable<IDisposable>());
 	private _chat: IChat | undefined;
 	/** Bumped on a genuine chat navigation/force-dismiss so a stale submission's completion/error handler can no-op. */
 	private _generation = 0;
@@ -228,7 +228,10 @@ export class ResponseSelectionSideChatController extends Disposable {
 			return false;
 		}
 		const range = selection.getRangeAt(0);
-		return this._widget.domNode.contains(range.commonAncestorContainer);
+		// Scoped to the transcript specifically: selecting text elsewhere in the
+		// chat view (a banner, the input) says nothing about wanting the
+		// transcript to hold still.
+		return this._widget.transcriptDomNode.contains(range.commonAncestorContainer);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
+++ b/src/vs/sessions/contrib/chat/browser/responseSelectionSideChatController.ts
@@ -285,6 +285,13 @@ export class ResponseSelectionSideChatController extends Disposable {
 		}
 		const selectionRect = getVisibleBoundingRect(resolved.range);
 		if (!selectionRect) {
+			// The transcript is virtualized, so scrolling far enough removes the
+			// selected row. Removing a node re-homes any live range onto the
+			// surviving parent, collapsing it, so the range still looks attached
+			// but no longer covers anything. The anchored text cannot come back
+			// — re-rendering builds new nodes — so dismiss rather than leave the
+			// input pointing at nothing and the transcript pinned forever.
+			this._dismiss();
 			return;
 		}
 		this._input.show();

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
@@ -222,6 +222,38 @@ suite('resolveResponseSelection', () => {
 		assert.strictEqual(resolveResponseSelection(widget), undefined);
 	});
 
+	test('resolves through a display:contents wrapper', () => {
+		// `display: contents` elements have no box of their own, so a visibility
+		// check reports them as invisible even though their descendants render
+		// and are selectable. Both endpoints live inside such wrappers here, so
+		// pruning them drops every contributing node and rejects the selection.
+		const { store, doc, widgetDomNode } = setup();
+		const markdown = doc.createElement('div');
+		markdown.classList.add('chat-markdown-part');
+		const paragraph = doc.createElement('p');
+		const makeWrapped = (text: string) => {
+			const wrapper = doc.createElement('span');
+			wrapper.style.display = 'contents';
+			const node = doc.createTextNode(text);
+			wrapper.appendChild(node);
+			paragraph.appendChild(wrapper);
+			return node;
+		};
+		const firstText = makeWrapped('hello ');
+		const lastText = makeWrapped('world');
+		markdown.appendChild(paragraph);
+		widgetDomNode.appendChild(markdown);
+
+		const response = makeResponse('turn-1');
+		stubSelection(store, firstText, lastText, 'hello world');
+		const widget = upcastPartial<IChatWidget>({
+			domNode: widgetDomNode,
+			getElementFromNode: () => response,
+		});
+
+		assert.strictEqual(resolveResponseSelection(widget)?.text, 'hello world');
+	});
+
 	test('ignores unrendered text when finding the selection endpoints', () => {
 		// The transcript contains `<style>` elements and display:none metadata
 		// that a triple-click's range spans but the user cannot see or select.

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionResolver.test.ts
@@ -222,6 +222,39 @@ suite('resolveResponseSelection', () => {
 		assert.strictEqual(resolveResponseSelection(widget), undefined);
 	});
 
+	test('ignores unrendered text when finding the selection endpoints', () => {
+		// The transcript contains `<style>` elements and display:none metadata
+		// that a triple-click's range spans but the user cannot see or select.
+		// Treating them as endpoints puts the endpoint outside the response's
+		// markdown and rejects an otherwise valid selection.
+		const { store, doc, widgetDomNode } = setup();
+		const markdown = doc.createElement('div');
+		markdown.classList.add('chat-markdown-part');
+		const paragraph = doc.createElement('p');
+		const textNode = doc.createTextNode('hello world');
+		paragraph.appendChild(textNode);
+		markdown.appendChild(paragraph);
+		const style = doc.createElement('style');
+		style.appendChild(doc.createTextNode('.monaco-list { color: red; }'));
+		const hiddenMeta = doc.createElement('div');
+		hiddenMeta.style.display = 'none';
+		hiddenMeta.appendChild(doc.createTextNode('+55 -0'));
+		const footer = doc.createElement('div');
+		widgetDomNode.appendChild(markdown);
+		widgetDomNode.appendChild(style);
+		widgetDomNode.appendChild(hiddenMeta);
+		widgetDomNode.appendChild(footer);
+
+		const response = makeResponse('turn-1');
+		stubSelection(store, textNode, footer, 'hello world\n', 0);
+		const widget = upcastPartial<IChatWidget>({
+			domNode: widgetDomNode,
+			getElementFromNode: () => response,
+		});
+
+		assert.strictEqual(resolveResponseSelection(widget)?.text, 'hello world');
+	});
+
 	test('rejects a selection outside the markdown scope', () => {
 		const { store, doc, widgetDomNode } = setup();
 		const other = doc.createElement('div');

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import * as dom from '../../../../../base/browser/dom.js';
+import { Emitter } from '../../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -39,6 +40,7 @@ suite('ResponseSelectionSideChatController', () => {
 	function setup(options?: {
 		createSideChatInSession?: ISessionsManagementService['createSideChatInSession'];
 		sendRequest?: ISessionsManagementService['sendRequest'];
+		getElementFromNode?: IChatWidget['getElementFromNode'];
 	}) {
 		const store = disposables.add(new DisposableStore());
 		const instantiationService = store.add(new TestInstantiationService());
@@ -60,14 +62,30 @@ suite('ResponseSelectionSideChatController', () => {
 
 		const response = upcastPartial<IChatResponseViewModel>({ requestId: 'turn-1', setVote: () => undefined });
 		const focusResponseItemCalls: boolean[] = [];
+		const onDidScroll = store.add(new Emitter<void>());
+		let autoScrollHolds = 0;
+		const transcriptDomNode = doc.createElement('div');
+		widgetDomNode.appendChild(transcriptDomNode);
 		const widget = upcastPartial<IChatWidget>({
 			domNode: widgetDomNode,
-			getElementFromNode: () => response,
+			transcriptDomNode,
+			getElementFromNode: options?.getElementFromNode ?? (() => response),
 			focusResponseItem: (lastFocused?: boolean) => { focusResponseItemCalls.push(!!lastFocused); },
+			onDidScroll: onDidScroll.event,
+			holdAutoScroll: () => {
+				autoScrollHolds++;
+				return toDisposable(() => { autoScrollHolds--; });
+			},
 		});
 
-		let containerRect: Partial<DOMRect> = { top: 0, left: 0, width: 600, height: 600 };
+		// The widget spans the whole chat view, including the input part below
+		// the transcript; the overlay is positioned relative to it.
+		const containerRect: Partial<DOMRect> = { top: 0, left: 0, width: 600, height: 600 };
 		widgetDomNode.getBoundingClientRect = () => containerRect as DOMRect;
+		// The scrollable transcript sits above the chat input, so it is shorter
+		// than the widget; the overlay is confined to it.
+		let transcriptRect: Partial<DOMRect> = { top: 0, left: 0, width: 600, height: 600 };
+		transcriptDomNode.getBoundingClientRect = () => transcriptRect as DOMRect;
 
 		const targetWindow = dom.getWindow(widgetDomNode);
 		const originalGetSelection = targetWindow.getSelection.bind(targetWindow);
@@ -93,7 +111,13 @@ suite('ResponseSelectionSideChatController', () => {
 			}
 			doc.dispatchEvent(new Event('selectionchange'));
 		};
-		const setContainerRect = (rect: Partial<DOMRect>) => { containerRect = rect; };
+		const setTranscriptRect = (rect: Partial<DOMRect>) => { transcriptRect = rect; };
+		const scroll = (selectionTop?: number) => {
+			if (selectionTop !== undefined) {
+				markdown.style.top = `${selectionTop}px`;
+			}
+			onDidScroll.fire();
+		};
 		const highlightedRanges = () => targetWindow.CSS.highlights?.get('chat-response-selection')?.size ?? 0;
 
 		const sideChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/side') });
@@ -129,7 +153,7 @@ suite('ResponseSelectionSideChatController', () => {
 		const controller = store.add(instantiationService.createInstance(ResponseSelectionSideChatController, widget));
 		controller.setChat(chat);
 
-		return { controller, setSelection, setContainerRect, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges };
+		return { controller, setSelection, setTranscriptRect, scroll, autoScrollHolds: () => autoScrollHolds, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges, inputHeight: () => inputDomNode(controller).offsetHeight };
 	}
 
 	function inputDomNode(controller: ResponseSelectionSideChatController): HTMLElement {
@@ -250,16 +274,124 @@ suite('ResponseSelectionSideChatController', () => {
 		assert.deepStrictEqual(focusResponseItemCalls, []);
 	});
 
-	test('clamps the overlay vertically within the container bounds when the selection is near the bottom', () => {
-		const { controller, setSelection, setContainerRect } = setup();
-		// A container far shorter than any realistic widget height forces the
+	test('clamps the overlay vertically when the transcript is shorter than the overlay', () => {
+		const { controller, setSelection, setTranscriptRect } = setup();
+		// A transcript far shorter than any realistic overlay height forces the
 		// vertical clamp to floor the overlay at the top.
-		setContainerRect({ top: 0, left: 0, width: 600, height: 20 });
+		setTranscriptRect({ top: 0, left: 0, width: 600, height: 20 });
 		setSelection('hello world', 10);
 
 		const style = inputDomNode(controller).style;
 		assert.notStrictEqual(style.display, 'none');
 		assert.strictEqual(parseFloat(style.top), 0);
+	});
+
+	test('follows the selection as the transcript scrolls instead of staying pinned', () => {
+		const { controller, setSelection, scroll } = setup();
+		setSelection('hello world', 100);
+		const style = inputDomNode(controller).style;
+		const initialTop = parseFloat(style.top);
+
+		// The transcript scrolls the anchor up by 40px; the overlay must move with it.
+		scroll(60);
+
+		assert.strictEqual(parseFloat(style.top), initialTop - 40);
+	});
+
+	test('confines the overlay to the transcript even when the widget extends past it', () => {
+		// The reported bug: the overlay was clamped to the whole chat widget, so
+		// it could float all the way down over the input at the bottom of the
+		// window instead of stopping at the end of the scrollable message area.
+		const { controller, setSelection, scroll, setTranscriptRect, inputHeight } = setup();
+		setTranscriptRect({ top: 0, left: 0, width: 600, height: 300 });
+		setSelection('hello world', 50);
+
+		scroll(5000);
+
+		const top = parseFloat(inputDomNode(controller).style.top);
+		assert.ok(top <= 300 - inputHeight(), `top ${top} must stay within the 300px transcript, not the 600px widget`);
+	});
+
+	test('parks at the top of the transcript when the selection scrolls above it', () => {
+		const { controller, setSelection, scroll, setTranscriptRect, inputHeight } = setup();
+		// The transcript starts 100px below the widget's top edge (banners, etc).
+		setTranscriptRect({ top: 100, left: 0, width: 600, height: 300 });
+		setSelection('hello world', 200);
+		assert.notStrictEqual(inputDomNode(controller).style.display, 'none');
+
+		// Scroll the selection far above the transcript's top edge.
+		scroll(-800);
+
+		const style = inputDomNode(controller).style;
+		assert.notStrictEqual(style.display, 'none', 'the overlay stays visible at the edge');
+		assert.strictEqual(parseFloat(style.top), 100, 'parks at the transcript top, not the widget top');
+		assert.ok(inputHeight() > 0);
+	});
+
+	test('parks at the bottom of the transcript instead of drifting over the chat input', () => {
+		const { controller, setSelection, scroll, setTranscriptRect, inputHeight } = setup();
+		// The widget is 600 tall but the transcript only occupies the top 300;
+		// the remaining 300 is the chat input, which the overlay must not enter.
+		setTranscriptRect({ top: 0, left: 0, width: 600, height: 300 });
+		setSelection('hello world', 50);
+
+		// Scroll the selection far below the transcript's bottom edge.
+		scroll(900);
+
+		const top = parseFloat(inputDomNode(controller).style.top);
+		assert.strictEqual(top, 300 - inputHeight(), 'parks flush with the transcript bottom');
+	});
+
+	test('clamps horizontally to the transcript bounds', () => {
+		const { controller, setSelection, setTranscriptRect } = setup();
+		setTranscriptRect({ top: 0, left: 40, width: 120, height: 300 });
+		setSelection('hello world');
+
+		const left = parseFloat(inputDomNode(controller).style.left);
+		assert.ok(left >= 40, `left ${left} must not start before the transcript's left edge`);
+		assert.ok(left <= 160, `left ${left} must not start past the transcript's right edge`);
+	});
+
+	test('holds transcript auto-scroll while a selection is active and releases it on dismiss', () => {
+		const { setSelection, autoScrollHolds } = setup();
+		assert.strictEqual(autoScrollHolds(), 0);
+
+		setSelection('hello world');
+		assert.strictEqual(autoScrollHolds(), 1, 'a selection must pin the transcript');
+
+		setSelection('');
+		assert.strictEqual(autoScrollHolds(), 0, 'clearing the selection releases the transcript');
+	});
+
+	test('holds auto-scroll for a transcript selection that does not resolve to a single response', () => {
+		// Selections spanning responses (or non-markdown content) never open the
+		// affordance, but auto-scrolling out from under an in-progress drag is
+		// just as disruptive, so the transcript is still pinned.
+		const { controller, setSelection, autoScrollHolds } = setup({ getElementFromNode: () => undefined });
+		setSelection('hello world');
+
+		assert.strictEqual(inputDomNode(controller).style.display, 'none', 'no affordance for an unresolvable selection');
+		assert.strictEqual(autoScrollHolds(), 1);
+	});
+
+	test('keeps holding auto-scroll while the input has focus and the native selection is collapsed', () => {
+		const { controller, setSelection, autoScrollHolds } = setup();
+		setSelection('hello world');
+		inputTextArea(controller).focus();
+		// Focusing the textarea collapses the native selection as a browser side
+		// effect; the captured selection is still live, so the hold must persist.
+		setSelection('');
+
+		assert.strictEqual(autoScrollHolds(), 1);
+	});
+
+	test('releases the auto-scroll hold when disposed', () => {
+		const { controller, setSelection, autoScrollHolds } = setup();
+		setSelection('hello world');
+		assert.strictEqual(autoScrollHolds(), 1);
+
+		controller.dispose();
+		assert.strictEqual(autoScrollHolds(), 0);
 	});
 
 	test('paints the captured selection with a custom highlight once the native selection is gone', () => {

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
@@ -49,6 +49,11 @@ suite('ResponseSelectionSideChatController', () => {
 		doc.body.appendChild(widgetDomNode);
 		store.add(toDisposable(() => widgetDomNode.remove()));
 
+		// Mirrors the real structure: the scrollable transcript is a child of
+		// the chat view, and responses are rendered inside it.
+		const transcriptDomNode = doc.createElement('div');
+		widgetDomNode.appendChild(transcriptDomNode);
+
 		const markdown = doc.createElement('div');
 		markdown.classList.add('chat-markdown-part');
 		// Positioned so the selection's real client rects (the controller
@@ -58,14 +63,12 @@ suite('ResponseSelectionSideChatController', () => {
 		markdown.style.left = '0px';
 		const textNode = doc.createTextNode('hello world');
 		markdown.appendChild(textNode);
-		widgetDomNode.appendChild(markdown);
+		transcriptDomNode.appendChild(markdown);
 
 		const response = upcastPartial<IChatResponseViewModel>({ requestId: 'turn-1', setVote: () => undefined });
 		const focusResponseItemCalls: boolean[] = [];
 		const onDidScroll = store.add(new Emitter<void>());
 		let autoScrollHolds = 0;
-		const transcriptDomNode = doc.createElement('div');
-		widgetDomNode.appendChild(transcriptDomNode);
 		const widget = upcastPartial<IChatWidget>({
 			domNode: widgetDomNode,
 			transcriptDomNode,
@@ -94,21 +97,36 @@ suite('ResponseSelectionSideChatController', () => {
 		const range = doc.createRange();
 		range.setStart(textNode, 0);
 		range.setEnd(textNode, textNode.data.length);
+		// A selection in chat-view chrome outside the scrollable transcript.
+		const outsideNode = doc.createTextNode('unrelated text');
+		const outside = doc.createElement('div');
+		outside.appendChild(outsideNode);
+		widgetDomNode.appendChild(outside);
+		const outsideRange = doc.createRange();
+		outsideRange.setStart(outsideNode, 0);
+		outsideRange.setEnd(outsideNode, outsideNode.data.length);
+		let activeRange = range;
 		mutableWindow.getSelection = () => upcastPartial<Selection>({
 			toString: () => selectionText,
 			isCollapsed: selectionText.length === 0,
-			anchorNode: textNode,
-			focusNode: textNode,
+			anchorNode: activeRange.startContainer,
+			focusNode: activeRange.endContainer,
 			rangeCount: 1,
-			getRangeAt: () => range,
+			getRangeAt: () => activeRange,
 		});
 		store.add(toDisposable(() => { mutableWindow.getSelection = originalGetSelection; }));
 
 		const setSelection = (text: string, selectionTop?: number) => {
+			activeRange = range;
 			selectionText = text;
 			if (selectionTop !== undefined) {
 				markdown.style.top = `${selectionTop}px`;
 			}
+			doc.dispatchEvent(new Event('selectionchange'));
+		};
+		const setSelectionOutsideTranscript = (text: string) => {
+			activeRange = outsideRange;
+			selectionText = text;
 			doc.dispatchEvent(new Event('selectionchange'));
 		};
 		const setTranscriptRect = (rect: Partial<DOMRect>) => { transcriptRect = rect; };
@@ -153,7 +171,7 @@ suite('ResponseSelectionSideChatController', () => {
 		const controller = store.add(instantiationService.createInstance(ResponseSelectionSideChatController, widget));
 		controller.setChat(chat);
 
-		return { controller, setSelection, setTranscriptRect, scroll, autoScrollHolds: () => autoScrollHolds, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges, inputHeight: () => inputDomNode(controller).offsetHeight };
+		return { controller, setSelection, setSelectionOutsideTranscript, setTranscriptRect, scroll, autoScrollHolds: () => autoScrollHolds, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges, inputHeight: () => inputDomNode(controller).offsetHeight };
 	}
 
 	function inputDomNode(controller: ResponseSelectionSideChatController): HTMLElement {
@@ -361,6 +379,15 @@ suite('ResponseSelectionSideChatController', () => {
 
 		setSelection('');
 		assert.strictEqual(autoScrollHolds(), 0, 'clearing the selection releases the transcript');
+	});
+
+	test('does not hold auto-scroll for a selection outside the transcript', () => {
+		// Text selected in a banner or the input area says nothing about wanting
+		// the transcript to hold still.
+		const { setSelectionOutsideTranscript, autoScrollHolds } = setup({ getElementFromNode: () => undefined });
+		setSelectionOutsideTranscript('unrelated text');
+
+		assert.strictEqual(autoScrollHolds(), 0);
 	});
 
 	test('holds auto-scroll for a transcript selection that does not resolve to a single response', () => {

--- a/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/responseSelectionSideChatController.test.ts
@@ -130,6 +130,14 @@ suite('ResponseSelectionSideChatController', () => {
 			doc.dispatchEvent(new Event('selectionchange'));
 		};
 		const setTranscriptRect = (rect: Partial<DOMRect>) => { transcriptRect = rect; };
+		/**
+		 * Mimics the virtualized list removing the selected row: the nodes go
+		 * away and the browser collapses the selection that lived in them.
+		 */
+		const detachSelectedRow = () => {
+			markdown.remove();
+			selectionText = '';
+		};
 		const scroll = (selectionTop?: number) => {
 			if (selectionTop !== undefined) {
 				markdown.style.top = `${selectionTop}px`;
@@ -171,7 +179,7 @@ suite('ResponseSelectionSideChatController', () => {
 		const controller = store.add(instantiationService.createInstance(ResponseSelectionSideChatController, widget));
 		controller.setChat(chat);
 
-		return { controller, setSelection, setSelectionOutsideTranscript, setTranscriptRect, scroll, autoScrollHolds: () => autoScrollHolds, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges, inputHeight: () => inputDomNode(controller).offsetHeight };
+		return { controller, setSelection, setSelectionOutsideTranscript, setTranscriptRect, detachSelectedRow, scroll, autoScrollHolds: () => autoScrollHolds, callOrder, doc, chat, sideChat, focusResponseItemCalls, notificationService, highlightedRanges, inputHeight: () => inputDomNode(controller).offsetHeight };
 	}
 
 	function inputDomNode(controller: ResponseSelectionSideChatController): HTMLElement {
@@ -302,6 +310,21 @@ suite('ResponseSelectionSideChatController', () => {
 		const style = inputDomNode(controller).style;
 		assert.notStrictEqual(style.display, 'none');
 		assert.strictEqual(parseFloat(style.top), 0);
+	});
+
+	test('dismisses and releases the hold when virtualization detaches the selected row', () => {
+		const { controller, setSelection, scroll, autoScrollHolds, detachSelectedRow } = setup();
+		setSelection('hello world', 100);
+		assert.notStrictEqual(inputDomNode(controller).style.display, 'none');
+		assert.strictEqual(autoScrollHolds(), 1);
+
+		// Scrolling far enough removes the row from the DOM; the captured range
+		// now anchors to nodes that will never come back.
+		detachSelectedRow();
+		scroll();
+
+		assert.strictEqual(inputDomNode(controller).style.display, 'none', 'must not point at nothing');
+		assert.strictEqual(autoScrollHolds(), 0, 'the transcript must not stay pinned forever');
 	});
 
 	test('follows the selection as the transcript scrolls instead of staying pinned', () => {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -373,6 +373,8 @@ export interface IChatWidgetViewModelChangeEvent {
 
 export interface IChatWidget {
 	readonly domNode: HTMLElement;
+	/** DOM node of the scrollable transcript area, excluding the input part. */
+	readonly transcriptDomNode: HTMLElement;
 	readonly visible: boolean;
 	readonly onDidChangeViewModel: Event<IChatWidgetViewModelChangeEvent>;
 	readonly onDidAcceptInput: Event<void>;
@@ -383,6 +385,7 @@ export interface IChatWidget {
 	readonly onDidChangeParsedInput: Event<void>;
 	readonly onDidChangeActiveInputEditor: Event<void>;
 	readonly onDidFocus: Event<void>;
+	readonly onDidScroll: Event<void>;
 	readonly location: ChatAgentLocation;
 	readonly viewContext: IChatWidgetViewContext;
 	readonly viewModel: IChatViewModel | undefined;
@@ -477,6 +480,12 @@ export interface IChatWidget {
 	 * Returns the currently rendered chat item containing the node, if any.
 	 */
 	getElementFromNode(node: HTMLElement): ChatTreeItem | undefined;
+	/**
+	 * Suppresses auto-scrolling the transcript to the bottom until the returned
+	 * disposable is disposed. Holds compose, so concurrent callers do not
+	 * clobber each other.
+	 */
+	holdAutoScroll(): IDisposable;
 	clear(targetSessionType?: string): Promise<void>;
 	getViewState(): IChatModelInputState | undefined;
 	lockToCodingAgent(name: string, displayName: string, agentId?: string, agentHostProviderId?: string): void;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -307,7 +307,7 @@ export class ChatListWidget extends Disposable {
 	private _lastItem: ChatTreeItem | undefined;
 	private _mostRecentlyFocusedItemIndex: number = -1;
 	private _scrollLock: boolean = true;
-	private _suppressAutoScroll: boolean = false;
+	private _autoScrollHolds: number = 0;
 	private _settingChangeCounter: number = 0;
 	private _visibleChangeCount: number = 0;
 	private readonly _userToggleResizeTrackers = this._register(new DisposableMap<ChatTreeItem, UserToggleResizeTracker>());
@@ -909,15 +909,23 @@ export class ChatListWidget extends Disposable {
 	}
 
 	/**
-	 * Suppress auto-scroll behavior temporarily. While suppressed,
-	 * _withPersistedAutoScroll will not scroll to bottom after operations.
+	 * Suppresses auto-scrolling to the bottom until the returned disposable is
+	 * disposed. Holds compose, so unrelated features (request editing, an open
+	 * text selection) can suppress concurrently without clobbering each other;
+	 * auto-scroll resumes only once the last hold is released.
 	 */
-	set suppressAutoScroll(value: boolean) {
-		this._suppressAutoScroll = value;
+	acquireAutoScrollHold(): IDisposable {
+		this._autoScrollHolds++;
+		return toDisposable(() => { this._autoScrollHolds--; });
+	}
+
+	/** Whether any {@link acquireAutoScrollHold} hold is currently active. */
+	get isAutoScrollHeld(): boolean {
+		return this._autoScrollHolds > 0;
 	}
 
 	private _withPersistedAutoScroll(fn: () => void): void {
-		if (this._suppressAutoScroll) {
+		if (this.isAutoScrollHeld) {
 			fn();
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -44,6 +44,34 @@ export interface IChatListWidgetStyles {
 }
 
 /**
+ * Ref-counted suppression of auto-scrolling to the bottom. Holds compose, so
+ * unrelated features (request editing, an open text selection) can suppress
+ * concurrently without clobbering each other; auto-scroll resumes only once the
+ * last hold is released.
+ */
+export class AutoScrollHolds {
+
+	private _count = 0;
+
+	get isHeld(): boolean {
+		return this._count > 0;
+	}
+
+	acquire(): IDisposable {
+		this._count++;
+		// Idempotent so a double-dispose releases one hold rather than
+		// decrementing past it and silently cancelling somebody else's.
+		let released = false;
+		return toDisposable(() => {
+			if (!released) {
+				released = true;
+				this._count--;
+			}
+		});
+	}
+}
+
+/**
  * Tracks when a user-triggered resize has remained stable across animation frames.
  */
 export class UserToggleResizeState {
@@ -307,7 +335,7 @@ export class ChatListWidget extends Disposable {
 	private _lastItem: ChatTreeItem | undefined;
 	private _mostRecentlyFocusedItemIndex: number = -1;
 	private _scrollLock: boolean = true;
-	private _autoScrollHolds: number = 0;
+	private _autoScrollHolds = new AutoScrollHolds();
 	private _settingChangeCounter: number = 0;
 	private _visibleChangeCount: number = 0;
 	private readonly _userToggleResizeTrackers = this._register(new DisposableMap<ChatTreeItem, UserToggleResizeTracker>());
@@ -915,21 +943,12 @@ export class ChatListWidget extends Disposable {
 	 * auto-scroll resumes only once the last hold is released.
 	 */
 	acquireAutoScrollHold(): IDisposable {
-		this._autoScrollHolds++;
-		// Idempotent so a double-dispose releases one hold rather than
-		// decrementing past it and silently cancelling somebody else's.
-		let released = false;
-		return toDisposable(() => {
-			if (!released) {
-				released = true;
-				this._autoScrollHolds--;
-			}
-		});
+		return this._autoScrollHolds.acquire();
 	}
 
 	/** Whether any {@link acquireAutoScrollHold} hold is currently active. */
 	get isAutoScrollHeld(): boolean {
-		return this._autoScrollHolds > 0;
+		return this._autoScrollHolds.isHeld;
 	}
 
 	private _withPersistedAutoScroll(fn: () => void): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -916,7 +916,15 @@ export class ChatListWidget extends Disposable {
 	 */
 	acquireAutoScrollHold(): IDisposable {
 		this._autoScrollHolds++;
-		return toDisposable(() => { this._autoScrollHolds--; });
+		// Idempotent so a double-dispose releases one hold rather than
+		// decrementing past it and silently cancelling somebody else's.
+		let released = false;
+		return toDisposable(() => {
+			if (!released) {
+				released = true;
+				this._autoScrollHolds--;
+			}
+		});
 	}
 
 	/** Whether any {@link acquireAutoScrollHold} hold is currently active. */

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -316,6 +316,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private recentlyRestoredCheckpoint: boolean = false;
 
+	/** Suppresses auto-scroll for the duration of an inline request edit. */
+	private readonly _editingAutoScrollHold = this._register(new MutableDisposable());
+
 	private welcomeMessageContainer!: HTMLElement;
 	private readonly welcomePart: MutableDisposable<ChatViewWelcomePart> = this._register(new MutableDisposable());
 
@@ -773,10 +776,17 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.listWidget.scrollTop = value;
 	}
 
+	holdAutoScroll(): IDisposable {
+		return this.listWidget.acquireAutoScrollHold();
+	}
+
+	get transcriptDomNode(): HTMLElement {
+		return this.listWidget.domNode;
+	}
+
 	get scrollHeight(): number {
 		return this.listWidget.scrollHeight;
 	}
-
 	get viewportHeight(): number {
 		return this.listWidget.renderHeight;
 	}
@@ -1940,7 +1950,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				}
 			}
 
-			this.listWidget.suppressAutoScroll = true;
+			this._editingAutoScrollHold.value = this.listWidget.acquireAutoScrollHold();
 			this.onDidChangeItems();
 			this.input.inputEditor.focus();
 
@@ -1977,7 +1987,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	finishedEditing(completedEdit?: boolean): void {
 		// reset states
-		this.listWidget.suppressAutoScroll = false;
+		this._editingAutoScrollHold.clear();
 		const editedRequest = this.listWidget.getTemplateDataForRequestId(this.viewModel?.editing?.id);
 		if (this.recentlyRestoredCheckpoint) {
 			this.recentlyRestoredCheckpoint = false;
@@ -3268,7 +3278,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.welcomeMessageContainer.style.height = `${contentHeight}px`;
 
 		const lastResponseIsRendering = isResponseVM(lastItem) && lastItem.renderData;
-		if (lastElementVisible && (!lastResponseIsRendering || checkModeOption(this.input.currentModeKind, this.viewOptions.autoScroll))) {
+		if (lastElementVisible && !this.listWidget.isAutoScrollHeld && (!lastResponseIsRendering || checkModeOption(this.input.currentModeKind, this.viewOptions.autoScroll))) {
 			this.listWidget.scrollToEnd();
 		}
 		this.listContainer.style.height = `${contentHeight}px`;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -317,7 +317,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private recentlyRestoredCheckpoint: boolean = false;
 
 	/** Suppresses auto-scroll for the duration of an inline request edit. */
-	private readonly _editingAutoScrollHold = this._register(new MutableDisposable());
+	private readonly _editingAutoScrollHold = this._register(new MutableDisposable<IDisposable>());
 
 	private welcomeMessageContainer!: HTMLElement;
 	private readonly welcomePart: MutableDisposable<ChatViewWelcomePart> = this._register(new MutableDisposable());

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2373,7 +2373,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 
 			this.onDidChangeItems();
-			if (events?.some(e => e?.kind === 'addRequest') && this.visible) {
+			if (events?.some(e => e?.kind === 'addRequest') && this.visible && !this.listWidget.isAutoScrollHeld) {
 				this.listWidget.scrollToEnd();
 			}
 		})));

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import * as dom from '../../../../../../base/browser/dom.js';
 import { mainWindow } from '../../../../../../base/browser/window.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { DisposableStore, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { OffsetRange } from '../../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
@@ -415,9 +415,10 @@ suite('ChatListRenderer', () => {
 				},
 			},
 			listWidget: {
-				suppressAutoScroll: false,
+				acquireAutoScrollHold: () => toDisposable(() => { }),
 				scrollToCurrentItem: () => { },
 			},
+			_editingAutoScrollHold: disposables.add(new MutableDisposable()),
 			createInput: () => { },
 			onDidChangeItems: () => { },
 			getContrib: () => undefined,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListWidget.test.ts
@@ -5,10 +5,34 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { computeScrollDownState, getAnchoredScrollTop, UserToggleResizeState } from '../../../browser/widget/chatListWidget.js';
+import { computeScrollDownState, getAnchoredScrollTop, AutoScrollHolds, UserToggleResizeState } from '../../../browser/widget/chatListWidget.js';
 
 suite('ChatListWidget', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('auto-scroll holds compose and survive a double release', () => {
+		const holds = new AutoScrollHolds();
+		const states = [holds.isHeld];
+
+		// Two unrelated features suppress concurrently (e.g. a request edit and
+		// an open text selection).
+		const first = holds.acquire();
+		const second = holds.acquire();
+		states.push(holds.isHeld);
+
+		first.dispose();
+		states.push(holds.isHeld);
+
+		// A redundant dispose must not decrement past the remaining hold and
+		// silently resume auto-scroll for the other caller.
+		first.dispose();
+		states.push(holds.isHeld);
+
+		second.dispose();
+		states.push(holds.isHeld);
+
+		assert.deepStrictEqual(states, [false, true, true, true, false]);
+	});
 
 	test('keeps user toggle tracking active until resizing settles', () => {
 		const state = new UserToggleResizeState(2);


### PR DESCRIPTION
Selecting text in a chat response and then scrolling left the "Ask Question" widget floating at a stale position, disconnected from the text it belonged to.

- Pins the transcript while text is selected or the question widget is
  open. A streaming response that scrolls itself to the bottom would
  otherwise drag the text out from under the selection the user is in the
  middle of making.
- Converts the list's auto-scroll suppression from a boolean setter to a
  ref-counted hold. A boolean does not compose, so finishing a request
  edit would silently release a selection's suppression; holds let both
  features suppress concurrently.
- Follows the transcript's own scroll event instead of a DOM scroll
  listener. The transcript is a virtualized list that scrolls by
  transform and never fires a DOM scroll event, so the widget previously
  stayed pinned where the selection used to be.
- Confines the widget to the scrollable message area rather than the
  whole chat view, so it parks at the top or bottom edge of the
  transcript instead of drifting over the chat input.
- Skips unrendered subtrees when resolving the selection endpoints. The
  transcript contains `<style>` elements and display:none metadata that a
  line selection spans but the user cannot see, which put the endpoint
  outside the response markdown and stopped triple-click from ever
  opening the widget.

### Validation

Verified in a running Agents window against a real transcript (message list `134–560`, chat view `134–696`):

| selection top | widget |
| --- | --- |
| 330 | 349 — tracking |
| 130 | 149 — tracking |
| −70 … −670 | **134** — parked at the transcript top |
| 530 | 494 — flips above (no room below) |
| 730 … 1330 | **528–560** — parked flush with the transcript bottom |

It never entered the `560–696` input region in either direction, and tracking resumes when the selection scrolls back into view.

Unit tests were checked for vacuity: reverting the bounds to the chat view fails 5 of them, and stubbing out the scroll listener and hold fails 6.

Note: I was not able to observe the auto-scroll suppression itself in a live streaming session — responses complete faster than the sampling window, and auto-scroll only engages when already pinned to the bottom. That path is covered by unit tests, but is worth a manual look.
