### PR TITLE
Require confirmation for shell state mutations in terminal auto-approval

### DIFF
--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -344,7 +344,7 @@ export class CommandAutoApprover extends Disposable {
 				// when it contains code the rules cannot see.
 				const query = new this._queryClass(language, isPowerShell
 					? '(command) @command (redirection) @redirection (generic_token) @generic_token (assignment_expression) @unanalyzable (invokation_expression) @unanalyzable'
-					: '(command) @command (file_redirect) @file_redirect (heredoc_redirect) @heredoc_redirect (herestring_redirect) @herestring_redirect');
+					: '(command) @command (file_redirect) @file_redirect (heredoc_redirect) @heredoc_redirect (herestring_redirect) @herestring_redirect (variable_assignment) @unanalyzable (declaration_command) @unanalyzable');
 				const captures: QueryCapture[] = query.captures(tree.rootNode);
 				const subCommands: string[] = [];
 				const unsafeWriteDests: (string | undefined)[] = [];
@@ -353,7 +353,7 @@ export class CommandAutoApprover extends Disposable {
 					const text = masked === commandLine ? capture.node.text : commandLine.substring(capture.node.startIndex, capture.node.endIndex);
 					if (capture.name === 'command') {
 						subCommands.push(text);
-					} else if (capture.name === 'unanalyzable') {
+					} else if (capture.name === 'unanalyzable' && (capture.node.type !== 'variable_assignment' || capture.node.parent?.type !== 'command')) {
 						unanalyzableType ??= capture.node.type;
 					} else if (capture.name === 'file_redirect' || capture.name === 'redirection' || (capture.name === 'generic_token' && pwshNoSpaceRedirectRegex.test(text))) {
 						// Writes to known-safe sinks (e.g. `> /dev/null`, `2>$null`)

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -132,6 +132,18 @@ suite('CommandAutoApprover', () => {
 			assert.strictEqual(approver.shouldAutoApprove('PATH=/evil:$PATH ls'), 'denied');
 		});
 
+		test('fails closed on Bash shell state mutations', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('FOO=bar && git status'),
+				approver.shouldAutoApprove('export FOO=bar && git status'),
+				approver.shouldAutoApprove('declare -x FOO=bar && git status'),
+				approver.shouldAutoApprove('typeset FOO=bar && git status'),
+				approver.shouldAutoApprove('readonly FOO=bar && git status'),
+				approver.shouldAutoApprove('local FOO=bar && git status'),
+				approver.shouldAutoApprove('FOO=bar git status'),
+			], ['noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'denied']);
+		});
+
 		// PowerShell
 		test('approves allowed PowerShell commands', () => {
 			assert.strictEqual(approver.shouldAutoApprove('Get-ChildItem'), 'approved');

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -440,7 +440,11 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 		const treeSitterLanguage = language === 'powershell' ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash;
 		let subCommands: string[];
 		try {
-			subCommands = await this._autoApproveCommandParser.extractSubCommands(treeSitterLanguage, trimmedCommandLine);
+			const parseResult = await this._autoApproveCommandParser.extractAutoApprovalSubCommands(treeSitterLanguage, trimmedCommandLine);
+			if (parseResult.hasUnanalyzableSyntax) {
+				return undefined;
+			}
+			subCommands = parseResult.subCommands;
 		} catch (e) {
 			this._logService.warn('Failed to parse sub-commands when generating auto approve actions', e);
 			return undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -71,16 +71,14 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		const trimmedCommandLine = options.commandLine.trimStart();
 
 		let subCommands: string[] | undefined;
+		let hasUnanalyzableSyntax = false;
 		try {
 			const parseResult = await this._treeSitterCommandParser.extractAutoApprovalSubCommands(options.treeSitterLanguage, trimmedCommandLine);
 			subCommands = parseResult.subCommands;
+			hasUnanalyzableSyntax = parseResult.hasUnanalyzableSyntax;
 			this._log(`Parsed sub-commands via ${options.treeSitterLanguage} grammar`, subCommands);
-			if (parseResult.hasUnanalyzableSyntax) {
+			if (hasUnanalyzableSyntax) {
 				this._log('Command line contains syntax that cannot be safely auto-approved');
-				return {
-					isAutoApproveAllowed: false,
-					disclaimers: [],
-				};
 			}
 		} catch (e) {
 			console.error(e);
@@ -149,6 +147,12 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 			}
 		}
 
+		// Shell-state mutations omitted from normal command extraction must never
+		// auto-approve, even when every extracted sub-command matches an allow rule.
+		if (hasUnanalyzableSyntax) {
+			isAutoApproved = false;
+		}
+
 		// Log detailed auto approval reasoning
 		for (const reason of autoApproveReasons) {
 			this._log(`- ${reason}`);
@@ -203,14 +207,15 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 			}
 		}
 
-		if (!isAutoApproved && isAutoApproveEnabled) {
+		// Unanalyzable shell-state syntax cannot be expressed as a safe persistent rule.
+		if (!isAutoApproved && isAutoApproveEnabled && !hasUnanalyzableSyntax) {
 			customActions = generateAutoApproveActions(trimmedCommandLine, subCommands, { subCommandResults, commandLineResult });
 		}
 
 		return {
 			isAutoApproved,
-			// This is not based on isDenied because we want the user to be able to configure it
-			isAutoApproveAllowed: true,
+			// Denied rules stay configurable; unanalyzable syntax cannot be auto-approved safely.
+			isAutoApproveAllowed: !hasUnanalyzableSyntax,
 			disclaimers,
 			autoApproveInfo,
 			customActions,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -72,8 +72,16 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 
 		let subCommands: string[] | undefined;
 		try {
-			subCommands = await this._treeSitterCommandParser.extractSubCommands(options.treeSitterLanguage, trimmedCommandLine);
+			const parseResult = await this._treeSitterCommandParser.extractAutoApprovalSubCommands(options.treeSitterLanguage, trimmedCommandLine);
+			subCommands = parseResult.subCommands;
 			this._log(`Parsed sub-commands via ${options.treeSitterLanguage} grammar`, subCommands);
+			if (parseResult.hasUnanalyzableSyntax) {
+				this._log('Command line contains syntax that cannot be safely auto-approved');
+				return {
+					isAutoApproveAllowed: false,
+					disclaimers: [],
+				};
+			}
 		} catch (e) {
 			console.error(e);
 			this._log(`Failed to parse sub-commands via ${options.treeSitterLanguage} grammar`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -19,6 +19,11 @@ export const enum TreeSitterCommandParserLanguage {
 	PowerShell = 'powershell',
 }
 
+export interface IAutoApprovalCommandParseResult {
+	readonly subCommands: string[];
+	readonly hasUnanalyzableSyntax: boolean;
+}
+
 /**
  * Matches a PowerShell command token of the form `-flag=` or `--flag=` at the
  * start of input or following whitespace. Used to work around a tree-sitter
@@ -64,6 +69,24 @@ export class TreeSitterCommandParser extends Disposable {
 		}
 		const captures = await this._queryTree(languageId, commandLine, '(command) @command');
 		return captures.map(e => e.node.text);
+	}
+
+	async extractAutoApprovalSubCommands(languageId: TreeSitterCommandParserLanguage, commandLine: string): Promise<IAutoApprovalCommandParseResult> {
+		const masked = languageId === TreeSitterCommandParserLanguage.PowerShell ? maskPwshFlagEquals(commandLine) : commandLine;
+		const query = languageId === TreeSitterCommandParserLanguage.PowerShell
+			? '(command) @command (assignment_expression) @unanalyzable (invokation_expression) @unanalyzable'
+			: '(command) @command (variable_assignment) @unanalyzable (declaration_command) @unanalyzable';
+		const captures = await this._queryTree(languageId, masked, query);
+		const subCommands: string[] = [];
+		let hasUnanalyzableSyntax = false;
+		for (const capture of captures) {
+			if (capture.name === 'command') {
+				subCommands.push(masked === commandLine ? capture.node.text : commandLine.substring(capture.node.startIndex, capture.node.endIndex));
+			} else if (capture.node.type !== 'variable_assignment' || capture.node.parent?.type !== 'command') {
+				hasUnanalyzableSyntax = true;
+			}
+		}
+		return { subCommands, hasUnanalyzableSyntax };
 	}
 
 	async extractPwshDoubleAmpersandChainOperators(commandLine: string): Promise<QueryCapture[]> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -82,8 +82,13 @@ export class TreeSitterCommandParser extends Disposable {
 		for (const capture of captures) {
 			if (capture.name === 'command') {
 				subCommands.push(masked === commandLine ? capture.node.text : commandLine.substring(capture.node.startIndex, capture.node.endIndex));
-			} else if (capture.node.type !== 'variable_assignment' || capture.node.parent?.type !== 'command') {
-				hasUnanalyzableSyntax = true;
+			} else if (capture.name === 'unanalyzable') {
+				// Prefix env assignments (`FOO=bar git status`) are children of the
+				// command node and are handled by the existing transient-env deny
+				// path; only standalone shell-state mutations fail closed here.
+				if (capture.node.type !== 'variable_assignment' || capture.node.parent?.type !== 'command') {
+					hasUnanalyzableSyntax = true;
+				}
 			}
 		}
 		return { subCommands, hasUnanalyzableSyntax };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
@@ -3,36 +3,41 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import type { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import type { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import type { ICommandLineAnalyzerOptions } from '../../browser/tools/commandLineAnalyzer/commandLineAnalyzer.js';
 import { CommandLineAutoApproveAnalyzer } from '../../browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
 import { RunInTerminalToolTelemetry } from '../../browser/runInTerminalToolTelemetry.js';
 import { type IAutoApprovalCommandParseResult, TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../../browser/treeSitterCommandParser.js';
+import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 
 suite('CommandLineAutoApproveAnalyzer', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
+	let configurationService: TestConfigurationService;
 	let instantiationService: IInstantiationService;
 	let analyzer: CommandLineAutoApproveAnalyzer;
 	let parseResult: IAutoApprovalCommandParseResult;
+	let prepareLogs: unknown[];
 
 	setup(() => {
-		const configurationService = new TestConfigurationService();
+		configurationService = new TestConfigurationService();
 		instantiationService = workbenchInstantiationService({
 			configurationService: () => configurationService
 		}, store);
 
 		parseResult = { subCommands: [], hasUnanalyzableSyntax: false };
+		prepareLogs = [];
 		const parser = {
 			extractAutoApprovalSubCommands: async () => parseResult,
 		} as unknown as TreeSitterCommandParser;
 		const telemetry = {
-			logPrepare: () => { },
+			logPrepare: (data: unknown) => { prepareLogs.push(data); },
 		} as unknown as RunInTerminalToolTelemetry;
 
 		analyzer = store.add(instantiationService.createInstance(
@@ -43,55 +48,97 @@ suite('CommandLineAutoApproveAnalyzer', () => {
 		));
 	});
 
-	test('should not allow auto approve when sub-command parsing returns an empty list', async () => {
-		const options: ICommandLineAnalyzerOptions = {
+	function setConfig(key: string, value: unknown) {
+		configurationService.setUserConfiguration(key, value);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: () => true,
+			affectedKeys: new Set([key]),
+			source: ConfigurationTarget.USER,
+			change: null!,
+		});
+	}
+
+	function createOptions(options?: Partial<ICommandLineAnalyzerOptions>): ICommandLineAnalyzerOptions {
+		return {
 			commandLine: 'rm -- file.txt',
-			cwd: undefined,
-			shell: 'pwsh',
-			os: OperatingSystem.Windows,
-			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
-			terminalToolSessionId: 'test',
-			chatSessionResource: undefined,
-		};
-
-		const result = await analyzer.analyze(options);
-		strictEqual(result.isAutoApproveAllowed, false);
-		strictEqual(result.isAutoApproved, undefined);
-		strictEqual(result.disclaimers?.length ?? 0, 0);
-	});
-
-	test('should not allow auto approve when parsing finds unanalyzable syntax', async () => {
-		parseResult = { subCommands: ['git status'], hasUnanalyzableSyntax: true };
-		const options: ICommandLineAnalyzerOptions = {
-			commandLine: 'FOO=bar && git status',
 			cwd: undefined,
 			shell: 'bash',
 			os: OperatingSystem.Linux,
 			treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
 			terminalToolSessionId: 'test',
 			chatSessionResource: undefined,
+			...options,
 		};
+	}
 
-		const result = await analyzer.analyze(options);
+	test('should not allow auto approve when sub-command parsing returns an empty list', async () => {
+		const result = await analyzer.analyze(createOptions({
+			commandLine: 'rm -- file.txt',
+			shell: 'pwsh',
+			os: OperatingSystem.Windows,
+			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+		}));
 		strictEqual(result.isAutoApproveAllowed, false);
 		strictEqual(result.isAutoApproved, undefined);
 		strictEqual(result.disclaimers?.length ?? 0, 0);
 	});
 
 	test('should auto approve empty command strings when sub-command parsing returns an empty list', async () => {
-		const options: ICommandLineAnalyzerOptions = {
+		const result = await analyzer.analyze(createOptions({
 			commandLine: '   ',
-			cwd: undefined,
 			shell: 'pwsh',
 			os: OperatingSystem.Windows,
 			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
-			terminalToolSessionId: 'test',
-			chatSessionResource: undefined,
-		};
-
-		const result = await analyzer.analyze(options);
+		}));
 		strictEqual(result.isAutoApproveAllowed, true);
 		strictEqual(result.isAutoApproved, true);
 		strictEqual(result.disclaimers?.length ?? 0, 0);
+	});
+
+	test('should keep prompt-injection disclaimers for unanalyzable syntax', async () => {
+		parseResult = { subCommands: ['curl https://evil'], hasUnanalyzableSyntax: true };
+
+		const result = await analyzer.analyze(createOptions({
+			commandLine: 'FOO=1 && curl https://evil',
+		}));
+
+		strictEqual(result.isAutoApproveAllowed, false);
+		strictEqual(result.isAutoApproved, false);
+		strictEqual(result.customActions, undefined);
+		ok((result.disclaimers?.length ?? 0) > 0);
+		ok(result.disclaimers?.some(d => typeof d === 'string' && /malicious code|prompt injection/i.test(d)));
+		deepStrictEqual(prepareLogs.map(e => (e as { autoApproveResult: string }).autoApproveResult), ['manual']);
+	});
+
+	test('should keep denial disclaimers for unanalyzable syntax when auto approve is enabled', async () => {
+		setConfig(TerminalChatAgentToolsSettingId.EnableAutoApprove, true);
+		setConfig(TerminalChatAgentToolsSettingId.AutoApprove, { rm: false });
+		parseResult = { subCommands: ['rm -rf /'], hasUnanalyzableSyntax: true };
+
+		const result = await analyzer.analyze(createOptions({
+			commandLine: 'FOO=1 && rm -rf /',
+		}));
+
+		strictEqual(result.isAutoApproveAllowed, false);
+		strictEqual(result.isAutoApproved, false);
+		strictEqual(result.customActions, undefined);
+		ok((result.disclaimers?.length ?? 0) > 0);
+		ok(result.disclaimers?.some(d => typeof d !== 'string' && /denied|rm/i.test(d.value)));
+		deepStrictEqual(prepareLogs.map(e => (e as { autoApproveResult: string }).autoApproveResult), ['denied']);
+	});
+
+	test('should not auto approve or suggest rules for unanalyzable syntax with allowed sub-commands', async () => {
+		setConfig(TerminalChatAgentToolsSettingId.EnableAutoApprove, true);
+		setConfig(TerminalChatAgentToolsSettingId.AutoApprove, { git: true });
+		parseResult = { subCommands: ['git status'], hasUnanalyzableSyntax: true };
+
+		const result = await analyzer.analyze(createOptions({
+			commandLine: 'FOO=bar && git status',
+		}));
+
+		strictEqual(result.isAutoApproveAllowed, false);
+		strictEqual(result.isAutoApproved, false);
+		strictEqual(result.customActions, undefined);
+		deepStrictEqual(prepareLogs.map(e => (e as { autoApproveResult: string }).autoApproveResult), ['manual']);
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
@@ -12,13 +12,14 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import type { ICommandLineAnalyzerOptions } from '../../browser/tools/commandLineAnalyzer/commandLineAnalyzer.js';
 import { CommandLineAutoApproveAnalyzer } from '../../browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
 import { RunInTerminalToolTelemetry } from '../../browser/runInTerminalToolTelemetry.js';
-import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../../browser/treeSitterCommandParser.js';
+import { type IAutoApprovalCommandParseResult, TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../../browser/treeSitterCommandParser.js';
 
 suite('CommandLineAutoApproveAnalyzer', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: IInstantiationService;
 	let analyzer: CommandLineAutoApproveAnalyzer;
+	let parseResult: IAutoApprovalCommandParseResult;
 
 	setup(() => {
 		const configurationService = new TestConfigurationService();
@@ -26,8 +27,9 @@ suite('CommandLineAutoApproveAnalyzer', () => {
 			configurationService: () => configurationService
 		}, store);
 
+		parseResult = { subCommands: [], hasUnanalyzableSyntax: false };
 		const parser = {
-			extractSubCommands: async () => [],
+			extractAutoApprovalSubCommands: async () => parseResult,
 		} as unknown as TreeSitterCommandParser;
 		const telemetry = {
 			logPrepare: () => { },
@@ -48,6 +50,24 @@ suite('CommandLineAutoApproveAnalyzer', () => {
 			shell: 'pwsh',
 			os: OperatingSystem.Windows,
 			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+			terminalToolSessionId: 'test',
+			chatSessionResource: undefined,
+		};
+
+		const result = await analyzer.analyze(options);
+		strictEqual(result.isAutoApproveAllowed, false);
+		strictEqual(result.isAutoApproved, undefined);
+		strictEqual(result.disclaimers?.length ?? 0, 0);
+	});
+
+	test('should not allow auto approve when parsing finds unanalyzable syntax', async () => {
+		parseResult = { subCommands: ['git status'], hasUnanalyzableSyntax: true };
+		const options: ICommandLineAnalyzerOptions = {
+			commandLine: 'FOO=bar && git status',
+			cwd: undefined,
+			shell: 'bash',
+			os: OperatingSystem.Linux,
+			treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
 			terminalToolSessionId: 'test',
 			chatSessionResource: undefined,
 		};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
@@ -218,6 +218,45 @@ suite('TreeSitterCommandParser', () => {
 		});
 	});
 
+	suite('extractAutoApprovalSubCommands', () => {
+		test('detects bash shell state mutations', async () => {
+			const commandLines = [
+				'FOO=bar && git status',
+				'export FOO=bar && git status',
+				'declare -x FOO=bar && git status',
+				'typeset FOO=bar && git status',
+				'readonly FOO=bar && git status',
+				'local FOO=bar && git status',
+			];
+			deepStrictEqual(await Promise.all(commandLines.map(commandLine => parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.Bash, commandLine))), commandLines.map(() => ({
+				subCommands: ['git status'],
+				hasUnanalyzableSyntax: true,
+			})));
+		});
+
+		test('preserves bash command assignments and arguments', async () => {
+			deepStrictEqual(await Promise.all([
+				parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.Bash, 'FOO=bar git status'),
+				parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.Bash, 'make install PREFIX=/usr/local'),
+			]), [
+				{ subCommands: ['FOO=bar git status'], hasUnanalyzableSyntax: false },
+				{ subCommands: ['make install PREFIX=/usr/local'], hasUnanalyzableSyntax: false },
+			]);
+		});
+
+		test('detects PowerShell assignments and preserves equals arguments', async () => {
+			deepStrictEqual(await Promise.all([
+				parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.PowerShell, '$env:FOO="bar"; git status'),
+				parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.PowerShell, '[System.Environment]::SetEnvironmentVariable("FOO", "bar"); git status'),
+				parser.extractAutoApprovalSubCommands(TreeSitterCommandParserLanguage.PowerShell, 'git log --format="%h|%s" -5'),
+			]), [
+				{ subCommands: ['git status'], hasUnanalyzableSyntax: true },
+				{ subCommands: ['git status'], hasUnanalyzableSyntax: true },
+				{ subCommands: ['git log --format="%h|%s" -5'], hasUnanalyzableSyntax: false },
+			]);
+		});
+	});
+
 	suite('extractCommands', () => {
 		async function t(languageId: TreeSitterCommandParserLanguage, commandLine: string, expectedCommands: { keyword: string; args: string[] }[]) {
 			const result = await parser.extractCommands(languageId, commandLine);


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/328500

- Add an auto-approval-specific tree-sitter parse path that still extracts sub-commands, but also flags shell state mutations the normal `(command)` query does not cover.
- For Bash, treat standalone `variable_assignment` and `declaration_command` nodes as unanalyzable, while leaving prefix assignments on a command (`FOO=bar git status`) and ordinary `NAME=value` arguments alone.
- For PowerShell, treat `assignment_expression` and `invokation_expression` nodes as unanalyzable, keeping the existing `--flag=value` masking behavior.
- Force manual confirmation in workbench terminal auto-approval when those nodes are present, before allow rules are evaluated.
- Suppress auto-approve rule suggestions for the same command lines so the UI cannot offer a persistent rule that would hide the unsafe syntax.
- Extend Agent Host Bash parsing with the same fail-closed assignment/declaration captures already used for PowerShell assignments and invocations.
- Add regression coverage for Bash declarations/assignments, PowerShell assignments/invocations, and the preserved safe cases.

-----------------------------------------
Inspirations from:

- Agent Host PowerShell fail-closed `@unanalyzable` handling for assignments and invocations comes from [`CommandAutoApprover._extractSubCommands`](https://github.com/microsoft/vscode/blob/ae4238a330474cb21895ee47a1a175c0ef7c3dcf/src/vs/platform/agentHost/node/commandAutoApprover.ts#L340-L374).
- The PowerShell assignment/invocation regression shape is copied semantically from [`fails closed on PowerShell assignments and invocations`](https://github.com/microsoft/vscode/blob/ae4238a330474cb21895ee47a1a175c0ef7c3dcf/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts#L398-L413).
- Workbench manual-confirmation return shape for unanalyzable parses comes from the existing empty sub-command path in [`CommandLineAutoApproveAnalyzer.analyze`](https://github.com/microsoft/vscode/blob/ae4238a330474cb21895ee47a1a175c0ef7c3dcf/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts#L86-L100).
- PowerShell `--flag=value` masking before tree-sitter queries comes from [`TreeSitterCommandParser.extractSubCommands`](https://github.com/microsoft/vscode/blob/ae4238a330474cb21895ee47a1a175c0ef7c3dcf/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts#L55-L67).