### PR TITLE
ipc: Avoid buffering unused native host blur events

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -1138,11 +1138,18 @@ export namespace ProxyChannel {
 		disableMarshalling?: boolean;
 	}
 
-	export interface ICreateServiceChannelOptions extends IProxyOptions { }
+	export interface ICreateServiceChannelOptions extends IProxyOptions {
+
+		/**
+		 * Events that should subscribe lazily and not replay emissions before the first IPC listener.
+		 */
+		unbufferedEvents?: readonly string[];
+	}
 
 	export function fromService<TContext>(service: unknown, disposables: DisposableStore, options?: ICreateServiceChannelOptions): IServerChannel<TContext> {
 		const handler = service as { [key: string]: unknown };
 		const disableMarshalling = options?.disableMarshalling;
+		const unbufferedEvents = options?.unbufferedEvents ? new Set(options.unbufferedEvents) : undefined;
 
 		// Buffer any event that should be supported by
 		// iterating over all property keys and finding them
@@ -1151,7 +1158,7 @@ export namespace ProxyChannel {
 		// still need to check later (see below).
 		const mapEventNameToEvent = new Map<string, Event<unknown>>();
 		for (const key in handler) {
-			if (propertyIsEvent(key)) {
+			if (propertyIsEvent(key) && !unbufferedEvents?.has(key)) {
 				mapEventNameToEvent.set(key, Event.buffer(handler[key] as Event<unknown>, key, true, undefined, disposables));
 			}
 		}
@@ -1171,6 +1178,10 @@ export namespace ProxyChannel {
 					}
 
 					if (propertyIsEvent(event)) {
+						if (unbufferedEvents?.has(event)) {
+							return handler[event] as Event<T>;
+						}
+
 						mapEventNameToEvent.set(event, Event.buffer(handler[event] as Event<unknown>, event, true, undefined, disposables));
 
 						return mapEventNameToEvent.get(event) as Event<T>;

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -117,6 +117,7 @@ class TestService implements ITestService {
 
 	private readonly _onPong = new Emitter<string>();
 	readonly onPong = this._onPong.event;
+	get hasPongListeners(): boolean { return this._onPong.hasListeners(); }
 
 	marco(): Promise<string> {
 		return Promise.resolve('polo');
@@ -318,6 +319,27 @@ suite('Base IPC', function () {
 			await timeout(0);
 
 			assert.deepStrictEqual(messages, ['hello', 'world']);
+		});
+
+		test('unbuffered events subscribe lazily', function () {
+			const service = store.add(new TestService());
+			const channelDisposables = store.add(new DisposableStore());
+			const channel = ProxyChannel.fromService(service, channelDisposables, { unbufferedEvents: ['onPong'] });
+			const onPong = channel.listen<string>('context', 'onPong');
+			const messages: string[] = [];
+
+			service.ping('before');
+			assert.strictEqual(service.hasPongListeners, false);
+
+			const listener = channelDisposables.add(onPong(message => messages.push(message)));
+			assert.strictEqual(service.hasPongListeners, true);
+			service.ping('after');
+			channelDisposables.delete(listener);
+
+			assert.deepStrictEqual({ messages, hasPongListeners: service.hasPongListeners }, {
+				messages: ['after'],
+				hasPongListeners: false
+			});
 		});
 
 		test('listen to events (resubscribe)', async function () {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1386,6 +1386,7 @@ export class CodeApplication extends Disposable {
 		// Native host (main & shared process)
 		this.nativeHostMainService = accessor.get(INativeHostMainService);
 		const nativeHostChannel = ProxyChannel.fromService(this.nativeHostMainService, disposables, {
+			// This event has main-process consumers but no IPC consumer, so its buffer would never drain.
 			unbufferedEvents: ['onDidBlurMainWindow']
 		});
 		mainProcessElectronServer.registerChannel('nativeHost', nativeHostChannel);

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1385,7 +1385,9 @@ export class CodeApplication extends Disposable {
 
 		// Native host (main & shared process)
 		this.nativeHostMainService = accessor.get(INativeHostMainService);
-		const nativeHostChannel = ProxyChannel.fromService(this.nativeHostMainService, disposables);
+		const nativeHostChannel = ProxyChannel.fromService(this.nativeHostMainService, disposables, {
+			unbufferedEvents: ['onDidBlurMainWindow']
+		});
 		mainProcessElectronServer.registerChannel('nativeHost', nativeHostChannel);
 		sharedProcessClient.then(client => client.registerChannel('nativeHost', nativeHostChannel));
 


### PR DESCRIPTION
## Problem

`ProxyChannel.fromService` eagerly subscribes to and buffers service events so startup events can be replayed when an IPC client attaches. `onDidBlurMainWindow` has no IPC consumer, so every main-window blur was retained indefinitely and the eager proxy subscription was unnecessary.

In dev builds this produces an `[Event.buffer][onDidBlurMainWindow] potential LEAK detected` warning after buffered events remain unconsumed.

## History

This is long-standing rather than a recent regression:

- [`42f5594892`](https://github.com/microsoft/vscode/commit/42f5594892084c2db0e08fa52d19288d87698779) (2023-11-02) split focus/blur into main-only and main-or-auxiliary events. Renderer consumers moved to the combined event, leaving the main-only blur buffer without an IPC listener.
- [`a837f16fbe`](https://github.com/microsoft/vscode/commit/a837f16fbe459f3a067aa94da0ddb9b9ae04ebe0) (2026-02-28) added `Event.buffer` leak diagnostics, making the existing unbounded buffer visible.

The main-only focus event remains buffered because Settings Sync consumes it through the shared-process native host channel.

## Fix

- add an opt-in `unbufferedEvents` proxy-channel option that subscribes only when an IPC client listens
- make `onDidBlurMainWindow` lazy/unbuffered while preserving the event API for future consumers
- cover lazy subscription, lack of replay, and listener cleanup with an IPC unit test

CC @bpasero for the auxiliary-window event history.

## Validation

- `npm run compile`
- `./scripts/test.sh --run src/vs/base/parts/ipc/test/common/ipc.test.ts` (23 passing)
- `npm run precommit`

(Written by Copilot)