### PR TITLE
build: support targeted ESLint files

### DIFF
--- a/build/eslint.ts
+++ b/build/eslint.ts
@@ -6,7 +6,15 @@
 import { ESLint } from 'eslint';
 import { eslintFilter } from './filters.ts';
 
-async function eslint(): Promise<void> {
+export function getEslintFilePatterns(args: readonly string[]): string[] {
+	if (args.length === 0) {
+		return Array.from(eslintFilter);
+	}
+
+	return Array.from(args);
+}
+
+async function eslint(args: readonly string[]): Promise<void> {
 	const linter = new ESLint({
 		cache: true,
 		cacheLocation: '.eslintcache',
@@ -16,7 +24,7 @@ async function eslint(): Promise<void> {
 	});
 	const formatter = await linter.loadFormatter('compact');
 
-	const results = await linter.lintFiles(Array.from(eslintFilter));
+	const results = await linter.lintFiles(getEslintFilePatterns(args));
 	const message = await formatter.format(results);
 	if (message) {
 		console.log(message);
@@ -34,7 +42,7 @@ async function eslint(): Promise<void> {
 }
 
 if (import.meta.main) {
-	eslint().catch((err) => {
+	eslint(process.argv.slice(2)).catch((err) => {
 		console.error();
 		console.error(err);
 		process.exit(1);

--- a/build/eslint.ts
+++ b/build/eslint.ts
@@ -14,13 +14,17 @@ export function getEslintFilePatterns(args: readonly string[]): string[] {
 	return Array.from(args);
 }
 
+export function shouldErrorOnUnmatchedPattern(args: readonly string[]): boolean {
+	return args.length > 0;
+}
+
 async function eslint(args: readonly string[]): Promise<void> {
 	const linter = new ESLint({
 		cache: true,
 		cacheLocation: '.eslintcache',
 		cacheStrategy: 'content',
 		concurrency: 'auto',
-		errorOnUnmatchedPattern: false,
+		errorOnUnmatchedPattern: shouldErrorOnUnmatchedPattern(args),
 	});
 	const formatter = await linter.loadFormatter('compact');
 

--- a/build/lib/test/eslint.test.ts
+++ b/build/lib/test/eslint.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import { getEslintFilePatterns } from '../../eslint.ts';
+import { eslintFilter } from '../../filters.ts';
+
+suite('eslint', () => {
+
+	test('uses the full filter when no positional arguments are provided', () => {
+		assert.deepStrictEqual(getEslintFilePatterns([]), Array.from(eslintFilter));
+	});
+
+	test('uses positional arguments without the full filter', () => {
+		const files = ['src/vs/base/common/arrays.ts', 'src/vs/base/common/async.ts'];
+
+		assert.deepStrictEqual(getEslintFilePatterns(files), files);
+	});
+});

--- a/build/lib/test/eslint.test.ts
+++ b/build/lib/test/eslint.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { suite, test } from 'node:test';
-import { getEslintFilePatterns } from '../../eslint.ts';
+import { getEslintFilePatterns, shouldErrorOnUnmatchedPattern } from '../../eslint.ts';
 import { eslintFilter } from '../../filters.ts';
 
 suite('eslint', () => {
@@ -18,5 +18,12 @@ suite('eslint', () => {
 		const files = ['src/vs/base/common/arrays.ts', 'src/vs/base/common/async.ts'];
 
 		assert.deepStrictEqual(getEslintFilePatterns(files), files);
+	});
+
+	test('errors on unmatched positional arguments only', () => {
+		assert.deepStrictEqual([
+			shouldErrorOnUnmatchedPattern([]),
+			shouldErrorOnUnmatchedPattern(['src/vs/base/common/arrays.ts']),
+		], [false, true]);
 	});
 });


### PR DESCRIPTION
## Summary

- accept positional file, directory, or glob targets in `build/eslint.ts`
- preserve the existing full-repository lint behavior when no targets are provided
- add unit coverage for both invocation modes

## Motivation

Agents commonly invoke the ESLint script with specific files, but the script previously ignored those arguments and linted the entire repository. Using the supplied targets avoids unnecessary CPU usage and reduces the reported four-file command from about 43 seconds to about 1.4 seconds locally.

## Validation

- `cd build && node --test lib/test/eslint.test.ts`
- `npm run typecheck --prefix build`
- `node --experimental-strip-types build/hygiene.ts build/eslint.ts build/lib/test/eslint.test.ts`
- exact reported four-file ESLint command

(Written by Copilot)