### PR TITLE
Create css best practices instructions file

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -32,7 +32,6 @@ applyTo: src/vs/**
 ## Styling
 
 - Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element (e.g. `element.style.width = '100px'`), or set a CSS custom property via `element.style.setProperty('--my-var', value)` when the value is needed across multiple CSS rules.
-- Never anchor a `:has()` selector on `body` or another workbench-wide root (e.g. `body:has(.my-dialog) .context-view { … }`). A `:has()` on a global root forces the style engine to re-evaluate the selector against the whole document on nearly every DOM mutation, which degrades interaction smoothness across the entire workbench. It costs even in builds where the feature is disabled, because the CSS still ships. Instead, toggle a class on the specific container while the state is active and scope the rules to that class: add the class to `layoutService.activeContainer` when the state begins, remove it via a registered disposable when it ends, and write `.my-dialog-open .context-view { … }`. Capture the container reference once so the class is removed from the same element it was added to.
 
 ## Editor Decorations
 

--- a/.github/instructions/css-best-practices.instructions.md
+++ b/.github/instructions/css-best-practices.instructions.md
@@ -1,0 +1,10 @@
+---
+description: CSS best practices for selector performance and maintainable state styling. Use when writing or reviewing CSS.
+applyTo: "**/*.css"
+---
+
+# CSS Best Practices
+
+## Selectors
+
+- Avoid `:has()` selectors. Because their result depends on descendant state, DOM mutations can invalidate styles on ancestors and cause expensive style recalculation, especially when selectors are broadly scoped. Instead, represent the state explicitly with a class or data attribute on the smallest container you own, and scope selectors to that marker. Add and remove the marker together with the state it represents.


### PR DESCRIPTION
First rule is to avoid :has, as it has caused performance issues.