### PR TITLE
fix: improve in-chat notification text contrast

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -691,17 +691,17 @@
 /* Severity variants */
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-info {
 	border-color: var(--vscode-focusBorder);
-	background-color: color-mix(in srgb, var(--vscode-focusBorder) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
 }
 
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-warning {
 	border-color: var(--vscode-editorWarning-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 6%, var(--vscode-editorWidget-background));
 }
 
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-error {
 	border-color: var(--vscode-editorError-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 6%, var(--vscode-editorWidget-background));
 }
 
 /* Remove the top border-radius from the input area when a notification is visible */

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -691,17 +691,17 @@
 /* Severity variants */
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-info {
 	border-color: var(--vscode-focusBorder);
-	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 10%, var(--vscode-editorWidget-background));
 }
 
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-warning {
 	border-color: var(--vscode-editorWarning-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 10%, var(--vscode-editorWidget-background));
 }
 
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-error {
 	border-color: var(--vscode-editorError-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 10%, var(--vscode-editorWidget-background));
 }
 
 /* Remove the top border-radius from the input area when a notification is visible */

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
@@ -30,10 +30,10 @@
 	color: var(--vscode-foreground);
 }
 
-/* Severity variants — slightly stronger tint so the banner separates from the input without washing out text */
+/* Severity variants */
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-info {
 	border-color: var(--vscode-input-border, transparent);
-	background-color: color-mix(in srgb, var(--vscode-focusBorder) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
 }
 
 /* Match the chat input's focus ring so the notification merges with it. */
@@ -48,12 +48,12 @@
 
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-warning {
 	border-color: var(--vscode-editorWarning-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 6%, var(--vscode-editorWidget-background));
 }
 
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-error {
 	border-color: var(--vscode-editorError-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 10%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 6%, var(--vscode-editorWidget-background));
 }
 
 /* Header row: icon + title + dismiss */

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
@@ -26,13 +26,14 @@
 	gap: 2px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	font-family: var(--vscode-chat-font-family, inherit);
-	color: var(--vscode-descriptionForeground);
+	/* Use full-contrast foreground — descriptionForeground fails WCAG AA on the lightly tinted banner (#328489). */
+	color: var(--vscode-foreground);
 }
 
-/* Severity variants */
+/* Severity variants — slightly stronger tint so the banner separates from the input without washing out text */
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-info {
 	border-color: var(--vscode-input-border, transparent);
-	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 10%, var(--vscode-editorWidget-background));
 }
 
 /* Match the chat input's focus ring so the notification merges with it. */
@@ -47,12 +48,12 @@
 
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-warning {
 	border-color: var(--vscode-editorWarning-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorWarning-foreground) 10%, var(--vscode-editorWidget-background));
 }
 
 .interactive-session .interactive-input-part > .chat-input-notification-container .chat-input-notification.severity-error {
 	border-color: var(--vscode-editorError-foreground);
-	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 6%, var(--vscode-editorWidget-background));
+	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 10%, var(--vscode-editorWidget-background));
 }
 
 /* Header row: icon + title + dismiss */
@@ -87,7 +88,7 @@
 	font-size: var(--vscode-agents-fontSize-label1);
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	line-height: 18px;
-	color: var(--vscode-foreground);
+	color: var(--vscode-strongForeground);
 	flex: 1;
 	min-width: 0;
 	overflow-wrap: break-word;
@@ -144,7 +145,7 @@
 .chat-input-notification .chat-input-notification-description {
 	font-size: var(--vscode-agents-fontSize-label1);
 	line-height: 18px;
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-foreground);
 	flex: 1 1 auto;
 	min-width: 0;
 	overflow-wrap: break-word;
@@ -176,12 +177,10 @@
 	background: transparent;
 	color: var(--vscode-foreground);
 	padding: 4px 8px;
-	opacity: 0.8;
 }
 
 .chat-input-notification .chat-input-notification-action-button.secondary:hover {
 	background: var(--vscode-toolbar-hoverBackground);
-	opacity: 1;
 }
 
 /* Dismiss + mute icon buttons (header, right-aligned) */


### PR DESCRIPTION
## Summary
- In-chat input notification banner used `--vscode-descriptionForeground` (and secondary actions at `opacity: 0.8`) on a lightly tinted `editorWidget` background, which fails readable contrast on light themes such as Quiet Light.
- Switch container/description text to `--vscode-foreground`, title to `--vscode-strongForeground`, and drop secondary opacity. Severity tint left at 6%.

Fixes #328489

## Test plan
- [ ] Open Chat with an in-input notification (e.g. PR checks / quota / promo banner)
- [ ] Quiet Light: title, description, and secondary actions are clearly readable
- [ ] Dark+ theme: banner still looks correct (no overly harsh contrast)
- [ ] Info / Warning / Error severities still show distinct border + tint
- [ ] New Agents session homepage notification matches the same contrast