### PR TITLE
voice: discard late audio for a timed-out narration

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -3972,6 +3972,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// playable (mirrors the `kind !== 'response'` carve-out there).
 		if (pending.kind !== 'response') {
 			this._rememberCancelledPendingNarration(narrationId);
+			this._discardCancelledPendingNarrationResponses(new Set([narrationId]));
 		}
 		// Only restore state when this was the last thing we were waiting on. If a
 		// direct chat reply is still expected (`_awaitingReplyAudio`) or another
@@ -5008,19 +5009,30 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (cancelledIds.size === 0) {
 			return;
 		}
-		// Drop any not-yet-played chunks of those narrations from the queue.
-		for (let i = this._audioQueue.length - 1; i >= 0; i--) {
-			const responseId = this._audioQueue[i].responseId;
-			if (responseId !== undefined && cancelledIds.has(responseId)) {
-				this._audioQueue.splice(i, 1);
-			}
-		}
 		// Remember the ids so trailing chunks (or a narration whose audio has
 		// not started arriving yet) are swallowed in the audio_response handler.
 		// Bound the set so ids that never yield audio can't leak across a long
 		// session.
 		for (const id of cancelledIds) {
 			this._rememberCancelledPendingNarration(id);
+		}
+		this._discardCancelledPendingNarrationResponses(cancelledIds);
+		// If one of the cancelled narrations is what's currently playing, cut it
+		// off. Mark it interrupted first so onPlaybackStopped doesn't treat it as
+		// "heard"; that handler then resets the slot, drains the queue and
+		// restores idle / hands-free listening.
+		if (this._currentPlaybackResponseId !== undefined && cancelledIds.has(this._currentPlaybackResponseId)) {
+			this._stopCurrentPlaybackAsInterrupted();
+		}
+	}
+
+	private _discardCancelledPendingNarrationResponses(cancelledIds: ReadonlySet<string>): void {
+		// Drop any not-yet-played chunks of those narrations from the queue.
+		for (let i = this._audioQueue.length - 1; i >= 0; i--) {
+			const responseId = this._audioQueue[i].responseId;
+			if (responseId !== undefined && cancelledIds.has(responseId)) {
+				this._audioQueue.splice(i, 1);
+			}
 		}
 		// A confirmation narration may already have been buffered for an
 		// unfocused session (in _deferredResponses); the queue splice above and
@@ -5044,13 +5056,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// cleanup), so their _responseRoutes entries would otherwise leak.
 		for (const id of cancelledIds) {
 			this._responseRoutes.delete(id);
-		}
-		// If one of the cancelled narrations is what's currently playing, cut it
-		// off. Mark it interrupted first so onPlaybackStopped doesn't treat it as
-		// "heard"; that handler then resets the slot, drains the queue and
-		// restores idle / hands-free listening.
-		if (this._currentPlaybackResponseId !== undefined && cancelledIds.has(this._currentPlaybackResponseId)) {
-			this._stopCurrentPlaybackAsInterrupted();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -3963,6 +3963,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}
 		this._pendingSolicitedNarrations.delete(narrationId);
 		this._solicitedNarrationIds.delete(narrationId);
+		// A timed-out attempt is abandoned, not merely untracked: for an
+		// actionable narration (confirmation/question/checkpoint) the form it
+		// speaks may already be gone by the time audio finally arrives, so plant
+		// the same tombstone _stopPendingNarration uses to make late audio for
+		// this id be discarded by the audio_response handler. A plain `response`
+		// is a completed reply that is still worth hearing late, so it is left
+		// playable (mirrors the `kind !== 'response'` carve-out there).
+		if (pending.kind !== 'response') {
+			this._rememberCancelledPendingNarration(narrationId);
+		}
 		// Only restore state when this was the last thing we were waiting on. If a
 		// direct chat reply is still expected (`_awaitingReplyAudio`) or another
 		// solicited narration is still waiting for its audio to start, restoring
@@ -5010,13 +5020,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// Bound the set so ids that never yield audio can't leak across a long
 		// session.
 		for (const id of cancelledIds) {
-			if (this._cancelledPendingNarrationIds.size >= 64) {
-				const oldest = this._cancelledPendingNarrationIds.values().next().value;
-				if (oldest !== undefined) {
-					this._cancelledPendingNarrationIds.delete(oldest);
-				}
-			}
-			this._cancelledPendingNarrationIds.add(id);
+			this._rememberCancelledPendingNarration(id);
 		}
 		// A confirmation narration may already have been buffered for an
 		// unfocused session (in _deferredResponses); the queue splice above and
@@ -5048,6 +5052,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (this._currentPlaybackResponseId !== undefined && cancelledIds.has(this._currentPlaybackResponseId)) {
 			this._stopCurrentPlaybackAsInterrupted();
 		}
+	}
+
+	/**
+	 * Tombstone a narration id so any audio that arrives for it afterwards is
+	 * swallowed by the audio_response handler instead of played. The set is
+	 * bounded to 64 entries with FIFO eviction so ids that never yield audio
+	 * (interrupted streams, legacy backends) can't leak across a long session.
+	 */
+	private _rememberCancelledPendingNarration(narrationId: string): void {
+		if (this._cancelledPendingNarrationIds.size >= 64) {
+			const oldest = this._cancelledPendingNarrationIds.values().next().value;
+			if (oldest !== undefined) {
+				this._cancelledPendingNarrationIds.delete(oldest);
+			}
+		}
+		this._cancelledPendingNarrationIds.add(narrationId);
 	}
 
 	private _enqueueAudio(sessionId: string | undefined, audio: string, isFirstChunk: boolean, isFinal: boolean, transcript: string | undefined, responseId?: string, narration?: IPlaybackNarration): void {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -4152,6 +4152,157 @@ suite('VoiceSessionController', () => {
 		assert.strictEqual(pendingSolicitedNarrations.size, 0);
 		assert.strictEqual(controller.statusText.get(), 'Tap to start');
 	});
+
+	test('discards late audio for a confirmation narration that timed out waiting for audio', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const ttsPlaybackService = new TestTtsPlaybackService();
+		const controller = createController(voiceClientService, ttsPlaybackService);
+		const sessionId = 'agent-host-copilot:/timed-out-confirmation';
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		await controller.connect(mainWindow);
+		controller.setActiveSessionShown(URI.parse(sessionId));
+
+		assert.strictEqual(narrate.call(controller, sessionId, 'confirmation', 'I need your approval to run the tests.'), true);
+		const narrationId = voiceClientService.requests[0].narrationId;
+
+		// The audio-start watchdog fires before any audio arrives, abandoning the
+		// attempt. The form it spoke may be gone by the time audio shows up.
+		clock.tick(30_000);
+
+		// Late audio for that confirmation must be swallowed, not spoken.
+		voiceClientService.fireAudioResponse({
+			audio: 'stale-approval',
+			isFirstChunk: true,
+			isFinal: true,
+			codingSessionId: sessionId,
+			responseId: narrationId,
+		});
+
+		assert.deepStrictEqual({
+			playedAudio: ttsPlaybackService.playedAudio,
+			stopCount: ttsPlaybackService.stopCount,
+		}, {
+			playedAudio: [],
+			stopCount: 0,
+		});
+	});
+
+	test('tombstones a timed-out confirmation narration id so it is remembered as cancelled', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const sessionId = 'agent-host-copilot:/tombstoned-confirmation';
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const cancelledIds = Reflect.get(controller, '_cancelledPendingNarrationIds') as Set<string>;
+		await controller.connect(mainWindow);
+		controller.setActiveSessionShown(URI.parse(sessionId));
+
+		assert.strictEqual(narrate.call(controller, sessionId, 'confirmation', 'Approve the deletion?'), true);
+		const narrationId = voiceClientService.requests[0].narrationId;
+		assert.strictEqual(cancelledIds.has(narrationId), false);
+
+		clock.tick(30_000);
+
+		// The abandoned attempt leaves a tombstone so any late audio is dropped.
+		assert.strictEqual(cancelledIds.has(narrationId), true);
+	});
+
+	test('still plays late audio for a response narration that timed out waiting for audio', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const ttsPlaybackService = new TestTtsPlaybackService();
+		const controller = createController(voiceClientService, ttsPlaybackService);
+		const sessionId = 'agent-host-copilot:/timed-out-response';
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const cancelledIds = Reflect.get(controller, '_cancelledPendingNarrationIds') as Set<string>;
+		await controller.connect(mainWindow);
+		controller.setActiveSessionShown(URI.parse(sessionId));
+
+		assert.strictEqual(narrate.call(controller, sessionId, 'response', 'All the tests passed.'), true);
+		const narrationId = voiceClientService.requests[0].narrationId;
+
+		clock.tick(30_000);
+
+		// A completed reply is deliberately exempt from the tombstone: it stays
+		// worth hearing even if its audio arrives late.
+		assert.strictEqual(cancelledIds.has(narrationId), false);
+		voiceClientService.fireAudioResponse({
+			audio: 'late-reply',
+			isFirstChunk: true,
+			isFinal: true,
+			codingSessionId: sessionId,
+			responseId: narrationId,
+		});
+
+		assert.deepStrictEqual(ttsPlaybackService.playedAudio, ['late-reply']);
+	});
+
+	test('bounds the cancelled-narration tombstone set at 64 entries, evicting oldest first', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const cancelledIds = Reflect.get(controller, '_cancelledPendingNarrationIds') as Set<string>;
+		await controller.connect(mainWindow);
+
+		// Arm 65 independent confirmation narrations (distinct sessions so none is
+		// deduped against another), then fire every audio-start watchdog at once.
+		const narrationIds: string[] = [];
+		for (let i = 0; i < 65; i++) {
+			assert.strictEqual(narrate.call(controller, `agent-host-copilot:/bounded-${i}`, 'confirmation', `Approve step ${i}?`), true);
+			narrationIds.push(voiceClientService.requests[i].narrationId);
+		}
+		clock.tick(30_000);
+
+		// Each timed-out confirmation tombstones its id; the set stays bounded and
+		// the very first id was evicted to make room for the last.
+		assert.strictEqual(cancelledIds.size, 64);
+		assert.strictEqual(cancelledIds.has(narrationIds[0]), false);
+		assert.strictEqual(cancelledIds.has(narrationIds[64]), true);
+	});
+
+	test('resolving an in-flight confirmation still cancels playback and swallows late frames after the helper extraction', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const ttsPlaybackService = new TestTtsPlaybackService();
+		const controller = createController(voiceClientService, ttsPlaybackService);
+		const sessionId = 'agent-host-copilot:/resolved-confirmation';
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const stopPendingNarration = Reflect.get(controller, '_stopPendingNarration') as (sessionId: string) => void;
+		const pendingSolicitedNarrations = Reflect.get(controller, '_pendingSolicitedNarrations') as Map<string, unknown>;
+		await controller.connect(mainWindow);
+		controller.setActiveSessionShown(URI.parse(sessionId));
+
+		assert.strictEqual(narrate.call(controller, sessionId, 'confirmation', 'Approve running the migration?'), true);
+		const narrationId = voiceClientService.requests[0].narrationId;
+		// Its audio starts playing live (well before any watchdog timeout).
+		voiceClientService.fireAudioResponse({
+			audio: 'approval',
+			isFirstChunk: true,
+			isFinal: false,
+			codingSessionId: sessionId,
+			responseId: narrationId,
+		});
+
+		// The user resolves the confirmation while it is still speaking.
+		stopPendingNarration.call(controller, sessionId);
+
+		// A trailing frame arriving afterwards must be dropped, not spoken.
+		voiceClientService.fireAudioResponse({
+			audio: 'stale-approval',
+			isFirstChunk: false,
+			isFinal: true,
+			codingSessionId: sessionId,
+			responseId: narrationId,
+		});
+
+		assert.deepStrictEqual({
+			playedAudio: ttsPlaybackService.playedAudio,
+			stopCount: ttsPlaybackService.stopCount,
+			pendingSize: pendingSolicitedNarrations.size,
+		}, {
+			playedAudio: ['approval'],
+			stopCount: 1,
+			pendingSize: 0,
+		});
+	});
+
 	test('auto-listen opens a passive mic turn so the backend does not latch user_is_speaking', () => {
 		const voiceClientService = new TestVoiceClientService();
 		const mic = new RecordingMicCaptureService();

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -514,6 +514,11 @@ suite('VoiceSessionController', () => {
 		));
 	}
 
+	function fireSolicitedNarrationAudioStartTimeout(controller: IVoiceSessionController, narrationId: string): void {
+		const handler = Reflect.get(controller, '_handleSolicitedNarrationAudioStartTimeout') as (narrationId: string) => void;
+		handler.call(controller, narrationId);
+	}
+
 	function createVoiceProgressResponse(id: string, requestId = `request-${id}`) {
 		const changeEmitter = store.add(new Emitter<{ reason: 'other' }>());
 		const parts: { kind: 'voiceProgress'; id: string; value: string }[] = [];
@@ -4165,9 +4170,9 @@ suite('VoiceSessionController', () => {
 		assert.strictEqual(narrate.call(controller, sessionId, 'confirmation', 'I need your approval to run the tests.'), true);
 		const narrationId = voiceClientService.requests[0].narrationId;
 
-		// The audio-start watchdog fires before any audio arrives, abandoning the
-		// attempt. The form it spoke may be gone by the time audio shows up.
-		clock.tick(30_000);
+		// Exercise the watchdog callback directly: advancing the connected
+		// controller's fake clock would also run its unrelated 5s session poll.
+		fireSolicitedNarrationAudioStartTimeout(controller, narrationId);
 
 		// Late audio for that confirmation must be swallowed, not spoken.
 		voiceClientService.fireAudioResponse({
@@ -4200,7 +4205,7 @@ suite('VoiceSessionController', () => {
 		const narrationId = voiceClientService.requests[0].narrationId;
 		assert.strictEqual(cancelledIds.has(narrationId), false);
 
-		clock.tick(30_000);
+		fireSolicitedNarrationAudioStartTimeout(controller, narrationId);
 
 		// The abandoned attempt leaves a tombstone so any late audio is dropped.
 		assert.strictEqual(cancelledIds.has(narrationId), true);
@@ -4219,7 +4224,7 @@ suite('VoiceSessionController', () => {
 		assert.strictEqual(narrate.call(controller, sessionId, 'response', 'All the tests passed.'), true);
 		const narrationId = voiceClientService.requests[0].narrationId;
 
-		clock.tick(30_000);
+		fireSolicitedNarrationAudioStartTimeout(controller, narrationId);
 
 		// A completed reply is deliberately exempt from the tombstone: it stays
 		// worth hearing even if its audio arrives late.
@@ -4249,13 +4254,70 @@ suite('VoiceSessionController', () => {
 			assert.strictEqual(narrate.call(controller, `agent-host-copilot:/bounded-${i}`, 'confirmation', `Approve step ${i}?`), true);
 			narrationIds.push(voiceClientService.requests[i].narrationId);
 		}
-		clock.tick(30_000);
+		for (const narrationId of narrationIds) {
+			fireSolicitedNarrationAudioStartTimeout(controller, narrationId);
+		}
 
 		// Each timed-out confirmation tombstones its id; the set stays bounded and
 		// the very first id was evicted to make room for the last.
 		assert.strictEqual(cancelledIds.size, 64);
 		assert.strictEqual(cancelledIds.has(narrationIds[0]), false);
 		assert.strictEqual(cancelledIds.has(narrationIds[64]), true);
+	});
+
+	test('purges transcript-only deferred state when a confirmation narration times out', async () => {
+		const voiceClientService = new TestVoiceClientService();
+		const controller = createController(voiceClientService);
+		const foregroundSessionId = 'agent-host-copilot:/foreground';
+		const backgroundSessionId = 'agent-host-copilot:/transcript-only-timeout';
+		const narrate = Reflect.get(controller, '_narrate') as (sessionId: string, kind: 'response' | 'confirmation', text: string) => boolean;
+		const deferredResponses = Reflect.get(controller, '_deferredResponses') as Map<string, unknown>;
+		const responseRoutes = Reflect.get(controller, '_responseRoutes') as Map<string, 'live' | 'deferred'>;
+		const recentlyRead = Reflect.get(controller, '_recentlyReadResponse') as Map<string, unknown>;
+		const lastHeard = Reflect.get(controller, '_lastHeardTranscriptById') as Map<string, string>;
+		await controller.connect(mainWindow);
+		Reflect.get(controller, '_isConnected').set(true, undefined);
+		controller.setActiveSessionShown(URI.parse(foregroundSessionId));
+
+		assert.strictEqual(narrate.call(controller, backgroundSessionId, 'confirmation', 'Approve deleting the branch?'), true);
+		const narrationId = voiceClientService.requests[0].narrationId;
+		voiceClientService.fireAudioResponse({
+			audio: '',
+			isFirstChunk: true,
+			isFinal: false,
+			codingSessionId: backgroundSessionId,
+			responseId: narrationId,
+			transcript: 'Approve deleting the branch?',
+		});
+
+		const beforeTimeout = {
+			deferred: deferredResponses.has(backgroundSessionId),
+			route: responseRoutes.get(narrationId),
+		};
+		fireSolicitedNarrationAudioStartTimeout(controller, narrationId);
+		const afterTimeout = {
+			deferred: deferredResponses.has(backgroundSessionId),
+			route: responseRoutes.has(narrationId),
+		};
+		controller.setActiveSessionShown(URI.parse(backgroundSessionId));
+
+		assert.deepStrictEqual({
+			beforeTimeout,
+			afterTimeout,
+			recentlyReadAfterFocus: recentlyRead.has(backgroundSessionId),
+			lastHeardAfterFocus: lastHeard.has(backgroundSessionId),
+		}, {
+			beforeTimeout: {
+				deferred: true,
+				route: 'deferred',
+			},
+			afterTimeout: {
+				deferred: false,
+				route: false,
+			},
+			recentlyReadAfterFocus: false,
+			lastHeardAfterFocus: false,
+		});
 	});
 
 	test('resolving an in-flight confirmation still cancels playback and swallows late frames after the helper extraction', async () => {


### PR DESCRIPTION
### Problem

`_handleSolicitedNarrationAudioStartTimeout` deletes both `_pendingSolicitedNarrations` and `_solicitedNarrationIds` when a solicited narration's audio never starts within 30s. That removes the **only cancellation identity** for that narration.

`_stopPendingNarration` — the routine that cancels stale actionable narration when the user resolves or replaces a pending item — builds its cancel set by iterating `_pendingSolicitedNarrations` and early-returns when it finds none. So after the watchdog has fired, resolving the form plants no tombstone, splices no queue, and stops no playback.

Late audio is only swallowed when its id is in `_cancelledPendingNarrationIds`. It isn't. The audio is enqueued and **played** — speaking a confirmation whose form the user already dismissed.

The 30s window is reachable in normal operation: the voice backend chains narrations behind a predecessor with an unbounded wait, and each backend TTS synthesis carries its own 30s HTTP timeout, so a single narration's LLM + synthesis can exceed the watchdog with no predecessor involved.

### Change

Treat a timed-out attempt as **abandoned** rather than merely untracked. When the watchdog fires, plant the same tombstone `_stopPendingNarration` uses so the existing check in the `audio_response` handler discards late frames.

- The bounded 64-entry FIFO tombstone add is extracted into `_rememberCancelledPendingNarration` and shared by both callers (behaviour identical — same bound, same eviction order).
- Scoped to actionable narrations (`kind !== 'response'`), mirroring the existing carve-out in `_stopPendingNarration`: a plain `response` is a completed reply still worth hearing late, while a confirmation or question refers to a form that may be gone.

34 lines of production change; the rest is tests.

### Verification

- **Typecheck:** clean — `tsc -p src/tsconfig.json --noEmit` reports 97 errors both with and without this change (all pre-existing, from stale local deps); **zero in `voiceClient`**.
- **Tests: NOT RUN LOCALLY.** `npm install` fails in this environment with a 404 for `@github/copilot-sdk@1.0.9-preview.1` from the package feed proxy, so the suite could not be executed. This is why the PR is a **draft** — CI running these tests is the first real execution.

5 tests added: late audio discarded after a confirmation times out; the id is tombstoned; a `response` narration still plays late audio (locks the carve-out); the tombstone set stays bounded at 64 with FIFO eviction; and `_stopPendingNarration`'s existing behaviour is unchanged by the helper extraction.

### Related

Backend counterpart in the voice service (`infinity-microsoft/yolo` #62288) fixes a related case where a confirmation could be narrated after its form closed. This client-side change is the independent half: it covers the window after the watchdog has already released the narration, which the backend cannot see.
