### PR TITLE
build: exclude Copilot Computer Use from Agent Host packaging

### DIFF
--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -573,12 +573,6 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 			promisify(glob)('**/*.node', { cwd }),
 			promisify(glob)('**/rg.exe', { cwd }),
 			promisify(glob)('**/tgrep.exe', { cwd }),
-			// Computer Use lives under plugins/computer-use/ in current @github/copilot
-			// platform packages. Keep legacy builtin-plugins globs for older layouts.
-			promisify(glob)('**/node_modules/@github/copilot-win32-*/plugins/computer-use/computer-use-mcp.exe', { cwd }),
-			promisify(glob)('**/node_modules/@github/copilot-win32-*/plugins/computer-use/CopilotComputerUse.exe', { cwd }),
-			promisify(glob)('**/node_modules/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/computer-use-mcp.exe', { cwd }),
-			promisify(glob)('**/node_modules/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/CopilotComputerUse.exe', { cwd }),
 		])).flatMap(o => o);
 		const packageJsonContents = JSON.parse(await fs.promises.readFile(path.join(cwd, 'package.json'), 'utf8'));
 		const productContents = JSON.parse(await fs.promises.readFile(path.join(cwd, 'product.json'), 'utf8'));

--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -573,6 +573,10 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 			promisify(glob)('**/*.node', { cwd }),
 			promisify(glob)('**/rg.exe', { cwd }),
 			promisify(glob)('**/tgrep.exe', { cwd }),
+			// Computer Use lives under plugins/computer-use/ in current @github/copilot
+			// platform packages. Keep legacy builtin-plugins globs for older layouts.
+			promisify(glob)('**/node_modules/@github/copilot-win32-*/plugins/computer-use/computer-use-mcp.exe', { cwd }),
+			promisify(glob)('**/node_modules/@github/copilot-win32-*/plugins/computer-use/CopilotComputerUse.exe', { cwd }),
 			promisify(glob)('**/node_modules/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/computer-use-mcp.exe', { cwd }),
 			promisify(glob)('**/node_modules/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/CopilotComputerUse.exe', { cwd }),
 		])).flatMap(o => o);

--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -628,6 +628,12 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 			glob('**/*.node', { cwd, ignore: 'extensions/node_modules/@parcel/watcher/**' }),
 			glob('**/rg.exe', { cwd }),
 			glob('**/tgrep.exe', { cwd }),
+			// Computer Use lives under plugins/computer-use/ in current @github/copilot
+			// platform packages. These globs are a safety net if packaging ever
+			// re-includes the binaries; the primary fix is excluding the tree in
+			// getCopilotRuntimePrebuildFiles.
+			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/plugins/computer-use/computer-use-mcp.exe', { cwd }),
+			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/plugins/computer-use/CopilotComputerUse.exe', { cwd }),
 			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/computer-use-mcp.exe', { cwd }),
 			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/CopilotComputerUse.exe', { cwd }),
 			glob('**/*explorer_command*.dll', { cwd }),

--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -628,14 +628,6 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 			glob('**/*.node', { cwd, ignore: 'extensions/node_modules/@parcel/watcher/**' }),
 			glob('**/rg.exe', { cwd }),
 			glob('**/tgrep.exe', { cwd }),
-			// Computer Use lives under plugins/computer-use/ in current @github/copilot
-			// platform packages. These globs are a safety net if packaging ever
-			// re-includes the binaries; the primary fix is excluding the tree in
-			// getCopilotRuntimePrebuildFiles.
-			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/plugins/computer-use/computer-use-mcp.exe', { cwd }),
-			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/plugins/computer-use/CopilotComputerUse.exe', { cwd }),
-			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/computer-use-mcp.exe', { cwd }),
-			glob('**/node_modules.asar.unpacked/@github/copilot-win32-*/builtin-plugins/computer-use/*/win32-*/CopilotComputerUse.exe', { cwd }),
 			glob('**/*explorer_command*.dll', { cwd }),
 		])).flatMap(o => o);
 		const packageJson = JSON.parse(await fs.promises.readFile(path.join(cwd, versionedResourcesFolder, 'resources', 'app', 'package.json'), 'utf8'));

--- a/build/lib/copilot.ts
+++ b/build/lib/copilot.ts
@@ -110,14 +110,10 @@ const copilotOptionalNativePayloadDirs = [
 
 function getCopilotOptionalNativePayloadFiles(platform: string): string[] {
 	const files = [
-		// Computer Use moved from prebuilds/* into plugins/computer-use/**.
-		// Keep the legacy prebuilds paths so older package layouts still strip.
+		// Computer Use ships under plugins/computer-use/** in current
+		// @github/copilot platform packages. Do not productize it.
 		'plugins/computer-use/**',
 		'prebuilds/*/computer.node',
-		'prebuilds/*/computer-use-mcp',
-		'prebuilds/*/computer-use-mcp.exe',
-		'prebuilds/*/Copilot Computer Use.app/**',
-		'prebuilds/*/CopilotComputerUse.exe',
 		'prebuilds/*/keytar.node',
 		// macOS voice media-pause helper (MediaRemote adapter). Optional and
 		// nested under prebuilds; keep it out of the product so universal

--- a/build/lib/copilot.ts
+++ b/build/lib/copilot.ts
@@ -110,6 +110,9 @@ const copilotOptionalNativePayloadDirs = [
 
 function getCopilotOptionalNativePayloadFiles(platform: string): string[] {
 	const files = [
+		// Computer Use moved from prebuilds/* into plugins/computer-use/**.
+		// Keep the legacy prebuilds paths so older package layouts still strip.
+		'plugins/computer-use/**',
 		'prebuilds/*/computer.node',
 		'prebuilds/*/computer-use-mcp',
 		'prebuilds/*/computer-use-mcp.exe',

--- a/build/lib/test/copilot.test.ts
+++ b/build/lib/test/copilot.test.ts
@@ -44,6 +44,7 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-linux-x64/mxc-bin/**',
 			'!node_modules/@github/copilot-linux-x64/pvrecorder/**',
 			'!node_modules/@github/copilot-linux-x64/webview/**',
+			'!node_modules/@github/copilot-linux-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer.node',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer-use-mcp',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer-use-mcp.exe',
@@ -75,6 +76,7 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-linuxmusl-x64/mxc-bin/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/pvrecorder/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/webview/**',
+			'!node_modules/@github/copilot-linuxmusl-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer.node',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer-use-mcp',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer-use-mcp.exe',
@@ -103,6 +105,7 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-win32-x64/mxc-bin/**',
 			'!node_modules/@github/copilot-win32-x64/pvrecorder/**',
 			'!node_modules/@github/copilot-win32-x64/webview/**',
+			'!node_modules/@github/copilot-win32-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer.node',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer-use-mcp',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer-use-mcp.exe',
@@ -132,6 +135,7 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-win32-arm64/mxc-bin/**',
 			'!node_modules/@github/copilot-win32-arm64/pvrecorder/**',
 			'!node_modules/@github/copilot-win32-arm64/webview/**',
+			'!node_modules/@github/copilot-win32-arm64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer.node',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer-use-mcp',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer-use-mcp.exe',
@@ -380,6 +384,10 @@ function assertOptionalCopilotNativeDependenciesExcluded(patterns: string[], pac
 		assert(patterns.includes(`!${packageDir}/${dir}/**`), dir);
 		assert(!matchesGlob(`${packageDir}/${dir}/index.js`, patterns), dir);
 	}
+	assert(patterns.includes(`!${packageDir}/plugins/computer-use/**`), 'plugins/computer-use');
+	assert(!matchesGlob(`${packageDir}/plugins/computer-use/computer-use-mcp.exe`, patterns), 'plugins/computer-use-mcp.exe');
+	assert(!matchesGlob(`${packageDir}/plugins/computer-use/CopilotComputerUse.exe`, patterns), 'plugins/CopilotComputerUse.exe');
+	assert(!matchesGlob(`${packageDir}/plugins/computer-use/Copilot Computer Use.app/Contents/MacOS/Copilot Computer Use`, patterns), 'plugins/Copilot Computer Use.app');
 	assert(patterns.includes(`!${packageDir}/prebuilds/*/computer.node`), 'computer.node');
 	assert(!matchesGlob(`${packageDir}/prebuilds/linux-x64/computer.node`, patterns), 'computer.node');
 	assert(patterns.includes(`!${packageDir}/prebuilds/*/computer-use-mcp`), 'computer-use-mcp');

--- a/build/lib/test/copilot.test.ts
+++ b/build/lib/test/copilot.test.ts
@@ -46,10 +46,6 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-linux-x64/webview/**',
 			'!node_modules/@github/copilot-linux-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer.node',
-			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer-use-mcp',
-			'!node_modules/@github/copilot-linux-x64/prebuilds/*/computer-use-mcp.exe',
-			'!node_modules/@github/copilot-linux-x64/prebuilds/*/Copilot Computer Use.app/**',
-			'!node_modules/@github/copilot-linux-x64/prebuilds/*/CopilotComputerUse.exe',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/keytar.node',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/mediaremote-adapter/**',
 			'!node_modules/@github/copilot-linux-x64/prebuilds/*/cli-native.node',
@@ -78,10 +74,6 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-linuxmusl-x64/webview/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer.node',
-			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer-use-mcp',
-			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/computer-use-mcp.exe',
-			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/Copilot Computer Use.app/**',
-			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/CopilotComputerUse.exe',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/keytar.node',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/mediaremote-adapter/**',
 			'!node_modules/@github/copilot-linuxmusl-x64/prebuilds/*/cli-native.node',
@@ -107,10 +99,6 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-win32-x64/webview/**',
 			'!node_modules/@github/copilot-win32-x64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer.node',
-			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer-use-mcp',
-			'!node_modules/@github/copilot-win32-x64/prebuilds/*/computer-use-mcp.exe',
-			'!node_modules/@github/copilot-win32-x64/prebuilds/*/Copilot Computer Use.app/**',
-			'!node_modules/@github/copilot-win32-x64/prebuilds/*/CopilotComputerUse.exe',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/keytar.node',
 			'!node_modules/@github/copilot-win32-x64/prebuilds/*/mediaremote-adapter/**',
 		]);
@@ -137,10 +125,6 @@ suite('copilot', () => {
 			'!node_modules/@github/copilot-win32-arm64/webview/**',
 			'!node_modules/@github/copilot-win32-arm64/plugins/computer-use/**',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer.node',
-			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer-use-mcp',
-			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/computer-use-mcp.exe',
-			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/Copilot Computer Use.app/**',
-			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/CopilotComputerUse.exe',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/keytar.node',
 			'!node_modules/@github/copilot-win32-arm64/prebuilds/*/mediaremote-adapter/**',
 		]);
@@ -390,14 +374,6 @@ function assertOptionalCopilotNativeDependenciesExcluded(patterns: string[], pac
 	assert(!matchesGlob(`${packageDir}/plugins/computer-use/Copilot Computer Use.app/Contents/MacOS/Copilot Computer Use`, patterns), 'plugins/Copilot Computer Use.app');
 	assert(patterns.includes(`!${packageDir}/prebuilds/*/computer.node`), 'computer.node');
 	assert(!matchesGlob(`${packageDir}/prebuilds/linux-x64/computer.node`, patterns), 'computer.node');
-	assert(patterns.includes(`!${packageDir}/prebuilds/*/computer-use-mcp`), 'computer-use-mcp');
-	assert(!matchesGlob(`${packageDir}/prebuilds/darwin-arm64/computer-use-mcp`, patterns), 'computer-use-mcp');
-	assert(patterns.includes(`!${packageDir}/prebuilds/*/computer-use-mcp.exe`), 'computer-use-mcp.exe');
-	assert(!matchesGlob(`${packageDir}/prebuilds/win32-x64/computer-use-mcp.exe`, patterns), 'computer-use-mcp.exe');
-	assert(patterns.includes(`!${packageDir}/prebuilds/*/Copilot Computer Use.app/**`), 'Copilot Computer Use.app');
-	assert(!matchesGlob(`${packageDir}/prebuilds/darwin-arm64/Copilot Computer Use.app/Contents/MacOS/Copilot Computer Use`, patterns), 'Copilot Computer Use.app');
-	assert(patterns.includes(`!${packageDir}/prebuilds/*/CopilotComputerUse.exe`), 'CopilotComputerUse.exe');
-	assert(!matchesGlob(`${packageDir}/prebuilds/win32-x64/CopilotComputerUse.exe`, patterns), 'CopilotComputerUse.exe');
 	assert(patterns.includes(`!${packageDir}/prebuilds/*/keytar.node`), 'keytar.node');
 	assert(!matchesGlob(`${packageDir}/prebuilds/linux-x64/keytar.node`, patterns), 'keytar.node');
 	assert(patterns.includes(`!${packageDir}/prebuilds/*/mediaremote-adapter/**`), 'mediaremote-adapter');


### PR DESCRIPTION
- Exclude `plugins/computer-use/**` from the Agent Host / public `@github/copilot-<platform>` package re-include path.
- Drop stale Computer Use packaging paths that no longer match current packages (`prebuilds/*/computer-use-*`, Win32 `builtin-plugins/computer-use` stamp globs).
- Keep chat-extension packaging unchanged; it already allowlists only selected SDK prebuilds and never ships Computer Use.
- Fixes Windows product sanity failures where `computer-use-mcp.exe` / `CopilotComputerUse.exe` shipped without `VersionInfo.ProductName`.

-----------------------------------------
Inspirations from:

- Agent Host package re-include policy comes from [`getCopilotRuntimePrebuildFiles`](https://github.com/microsoft/vscode/blob/66dca3fc7d2cc95b774a25ac847298364365bf8e/build/lib/copilot.ts#L206-L217).
- Optional native payload stripping pattern comes from [`getCopilotOptionalNativePayloadFiles`](https://github.com/microsoft/vscode/blob/66dca3fc7d2cc95b774a25ac847298364365bf8e/build/lib/copilot.ts#L111-L127).
- Product packaging wires the re-include after `.moduleignore` in [`gulpfile.vscode.ts`](https://github.com/microsoft/vscode/blob/66dca3fc7d2cc95b774a25ac847298364365bf8e/build/gulpfile.vscode.ts#L370-L373).
- Chat extension allowlist packaging (already safe) comes from [`.vscodeignore`](https://github.com/microsoft/vscode/blob/66dca3fc7d2cc95b774a25ac847298364365bf8e/extensions/copilot/.vscodeignore#L1-L44).