### PR TITLE
Route native Agent Host telemetry and trace context

### DIFF
--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -19,7 +19,7 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
 | Mode | Trigger | Behavior |
 |---|---|---|
 | **Pass-through** | `chat.agentHost.otel.enabled` is `true` and `dbSpanExporter.enabled` is `false` | The SDK exports directly to the user-configured exporter (OTLP/HTTP, OTLP/gRPC, file, or console). SDK spans are not intercepted; host-produced session-title metadata uses the matching JSON/file/console forwarder. |
-| **DB mode** | `chat.agentHost.otel.dbSpanExporter.enabled` is `true` (implicitly enables OTel) | The SDK is pointed at a loopback OTLP/HTTP receiver inside the agent host. Spans are decoded and written to a local SQLite database. If `otlpEndpoint` is **also** configured, the receiver fans the raw OTLP body out to it — so an external collector keeps receiving traces alongside the local DB. |
+| **DB mode** | `chat.agentHost.otel.dbSpanExporter.enabled` is `true` (implicitly enables OTel) | The SDK is pointed at a loopback OTLP/HTTP receiver inside the agent host. Spans are decoded and written to a local SQLite database. With an OTLP/HTTP JSON external endpoint, the receiver also fans the normalized JSON body out to it. Protobuf and gRPC traces remain local because Agent Host does not transcode wire formats. |
 
 ```
                  ┌─────────────────────────────────────────────────────────────────┐
@@ -50,7 +50,7 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
 ```
 
 - **Pass-through mode** (default when only `otlpEndpoint` is configured): the SDK is constructed with the user's exporter settings unmodified and exports directly. SDK span data is not intercepted; the agent host additionally emits the session-title metadata span described below through the configured exporter.
-- **DB mode** (`COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED=true`): `AgentHostOTelService` starts a `LocalOtlpHttpReceiver` on `127.0.0.1` with an ephemeral port, then configures every native provider's trace exporter to use that loopback over OTLP/HTTP JSON. For each batch the receiver decodes the body and inserts spans into `OTelSqliteStore` (`onSpans`). If an external `otlpEndpoint` is also configured, the receiver fans the raw trace body out to an `OtlpHttpForwarder` (`onForward`) so the user's collector keeps receiving traces alongside the local DB.
+- **DB mode** (`COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED=true`): `AgentHostOTelService` starts a `LocalOtlpHttpReceiver` on `127.0.0.1` with an ephemeral port, then configures every native provider's trace exporter to use that loopback over OTLP/HTTP JSON. For each batch the receiver decodes the body and inserts spans into `OTelSqliteStore` (`onSpans`). If an OTLP/HTTP JSON external endpoint is also configured, the receiver fans the normalized JSON trace body out to an `OtlpHttpForwarder` (`onForward`) so the collector keeps receiving traces alongside the local DB. For OTLP/HTTP protobuf and OTLP/gRPC external protocols, traces remain in SQLite while native logs and metrics still export directly.
 
 ## Native Provider Signal Routing
 
@@ -64,7 +64,7 @@ Only traces enter the Agent Host loopback and SQLite database. When an external 
 
 In DB mode the private trace hop always uses OTLP/HTTP JSON, which all three runtimes support and the local receiver decodes. The external logs/metrics hop retains the configured provider-supported protocol. Agent Host does not receive or persist `/v1/logs` or `/v1/metrics`.
 
-When Agent Host OTel is enabled, its launch configuration overrides standalone Claude/Codex exporter destinations for that Agent Host process. When it is disabled, standalone provider telemetry remains untouched. Authentication headers are supported through inherited standard OTel environment variables; managed-header delivery to provider subprocesses is not currently supported.
+When Agent Host OTel is enabled, its launch configuration overrides standalone Claude/Codex exporter destinations for that Agent Host process. When it is disabled, standalone provider telemetry remains untouched. Authentication headers are supported through inherited standard OTel environment variables; percent-encoded OTLP header values are decoded before HTTP/Codex use and re-encoded for Claude's environment. Managed-header delivery to provider subprocesses is not currently supported.
 
 ### Temporary Codex 0.142 trace filter
 
@@ -115,7 +115,7 @@ Open **Settings** (`Ctrl+,`) and search for `agentHost otel`:
 | `chat.agentHost.otel.otlpEndpoint` | string | `""` | OTLP endpoint URL. Accepts a bare base URL (`http://localhost:4318`) — `/v1/traces` is appended automatically when needed, matching the standard `OTEL_EXPORTER_OTLP_ENDPOINT` convention. A full signal-specific URL (`http://host:4318/v1/traces`) is used verbatim. |
 | `chat.agentHost.otel.captureContent` | boolean | `false` | Capture prompt/response content in span attributes. Privacy-sensitive — do not enable in environments that ship spans to shared sinks. |
 | `chat.agentHost.otel.outfile` | string | `""` | Output path for JSON-lines spans when `exporterType` is `file`. |
-| `chat.agentHost.otel.dbSpanExporter.enabled` | boolean | `false` | Persist every emitted span to a local SQLite database at `<userData>/agent-host/otel/agent-host-traces.db`. Implicitly enables OTel. Compatible with external exporters — spans are written to SQLite **and** forwarded to the user-configured sink. |
+| `chat.agentHost.otel.dbSpanExporter.enabled` | boolean | `false` | Persist every emitted span to a local SQLite database at `<userData>/agent-host/otel/agent-host-traces.db`. Implicitly enables OTel. OTLP/HTTP JSON traces can also be forwarded; protobuf and gRPC traces remain local. |
 
 ## Environment Variables
 
@@ -129,7 +129,7 @@ The workbench-side starter translates the settings above into the following env 
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `chat.agentHost.otel.captureContent` | |
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | `chat.agentHost.otel.outfile` | |
 | `COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED` | `chat.agentHost.otel.dbSpanExporter.enabled` | |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | (inherited or enterprise policy) | `grpc` selects gRPC; any other value uses HTTP. Set from the managed `telemetry.protocol` when configured. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | (inherited or enterprise policy) | `grpc` and `http/grpc` select gRPC; `http/protobuf` selects HTTP protobuf; other values use HTTP JSON. Set from the managed `telemetry.protocol` when configured. |
 | `OTEL_SERVICE_NAME` | (inherited or enterprise policy) | `service.name` resource attribute; set from the managed `telemetry.serviceName`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | (inherited or enterprise policy) | Extra resource attributes (`k=v,k2=v2`); set from the managed `telemetry.resourceAttributes`. |
 | `OTEL_EXPORTER_OTLP_HEADERS` | (inherited) | Auth headers (e.g., `Authorization=Bearer …`). **Not** delivered from managed settings — env delivery would leak the secret to tool subprocesses; managed headers apply to the Copilot Chat extension only. |

--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -1,6 +1,6 @@
 # Agent Host OTel Pipeline
 
-The **agent host** is a separate utility process (under `src/vs/platform/agentHost/`) that embeds the native [`@github/copilot-sdk`](https://github.com/github/copilot-cli) runtime instead of using the extension's in-process tool-calling loop. The agent host has its own OTel pipeline so traces from native-SDK sessions can be exported to a collector or persisted locally for inspection.
+The **agent host** is a separate utility process (under `src/vs/platform/agentHost/`) that hosts native Copilot, Claude, and Codex runtimes instead of using the extension's in-process harnesses. The agent host has its own OTel pipeline so provider-native traces can be exported to a collector or persisted locally for inspection.
 
 > **Availability:** Insiders / non-stable builds only. Requires `chat.agentHost.enabled` to be `true`.
 
@@ -11,7 +11,7 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
 | Process | Separate utility process (`src/vs/platform/agentHost/node/`) | Extension host |
 | Settings prefix | `chat.agentHost.otel.*` | `github.copilot.chat.otel.*` |
 | Service | `IAgentHostOTelService` (`node/otel/agentHostOTelService.ts`) | `IOTelService` (`extensions/copilot/src/platform/otel/`) |
-| SDK | `@github/copilot-sdk` `TelemetryConfig` | `@opentelemetry/sdk-node` directly |
+| SDK | Copilot `TelemetryConfig`, Claude environment, and Codex `otel.*` launch overrides | `@opentelemetry/sdk-node` directly |
 | Persistence | `<userData>/agent-host/otel/agent-host-traces.db` | `<extensionGlobalStorage>/otel/spans.db` |
 
 ## Two Modes
@@ -50,7 +50,25 @@ This doc lives next to the code (`IAgentHostOTelService` in [node/otel/agentHost
 ```
 
 - **Pass-through mode** (default when only `otlpEndpoint` is configured): the SDK is constructed with the user's exporter settings unmodified and exports directly. SDK span data is not intercepted; the agent host additionally emits the session-title metadata span described below through the configured exporter.
-- **DB mode** (`COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED=true`): `AgentHostOTelService` starts a `LocalOtlpHttpReceiver` on `127.0.0.1` with an ephemeral port, then constructs the SDK pointing at that loopback URL. For each batch the receiver decodes the OTLP-JSON body and inserts spans into `OTelSqliteStore` (`onSpans`). If an external `otlpEndpoint` is also configured, the receiver fans the **raw** OTLP body out to an `OtlpHttpForwarder` (`onForward`) so the user's collector keeps receiving traces alongside the local DB.
+- **DB mode** (`COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED=true`): `AgentHostOTelService` starts a `LocalOtlpHttpReceiver` on `127.0.0.1` with an ephemeral port, then configures every native provider's trace exporter to use that loopback over OTLP/HTTP JSON. For each batch the receiver decodes the body and inserts spans into `OTelSqliteStore` (`onSpans`). If an external `otlpEndpoint` is also configured, the receiver fans the raw trace body out to an `OtlpHttpForwarder` (`onForward`) so the user's collector keeps receiving traces alongside the local DB.
+
+## Native Provider Signal Routing
+
+Only traces enter the Agent Host loopback and SQLite database. When an external OTLP endpoint is configured, provider-native logs and metrics bypass Agent Host and export directly from the SDK:
+
+| Provider | Trace configuration | Direct external signals |
+|---|---|---|
+| Copilot | SDK `TelemetryConfig` plus a trace-specific endpoint | Metrics |
+| Claude | `OTEL_TRACES_EXPORTER` and trace-specific endpoint | Logs and metrics |
+| Codex | `otel.trace_exporter` launch override | Logs and metrics |
+
+In DB mode the private trace hop always uses OTLP/HTTP JSON, which all three runtimes support and the local receiver decodes. The external logs/metrics hop retains the configured provider-supported protocol. Agent Host does not receive or persist `/v1/logs` or `/v1/metrics`.
+
+When Agent Host OTel is enabled, its launch configuration overrides standalone Claude/Codex exporter destinations for that Agent Host process. When it is disabled, standalone provider telemetry remains untouched. Authentication headers are supported through inherited standard OTel environment variables; managed-header delivery to provider subprocesses is not currently supported.
+
+## Distributed Trace Context
+
+The host emits a zero-duration `vscode.agent_host.session` anchor and passes its W3C `traceparent`/`tracestate` to native runtimes. Copilot reads the context through `CopilotClientOptions.onGetTraceContext`, Claude receives it in its session subprocess environment, and Codex receives it on session-scoped JSON-RPC request envelopes. Provider-native traces can therefore share one trace id while retaining their provider conversation attributes.
 
 ## Session Title Metadata
 
@@ -58,13 +76,12 @@ When content capture is enabled, the agent host emits a zero-duration `vscode.ag
 
 | Attribute | Description |
 |---|---|
-| `gen_ai.conversation.id` | Provider conversation identifier (Copilot conversation ID or Claude SDK session ID; native Claude currently reports it as `session.id`). |
+| `gen_ai.conversation.id` | Provider conversation identifier (Copilot conversation ID or Claude SDK session ID). |
 | `vscode.agent_host.session.title` | Latest session title, bounded to 200 characters. |
 | `vscode.agent_host.session.uri` | Agent Host protocol URI for the session. |
 
 Title text is user-derived content, so these spans are emitted only when `chat.agentHost.otel.captureContent` is enabled. Host-produced title spans copy `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` so collectors group them with the SDK telemetry. They are persisted in DB mode and use the configured OTLP, file, or console forwarder. Synthetic OTLP forwarding currently uses OTLP/HTTP JSON; when `http/protobuf` or gRPC is configured, title spans remain available in DB mode but are not sent to that external endpoint.
 
-Emitting title metadata does not itself enable provider-native telemetry. In particular, `chat.agentHost.otel.*` does not currently turn on Claude's native OTel: an agent-host Claude turn emits no `claude_code.*` spans unless Claude's standalone OTel settings are configured separately.
 
 ## VS Code Settings
 

--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -66,6 +66,21 @@ In DB mode the private trace hop always uses OTLP/HTTP JSON, which all three run
 
 When Agent Host OTel is enabled, its launch configuration overrides standalone Claude/Codex exporter destinations for that Agent Host process. When it is disabled, standalone provider telemetry remains untouched. Authentication headers are supported through inherited standard OTel environment variables; managed-header delivery to provider subprocesses is not currently supported.
 
+## Resource Identity
+
+Agent Host is one logical system with several native OTel producers. Agent Host-owned launch and ingest boundaries assign the standard resource attribute `service.namespace=vscode.agent-host` while keeping component service names distinct:
+
+| Producer | `service.name` |
+|---|---|
+| Host session/title metadata | `vscode-agent-host` (unless the host has an explicit service-name override) |
+| Copilot runtime | `github-copilot` |
+| Claude runtime | `claude` |
+| Codex app-server | `codex` for traces normalized at the Agent Host receiver |
+
+Unrelated inherited resource attributes are preserved. A conflicting inherited `service.namespace` is replaced only inside Agent Host-owned telemetry and provider launch environments; no global VS Code namespace is set. Provider launch environments do not inherit a host `OTEL_SERVICE_NAME`.
+
+Claude honors these standard resource variables for traces, logs, and metrics. The current Codex app-server hardcodes `codex-app-server` and does not consume standard resource overrides for its direct logs/metrics; Agent Host therefore normalizes intercepted Codex traces, while direct Codex logs/metrics retain their upstream identity until Codex adds standard resource override support.
+
 ## Distributed Trace Context
 
 The host emits a zero-duration `vscode.agent_host.session` anchor and passes its W3C `traceparent`/`tracestate` to native runtimes. Copilot reads the context through `CopilotClientOptions.onGetTraceContext`, Claude receives it in its session subprocess environment, and Codex receives it on session-scoped JSON-RPC request envelopes. Provider-native traces can therefore share one trace id while retaining their provider conversation attributes.

--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -74,12 +74,12 @@ Agent Host is one logical system with several native OTel producers. Agent Host-
 |---|---|
 | Host session/title metadata | `vscode-agent-host` (unless the host has an explicit service-name override) |
 | Copilot runtime | `github-copilot` |
-| Claude runtime | `claude` |
-| Codex app-server | `codex` for traces normalized at the Agent Host receiver |
+| Claude runtime | `claude-code` |
+| Codex app-server | `codex-app-server` |
 
 Unrelated inherited resource attributes are preserved. A conflicting inherited `service.namespace` is replaced only inside Agent Host-owned telemetry and provider launch environments; no global VS Code namespace is set. Provider launch environments do not inherit a host `OTEL_SERVICE_NAME`.
 
-Claude honors these standard resource variables for traces, logs, and metrics. The current Codex app-server hardcodes `codex-app-server` and does not consume standard resource overrides for its direct logs/metrics; Agent Host therefore normalizes intercepted Codex traces, while direct Codex logs/metrics retain their upstream identity until Codex adds standard resource override support.
+Claude honors these standard resource variables for traces, logs, and metrics while retaining its native `claude-code` service name. The current Codex app-server hardcodes `codex-app-server` and does not consume standard resource overrides; Agent Host preserves that native name and adds the shared namespace to intercepted traces. Direct Codex logs/metrics cannot carry the namespace until Codex adds standard resource-attribute support.
 
 ## Distributed Trace Context
 

--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -66,6 +66,12 @@ In DB mode the private trace hop always uses OTLP/HTTP JSON, which all three run
 
 When Agent Host OTel is enabled, its launch configuration overrides standalone Claude/Codex exporter destinations for that Agent Host process. When it is disabled, standalone provider telemetry remains untouched. Authentication headers are supported through inherited standard OTel environment variables; managed-header delivery to provider subprocesses is not currently supported.
 
+### Temporary Codex 0.142 trace filter
+
+In DB mode, the loopback receiver drops only Codex spans with all three stable identifiers: resource `service.name=codex-app-server`, span name `auth`, and `code.module.name=codex_login::auth::manager`. Codex 0.142 emits this internal authentication polling span about twice per second, mostly as standalone root traces. The receiver keeps an aggregate filtered count and logs it at most once per minute; all other Codex spans are retained. Remove this compatibility filter after Codex stops exporting the polling span or provides native sampling/filtering.
+
+External-only mode sends traces directly from each SDK to the user's collector and bypasses the Agent Host receiver, so this narrow filter does not apply there. Covering that path would require a general telemetry proxy or a provider change and is intentionally outside this PR.
+
 ## Resource Identity
 
 Agent Host is one logical system with several native OTel producers. Agent Host-owned launch and ingest boundaries assign the standard resource attribute `service.namespace=vscode.agent-host` while keeping component service names distinct:

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -38,7 +38,11 @@ export interface IAgentHostNativeOTelConfig {
 	/** Trace destination. In DB mode this is the Agent Host HTTP/JSON loopback. */
 	readonly traces?: { readonly endpoint: string; readonly protocol: 'http/json' | 'http/protobuf' | 'grpc' };
 	/** User-owned OTLP destination used directly by native SDK logs and metrics. */
-	readonly external?: { readonly endpoint: string; readonly protocol: 'http/json' | 'http/protobuf' | 'grpc' };
+	readonly external?: {
+		readonly endpoint: string;
+		readonly protocol: 'http/json' | 'http/protobuf' | 'grpc';
+		readonly headers?: Readonly<Record<string, string>>;
+	};
 	readonly captureContent: boolean;
 }
 

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -21,6 +21,8 @@ import { createDecorator } from '../../../instantiation/common/instantiation.js'
  * in other layers) can import it without pulling in the node-only concrete
  * implementation and its transitive native dependencies (`node:sqlite`).
  */
+export const AgentHostOTelServiceNamespace = 'vscode.agent-host';
+export const AgentHostOTelServiceName = 'vscode-agent-host';
 export const AgentHostSessionSpanName = 'vscode.agent_host.session';
 export const AgentHostSessionTitleSpanName = 'vscode.agent_host.session.title_changed';
 
@@ -44,6 +46,7 @@ export interface IAgentHostNativeOTelConfig {
 		readonly headers?: Readonly<Record<string, string>>;
 	};
 	readonly captureContent: boolean;
+	readonly resourceAttributes: Readonly<Record<string, string>>;
 }
 
 export interface IAgentHostOTelService {

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -21,10 +21,26 @@ import { createDecorator } from '../../../instantiation/common/instantiation.js'
  * in other layers) can import it without pulling in the node-only concrete
  * implementation and its transitive native dependencies (`node:sqlite`).
  */
+export const AgentHostSessionSpanName = 'vscode.agent_host.session';
 export const AgentHostSessionTitleSpanName = 'vscode.agent_host.session.title_changed';
 
 export const AgentHostSessionTitleAttribute = 'vscode.agent_host.session.title';
 export const AgentHostSessionUriAttribute = 'vscode.agent_host.session.uri';
+
+export interface IAgentHostTraceContext {
+	readonly traceId: string;
+	readonly spanId: string;
+	readonly traceparent: string;
+	readonly tracestate?: string;
+}
+
+export interface IAgentHostNativeOTelConfig {
+	/** Trace destination. In DB mode this is the Agent Host HTTP/JSON loopback. */
+	readonly traces?: { readonly endpoint: string; readonly protocol: 'http/json' | 'http/protobuf' | 'grpc' };
+	/** User-owned OTLP destination used directly by native SDK logs and metrics. */
+	readonly external?: { readonly endpoint: string; readonly protocol: 'http/json' | 'http/protobuf' | 'grpc' };
+	readonly captureContent: boolean;
+}
 
 export interface IAgentHostOTelService {
 	readonly _serviceBrand: undefined;
@@ -35,6 +51,17 @@ export interface IAgentHostOTelService {
 	 * Resolves to `undefined` when telemetry is disabled.
 	 */
 	getSdkTelemetryConfig(): Promise<TelemetryConfig | undefined>;
+
+	/** Resolve provider-neutral native SDK destinations. Logs and metrics always
+	 * use {@link IAgentHostNativeOTelConfig.external}; only traces use the DB loopback. */
+	getNativeSdkTelemetryConfig(): Promise<IAgentHostNativeOTelConfig | undefined>;
+
+	/** Return a stable W3C parent for a provider session and emit its anchor span. */
+	getSessionTraceContext(conversationId: string, sessionUri: string): IAgentHostTraceContext | undefined;
+
+	/** Scope a provider SDK operation so callback-based propagation can read its parent. */
+	withTraceContext<T>(context: IAgentHostTraceContext | undefined, fn: () => T): T;
+	getCurrentTraceContext(): IAgentHostTraceContext | undefined;
 
 	/**
 	 * Path of the SQLite span store, or `undefined` when DB mode is off.

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -66,6 +66,9 @@ export interface IAgentHostOTelService {
 	/** Return a stable W3C parent for a provider session and emit its anchor span. */
 	getSessionTraceContext(conversationId: string, sessionUri: string): IAgentHostTraceContext | undefined;
 
+	/** Release a permanent session's retained W3C context. Idle eviction must not call this. */
+	releaseSessionTraceContext(sessionUri: string): void;
+
 	/** Scope a provider SDK operation so callback-based propagation can read its parent. */
 	withTraceContext<T>(context: IAgentHostTraceContext | undefined, fn: () => T): T;
 	getCurrentTraceContext(): IAgentHostTraceContext | undefined;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1231,6 +1231,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		return this._disposeSequencer.queue(sessionId, async () => {
 			await this._teardownEntry(sessionId);
 			this._pruneActiveClientHandles(sessionId);
+			this._otelService.releaseSessionTraceContext(session.toString());
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -39,6 +39,7 @@ import { applyMcpServerEnablement, findMcpChildId, findMcpServerName, getEffecti
 import { scanClaudeHooks } from './customizations/scan/claudeHookScan.js';
 import { scanClaudeMcpServers } from './customizations/scan/claudeMcpScan.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { scanClaudeRules } from './customizations/scan/claudeRuleScan.js';
 import { discoverClaudeMultiRootCustomizations } from './customizations/claudeMultiRootCustomizationDiscovery.js';
 import { resolvePromptToContentBlocks } from './claudePromptResolver.js';
@@ -377,6 +378,7 @@ export class ClaudeAgentSession extends Disposable {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
+		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 		@IClaudeAgentSdkService private readonly _sdkService: IClaudeAgentSdkService,
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@ILogService private readonly _logService: ILogService,
@@ -500,6 +502,8 @@ export class ClaudeAgentSession extends Disposable {
 		const permissionMode = readClaudePermissionMode(this._configurationService, this._storageUri) ?? this._permissionModeFallback;
 		const { mcpServers, allowedTools } = await this._buildStartupToolWiring(ctx.serverToolHost);
 		const agentName = await resolveClaudeAgentName(this._provisionalAgent, this._fileService, this._logService, this.sessionId);
+		const telemetry = await this._otelService.getNativeSdkTelemetryConfig();
+		const traceContext = this._otelService.getSessionTraceContext(this.sessionId, this.sessionUri.toString());
 
 		const options = await buildOptions(
 			{
@@ -517,6 +521,8 @@ export class ClaudeAgentSession extends Disposable {
 				allowedTools,
 				plugins: this.clientCustomizationsDiff.consume(this._desiredClientPluginPaths()),
 				agent: agentName,
+				telemetry,
+				traceContext,
 			},
 			ctx.transport,
 			data => this._logService.error(`[Claude SDK stderr] ${data}`),
@@ -620,6 +626,8 @@ export class ClaudeAgentSession extends Disposable {
 						allowedTools: rebuildAllowedTools,
 						plugins: this.clientCustomizationsDiff.consume(this._desiredClientPluginPaths()),
 						agent: rebuildAgentName,
+						telemetry,
+						traceContext,
 					},
 					ctx.transport,
 					data => this._logService.error(`[Claude SDK stderr] ${data}`),

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -251,6 +251,8 @@ export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | und
 	}
 	const env: Record<string, string> = {
 		CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+		OTEL_SERVICE_NAME: 'claude',
+		OTEL_RESOURCE_ATTRIBUTES: serializeResourceAttributes(config.resourceAttributes),
 		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: config.traces ? '1' : '0',
 		OTEL_TRACES_EXPORTER: config.traces ? 'otlp' : 'none',
 		OTEL_LOGS_EXPORTER: config.external ? 'otlp' : 'none',
@@ -280,6 +282,10 @@ export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | und
 		}
 	}
 	return env;
+}
+
+function serializeResourceAttributes(attributes: Readonly<Record<string, string>>): string {
+	return Object.entries(attributes).map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(',');
 }
 
 function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -17,6 +17,7 @@ import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildClientToolMcpServer } from './clientTools/claudeClientToolMcpServer.js';
 import { toSdkModelId } from './claudeModelId.js';
+import type { IAgentHostNativeOTelConfig, IAgentHostTraceContext } from '../../common/otel/agentHostOTelService.js';
 import type { ClaudeTransport } from './claudeProxyService.js';
 import { SessionClientToolsDiff } from './clientTools/claudeSessionClientToolsModel.js';
 
@@ -79,6 +80,8 @@ export interface IBuildOptionsInput {
 	 * Omit when no custom agent is selected (SDK default behavior).
 	 */
 	readonly agent?: string;
+	readonly telemetry?: IAgentHostNativeOTelConfig;
+	readonly traceContext?: IAgentHostTraceContext;
 }
 
 /**
@@ -104,8 +107,11 @@ export async function buildOptions(
 ): Promise<Options> {
 	const isProxy = transport.kind === 'proxy';
 	const subprocessEnv = buildSubprocessEnv(isProxy);
+	const telemetryEnv = buildClaudeTelemetryEnv(input.telemetry, input.traceContext);
+	Object.assign(subprocessEnv, telemetryEnv);
 	const resolvedRgDiskPath = await rgDiskPath();
 	const settingsEnv: Record<string, string> = {
+		...telemetryEnv,
 		// Proxied (Copilot-routed) mode points the SDK at the local proxy on a
 		// per-session bearer. Native (BYO-Anthropic) mode omits both so the SDK
 		// uses its own credential resolution from the subprocess env
@@ -239,6 +245,52 @@ export function buildModelEnumerationOptions(): Options {
  *
  * Exported for unit testing as a pure function over `process.env`.
  */
+export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | undefined, traceContext?: IAgentHostTraceContext): Record<string, string> {
+	if (!config) {
+		return {};
+	}
+	const env: Record<string, string> = {
+		CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: config.traces ? '1' : '0',
+		OTEL_TRACES_EXPORTER: config.traces ? 'otlp' : 'none',
+		OTEL_LOGS_EXPORTER: config.external ? 'otlp' : 'none',
+		OTEL_METRICS_EXPORTER: config.external ? 'otlp' : 'none',
+		OTEL_LOG_USER_PROMPTS: config.captureContent ? '1' : '0',
+		OTEL_LOG_ASSISTANT_RESPONSES: config.captureContent ? '1' : '0',
+		OTEL_LOG_TOOL_DETAILS: config.captureContent ? '1' : '0',
+		OTEL_LOG_TOOL_CONTENT: config.captureContent ? '1' : '0',
+	};
+	if (config.traces) {
+		env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = config.traces.endpoint;
+		env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = config.traces.protocol;
+	}
+	if (config.external) {
+		env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'logs');
+		env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = config.external.protocol;
+		env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'metrics');
+		env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = config.external.protocol;
+	}
+	if (traceContext) {
+		env.TRACEPARENT = traceContext.traceparent;
+		if (traceContext.tracestate) {
+			env.TRACESTATE = traceContext.tracestate;
+		}
+	}
+	return env;
+}
+
+function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {
+	try {
+		const url = new URL(endpoint);
+		if (url.pathname === '' || url.pathname === '/') {
+			url.pathname = `/v1/${signal}`;
+		}
+		return url.toString().replace(/\/$/, '');
+	} catch {
+		return endpoint;
+	}
+}
+
 export function buildSubprocessEnv(proxied: boolean = true): Record<string, string | undefined> {
 	// Proxy mode: a sparse env (creds arrive via settings.env), and the user's
 	// personal ANTHROPIC_API_KEY must not leak to the Copilot proxy.

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -251,7 +251,7 @@ export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | und
 	}
 	const env: Record<string, string> = {
 		CLAUDE_CODE_ENABLE_TELEMETRY: '1',
-		OTEL_SERVICE_NAME: 'claude',
+		OTEL_SERVICE_NAME: 'claude-code',
 		OTEL_RESOURCE_ATTRIBUTES: serializeResourceAttributes(config.resourceAttributes),
 		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: config.traces ? '1' : '0',
 		OTEL_TRACES_EXPORTER: config.traces ? 'otlp' : 'none',

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -269,6 +269,9 @@ export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | und
 		env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = config.external.protocol;
 		env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'metrics');
 		env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = config.external.protocol;
+		if (config.external.headers && Object.keys(config.external.headers).length > 0) {
+			env.OTEL_EXPORTER_OTLP_HEADERS = Object.entries(config.external.headers).map(([key, value]) => `${key}=${value}`).join(',');
+		}
 	}
 	if (traceContext) {
 		env.TRACEPARENT = traceContext.traceparent;

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -287,6 +287,8 @@ function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): st
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {
 			url.pathname = `/v1/${signal}`;
+		} else if (url.pathname.endsWith('/v1/traces')) {
+			url.pathname = `${url.pathname.slice(0, -'/v1/traces'.length)}/v1/${signal}`;
 		}
 		return url.toString().replace(/\/$/, '');
 	} catch {

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -267,12 +267,12 @@ export function buildClaudeTelemetryEnv(config: IAgentHostNativeOTelConfig | und
 		env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = config.traces.protocol;
 	}
 	if (config.external) {
-		env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'logs');
+		env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'logs', config.external.protocol);
 		env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = config.external.protocol;
-		env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'metrics');
+		env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = resolveSignalEndpoint(config.external.endpoint, 'metrics', config.external.protocol);
 		env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = config.external.protocol;
 		if (config.external.headers && Object.keys(config.external.headers).length > 0) {
-			env.OTEL_EXPORTER_OTLP_HEADERS = Object.entries(config.external.headers).map(([key, value]) => `${key}=${value}`).join(',');
+			env.OTEL_EXPORTER_OTLP_HEADERS = Object.entries(config.external.headers).map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join(',');
 		}
 	}
 	if (traceContext) {
@@ -288,7 +288,10 @@ function serializeResourceAttributes(attributes: Readonly<Record<string, string>
 	return Object.entries(attributes).map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(',');
 }
 
-function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {
+function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics', protocol: 'http/json' | 'http/protobuf' | 'grpc'): string {
+	if (protocol === 'grpc') {
+		return endpoint;
+	}
 	try {
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -52,6 +52,7 @@ import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
 import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { CodexAppServerClient, JsonRpcError, transportFromChildProcess, type ICodexAppServerClient, type ServerRequestHandlerResult } from './codexAppServerClient.js';
 import { ICodexProxyService, type ICodexProxyHandle } from './codexProxyService.js';
 import { createCodexSessionMapState, extractUserInputText, mapAgentMessageDelta, mapCommandExecutionOutputDelta, mapFileChangeOutputDelta, mapFileChangePatchUpdated, mapItemCompleted, mapItemStarted, mapMcpToolCallProgress, mapReasoningSummaryPartAdded, mapReasoningSummaryTextDelta, mapReasoningTextDelta, mapTokenUsageUpdated, mapTurnCompleted, mapTurnStarted, resetCodexTurnMapState, type ICodexSessionMapState } from './codexMapAppServerEvents.js';
@@ -838,6 +839,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		@IFileService private readonly _fileService: IFileService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 	) {
 		super();
 		this._metadataStore = this._instantiationService.createInstance(CodexSessionMetadataStore);
@@ -1487,7 +1489,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);
-		const launchConfig = buildCodexLaunchConfig(usageSource, process.env, proxyHandle, extraArgs);
+		const telemetry = await this._otelService.getNativeSdkTelemetryConfig();
+		const launchConfig = buildCodexLaunchConfig(usageSource, process.env, proxyHandle, extraArgs, telemetry);
 		const env = launchConfig.env;
 		const userCodexHome = process.env[AgentHostCodexAgentCodexHomeEnvVar];
 		if (userCodexHome) {
@@ -3095,6 +3098,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 	}
 
+	private _traceContext(session: ICodexSession) {
+		return this._otelService.getSessionTraceContext(session.sessionId, session.sessionUri.toString());
+	}
+
 	private async _materialize(session: ICodexSession): Promise<void> {
 		if (session.disposed) {
 			return;
@@ -3139,7 +3146,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			approvalsReviewer,
 			config: threadConfig,
 			dynamicTools: this._buildDynamicTools(session),
-		});
+		}, this._traceContext(session));
 		const threadId = startResult.thread.id;
 		if (multiRootActive && !session.workingDirectories && startResult.runtimeWorkspaceRoots?.length) {
 			session.workingDirectories = startResult.runtimeWorkspaceRoots.map(path => URI.file(path));
@@ -3433,6 +3440,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				const resumeResult = await conn.client.request<'thread/resume', ThreadResumeResponse>(
 					'thread/resume',
 					buildCodexResumeParams(this._usageSource, threadId, mcpServers, runtimeWorkspaceRoots),
+					this._traceContext(session),
 				);
 				if (multiRootActive && !session.workingDirectories && resumeResult.runtimeWorkspaceRoots?.length) {
 					session.workingDirectories = resumeResult.runtimeWorkspaceRoots.map(path => URI.file(path));
@@ -3469,7 +3477,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				input: input.slice(),
 				model: model.id,
 				...turnOptions,
-			});
+			}, this._traceContext(session));
 			// The thread now has committed history; client tools are locked to
 			// what was registered at `thread/start` and won't be re-applied.
 			session.firstTurnSent = true;

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -3599,10 +3599,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._logService.info(`[Codex DEBUG] disposeSession session=${sessionUri.toString()}`);
 		const sessionId = AgentSession.id(sessionUri);
 		const session = this._sessions.get(sessionId);
-		if (!session) {
-			return;
+		if (session) {
+			await this._teardownSessionInMemory(session, sessionId);
 		}
-		await this._teardownSessionInMemory(session, sessionId);
+		this._otelService.releaseSessionTraceContext(sessionUri.toString());
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexAppServerClient.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAppServerClient.ts
@@ -13,6 +13,7 @@ import type { ClientRequest } from './protocol/generated/ClientRequest.js';
 import type { RequestId } from './protocol/generated/RequestId.js';
 import type { ServerNotification } from './protocol/generated/ServerNotification.js';
 import type { ServerRequest } from './protocol/generated/ServerRequest.js';
+import type { IAgentHostTraceContext } from '../../common/otel/agentHostOTelService.js';
 
 // #region Wire types
 //
@@ -148,6 +149,7 @@ export interface ICodexAppServerClient extends IDisposable {
 	request<M extends ClientRequestMethod, R = unknown>(
 		method: M,
 		params: ClientRequestParams<M>,
+		trace?: IAgentHostTraceContext,
 	): Promise<R>;
 
 	/**
@@ -360,6 +362,7 @@ export class CodexAppServerClient extends Disposable implements ICodexAppServerC
 	request<M extends ClientRequestMethod, R = unknown>(
 		method: M,
 		params: ClientRequestParams<M>,
+		trace?: IAgentHostTraceContext,
 	): Promise<R> {
 		if (this._disposed) {
 			return Promise.reject(new CancellationError());
@@ -370,7 +373,12 @@ export class CodexAppServerClient extends Disposable implements ICodexAppServerC
 		const id = this._nextId++;
 		return new Promise<R>((resolve, reject) => {
 			this._pending.set(id, { method, resolve: resolve as (v: unknown) => void, reject });
-			const ok = this._writeMessage({ id, method, params });
+			const ok = this._writeMessage({
+				id,
+				method,
+				params,
+				...(trace ? { trace: { traceparent: trace.traceparent, tracestate: trace.tracestate } } : {}),
+			});
 			if (!ok) {
 				this._pending.delete(id);
 				reject(new JsonRpcError(JsonRpcErrorCode.InternalError, 'write failed; transport closed'));

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -102,6 +102,8 @@ function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): st
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {
 			url.pathname = `/v1/${signal}`;
+		} else if (url.pathname.endsWith('/v1/traces')) {
+			url.pathname = `${url.pathname.slice(0, -'/v1/traces'.length)}/v1/${signal}`;
 		}
 		return url.toString().replace(/\/$/, '');
 	} catch {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -85,8 +85,8 @@ export function codexTelemetryOverrides(config: IAgentHostNativeOTelConfig | und
 	return [
 		`otel.log_user_prompt=${config.captureContent}`,
 		config.traces ? `otel.trace_exporter=${codexExporter(config.traces)}` : 'otel.trace_exporter="none"',
-		config.external ? `otel.exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'logs') })}` : 'otel.exporter="none"',
-		config.external ? `otel.metrics_exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'metrics') })}` : 'otel.metrics_exporter="none"',
+		config.external ? `otel.exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'logs', config.external.protocol) })}` : 'otel.exporter="none"',
+		config.external ? `otel.metrics_exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'metrics', config.external.protocol) })}` : 'otel.metrics_exporter="none"',
 	];
 }
 
@@ -105,7 +105,10 @@ function serializeResourceAttributes(attributes: Readonly<Record<string, string>
 	return Object.entries(attributes).map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(',');
 }
 
-function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {
+function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics', protocol: 'http/json' | 'http/protobuf' | 'grpc'): string {
+	if (protocol === 'grpc') {
+		return endpoint;
+	}
 	try {
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -5,6 +5,7 @@
 
 import { AiAgentEnvValue, AiAgentEnvVar } from '../../../chat/common/aiAgentEnv.js';
 import type { CodexUsageSource } from '../../common/agentHostCustomizationConfig.js';
+import type { IAgentHostNativeOTelConfig } from '../../common/otel/agentHostOTelService.js';
 import type { ThreadResumeParams } from './protocol/generated/v2/ThreadResumeParams.js';
 import type { JsonValue } from './protocol/generated/serde_json/JsonValue.js';
 
@@ -40,6 +41,7 @@ export function buildCodexLaunchConfig(
 	inheritedEnv: NodeJS.ProcessEnv,
 	proxy: ICodexLaunchProxy | undefined,
 	extraArgs: readonly string[],
+	telemetry?: IAgentHostNativeOTelConfig,
 ): ICodexLaunchConfig {
 	if ((usageSource === 'copilot') !== (proxy !== undefined)) {
 		throw new Error(`Codex ${usageSource} launch received an invalid proxy configuration`);
@@ -64,9 +66,42 @@ export function buildCodexLaunchConfig(
 		`shell_environment_policy.set.${AiAgentEnvVar}="${AiAgentEnvValue}"`,
 		`features.tool_call_mcp_elicitation=false`,
 		...(proxy ? [`features.image_generation=false`] : []),
+		...codexTelemetryOverrides(telemetry),
 	];
 	return {
 		env,
 		args: ['app-server', ...overrides.flatMap(value => ['-c', value]), ...extraArgs],
 	};
+}
+
+export function codexTelemetryOverrides(config: IAgentHostNativeOTelConfig | undefined): string[] {
+	if (!config) {
+		return [];
+	}
+	return [
+		`otel.log_user_prompt=${config.captureContent}`,
+		config.traces ? `otel.trace_exporter=${codexExporter(config.traces)}` : 'otel.trace_exporter="none"',
+		config.external ? `otel.exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'logs') })}` : 'otel.exporter="none"',
+		config.external ? `otel.metrics_exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'metrics') })}` : 'otel.metrics_exporter="none"',
+	];
+}
+
+function codexExporter(config: { endpoint: string; protocol: 'http/json' | 'http/protobuf' | 'grpc' }): string {
+	if (config.protocol === 'grpc') {
+		return `{ otlp-grpc = { endpoint = ${JSON.stringify(config.endpoint)} } }`;
+	}
+	const protocol = config.protocol === 'http/json' ? 'json' : 'binary';
+	return `{ otlp-http = { endpoint = ${JSON.stringify(config.endpoint)}, protocol = ${JSON.stringify(protocol)} } }`;
+}
+
+function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {
+	try {
+		const url = new URL(endpoint);
+		if (url.pathname === '' || url.pathname === '/') {
+			url.pathname = `/v1/${signal}`;
+		}
+		return url.toString().replace(/\/$/, '');
+	} catch {
+		return endpoint;
+	}
 }

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -48,7 +48,7 @@ export function buildCodexLaunchConfig(
 	}
 	const env: NodeJS.ProcessEnv = { ...inheritedEnv, [AiAgentEnvVar]: AiAgentEnvValue };
 	if (telemetry) {
-		env.OTEL_SERVICE_NAME = 'codex';
+		delete env.OTEL_SERVICE_NAME;
 		env.OTEL_RESOURCE_ATTRIBUTES = serializeResourceAttributes(telemetry.resourceAttributes);
 	}
 	if (proxy) {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -47,6 +47,10 @@ export function buildCodexLaunchConfig(
 		throw new Error(`Codex ${usageSource} launch received an invalid proxy configuration`);
 	}
 	const env: NodeJS.ProcessEnv = { ...inheritedEnv, [AiAgentEnvVar]: AiAgentEnvValue };
+	if (telemetry) {
+		env.OTEL_SERVICE_NAME = 'codex';
+		env.OTEL_RESOURCE_ATTRIBUTES = serializeResourceAttributes(telemetry.resourceAttributes);
+	}
 	if (proxy) {
 		env.OPENAI_API_KEY = proxy.nonce;
 	}
@@ -95,6 +99,10 @@ function codexExporter(config: { endpoint: string; protocol: 'http/json' | 'http
 	}
 	const protocol = config.protocol === 'http/json' ? 'json' : 'binary';
 	return `{ otlp-http = { endpoint = ${JSON.stringify(config.endpoint)}, protocol = ${JSON.stringify(protocol)}${headers} } }`;
+}
+
+function serializeResourceAttributes(attributes: Readonly<Record<string, string>>): string {
+	return Object.entries(attributes).map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(',');
 }
 
 function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -86,12 +86,15 @@ export function codexTelemetryOverrides(config: IAgentHostNativeOTelConfig | und
 	];
 }
 
-function codexExporter(config: { endpoint: string; protocol: 'http/json' | 'http/protobuf' | 'grpc' }): string {
+function codexExporter(config: { endpoint: string; protocol: 'http/json' | 'http/protobuf' | 'grpc'; headers?: Readonly<Record<string, string>> }): string {
+	const headers = config.headers && Object.keys(config.headers).length > 0
+		? `, headers = { ${Object.entries(config.headers).map(([key, value]) => `${JSON.stringify(key)} = ${JSON.stringify(value)}`).join(', ')} }`
+		: '';
 	if (config.protocol === 'grpc') {
-		return `{ otlp-grpc = { endpoint = ${JSON.stringify(config.endpoint)} } }`;
+		return `{ otlp-grpc = { endpoint = ${JSON.stringify(config.endpoint)}${headers} } }`;
 	}
 	const protocol = config.protocol === 'http/json' ? 'json' : 'binary';
-	return `{ otlp-http = { endpoint = ${JSON.stringify(config.endpoint)}, protocol = ${JSON.stringify(protocol)} } }`;
+	return `{ otlp-http = { endpoint = ${JSON.stringify(config.endpoint)}, protocol = ${JSON.stringify(protocol)}${headers} } }`;
 }
 
 function resolveSignalEndpoint(endpoint: string, signal: 'logs' | 'metrics'): string {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -274,7 +274,10 @@ export function rebaseUnder(uri: URI, fromDir: URI, toDir: URI): URI | undefined
  */
 export class CopilotSessionEntry extends AgentSessionEntry<CopilotAgentSession> { }
 
-function resolveOtlpMetricsEndpoint(endpoint: string): string {
+export function resolveCopilotOtlpMetricsEndpoint(endpoint: string, protocol: 'http/json' | 'http/protobuf' | 'grpc'): string {
+	if (protocol === 'grpc') {
+		return endpoint;
+	}
 	try {
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {
@@ -1348,7 +1351,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				env['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL'] = nativeTelemetry.traces.protocol;
 			}
 			if (nativeTelemetry?.external) {
-				env['OTEL_EXPORTER_OTLP_METRICS_ENDPOINT'] = resolveOtlpMetricsEndpoint(nativeTelemetry.external.endpoint);
+				env['OTEL_EXPORTER_OTLP_METRICS_ENDPOINT'] = resolveCopilotOtlpMetricsEndpoint(nativeTelemetry.external.endpoint, nativeTelemetry.external.protocol);
 				env['OTEL_EXPORTER_OTLP_METRICS_PROTOCOL'] = nativeTelemetry.external.protocol;
 			} else if (nativeTelemetry) {
 				env['OTEL_METRICS_EXPORTER'] = 'none';
@@ -2501,6 +2504,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				await this._cleanupWorkspacelessScratchDir(this._workspacelessScratchDir(sessionId), sessionId);
 			}
 		});
+		this._otelService.releaseSessionTraceContext(session.toString());
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -279,6 +279,8 @@ function resolveOtlpMetricsEndpoint(endpoint: string): string {
 		const url = new URL(endpoint);
 		if (url.pathname === '' || url.pathname === '/') {
 			url.pathname = '/v1/metrics';
+		} else if (url.pathname.endsWith('/v1/traces')) {
+			url.pathname = `${url.pathname.slice(0, -'/v1/traces'.length)}/v1/metrics`;
 		}
 		return url.toString().replace(/\/$/, '');
 	} catch {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1339,6 +1339,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 			const telemetry = await this._otelService.getSdkTelemetryConfig();
 			const nativeTelemetry = await this._otelService.getNativeSdkTelemetryConfig();
+			if (nativeTelemetry) {
+				env['OTEL_SERVICE_NAME'] = 'github-copilot';
+				env['OTEL_RESOURCE_ATTRIBUTES'] = Object.entries(nativeTelemetry.resourceAttributes).map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(',');
+			}
 			if (nativeTelemetry?.traces) {
 				env['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] = nativeTelemetry.traces.endpoint;
 				env['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL'] = nativeTelemetry.traces.protocol;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -274,6 +274,18 @@ export function rebaseUnder(uri: URI, fromDir: URI, toDir: URI): URI | undefined
  */
 export class CopilotSessionEntry extends AgentSessionEntry<CopilotAgentSession> { }
 
+function resolveOtlpMetricsEndpoint(endpoint: string): string {
+	try {
+		const url = new URL(endpoint);
+		if (url.pathname === '' || url.pathname === '/') {
+			url.pathname = '/v1/metrics';
+		}
+		return url.toString().replace(/\/$/, '');
+	} catch {
+		return endpoint;
+	}
+}
+
 /**
  * Agent provider backed by the Copilot SDK {@link CopilotClient}.
  */
@@ -1324,6 +1336,17 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.info(`[Copilot] Resolved CLI path: ${cliPath}`);
 
 			const telemetry = await this._otelService.getSdkTelemetryConfig();
+			const nativeTelemetry = await this._otelService.getNativeSdkTelemetryConfig();
+			if (nativeTelemetry?.traces) {
+				env['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] = nativeTelemetry.traces.endpoint;
+				env['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL'] = nativeTelemetry.traces.protocol;
+			}
+			if (nativeTelemetry?.external) {
+				env['OTEL_EXPORTER_OTLP_METRICS_ENDPOINT'] = resolveOtlpMetricsEndpoint(nativeTelemetry.external.endpoint);
+				env['OTEL_EXPORTER_OTLP_METRICS_PROTOCOL'] = nativeTelemetry.external.protocol;
+			} else if (nativeTelemetry) {
+				env['OTEL_METRICS_EXPORTER'] = 'none';
+			}
 			const copilotSdkLogLevelAtStartup = this._resolveCopilotSdkLogLevel(copilotSdkLogLevelSettingAtStartup);
 
 			const clientOptions: CopilotClientOptions = {
@@ -1333,6 +1356,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				telemetry,
 				logLevel: copilotSdkLogLevelAtStartup,
 				enableRemoteSessions: sessionSyncAtStartup,
+				onGetTraceContext: () => this._otelService.getCurrentTraceContext() ?? {},
 				onGitHubTelemetry: notification => { void this._routeGitHubTelemetry(notification).catch(err => this._logService.trace(`[Copilot] GitHub telemetry routing failed: ${err instanceof Error ? err.message : String(err)}`)); },
 			};
 			const client = this._createCopilotClient(clientOptions);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -43,6 +43,7 @@ import { resolveCopilotConfigSlashCommandOnSend } from '../../common/copilotConf
 import { STREAMING_TOOL_DISPLAY_INTERVAL_MS, streamingToolDisplayText } from '../../common/streamingToolCallDisplay.js';
 import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment, type ToolCallContributor } from '../../common/state/protocol/state.js';
 import { ActionType, isChatAction, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, isDefaultChatUri, isSubagentSession, readSessionPromptCacheState, withSessionPromptCacheState, type Message, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type ToolResultTerminalContent, type Turn, type UsageInfo, type UsageInfoMeta, type IContextAttributionData, type ISessionPromptCacheState } from '../../common/state/sessionState.js';
@@ -859,6 +860,7 @@ export class CopilotAgentSession extends Disposable {
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
+		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 	) {
 		super();
 		this._abortCts.value = new CancellationTokenSource();
@@ -2079,7 +2081,8 @@ export class CopilotAgentSession extends Disposable {
 		await this.syncPermissionMode('turn-start');
 		await this._applyEffectiveSandboxConfig();
 		await this._reconcileMcpServerEnablement();
-		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
+		const traceContext = this._otelService.getSessionTraceContext(this.sessionId, this.sessionUri.toString());
+		await this._otelService.withTraceContext(traceContext, () => this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined }));
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -12,6 +12,8 @@ import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { CopilotCliConfigKey, applyModelFamilyAlias, copilotCliConfigSchema, normalizeToolSearchDeferThreshold } from '../../common/copilotCliConfig.js';
 import { agentHostModelSupportsToolSearch, CLIENT_TOOL_SEARCH_REFERENCE_NAME } from './toolSearchDeferral.js';
 import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
+import { AgentSession } from '../../common/agentService.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
@@ -389,6 +391,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		@IFileService private readonly _fileService: IFileService,
 		@IByokLmProxyService private readonly _byokLmProxyService: IByokLmProxyService,
 		@IByokLmBridgeRegistry private readonly _byokLmBridgeRegistry: IByokLmBridgeRegistry,
+		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 	) { }
 
 	async launch(plan: CopilotSessionLaunchPlan, runtime: ICopilotSessionRuntime): Promise<CopilotSessionWrapper> {
@@ -403,7 +406,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		try {
 			const stopWatch = new StopWatch();
 			this._logService.trace(`[Copilot:${plan.sessionId}] Calling SDK resumeSession...`);
-			const raw = await plan.client.resumeSession(plan.sessionId, config);
+			const raw = await this._withTraceContext(plan.sessionId, () => plan.client.resumeSession(plan.sessionId, config));
 			this._logService.trace(`[Copilot:${plan.sessionId}] SDK resumeSession succeeded after ${stopWatch.elapsed()}ms`);
 			await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
 			return new CopilotSessionWrapper(raw);
@@ -417,7 +420,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 				fallbackConfig = { ...config, agent: undefined };
 				this._logService.warn(`[Copilot:${plan.sessionId}] Stored custom agent '${plan.resolvedAgentName}' was not found; retrying resume without a custom agent`);
 				try {
-					const raw = await fallbackPlan.client.resumeSession(fallbackPlan.sessionId, fallbackConfig);
+					const raw = await this._withTraceContext(fallbackPlan.sessionId, () => fallbackPlan.client.resumeSession(fallbackPlan.sessionId, fallbackConfig));
 					await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
 					return new CopilotSessionWrapper(raw);
 				} catch (retryErr) {
@@ -446,8 +449,13 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		}
 	}
 
+	private _withTraceContext<T>(sessionId: string, fn: () => T): T {
+		const sessionUri = AgentSession.uri('copilotcli', sessionId).toString();
+		return this._otelService.withTraceContext(this._otelService.getSessionTraceContext(sessionId, sessionUri), fn);
+	}
+
 	private async _createSession(plan: ICopilotCreateSessionLaunchPlan, config: CopilotSessionLaunchConfig, sandboxConfig: ISdkSandboxConfig | undefined): Promise<CopilotSessionWrapper> {
-		const raw = await plan.client.createSession({
+		const raw = await this._withTraceContext(plan.sessionId, () => plan.client.createSession({
 			...config,
 			sessionId: plan.sessionId,
 			streaming: true,
@@ -456,7 +464,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			contextTier: getCopilotContextTier(plan.model, plan.longContextWindow, plan.freeLongContext),
 			...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
 			workingDirectory: plan.workingDirectory?.fsPath,
-		});
+		}));
 		await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
 		return new CopilotSessionWrapper(raw);
 	}

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -23,7 +23,7 @@ import { GenAiAttr } from '../../../otel/common/genAiAttributes.js';
 import { ICompletedSpanData, SpanStatusCode } from '../../../otel/common/spanData.js';
 import { OTelSqliteStore } from '../../../otel/node/sqlite/otelSqliteStore.js';
 import { AgentHostOTelSpansDbSubPath } from '../../common/agentService.js';
-import { AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
+import { AgentHostSessionSpanName, AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostNativeOTelConfig, IAgentHostOTelService, IAgentHostTraceContext } from '../../common/otel/agentHostOTelService.js';
 
 /** Sub-path under the user data directory where the span DB lives. */
 const SPANS_DB_SUBPATH = AgentHostOTelSpansDbSubPath;
@@ -153,7 +153,9 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 	private _spanStore: OTelSqliteStore | undefined;
 	private _forwarder: IOutboundForwarder | undefined;
 	private _startPromise: Promise<void> | undefined;
-	private _titleExportQueue = Promise.resolve();
+	private _metadataExportQueue = Promise.resolve();
+	private readonly _sessionContexts = new Map<string, IAgentHostTraceContext>();
+	private _currentTraceContext: IAgentHostTraceContext | undefined;
 
 	constructor(
 		private readonly _fetchFn: typeof globalThis.fetch | undefined,
@@ -186,6 +188,72 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		return this._buildPassthroughConfig();
 	}
 
+	async getNativeSdkTelemetryConfig(): Promise<IAgentHostNativeOTelConfig | undefined> {
+		if (!this._config.enabled) {
+			return undefined;
+		}
+		const protocol = this._config.otlpProtocol === 'grpc'
+			? 'grpc'
+			: this._config.otlpProtocol === 'http/protobuf' ? 'http/protobuf' : 'http/json';
+		const external = this._config.otlpEndpoint ? { endpoint: this._config.otlpEndpoint, protocol } as const : undefined;
+		if (!this._config.dbSpanExporter) {
+			return { traces: external, external, captureContent: this._config.captureContent === true };
+		}
+		await this._ensureStarted();
+		return {
+			traces: this._receiver ? { endpoint: `${this._receiver.baseUrl}/v1/traces`, protocol: 'http/json' } : external,
+			external,
+			captureContent: this._config.captureContent === true,
+		};
+	}
+
+	getSessionTraceContext(conversationId: string, sessionUri: string): IAgentHostTraceContext | undefined {
+		if (!this._config.enabled || !conversationId || !sessionUri) {
+			return undefined;
+		}
+		const existing = this._sessionContexts.get(sessionUri);
+		if (existing) {
+			return existing;
+		}
+		const traceId = generateUuid().replaceAll('-', '');
+		const spanId = generateUuid().replaceAll('-', '').slice(0, 16);
+		const context: IAgentHostTraceContext = { traceId, spanId, traceparent: `00-${traceId}-${spanId}-01` };
+		this._sessionContexts.set(sessionUri, context);
+		const now = Date.now();
+		this._queueSyntheticSpan({
+			name: AgentHostSessionSpanName,
+			traceId,
+			spanId,
+			startTime: now,
+			endTime: now,
+			status: { code: SpanStatusCode.OK },
+			attributes: {
+				...this._config.resourceAttributes,
+				[GenAiAttr.CONVERSATION_ID]: conversationId,
+				[AgentHostSessionUriAttribute]: sessionUri,
+			},
+			events: [],
+		});
+		return context;
+	}
+
+	withTraceContext<T>(context: IAgentHostTraceContext | undefined, fn: () => T): T {
+		const previous = this._currentTraceContext;
+		this._currentTraceContext = context;
+		try {
+			// Provider SDKs read their callback-based trace carrier synchronously
+			// while constructing the RPC promise. Do not retain context for the
+			// lifetime of that promise: concurrent turns must not inherit it.
+			return fn();
+		} finally {
+			this._currentTraceContext = previous;
+		}
+	}
+
+	getCurrentTraceContext(): IAgentHostTraceContext | undefined {
+		return this._currentTraceContext;
+	}
+
 	getSpansDbPath(): URI | undefined {
 		return this._config.dbSpanExporter ? URI.file(this._spansDbPath) : undefined;
 	}
@@ -199,13 +267,28 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		}
 
 		const boundedTitle = title.slice(0, 200);
-		this._titleExportQueue = this._titleExportQueue
-			.then(() => this._emitSessionTitleSpan(conversationId, sessionUri, boundedTitle))
-			.catch(err => this._logService.warn('[agentHost.otel] failed to emit session title span', err));
+		const context = this.getSessionTraceContext(conversationId, sessionUri);
+		const now = Date.now();
+		this._queueSyntheticSpan({
+			name: AgentHostSessionTitleSpanName,
+			traceId: context?.traceId ?? generateUuid().replaceAll('-', ''),
+			spanId: generateUuid().replaceAll('-', '').slice(0, 16),
+			parentSpanId: context?.spanId,
+			startTime: now,
+			endTime: now,
+			status: { code: SpanStatusCode.OK },
+			attributes: {
+				...this._config.resourceAttributes,
+				[GenAiAttr.CONVERSATION_ID]: conversationId,
+				[AgentHostSessionTitleAttribute]: boundedTitle,
+				[AgentHostSessionUriAttribute]: sessionUri,
+			},
+			events: [],
+		});
 	}
 
 	async flush(): Promise<void> {
-		await this._titleExportQueue;
+		await this._metadataExportQueue;
 		await this._startPromise;
 		if (this._forwarder) {
 			await this._forwarder.flush();
@@ -292,7 +375,13 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		this._logService.info(`[agentHost.otel] loopback receiver at ${receiver.baseUrl}, db ${this._spansDbPath}`);
 	}
 
-	private async _emitSessionTitleSpan(conversationId: string, sessionUri: string, title: string): Promise<void> {
+	private _queueSyntheticSpan(span: ICompletedSpanData): void {
+		this._metadataExportQueue = this._metadataExportQueue
+			.then(() => this._emitSyntheticSpan(span))
+			.catch(err => this._logService.warn('[agentHost.otel] failed to emit metadata span', err));
+	}
+
+	private async _emitSyntheticSpan(span: ICompletedSpanData): Promise<void> {
 		if (this._config.dbSpanExporter) {
 			await this._ensureStarted();
 		} else if (!this._forwarder) {
@@ -301,24 +390,6 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 				this._register(this._forwarder);
 			}
 		}
-
-		const now = Date.now();
-		const traceId = generateUuid().replaceAll('-', '');
-		const span: ICompletedSpanData = {
-			name: AgentHostSessionTitleSpanName,
-			traceId,
-			spanId: generateUuid().replaceAll('-', '').slice(0, 16),
-			startTime: now,
-			endTime: now,
-			status: { code: SpanStatusCode.OK },
-			attributes: {
-				...this._config.resourceAttributes,
-				[GenAiAttr.CONVERSATION_ID]: conversationId,
-				[AgentHostSessionTitleAttribute]: title,
-				[AgentHostSessionUriAttribute]: sessionUri,
-			},
-			events: [],
-		};
 
 		try {
 			this._spanStore?.insertSpan(span);
@@ -358,6 +429,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 					spans: [{
 						traceId: span.traceId,
 						spanId: span.spanId,
+						...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
 						name: span.name,
 						kind: 1,
 						startTimeUnixNano: `${span.startTime}000000`,

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -75,10 +75,14 @@ function parseOtlpHeaders(raw: string | undefined): Record<string, string> | und
 		if (eq <= 0) {
 			continue;
 		}
-		const key = pair.slice(0, eq).trim();
-		const value = pair.slice(eq + 1).trim();
-		if (key) {
-			out[key] = value;
+		const rawKey = pair.slice(0, eq).trim();
+		const rawValue = pair.slice(eq + 1).trim();
+		if (rawKey) {
+			try {
+				out[decodeURIComponent(rawKey)] = decodeURIComponent(rawValue);
+			} catch {
+				out[rawKey] = rawValue;
+			}
 		}
 	}
 	return Object.keys(out).length ? out : undefined;
@@ -266,7 +270,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		if (!this._config.enabled) {
 			return undefined;
 		}
-		const protocol = this._config.otlpProtocol === 'grpc'
+		const protocol = this._config.otlpProtocol === 'grpc' || this._config.otlpProtocol === 'http/grpc'
 			? 'grpc'
 			: this._config.otlpProtocol === 'http/protobuf' ? 'http/protobuf' : 'http/json';
 		const external = this._config.otlpEndpoint ? {
@@ -290,7 +294,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 	}
 
 	getSessionTraceContext(conversationId: string, sessionUri: string): IAgentHostTraceContext | undefined {
-		if (!this._config.enabled || !conversationId || !sessionUri) {
+		if (!this._config.enabled || !conversationId || !sessionUri || (!this._config.dbSpanExporter && !this._canForwardSyntheticSpan())) {
 			return undefined;
 		}
 		const existing = this._sessionContexts.get(sessionUri);
@@ -317,6 +321,10 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 			events: [],
 		});
 		return context;
+	}
+
+	releaseSessionTraceContext(sessionUri: string): void {
+		this._sessionContexts.delete(sessionUri);
 	}
 
 	withTraceContext<T>(context: IAgentHostTraceContext | undefined, fn: () => T): T {
@@ -553,8 +561,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		const children: IOutboundForwarder[] = [];
 		switch (this._config.exporterType) {
 			case 'otlp-http':
-			case 'otlp-grpc':
-				if (this._config.otlpEndpoint) {
+				if (this._config.otlpEndpoint && this._config.otlpProtocol !== 'http/protobuf') {
 					children.push(new OtlpHttpForwarder(
 						{
 							endpoint: this._config.otlpEndpoint,
@@ -563,6 +570,13 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 						this._logService,
 						this._fetchFn,
 					));
+				} else if (this._config.otlpEndpoint) {
+					this._logService.warn('[agentHost.otel] DB trace fan-out is unavailable for OTLP/HTTP protobuf; traces remain in the local DB while provider logs and metrics export directly');
+				}
+				break;
+			case 'otlp-grpc':
+				if (this._config.otlpEndpoint) {
+					this._logService.warn('[agentHost.otel] DB trace fan-out is unavailable for OTLP/gRPC; traces remain in the local DB while provider logs and metrics export directly');
 				}
 				break;
 			case 'file':

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -195,7 +195,11 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		const protocol = this._config.otlpProtocol === 'grpc'
 			? 'grpc'
 			: this._config.otlpProtocol === 'http/protobuf' ? 'http/protobuf' : 'http/json';
-		const external = this._config.otlpEndpoint ? { endpoint: this._config.otlpEndpoint, protocol } as const : undefined;
+		const external = this._config.otlpEndpoint ? {
+			endpoint: this._config.otlpEndpoint,
+			protocol,
+			...(this._config.headers ? { headers: this._config.headers } : {}),
+		} as const : undefined;
 		if (!this._config.dbSpanExporter) {
 			return { traces: external, external, captureContent: this._config.captureContent === true };
 		}

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -23,7 +23,7 @@ import { GenAiAttr } from '../../../otel/common/genAiAttributes.js';
 import { ICompletedSpanData, SpanStatusCode } from '../../../otel/common/spanData.js';
 import { OTelSqliteStore } from '../../../otel/node/sqlite/otelSqliteStore.js';
 import { AgentHostOTelSpansDbSubPath } from '../../common/agentService.js';
-import { AgentHostSessionSpanName, AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostNativeOTelConfig, IAgentHostOTelService, IAgentHostTraceContext } from '../../common/otel/agentHostOTelService.js';
+import { AgentHostOTelServiceName, AgentHostOTelServiceNamespace, AgentHostSessionSpanName, AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostNativeOTelConfig, IAgentHostOTelService, IAgentHostTraceContext } from '../../common/otel/agentHostOTelService.js';
 
 /** Sub-path under the user data directory where the span DB lives. */
 const SPANS_DB_SUBPATH = AgentHostOTelSpansDbSubPath;
@@ -100,9 +100,8 @@ function parseResourceAttributes(raw: string | undefined, serviceName: string | 
 			}
 		}
 	}
-	if (serviceName) {
-		attributes['service.name'] = serviceName;
-	}
+	attributes['service.namespace'] = AgentHostOTelServiceNamespace;
+	attributes['service.name'] = serviceName ?? attributes['service.name'] ?? AgentHostOTelServiceName;
 	return attributes;
 }
 
@@ -140,6 +139,15 @@ export function readAgentHostOTelEnv(env: NodeJS.ProcessEnv): ResolvedConfig {
 		otlpProtocol: protocol,
 		resourceAttributes: parseResourceAttributes(env.OTEL_RESOURCE_ATTRIBUTES, env.OTEL_SERVICE_NAME),
 	};
+}
+
+function upsertResourceAttribute(attributes: Array<{ key?: string; value?: { stringValue?: string } }>, key: string, value: string): void {
+	const existing = attributes.find(attribute => attribute.key === key);
+	if (existing) {
+		existing.value = { stringValue: value };
+	} else {
+		attributes.push({ key, value: { stringValue: value } });
+	}
 }
 
 export class AgentHostOTelService extends Disposable implements IAgentHostOTelService {
@@ -200,14 +208,18 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 			protocol,
 			...(this._config.headers ? { headers: this._config.headers } : {}),
 		} as const : undefined;
+		const resourceAttributes = { ...this._config.resourceAttributes };
+		delete resourceAttributes['service.name'];
+		resourceAttributes['service.namespace'] = AgentHostOTelServiceNamespace;
 		if (!this._config.dbSpanExporter) {
-			return { traces: external, external, captureContent: this._config.captureContent === true };
+			return { traces: external, external, captureContent: this._config.captureContent === true, resourceAttributes };
 		}
 		await this._ensureStarted();
 		return {
 			traces: this._receiver ? { endpoint: `${this._receiver.baseUrl}/v1/traces`, protocol: 'http/json' } : external,
 			external,
 			captureContent: this._config.captureContent === true,
+			resourceAttributes,
 		};
 	}
 
@@ -351,6 +363,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		// 3. Loopback OTLP/HTTP receiver.
 		const receiver = await startLocalOtlpHttpReceiver(
 			{
+				transformBody: body => this._normalizeNativeResourceIdentity(body),
 				onSpans: result => {
 					for (const span of result.spans) {
 						try {
@@ -405,6 +418,21 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		if (this._canForwardSyntheticSpan()) {
 			this._forwarder?.forwardRaw?.(this._encodeOtlpSpan(span), 'application/json');
 		}
+	}
+
+	private _normalizeNativeResourceIdentity(body: Buffer): Buffer {
+		const payload = JSON.parse(body.toString('utf8')) as { resourceSpans?: Array<{ resource?: { attributes?: Array<{ key?: string; value?: { stringValue?: string } }> } }> };
+		for (const resourceSpan of payload.resourceSpans ?? []) {
+			const attributes = resourceSpan.resource ??= {};
+			const values = attributes.attributes ??= [];
+			const serviceName = values.find(attribute => attribute.key === 'service.name')?.value?.stringValue;
+			const normalizedName = serviceName === 'claude-code' ? 'claude' : serviceName === 'codex-app-server' ? 'codex' : serviceName;
+			upsertResourceAttribute(values, 'service.namespace', AgentHostOTelServiceNamespace);
+			if (normalizedName) {
+				upsertResourceAttribute(values, 'service.name', normalizedName);
+			}
+		}
+		return Buffer.from(JSON.stringify(payload));
 	}
 
 	private _canForwardSyntheticSpan(): boolean {

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { mkdir } from 'fs/promises';
+import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { dirname, join } from '../../../../base/common/path.js';
 import type { TelemetryConfig } from '@github/copilot-sdk';
 import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -141,13 +142,74 @@ export function readAgentHostOTelEnv(env: NodeJS.ProcessEnv): ResolvedConfig {
 	};
 }
 
-function upsertResourceAttribute(attributes: Array<{ key?: string; value?: { stringValue?: string } }>, key: string, value: string): void {
+interface IOtlpAttribute {
+	key?: string;
+	value?: { stringValue?: string };
+}
+
+interface IOtlpSpan {
+	name?: string;
+	attributes?: IOtlpAttribute[];
+}
+
+interface IOtlpScopeSpans {
+	spans?: IOtlpSpan[];
+}
+
+interface IOtlpResourceSpans {
+	resource?: { attributes?: IOtlpAttribute[] };
+	scopeSpans?: IOtlpScopeSpans[];
+}
+
+interface IOtlpTracePayload {
+	resourceSpans?: IOtlpResourceSpans[];
+}
+
+export interface INormalizedAgentHostOtlpBody {
+	readonly body: Buffer;
+	readonly filteredSpanCount: number;
+}
+
+const CodexAuthPollingServiceName = 'codex-app-server';
+const CodexAuthPollingSpanName = 'auth';
+const CodexAuthPollingModuleName = 'codex_login::auth::manager';
+
+function attributeValue(attributes: readonly IOtlpAttribute[] | undefined, key: string): string | undefined {
+	return attributes?.find(attribute => attribute.key === key)?.value?.stringValue;
+}
+
+function upsertResourceAttribute(attributes: IOtlpAttribute[], key: string, value: string): void {
 	const existing = attributes.find(attribute => attribute.key === key);
 	if (existing) {
 		existing.value = { stringValue: value };
 	} else {
 		attributes.push({ key, value: { stringValue: value } });
 	}
+}
+
+/** Normalize Agent Host resource identity and suppress the Codex 0.142 auth polling span. */
+export function normalizeAgentHostOtlpBody(body: Buffer): INormalizedAgentHostOtlpBody {
+	const payload = JSON.parse(body.toString('utf8')) as IOtlpTracePayload;
+	let filteredSpanCount = 0;
+	for (const resourceSpan of payload.resourceSpans ?? []) {
+		const resource = resourceSpan.resource ??= {};
+		const resourceAttributes = resource.attributes ??= [];
+		const isCodex = attributeValue(resourceAttributes, 'service.name') === CodexAuthPollingServiceName;
+		upsertResourceAttribute(resourceAttributes, 'service.namespace', AgentHostOTelServiceNamespace);
+		for (const scopeSpans of resourceSpan.scopeSpans ?? []) {
+			const spans = scopeSpans.spans ?? [];
+			scopeSpans.spans = spans.filter(span => {
+				const shouldFilter = isCodex
+					&& span.name === CodexAuthPollingSpanName
+					&& attributeValue(span.attributes, 'code.module.name') === CodexAuthPollingModuleName;
+				if (shouldFilter) {
+					filteredSpanCount++;
+				}
+				return !shouldFilter;
+			});
+		}
+	}
+	return { body: Buffer.from(JSON.stringify(payload)), filteredSpanCount };
 }
 
 export class AgentHostOTelService extends Disposable implements IAgentHostOTelService {
@@ -164,6 +226,9 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 	private _metadataExportQueue = Promise.resolve();
 	private readonly _sessionContexts = new Map<string, IAgentHostTraceContext>();
 	private _currentTraceContext: IAgentHostTraceContext | undefined;
+	private _pendingFilteredCodexAuthSpans = 0;
+	private _totalFilteredCodexAuthSpans = 0;
+	private readonly _filteredSpanLogScheduler: RunOnceScheduler;
 
 	constructor(
 		private readonly _fetchFn: typeof globalThis.fetch | undefined,
@@ -171,6 +236,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 	) {
 		super();
+		this._filteredSpanLogScheduler = this._register(new RunOnceScheduler(() => this._logFilteredCodexAuthSpans(), 60_000));
 		this._config = readAgentHostOTelEnv(process.env);
 		this._spansDbPath = join(environmentService.userDataPath, SPANS_DB_SUBPATH);
 	}
@@ -304,6 +370,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 	}
 
 	async flush(): Promise<void> {
+		this._filteredSpanLogScheduler.flush();
 		await this._metadataExportQueue;
 		await this._startPromise;
 		if (this._forwarder) {
@@ -363,7 +430,11 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		// 3. Loopback OTLP/HTTP receiver.
 		const receiver = await startLocalOtlpHttpReceiver(
 			{
-				transformBody: body => this._normalizeNativeResourceIdentity(body),
+				transformBody: body => {
+					const normalized = normalizeAgentHostOtlpBody(body);
+					this._recordFilteredCodexAuthSpans(normalized.filteredSpanCount);
+					return normalized.body;
+				},
 				onSpans: result => {
 					for (const span of result.spans) {
 						try {
@@ -420,14 +491,23 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		}
 	}
 
-	private _normalizeNativeResourceIdentity(body: Buffer): Buffer {
-		const payload = JSON.parse(body.toString('utf8')) as { resourceSpans?: Array<{ resource?: { attributes?: Array<{ key?: string; value?: { stringValue?: string } }> } }> };
-		for (const resourceSpan of payload.resourceSpans ?? []) {
-			const attributes = resourceSpan.resource ??= {};
-			const values = attributes.attributes ??= [];
-			upsertResourceAttribute(values, 'service.namespace', AgentHostOTelServiceNamespace);
+	private _recordFilteredCodexAuthSpans(count: number): void {
+		if (count <= 0) {
+			return;
 		}
-		return Buffer.from(JSON.stringify(payload));
+		this._pendingFilteredCodexAuthSpans = Math.min(Number.MAX_SAFE_INTEGER, this._pendingFilteredCodexAuthSpans + count);
+		this._totalFilteredCodexAuthSpans = Math.min(Number.MAX_SAFE_INTEGER, this._totalFilteredCodexAuthSpans + count);
+		if (!this._filteredSpanLogScheduler.isScheduled()) {
+			this._filteredSpanLogScheduler.schedule();
+		}
+	}
+
+	private _logFilteredCodexAuthSpans(): void {
+		if (this._pendingFilteredCodexAuthSpans === 0) {
+			return;
+		}
+		this._logService.info(`[agentHost.otel] filtered ${this._pendingFilteredCodexAuthSpans} Codex 0.142 auth polling span(s); total=${this._totalFilteredCodexAuthSpans}`);
+		this._pendingFilteredCodexAuthSpans = 0;
 	}
 
 	private _canForwardSyntheticSpan(): boolean {

--- a/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/node/otel/agentHostOTelService.ts
@@ -425,12 +425,7 @@ export class AgentHostOTelService extends Disposable implements IAgentHostOTelSe
 		for (const resourceSpan of payload.resourceSpans ?? []) {
 			const attributes = resourceSpan.resource ??= {};
 			const values = attributes.attributes ??= [];
-			const serviceName = values.find(attribute => attribute.key === 'service.name')?.value?.stringValue;
-			const normalizedName = serviceName === 'claude-code' ? 'claude' : serviceName === 'codex-app-server' ? 'codex' : serviceName;
 			upsertResourceAttribute(values, 'service.namespace', AgentHostOTelServiceNamespace);
-			if (normalizedName) {
-				upsertResourceAttribute(values, 'service.name', normalizedName);
-			}
 		}
 		return Buffer.from(JSON.stringify(payload));
 	}

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -54,6 +54,7 @@ import { type AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../commo
 import { ActionType } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, ToolResultContentType, ChatInputResponseKind, ChatInputAnswerState, ChatInputAnswerValueKind, type ChatInputRequest, type ClientPluginCustomization } from '../../common/state/sessionState.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
@@ -76,6 +77,18 @@ import {
 	makeTextDelta,
 	makeUserToolResultMessage,
 } from './claudeMapSessionEventsTestUtils.js';
+
+const noopOTelService: IAgentHostOTelService = {
+	_serviceBrand: undefined,
+	getSdkTelemetryConfig: async () => undefined,
+	getNativeSdkTelemetryConfig: async () => undefined,
+	getSessionTraceContext: () => undefined,
+	withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
+	getCurrentTraceContext: () => undefined,
+	getSpansDbPath: () => undefined,
+	emitSessionTitleChanged: () => { },
+	flush: async () => { },
+};
 
 // #region Test fixtures
 
@@ -656,6 +669,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostOTelService, noopOTelService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
@@ -788,6 +802,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostOTelService, noopOTelService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
@@ -864,6 +879,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostOTelService, noopOTelService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -83,6 +83,7 @@ const noopOTelService: IAgentHostOTelService = {
 	getSdkTelemetryConfig: async () => undefined,
 	getNativeSdkTelemetryConfig: async () => undefined,
 	getSessionTraceContext: () => undefined,
+	releaseSessionTraceContext: () => { },
 	withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
 	getCurrentTraceContext: () => undefined,
 	getSpansDbPath: () => undefined,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5004,6 +5004,7 @@ suite('ClaudeAgentSession (Phase 7 §3.2)', () => {
 			[ILogService, new NullLogService()],
 			[IAgentConfigurationService, fakeConfigService],
 			[IAgentHostStateManager, stateManager],
+			[IAgentHostOTelService, new RecordingOTelService()],
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[ISessionDataService, sessionData],

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -771,6 +771,7 @@ class RecordingOTelService implements IAgentHostOTelService {
 	async getSdkTelemetryConfig(): Promise<undefined> { return undefined; }
 	async getNativeSdkTelemetryConfig(): Promise<undefined> { return undefined; }
 	getSessionTraceContext(): undefined { return undefined; }
+	releaseSessionTraceContext(): void { }
 	withTraceContext<T>(_context: undefined, fn: () => T): T { return fn(); }
 	getCurrentTraceContext(): undefined { return undefined; }
 	getSpansDbPath(): undefined { return undefined; }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -769,6 +769,10 @@ class RecordingOTelService implements IAgentHostOTelService {
 	readonly _serviceBrand: undefined;
 	readonly titleChanges: Array<{ conversationId: string; sessionUri: string; title: string }> = [];
 	async getSdkTelemetryConfig(): Promise<undefined> { return undefined; }
+	async getNativeSdkTelemetryConfig(): Promise<undefined> { return undefined; }
+	getSessionTraceContext(): undefined { return undefined; }
+	withTraceContext<T>(_context: undefined, fn: () => T): T { return fn(); }
+	getCurrentTraceContext(): undefined { return undefined; }
 	getSpansDbPath(): undefined { return undefined; }
 	emitSessionTitleChanged(conversationId: string, sessionUri: string, title: string): void {
 		this.titleChanges.push({ conversationId, sessionUri, title });

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -82,6 +82,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
 			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf' },
 			captureContent: false,
+			resourceAttributes: { 'service.namespace': 'vscode.agent-host', region: 'west us' },
 		}, {
 			traceId: '1'.repeat(32),
 			spanId: '2'.repeat(16),
@@ -90,6 +91,8 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 
 		assert.deepStrictEqual(env, {
 			CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+			OTEL_SERVICE_NAME: 'claude',
+			OTEL_RESOURCE_ATTRIBUTES: 'service.namespace=vscode.agent-host,region=west%20us',
 			CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: '1',
 			OTEL_TRACES_EXPORTER: 'otlp',
 			OTEL_LOGS_EXPORTER: 'otlp',

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -91,7 +91,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 
 		assert.deepStrictEqual(env, {
 			CLAUDE_CODE_ENABLE_TELEMETRY: '1',
-			OTEL_SERVICE_NAME: 'claude',
+			OTEL_SERVICE_NAME: 'claude-code',
 			OTEL_RESOURCE_ATTRIBUTES: 'service.namespace=vscode.agent-host,region=west%20us',
 			CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: '1',
 			OTEL_TRACES_EXPORTER: 'otlp',

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { buildOptions, buildSubprocessEnv } from '../../node/claude/claudeSdkOptions.js';
+import { buildClaudeTelemetryEnv, buildOptions, buildSubprocessEnv } from '../../node/claude/claudeSdkOptions.js';
 import type { ClaudeTransport, IClaudeProxyHandle } from '../../node/claude/claudeProxyService.js';
 
 suite('claudeSdkOptions / buildSubprocessEnv', () => {
@@ -74,6 +74,37 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			home: '/Users/test',
 			userProfile: 'C:\\Users\\test',
 			aiAgent: 'github_copilot_vscode_agent',
+		});
+	});
+
+	test('maps Agent Host traces to loopback and logs/metrics to the external sink', () => {
+		const env = buildClaudeTelemetryEnv({
+			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
+			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf' },
+			captureContent: false,
+		}, {
+			traceId: '1'.repeat(32),
+			spanId: '2'.repeat(16),
+			traceparent: `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`,
+		});
+
+		assert.deepStrictEqual(env, {
+			CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+			CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: '1',
+			OTEL_TRACES_EXPORTER: 'otlp',
+			OTEL_LOGS_EXPORTER: 'otlp',
+			OTEL_METRICS_EXPORTER: 'otlp',
+			OTEL_LOG_USER_PROMPTS: '0',
+			OTEL_LOG_ASSISTANT_RESPONSES: '0',
+			OTEL_LOG_TOOL_DETAILS: '0',
+			OTEL_LOG_TOOL_CONTENT: '0',
+			OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: 'http://127.0.0.1:4567/v1/traces',
+			OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: 'http/json',
+			OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: 'http://collector:4318/v1/logs',
+			OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: 'http/protobuf',
+			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: 'http://collector:4318/v1/metrics',
+			OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: 'http/protobuf',
+			TRACEPARENT: `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -80,7 +80,7 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 	test('maps Agent Host traces to loopback and logs/metrics to the external sink', () => {
 		const env = buildClaudeTelemetryEnv({
 			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
-			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf' },
+			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf', headers: { authorization: 'Bearer test/token' } },
 			captureContent: false,
 			resourceAttributes: { 'service.namespace': 'vscode.agent-host', region: 'west us' },
 		}, {
@@ -107,7 +107,26 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: 'http/protobuf',
 			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: 'http://collector:4318/v1/metrics',
 			OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: 'http/protobuf',
+			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer%20test%2Ftoken',
 			TRACEPARENT: `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`,
+		});
+	});
+
+	test('keeps gRPC signal endpoints unchanged', () => {
+		const env = buildClaudeTelemetryEnv({
+			traces: { endpoint: 'https://collector:4317', protocol: 'grpc' },
+			external: { endpoint: 'https://collector:4317', protocol: 'grpc' },
+			captureContent: false,
+			resourceAttributes: {},
+		});
+		assert.deepStrictEqual({
+			trace: env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+			logs: env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+			metrics: env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+		}, {
+			trace: 'https://collector:4317',
+			logs: 'https://collector:4317',
+			metrics: 'https://collector:4317',
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexAppServerClient.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexAppServerClient.test.ts
@@ -150,6 +150,29 @@ suite('CodexAppServerClient', () => {
 		}
 	});
 
+	test('request includes W3C trace context when provided', async () => {
+		const peer = makeFakePeer();
+		const client = new CodexAppServerClient(peer.transport);
+		try {
+			const responsePromise = client.request('getAuthStatus', { refreshToken: false, includeToken: false }, {
+				traceId: '1'.repeat(32),
+				spanId: '2'.repeat(16),
+				traceparent: `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`,
+				tracestate: 'vendor=value',
+			});
+			const sent = await readNextMessage(peer.outbound) as { id: number; trace: unknown };
+			assert.deepStrictEqual(sent.trace, {
+				traceparent: `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`,
+				tracestate: 'vendor=value',
+			});
+			peer.push({ id: sent.id, result: { authMode: 'apikey' } });
+			await responsePromise;
+		} finally {
+			client.dispose();
+			peer.dispose();
+		}
+	});
+
 	test('request rejects with JsonRpcError on error envelope', async () => {
 		const peer = makeFakePeer();
 		const client = new CodexAppServerClient(peer.transport);

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -43,6 +43,18 @@ suite('CodexLaunchConfig', () => {
 		assert.ok(config.args.includes('otel.metrics_exporter={ otlp-http = { endpoint = "http://collector:4318/v1/metrics", protocol = "binary", headers = { "authorization" = "Bearer test" } } }'));
 	});
 
+	test('keeps gRPC signal endpoints unchanged and uses decoded headers', () => {
+		const config = buildCodexLaunchConfig('openai', {}, undefined, [], {
+			traces: { endpoint: 'https://collector:4317', protocol: 'grpc' },
+			external: { endpoint: 'https://collector:4317', protocol: 'grpc', headers: { authorization: 'Bearer test/token' } },
+			captureContent: false,
+			resourceAttributes: {},
+		});
+		const expected = '{ otlp-grpc = { endpoint = "https://collector:4317", headers = { "authorization" = "Bearer test/token" } } }';
+		assert.ok(config.args.includes(`otel.exporter=${expected}`));
+		assert.ok(config.args.includes(`otel.metrics_exporter=${expected}`));
+	});
+
 	test('identifies provider-compatible threads', () => {
 		assert.deepStrictEqual({
 			copilotProxy: isCodexThreadProviderCompatible('copilot', 'vscode-proxy'),

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -28,6 +28,18 @@ suite('CodexLaunchConfig', () => {
 		]);
 	});
 
+	test('routes traces to loopback and logs/metrics directly to the external sink', () => {
+		const config = buildCodexLaunchConfig('openai', {}, undefined, [], {
+			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
+			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf' },
+			captureContent: false,
+		});
+		assert.ok(config.args.includes('otel.log_user_prompt=false'));
+		assert.ok(config.args.includes('otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:4567/v1/traces", protocol = "json" } }'));
+		assert.ok(config.args.includes('otel.exporter={ otlp-http = { endpoint = "http://collector:4318/v1/logs", protocol = "binary" } }'));
+		assert.ok(config.args.includes('otel.metrics_exporter={ otlp-http = { endpoint = "http://collector:4318/v1/metrics", protocol = "binary" } }'));
+	});
+
 	test('identifies provider-compatible threads', () => {
 		assert.deepStrictEqual({
 			copilotProxy: isCodexThreadProviderCompatible('copilot', 'vscode-proxy'),

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -31,13 +31,13 @@ suite('CodexLaunchConfig', () => {
 	test('routes traces to loopback and logs/metrics directly to the external sink', () => {
 		const config = buildCodexLaunchConfig('openai', {}, undefined, [], {
 			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
-			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf' },
+			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf', headers: { authorization: 'Bearer test' } },
 			captureContent: false,
 		});
 		assert.ok(config.args.includes('otel.log_user_prompt=false'));
 		assert.ok(config.args.includes('otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:4567/v1/traces", protocol = "json" } }'));
-		assert.ok(config.args.includes('otel.exporter={ otlp-http = { endpoint = "http://collector:4318/v1/logs", protocol = "binary" } }'));
-		assert.ok(config.args.includes('otel.metrics_exporter={ otlp-http = { endpoint = "http://collector:4318/v1/metrics", protocol = "binary" } }'));
+		assert.ok(config.args.includes('otel.exporter={ otlp-http = { endpoint = "http://collector:4318/v1/logs", protocol = "binary", headers = { "authorization" = "Bearer test" } } }'));
+		assert.ok(config.args.includes('otel.metrics_exporter={ otlp-http = { endpoint = "http://collector:4318/v1/metrics", protocol = "binary", headers = { "authorization" = "Bearer test" } } }'));
 	});
 
 	test('identifies provider-compatible threads', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -35,7 +35,7 @@ suite('CodexLaunchConfig', () => {
 			captureContent: false,
 			resourceAttributes: { 'service.namespace': 'vscode.agent-host', region: 'west us' },
 		});
-		assert.strictEqual(config.env.OTEL_SERVICE_NAME, 'codex');
+		assert.strictEqual(config.env.OTEL_SERVICE_NAME, undefined);
 		assert.strictEqual(config.env.OTEL_RESOURCE_ATTRIBUTES, 'service.namespace=vscode.agent-host,region=west%20us');
 		assert.ok(config.args.includes('otel.log_user_prompt=false'));
 		assert.ok(config.args.includes('otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:4567/v1/traces", protocol = "json" } }'));

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -33,7 +33,10 @@ suite('CodexLaunchConfig', () => {
 			traces: { endpoint: 'http://127.0.0.1:4567/v1/traces', protocol: 'http/json' },
 			external: { endpoint: 'http://collector:4318', protocol: 'http/protobuf', headers: { authorization: 'Bearer test' } },
 			captureContent: false,
+			resourceAttributes: { 'service.namespace': 'vscode.agent-host', region: 'west us' },
 		});
+		assert.strictEqual(config.env.OTEL_SERVICE_NAME, 'codex');
+		assert.strictEqual(config.env.OTEL_RESOURCE_ATTRIBUTES, 'service.namespace=vscode.agent-host,region=west%20us');
 		assert.ok(config.args.includes('otel.log_user_prompt=false'));
 		assert.ok(config.args.includes('otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:4567/v1/traces", protocol = "json" } }'));
 		assert.ok(config.args.includes('otel.exporter={ otlp-http = { endpoint = "http://collector:4318/v1/logs", protocol = "binary", headers = { "authorization" = "Bearer test" } } }'));

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -22,6 +22,7 @@ import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { ISessionDataService } from '../../../common/sessionDataService.js';
 import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
 import { AgentHostCodexMultiRootEnabledConfigKey } from '../../../common/agentHostSchema.js';
+import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 
 function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Promise<CCAModel[]>, rootConfig: Record<string, boolean> = {}): CodexAgent {
 	const instantiationService = new TestInstantiationService();
@@ -35,6 +36,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Pr
 	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(ILogService, logService);

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -180,6 +180,7 @@ async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: I
 		_serviceBrand: undefined,
 		getNativeSdkTelemetryConfig: async () => undefined,
 		getSessionTraceContext: () => undefined,
+		releaseSessionTraceContext: () => { },
 	});
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -27,6 +27,7 @@ import { AgentConfigurationService, IAgentConfigurationService } from '../../../
 import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 import { CodexAgent } from '../../../node/codex/codexAgent.js';
 import { CodexAppServerClient, type ICodexAppServerTransport } from '../../../node/codex/codexAppServerClient.js';
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
@@ -175,6 +176,7 @@ async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: I
 	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined, isSdkResolvableWithoutDownload: async () => true });
+	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(IFileService, fileService);

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -176,7 +176,11 @@ async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: I
 	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined, isSdkResolvableWithoutDownload: async () => true });
-	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
+	instantiationService.stub(IAgentHostOTelService, {
+		_serviceBrand: undefined,
+		getNativeSdkTelemetryConfig: async () => undefined,
+		getSessionTraceContext: () => undefined,
+	});
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(IFileService, fileService);

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -20,6 +20,7 @@ import { IAgentConfigurationService } from '../../../node/agentConfigurationServ
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
+import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 
 function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 	const instantiationService = new TestInstantiationService();
@@ -32,6 +33,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 		getRootValue: () => undefined,
 	});
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(ILogService, new NullLogService());

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -47,7 +47,7 @@ import { IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../c
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentHostCompletions, IAgentHostCompletions } from '../../node/agentHostCompletions.js';
-import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, rebaseUnder, REFRESH_DEBOUNCE_MS } from '../../node/copilot/copilotAgent.js';
+import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, rebaseUnder, REFRESH_DEBOUNCE_MS, resolveCopilotOtlpMetricsEndpoint } from '../../node/copilot/copilotAgent.js';
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS } from '../../node/copilot/prompts/systemMessage.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostReviewService, NULL_REVIEW_SERVICE } from '../../common/agentHostReviewService.js';
@@ -472,6 +472,7 @@ class MockAgentHostOTelService implements IAgentHostOTelService {
 	}
 	async getNativeSdkTelemetryConfig() { return undefined; }
 	getSessionTraceContext() { return undefined; }
+	releaseSessionTraceContext() { }
 	withTraceContext<T>(_context: undefined, fn: () => T): T { return fn(); }
 	getCurrentTraceContext() { return undefined; }
 	getSpansDbPath() {
@@ -622,6 +623,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 		getSdkTelemetryConfig: async () => undefined,
 		getNativeSdkTelemetryConfig: async () => undefined,
 		getSessionTraceContext: () => undefined,
+		releaseSessionTraceContext: () => { },
 		withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
 		getCurrentTraceContext: () => undefined,
 		getSpansDbPath: () => undefined,
@@ -5133,6 +5135,12 @@ suite('CopilotAgent', () => {
 	});
 
 	suite('customization anchoring', () => {
+
+		test('uses signal paths only for Copilot OTLP/HTTP metrics endpoints', () => {
+			assert.strictEqual(resolveCopilotOtlpMetricsEndpoint('http://collector:4318', 'http/protobuf'), 'http://collector:4318/v1/metrics');
+			assert.strictEqual(resolveCopilotOtlpMetricsEndpoint('http://collector:4318/custom', 'http/json'), 'http://collector:4318/custom');
+			assert.strictEqual(resolveCopilotOtlpMetricsEndpoint('https://collector:4317', 'grpc'), 'https://collector:4317');
+		});
 
 		test('rebaseUnder rebases paths under the source dir and leaves others untouched', () => {
 			const original = URI.file('/Users/me/src/vscode');

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -470,6 +470,10 @@ class MockAgentHostOTelService implements IAgentHostOTelService {
 	async getSdkTelemetryConfig() {
 		return undefined;
 	}
+	async getNativeSdkTelemetryConfig() { return undefined; }
+	getSessionTraceContext() { return undefined; }
+	withTraceContext<T>(_context: undefined, fn: () => T): T { return fn(); }
+	getCurrentTraceContext() { return undefined; }
 	getSpansDbPath() {
 		return undefined;
 	}
@@ -616,6 +620,10 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 	services.set(IAgentHostOTelService, {
 		_serviceBrand: undefined,
 		getSdkTelemetryConfig: async () => undefined,
+		getNativeSdkTelemetryConfig: async () => undefined,
+		getSessionTraceContext: () => undefined,
+		withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
+		getCurrentTraceContext: () => undefined,
 		getSpansDbPath: () => undefined,
 		emitSessionTitleChanged: () => { },
 		flush: async () => undefined,

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -29,6 +29,7 @@ import { AgentFeedbackAttachmentDisplayKind } from '../../common/meta/agentFeedb
 import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService, type ISessionDatabase } from '../../common/sessionDataService.js';
+import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { ActionType, type ChatDeltaAction, type ChatErrorAction, type ChatInputRequestedAction, type ChatResponsePartAction, type ChatToolCallCompleteAction, type ChatToolCallDeltaAction, type ChatToolCallReadyAction, type ChatToolCallStartAction, type ChatTurnCompleteAction, type ChatUsageAction, type SessionAction, type StateAction } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildChatUri, buildDefaultChatUri, createSessionState, mergeSessionWithDefaultChat, readSessionPromptCacheState, readUsageInfoMeta, SessionStatus, withSessionPromptCacheState, type ToolDefinition, type ToolResultContent, type ToolResultFileEditContent, type ToolResultTerminalContent, type UsageInfoMeta } from '../../common/state/sessionState.js';
 import { TerminalClaimKind } from '../../common/state/protocol/state.js';
@@ -623,6 +624,11 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	services.set(ITelemetryService, options?.telemetryService ?? new NullTelemetryServiceShape());
 	services.set(IAgentHostGitService, options?.gitService ?? createNoopGitService());
 	services.set(IAgentHostGitHubEndpointService, options?.gitHubEndpointService ?? createTestGitHubEndpointService());
+	services.set(IAgentHostOTelService, {
+		_serviceBrand: undefined,
+		getSessionTraceContext: () => undefined,
+		withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
+	} as unknown as IAgentHostOTelService);
 	const copilotApiService = new TestCopilotApiService();
 	copilotApiService.apiEndpoint = options?.copilotApiEndpoint;
 	if (options?.restrictedTelemetryContext) {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -627,6 +627,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	services.set(IAgentHostOTelService, {
 		_serviceBrand: undefined,
 		getSessionTraceContext: () => undefined,
+		releaseSessionTraceContext: () => { },
 		withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
 	} as unknown as IAgentHostOTelService);
 	const copilotApiService = new TestCopilotApiService();

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -17,6 +17,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { IByokLmBridgeConnection, IByokLmChatRequest, IByokLmChatResult, IByokLmModelInfo } from '../../common/agentHostByokLm.js';
 import { CustomizationType, type ModelSelection } from '../../common/state/protocol/state.js';
 import type { IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import type { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { ActiveClientToolSet } from '../../node/activeClientState.js';
 import type { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { ByokLmBridgeRegistry, IByokLmBridgeRegistry } from '../../node/byokLmBridgeRegistry.js';
@@ -50,6 +51,11 @@ function createTestLauncher(): CopilotSessionLauncher {
 		{} as IFileService,
 		{ _serviceBrand: undefined, start: async () => { throw new Error('Unexpected proxy start'); }, dispose: () => { } },
 		new ByokLmBridgeRegistry(),
+		{
+			_serviceBrand: undefined,
+			getSessionTraceContext: () => undefined,
+			withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
+		} as unknown as IAgentHostOTelService,
 	);
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -54,6 +54,7 @@ function createTestLauncher(): CopilotSessionLauncher {
 		{
 			_serviceBrand: undefined,
 			getSessionTraceContext: () => undefined,
+			releaseSessionTraceContext: () => { },
 			withTraceContext: <T>(_context: undefined, fn: () => T): T => fn(),
 		} as unknown as IAgentHostOTelService,
 	);

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -164,7 +164,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		const cfg = readAgentHostOTelEnv({
 			COPILOT_OTEL_ENABLED: 'true',
 			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer xyz,x-tenant=acme',
-			OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment.name=dev,custom=value%20with%20spaces,service.name=ignored',
+			OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment.name=dev,custom=value%20with%20spaces,service.name=ignored,service.namespace=foreign',
 			OTEL_SERVICE_NAME: 'agent-host',
 		});
 		deepStrictEqual({ headers: cfg.headers, resourceAttributes: cfg.resourceAttributes }, {
@@ -173,6 +173,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 				'deployment.environment.name': 'dev',
 				custom: 'value with spaces',
 				'service.name': 'agent-host',
+				'service.namespace': 'vscode.agent-host',
 			},
 		});
 	});
@@ -239,6 +240,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			ok(config?.traces?.endpoint.startsWith('http://127.0.0.1:'));
 			strictEqual(config?.traces?.protocol, 'http/json');
 			deepStrictEqual(config?.external, { endpoint: 'http://collector:4318', protocol: 'http/protobuf' });
+			deepStrictEqual(config?.resourceAttributes, { 'service.namespace': 'vscode.agent-host' });
 			const context = svc.getSessionTraceContext('conversation', 'claude:/conversation');
 			ok(context);
 			strictEqual(context.traceparent, `00-${context.traceId}-${context.spanId}-01`);
@@ -337,6 +339,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 				strictEqual(reader.getSpanAttribute(titleSpan.span_id, AgentHostSessionTitleAttribute)?.length, 200);
 				strictEqual(reader.getSpanAttribute(titleSpan.span_id, AgentHostSessionUriAttribute), 'copilotcli:/conv-title');
 				strictEqual(reader.getSpanAttribute(titleSpan.span_id, 'service.name'), 'agent-host-test');
+				strictEqual(reader.getSpanAttribute(titleSpan.span_id, 'service.namespace'), 'vscode.agent-host');
 			} finally {
 				reader.close();
 			}

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -151,24 +151,26 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		strictEqual(cfg.dbSpanExporter, true);
 	});
 
-	test('readAgentHostOTelEnv: protocol=grpc downgrades to otlp-grpc exporter type', () => {
-		const cfg = readAgentHostOTelEnv({
-			COPILOT_OTEL_ENABLED: 'true',
-			COPILOT_OTEL_EXPORTER_TYPE: 'otlp-http',
-			OTEL_EXPORTER_OTLP_PROTOCOL: 'grpc',
-		});
-		strictEqual(cfg.exporterType, 'otlp-grpc');
+	test('readAgentHostOTelEnv: grpc aliases select the gRPC exporter type', () => {
+		for (const protocol of ['grpc', 'http/grpc']) {
+			const cfg = readAgentHostOTelEnv({
+				COPILOT_OTEL_ENABLED: 'true',
+				COPILOT_OTEL_EXPORTER_TYPE: 'otlp-http',
+				OTEL_EXPORTER_OTLP_PROTOCOL: protocol,
+			});
+			strictEqual(cfg.exporterType, 'otlp-grpc');
+		}
 	});
 
 	test('readAgentHostOTelEnv: parses headers and resource attributes', () => {
 		const cfg = readAgentHostOTelEnv({
 			COPILOT_OTEL_ENABLED: 'true',
-			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer xyz,x-tenant=acme',
+			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer%20xyz,x-tenant=acme%2Fprod',
 			OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment.name=dev,custom=value%20with%20spaces,service.name=ignored,service.namespace=foreign',
 			OTEL_SERVICE_NAME: 'agent-host',
 		});
 		deepStrictEqual({ headers: cfg.headers, resourceAttributes: cfg.resourceAttributes }, {
-			headers: { authorization: 'Bearer xyz', 'x-tenant': 'acme' },
+			headers: { authorization: 'Bearer xyz', 'x-tenant': 'acme/prod' },
 			resourceAttributes: {
 				'deployment.environment.name': 'dev',
 				custom: 'value with spaces',
@@ -261,6 +263,46 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			strictEqual(cfg!.sourceName, 'agent-host');
 			strictEqual(cfg!.captureContent, true);
 			strictEqual(svc.getSpansDbPath(), undefined);
+		} finally {
+			restoreEnv(saved);
+		}
+	});
+
+	test('external-only unsupported synthetic protocols do not propagate a missing anchor', async () => {
+		const saved = saveEnv();
+		try {
+			for (const protocol of ['http/protobuf', 'grpc', 'http/grpc']) {
+				process.env.COPILOT_OTEL_ENABLED = 'true';
+				process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://collector:4318';
+				process.env.OTEL_EXPORTER_OTLP_PROTOCOL = protocol;
+				const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
+				store.add({ dispose: () => void rm(tmp, { recursive: true, force: true }).catch(() => undefined) });
+				const di = store.add(new TestInstantiationService());
+				di.set(ILogService, new NullLogService());
+				di.set(INativeEnvironmentService, makeEnvService(tmp));
+				const svc = store.add(di.createInstance(AgentHostOTelService, undefined));
+				const config = await svc.getNativeSdkTelemetryConfig();
+				strictEqual(config?.external?.protocol, protocol === 'http/grpc' ? 'grpc' : protocol);
+				strictEqual(svc.getSessionTraceContext('conversation', `claude:/${protocol}`), undefined);
+			}
+		} finally {
+			restoreEnv(saved);
+		}
+	});
+
+	test('session trace contexts are stable until permanent release', () => {
+		const saved = saveEnv();
+		try {
+			process.env.COPILOT_OTEL_ENABLED = 'true';
+			process.env.COPILOT_OTEL_EXPORTER_TYPE = 'console';
+			const di = store.add(new TestInstantiationService());
+			di.set(ILogService, new NullLogService());
+			di.set(INativeEnvironmentService, makeEnvService(tmpdir()));
+			const svc = store.add(di.createInstance(AgentHostOTelService, undefined));
+			const first = svc.getSessionTraceContext('conversation', 'claude:/conversation');
+			strictEqual(svc.getSessionTraceContext('conversation', 'claude:/conversation'), first);
+			svc.releaseSessionTraceContext('claude:/conversation');
+			notStrictEqual(svc.getSessionTraceContext('conversation', 'claude:/conversation'), first);
 		} finally {
 			restoreEnv(saved);
 		}
@@ -388,6 +430,35 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		} finally {
 			restoreEnv(saved);
 			await cleanup();
+		}
+	});
+
+	test('DB mode keeps protobuf and gRPC traces local instead of HTTP-posting the wrong wire format', async () => {
+		const saved = saveEnv();
+		try {
+			for (const protocol of ['http/protobuf', 'grpc']) {
+				process.env.COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED = 'true';
+				process.env.COPILOT_OTEL_EXPORTER_TYPE = protocol === 'grpc' ? 'otlp-grpc' : 'otlp-http';
+				process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://collector:4318';
+				process.env.OTEL_EXPORTER_OTLP_PROTOCOL = protocol;
+				let fetchCalls = 0;
+				const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
+				store.add({ dispose: () => void rm(tmp, { recursive: true, force: true }).catch(() => undefined) });
+				const di = store.add(new TestInstantiationService());
+				di.set(ILogService, new NullLogService());
+				di.set(INativeEnvironmentService, makeEnvService(tmp));
+				const svc = store.add(di.createInstance(AgentHostOTelService, async () => {
+					fetchCalls++;
+					return new Response(null, { status: 200 });
+				}));
+				const config = await svc.getSdkTelemetryConfig();
+				const res = await postOtlp(config!.otlpEndpoint!, makeOtlpRequest('ffeeddccbbaa99887766554433221100', '00000000000000aa'));
+				strictEqual(res.statusCode, 200);
+				await svc.flush();
+				strictEqual(fetchCalls, 0);
+			}
+		} finally {
+			restoreEnv(saved);
 		}
 	});
 

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -269,6 +269,7 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 	test('native SDK config splits DB traces from direct external signals', async () => {
 		const saved = saveEnv();
 		const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
+		store.add({ dispose: () => void rm(tmp, { recursive: true, force: true }).catch(() => undefined) });
 		try {
 			process.env.COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED = 'true';
 			process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://collector:4318';
@@ -290,7 +291,6 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			strictEqual(svc.getCurrentTraceContext(), undefined);
 		} finally {
 			restoreEnv(saved);
-			await rm(tmp, { recursive: true, force: true });
 		}
 	});
 

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -19,7 +19,7 @@ import {
 	OtlpSpanKind,
 } from '../../../../otel/node/otlp/otlpJsonTypes.js';
 import { AgentHostSessionTitleAttribute, AgentHostSessionTitleSpanName, AgentHostSessionUriAttribute, IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
-import { AgentHostOTelService, readAgentHostOTelEnv } from '../../../node/otel/agentHostOTelService.js';
+import { AgentHostOTelService, normalizeAgentHostOtlpBody, readAgentHostOTelEnv } from '../../../node/otel/agentHostOTelService.js';
 import { AgentHostOTelSpansDbSubPath } from '../../../common/agentService.js';
 
 interface IPostResponse {
@@ -176,6 +176,48 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 				'service.namespace': 'vscode.agent-host',
 			},
 		});
+	});
+
+	test('normalizes resources and narrowly filters Codex 0.142 auth polling spans', () => {
+		const payload = {
+			resourceSpans: [
+				{
+					resource: {
+						attributes: [
+							{ key: 'service.name', value: { stringValue: 'codex-app-server' } },
+							{ key: 'service.namespace', value: { stringValue: 'foreign' } },
+							{ key: 'deployment.environment.name', value: { stringValue: 'test' } },
+						]
+					},
+					scopeSpans: [
+						{
+							spans: [
+								{ name: 'auth', attributes: [{ key: 'code.module.name', value: { stringValue: 'codex_login::auth::manager' } }] },
+								{ name: 'auth', attributes: [{ key: 'code.module.name', value: { stringValue: 'other::module' } }] },
+								{ name: 'list_models', attributes: [] },
+							]
+						},
+						{ spans: [] },
+						{ spans: [{ name: 'auth', attributes: [{ key: 'code.module.name', value: { stringValue: 'codex_login::auth::manager' } }] }] },
+					],
+				},
+				{
+					resource: { attributes: [{ key: 'service.name', value: { stringValue: 'another-service' } }] },
+					scopeSpans: [{ spans: [{ name: 'auth', attributes: [{ key: 'code.module.name', value: { stringValue: 'codex_login::auth::manager' } }] }] }],
+				},
+				{ resource: { attributes: [{ key: 'custom', value: { stringValue: 'kept' } }] }, scopeSpans: [] },
+			],
+		};
+
+		const normalized = normalizeAgentHostOtlpBody(Buffer.from(JSON.stringify(payload)));
+		const result = JSON.parse(normalized.body.toString('utf8')) as typeof payload;
+		strictEqual(normalized.filteredSpanCount, 2);
+		deepStrictEqual(result.resourceSpans[0].scopeSpans[0].spans.map(span => span.name), ['auth', 'list_models']);
+		deepStrictEqual(result.resourceSpans[0].scopeSpans[1].spans, []);
+		deepStrictEqual(result.resourceSpans[0].scopeSpans[2].spans, []);
+		strictEqual(result.resourceSpans[1].scopeSpans[0].spans.length, 1);
+		ok(result.resourceSpans[0].resource.attributes.some(attribute => attribute.key === 'deployment.environment.name' && attribute.value.stringValue === 'test'));
+		ok(result.resourceSpans.every(resourceSpan => resourceSpan.resource.attributes.some(attribute => attribute.key === 'service.namespace' && attribute.value.stringValue === 'vscode.agent-host')));
 	});
 
 	test('getSdkTelemetryConfig: returns undefined when fully disabled', async () => {

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -223,6 +223,33 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 		}
 	});
 
+	test('native SDK config splits DB traces from direct external signals', async () => {
+		const saved = saveEnv();
+		const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
+		try {
+			process.env.COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED = 'true';
+			process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://collector:4318';
+			process.env.OTEL_EXPORTER_OTLP_PROTOCOL = 'http/protobuf';
+			const di = store.add(new TestInstantiationService());
+			di.set(ILogService, new NullLogService());
+			di.set(INativeEnvironmentService, makeEnvService(tmp));
+			const svc = store.add(di.createInstance(AgentHostOTelService, undefined));
+
+			const config = await svc.getNativeSdkTelemetryConfig();
+			ok(config?.traces?.endpoint.startsWith('http://127.0.0.1:'));
+			strictEqual(config?.traces?.protocol, 'http/json');
+			deepStrictEqual(config?.external, { endpoint: 'http://collector:4318', protocol: 'http/protobuf' });
+			const context = svc.getSessionTraceContext('conversation', 'claude:/conversation');
+			ok(context);
+			strictEqual(context.traceparent, `00-${context.traceId}-${context.spanId}-01`);
+			strictEqual(svc.withTraceContext(context, () => svc.getCurrentTraceContext()), context);
+			strictEqual(svc.getCurrentTraceContext(), undefined);
+		} finally {
+			restoreEnv(saved);
+			await rm(tmp, { recursive: true, force: true });
+		}
+	});
+
 	test('DB mode: starts loopback, persists posted spans to SQLite, and exposes db path', async () => {
 		const saved = saveEnv();
 		const tmp = await mkdtemp(join(tmpdir(), 'vscode-otel-svc-'));
@@ -304,11 +331,12 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			const reader = new OTelSqliteStore(dbPath!.fsPath);
 			try {
 				const spans = reader.getSpansByConversationId('conv-title');
-				strictEqual(spans.length, 1);
-				strictEqual(spans[0].name, AgentHostSessionTitleSpanName);
-				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionTitleAttribute)?.length, 200);
-				strictEqual(reader.getSpanAttribute(spans[0].span_id, AgentHostSessionUriAttribute), 'copilotcli:/conv-title');
-				strictEqual(reader.getSpanAttribute(spans[0].span_id, 'service.name'), 'agent-host-test');
+				strictEqual(spans.length, 2);
+				const titleSpan = spans.find(span => span.name === AgentHostSessionTitleSpanName);
+				ok(titleSpan);
+				strictEqual(reader.getSpanAttribute(titleSpan.span_id, AgentHostSessionTitleAttribute)?.length, 200);
+				strictEqual(reader.getSpanAttribute(titleSpan.span_id, AgentHostSessionUriAttribute), 'copilotcli:/conv-title');
+				strictEqual(reader.getSpanAttribute(titleSpan.span_id, 'service.name'), 'agent-host-test');
 			} finally {
 				reader.close();
 			}

--- a/src/vs/platform/otel/node/otlp/localOtlpReceiver.ts
+++ b/src/vs/platform/otel/node/otlp/localOtlpReceiver.ts
@@ -18,6 +18,8 @@ const DEFAULT_MAX_BODY_BYTES = 64 * 1024 * 1024;
 
 /** Callbacks the receiver invokes for each accepted request. */
 export interface IOtlpReceiverHandlers {
+	/** Optionally rewrite an OTLP/JSON request before local decode and forwarding. */
+	transformBody?(body: Buffer): Buffer;
 	/** Invoked with the decoded spans for every successfully-parsed request. */
 	onSpans(result: IDecodeResult): void;
 	/**
@@ -152,8 +154,16 @@ async function handleRequest(
 		return;
 	}
 
+	if (handlers.transformBody) {
+		try {
+			body = handlers.transformBody(body);
+		} catch (err) {
+			logService.warn(`[agentHost-otel] transform callback threw: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
 	// Best-effort forward of raw bytes BEFORE decoding so the upstream
-	// collector sees an identical payload to what the SDK emitted. Failures
+	// collector sees the normalized payload. Failures
 	// here are isolated from the local-decode path.
 	if (handlers.onForward) {
 		try {

--- a/src/vs/platform/otel/test/node/otlp/localOtlpReceiver.test.ts
+++ b/src/vs/platform/otel/test/node/otlp/localOtlpReceiver.test.ts
@@ -167,6 +167,27 @@ suite('platform/otel - localOtlpHttpReceiver', () => {
 		}
 	});
 
+	test('transforms the body before forwarding and local decoding', async () => {
+		let forwarded: Buffer | undefined;
+		let decoded: IDecodeResult | undefined;
+		const receiver = await startLocalOtlpHttpReceiver(
+			{
+				transformBody: body => Buffer.from(body.toString('utf8').replace('invoke_agent copilotcli', 'transformed span')),
+				onSpans: result => { decoded = result; },
+				onForward: body => { forwarded = body; },
+			},
+			logService,
+		);
+		try {
+			const res = await send(receiver.port, { contentType: 'application/json', body: JSON.stringify(validRequestBody()) });
+			strictEqual(res.statusCode, 200);
+			ok(forwarded?.toString('utf8').includes('transformed span'));
+			strictEqual(decoded?.spans[0].name, 'transformed span');
+		} finally {
+			receiver.dispose();
+		}
+	});
+
 	test('still responds 200 even if onForward throws', async () => {
 		const receiver = await startLocalOtlpHttpReceiver(
 			{


### PR DESCRIPTION
## Summary

Extends Agent Host OpenTelemetry to its native Copilot, Claude, and Codex runtimes.

- In DB mode, native traces use the Agent Host OTLP/HTTP JSON loopback, which persists them to the existing SQLite span database and optionally forwards them to an OTLP/HTTP JSON collector. Protobuf and gRPC traces remain local rather than being forwarded with the wrong wire format.
- Provider logs and metrics bypass Agent Host and export directly to the user's collector. Agent Host does not receive or store `/v1/logs` or `/v1/metrics`.
- A host-produced `vscode.agent_host.session` span supplies W3C parent context to Copilot, Claude, and Codex. Session-title metadata uses the same trace.
- When Agent Host OTel is enabled, its provider launch configuration wins over standalone Claude and Codex exporter settings. When disabled, standalone telemetry remains unchanged.
- OTLP protocol aliases, gRPC endpoint handling, percent-encoded headers, and permanent session-context cleanup are handled consistently across providers.

## Resource identity

Agent Host is one multi-service system. Agent Host-owned boundaries set `service.namespace=vscode.agent-host` and preserve unrelated inherited resource attributes.

| Producer | `service.name` |
|---|---|
| Host anchors and title metadata | `vscode-agent-host` (or an explicit host override) |
| Copilot | `github-copilot` |
| Claude | `claude-code` |
| Codex | `codex-app-server` |

Codex 0.142 ignores standard resource overrides. Agent Host adds the namespace to intercepted Codex traces, but direct Codex logs and metrics cannot carry it until Codex adds upstream support.

## Codex 0.142 compatibility

In DB mode, the Agent Host receiver drops only the high-volume internal `auth` polling span identified by `service.name=codex-app-server`, span name `auth`, and `code.module.name=codex_login::auth::manager`. It keeps a bounded aggregate count and logs it at most once per minute. All other Codex spans are retained. External-only mode bypasses the receiver, so this filter does not apply there.

## Validation

- `npm run typecheck-client`
- `npm run compile`
- Full Node test suite: 13,204 passing, 192 pending
- Focused telemetry tests: 15 AgentHostOTelService integration, 17 Claude SDK options, 7 Codex launch config, and 149 CopilotAgent tests
- Live Code OSS + OTelux verification confirmed connected host/provider trace trees for Copilot, Claude, and Codex, plus direct Codex log export. Claude direct logs and provider metrics still need a backend/UI spot-check.

Fixes #328322

Related: #328485
