### PR TITLE
fix: force terminal redraw on visibility change to fix stale rendering (#311614)

### DIFF
--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalNativeContribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalNativeContribution.ts
@@ -13,7 +13,7 @@ import { INativeHostService } from '../../../../platform/native/common/native.js
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ITerminalService } from '../browser/terminal.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { disposableWindowInterval, getActiveWindow } from '../../../../base/browser/dom.js';
+import { addDisposableListener, disposableWindowInterval, EventType, getActiveWindow } from '../../../../base/browser/dom.js';
 
 export class TerminalNativeContribution extends Disposable implements IWorkbenchContribution {
 	declare _serviceBrand: undefined;
@@ -29,6 +29,19 @@ export class TerminalNativeContribution extends Disposable implements IWorkbench
 		ipcRenderer.on('vscode:openFiles', (_: unknown, ...args: unknown[]) => { this._onOpenFileRequest(args[0] as INativeOpenFileRequest); });
 		this._register(nativeHostService.onDidResumeOS(() => this._onOsResume()));
 
+		// Force a redraw of all terminal instances when the window regains
+		// visibility. On macOS, switching desktops/spaces or locking/unlocking
+		// the screen can leave the GPU-accelerated terminal canvas in a stale
+		// state where text content is present but not rendered correctly.
+		// The `onDidResumeOS` event does not always fire for these scenarios
+		// (e.g. desktop switching), so we also listen for the browser-level
+		// `visibilitychange` event. See #311614.
+		this._register(addDisposableListener(getActiveWindow().document, EventType.VISIBILITY_CHANGE, () => {
+			if (getActiveWindow().document.visibilityState === 'visible') {
+				this._forceRedrawAllTerminals();
+			}
+		}));
+
 		this._terminalService.setNativeDelegate({
 			getWindowCount: () => nativeHostService.getWindowCount()
 		});
@@ -40,6 +53,10 @@ export class TerminalNativeContribution extends Disposable implements IWorkbench
 	}
 
 	private _onOsResume(): void {
+		this._forceRedrawAllTerminals();
+	}
+
+	private _forceRedrawAllTerminals(): void {
 		for (const instance of this._terminalService.instances) {
 			instance.xterm?.forceRedraw();
 		}


### PR DESCRIPTION
## Summary

Fixes #311614

On macOS, switching desktops/spaces or locking/unlocking the screen can leave the GPU-accelerated terminal canvas in a stale state where text content is present but not rendered correctly (characters appear garbled/corrupted). Selecting the text or resizing the window temporarily fixes it, confirming the buffer is intact but the canvas isn't redrawn.

## Root Cause

VS Code already handles OS resume (sleep/wake) via `nativeHostService.onDidResumeOS`, which calls `forceRedraw()` on all terminal instances to clear the WebGL texture atlas. However, on macOS:

- **Switching desktops/spaces** does **not** trigger `onDidResumeOS`
- **Locking/unlocking the screen** may not reliably trigger `onDidResumeOS`

This means the terminal canvas remains stale after these common operations, producing the corrupted rendering described in #311614.

## Fix

Added a `visibilitychange` event listener in `TerminalNativeContribution` that fires whenever the window's visibility state changes. When the window transitions back to `visible`, it calls `forceRedraw()` on all terminal instances, ensuring the viewport is always re-rendered correctly.

The existing redraw logic was refactored into a shared `_forceRedrawAllTerminals()` method called by both:
- The existing `onDidResumeOS` handler (sleep/wake)
- The new `visibilitychange` handler (desktop switching, lock/unlock, minimize/restore)

## Testing

- Verified that the `visibilitychange` event fires reliably on macOS when switching spaces, locking/unlocking, and minimizing/restoring windows.
- The fix only triggers `forceRedraw()` when transitioning to `visible`, not on every visibility change, minimizing unnecessary redraws.
- Disabling GPU acceleration (`terminal.integrated.gpuAcceleration: "off"`) already avoids the issue, confirming this is a WebGL renderer problem.

## Complementary to upstream xterm.js fixes

This complements the upstream xterm.js fixes from #326772 (which address texture atlas page merge issues in the WebGL renderer itself). The VS Code-side fix ensures a redraw is triggered even when the OS-level resume event doesn't fire.