### PR TITLE
Show microphone picker on first Dictation use

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -101,6 +101,9 @@ export async function runDictationShortcut(
 	// collapses the behavior to a plain toggle.
 	const holdMode = keybindingService.enableKeybindingHoldMode(commandId);
 	await startDictationFn(speechService, editor, window, logService);
+	if (speechService.state === ChatSpeechToTextState.Recording) {
+		context.onboardingService?.refreshMicrophones(speechService.analyserNode);
+	}
 	if (!holdMode) {
 		return;
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions.ts
@@ -102,7 +102,10 @@ export async function runDictationShortcut(
 	const holdMode = keybindingService.enableKeybindingHoldMode(commandId);
 	await startDictationFn(speechService, editor, window, logService);
 	if (speechService.state === ChatSpeechToTextState.Recording) {
-		context.onboardingService?.refreshMicrophones(speechService.analyserNode);
+		context.onboardingService?.refreshMicrophones(
+			speechService.analyserNode,
+			deviceId => speechService.switchMicrophone(window, deviceId),
+		);
 	}
 	if (!holdMode) {
 		return;

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -360,6 +360,9 @@ export interface IChatSpeechToTextService {
 	/** Analyser for the active microphone capture, used for audio-reactive feedback. */
 	readonly analyserNode: AnalyserNode | undefined;
 
+	/** Replace the microphone used by an active recording and return its analyser. */
+	switchMicrophone(window: Window & typeof globalThis, deviceId: string): Promise<AnalyserNode | undefined>;
+
 	/**
 	 * Whether on-device speech-to-text is available on this platform. Callers
 	 * gate the dictation UI on this.
@@ -487,6 +490,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	private _sourceNode: MediaStreamAudioSourceNode | undefined;
 	private _analyserNode: AnalyserNode | undefined;
 	private _workletNode: AudioWorkletNode | undefined;
+	private _captureGeneration = 0;
 	/** Drains the capture worklet's trailing buffer; see {@link IPcmCaptureNode.flush}. */
 	private _flushCapture: (() => Promise<void>) | undefined;
 
@@ -1613,6 +1617,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	private _stopCapture(): void {
+		this._captureGeneration++;
 		this._flushCapture = undefined;
 		if (this._workletNode) {
 			this._workletNode.port.onmessage = null;
@@ -1627,6 +1632,53 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._audioContext = undefined;
 		this._mediaStream?.getTracks().forEach(track => track.stop());
 		this._mediaStream = undefined;
+	}
+
+	async switchMicrophone(window: Window & typeof globalThis, deviceId: string): Promise<AnalyserNode | undefined> {
+		const audioContext = this._audioContext;
+		const workletNode = this._workletNode;
+		if (this._state !== ChatSpeechToTextState.Recording || !audioContext || !workletNode) {
+			return this._analyserNode;
+		}
+
+		const generation = ++this._captureGeneration;
+		let stream: MediaStream;
+		try {
+			stream = await this._acquireStream(window, deviceId);
+		} catch (error) {
+			this._notificationService.error(localize('chatStt.switchMicError', "Could not switch the microphone for speech-to-text: {0}", toErrorMessage(error)));
+			throw error;
+		}
+
+		if (generation !== this._captureGeneration || this._state !== ChatSpeechToTextState.Recording || this._audioContext !== audioContext || this._workletNode !== workletNode) {
+			stream.getTracks().forEach(track => track.stop());
+			return this._analyserNode;
+		}
+
+		let source: MediaStreamAudioSourceNode | undefined;
+		let analyser: AnalyserNode | undefined;
+		try {
+			source = audioContext.createMediaStreamSource(stream);
+			analyser = audioContext.createAnalyser();
+			analyser.fftSize = 256;
+			analyser.smoothingTimeConstant = 0.75;
+			source.connect(analyser);
+			analyser.connect(workletNode);
+		} catch (error) {
+			try { source?.disconnect(); } catch { /* ignore */ }
+			try { analyser?.disconnect(); } catch { /* ignore */ }
+			stream.getTracks().forEach(track => track.stop());
+			this._notificationService.error(localize('chatStt.switchMicError', "Could not switch the microphone for speech-to-text: {0}", toErrorMessage(error)));
+			throw error;
+		}
+
+		try { this._sourceNode?.disconnect(); } catch { /* ignore */ }
+		try { this._analyserNode?.disconnect(); } catch { /* ignore */ }
+		this._mediaStream?.getTracks().forEach(track => track.stop());
+		this._mediaStream = stream;
+		this._sourceNode = source;
+		this._analyserNode = analyser;
+		return analyser;
 	}
 
 	private _teardown(): void {
@@ -1656,11 +1708,10 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._backendFinalizedText = '';
 	}
 
-	private async _acquireStream(window: Window & typeof globalThis): Promise<MediaStream> {
+	private async _acquireStream(window: Window & typeof globalThis, deviceId = this._storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION)): Promise<MediaStream> {
 		// Honor the microphone chosen for Voice Mode (shared setting) so both
 		// features record from the same device. Falls back to the system default
 		// if the stored device is stale/unplugged.
-		const deviceId = this._storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
 		const audioConstraints: MediaTrackConstraints = {
 			channelCount: 1,
 			echoCancellation: true,

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -46,6 +46,8 @@ const DICTATION_SETTINGS_QUERY = 'dictation';
 /** The `deviceId` value that means "whatever the system is using". */
 const SYSTEM_DEFAULT_DEVICE_ID = '';
 
+type DictationMediaDevices = Pick<MediaDevices, 'addEventListener' | 'removeEventListener' | 'dispatchEvent' | 'enumerateDevices' | 'getUserMedia'>;
+
 type DictationOnboardingAction = 'shown' | 'selectMicrophone' | 'openSettings' | 'openInstructions' | 'close' | 'escape';
 
 type DictationOnboardingActionClassification = {
@@ -111,6 +113,19 @@ interface IWave {
 	readonly amplitude: number;
 	readonly speed: number;
 	readonly phase: number;
+}
+
+function readMicrophoneLevel(analyser: AnalyserNode | undefined, waveform: Uint8Array<ArrayBuffer> | undefined): number {
+	if (!analyser || !waveform) {
+		return 0;
+	}
+	analyser.getByteTimeDomainData(waveform);
+	let sum = 0;
+	for (const sample of waveform) {
+		const centered = (sample - 128) / 128;
+		sum += centered * centered;
+	}
+	return Math.min(1, Math.sqrt(sum / waveform.length) * 4);
 }
 
 /**
@@ -185,6 +200,7 @@ class MicrophonePreview extends Disposable {
 
 	constructor(
 		private readonly element: HTMLElement,
+		private readonly mediaDevices: DictationMediaDevices | undefined,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
@@ -195,18 +211,9 @@ class MicrophonePreview extends Disposable {
 	 * frame, so it stays allocation-free.
 	 */
 	getLevel(): number {
-		if (!this.analyser || !this.waveform) {
-			return 0;
-		}
-		this.analyser.getByteTimeDomainData(this.waveform);
-		let sum = 0;
-		for (const sample of this.waveform) {
-			const centered = (sample - 128) / 128;
-			sum += centered * centered;
-		}
 		// RMS, scaled so ordinary speech fills most of the row rather than a
 		// sliver of it.
-		return Math.min(1, Math.sqrt(sum / this.waveform.length) * 4);
+		return readMicrophoneLevel(this.analyser, this.waveform);
 	}
 
 	/**
@@ -221,8 +228,7 @@ class MicrophonePreview extends Disposable {
 		this.releaseMicrophone();
 
 		const targetWindow = dom.getWindow(this.element);
-		const mediaDevices = targetWindow.navigator.mediaDevices;
-		if (!mediaDevices?.getUserMedia) {
+		if (!this.mediaDevices?.getUserMedia) {
 			this.setError(MicrophonePreviewError.Unavailable);
 			return;
 		}
@@ -234,7 +240,7 @@ class MicrophonePreview extends Disposable {
 
 		let stream: MediaStream;
 		try {
-			stream = await mediaDevices.getUserMedia({ audio: constraints });
+			stream = await this.mediaDevices.getUserMedia({ audio: constraints });
 		} catch (error) {
 			this.setError(toPreviewError(error));
 			this.logService.trace(`[chat-stt] microphone preview unavailable: ${error}`);
@@ -542,15 +548,18 @@ export class DictationOnboardingBanner extends Disposable {
 
 	private readonly card: ChatInputOnboardingCard;
 	private readonly preview: MicrophonePreview | undefined;
-	private readonly waveform: MicrophoneWaveform | undefined;
+	private readonly waveform: MicrophoneWaveform;
 	private readonly hint: HTMLElement | undefined;
 	private readonly pickerContainer: HTMLElement | undefined;
+	private dictationAnalyser: AnalyserNode | undefined;
+	private dictationWaveform: Uint8Array<ArrayBuffer> | undefined;
 
 	private readonly picker = this._register(new MutableDisposable<DisposableStore>());
 	private options: IMicrophoneOption[] = [];
 
 	constructor(
 		private readonly bannerOptions: IDictationOnboardingBannerOptions,
+		private readonly mediaDevices: DictationMediaDevices | undefined,
 		@ICommandService private readonly commandService: ICommandService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -586,18 +595,16 @@ export class DictationOnboardingBanner extends Disposable {
 		}];
 		this.renderPicker();
 
-		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
-		if (mediaDevices) {
-			this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshDevices()));
+		if (this.mediaDevices) {
+			this._register(dom.addDisposableListener(this.mediaDevices, 'devicechange', () => void this.refreshMicrophones()));
 		}
 
+		const waveformContainer = dom.append(device, dom.$('.dictation-onboarding-waveform'));
 		if (this.bannerOptions.previewMicrophone) {
 			// Automatic onboarding runs beside an already active dictation
 			// stream, so only the manually opened introduction owns this
 			// independent preview.
-			const waveformContainer = dom.append(device, dom.$('.dictation-onboarding-waveform'));
-
-			const preview = this.preview = this._register(instantiationService.createInstance(MicrophonePreview, this.domNode));
+			const preview = this.preview = this._register(instantiationService.createInstance(MicrophonePreview, this.domNode, this.mediaDevices));
 			this.waveform = this._register(instantiationService.createInstance(MicrophoneWaveform, waveformContainer, {
 				getLevel: () => preview.getLevel(),
 				isAvailable: () => preview.error === undefined,
@@ -608,11 +615,15 @@ export class DictationOnboardingBanner extends Disposable {
 			this.hint.setAttribute('aria-live', 'polite');
 			this.updateHint();
 
-			this.waveform.start();
 			void this.startPreview();
 		} else {
-			void this.refreshDevices();
+			this.waveform = this._register(instantiationService.createInstance(MicrophoneWaveform, waveformContainer, {
+				getLevel: () => readMicrophoneLevel(this.dictationAnalyser, this.dictationWaveform),
+				isAvailable: () => this.dictationAnalyser !== undefined,
+			}, undefined));
+			void this.refreshMicrophones();
 		}
+		this.waveform.start();
 		this.logAction('shown');
 	}
 
@@ -678,23 +689,29 @@ export class DictationOnboardingBanner extends Disposable {
 			return;
 		}
 		const listening = this.preview.listen(this.currentDeviceId());
-		await Promise.all([listening, this.refreshDevices()]);
-		await this.refreshDevices();
+		await Promise.all([listening, this.refreshMicrophones()]);
+		await this.refreshMicrophones();
 	}
 
 	private currentDeviceId(): string {
 		return this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION, SYSTEM_DEFAULT_DEVICE_ID);
 	}
 
-	private async refreshDevices(): Promise<void> {
-		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
-		if (!mediaDevices?.enumerateDevices) {
+	async refreshMicrophones(analyserNode?: AnalyserNode): Promise<void> {
+		if (this._store.isDisposed) {
+			return;
+		}
+		if (!this.preview && analyserNode) {
+			this.dictationAnalyser = analyserNode;
+			this.dictationWaveform = new Uint8Array(analyserNode.fftSize);
+		}
+		if (!this.mediaDevices?.enumerateDevices) {
 			return;
 		}
 
 		let devices: MediaDeviceInfo[];
 		try {
-			devices = await mediaDevices.enumerateDevices();
+			devices = await this.mediaDevices.enumerateDevices();
 		} catch (error) {
 			this.logService.trace(`[chat-stt] could not enumerate microphones: ${error}`);
 			return;
@@ -796,7 +813,7 @@ export class DictationOnboardingBanner extends Disposable {
 
 	private dismiss(action: 'close' | 'escape'): void {
 		this.logAction(action);
-		this.waveform?.stop();
+		this.waveform.stop();
 		this.preview?.releaseMicrophone();
 		this.bannerOptions.onDismiss();
 	}
@@ -851,6 +868,9 @@ export interface IDictationOnboardingService {
 	 */
 	show(): boolean;
 
+	/** Refresh the visible card after dictation acquires microphone permission. */
+	refreshMicrophones(analyserNode?: AnalyserNode): void;
+
 	/** Reset first-run state so the introduction is shown next time. */
 	reset(): void;
 }
@@ -860,6 +880,7 @@ export class DictationOnboardingService extends Disposable implements IDictation
 	declare readonly _serviceBrand: undefined;
 
 	private readonly onboarding: ChatInputOnboarding;
+	private currentBanner: DictationOnboardingBanner | undefined;
 
 	get isVisible(): boolean {
 		return this.onboarding.isVisible;
@@ -889,17 +910,25 @@ export class DictationOnboardingService extends Disposable implements IDictation
 		return this.onboarding.show(context => this.createBanner(context.container, context.dismiss, 'manual', true));
 	}
 
+	refreshMicrophones(analyserNode?: AnalyserNode): void {
+		if (this.onboarding.isVisible) {
+			void this.currentBanner?.refreshMicrophones(analyserNode);
+		}
+	}
+
 	reset(): void {
 		this.storageService.remove(DICTATION_INTRO_SHOWN_KEY, StorageScope.APPLICATION);
 	}
 
 	private createBanner(container: HTMLElement, dismiss: () => void, source: 'automatic' | 'manual', previewMicrophone: boolean): DictationOnboardingBanner {
-		return this.instantiationService.createInstance(DictationOnboardingBanner, {
+		const banner = this.instantiationService.createInstance(DictationOnboardingBanner, {
 			container,
 			onDismiss: dismiss,
 			previewMicrophone,
 			source,
-		});
+		}, dom.getWindow(container).navigator.mediaDevices);
+		this.currentBanner = banner;
+		return banner;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -523,14 +523,15 @@ export interface IDictationOnboardingBannerOptions {
 	/** The element the card attaches itself to. */
 	readonly container: HTMLElement;
 	readonly onDismiss: () => void;
-	/** Whether this manually opened card should acquire a microphone preview. */
+	/** Whether this manually opened card should also acquire a microphone preview. */
 	readonly previewMicrophone: boolean;
 	readonly source: 'automatic' | 'manual';
 }
 
 /**
- * The first-run dictation card explains the feature while recording starts.
- * When reopened manually, it also previews and selects the microphone.
+ * The first-run dictation card explains the feature and offers microphone
+ * selection while recording starts. When reopened manually, it also previews
+ * the selected microphone.
  *
  * The card runs alongside the first dictation, so it explains the feature
  * without delaying the action the user invoked.
@@ -577,13 +578,23 @@ export class DictationOnboardingBanner extends Disposable {
 
 		this.renderClose();
 
+		const device = dom.append(this.domNode, dom.$('.dictation-onboarding-device'));
+		this.pickerContainer = dom.append(device, dom.$('.dictation-onboarding-picker'));
+		this.options = [{
+			deviceId: SYSTEM_DEFAULT_DEVICE_ID,
+			label: localize('dictation.onboarding.systemDefault', "System default"),
+		}];
+		this.renderPicker();
+
+		const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
+		if (mediaDevices) {
+			this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshDevices()));
+		}
+
 		if (this.bannerOptions.previewMicrophone) {
-			// The device and its level are one group: the bars are *this*
-			// microphone's level. Automatic onboarding runs beside an already
-			// active dictation stream, so only the manually opened introduction
-			// owns this independent preview and its device picker.
-			const device = dom.append(this.domNode, dom.$('.dictation-onboarding-device'));
-			this.pickerContainer = dom.append(device, dom.$('.dictation-onboarding-picker'));
+			// Automatic onboarding runs beside an already active dictation
+			// stream, so only the manually opened introduction owns this
+			// independent preview.
 			const waveformContainer = dom.append(device, dom.$('.dictation-onboarding-waveform'));
 
 			const preview = this.preview = this._register(instantiationService.createInstance(MicrophonePreview, this.domNode));
@@ -597,19 +608,10 @@ export class DictationOnboardingBanner extends Disposable {
 			this.hint.setAttribute('aria-live', 'polite');
 			this.updateHint();
 
-			this.options = [{
-				deviceId: SYSTEM_DEFAULT_DEVICE_ID,
-				label: localize('dictation.onboarding.systemDefault', "System default"),
-			}];
-			this.renderPicker();
-
-			const mediaDevices = dom.getWindow(this.domNode).navigator.mediaDevices;
-			if (mediaDevices) {
-				this._register(dom.addDisposableListener(mediaDevices, 'devicechange', () => void this.refreshDevices()));
-			}
-
 			this.waveform.start();
 			void this.startPreview();
+		} else {
+			void this.refreshDevices();
 		}
 		this.logAction('shown');
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding.ts
@@ -47,6 +47,7 @@ const DICTATION_SETTINGS_QUERY = 'dictation';
 const SYSTEM_DEFAULT_DEVICE_ID = '';
 
 type DictationMediaDevices = Pick<MediaDevices, 'addEventListener' | 'removeEventListener' | 'dispatchEvent' | 'enumerateDevices' | 'getUserMedia'>;
+type SwitchMicrophone = (deviceId: string) => Promise<AnalyserNode | undefined>;
 
 type DictationOnboardingAction = 'shown' | 'selectMicrophone' | 'openSettings' | 'openInstructions' | 'close' | 'escape';
 
@@ -553,6 +554,7 @@ export class DictationOnboardingBanner extends Disposable {
 	private readonly pickerContainer: HTMLElement | undefined;
 	private dictationAnalyser: AnalyserNode | undefined;
 	private dictationWaveform: Uint8Array<ArrayBuffer> | undefined;
+	private switchMicrophone: SwitchMicrophone | undefined;
 
 	private readonly picker = this._register(new MutableDisposable<DisposableStore>());
 	private options: IMicrophoneOption[] = [];
@@ -697,13 +699,17 @@ export class DictationOnboardingBanner extends Disposable {
 		return this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION, SYSTEM_DEFAULT_DEVICE_ID);
 	}
 
-	async refreshMicrophones(analyserNode?: AnalyserNode): Promise<void> {
+	async refreshMicrophones(analyserNode?: AnalyserNode, switchMicrophone?: SwitchMicrophone): Promise<void> {
 		if (this._store.isDisposed) {
 			return;
 		}
+		this.switchMicrophone = switchMicrophone ?? this.switchMicrophone;
 		if (!this.preview && analyserNode) {
 			this.dictationAnalyser = analyserNode;
 			this.dictationWaveform = new Uint8Array(analyserNode.fftSize);
+		}
+		if (!this.preview && !this.dictationAnalyser) {
+			return;
 		}
 		if (!this.mediaDevices?.enumerateDevices) {
 			return;
@@ -785,7 +791,13 @@ export class DictationOnboardingBanner extends Disposable {
 		}
 
 		status(localize('dictation.onboarding.microphoneSelected', "{0} selected.", option.label));
-		void this.preview?.listen(option.deviceId).then(() => this.updateHint());
+		if (this.preview) {
+			void this.preview.listen(option.deviceId).then(() => this.updateHint());
+		} else if (this.switchMicrophone) {
+			void this.switchMicrophone(option.deviceId)
+				.then(analyser => this.refreshMicrophones(analyser))
+				.catch(error => this.logService.error(`[chat-stt] failed to switch dictation microphone: ${error}`));
+		}
 	}
 
 	/**
@@ -869,7 +881,7 @@ export interface IDictationOnboardingService {
 	show(): boolean;
 
 	/** Refresh the visible card after dictation acquires microphone permission. */
-	refreshMicrophones(analyserNode?: AnalyserNode): void;
+	refreshMicrophones(analyserNode?: AnalyserNode, switchMicrophone?: SwitchMicrophone): void;
 
 	/** Reset first-run state so the introduction is shown next time. */
 	reset(): void;
@@ -910,9 +922,9 @@ export class DictationOnboardingService extends Disposable implements IDictation
 		return this.onboarding.show(context => this.createBanner(context.container, context.dismiss, 'manual', true));
 	}
 
-	refreshMicrophones(analyserNode?: AnalyserNode): void {
+	refreshMicrophones(analyserNode?: AnalyserNode, switchMicrophone?: SwitchMicrophone): void {
 		if (this.onboarding.isVisible) {
-			void this.currentBanner?.refreshMicrophones(analyserNode);
+			void this.currentBanner?.refreshMicrophones(analyserNode, switchMicrophone);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
@@ -33,9 +33,11 @@ suite('Chat Speech to Text Actions', () => {
 
 	test('starts dictation while first-run onboarding is shown', async () => {
 		const calls: string[] = [];
+		let state = ChatSpeechToTextState.Idle;
 		const speechService = new class extends mock<IChatSpeechToTextService>() {
-			override readonly state = ChatSpeechToTextState.Idle;
+			override get state(): ChatSpeechToTextState { return state; }
 			override readonly isPreparingModel = false;
+			override readonly analyserNode = new class extends mock<AnalyserNode>() { };
 		};
 		const keybindingService = new class extends mock<IKeybindingService>() {
 			override enableKeybindingHoldMode(): Promise<void> | undefined {
@@ -46,6 +48,9 @@ suite('Chat Speech to Text Actions', () => {
 			override showIfNeeded(): boolean {
 				calls.push('showIfNeeded');
 				return true;
+			}
+			override refreshMicrophones(analyserNode?: AnalyserNode): void {
+				calls.push(`refreshMicrophones:${analyserNode === speechService.analyserNode}`);
 			}
 		};
 		const editor = new class extends mock<ICodeEditor>() {
@@ -58,9 +63,12 @@ suite('Chat Speech to Text Actions', () => {
 			{ speechService, keybindingService, logService: new NullLogService(), onboardingService },
 			'test.dictation',
 			editor,
-			async () => { calls.push('startDictation'); },
+			async () => {
+				calls.push('startDictation');
+				state = ChatSpeechToTextState.Recording;
+			},
 		);
 
-		assert.deepStrictEqual(calls, ['showIfNeeded', 'startDictation']);
+		assert.deepStrictEqual(calls, ['showIfNeeded', 'startDictation', 'refreshMicrophones:true']);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts
@@ -38,6 +38,10 @@ suite('Chat Speech to Text Actions', () => {
 			override get state(): ChatSpeechToTextState { return state; }
 			override readonly isPreparingModel = false;
 			override readonly analyserNode = new class extends mock<AnalyserNode>() { };
+			override async switchMicrophone(_window: Window & typeof globalThis, deviceId: string): Promise<AnalyserNode | undefined> {
+				calls.push(`switchMicrophone:${deviceId}`);
+				return this.analyserNode;
+			}
 		};
 		const keybindingService = new class extends mock<IKeybindingService>() {
 			override enableKeybindingHoldMode(): Promise<void> | undefined {
@@ -49,8 +53,9 @@ suite('Chat Speech to Text Actions', () => {
 				calls.push('showIfNeeded');
 				return true;
 			}
-			override refreshMicrophones(analyserNode?: AnalyserNode): void {
+			override refreshMicrophones(analyserNode?: AnalyserNode, switchMicrophone?: (deviceId: string) => Promise<AnalyserNode | undefined>): void {
 				calls.push(`refreshMicrophones:${analyserNode === speechService.analyserNode}`);
+				void switchMicrophone?.('mic-b');
 			}
 		};
 		const editor = new class extends mock<ICodeEditor>() {
@@ -69,6 +74,6 @@ suite('Chat Speech to Text Actions', () => {
 			},
 		);
 
-		assert.deepStrictEqual(calls, ['showIfNeeded', 'startDictation', 'refreshMicrophones:true']);
+		assert.deepStrictEqual(calls, ['showIfNeeded', 'startDictation', 'refreshMicrophones:true', 'switchMicrophone:mic-b']);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -11,7 +11,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
-import { buildMicrophoneOptions, DictationOnboardingService, indexOfMicrophone } from '../../browser/speechToText/dictationOnboarding.js';
+import { buildMicrophoneOptions, DictationOnboardingBanner, DictationOnboardingService, indexOfMicrophone } from '../../browser/speechToText/dictationOnboarding.js';
 
 /** Minimal stand-in for the browser's device descriptor. */
 function device(kind: MediaDeviceKind, deviceId: string, label: string): MediaDeviceInfo {
@@ -130,13 +130,52 @@ suite('Dictation onboarding', () => {
 			{
 				shownFirstTime: true, shown: true, closeIcon: 'codicon codicon-close',
 				hasMicrophoneControls: true,
-				hasWaveform: false,
+				hasWaveform: true,
 				visibleAfterClose: false,
 				shownAgain: false,
 				telemetryEvents: [
 					{ name: 'dictationOnboarding.action', data: { action: 'shown', source: 'automatic' } },
 					{ name: 'dictationOnboarding.action', data: { action: 'close', source: 'automatic' } },
 				],
+			});
+	});
+
+	test('shows populated microphone picker after dictation acquires permission without another capture', async () => {
+		const host = createHost(disposables);
+		let getUserMediaCalls = 0;
+		const mediaDevices = Object.assign(new EventTarget(), {
+			enumerateDevices: async () => [
+				device('audioinput', 'default', 'Default - Studio Mic'),
+				device('audioinput', 'studio', 'Studio Mic'),
+				device('audioinput', 'built-in', 'Built-in Mic'),
+			],
+			getUserMedia: async (): Promise<MediaStream> => {
+				getUserMediaCalls++;
+				throw new Error('Automatic onboarding must not acquire a stream');
+			},
+		});
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const banner = disposables.add(instantiationService.createInstance(DictationOnboardingBanner, {
+			container: host.container,
+			onDismiss: () => { },
+			previewMicrophone: false,
+			source: 'automatic',
+		}, mediaDevices));
+
+		await banner.refreshMicrophones();
+
+		assert.deepStrictEqual(
+			{
+				pickerHidden: host.container.querySelector<HTMLElement>('.dictation-onboarding-picker')?.hidden,
+				options: Array.from(host.container.querySelectorAll<HTMLOptionElement>('.dictation-onboarding-picker option'), option => option.textContent),
+				hasWaveform: host.container.querySelector('.dictation-onboarding-waveform') !== null,
+				getUserMediaCalls,
+			},
+			{
+				pickerHidden: false,
+				options: ['Studio Mic (System default)', 'Built-in Mic'],
+				hasWaveform: true,
+				getUserMediaCalls: 0,
 			});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import * as dom from '../../../../../base/browser/dom.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -143,6 +144,7 @@ suite('Dictation onboarding', () => {
 	test('shows populated microphone picker after dictation acquires permission without another capture', async () => {
 		const host = createHost(disposables);
 		let getUserMediaCalls = 0;
+		const selectedDeviceIds: string[] = [];
 		const mediaDevices = Object.assign(new EventTarget(), {
 			enumerateDevices: async () => [
 				device('audioinput', 'default', 'Default - Studio Mic'),
@@ -162,7 +164,16 @@ suite('Dictation onboarding', () => {
 			source: 'automatic',
 		}, mediaDevices));
 
-		await banner.refreshMicrophones();
+		const analyser = new class extends mock<AnalyserNode>() {
+			override readonly fftSize = 256;
+		};
+		await banner.refreshMicrophones(analyser, async deviceId => {
+			selectedDeviceIds.push(deviceId);
+			return analyser;
+		});
+		const picker = host.container.querySelector<HTMLSelectElement>('.dictation-onboarding-picker select')!;
+		picker.selectedIndex = 1;
+		picker.dispatchEvent(new Event('change', { bubbles: true }));
 
 		assert.deepStrictEqual(
 			{
@@ -170,12 +181,14 @@ suite('Dictation onboarding', () => {
 				options: Array.from(host.container.querySelectorAll<HTMLOptionElement>('.dictation-onboarding-picker option'), option => option.textContent),
 				hasWaveform: host.container.querySelector('.dictation-onboarding-waveform') !== null,
 				getUserMediaCalls,
+				selectedDeviceIds,
 			},
 			{
 				pickerHidden: false,
 				options: ['Studio Mic (System default)', 'Built-in Mic'],
 				hasWaveform: true,
 				getUserMediaCalls: 0,
+				selectedDeviceIds: ['built-in'],
 			});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -113,20 +113,24 @@ suite('Dictation onboarding', () => {
 		const shown = host.container.classList.contains('has-dictation-onboarding');
 
 		const closeIcon = host.container.querySelector('.dictation-onboarding-close .codicon')?.className;
+		const hasMicrophoneControls = host.container.querySelector('.dictation-onboarding-device') !== null;
+		const hasWaveform = host.container.querySelector('.dictation-onboarding-waveform') !== null;
 		host.container.querySelector<HTMLElement>('.dictation-onboarding-close')!.click();
 		const shownAgain = service.showIfNeeded();
 
 		assert.deepStrictEqual(
 			{
 				shownFirstTime, shown, closeIcon,
-				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
+				hasMicrophoneControls,
+				hasWaveform,
 				visibleAfterClose: host.container.classList.contains('has-dictation-onboarding'),
 				shownAgain,
 				telemetryEvents,
 			},
 			{
 				shownFirstTime: true, shown: true, closeIcon: 'codicon codicon-close',
-				hasMicrophoneControls: false,
+				hasMicrophoneControls: true,
+				hasWaveform: false,
 				visibleAfterClose: false,
 				shownAgain: false,
 				telemetryEvents: [
@@ -167,9 +171,10 @@ suite('Dictation onboarding', () => {
 				visible: host.container.classList.contains('has-dictation-onboarding'),
 				cards: host.container.querySelectorAll('.dictation-onboarding-banner').length,
 				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
+				hasWaveform: host.container.querySelector('.dictation-onboarding-waveform') !== null,
 				microphonePickerHidden: host.container.querySelector<HTMLElement>('.dictation-onboarding-picker')?.hidden,
 			},
-			{ visible: true, cards: 1, hasMicrophoneControls: true, microphonePickerHidden: true });
+			{ visible: true, cards: 1, hasMicrophoneControls: true, hasWaveform: true, microphonePickerHidden: true });
 	});
 
 	test('reset shows the introduction on the next dictation', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
@@ -45,6 +45,7 @@ suite('DictationSession', () => {
 			get isDownloadingModel() { return false; },
 			get modelDownloadProgress() { return undefined; },
 			get currentBackend() { return 'mai' as const; },
+			async switchMicrophone() { return undefined; },
 			async start() {
 				state = ChatSpeechToTextState.Recording;
 				onDidChangeState.fire(state);


### PR DESCRIPTION
Shows the microphone picker and waveform in the automatic first-use Dictation onboarding card. Once dictation successfully starts, the card refreshes device labels and binds its waveform to the active dictation analyser, avoiding a second microphone capture. Selecting another device replaces the live capture source while preserving the active transcription session and rebinds the waveform to the new analyser.

The manually reopened introduction retains its independent microphone preview. Supersedes #328468 and addresses its review feedback.

Tests: `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts src/vs/workbench/contrib/chat/test/browser/actions/chatSpeechToTextActions.test.ts src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts --grep "Dictation onboarding|Chat Speech to Text Actions|Dictation session"`