### PR TITLE
Execution Subagent: Remove gating on Gemini Availability

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -251,11 +251,11 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 		const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);
 		const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
 
-		// Only look up endpoints when a subagent that depends on model availability
-		// could actually be enabled, since the lookup is otherwise unnecessary.
+		// The search/explore subagents are the only ones whose availability depends
+		// on the model list, so skip the lookup entirely when they are off.
 		const allEndpoints = searchSubagentEnabled
 			? await endpointProvider.getAllChatEndpoints().catch(err => {
-				logService.warn(`getAgentTools: failed to fetch chat endpoints, disabling availability-gated subagents: ${err}`);
+				logService.warn(`getAgentTools: failed to fetch chat endpoints, disabling the search/explore subagents: ${err}`);
 				return [] as IChatEndpoint[];
 			})
 			: [];

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -253,7 +253,7 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 
 		// Only look up endpoints when a subagent that depends on model availability
 		// could actually be enabled, since the lookup is otherwise unnecessary.
-		const allEndpoints = searchSubagentEnabled || executionSubagentEnabled
+		const allEndpoints = searchSubagentEnabled
 			? await endpointProvider.getAllChatEndpoints().catch(err => {
 				logService.warn(`getAgentTools: failed to fetch chat endpoints, disabling availability-gated subagents: ${err}`);
 				return [] as IChatEndpoint[];

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -264,11 +264,7 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 		allowTools[ToolName.SearchSubagent] = searchSubagentEnabled && exploreAgentEnabled && searchAgentAvailable;
 		allowTools[ToolName.ExploreSubagent] = searchSubagentEnabled && !exploreAgentEnabled && searchAgentAvailable;
 
-		// The execution subagent is powered by gemini-3-flash, so it can only be
-		// offered when that model is actually available to the user. If it isn't
-		// in the user's endpoints, keep the tool disabled regardless of the setting.
-		const hasGemini3Flash = allEndpoints.some(ep => ep.family.toLowerCase().includes('gemini-3-flash'));
-		allowTools[ToolName.ExecutionSubagent] = executionSubagentEnabled && hasGemini3Flash;
+		allowTools[ToolName.ExecutionSubagent] = executionSubagentEnabled;
 	}
 
 	const skillToolEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SkillToolEnabled, experimentationService);

--- a/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
@@ -27,10 +27,18 @@ import { getAgentTools } from '../agentIntent';
 class StubEndpointProvider implements IEndpointProvider {
 	declare readonly _serviceBrand: undefined;
 	endpoints: IChatEndpoint[] = [];
+	failGetAllChatEndpoints = false;
+	getAllChatEndpointsCallCount = 0;
 	readonly onDidModelsRefresh = Event.None;
 	async getChatEndpoint(): Promise<IChatEndpoint> { return this.endpoints[0]; }
 	async getEmbeddingsEndpoint(): Promise<never> { throw new Error('not implemented'); }
-	async getAllChatEndpoints(): Promise<IChatEndpoint[]> { return this.endpoints; }
+	async getAllChatEndpoints(): Promise<IChatEndpoint[]> {
+		this.getAllChatEndpointsCallCount++;
+		if (this.failGetAllChatEndpoints) {
+			throw new Error('CAPI unreachable');
+		}
+		return this.endpoints;
+	}
 	async getAllCompletionModels(): Promise<never[]> { return []; }
 }
 
@@ -71,6 +79,8 @@ describe('getAgentTools search subagent gating', () => {
 
 	beforeEach(() => {
 		endpointProvider.endpoints = [userEndpoint];
+		endpointProvider.failGetAllChatEndpoints = false;
+		endpointProvider.getAllChatEndpointsCallCount = 0;
 		configService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, true);
 		configService.setConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, false);
 		configService.setConfig(ConfigKey.ExploreAgentEnabled, true);
@@ -104,16 +114,24 @@ describe('getAgentTools search subagent gating', () => {
 		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
 	});
 
-	test('exposes ExecutionSubagent when enabled without a Gemini endpoint', async () => {
+	test('exposes ExecutionSubagent when enabled without a Gemini endpoint, and skips the endpoint lookup', async () => {
 		configService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, false);
 		configService.setConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, true);
 		const request = new TestChatRequest('run tests for foo');
 		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
 		expect(hasTool(tools, ToolName.ExecutionSubagent)).toBe(true);
+		expect(endpointProvider.getAllChatEndpointsCallCount).toBe(0);
+	});
+
+	test('hides ExecutionSubagent when the experiment is off', async () => {
+		configService.setConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, false);
+		const request = new TestChatRequest('run tests for foo');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.ExecutionSubagent)).toBe(false);
 	});
 
 	test('hides both subagents when CAPI fetch fails', async () => {
-		endpointProvider.getAllChatEndpoints = async () => { throw new Error('CAPI unreachable'); };
+		endpointProvider.failGetAllChatEndpoints = true;
 		const request = new TestChatRequest('find usages of foo');
 		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
 		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);

--- a/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
@@ -41,7 +41,6 @@ describe('getAgentTools search subagent gating', () => {
 	let endpointProvider: StubEndpointProvider;
 	let userEndpoint: IChatEndpoint;
 	let searchAgentEndpoint: IChatEndpoint;
-	let executionAgentEndpoint: IChatEndpoint;
 
 	beforeAll(() => {
 		const services = createExtensionUnitTestingServices();
@@ -64,7 +63,6 @@ describe('getAgentTools search subagent gating', () => {
 		(userEndpoint as { family: string }).family = 'gemini-3-pro';
 		(userEndpoint as { urlOrRequestMetadata: RequestMetadata }).urlOrRequestMetadata = { type: RequestType.ChatCompletions };
 		searchAgentEndpoint = instantiationService.createInstance(MockEndpoint, SEARCH_AGENT_FAMILY);
-		executionAgentEndpoint = instantiationService.createInstance(MockEndpoint, 'gemini-3-flash');
 	});
 
 	afterAll(() => {
@@ -74,6 +72,7 @@ describe('getAgentTools search subagent gating', () => {
 	beforeEach(() => {
 		endpointProvider.endpoints = [userEndpoint];
 		configService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, true);
+		configService.setConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, false);
 		configService.setConfig(ConfigKey.ExploreAgentEnabled, true);
 	});
 
@@ -105,8 +104,7 @@ describe('getAgentTools search subagent gating', () => {
 		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
 	});
 
-	test('exposes ExecutionSubagent when gemini-3-flash is available for a non-gpt/non-anthropic CAPI model', async () => {
-		endpointProvider.endpoints = [userEndpoint, executionAgentEndpoint];
+	test('exposes ExecutionSubagent when enabled without a Gemini endpoint', async () => {
 		configService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, false);
 		configService.setConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, true);
 		const request = new TestChatRequest('run tests for foo');


### PR DESCRIPTION
The execution subagent enablement is currently gated on `gemini-3-flash-preview` availability. However, Gemini 3 Flash is now being deprecated. This PR removes the check in `agentIntent.ts`.
