### PR TITLE
Prevent Agent Host session loss after resume failures

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -6,6 +6,7 @@
 import { open, unlink, type FileHandle } from 'fs/promises';
 import { decodeBase64, VSBuffer } from '../../../base/common/buffer.js';
 import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base/common/async.js';
+import { CancellationToken, cancelOnDispose } from '../../../base/common/cancellation.js';
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
@@ -34,7 +35,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type ChatOrigin, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionStatusFlag, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionStatusFlag, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
 import { readToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
@@ -325,8 +326,6 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _resourceSubscribers = new ResourceMap<Set<string>>();
 	private readonly _restoreSessionInFlight = new Map<string, Promise<void>>();
 	private readonly _restoreSubagentInFlight = new Map<string, Promise<void>>();
-	/** Fresh provider-declared provisional sessions that remain eligible for abandoned-draft GC. */
-	private readonly _provisionalSessionGcCandidates = new Map<string, symbol>();
 
 	/** Subagent chats armed for a bounded wait (once execution is confirmed); resolved by {@link _onChatSpawned}, awaited by {@link subscribe}. */
 	private readonly _pendingSubagentChats = new Map<string /* subagentChatUri */, DeferredPromise<void>>();
@@ -1060,6 +1059,13 @@ export class AgentService extends Disposable implements IAgentService {
 		if (!provider) {
 			throw new Error(`No agent provider registered for: ${providerId ?? '(none)'}`);
 		}
+		const cleanupWasPending = config?.session
+			? this._pendingSessionGc.has(config.session) || this._pendingSessionRelease.has(config.session)
+			: false;
+		if (config?.session) {
+			this._cancelPendingSessionGc(config.session);
+			this._cancelPendingSessionRelease(config.session);
+		}
 
 		// Capability gate: only a provider that advertises
 		// `multipleWorkingDirectories` accepts more than one working directory.
@@ -1119,27 +1125,25 @@ export class AgentService extends Disposable implements IAgentService {
 		// client-chosen worktree session pending first prevents that prewarm from
 		// materializing in the picked folder before the host creates the worktree.
 		const initializeSideEffects = this._sideEffects.initialize();
-		const sessionConfig = await this._resolveCreatedSessionConfig(provider, config);
-		const deferWorktreeCreation = sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree' && !config?.fork && !config?.importConversation;
+		let sessionConfig: SessionConfigState | undefined;
+		let created: IAgentCreateSessionResult;
+		try {
+			sessionConfig = await this._resolveCreatedSessionConfig(provider, config);
+			const deferWorktreeCreation = sessionConfig?.values?.[SessionConfigKey.Isolation] === 'worktree' && !config?.fork && !config?.importConversation;
 
-		this._logService.trace(`[AgentService] createSession: initializing auto-approver and creating session...`);
-		const [, created] = await Promise.all([
-			initializeSideEffects,
-			this._createProviderSession(provider, config, deferWorktreeCreation),
-		]);
+			this._logService.trace(`[AgentService] createSession: initializing auto-approver and creating session...`);
+			[, created] = await Promise.all([
+				initializeSideEffects,
+				this._createProviderSession(provider, config, deferWorktreeCreation),
+			]);
+		} catch (error) {
+			if (config?.session && cleanupWasPending) {
+				this._scheduleSessionCleanup(config.session);
+			}
+			throw error;
+		}
 		const session = created.session;
 		this._logService.trace(`[AgentService] createSession: initialization complete`);
-		if (created.provisional) {
-			this._provisionalSessionGcCandidates.set(session.toString(), Symbol());
-		} else {
-			this._provisionalSessionGcCandidates.delete(session.toString());
-		}
-
-		// Cancel any pending GC armed for this URI. A client may be
-		// re-issuing `createSession` for an existing URI mid-grace (e.g.
-		// during a reconnect that returned `missing`); without this, the
-		// timer would still fire and dispose the just-revived session
-		// before the follow-up `subscribe` arrives.
 		this._cancelPendingSessionGc(session);
 		this._cancelPendingSessionRelease(session);
 
@@ -1763,7 +1767,6 @@ export class AgentService extends Disposable implements IAgentService {
 	 */
 	private _onDidMaterializeSession(e: IAgentMaterializeSessionEvent): void {
 		const sessionKey = e.session.toString();
-		this._provisionalSessionGcCandidates.delete(sessionKey);
 		this._cancelPendingSessionGc(e.session);
 		// The session is now materialized — its SDK is resolved (any cold
 		// download already finished), so no further progress is expected for it.
@@ -1997,20 +2000,20 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	async disposeSession(session: URI): Promise<void> {
-		this._logService.trace(`[AgentService] disposeSession: ${session.toString()}`);
-		this._provisionalSessionGcCandidates.delete(session.toString());
+		const sessionKey = session.toString();
+		this._logService.trace(`[AgentService] disposeSession: ${sessionKey}`);
 		this._cancelPendingSessionGc(session);
 		// Resolve the working directories up front and pass them explicitly:
 		// the checkpoint and review services need them to locate the
 		// repositories holding this session's refs, and reading them from
 		// session state would silently break the moment `deleteSession` below
 		// is reordered ahead of the data deletion.
-		const workingDirectories = this._configurationService.getEffectiveWorkingDirectories(session.toString());
+		const workingDirectories = this._configurationService.getEffectiveWorkingDirectories(sessionKey);
 		const provider = this._findProviderForSession(session);
 		if (provider) {
 			await this._disposeSession(provider, session);
-			this._sessionToProvider.delete(session.toString());
-			this._clearDownloadProgressInterest(session.toString());
+			this._sessionToProvider.delete(sessionKey);
+			this._clearDownloadProgressInterest(sessionKey);
 		}
 		// Remove the VS Code per-session data directory (metadata DB + checkpoints) to mirror the SDK-side cleanup
 		// performed by the provider above. No-op when the directory does not exist.
@@ -2024,14 +2027,14 @@ export class AgentService extends Disposable implements IAgentService {
 		// Remove any worktree this process created for the session (host-owned;
 		// agents stay unaware).
 		await this._worktree?.removeCreatedWorktree(AgentSession.id(session));
-		this._changesetCoordinator.onSessionDisposed(session.toString());
-		this._sideEffects.cancelSessionTitleGeneration(session.toString());
-		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {
+		this._changesetCoordinator.onSessionDisposed(sessionKey);
+		this._sideEffects.cancelSessionTitleGeneration(sessionKey);
+		for (const chat of this._stateManager.getSessionState(sessionKey)?.chats ?? []) {
 			this._sideEffects.clearQueuedMessageSenders(chat.resource);
 		}
 		// Remove all subagent sessions for this parent
-		this._sideEffects.removeSubagentSessions(session.toString());
-		this._stateManager.deleteSession(session.toString());
+		this._sideEffects.removeSubagentSessions(sessionKey);
+		this._stateManager.deleteSession(sessionKey);
 	}
 
 	// ---- Protocol methods ---------------------------------------------------
@@ -2159,8 +2162,9 @@ export class AgentService extends Disposable implements IAgentService {
 		set.add(clientId);
 		// A new subscriber means the session is being observed again; cancel
 		// any pending GC or idle-release armed while it had no subscribers.
-		this._cancelPendingSessionGc(resource);
-		this._cancelPendingSessionRelease(resource);
+		const sessionResource = this._getOwningSessionResource(resource);
+		this._cancelPendingSessionGc(sessionResource);
+		this._cancelPendingSessionRelease(sessionResource);
 		// 0→1 transition — covers both the full subscribe path AND the
 		// handshake fast-path used by `ProtocolServerHandler` when state is
 		// already cached. The coordinator decides whether the URI is one
@@ -2183,14 +2187,16 @@ export class AgentService extends Disposable implements IAgentService {
 		this._changesetCoordinator.onLastSubscriber(resource);
 		this._stateManager.onChangesetLivenessChanged();
 		const sessionResource = this._getOwningSessionResource(resource);
-		// An empty session whose last subscriber dropped is a candidate for
-		// full GC (provider session, worktree, on-disk state). Sessions with
-		// at least one turn fall through to {@link _maybeEvictIdleSession},
-		// which only drops the in-memory cache and lets the session be
-		// restored from disk later. Skipping eviction here for empty
-		// sessions ensures their state stays observable so a re-subscribe
-		// can re-arm GC.
-		if (this._maybeScheduleSessionGc(sessionResource)) {
+		this._scheduleSessionCleanup(sessionResource);
+	}
+
+	private _scheduleSessionCleanup(resource: URI): void {
+		if (this._hasSessionSubscribers(resource)) {
+			return;
+		}
+		// Empty provisional sessions are destructively collected; materialized
+		// sessions only release their in-memory provider resources.
+		if (this._maybeScheduleSessionGc(resource)) {
 			return;
 		}
 		// Defer the idle-session release behind a grace window rather than
@@ -2253,30 +2259,30 @@ export class AgentService extends Disposable implements IAgentService {
 			return false;
 		}
 		const key = resource.toString();
-		if (!this._getEmptySessionGcCandidate(resource)) {
+		if (!this._isEmptyProvisionalSession(resource)) {
 			return false;
 		}
-		this._pendingSessionGc.set(resource, disposableTimeout(() => {
-			this._pendingSessionGc.deleteAndDispose(resource);
-			this._runSessionGc(resource).catch(err => {
+		const pending = new DisposableStore();
+		const cancellation = cancelOnDispose(pending);
+		pending.add(disposableTimeout(() => {
+			this._runSessionGc(resource, cancellation).catch(err => {
 				this._logService.error(err, `[AgentService] GC failed for ${key}`);
+			}).finally(() => {
+				if (this._pendingSessionGc.get(resource) === pending) {
+					this._pendingSessionGc.deleteAndDispose(resource);
+				}
 			});
 		}, SESSION_GC_GRACE_MS));
+		this._pendingSessionGc.set(resource, pending);
 		return true;
 	}
 
-	private _getEmptySessionGcCandidate(resource: URI): symbol | undefined {
-		const key = resource.toString();
-		const candidate = this._provisionalSessionGcCandidates.get(key);
-		if (!candidate) {
-			return undefined;
-		}
-		const state = this._stateManager.getSessionState(key);
-		if (!state || state.turns.length > 0 || state.activeTurn !== undefined) {
-			this._provisionalSessionGcCandidates.delete(key);
-			return undefined;
-		}
-		return candidate;
+	private _isEmptyProvisionalSession(resource: URI): boolean {
+		const state = this._stateManager.getSessionState(resource.toString());
+		return state?.lifecycle === SessionLifecycle.Creating
+			&& state.turns.length === 0
+			&& state.activeTurn === undefined
+			&& state.draft === undefined;
 	}
 
 	private _cancelPendingSessionGc(resource: URI): void {
@@ -2294,22 +2300,15 @@ export class AgentService extends Disposable implements IAgentService {
 	 * subscriber while it was still empty. Re-checks every invariant before
 	 * tearing the session down via {@link disposeSession}.
 	 */
-	private async _runSessionGc(resource: URI): Promise<void> {
+	private async _runSessionGc(resource: URI, token: CancellationToken): Promise<void> {
 		const key = resource.toString();
-		if (this._hasSessionSubscribers(resource)) {
-			return;
-		}
-		const candidate = this._getEmptySessionGcCandidate(resource);
-		if (!candidate) {
+		if (token.isCancellationRequested || this._hasSessionSubscribers(resource) || !this._isEmptyProvisionalSession(resource)) {
 			return;
 		}
 		if (await this._hasPersistedSessionData(resource)) {
-			if (this._provisionalSessionGcCandidates.get(key) === candidate) {
-				this._provisionalSessionGcCandidates.delete(key);
-			}
 			return;
 		}
-		if (this._hasSessionSubscribers(resource) || this._getEmptySessionGcCandidate(resource) !== candidate) {
+		if (token.isCancellationRequested || this._hasSessionSubscribers(resource) || !this._isEmptyProvisionalSession(resource)) {
 			return;
 		}
 		this._logService.info(`[AgentService] GC: disposing empty unsubscribed session ${key}`);
@@ -2351,9 +2350,6 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		const evictionTargetKey = evictionTarget.toString();
-		if (this._provisionalSessionGcCandidates.has(evictionTargetKey)) {
-			return;
-		}
 		// A restore/resume racing this unsubscribe means a client is about to
 		// observe the session again; releasing now would tear down state that
 		// the in-flight rehydrate is populating.
@@ -2361,7 +2357,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return;
 		}
 		const targetState = this._stateManager.getSessionState(evictionTargetKey);
-		if (!targetState || this._stateManager.hasActiveTurn(evictionTargetKey)) {
+		if (!targetState || targetState.lifecycle === SessionLifecycle.Creating || this._stateManager.hasActiveTurn(evictionTargetKey)) {
 			return;
 		}
 		this._logService.info(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
@@ -2489,7 +2485,6 @@ export class AgentService extends Disposable implements IAgentService {
 			|| action.type === ActionType.SessionIsArchivedChanged
 			|| action.type === ActionType.SessionTitleChanged
 		) {
-			this._provisionalSessionGcCandidates.delete(sessionChannel);
 			this._cancelPendingSessionGc(URI.parse(sessionChannel));
 		}
 		this._stateManager.dispatchClientAction(channel, action, origin);
@@ -2679,7 +2674,6 @@ export class AgentService extends Disposable implements IAgentService {
 
 	async restoreSession(session: URI): Promise<void> {
 		const sessionStr = session.toString();
-		this._provisionalSessionGcCandidates.delete(sessionStr);
 		this._cancelPendingSessionGc(session);
 
 		// Already in state manager - nothing to do.
@@ -2689,7 +2683,8 @@ export class AgentService extends Disposable implements IAgentService {
 
 		const inFlight = this._restoreSessionInFlight.get(sessionStr);
 		if (inFlight) {
-			return inFlight;
+			await inFlight;
+			return;
 		}
 
 		const restore = this._doRestoreSession(session, sessionStr);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -70,6 +70,7 @@ import { AgentHostClientType } from '../common/agentHostClientInfo.js';
 import { AgentHostChangesetOperationService } from './agentHostChangesetOperationService.js';
 import { AgentHostGitStateService } from './agentHostGitStateService.js';
 import { AgentHostGitHubEndpointService, IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
+import { parseAnnotationsUri } from '../common/annotationsUri.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
@@ -324,6 +325,8 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _resourceSubscribers = new ResourceMap<Set<string>>();
 	private readonly _restoreSessionInFlight = new Map<string, Promise<void>>();
 	private readonly _restoreSubagentInFlight = new Map<string, Promise<void>>();
+	/** Fresh provider-declared provisional sessions that remain eligible for abandoned-draft GC. */
+	private readonly _provisionalSessionGcCandidates = new Map<string, symbol>();
 
 	/** Subagent chats armed for a bounded wait (once execution is confirmed); resolved by {@link _onChatSpawned}, awaited by {@link subscribe}. */
 	private readonly _pendingSubagentChats = new Map<string /* subagentChatUri */, DeferredPromise<void>>();
@@ -1126,6 +1129,11 @@ export class AgentService extends Disposable implements IAgentService {
 		]);
 		const session = created.session;
 		this._logService.trace(`[AgentService] createSession: initialization complete`);
+		if (created.provisional) {
+			this._provisionalSessionGcCandidates.set(session.toString(), Symbol());
+		} else {
+			this._provisionalSessionGcCandidates.delete(session.toString());
+		}
 
 		// Cancel any pending GC armed for this URI. A client may be
 		// re-issuing `createSession` for an existing URI mid-grace (e.g.
@@ -1755,6 +1763,8 @@ export class AgentService extends Disposable implements IAgentService {
 	 */
 	private _onDidMaterializeSession(e: IAgentMaterializeSessionEvent): void {
 		const sessionKey = e.session.toString();
+		this._provisionalSessionGcCandidates.delete(sessionKey);
+		this._cancelPendingSessionGc(e.session);
 		// The session is now materialized — its SDK is resolved (any cold
 		// download already finished), so no further progress is expected for it.
 		this._clearDownloadProgressInterest(sessionKey);
@@ -1988,6 +1998,8 @@ export class AgentService extends Disposable implements IAgentService {
 
 	async disposeSession(session: URI): Promise<void> {
 		this._logService.trace(`[AgentService] disposeSession: ${session.toString()}`);
+		this._provisionalSessionGcCandidates.delete(session.toString());
+		this._cancelPendingSessionGc(session);
 		// Resolve the working directories up front and pass them explicitly:
 		// the checkpoint and review services need them to locate the
 		// repositories holding this session's refs, and reading them from
@@ -2170,6 +2182,7 @@ export class AgentService extends Disposable implements IAgentService {
 		this._resourceSubscribers.delete(resource);
 		this._changesetCoordinator.onLastSubscriber(resource);
 		this._stateManager.onChangesetLivenessChanged();
+		const sessionResource = this._getOwningSessionResource(resource);
 		// An empty session whose last subscriber dropped is a candidate for
 		// full GC (provider session, worktree, on-disk state). Sessions with
 		// at least one turn fall through to {@link _maybeEvictIdleSession},
@@ -2177,7 +2190,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// restored from disk later. Skipping eviction here for empty
 		// sessions ensures their state stays observable so a re-subscribe
 		// can re-arm GC.
-		if (this._maybeScheduleSessionGc(resource)) {
+		if (this._maybeScheduleSessionGc(sessionResource)) {
 			return;
 		}
 		// Defer the idle-session release behind a grace window rather than
@@ -2196,13 +2209,31 @@ export class AgentService extends Disposable implements IAgentService {
 		this._pendingSessionRelease.deleteAndDispose(resource);
 	}
 
+	private _getOwningSessionResource(resource: URI): URI {
+		const resourceString = resource.toString();
+		if (isAhpChatChannel(resourceString)) {
+			return URI.parse(parseRequiredSessionUriFromChatUri(resourceString));
+		}
+		const changeset = parseChangesetUri(resourceString);
+		if (changeset) {
+			return URI.parse(changeset.sessionUri);
+		}
+		const annotations = parseAnnotationsUri(resourceString);
+		return annotations ? URI.parse(annotations.sessionUri) : resource;
+	}
+
+	private _hasSessionSubscribers(resource: URI): boolean {
+		for (const subscribedResource of this._resourceSubscribers.keys()) {
+			if (isEqual(this._getOwningSessionResource(subscribedResource), resource)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	/**
-	 * If `resource` names a session that no client is still subscribed to and
-	 * that has produced no turns (and has no active turn), schedule a delayed
-	 * {@link _runSessionGc} to fully tear it down — provider session, worktree,
-	 * persisted state and all. Sessions with at least one turn are left to the
-	 * existing {@link _maybeEvictIdleSession} path which only drops cached
-	 * state and lets the session be restored from disk later.
+	 * If `resource` names a newly-created empty session that no client is still
+	 * subscribed to, schedule a delayed {@link _runSessionGc} to fully tear it down.
 	 *
 	 * The delay ({@link SESSION_GC_GRACE_MS}) gives a disconnected client time
 	 * to reconnect or a workspace switch to settle. Any subsequent subscribe
@@ -2218,12 +2249,11 @@ export class AgentService extends Disposable implements IAgentService {
 		if (parseSubagentSessionUri(resource)) {
 			return false;
 		}
-		const key = resource.toString();
-		const state = this._stateManager.getSessionState(key);
-		if (!state) {
+		if (this._hasSessionSubscribers(resource)) {
 			return false;
 		}
-		if (state.turns.length > 0 || state.activeTurn !== undefined) {
+		const key = resource.toString();
+		if (!this._getEmptySessionGcCandidate(resource)) {
 			return false;
 		}
 		this._pendingSessionGc.set(resource, disposableTimeout(() => {
@@ -2235,25 +2265,51 @@ export class AgentService extends Disposable implements IAgentService {
 		return true;
 	}
 
+	private _getEmptySessionGcCandidate(resource: URI): symbol | undefined {
+		const key = resource.toString();
+		const candidate = this._provisionalSessionGcCandidates.get(key);
+		if (!candidate) {
+			return undefined;
+		}
+		const state = this._stateManager.getSessionState(key);
+		if (!state || state.turns.length > 0 || state.activeTurn !== undefined) {
+			this._provisionalSessionGcCandidates.delete(key);
+			return undefined;
+		}
+		return candidate;
+	}
+
 	private _cancelPendingSessionGc(resource: URI): void {
 		this._pendingSessionGc.deleteAndDispose(resource);
 	}
 
+	private async _hasPersistedSessionData(resource: URI): Promise<boolean> {
+		const ref = await this._sessionDataService.tryOpenDatabase(resource);
+		ref?.dispose();
+		return ref !== undefined;
+	}
+
 	/**
 	 * Fires {@link SESSION_GC_GRACE_MS} after a session lost its last
-	 * subscriber while empty. Re-checks both invariants (still no subscribers,
-	 * still empty) before tearing the session down via {@link disposeSession}.
-	 * The cached state may already have been evicted by
-	 * {@link _maybeEvictIdleSession}; in that case we still proceed because
-	 * "evicted + no resubscribe" implies no client is observing the session.
+	 * subscriber while it was still empty. Re-checks every invariant before
+	 * tearing the session down via {@link disposeSession}.
 	 */
 	private async _runSessionGc(resource: URI): Promise<void> {
 		const key = resource.toString();
-		if (this._resourceSubscribers.has(resource)) {
+		if (this._hasSessionSubscribers(resource)) {
 			return;
 		}
-		const state = this._stateManager.getSessionState(key);
-		if (state && (state.turns.length > 0 || state.activeTurn !== undefined)) {
+		const candidate = this._getEmptySessionGcCandidate(resource);
+		if (!candidate) {
+			return;
+		}
+		if (await this._hasPersistedSessionData(resource)) {
+			if (this._provisionalSessionGcCandidates.get(key) === candidate) {
+				this._provisionalSessionGcCandidates.delete(key);
+			}
+			return;
+		}
+		if (this._hasSessionSubscribers(resource) || this._getEmptySessionGcCandidate(resource) !== candidate) {
 			return;
 		}
 		this._logService.info(`[AgentService] GC: disposing empty unsubscribed session ${key}`);
@@ -2278,23 +2334,26 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		// Walk up the subagent ancestry: the SDK session and its turn tree are
 		// owned by the root session, so eviction must target the root.
-		let evictionTarget = resource;
+		let evictionTarget = this._getOwningSessionResource(resource);
 		{
 			let parsed;
 			while ((parsed = parseSubagentSessionUri(evictionTarget))) {
 				evictionTarget = parsed.parentSession;
 			}
 		}
-		// Don't evict if the root or any of its subagent descendants still has subscribers.
-		if (this._resourceSubscribers.has(evictionTarget)) {
+		// Don't evict if the root, one of its chats, or any subagent descendant still has subscribers.
+		if (this._hasSessionSubscribers(evictionTarget)) {
 			return;
 		}
 		for (const subscribedUri of this._resourceSubscribers.keys()) {
-			if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
+			if (this._isSubagentDescendantOf(this._getOwningSessionResource(subscribedUri), evictionTarget)) {
 				return;
 			}
 		}
 		const evictionTargetKey = evictionTarget.toString();
+		if (this._provisionalSessionGcCandidates.has(evictionTargetKey)) {
+			return;
+		}
 		// A restore/resume racing this unsubscribe means a client is about to
 		// observe the session again; releasing now would tear down state that
 		// the in-flight rehydrate is populating.
@@ -2302,7 +2361,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return;
 		}
 		const targetState = this._stateManager.getSessionState(evictionTargetKey);
-		if (!targetState || targetState.activeTurn !== undefined) {
+		if (!targetState || this._stateManager.hasActiveTurn(evictionTargetKey)) {
 			return;
 		}
 		this._logService.info(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
@@ -2422,6 +2481,17 @@ export class AgentService extends Disposable implements IAgentService {
 
 	private _dispatchActionNow(channel: string, sessionChannel: string, action: SessionAction | ChatAction | TerminalAction | ClientChangesetAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number, clientType: AgentHostClientType): void {
 		const origin = { clientId, clientSeq };
+		if (
+			action.type === ActionType.ChatTurnStarted
+			|| action.type === ActionType.ChatDraftChanged
+			|| action.type === ActionType.SessionConfigChanged
+			|| action.type === ActionType.SessionIsReadChanged
+			|| action.type === ActionType.SessionIsArchivedChanged
+			|| action.type === ActionType.SessionTitleChanged
+		) {
+			this._provisionalSessionGcCandidates.delete(sessionChannel);
+			this._cancelPendingSessionGc(URI.parse(sessionChannel));
+		}
 		this._stateManager.dispatchClientAction(channel, action, origin);
 		if (action.type === ActionType.RootConfigChanged) {
 			this._configurationService.persistRootConfig();
@@ -2609,6 +2679,8 @@ export class AgentService extends Disposable implements IAgentService {
 
 	async restoreSession(session: URI): Promise<void> {
 		const sessionStr = session.toString();
+		this._provisionalSessionGcCandidates.delete(sessionStr);
+		this._cancelPendingSessionGc(session);
 
 		// Already in state manager - nothing to do.
 		if (this._stateManager.getSessionState(sessionStr)) {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -205,26 +205,11 @@ function getErrorMessage(err: unknown): string {
 }
 
 /**
- * Decide whether a Copilot SDK `resumeSession` failure should fall back to
- * `createSession({ sessionId })`. We want to preserve the original
- * recovery for empty / truncated sessions (e.g. after the user invoked
- * "Start Over", which calls `truncateSession` and leaves the on-disk
- * session with zero events - the SDK then refuses to resume it), but we
- * must NOT silently swallow corruption / schema-validation / parse
- * failures: those should surface so the user sees the real error and the
- * original session contents are not masked by a fresh empty session.
- *
- * Heuristic: any `-32603` Internal Error is treated as the empty-session
- * case UNLESS the message clearly indicates corruption, schema
- * validation, parse failure, or malformed input.
+ * Returns whether the SDK explicitly reported that the persisted session has no events.
  */
-function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
-	if (getCopilotSdkErrorCode(err) !== -32603) {
-		return false;
-	}
-
-	const message = getErrorMessage(err);
-	return !/\b(corrupt|corrupted|invalid|validation|schema|must be|parse|malformed|unexpected token)\b/i.test(message);
+function isEmptySessionResumeError(err: unknown): boolean {
+	return getCopilotSdkErrorCode(err) === -32603
+		&& /'session\.getMessages' returned no events for session\b/i.test(getErrorMessage(err));
 }
 
 function isCustomAgentNotFoundError(err: unknown): boolean {
@@ -424,7 +409,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// The SDK fails to resume sessions that have no messages.
 			// Fall back to creating a new session with the same ID,
 			// seeding model & working directory from stored metadata.
-			if (!shouldCreateEmptySessionAfterResumeError(resumeError)) {
+			if (!isEmptySessionResumeError(resumeError)) {
 				throw resumeError;
 			}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -204,12 +204,13 @@ function getErrorMessage(err: unknown): string {
 	return String(err);
 }
 
-/**
- * Returns whether the SDK explicitly reported that the persisted session has no events.
- */
-function isEmptySessionResumeError(err: unknown): boolean {
-	return getCopilotSdkErrorCode(err) === -32603
-		&& /'session\.getMessages' returned no events for session\b/i.test(getErrorMessage(err));
+function shouldCreateSessionAfterResumeError(err: unknown): boolean {
+	if (getCopilotSdkErrorCode(err) !== -32603) {
+		return false;
+	}
+	const message = getErrorMessage(err);
+	return /'session\.getMessages' returned no events for session\b/i.test(message)
+		|| /\bSession not found: [^\s]+$/i.test(message);
 }
 
 function isCustomAgentNotFoundError(err: unknown): boolean {
@@ -409,7 +410,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// The SDK fails to resume sessions that have no messages.
 			// Fall back to creating a new session with the same ID,
 			// seeding model & working directory from stored metadata.
-			if (!isEmptySessionResumeError(resumeError)) {
+			if (!shouldCreateSessionAfterResumeError(resumeError)) {
 				throw resumeError;
 			}
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -4652,6 +4652,28 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'active-turn session must not be evicted');
 		});
 
+		test('a session with an active peer-chat turn is NOT evicted when its last subscriber drops', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				copilotAgent.createChat = async () => { };
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				const peerChat = URI.parse(buildChatUri(sessionResource, 'peer-1'));
+				await service.createChat(sessionResource, peerChat);
+				service.addSubscriber(sessionResource, 'client-1');
+				service.dispatchAction(
+					peerChat.toString(),
+					{ type: ActionType.ChatTurnStarted, turnId: 'turn-1', startedAt: '2025-01-01T00:00:00.000Z', message: { text: 'hello', origin: { kind: MessageKind.User } } },
+					'client-1', 1,
+				);
+
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'peer-chat active turn must pin the session');
+				assert.strictEqual(copilotAgent.releaseSessionCalls.length, 0);
+			});
+		});
+
 		test('a restored idle session is evicted when its last subscriber drops', () => {
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				service.registerProvider(copilotAgent);
@@ -5001,6 +5023,8 @@ suite('AgentService (node dispatcher)', () => {
 
 	suite('empty-session GC', () => {
 
+		setup(() => copilotAgent.createSessionProvisional = true);
+
 		test('an empty unsubscribed session is disposed after the grace period', () => {
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				service.registerProvider(copilotAgent);
@@ -5042,6 +5066,137 @@ suite('AgentService (node dispatcher)', () => {
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 
 				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'session with turns must not be GC-disposed');
+			});
+		});
+
+		test('a restored empty session is not GC-disposed', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				service.stateManager.removeSession(sessionResource.toString());
+				await service.restoreSession(sessionResource);
+				service.addSubscriber(sessionResource, 'client-1');
+
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'restored sessions must not be GC-disposed');
+			});
+		});
+
+		test('a first turn during the grace period prevents destructive GC', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 5_000));
+				service.dispatchAction(
+					buildDefaultChatUri(sessionResource.toString()),
+					{ type: ActionType.ChatTurnStarted, turnId: 'turn-1', startedAt: '2025-01-01T00:00:00.000Z', message: { text: 'hello', origin: { kind: MessageKind.User } } },
+					'client-1', 1,
+				);
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'the first turn must prevent pending destructive GC');
+			});
+		});
+
+		test('missing state when the grace period expires does not trigger destructive GC', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+
+				service.stateManager.removeSession(sessionResource.toString());
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'missing state must fail closed');
+			});
+		});
+
+		test('persisted session data prevents destructive GC when a provider reports provisional', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const localAgent = new MockAgent('copilot');
+				localAgent.createSessionProvisional = true;
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					createSessionDataService(),
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const sessionResource = await localService.createSession({ provider: 'copilot' });
+				localService.addSubscriber(sessionResource, 'client-1');
+
+				localService.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(localAgent.disposeSessionCalls.length, 0, 'persisted sessions must not be GC-disposed');
+			});
+		});
+
+		test('draft persistence while the persisted-data probe is pending prevents destructive GC', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const probeStarted = new DeferredPromise<void>();
+				const databaseProbe = new DeferredPromise<IReference<ISessionDatabase> | undefined>();
+				const persistedSessionDataService = createSessionDataService();
+				const sessionDataService: ISessionDataService = {
+					...persistedSessionDataService,
+					tryOpenDatabase: async () => {
+						probeStarted.complete();
+						return databaseProbe.p;
+					},
+				};
+				const localAgent = new MockAgent('copilot');
+				localAgent.createSessionProvisional = true;
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					sessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const sessionResource = await localService.createSession({ provider: 'copilot' });
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				await probeStarted.p;
+				localService.dispatchAction(
+					buildDefaultChatUri(sessionResource.toString()),
+					{ type: ActionType.ChatDraftChanged, draft: { text: 'keep this draft', origin: { kind: MessageKind.User } } },
+					'client-1', 1,
+				);
+				databaseProbe.complete(undefined);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				assert.strictEqual(localAgent.disposeSessionCalls.length, 0, 'sessions with persisted drafts must not be GC-disposed');
+			});
+		});
+
+		test('a chat subscription pins its provisional session', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				const chatResource = URI.parse(buildDefaultChatUri(sessionResource.toString()));
+				service.addSubscriber(sessionResource, 'client-1');
+				service.addSubscriber(chatResource, 'client-1');
+
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'chat subscriptions must pin their session');
+
+				service.unsubscribe(chatResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.deepStrictEqual(copilotAgent.disposeSessionCalls.map(uri => uri.toString()), [sessionResource.toString()]);
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5084,6 +5084,27 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('a failed restore does not suppress later provisional GC', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = AgentSession.uri('copilot', 'failed-restore');
+				await assert.rejects(() => service.restoreSession(sessionResource), /Session not found on backend/);
+
+				await service.createSession({ provider: 'copilot', session: sessionResource });
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual({
+					disposeCalls: copilotAgent.disposeSessionCalls.map(uri => uri.toString()),
+					releaseCalls: copilotAgent.releaseSessionCalls.length,
+				}, {
+					disposeCalls: [sessionResource.toString()],
+					releaseCalls: 0,
+				});
+			});
+		});
+
 		test('a first turn during the grace period prevents destructive GC', () => {
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				service.registerProvider(copilotAgent);
@@ -5100,6 +5121,52 @@ suite('AgentService (node dispatcher)', () => {
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 
 				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'the first turn must prevent pending destructive GC');
+				assert.strictEqual(copilotAgent.releaseSessionCalls.length, 0, 'a still-provisional provider session must not be released');
+				assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'a still-provisional provider session must remain observable');
+			});
+		});
+
+		test('a persisted draft keeps the provider-provisional session observable until materialization', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const persistedSessionDataService = createSessionDataService();
+				let hasDatabase = false;
+				const sessionDataService: ISessionDataService = {
+					...persistedSessionDataService,
+					openDatabase: session => {
+						hasDatabase = true;
+						return persistedSessionDataService.openDatabase(session);
+					},
+					tryOpenDatabase: session => hasDatabase ? persistedSessionDataService.tryOpenDatabase(session) : Promise.resolve(undefined),
+				};
+				const localAgent = new MockAgent('copilot');
+				localAgent.createSessionProvisional = true;
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					sessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const sessionResource = await localService.createSession({ provider: 'copilot' });
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.dispatchAction(
+					buildDefaultChatUri(sessionResource.toString()),
+					{ type: ActionType.ChatDraftChanged, draft: { text: 'keep this draft', origin: { kind: MessageKind.User } } },
+					'client-1', 1,
+				);
+
+				localService.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual({
+					releaseCalls: localAgent.releaseSessionCalls.length,
+					statePresent: localService.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					releaseCalls: 0,
+					statePresent: true,
+				});
 			});
 		});
 
@@ -5136,7 +5203,140 @@ suite('AgentService (node dispatcher)', () => {
 				localService.unsubscribe(sessionResource, 'client-1');
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 
-				assert.strictEqual(localAgent.disposeSessionCalls.length, 0, 'persisted sessions must not be GC-disposed');
+				assert.deepStrictEqual({
+					disposeCalls: localAgent.disposeSessionCalls.length,
+					releaseCalls: localAgent.releaseSessionCalls.length,
+					statePresent: localService.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					disposeCalls: 0,
+					releaseCalls: 0,
+					statePresent: true,
+				});
+			});
+		});
+
+		test('a stale duplicate provisional result cannot re-pin a materialized session', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				class MaterializingAgent extends MockAgent {
+					private readonly _onDidMaterialize = new Emitter<{ session: URI; workingDirectories: readonly URI[] | undefined; project: undefined }>();
+					readonly onDidMaterializeSession = this._onDidMaterialize.event;
+					private readonly _duplicateCreate = new DeferredPromise<IAgentCreateSessionResult>();
+					private createCount = 0;
+
+					override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+						if (this.createCount++ === 0) {
+							return { ...await super.createSession(config), provisional: true };
+						}
+						return this._duplicateCreate.p;
+					}
+
+					materialize(session: URI): void {
+						this._onDidMaterialize.fire({ session, workingDirectories: undefined, project: undefined });
+					}
+
+					completeDuplicateCreate(session: URI): void {
+						this._duplicateCreate.complete({ session, provisional: true });
+					}
+
+					override dispose(): void {
+						this._onDidMaterialize.dispose();
+						super.dispose();
+					}
+				}
+
+				const localAgent = new MaterializingAgent('copilot');
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					nullSessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const session = AgentSession.uri('copilot', 'materialization-race');
+				const sessionResource = await localService.createSession({ provider: 'copilot', session });
+				const duplicateCreate = localService.createSession({ provider: 'copilot', session });
+
+				localAgent.materialize(sessionResource);
+				localAgent.completeDuplicateCreate(sessionResource);
+				await duplicateCreate;
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual({
+					releaseCalls: localAgent.releaseSessionCalls.map(uri => uri.toString()),
+					statePresent: localService.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					releaseCalls: [sessionResource.toString()],
+					statePresent: false,
+				});
+			});
+		});
+
+		test('late materialization during disposal cannot affect a recreated session', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				class DisposalRaceAgent extends MockAgent {
+					private readonly _onDidMaterialize = new Emitter<{ session: URI; workingDirectories: readonly URI[] | undefined; project: undefined }>();
+					readonly onDidMaterializeSession = this._onDidMaterialize.event;
+					private readonly _firstDispose = new DeferredPromise<void>();
+
+					override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+						return { ...await super.createSession(config), provisional: true };
+					}
+
+					materialize(session: URI): void {
+						this._onDidMaterialize.fire({ session, workingDirectories: undefined, project: undefined });
+					}
+
+					completeFirstDispose(): void {
+						this._firstDispose.complete();
+					}
+
+					override async disposeSession(session: URI): Promise<void> {
+						if (this.disposeSessionCalls.length === 0) {
+							this.disposeSessionCalls.push(session);
+							return this._firstDispose.p;
+						}
+						return super.disposeSession(session);
+					}
+
+					override dispose(): void {
+						this._onDidMaterialize.dispose();
+						super.dispose();
+					}
+				}
+
+				const localAgent = new DisposalRaceAgent('copilot');
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					nullSessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const session = AgentSession.uri('copilot', 'dispose-materialization-race');
+				const sessionResource = await localService.createSession({ provider: 'copilot', session });
+				const disposing = localService.disposeSession(sessionResource);
+
+				localAgent.materialize(sessionResource);
+				localAgent.completeFirstDispose();
+				await disposing;
+				await localService.createSession({ provider: 'copilot', session });
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual({
+					disposeCalls: localAgent.disposeSessionCalls.map(uri => uri.toString()),
+					releaseCalls: localAgent.releaseSessionCalls.length,
+				}, {
+					disposeCalls: [session.toString(), session.toString()],
+					releaseCalls: 0,
+				});
 			});
 		});
 
@@ -5236,25 +5436,77 @@ suite('AgentService (node dispatcher)', () => {
 		});
 
 		test('createSession on the same URI cancels a pending GC', () => {
-			// Models the reconnect path: client subscribes to a session,
-			// drops the subscription (GC armed), then re-issues
-			// `createSession` for the same URI before the grace expires.
-			// Without explicit cancellation, the timer would fire and
-			// dispose the just-revived session.
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
-				service.registerProvider(copilotAgent);
-				const sessionResource = await service.createSession({ provider: 'copilot', session: AgentSession.uri('copilot', 'recreate-test') });
-				service.addSubscriber(sessionResource, 'client-1');
-				service.unsubscribe(sessionResource, 'client-1');
+				const probeStarted = new DeferredPromise<void>();
+				const databaseProbe = new DeferredPromise<IReference<ISessionDatabase> | undefined>();
+				const sessionDataService: ISessionDataService = {
+					...nullSessionDataService,
+					tryOpenDatabase: async () => {
+						probeStarted.complete();
+						return databaseProbe.p;
+					},
+				};
+				const localAgent = new MockAgent('copilot');
+				localAgent.createSessionProvisional = true;
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					sessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const session = AgentSession.uri('copilot', 'recreate-test');
+				const sessionResource = await localService.createSession({ provider: 'copilot', session });
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.unsubscribe(sessionResource, 'client-1');
 
-				// Re-issue createSession mid-grace.
-				await new Promise(resolve => setTimeout(resolve, 5_000));
-				await service.createSession({ provider: 'copilot', session: AgentSession.uri('copilot', 'recreate-test') });
-
-				// Wait past the original grace window. If GC wasn't
-				// cancelled by createSession, dispose would have fired.
 				await new Promise(resolve => setTimeout(resolve, 30_000));
-				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'createSession on same URI must cancel pending GC');
+				await probeStarted.p;
+				const recreate = localService.createSession({ provider: 'copilot', session });
+				databaseProbe.complete(undefined);
+				await recreate;
+				await Promise.resolve();
+
+				assert.strictEqual(localAgent.disposeSessionCalls.length, 0, 'createSession must cancel in-flight GC');
+			});
+		});
+
+		test('failed createSession on the same URI rearms pending GC', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				class FailingRecreateAgent extends MockAgent {
+					failCreate = false;
+
+					override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+						if (this.failCreate) {
+							throw new Error('create failed');
+						}
+						return { ...await super.createSession(config), provisional: true };
+					}
+				}
+
+				const localAgent = new FailingRecreateAgent('copilot');
+				disposables.add(toDisposable(() => localAgent.dispose()));
+				const localService = disposables.add(new AgentService(
+					new NullLogService(),
+					fileService,
+					nullSessionDataService,
+					{ _serviceBrand: undefined } as IProductService,
+					createNoopGitService(),
+				));
+				localService.registerProvider(localAgent);
+				const session = AgentSession.uri('copilot', 'failed-recreate');
+				const sessionResource = await localService.createSession({ provider: 'copilot', session });
+				localService.addSubscriber(sessionResource, 'client-1');
+				localService.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 5_000));
+				localAgent.failCreate = true;
+				await assert.rejects(() => localService.createSession({ provider: 'copilot', session }), /create failed/);
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual(localAgent.disposeSessionCalls.map(uri => uri.toString()), [session.toString()]);
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -445,15 +445,24 @@ suite('CopilotSessionLauncher resume fallback', () => {
 		}
 	});
 
-	test('falls back to createSession for an unknown -32603 from resumeSession', async () => {
+	test('does not replace a session after an unknown -32603 from resumeSession', async () => {
 		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed: something went wrong');
 
-		const sessions = new DisposableStore();
 		try {
-			sessions.add(await launcher.launch(plan, testRuntime));
-			assert.strictEqual(getCreateSessionCalls(), 1);
+			await assert.rejects(() => launcher.launch(plan, testRuntime), /something went wrong/);
+			assert.strictEqual(getCreateSessionCalls(), 0);
 		} finally {
-			sessions.dispose();
+			await launcher.disposeByokProxyHandle();
+		}
+	});
+
+	test('does not replace a session after a network failure', async () => {
+		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed with message: network fetch failed: request failed: error sending request for url (https://api.github.com/copilot_internal/user)');
+
+		try {
+			await assert.rejects(() => launcher.launch(plan, testRuntime), /network fetch failed/);
+			assert.strictEqual(getCreateSessionCalls(), 0);
+		} finally {
 			await launcher.disposeByokProxyHandle();
 		}
 	});

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -456,6 +456,19 @@ suite('CopilotSessionLauncher resume fallback', () => {
 		}
 	});
 
+	test('falls back to createSession when the SDK session is not found', async () => {
+		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed with message: Session not found: session-1');
+
+		const sessions = new DisposableStore();
+		try {
+			sessions.add(await launcher.launch(plan, testRuntime));
+			assert.strictEqual(getCreateSessionCalls(), 1);
+		} finally {
+			sessions.dispose();
+			await launcher.disposeByokProxyHandle();
+		}
+	});
+
 	test('does not replace a session after a network failure', async () => {
 		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed with message: network fetch failed: request failed: error sending request for url (https://api.github.com/copilot_internal/user)');
 

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -123,6 +123,7 @@ export class MockAgent implements IAgent {
 
 	/** Optional override for the working directory returned by createSession. */
 	resolvedWorkingDirectory: URI | undefined;
+	createSessionProvisional = false;
 
 	/**
 	 * When set, {@link sendMessage} rejects with this error after recording the
@@ -134,7 +135,12 @@ export class MockAgent implements IAgent {
 		const session = config?.session ?? AgentSession.uri(this.id, `${this.id}-session-${this._nextId++}`);
 		const rawId = AgentSession.id(session);
 		this._sessions.set(rawId, session);
-		return { session, project: mockProject(this.id), resolvedWorkingDirectory: this.resolvedWorkingDirectory };
+		return {
+			session,
+			project: mockProject(this.id),
+			resolvedWorkingDirectory: this.resolvedWorkingDirectory,
+			...(this.createSessionProvisional ? { provisional: true } : {}),
+		};
 	}
 
 	async resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult> {


### PR DESCRIPTION
## Summary

Fixes [#328590](https://github.com/microsoft/vscode/issues/328590).

Prevent a transient Copilot SDK resume failure from turning an existing Agent Host session into an empty session that is later garbage-collected.

- only fall back to `createSession({ sessionId })` for the SDK's explicit `session.getMessages returned no events` and `Session not found` errors
- propagate network, corruption, and unknown resume failures without replacing durable history
- limit destructive empty-session GC to pristine sessions whose AHP lifecycle is still `Creating` and which have no persisted database
- count chat, changeset, and annotations subscriptions as session liveness
- carry cancellation through asynchronous persistence checks using the existing pending-GC disposable
- keep idle release non-destructive and prevent it from preempting provisional-session GC

## Background

Two different empty-session concepts had become coupled:

1. [#313841](https://github.com/microsoft/vscode/pull/313841) introduced eagerly-created provisional drafts so model/config/customization UI could operate against a real session URI before the first message. Its 30-second GC was intended as a crash/disconnect backstop for those never-materialized drafts.
2. The Copilot resume fallback, originally added in [#305372](https://github.com/microsoft/vscode/pull/305372) and refined in [#319456](https://github.com/microsoft/vscode/pull/319456), recreates deliberately empty SDK histories after **Start Over** because the SDK refuses to resume a session with no events.

The fallback still treated almost every JSON-RPC `-32603` as the Start Over case. A transient network failure could therefore produce a zero-turn restored state. Empty-session GC then mistook that durable session for an abandoned draft and called the destructive disposal path. The SDK's exact `Session not found` error remains a supported recovery case because customization refresh intentionally replaces a just-created SDK session and resumes it under the same ID.

The non-destructive idle release added in [#324854](https://github.com/microsoft/vscode/pull/324854) made this latent problem easier to hit because reopening an idle session now correctly exercises SDK resume instead of retaining the live SDK object indefinitely.

## Validation

- `npm run compile`
- targeted `CopilotSessionLauncher resume fallback`, `empty-session GC`, and `subscriber refcount eviction` unit suites
- Copilot customizations provider integration suite: 17 passing, 2 pending
- `npm run precommit`
- final code review: no significant issues

(Written by Copilot)
