### PR TITLE
agentHost: Fix edit harness attribution

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeSdkMessageRouter.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkMessageRouter.ts
@@ -11,6 +11,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { ILogService } from '../../../log/common/log.js';
 import { AgentSignal } from '../../common/agentService.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
+import { resolveChatUri } from '../../common/state/sessionState.js';
 import { ClaudeFileEditObserver } from './claudeFileEditObserver.js';
 import { ClaudeMapperState, mapSDKMessageToAgentSignals } from './claudeMapSessionEvents.js';
 import type { SubagentRegistry } from './claudeSubagentRegistry.js';
@@ -50,7 +51,7 @@ export class ClaudeSdkMessageRouter extends Disposable {
 		super();
 		this._clientToolOwner = clientToolOwner;
 		this._editObserver = this._register(
-			instantiationService.createInstance(ClaudeFileEditObserver, sessionUri.toString(), dbRef),
+			instantiationService.createInstance(ClaudeFileEditObserver, resolveChatUri(sessionUri, this._chatChannelUri).toString(), dbRef),
 		);
 	}
 

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -18,6 +18,7 @@ import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/tel
 import { AgentSession } from '../../common/agentService.js';
 import { IDiffComputeService, IOffsetEdit } from '../../common/diffComputeService.js';
 import { createFileEditContentDigest, IAgentEditAttribution, IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IFileEditAttributionMarker, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, MAX_EDIT_ATTRIBUTION_FILE_SIZE } from '../../common/fileEditAttribution.js';
+import { isAhpChatChannel, parseRequiredSessionUriFromChatUri } from '../../common/state/sessionState.js';
 import { IAgentHostTelemetryService } from '../agentHostTelemetryService.js';
 
 const MAX_TOTAL_TRACKED_TEXT = 20 * 1024 * 1024;
@@ -210,7 +211,8 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			this._applyChanges(resource, bridge.changes, undefined, edit.beforeText);
 		}
 
-		const provider = AgentSession.provider(edit.sessionUri) ?? 'unknown';
+		const providerSessionUri = isAhpChatChannel(edit.sessionUri) ? parseRequiredSessionUriFromChatUri(edit.sessionUri) : edit.sessionUri;
+		const provider = AgentSession.provider(providerSessionUri) ?? 'unknown';
 		const modelSegment = edit.modelId ? `-$modelId:${edit.modelId}` : '';
 		const sourceKey = `source:Chat.applyEdits${modelSegment}-$harness:${provider}-$origin:agentHost`;
 		let source = resource.sources.get(sourceKey);

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -15,8 +15,10 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { createFileEditContentDigest } from '../../common/fileEditAttribution.js';
+import { buildChatUri, buildDefaultChatUri } from '../../common/state/sessionState.js';
 import { AgentEditAttributionService } from '../../node/shared/agentEditAttributionService.js';
 import { computeDiffCounts } from '../../node/diffWorkerMain.js';
 import { TestDiffComputeService } from '../common/sessionTestHelpers.js';
@@ -46,7 +48,7 @@ suite('Agent Edit Attribution Service', () => {
 		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, undefined, undefined));
 
 		const marker = await service.recordEdit({
-			sessionUri: 'copilot:/session-1',
+			sessionUri: 'copilotcli:/session-1',
 			turnId: 'turn-1',
 			toolCallId: 'tool-1',
 			filePath: resource.fsPath,
@@ -59,7 +61,7 @@ suite('Agent Edit Attribution Service', () => {
 			modelId: 'model',
 			toolName: 'edit',
 		});
-		await service.flushSession('copilot:/session-1');
+		await service.flushSession('copilotcli:/session-1');
 		const acknowledged = await service.prepareFlush({
 			resource,
 			trigger: 'closed',
@@ -84,6 +86,8 @@ suite('Agent Edit Attribution Service', () => {
 			events: events.map(event => ({
 				eventName: event.eventName,
 				sourceKey: event.data.sourceKey,
+				sourceKeyCleaned: event.data.sourceKeyCleaned,
+				conversationId: event.data.conversationId,
 				modifiedCount: event.data.modifiedCount,
 				deltaModifiedCount: event.data.deltaModifiedCount,
 				totalModifiedCount: event.data.totalModifiedCount,
@@ -104,12 +108,14 @@ suite('Agent Edit Attribution Service', () => {
 			},
 			events: [{
 				eventName: 'editTelemetry.editSources.details',
-				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilot-$origin:agentHost',
+				sourceKey: 'source:Chat.applyEdits-$modelId:model-$harness:copilotcli-$origin:agentHost',
+				sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+				conversationId: 'session-1',
 				modifiedCount: 2,
 				deltaModifiedCount: 2,
 				totalModifiedCount: 2,
 				origin: 'agentHost',
-				harness: 'copilot',
+				harness: 'copilotcli',
 			}],
 			acknowledged: {
 				agentModifiedCount: 2,
@@ -118,6 +124,91 @@ suite('Agent Edit Attribution Service', () => {
 					agentModifiedCount: 2,
 				},
 			},
+		});
+	});
+
+	test('normalizes ahp chat harness without coalescing chat resources', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const copilotResource = URI.file('/workspace/copilot.ts');
+		const claudeResource = URI.file('/workspace/claude.ts');
+		await fileService.writeFile(copilotResource, VSBuffer.fromString('ab'));
+		await fileService.writeFile(claudeResource, VSBuffer.fromString('ab'));
+
+		const events: Record<string, string | number | undefined>[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, {
+			telemetryLevel: TelemetryLevel.USAGE,
+			publicLog2(_eventName, data) {
+				events.push(data as Record<string, string | number | undefined>);
+			},
+		});
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+		const copilotSessionUri = 'copilotcli:/session-1';
+		const copilotDefaultChatUri = buildDefaultChatUri(copilotSessionUri);
+		const copilotPeerChatUri = buildChatUri(copilotSessionUri, 'peer');
+		const claudeChatUri = buildChatUri('claude:/session-2', 'peer');
+
+		for (const edit of [
+			{ sessionUri: copilotDefaultChatUri, turnId: 'turn-default', filePath: copilotResource.fsPath, modelId: 'copilot-model' },
+			{ sessionUri: copilotPeerChatUri, turnId: 'turn-peer', filePath: copilotResource.fsPath, modelId: 'copilot-model' },
+			{ sessionUri: claudeChatUri, turnId: 'turn-claude', filePath: claudeResource.fsPath, modelId: 'claude-model' },
+		]) {
+			await service.recordEdit({
+				...edit,
+				toolCallId: `tool-${edit.turnId}`,
+				beforeText: 'a',
+				afterText: 'ab',
+				changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+				toolName: 'edit',
+			});
+		}
+
+		await service.flushSession(copilotDefaultChatUri);
+		const afterDefaultChatFlush = events.length;
+		await service.flushSession(copilotPeerChatUri);
+		const afterPeerChatFlush = events.length;
+		await service.flushSession(claudeChatUri);
+
+		assert.deepStrictEqual({
+			afterDefaultChatFlush,
+			afterPeerChatFlush,
+			events: events.map(event => ({
+				sourceKey: event.sourceKey,
+				sourceKeyCleaned: event.sourceKeyCleaned,
+				conversationId: event.conversationId,
+				requestId: event.requestId,
+				harness: event.harness,
+			})),
+		}, {
+			afterDefaultChatFlush: 1,
+			afterPeerChatFlush: 2,
+			events: [
+				{
+					sourceKey: 'source:Chat.applyEdits-$modelId:copilot-model-$harness:copilotcli-$origin:agentHost',
+					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+					conversationId: AgentSession.id(copilotDefaultChatUri),
+					requestId: 'turn-default',
+					harness: 'copilotcli',
+				},
+				{
+					sourceKey: 'source:Chat.applyEdits-$modelId:copilot-model-$harness:copilotcli-$origin:agentHost',
+					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+					conversationId: AgentSession.id(copilotPeerChatUri),
+					requestId: 'turn-peer',
+					harness: 'copilotcli',
+				},
+				{
+					sourceKey: 'source:Chat.applyEdits-$modelId:claude-model-$harness:claude-$origin:agentHost',
+					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:claude-$origin:agentHost',
+					conversationId: AgentSession.id(claudeChatUri),
+					requestId: 'turn-claude',
+					harness: 'claude',
+				},
+			],
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -15,7 +15,6 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentSession } from '../../common/agentService.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { createFileEditContentDigest } from '../../common/fileEditAttribution.js';
 import { buildChatUri, buildDefaultChatUri } from '../../common/state/sessionState.js';
@@ -190,21 +189,21 @@ suite('Agent Edit Attribution Service', () => {
 				{
 					sourceKey: 'source:Chat.applyEdits-$modelId:copilot-model-$harness:copilotcli-$origin:agentHost',
 					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
-					conversationId: AgentSession.id(copilotDefaultChatUri),
+					conversationId: 'Y29waWxvdGNsaTovc2Vzc2lvbi0x',
 					requestId: 'turn-default',
 					harness: 'copilotcli',
 				},
 				{
 					sourceKey: 'source:Chat.applyEdits-$modelId:copilot-model-$harness:copilotcli-$origin:agentHost',
 					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
-					conversationId: AgentSession.id(copilotPeerChatUri),
+					conversationId: 'Y29waWxvdGNsaTovc2Vzc2lvbi0x',
 					requestId: 'turn-peer',
 					harness: 'copilotcli',
 				},
 				{
 					sourceKey: 'source:Chat.applyEdits-$modelId:claude-model-$harness:claude-$origin:agentHost',
 					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:claude-$origin:agentHost',
-					conversationId: AgentSession.id(claudeChatUri),
+					conversationId: 'Y2xhdWRlOi9zZXNzaW9uLTI',
 					requestId: 'turn-claude',
 					harness: 'claude',
 				},

--- a/src/vs/platform/agentHost/test/node/claudeSdkMessageRouter.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkMessageRouter.test.ts
@@ -6,6 +6,7 @@
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { DisposableStore, IReference } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -18,10 +19,13 @@ import { ServiceCollection } from '../../../instantiation/common/serviceCollecti
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { AgentSignal } from '../../common/agentService.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
+import { IAgentEditAttribution, IAgentEditAttributionService, NullAgentEditAttributionService } from '../../common/fileEditAttribution.js';
 import { ISessionDatabase } from '../../common/sessionDataService.js';
-import { buildDefaultChatUri } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri } from '../../common/state/sessionState.js';
 import { ClaudeSdkMessageRouter } from '../../node/claude/claudeSdkMessageRouter.js';
 import { SubagentRegistry } from '../../node/claude/claudeSubagentRegistry.js';
+import { IEditArcReporterService, NullEditArcReporterService } from '../../node/shared/editArcReporter.js';
+import { IEditSurvivalReporterFactory, NullEditSurvivalReporterFactory } from '../../node/shared/editSurvivalReporter.js';
 import { createZeroDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import {
 	makeContentBlockStartText,
@@ -38,7 +42,25 @@ interface IRouterHarness {
 	readonly fileService: FileService;
 }
 
-function createRouter(disposables: Pick<DisposableStore, 'add'>): IRouterHarness {
+class RecordingAgentEditAttributionService extends NullAgentEditAttributionService {
+	readonly recordedSessionUris: string[] = [];
+	readonly flushedSessionUris: string[] = [];
+
+	override async recordEdit(edit: IAgentEditAttribution) {
+		this.recordedSessionUris.push(edit.sessionUri);
+		return undefined;
+	}
+
+	override async flushSession(sessionUri: string): Promise<void> {
+		this.flushedSessionUris.push(sessionUri);
+	}
+}
+
+function createRouter(
+	disposables: Pick<DisposableStore, 'add'>,
+	chatChannelUri = URI.parse(buildDefaultChatUri('claude:/sess-1')),
+	attributionService = new NullAgentEditAttributionService(),
+): IRouterHarness {
 	const fileService = disposables.add(new FileService(new NullLogService()));
 	const fs = disposables.add(new InMemoryFileSystemProvider());
 	disposables.add(fileService.registerProvider('file', fs));
@@ -50,13 +72,16 @@ function createRouter(disposables: Pick<DisposableStore, 'add'>): IRouterHarness
 		[ILogService, new NullLogService()],
 		[IFileService, fileService],
 		[IDiffComputeService, createZeroDiffComputeService()],
+		[IAgentEditAttributionService, attributionService],
+		[IEditSurvivalReporterFactory, new NullEditSurvivalReporterFactory()],
+		[IEditArcReporterService, new NullEditArcReporterService()],
 	);
 	const inst: IInstantiationService = disposables.add(new InstantiationService(services));
 	const subagents = disposables.add(new SubagentRegistry());
 	const router = disposables.add(inst.createInstance(
 		ClaudeSdkMessageRouter,
 		URI.parse('claude:/sess-1'),
-		URI.parse(buildDefaultChatUri('claude:/sess-1')),
+		chatChannelUri,
 		dbRef,
 		subagents,
 		undefined,
@@ -64,6 +89,14 @@ function createRouter(disposables: Pick<DisposableStore, 'add'>): IRouterHarness
 	const signals: AgentSignal[] = [];
 	disposables.add(router.onDidProduceSignal(s => signals.push(s)));
 	return { router, signals, fileService };
+}
+
+function assistantMessage(content: unknown): Extract<SDKMessage, { type: 'assistant' }> {
+	return { type: 'assistant', message: { content } } as Extract<SDKMessage, { type: 'assistant' }>;
+}
+
+function userMessage(content: unknown): Extract<SDKMessage, { type: 'user' }> {
+	return { type: 'user', message: { content } } as Extract<SDKMessage, { type: 'user' }>;
 }
 
 suite('ClaudeSdkMessageRouter', () => {
@@ -100,5 +133,30 @@ suite('ClaudeSdkMessageRouter', () => {
 		const p1 = router.handle(makeStreamEvent('sess-1', makeMessageStart()), 'turn-1');
 		assert.ok(p1 instanceof Promise);
 		await p1;
+	});
+
+	test('tracks and flushes peer chat edits by their chat channel URI', async () => {
+		const chatChannelUri = URI.parse(buildChatUri('claude:/sess-1', 'peer'));
+		const attributionService = new RecordingAgentEditAttributionService();
+		const { router, fileService } = createRouter(disposables, chatChannelUri, attributionService);
+		const file = URI.file('/work/a.txt');
+		await fileService.writeFile(file, VSBuffer.fromString('before'));
+
+		await router.handle(assistantMessage([
+			{ type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: file.fsPath, content: 'after' } },
+		]), 'turn-1');
+		await fileService.writeFile(file, VSBuffer.fromString('after'));
+		await router.handle(userMessage([
+			{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok' },
+		]), 'turn-1');
+		router.dispose();
+
+		assert.deepStrictEqual({
+			recordedSessionUris: attributionService.recordedSessionUris,
+			flushedSessionUris: attributionService.flushedSessionUris,
+		}, {
+			recordedSessionUris: [chatChannelUri.toString()],
+			flushedSessionUris: [chatChannelUri.toString()],
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- resolve `ahp-chat` channel URIs to their owning Agent Host session when deriving edit telemetry harnesses
  - `ahp-chat` is not an Agent Host provider/harness, so it is an unknown attribution currently
- preserve existing chat-channel conversation ID semantics
- route Claude peer-chat edit tracking through the effective chat storage URI so peer edits remain independently recorded and flushed

Fixes microsoft/vscode-internalbacklog#8664.

## Testing

- targeted Agent Edit Attribution Service and Claude SDK message router tests (29 passing)
- hygiene check for changed files
- client typecheck attempted; blocked by pre-existing `copilotSystemNotification.ts` TS2678 error