### PR TITLE
Refine MCP registry-only enforcement

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -536,7 +536,7 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 
 	async updateMetadata(local: ILocalMcpServer, gallery: IGalleryMcpServer): Promise<ILocalMcpServer> {
 		await this.updateMetadataFromGallery(gallery);
-		await this.updateLocal();
+		await this.updateLocal(gallery);
 		const updatedLocal = (await this.getInstalled()).find(s => s.name === local.name);
 		if (!updatedLocal) {
 			throw new Error(`Failed to find MCP server: ${local.name}`);

--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -393,7 +393,7 @@ export abstract class AbstractMcpResourceManagementService extends AbstractCommo
 		}));
 	}
 
-	protected async updateLocal(): Promise<void> {
+	protected async updateLocal(source?: IGalleryMcpServer): Promise<void> {
 		try {
 			const current = await this.populateLocalServers();
 
@@ -424,11 +424,11 @@ export abstract class AbstractMcpResourceManagementService extends AbstractCommo
 			}
 
 			if (updated.length) {
-				this._onDidUpdateMcpServers.fire(updated.map(server => ({ name: server.name, local: server, mcpResource: this.mcpResource })));
+				this._onDidUpdateMcpServers.fire(updated.map(server => ({ name: server.name, local: server, source: source?.name === server.name ? source : undefined, mcpResource: this.mcpResource })));
 			}
 
 			if (added.length) {
-				this._onDidInstallMcpServers.fire(added.map(server => ({ name: server.name, local: server, mcpResource: this.mcpResource })));
+				this._onDidInstallMcpServers.fire(added.map(server => ({ name: server.name, local: server, source: source?.name === server.name ? source : undefined, mcpResource: this.mcpResource })));
 			}
 
 		} catch (error) {

--- a/src/vs/platform/mcp/node/mcpManagementService.ts
+++ b/src/vs/platform/mcp/node/mcpManagementService.ts
@@ -59,7 +59,7 @@ export class McpUserResourceManagementService extends CommonMcpUserResourceManag
 
 			await this.mcpResourceScannerService.addMcpServers([installable], this.mcpResource, this.target);
 
-			await this.updateLocal();
+			await this.updateLocal(server);
 			const local = (await this.getInstalled()).find(s => s.name === server.name);
 			if (!local) {
 				throw new Error(`Failed to install MCP server: ${server.name}`);

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -5,10 +5,11 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
+import { upcastPartial } from '../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { AbstractCommonMcpManagementService, AbstractMcpResourceManagementService } from '../../common/mcpManagementService.js';
+import { AbstractCommonMcpManagementService, AbstractMcpResourceManagementService, McpUserResourceManagementService } from '../../common/mcpManagementService.js';
 import { GalleryMcpServerStatus, IAllowedMcpServersService, IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, ILocalMcpServer, IMcpGalleryService, InstallOptions, RegistryType, TransportType, UninstallOptions } from '../../common/mcpManagement.js';
 import { IMcpSandboxConfiguration, McpServerType, McpServerVariableType, IMcpServerConfiguration, IMcpServerVariable } from '../../common/mcpPlatformTypes.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
@@ -20,6 +21,7 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { NullLogService } from '../../../log/common/log.js';
 import { McpResourceScannerService } from '../../common/mcpResourceScannerService.js';
 import { UriIdentityService } from '../../../uriIdentity/common/uriIdentityService.js';
+import { IEnvironmentService } from '../../../environment/common/environment.js';
 
 class TestMcpManagementService extends AbstractCommonMcpManagementService {
 
@@ -1125,6 +1127,8 @@ suite('McpResourceManagementService', () => {
 	const mcpResource = URI.from({ scheme: Schemas.inMemory, path: '/mcp.json' });
 	let disposables: DisposableStore;
 	let fileService: FileService;
+	let uriIdentityService: UriIdentityService;
+	let scannerService: McpResourceScannerService;
 	let service: TestMcpResourceManagementService;
 
 	function createGallery(): IGalleryMcpServer {
@@ -1144,8 +1148,8 @@ suite('McpResourceManagementService', () => {
 		disposables = new DisposableStore();
 		fileService = disposables.add(new FileService(new NullLogService()));
 		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
-		const uriIdentityService = disposables.add(new UriIdentityService(fileService));
-		const scannerService = disposables.add(new McpResourceScannerService(fileService, uriIdentityService));
+		uriIdentityService = disposables.add(new UriIdentityService(fileService));
+		scannerService = disposables.add(new McpResourceScannerService(fileService, uriIdentityService));
 		service = disposables.add(new TestMcpResourceManagementService(mcpResource, fileService, uriIdentityService, scannerService));
 
 		await fileService.writeFile(mcpResource, VSBuffer.fromString(JSON.stringify({
@@ -1214,24 +1218,33 @@ suite('McpResourceManagementService', () => {
 		assert.strictEqual(result[0].source, gallery);
 	});
 
-	test('propagates the gallery source when updating an installed server', async () => {
-		await service.getInstalled();
-		const gallery = createGallery();
-		const updatePromise = Event.toPromise(service.onDidUpdateMcpServers);
-		await fileService.writeFile(mcpResource, VSBuffer.fromString(JSON.stringify({
-			sandbox: {
-				network: { allowedDomains: ['updated.example.com'] }
-			},
+	test('updateMetadata propagates the gallery source when updating an installed server', async () => {
+		const galleryResource = URI.from({ scheme: Schemas.inMemory, path: '/gallery-mcp.json' });
+		await fileService.writeFile(galleryResource, VSBuffer.fromString(JSON.stringify({
 			servers: {
 				test: {
 					type: 'stdio',
 					command: 'node',
-					sandboxEnabled: true
+					gallery: true,
+					version: '1.0.0'
 				}
 			}
 		}, null, '\t')));
+		const gallery = createGallery();
+		const galleryService = disposables.add(new McpUserResourceManagementService(
+			galleryResource,
+			upcastPartial<IMcpGalleryService>({}),
+			fileService,
+			uriIdentityService,
+			new NullLogService(),
+			scannerService,
+			{ _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true },
+			upcastPartial<IEnvironmentService>({ userRoamingDataHome: URI.from({ scheme: Schemas.inMemory, path: '/user' }) }),
+		));
+		const [local] = await galleryService.getInstalled();
+		const updatePromise = Event.toPromise(galleryService.onDidUpdateMcpServers);
 
-		await service.reload(gallery);
+		await galleryService.updateMetadata(local, gallery);
 		const result = await updatePromise;
 
 		assert.strictEqual(result[0].source, gallery);

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { AbstractCommonMcpManagementService, AbstractMcpResourceManagementService } from '../../common/mcpManagementService.js';
-import { IAllowedMcpServersService, IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, ILocalMcpServer, IMcpGalleryService, InstallOptions, RegistryType, TransportType, UninstallOptions } from '../../common/mcpManagement.js';
+import { GalleryMcpServerStatus, IAllowedMcpServersService, IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, ILocalMcpServer, IMcpGalleryService, InstallOptions, RegistryType, TransportType, UninstallOptions } from '../../common/mcpManagement.js';
 import { IMcpSandboxConfiguration, McpServerType, McpServerVariableType, IMcpServerConfiguration, IMcpServerVariable } from '../../common/mcpPlatformTypes.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Event } from '../../../../base/common/event.js';
@@ -64,8 +64,8 @@ class TestMcpResourceManagementService extends AbstractMcpResourceManagementServ
 		);
 	}
 
-	public reload(): Promise<void> {
-		return this.updateLocal();
+	public reload(source?: IGalleryMcpServer): Promise<void> {
+		return this.updateLocal(source);
 	}
 
 	override canInstall(_server: IGalleryMcpServer | IInstallableMcpServer): true | IMarkdownString {
@@ -1127,6 +1127,19 @@ suite('McpResourceManagementService', () => {
 	let fileService: FileService;
 	let service: TestMcpResourceManagementService;
 
+	function createGallery(): IGalleryMcpServer {
+		return {
+			name: 'test',
+			displayName: 'Test',
+			description: '',
+			version: '1.0.0',
+			isLatest: true,
+			status: GalleryMcpServerStatus.Active,
+			configuration: {},
+			publisher: 'test',
+		};
+	}
+
 	setup(async () => {
 		disposables = new DisposableStore();
 		fileService = disposables.add(new FileService(new NullLogService()));
@@ -1190,6 +1203,39 @@ suite('McpResourceManagementService', () => {
 		assert.strictEqual(updateCount, 1);
 		assert.deepStrictEqual(updated[0].rootSandbox, updatedSandbox);
 	});
+
+	test('propagates the gallery source when loading an installed server', async () => {
+		const gallery = createGallery();
+		const installPromise = Event.toPromise(service.onDidInstallMcpServers);
+
+		await service.reload(gallery);
+		const result = await installPromise;
+
+		assert.strictEqual(result[0].source, gallery);
+	});
+
+	test('propagates the gallery source when updating an installed server', async () => {
+		await service.getInstalled();
+		const gallery = createGallery();
+		const updatePromise = Event.toPromise(service.onDidUpdateMcpServers);
+		await fileService.writeFile(mcpResource, VSBuffer.fromString(JSON.stringify({
+			sandbox: {
+				network: { allowedDomains: ['updated.example.com'] }
+			},
+			servers: {
+				test: {
+					type: 'stdio',
+					command: 'node',
+					sandboxEnabled: true
+				}
+			}
+		}, null, '\t')));
+
+		await service.reload(gallery);
+		const result = await updatePromise;
+
+		assert.strictEqual(result[0].source, gallery);
+	});
 });
 
 suite('McpResourceManagementService - install policy enforcement', () => {
@@ -1235,4 +1281,3 @@ suite('McpResourceManagementService - install policy enforcement', () => {
 		assert.ok((await service.getInstalled()).some(s => s.name === server.name));
 	});
 });
-

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -964,7 +964,7 @@ configurationRegistry.registerConfiguration({
 			],
 			enumDescriptions: [
 				nls.localize('chat.mcp.access.none', "No access to MCP servers."),
-				nls.localize('chat.mcp.access.registry', "Allows access to MCP servers installed from the registry that VS Code is connected to."),
+				nls.localize('chat.mcp.access.registry', "Allows access to MCP servers listed in the registry that VS Code is connected to."),
 				nls.localize('chat.mcp.access.any', "Allow access to any installed MCP server.")
 			],
 			default: McpAccessValue.All,
@@ -991,7 +991,7 @@ configurationRegistry.registerConfiguration({
 							key: 'chat.mcp.access.none', value: nls.localize('chat.mcp.access.none', "No access to MCP servers."),
 						},
 						{
-							key: 'chat.mcp.access.registry', value: nls.localize('chat.mcp.access.registry', "Allows access to MCP servers installed from the registry that VS Code is connected to."),
+							key: 'chat.mcp.access.registry', value: nls.localize('chat.mcp.access.registry', "Allows access to MCP servers listed in the registry that VS Code is connected to."),
 						},
 						{
 							key: 'chat.mcp.access.any', value: nls.localize('chat.mcp.access.any', "Allow access to any installed MCP server.")

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -167,6 +167,11 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 
 	private _local: McpWorkbenchServer[] = [];
 	private registrySyncGeneration = 0;
+	private registryGeneration = 0;
+	private localQueryGeneration = 0;
+	private profileChangeGeneration = 0;
+	// Source identity is intentionally trusted only in-process; IPC copies are re-verified.
+	private readonly gallerySourceGenerations = new WeakMap<IGalleryMcpServer, number>();
 	private readonly registrySyncDelayer = this._register(new ThrottledDelayer<void>(0));
 	get local(): readonly McpWorkbenchServer[] { return [...this._local]; }
 
@@ -237,13 +242,19 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 	}
 
 	private async onDidChangeProfile() {
+		const profileChangeGeneration = ++this.profileChangeGeneration;
+		const generation = ++this.localQueryGeneration;
 		this.invalidateRegistryVerification();
-		await this.queryLocal();
+		await this.queryLocalForGeneration(generation);
+		if (profileChangeGeneration !== this.profileChangeGeneration) {
+			return;
+		}
 		this._onReset.fire();
 		this.scheduleRegistrySync();
 	}
 
 	private invalidateRegistryVerification(): void {
+		this.registryGeneration++;
 		this.registrySyncGeneration++;
 		for (const server of this._local) {
 			server.gallery = undefined;
@@ -278,7 +289,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			let server = this.installing.find(server => server.local && local ? this.areSameMcpServers(server.local, local) : server.name === name);
 			this.installing = server ? this.installing.filter(e => e !== server) : this.installing;
 			if (local) {
-				const trustedGallery = source ?? server?.gallery;
+				const trustedGallery = this.getTrustedGallerySource(source) ?? this.getTrustedGallerySource(server?.gallery);
 				if (server) {
 					server.local = local;
 				} else {
@@ -311,7 +322,8 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 				server = this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), result.local, undefined, undefined);
 				this.addServer(server);
 			}
-			server.gallery = result.source?.name === result.local.name ? result.source : undefined;
+			const trustedGallery = this.getTrustedGallerySource(result.source) ?? this.getTrustedGallerySource(server.gallery);
+			server.gallery = trustedGallery?.name === result.local.name ? trustedGallery : undefined;
 			needsRegistrySync = true;
 			this._onChange.fire(server);
 		}
@@ -320,7 +332,8 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		}
 	}
 
-	private fromGallery(gallery: IGalleryMcpServer): IWorkbenchMcpServer | undefined {
+	private fromGallery(gallery: IGalleryMcpServer, registryGeneration: number): IWorkbenchMcpServer | undefined {
+		this.rememberGallerySource(gallery, registryGeneration);
 		for (const local of this._local) {
 			if (local.name === gallery.name) {
 				return local;
@@ -389,6 +402,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 
 			const gallery = result.server;
 			const changed = mcpServer.gallery !== gallery;
+			this.rememberGallerySource(gallery);
 			mcpServer.gallery = gallery;
 			if (changed) {
 				this._onChange.fire(mcpServer);
@@ -403,10 +417,10 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 				getNextPage: async () => ({ items: [], hasMore: false })
 			};
 		}
+		const registryGeneration = this.registryGeneration;
 		const pager = await this.mcpGalleryService.query(options, token);
-
 		const mapPage = (page: IIterativePage<IGalleryMcpServer>): IIterativePage<IWorkbenchMcpServer> => ({
-			items: page.items.map(gallery => this.fromGallery(gallery) ?? this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), undefined, gallery, undefined)),
+			items: page.items.map(gallery => this.fromGallery(gallery, registryGeneration) ?? this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), undefined, gallery, undefined)),
 			hasMore: page.hasMore
 		});
 
@@ -420,7 +434,15 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 	}
 
 	async queryLocal(): Promise<IWorkbenchMcpServer[]> {
+		await this.queryLocalForGeneration(++this.localQueryGeneration);
+		return [...this.local];
+	}
+
+	private async queryLocalForGeneration(generation: number): Promise<boolean> {
 		const installed = await this.mcpManagementService.getInstalled();
+		if (generation !== this.localQueryGeneration) {
+			return false;
+		}
 		this._local = this.sort(installed.map(i => {
 			const existing = this._local.find(local => local.id === i.id);
 			const local = existing ?? this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), undefined, undefined, undefined);
@@ -428,7 +450,17 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			return local;
 		}));
 		this._onChange.fire(undefined);
-		return [...this.local];
+		return true;
+	}
+
+	private rememberGallerySource(gallery: IGalleryMcpServer, registryGeneration = this.registryGeneration): void {
+		if (registryGeneration === this.registryGeneration) {
+			this.gallerySourceGenerations.set(gallery, registryGeneration);
+		}
+	}
+
+	private getTrustedGallerySource(gallery: IGalleryMcpServer | undefined): IGalleryMcpServer | undefined {
+		return gallery && this.gallerySourceGenerations.get(gallery) === this.registryGeneration ? gallery : undefined;
 	}
 
 	private addServer(server: McpWorkbenchServer): void {
@@ -731,10 +763,12 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			// route through the gallery-only path (matching handleMcpServerByName).
 			if (config.gallery && this.mcpGalleryService.isEnabled()) {
 				try {
+					const registryGeneration = this.registryGeneration;
 					// Verify by name against the active gallery (not by URL, which would
 					// make outbound requests to untrusted URLs from the protocol payload).
 					const [galleryServer] = await this.mcpGalleryService.getMcpServersFromGallery([{ name }]);
 					if (galleryServer) {
+						this.rememberGallerySource(galleryServer, registryGeneration);
 						const local = this.local.find(e => e.name === galleryServer.name) ?? this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), undefined, galleryServer, undefined);
 						this.open(local);
 						return true;
@@ -773,11 +807,13 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 
 	private async handleMcpServerByName(name: string): Promise<boolean> {
 		try {
+			const registryGeneration = this.registryGeneration;
 			const [gallery] = await this.mcpGalleryService.getMcpServersFromGallery([{ name }]);
 			if (!gallery) {
 				this.logService.info(`MCP server '${name}' not found`);
 				return true;
 			}
+			this.rememberGallerySource(gallery, registryGeneration);
 			const local = this.local.find(e => e.name === gallery.name) ?? this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), undefined, gallery, undefined);
 			this.open(local);
 		} catch (e) {

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -36,7 +36,7 @@ import { DidUninstallWorkbenchMcpServerEvent, IWorkbenchLocalMcpServer, IWorkben
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { McpServerInstallData, McpServerInstallClassification } from '../common/mcpServer.js';
-import { HasInstalledMcpServersContext, IMcpConfigPath, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCollectionSortOrder, McpServerEnablementState, McpServerInstallState, McpServerEnablementStatus, McpServersGalleryStatusContext, McpServerRegistryStatus } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpConfigPath, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCollectionSortOrder, McpServerEnablementState, McpServerInstallState, McpServerEnablementStatus, McpServersGalleryStatusContext } from '../common/mcpTypes.js';
 import { ContributionEnablementState } from '../../chat/common/enablement.js';
 import { McpServerEditorInput } from './mcpServerEditorInput.js';
 import { IMcpGalleryManifestService } from '../../../../platform/mcp/common/mcpGalleryManifest.js';
@@ -44,15 +44,13 @@ import { IIterativePager, IIterativePage } from '../../../../base/common/paging.
 import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
 import { autorun, runOnChange } from '../../../../base/common/observable.js';
 import Severity from '../../../../base/common/severity.js';
-import { Queue } from '../../../../base/common/async.js';
+import { ThrottledDelayer } from '../../../../base/common/async.js';
 
 interface IMcpServerStateProvider<T> {
 	(mcpWorkbenchServer: McpWorkbenchServer): T;
 }
 
 class McpWorkbenchServer implements IWorkbenchMcpServer {
-
-	registryStatus: McpServerRegistryStatus = McpServerRegistryStatus.Unknown;
 
 	constructor(
 		private installStateProvider: IMcpServerStateProvider<McpServerInstallState>,
@@ -169,6 +167,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 
 	private _local: McpWorkbenchServer[] = [];
 	private registrySyncGeneration = 0;
+	private readonly registrySyncDelayer = this._register(new ThrottledDelayer<void>(0));
 	get local(): readonly McpWorkbenchServer[] { return [...this._local]; }
 
 	private readonly _onChange = this._register(new Emitter<IWorkbenchMcpServer | undefined>());
@@ -207,12 +206,11 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			if (this._store.isDisposed) {
 				return;
 			}
-			const queue = this._register(new Queue());
 			this._register(mcpGalleryManifestService.onDidChangeMcpGalleryManifest(() => {
 				this.invalidateRegistryVerification();
-				queue.queue(() => this.syncInstalledMcpServers());
+				this.scheduleRegistrySync();
 			}));
-			queue.queue(() => this.syncInstalledMcpServers());
+			this.scheduleRegistrySync();
 		});
 		urlService.registerHandler(this);
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
@@ -242,14 +240,13 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		this.invalidateRegistryVerification();
 		await this.queryLocal();
 		this._onReset.fire();
-		this.syncInstalledMcpServers();
+		this.scheduleRegistrySync();
 	}
 
 	private invalidateRegistryVerification(): void {
 		this.registrySyncGeneration++;
 		for (const server of this._local) {
 			server.gallery = undefined;
-			server.registryStatus = McpServerRegistryStatus.Unknown;
 		}
 		this._onChange.fire(undefined);
 	}
@@ -277,17 +274,17 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 
 	private onDidInstallMcpServers(e: readonly IWorkbenchMcpServerInstallResult[]) {
 		let needsRegistrySync = false;
-		for (const { local, name } of e) {
+		for (const { local, name, source } of e) {
 			let server = this.installing.find(server => server.local && local ? this.areSameMcpServers(server.local, local) : server.name === name);
 			this.installing = server ? this.installing.filter(e => e !== server) : this.installing;
 			if (local) {
+				const trustedGallery = source ?? server?.gallery;
 				if (server) {
 					server.local = local;
 				} else {
 					server = this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), local, undefined, undefined);
 				}
-				server.gallery = undefined;
-				server.registryStatus = McpServerRegistryStatus.Unknown;
+				server.gallery = trustedGallery?.name === local.name ? trustedGallery : undefined;
 				needsRegistrySync = true;
 				this._local = this._local.filter(server => !this.areSameMcpServers(server.local, local));
 				this.addServer(server);
@@ -295,7 +292,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			this._onChange.fire(server);
 		}
 		if (needsRegistrySync) {
-			this.syncInstalledMcpServers();
+			this.scheduleRegistrySync();
 		}
 	}
 
@@ -314,13 +311,12 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 				server = this.instantiationService.createInstance(McpWorkbenchServer, e => this.getInstallState(e), e => this.getRuntimeStatus(e), result.local, undefined, undefined);
 				this.addServer(server);
 			}
-			server.gallery = undefined;
-			server.registryStatus = McpServerRegistryStatus.Unknown;
+			server.gallery = result.source?.name === result.local.name ? result.source : undefined;
 			needsRegistrySync = true;
 			this._onChange.fire(server);
 		}
 		if (needsRegistrySync) {
-			this.syncInstalledMcpServers();
+			this.scheduleRegistrySync();
 		}
 	}
 
@@ -333,14 +329,26 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		return undefined;
 	}
 
-	private async syncInstalledMcpServers(): Promise<void> {
+	private scheduleRegistrySync(): void {
+		const generation = ++this.registrySyncGeneration;
+		void this.registrySyncDelayer.trigger(() => this.syncInstalledMcpServers(generation))
+			.catch(error => this.logService.error(error));
+	}
+
+	private async syncInstalledMcpServers(generation: number): Promise<void> {
 		if (!this.mcpGalleryService.isEnabled()) {
 			return;
 		}
 
-		const generation = ++this.registrySyncGeneration;
 		const servers = this.local.flatMap(server => server.local ? [{ server, local: server.local }] : []);
-		const infos = servers.map(({ local }) => ({ name: local.name, id: local.galleryId }));
+		const infosByName = new Map<string, { name: string; id?: string }>();
+		for (const { local } of servers) {
+			const existing = infosByName.get(local.name);
+			if (!existing || (!existing.id && local.galleryId)) {
+				infosByName.set(local.name, { name: local.name, id: local.galleryId });
+			}
+		}
+		const infos = [...infosByName.values()];
 
 		if (!infos.length) {
 			return;
@@ -372,18 +380,16 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			}
 
 			if (result.status === McpGalleryResolveStatus.NotFound) {
-				if (mcpServer.gallery || mcpServer.registryStatus !== McpServerRegistryStatus.NotFound) {
+				if (mcpServer.gallery) {
 					mcpServer.gallery = undefined;
-					mcpServer.registryStatus = McpServerRegistryStatus.NotFound;
 					this._onChange.fire(mcpServer);
 				}
 				continue;
 			}
 
 			const gallery = result.server;
-			const changed = mcpServer.gallery !== gallery || mcpServer.registryStatus !== McpServerRegistryStatus.Matched;
+			const changed = mcpServer.gallery !== gallery;
 			mcpServer.gallery = gallery;
-			mcpServer.registryStatus = McpServerRegistryStatus.Matched;
 			if (changed) {
 				this._onChange.fire(mcpServer);
 			}
@@ -856,7 +862,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		}
 
 		if (accessValue === McpAccessValue.Registry) {
-			if (!this.isAllowedByRegistry(mcpServer)) {
+			if (!mcpServer.gallery) {
 				return {
 					state: McpServerEnablementState.DisabledByAccess,
 					message: {
@@ -866,10 +872,9 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 				};
 			}
 
-			// The registry can restrict which remote URLs are permitted for a server.
-			// This can only be enforced when the gallery metadata is available.
+			// Registry membership is name-based for local configurations; remote URLs must match exactly.
 			const remoteUrl = mcpServer.local.config.type === McpServerType.REMOTE && mcpServer.local.config.url;
-			if (remoteUrl && mcpServer.gallery && !mcpServer.gallery.configuration.remotes?.some(remote => remote.url === remoteUrl)) {
+			if (remoteUrl && !mcpServer.gallery.configuration.remotes?.some(remote => remote.url === remoteUrl)) {
 				return {
 					state: McpServerEnablementState.DisabledByAccess,
 					message: {
@@ -881,23 +886,6 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		}
 
 		return undefined;
-	}
-
-	/**
-	 * Whether a server satisfies the "Registry only" access policy. Enforcement is
-	 * based exclusively on membership verified against the active registry. Unknown
-	 * status remains blocked because install metadata is user-editable and is not
-	 * trusted proof of registry membership.
-	 */
-	private isAllowedByRegistry(mcpServer: McpWorkbenchServer): boolean {
-		switch (mcpServer.registryStatus) {
-			case McpServerRegistryStatus.Matched:
-				return true;
-			case McpServerRegistryStatus.NotFound:
-			case McpServerRegistryStatus.Unknown:
-			default:
-				return false;
-		}
 	}
 
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -866,20 +866,6 @@ export const enum McpServerEnablementState {
 	Enabled,
 }
 
-/**
- * Whether an installed MCP server has been verified against the configured
- * registry. Used to enforce the "Registry only" access policy without relying on
- * transient install-time metadata.
- */
-export const enum McpServerRegistryStatus {
-	/** Membership has not been determined yet (or could not be determined). */
-	Unknown,
-	/** The server was found in the active registry. */
-	Matched,
-	/** The active registry authoritatively does not contain the server. */
-	NotFound,
-}
-
 export const enum McpServerInstallState {
 	Installing,
 	Installed,
@@ -907,7 +893,6 @@ export interface IWorkbenchMcpServer {
 	readonly installable: IInstallableMcpServer | undefined;
 	readonly installState: McpServerInstallState;
 	readonly runtimeStatus: McpServerEnablementStatus | undefined;
-	readonly registryStatus: McpServerRegistryStatus;
 	readonly id: string;
 	readonly name: string;
 	readonly label: string;

--- a/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
@@ -1,0 +1,505 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { GalleryMcpServerStatus, IAllowedMcpServersService, IGalleryMcpServer, IMcpGalleryServerResolveResult, IMcpGalleryService, IInstallableMcpServer, InstallOptions, McpAccessValue, McpGalleryResolveStatus, mcpAccessConfig, TransportType } from '../../../../../platform/mcp/common/mcpManagement.js';
+import { IMcpGalleryManifest, IMcpGalleryManifestService, McpGalleryManifestStatus } from '../../../../../platform/mcp/common/mcpGalleryManifest.js';
+import { IMcpServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IURLService } from '../../../../../platform/url/common/url.js';
+import { IUserDataProfilesService } from '../../../../../platform/userDataProfile/common/userDataProfile.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { IWorkbenchLocalMcpServer, IWorkbenchMcpManagementService, IWorkbenchMcpServerInstallResult, LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
+import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
+import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
+import { McpWorkbenchService } from '../../browser/mcpWorkbenchService.js';
+import { IMcpService } from '../../common/mcpTypes.js';
+
+interface IResolveRequest {
+	readonly infos: readonly { name: string; id?: string }[];
+	readonly result: DeferredPromise<Map<string, IMcpGalleryServerResolveResult>>;
+}
+
+class TestMcpGalleryService extends mock<IMcpGalleryService>() {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly requests: IResolveRequest[] = [];
+	private nextRequestIndex = 0;
+	private readonly onDidRequestEmitter: Emitter<void>;
+	queryItems: IGalleryMcpServer[] = [];
+	get requestCount(): number { return this.requests.length; }
+
+	constructor(store: Pick<DisposableStore, 'add'>) {
+		super();
+		this.onDidRequestEmitter = store.add(new Emitter<void>());
+	}
+
+	override isEnabled(): boolean {
+		return true;
+	}
+
+	override resolveMcpServersFromGallery(infos: { name: string; id?: string }[]): Promise<Map<string, IMcpGalleryServerResolveResult>> {
+		const result = new DeferredPromise<Map<string, IMcpGalleryServerResolveResult>>();
+		this.requests.push({ infos, result });
+		this.onDidRequestEmitter.fire();
+		return result.p;
+	}
+
+	override async query() {
+		return {
+			firstPage: { items: this.queryItems, hasMore: false },
+			getNextPage: async () => ({ items: [], hasMore: false })
+		};
+	}
+
+	async nextRequest(): Promise<IResolveRequest> {
+		if (this.nextRequestIndex >= this.requests.length) {
+			await Event.toPromise(this.onDidRequestEmitter.event);
+		}
+		return this.requests[this.nextRequestIndex++];
+	}
+}
+
+class TestMcpGalleryManifestService extends mock<IMcpGalleryManifestService>() {
+
+	declare readonly _serviceBrand: undefined;
+
+	override readonly mcpGalleryManifestStatus = McpGalleryManifestStatus.Available;
+	override readonly onDidChangeMcpGalleryManifestStatus = Event.None;
+	private readonly onDidChangeMcpGalleryManifestEmitter: Emitter<IMcpGalleryManifest | null>;
+	override readonly onDidChangeMcpGalleryManifest: Event<IMcpGalleryManifest | null>;
+
+	constructor(store: Pick<DisposableStore, 'add'>) {
+		super();
+		this.onDidChangeMcpGalleryManifestEmitter = store.add(new Emitter<IMcpGalleryManifest | null>());
+		this.onDidChangeMcpGalleryManifest = this.onDidChangeMcpGalleryManifestEmitter.event;
+	}
+
+	fireChange(): void {
+		this.onDidChangeMcpGalleryManifestEmitter.fire(null);
+	}
+}
+
+class TestWorkbenchMcpManagementService extends mock<IWorkbenchMcpManagementService>() {
+
+	declare readonly _serviceBrand: undefined;
+
+	override readonly onInstallMcpServer = Event.None;
+	override readonly onDidInstallMcpServers = Event.None;
+	override readonly onDidUpdateMcpServers = Event.None;
+	override readonly onUninstallMcpServer = Event.None;
+	override readonly onDidUninstallMcpServer = Event.None;
+	override readonly onInstallMcpServerInCurrentProfile = Event.None;
+	override readonly onUninstallMcpServerInCurrentProfile = Event.None;
+	override readonly onDidUninstallMcpServerInCurrentProfile = Event.None;
+	private readonly onDidChangeProfileEmitter: Emitter<void>;
+	override readonly onDidChangeProfile: Event<void>;
+	private readonly onDidInstallMcpServersInCurrentProfileEmitter: Emitter<readonly IWorkbenchMcpServerInstallResult[]>;
+	override readonly onDidInstallMcpServersInCurrentProfile: Event<readonly IWorkbenchMcpServerInstallResult[]>;
+	private readonly onDidUpdateMcpServersInCurrentProfileEmitter: Emitter<readonly IWorkbenchMcpServerInstallResult[]>;
+	override readonly onDidUpdateMcpServersInCurrentProfile: Event<readonly IWorkbenchMcpServerInstallResult[]>;
+	installed: IWorkbenchLocalMcpServer[] = [];
+	installFromGalleryResult: IWorkbenchLocalMcpServer | undefined;
+
+	constructor(store: Pick<DisposableStore, 'add'>) {
+		super();
+		this.onDidInstallMcpServersInCurrentProfileEmitter = store.add(new Emitter<readonly IWorkbenchMcpServerInstallResult[]>());
+		this.onDidInstallMcpServersInCurrentProfile = this.onDidInstallMcpServersInCurrentProfileEmitter.event;
+		this.onDidUpdateMcpServersInCurrentProfileEmitter = store.add(new Emitter<readonly IWorkbenchMcpServerInstallResult[]>());
+		this.onDidUpdateMcpServersInCurrentProfile = this.onDidUpdateMcpServersInCurrentProfileEmitter.event;
+		this.onDidChangeProfileEmitter = store.add(new Emitter<void>());
+		this.onDidChangeProfile = this.onDidChangeProfileEmitter.event;
+	}
+
+	override async getInstalled(): Promise<IWorkbenchLocalMcpServer[]> {
+		return this.installed;
+	}
+
+	override canInstall(): true {
+		return true;
+	}
+
+	override async install(_server: IInstallableMcpServer): Promise<IWorkbenchLocalMcpServer> {
+		throw new Error('Not supported');
+	}
+
+	override async installFromGallery(server: IGalleryMcpServer, _options?: InstallOptions): Promise<IWorkbenchLocalMcpServer> {
+		const local = this.installFromGalleryResult;
+		if (!local) {
+			throw new Error('No gallery install result configured');
+		}
+		this.installed.push(local);
+		this.fireInstall([{ name: server.name, local, mcpResource: local.mcpResource }]);
+		return local;
+	}
+
+	override async updateMetadata(): Promise<IWorkbenchLocalMcpServer> {
+		throw new Error('Not supported');
+	}
+
+	override async uninstall(): Promise<void> { }
+
+	fireInstall(results: readonly IWorkbenchMcpServerInstallResult[]): void {
+		this.onDidInstallMcpServersInCurrentProfileEmitter.fire(results);
+	}
+
+	fireUpdate(results: readonly IWorkbenchMcpServerInstallResult[]): void {
+		this.onDidUpdateMcpServersInCurrentProfileEmitter.fire(results);
+	}
+
+	fireProfileChange(): void {
+		this.onDidChangeProfileEmitter.fire();
+	}
+}
+
+function createGallery(name: string, remoteUrls: readonly string[] = []): IGalleryMcpServer {
+	return {
+		name,
+		displayName: name,
+		description: '',
+		version: '1.0.0',
+		isLatest: true,
+		status: GalleryMcpServerStatus.Active,
+		configuration: {
+			remotes: remoteUrls.map(url => ({ type: TransportType.STREAMABLE_HTTP, url }))
+		},
+		publisher: 'test'
+	};
+}
+
+function createLocal(name: string, scope: LocalMcpServerScope = LocalMcpServerScope.User, config?: IMcpServerConfiguration): IWorkbenchLocalMcpServer {
+	return {
+		id: `${scope}/${name}`,
+		name,
+		config: config ?? { type: McpServerType.LOCAL, command: 'node' },
+		mcpResource: URI.parse(`test://${scope}/mcp.json`),
+		scope,
+		source: 'local'
+	};
+}
+
+function found(server: IGalleryMcpServer): IMcpGalleryServerResolveResult {
+	return { status: McpGalleryResolveStatus.Found, server };
+}
+
+function failed(): IMcpGalleryServerResolveResult {
+	return { status: McpGalleryResolveStatus.Failed };
+}
+
+function notFound(): IMcpGalleryServerResolveResult {
+	return { status: McpGalleryResolveStatus.NotFound };
+}
+
+suite('McpWorkbenchService - registry-only enforcement', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function createFixture(installed: IWorkbenchLocalMcpServer[]) {
+		const galleryService = new TestMcpGalleryService(store);
+		const manifestService = new TestMcpGalleryManifestService(store);
+		const managementService = new TestWorkbenchMcpManagementService(store);
+		managementService.installed = [...installed];
+		const configurationService = new TestConfigurationService({ [mcpAccessConfig]: McpAccessValue.Registry });
+		const services = new ServiceCollection(
+			[IMcpGalleryManifestService, manifestService],
+			[IMcpGalleryService, galleryService],
+			[IWorkbenchMcpManagementService, managementService],
+			[IEditorService, upcastPartial<IEditorService>({})],
+			[IUserDataProfilesService, upcastPartial<IUserDataProfilesService>({ profiles: [] })],
+			[IUriIdentityService, upcastPartial<IUriIdentityService>({})],
+			[IWorkspaceContextService, upcastPartial<IWorkspaceContextService>({})],
+			[IWorkbenchEnvironmentService, upcastPartial<IWorkbenchEnvironmentService>({})],
+			[ILabelService, upcastPartial<ILabelService>({})],
+			[IProductService, TestProductService],
+			[IRemoteAgentService, upcastPartial<IRemoteAgentService>({})],
+			[IConfigurationService, configurationService],
+			[ITelemetryService, NullTelemetryService],
+			[ILogService, store.add(new NullLogService())],
+			[IExtensionsWorkbenchService, upcastPartial<IExtensionsWorkbenchService>({})],
+			[IAllowedMcpServersService, upcastPartial<IAllowedMcpServersService>({ onDidChangeAllowedMcpServers: Event.None })],
+			[IMcpService, upcastPartial<IMcpService>({ servers: constObservable([]) })],
+			[IURLService, upcastPartial<IURLService>({ registerHandler: () => Disposable.None })],
+			[IFileService, upcastPartial<IFileService>({})],
+		);
+		const instantiationService = store.add(new TestInstantiationService(services));
+		const service = store.add(instantiationService.createInstance(McpWorkbenchService));
+		await Event.toPromise(service.onChange);
+		return { service, galleryService, manifestService, managementService };
+	}
+
+	async function complete(request: IResolveRequest, result: Map<string, IMcpGalleryServerResolveResult>): Promise<void> {
+		await request.result.complete(result);
+		await timeout(0);
+		await timeout(0);
+	}
+
+	test('enables only manually configured servers found in the registry', async () => {
+		const foundLocal = createLocal('found');
+		const missingLocal = createLocal('missing');
+		const failedLocal = createLocal('failed');
+		const { service, galleryService } = await createFixture([foundLocal, missingLocal, failedLocal]);
+		const request = await galleryService.nextRequest();
+
+		await complete(request, new Map([
+			['found', found(createGallery('found'))],
+			['missing', notFound()],
+			['failed', failed()],
+		]));
+
+		assert.deepStrictEqual({
+			requested: request.infos.map(info => info.name).sort(),
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+			verified: service.local.map(server => [server.name, !!server.gallery]),
+		}, {
+			requested: ['failed', 'found', 'missing'],
+			enabled: ['found'],
+			verified: [['failed', false], ['found', true], ['missing', false]],
+		});
+	});
+
+	test('preserves verified membership on transient failure and clears it on not found', async () => {
+		const verified = createLocal('verified');
+		const removed = createLocal('removed');
+		const { service, galleryService, managementService } = await createFixture([verified, removed]);
+		await complete(await galleryService.nextRequest(), new Map([
+			['verified', found(createGallery('verified'))],
+			['removed', found(createGallery('removed'))],
+		]));
+
+		const added = createLocal('added');
+		managementService.fireInstall([{ name: added.name, local: added, mcpResource: added.mcpResource }]);
+		await complete(await galleryService.nextRequest(), new Map([
+			['verified', failed()],
+			['removed', notFound()],
+			['added', failed()],
+		]));
+
+		assert.deepStrictEqual({
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+			verified: service.local.map(server => [server.name, !!server.gallery]),
+		}, {
+			enabled: ['verified'],
+			verified: [['added', false], ['removed', false], ['verified', true]],
+		});
+	});
+
+	test('invalidates membership immediately when the active registry changes', async () => {
+		const local = createLocal('server');
+		const { service, galleryService, manifestService } = await createFixture([local]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, found(createGallery(local.name))],
+		]));
+
+		manifestService.fireChange();
+		const enabledAfterInvalidation = service.getEnabledLocalMcpServers().map(server => server.name);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			enabledAfterInvalidation,
+			enabledAfterFailure: service.getEnabledLocalMcpServers().map(server => server.name),
+			hasGallery: !!service.local[0].gallery,
+		}, {
+			enabledAfterInvalidation: [],
+			enabledAfterFailure: [],
+			hasGallery: false,
+		});
+	});
+
+	test('replaces and re-verifies installed servers when the profile changes', async () => {
+		const oldLocal = createLocal('old-profile');
+		const newLocal = createLocal('new-profile');
+		const { service, galleryService, managementService } = await createFixture([oldLocal]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[oldLocal.name, found(createGallery(oldLocal.name))],
+		]));
+		const resetPromise = Event.toPromise(service.onReset);
+		managementService.installed = [newLocal];
+
+		managementService.fireProfileChange();
+		const enabledAfterInvalidation = service.getEnabledLocalMcpServers().map(server => server.name);
+		await resetPromise;
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[newLocal.name, found(createGallery(newLocal.name))],
+		]));
+
+		assert.deepStrictEqual({
+			enabledAfterInvalidation,
+			requested: request.infos.map(info => info.name),
+			local: service.local.map(server => server.name),
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			enabledAfterInvalidation: [],
+			requested: [newLocal.name],
+			local: [newLocal.name],
+			enabled: [newLocal.name],
+		});
+	});
+
+	test('ignores stale lookup results after a local configuration update', async () => {
+		const local = createLocal('server');
+		const { service, galleryService, managementService } = await createFixture([local]);
+		const staleRequest = await galleryService.nextRequest();
+
+		managementService.fireUpdate([{ name: local.name, local, mcpResource: local.mcpResource }]);
+		managementService.fireUpdate([{ name: local.name, local, mcpResource: local.mcpResource }]);
+		managementService.fireUpdate([{ name: local.name, local, mcpResource: local.mcpResource }]);
+		await complete(staleRequest, new Map([
+			[local.name, found(createGallery(local.name))],
+		]));
+		const currentRequest = await galleryService.nextRequest();
+		const staleResultApplied = !!service.local[0].gallery;
+		await complete(currentRequest, new Map([
+			[local.name, notFound()],
+		]));
+
+		assert.deepStrictEqual({
+			staleResultApplied,
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+			requestCount: galleryService.requestCount,
+		}, {
+			staleResultApplied: false,
+			enabled: [],
+			requestCount: 2,
+		});
+	});
+
+	test('preserves matching trusted update sources and rejects mismatched sources', async () => {
+		const local = createLocal('updated');
+		const { service, galleryService, managementService } = await createFixture([local]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, found(createGallery(local.name))],
+		]));
+		const trustedUpdate = createGallery(local.name);
+
+		managementService.fireUpdate([{ name: local.name, local, source: trustedUpdate, mcpResource: local.mcpResource }]);
+		const trustedUpdateApplied = service.local[0].gallery === trustedUpdate;
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, failed()],
+		]));
+		const mismatchedUpdate = createGallery('different-name');
+
+		managementService.fireUpdate([{ name: local.name, local, source: mismatchedUpdate, mcpResource: local.mcpResource }]);
+		const mismatchedUpdateApplied = service.local[0].gallery === mismatchedUpdate;
+		const enabledAfterMismatch = service.getEnabledLocalMcpServers().map(server => server.name);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			trustedUpdateApplied,
+			mismatchedUpdateApplied,
+			enabledAfterMismatch,
+			enabledAfterFailure: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			trustedUpdateApplied: true,
+			mismatchedUpdateApplied: false,
+			enabledAfterMismatch: [],
+			enabledAfterFailure: [],
+		});
+	});
+
+	test('deduplicates registry lookups for the same server name across scopes', async () => {
+		const user = createLocal('duplicate', LocalMcpServerScope.User);
+		const workspace = { ...createLocal('duplicate', LocalMcpServerScope.Workspace), galleryId: 'registry-id' };
+		const { service, galleryService } = await createFixture([user, workspace]);
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			['duplicate', found(createGallery('duplicate'))],
+		]));
+
+		assert.deepStrictEqual({
+			requested: request.infos,
+			verified: service.local.map(server => !!server.gallery),
+			enabledScopes: service.getEnabledLocalMcpServers().map(server => server.scope),
+		}, {
+			requested: [{ name: 'duplicate', id: 'registry-id' }],
+			verified: [true, true],
+			enabledScopes: [LocalMcpServerScope.Workspace],
+		});
+	});
+
+	test('keeps trusted gallery metadata while an install is revalidated', async () => {
+		const { service, galleryService, managementService } = await createFixture([]);
+		const gallery = createGallery('gallery-install');
+		const local = createLocal(gallery.name);
+		galleryService.queryItems = [gallery];
+		managementService.installFromGalleryResult = local;
+		const pager = await service.queryGallery();
+
+		const installed = await service.install(pager.firstPage.items[0]);
+		const enabledBeforeRevalidation = service.getEnabledLocalMcpServers().map(server => server.name);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			trustedGalleryPreserved: installed.gallery === gallery,
+			enabledBeforeRevalidation,
+			enabledAfterFailure: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			trustedGalleryPreserved: true,
+			enabledBeforeRevalidation: [local.name],
+			enabledAfterFailure: [local.name],
+		});
+	});
+
+	test('trusts gallery metadata propagated by an external gallery install', async () => {
+		const { service, galleryService, managementService } = await createFixture([]);
+		const gallery = createGallery('external-gallery-install');
+		const local = createLocal(gallery.name);
+
+		managementService.fireInstall([{ name: local.name, local, source: gallery, mcpResource: local.mcpResource }]);
+		const enabledBeforeRevalidation = service.getEnabledLocalMcpServers().map(server => server.name);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			galleryPreserved: service.local[0].gallery === gallery,
+			enabledBeforeRevalidation,
+			enabledAfterFailure: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			galleryPreserved: true,
+			enabledBeforeRevalidation: [local.name],
+			enabledAfterFailure: [local.name],
+		});
+	});
+
+	test('requires remote URLs to match the registry entry exactly', async () => {
+		const allowed = createLocal('allowed', LocalMcpServerScope.User, { type: McpServerType.REMOTE, url: 'https://allowed.test/mcp' });
+		const blocked = createLocal('blocked', LocalMcpServerScope.User, { type: McpServerType.REMOTE, url: 'https://blocked.test/mcp' });
+		const { service, galleryService } = await createFixture([allowed, blocked]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[allowed.name, found(createGallery(allowed.name, ['https://allowed.test/mcp']))],
+			[blocked.name, found(createGallery(blocked.name, ['https://different.test/mcp']))],
+		]));
+
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name), ['allowed']);
+	});
+});

--- a/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
@@ -50,6 +50,7 @@ class TestMcpGalleryService extends mock<IMcpGalleryService>() {
 	private nextRequestIndex = 0;
 	private readonly onDidRequestEmitter: Emitter<void>;
 	queryItems: IGalleryMcpServer[] = [];
+	queryBarrier: DeferredPromise<void> | undefined;
 	get requestCount(): number { return this.requests.length; }
 
 	constructor(store: Pick<DisposableStore, 'add'>) {
@@ -69,6 +70,7 @@ class TestMcpGalleryService extends mock<IMcpGalleryService>() {
 	}
 
 	override async query() {
+		await this.queryBarrier?.p;
 		return {
 			firstPage: { items: this.queryItems, hasMore: false },
 			getNextPage: async () => ({ items: [], hasMore: false })
@@ -123,6 +125,8 @@ class TestWorkbenchMcpManagementService extends mock<IWorkbenchMcpManagementServ
 	override readonly onDidUpdateMcpServersInCurrentProfile: Event<readonly IWorkbenchMcpServerInstallResult[]>;
 	installed: IWorkbenchLocalMcpServer[] = [];
 	installFromGalleryResult: IWorkbenchLocalMcpServer | undefined;
+	installFromGalleryBarrier: DeferredPromise<void> | undefined;
+	private readonly installedResults: Promise<IWorkbenchLocalMcpServer[]>[] = [];
 
 	constructor(store: Pick<DisposableStore, 'add'>) {
 		super();
@@ -135,7 +139,7 @@ class TestWorkbenchMcpManagementService extends mock<IWorkbenchMcpManagementServ
 	}
 
 	override async getInstalled(): Promise<IWorkbenchLocalMcpServer[]> {
-		return this.installed;
+		return this.installedResults.shift() ?? this.installed;
 	}
 
 	override canInstall(): true {
@@ -151,8 +155,9 @@ class TestWorkbenchMcpManagementService extends mock<IWorkbenchMcpManagementServ
 		if (!local) {
 			throw new Error('No gallery install result configured');
 		}
+		await this.installFromGalleryBarrier?.p;
 		this.installed.push(local);
-		this.fireInstall([{ name: server.name, local, mcpResource: local.mcpResource }]);
+		this.fireInstall([{ name: server.name, local, source: server, mcpResource: local.mcpResource }]);
 		return local;
 	}
 
@@ -172,6 +177,10 @@ class TestWorkbenchMcpManagementService extends mock<IWorkbenchMcpManagementServ
 
 	fireProfileChange(): void {
 		this.onDidChangeProfileEmitter.fire();
+	}
+
+	queueInstalledResult(result: Promise<IWorkbenchLocalMcpServer[]>): void {
+		this.installedResults.push(result);
 	}
 }
 
@@ -361,6 +370,81 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 		});
 	});
 
+	test('ignores an older profile query that completes after a newer profile query', async () => {
+		const initial = createLocal('initial-profile');
+		const older = createLocal('older-profile');
+		const newer = createLocal('newer-profile');
+		const { service, galleryService, managementService } = await createFixture([initial]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[initial.name, found(createGallery(initial.name))],
+		]));
+		const olderResult = new DeferredPromise<IWorkbenchLocalMcpServer[]>();
+		const newerResult = new DeferredPromise<IWorkbenchLocalMcpServer[]>();
+		managementService.queueInstalledResult(olderResult.p);
+		managementService.queueInstalledResult(newerResult.p);
+		let resetCount = 0;
+		store.add(service.onReset(() => resetCount++));
+		const resetPromise = Event.toPromise(service.onReset);
+
+		managementService.fireProfileChange();
+		managementService.fireProfileChange();
+		await newerResult.complete([newer]);
+		await resetPromise;
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[newer.name, found(createGallery(newer.name))],
+		]));
+		await olderResult.complete([older]);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			requested: request.infos.map(info => info.name),
+			local: service.local.map(server => server.name),
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+			resetCount,
+		}, {
+			requested: [newer.name],
+			local: [newer.name],
+			enabled: [newer.name],
+			resetCount: 1,
+		});
+	});
+
+	test('re-verifies the current profile when a public local query supersedes its profile query', async () => {
+		const initial = createLocal('initial-profile');
+		const current = createLocal('current-profile');
+		const { service, galleryService, managementService } = await createFixture([initial]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[initial.name, found(createGallery(initial.name))],
+		]));
+		const profileResult = new DeferredPromise<IWorkbenchLocalMcpServer[]>();
+		const publicResult = new DeferredPromise<IWorkbenchLocalMcpServer[]>();
+		managementService.queueInstalledResult(profileResult.p);
+		managementService.queueInstalledResult(publicResult.p);
+		const resetPromise = Event.toPromise(service.onReset);
+
+		managementService.fireProfileChange();
+		const publicQuery = service.queryLocal();
+		await publicResult.complete([current]);
+		await publicQuery;
+		await profileResult.complete([initial]);
+		await resetPromise;
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[current.name, found(createGallery(current.name))],
+		]));
+
+		assert.deepStrictEqual({
+			requested: request.infos.map(info => info.name),
+			local: service.local.map(server => server.name),
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			requested: [current.name],
+			local: [current.name],
+			enabled: [current.name],
+		});
+	});
+
 	test('ignores stale lookup results after a local configuration update', async () => {
 		const local = createLocal('server');
 		const { service, galleryService, managementService } = await createFixture([local]);
@@ -396,6 +480,8 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 			[local.name, found(createGallery(local.name))],
 		]));
 		const trustedUpdate = createGallery(local.name);
+		galleryService.queryItems = [trustedUpdate];
+		await service.queryGallery();
 
 		managementService.fireUpdate([{ name: local.name, local, source: trustedUpdate, mcpResource: local.mcpResource }]);
 		const trustedUpdateApplied = service.local[0].gallery === trustedUpdate;
@@ -419,8 +505,8 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 		}, {
 			trustedUpdateApplied: true,
 			mismatchedUpdateApplied: false,
-			enabledAfterMismatch: [],
-			enabledAfterFailure: [],
+			enabledAfterMismatch: [local.name],
+			enabledAfterFailure: [local.name],
 		});
 	});
 
@@ -469,10 +555,69 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 		});
 	});
 
+	test('rejects gallery metadata from an install that completes after a registry change', async () => {
+		const { service, galleryService, manifestService, managementService } = await createFixture([]);
+		const gallery = createGallery('stale-gallery-install');
+		const local = createLocal(gallery.name);
+		const installBarrier = new DeferredPromise<void>();
+		galleryService.queryItems = [gallery];
+		managementService.installFromGalleryResult = local;
+		managementService.installFromGalleryBarrier = installBarrier;
+		const pager = await service.queryGallery();
+
+		const installPromise = service.install(pager.firstPage.items[0]);
+		await timeout(0);
+		manifestService.fireChange();
+		await installBarrier.complete();
+		const installed = await installPromise;
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			staleGalleryApplied: installed.gallery === gallery,
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			staleGalleryApplied: false,
+			enabled: [],
+		});
+	});
+
+	test('rejects gallery metadata returned by a query that completes after a registry change', async () => {
+		const { service, galleryService, manifestService, managementService } = await createFixture([]);
+		const gallery = createGallery('stale-gallery-query');
+		const local = createLocal(gallery.name);
+		const queryBarrier = new DeferredPromise<void>();
+		galleryService.queryItems = [gallery];
+		galleryService.queryBarrier = queryBarrier;
+
+		const queryPromise = service.queryGallery();
+		await timeout(0);
+		manifestService.fireChange();
+		await queryBarrier.complete();
+		const pager = await queryPromise;
+		managementService.fireInstall([{ name: local.name, local, source: pager.firstPage.items[0].gallery, mcpResource: local.mcpResource }]);
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			staleGalleryApplied: service.local[0].gallery === gallery,
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			staleGalleryApplied: false,
+			enabled: [],
+		});
+	});
+
 	test('trusts gallery metadata propagated by an external gallery install', async () => {
 		const { service, galleryService, managementService } = await createFixture([]);
 		const gallery = createGallery('external-gallery-install');
 		const local = createLocal(gallery.name);
+		galleryService.queryItems = [gallery];
+		await service.queryGallery();
 
 		managementService.fireInstall([{ name: local.name, local, source: gallery, mcpResource: local.mcpResource }]);
 		const enabledBeforeRevalidation = service.getEnabledLocalMcpServers().map(server => server.name);
@@ -488,6 +633,32 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 			galleryPreserved: true,
 			enabledBeforeRevalidation: [local.name],
 			enabledAfterFailure: [local.name],
+		});
+	});
+
+	test('rejects gallery metadata from an update that completes after a registry change', async () => {
+		const local = createLocal('stale-gallery-update');
+		const { service, galleryService, manifestService, managementService } = await createFixture([local]);
+		await complete(await galleryService.nextRequest(), new Map([
+			[local.name, found(createGallery(local.name))],
+		]));
+		const staleGallery = createGallery(local.name);
+		galleryService.queryItems = [staleGallery];
+		await service.queryGallery();
+
+		manifestService.fireChange();
+		managementService.fireUpdate([{ name: local.name, local, source: staleGallery, mcpResource: local.mcpResource }]);
+		const request = await galleryService.nextRequest();
+		await complete(request, new Map([
+			[local.name, failed()],
+		]));
+
+		assert.deepStrictEqual({
+			staleGalleryApplied: service.local[0].gallery === staleGallery,
+			enabled: service.getEnabledLocalMcpServers().map(server => server.name),
+		}, {
+			staleGalleryApplied: false,
+			enabled: [],
 		});
 	});
 

--- a/src/vs/workbench/services/mcp/common/mcpWorkbenchManagementService.ts
+++ b/src/vs/workbench/services/mcp/common/mcpWorkbenchManagementService.ts
@@ -481,7 +481,7 @@ class WorkspaceMcpResourceManagementService extends AbstractMcpResourceManagemen
 
 			await this.mcpResourceScannerService.addMcpServers([installable], this.mcpResource, this.target);
 
-			await this.updateLocal();
+			await this.updateLocal(server);
 			const local = (await this.getInstalled()).find(s => s.name === server.name);
 			if (!local) {
 				throw new Error(`Failed to install MCP server: ${server.name}`);


### PR DESCRIPTION
Follow-up to #325380 that simplifies and hardens the Registry-only enforcement lifecycle.

## Summary

- use verified gallery metadata as the registry membership proof instead of maintaining a parallel registry-status enum
- preserve trusted gallery metadata from successful installs and updates while still failing closed for unverified local configuration
- tie trusted gallery sources to the active registry generation so installs, updates, and queries completing after a registry change cannot restore stale authorization
- keep local registry membership name-based and require exact registry URL matches for remote servers
- invalidate verification immediately when the active registry or profile changes, ignore stale asynchronous lookups, and order concurrent profile reloads
- coalesce rapid synchronization requests and deduplicate registry lookups by server name
- propagate gallery provenance through the production metadata-update path
- clarify that Registry-only permits MCP servers listed in the active registry
- add workbench-level coverage for manual configuration, authoritative 404s, transient failures, registry and profile changes, stale install/update/query results, concurrent profile loads, trusted installs and updates, duplicate names, and remote URL enforcement

## Test plan

- `npm run transpile-client`
- `scripts\test.bat --run src\vs\workbench\contrib\mcp\test\browser\mcpWorkbenchService.test.ts --run src\vs\platform\mcp\test\common\mcpGalleryService.test.ts --run src\vs\platform\mcp\test\common\mcpManagementService.test.ts` (62 passing)
- `npm run typecheck-client`
- `npm run precommit`