### PR TITLE
Show extension installation progress in the Extensions view

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -22,7 +22,8 @@ import {
 	DidUpdateExtensionMetadata,
 	UninstallExtensionInfo,
 	ExtensionSignatureVerificationCode,
-	IAllowedExtensionsService
+	IAllowedExtensionsService,
+	InstallExtensionProgressEvent
 } from './extensionManagement.js';
 import { areSameExtensions, ExtensionKey, getGalleryExtensionId, getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData, isMalicious } from './extensionManagementUtil.js';
 import { ExtensionType, IExtensionManifest, isApplicationScopedExtension, TargetPlatform } from '../../extensions/common/extensions.js';
@@ -92,6 +93,7 @@ export abstract class CommontExtensionManagementService extends Disposable imple
 	}
 
 	abstract readonly onInstallExtension: Event<InstallExtensionEvent>;
+	abstract readonly onInstallExtensionProgress: Event<InstallExtensionProgressEvent>;
 	abstract readonly onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
 	abstract readonly onUninstallExtension: Event<UninstallExtensionEvent>;
 	abstract readonly onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
@@ -128,6 +130,9 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 
 	private readonly _onInstallExtension = this._register(new Emitter<InstallExtensionEvent>());
 	get onInstallExtension() { return this._onInstallExtension.event; }
+
+	private readonly _onInstallExtensionProgress = this._register(new Emitter<InstallExtensionProgressEvent>());
+	get onInstallExtensionProgress() { return this._onInstallExtensionProgress.event; }
 
 	protected readonly _onDidInstallExtensions = this._register(new Emitter<InstallExtensionResult[]>());
 	get onDidInstallExtensions() { return this._onDidInstallExtensions.event; }
@@ -323,7 +328,11 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				}
 				uninstallTaskToWaitFor = this.uninstallingExtensions.get(this.getUninstallExtensionTaskKey(extension.identifier, options.profileLocation));
 			}
-			const installExtensionTask = this.createInstallExtensionTask(manifest, extension, options);
+			const installExtensionTask = this.createInstallExtensionTask(manifest, extension, options, progress => this._onInstallExtensionProgress.fire({
+				identifier: { id: getGalleryExtensionId(manifest.publisher, manifest.name) },
+				profileLocation: options.profileLocation,
+				...progress,
+			}));
 			const key = `${getGalleryExtensionId(manifest.publisher, manifest.name)}-${options.profileLocation.toString()}`;
 			installingExtensionsMap.set(key, { task: installExtensionTask, root, uninstallTaskToWaitFor });
 			this._onInstallExtension.fire({ identifier: installExtensionTask.identifier, source: extension, profileLocation: options.profileLocation });
@@ -1015,7 +1024,7 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 	}
 
 	protected abstract getCurrentExtensionsManifestLocation(): URI;
-	protected abstract createInstallExtensionTask(manifest: IExtensionManifest, extension: URI | IGalleryExtension, options: InstallExtensionTaskOptions): IInstallExtensionTask;
+	protected abstract createInstallExtensionTask(manifest: IExtensionManifest, extension: URI | IGalleryExtension, options: InstallExtensionTaskOptions, progress: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void): IInstallExtensionTask;
 	protected abstract createUninstallExtensionTask(extension: ILocalExtension, options: UninstallExtensionTaskOptions): IUninstallExtensionTask;
 	protected abstract copyExtension(extension: ILocalExtension, fromProfileLocation: URI, toProfileLocation: URI, metadata?: Partial<Metadata>): Promise<ILocalExtension>;
 	protected abstract moveExtension(extension: ILocalExtension, fromProfileLocation: URI, toProfileLocation: URI, metadata?: Partial<Metadata>): Promise<ILocalExtension>;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../base/common/uri.js';
 import { IHeaders, IRequestContext, IRequestOptions, isOfflineError } from '../../../base/parts/request/common/request.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { getTargetPlatform, IExtensionGalleryService, IExtensionIdentifier, IExtensionInfo, IGalleryExtension, IGalleryExtensionAsset, IGalleryExtensionAssets, IGalleryExtensionVersion, InstallOperation, IQueryOptions, IExtensionsControlManifest, isNotWebExtensionInWebTargetPlatform, isTargetPlatformCompatible, ITranslation, SortOrder, StatisticType, toTargetPlatform, WEB_EXTENSION_TAG, IExtensionQueryOptions, IDeprecationInfo, ISearchPrefferedResults, ExtensionGalleryError, ExtensionGalleryErrorCode, IProductVersion, IAllowedExtensionsService, EXTENSION_IDENTIFIER_REGEX, SortBy, FilterType, MaliciousExtensionInfo, ExtensionRequestsTimeoutConfigKey } from './extensionManagement.js';
+import { getTargetPlatform, IExtensionGalleryService, IExtensionIdentifier, IExtensionInfo, IGalleryExtension, IGalleryExtensionAsset, IGalleryExtensionAssets, IGalleryExtensionVersion, InstallOperation, IQueryOptions, IExtensionsControlManifest, isNotWebExtensionInWebTargetPlatform, isTargetPlatformCompatible, ITranslation, SortOrder, StatisticType, toTargetPlatform, WEB_EXTENSION_TAG, IExtensionQueryOptions, IDeprecationInfo, ISearchPrefferedResults, ExtensionGalleryError, ExtensionGalleryErrorCode, IProductVersion, IAllowedExtensionsService, EXTENSION_IDENTIFIER_REGEX, SortBy, FilterType, MaliciousExtensionInfo, ExtensionRequestsTimeoutConfigKey, ExtensionDownloadProgress } from './extensionManagement.js';
 import { adoptToGalleryExtensionId, areSameExtensions, getGalleryExtensionId, getGalleryExtensionTelemetryData } from './extensionManagementUtil.js';
 import { IExtensionManifest, TargetPlatform } from '../../extensions/common/extensions.js';
 import { isEngineValid } from '../../extensions/common/extensionValidator.js';
@@ -31,6 +31,8 @@ import { StopWatch } from '../../../base/common/stopwatch.js';
 import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
+import { VSBuffer } from '../../../base/common/buffer.js';
+import { transform } from '../../../base/common/stream.js';
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
 const SEARCH_ACTIVITY_HEADER_NAME = 'X-Market-Search-Activity-Id';
@@ -1688,7 +1690,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		} catch (error) { /* Ignore */ }
 	}
 
-	async download(extension: IGalleryExtension, location: URI, operation: InstallOperation): Promise<void> {
+	async download(extension: IGalleryExtension, location: URI, operation: InstallOperation, progress?: (progress: ExtensionDownloadProgress) => void): Promise<void> {
 		this.logService.trace('ExtensionGalleryService#download', extension.identifier.id);
 		const data = getGalleryExtensionTelemetryData(extension);
 		const startTime = new Date().getTime();
@@ -1702,9 +1704,29 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const activityId = extension.queryContext?.[SEARCH_ACTIVITY_HEADER_NAME];
 		const headers: IHeaders | undefined = activityId && typeof activityId === 'string' ? { [SEARCH_ACTIVITY_HEADER_NAME]: activityId } : undefined;
 		const context = await this.getAsset(extension.identifier.id, downloadAsset, AssetType.VSIX, extension.version, 'extensionGalleryService.download', headers ? { headers } : undefined);
+		const parsedTotalBytes = Number(context.res.headers['content-length']);
+		const totalBytes = Number.isFinite(parsedTotalBytes) && parsedTotalBytes >= 0 ? parsedTotalBytes : undefined;
+		let downloadedBytes = 0;
+		let lastReportTime = 0;
+		const reportProgress = (force: boolean): void => {
+			const now = Date.now();
+			if (progress && (force || now - lastReportTime >= 250)) {
+				lastReportTime = now;
+				progress({ downloadedBytes, totalBytes });
+			}
+		};
+		reportProgress(true);
+		const stream = progress ? transform(context.stream, {
+			data: data => {
+				downloadedBytes += data.byteLength;
+				reportProgress(false);
+				return data;
+			}
+		}, chunks => VSBuffer.concat(chunks)) : context.stream;
 
 		try {
-			await this.fileService.writeFile(location, context.stream);
+			await this.fileService.writeFile(location, stream);
+			reportProgress(true);
 		} catch (error) {
 			try {
 				await this.fileService.del(location);

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -418,7 +418,7 @@ export interface IExtensionGalleryService {
 	getCompatibleExtension(extension: IGalleryExtension, includePreRelease: boolean, targetPlatform: TargetPlatform, productVersion?: IProductVersion): Promise<IGalleryExtension | null>;
 	getAllCompatibleVersions(extensionIdentifier: IExtensionIdentifier, includePreRelease: boolean, targetPlatform: TargetPlatform): Promise<IGalleryExtensionVersion[]>;
 	getAllVersions(extensionIdentifier: IExtensionIdentifier): Promise<IGalleryExtensionVersion[]>;
-	download(extension: IGalleryExtension, location: URI, operation: InstallOperation): Promise<void>;
+	download(extension: IGalleryExtension, location: URI, operation: InstallOperation, progress?: (progress: ExtensionDownloadProgress) => void): Promise<void>;
 	downloadSignatureArchive(extension: IGalleryExtension, location: URI): Promise<void>;
 	reportStatistic(publisher: string, name: string, version: string, type: StatisticType): Promise<void>;
 	getReadme(extension: IGalleryExtension, token: CancellationToken): Promise<string>;
@@ -426,6 +426,26 @@ export interface IExtensionGalleryService {
 	getChangelog(extension: IGalleryExtension, token: CancellationToken): Promise<string>;
 	getCoreTranslation(extension: IGalleryExtension, languageId: string): Promise<ITranslation | null>;
 	getExtensionsControlManifest(): Promise<IExtensionsControlManifest>;
+}
+
+export interface ExtensionDownloadProgress {
+	readonly downloadedBytes: number;
+	readonly totalBytes?: number;
+}
+
+export const enum ExtensionInstallStage {
+	Downloading = 'downloading',
+	Verifying = 'verifying',
+	Extracting = 'extracting',
+	Installing = 'installing',
+}
+
+export interface InstallExtensionProgressEvent {
+	readonly identifier: IExtensionIdentifier;
+	readonly profileLocation: URI;
+	readonly stage: ExtensionInstallStage;
+	readonly downloadedBytes?: number;
+	readonly totalBytes?: number;
 }
 
 export interface InstallExtensionEvent {
@@ -611,6 +631,7 @@ export interface IExtensionManagementService {
 	readonly preferPreReleases: boolean;
 
 	onInstallExtension: Event<InstallExtensionEvent>;
+	onInstallExtensionProgress: Event<InstallExtensionProgressEvent>;
 	onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
 	onUninstallExtension: Event<UninstallExtensionEvent>;
 	onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
@@ -805,4 +826,3 @@ export function shouldRequireRepositorySignatureFor(isPrivate: boolean, galleryM
 	}
 	return galleryManifest?.capabilities.signing?.allPublicRepositorySigned === true;
 }
-

--- a/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
@@ -12,7 +12,7 @@ import {
 	IExtensionIdentifier, IExtensionTipsService, IGalleryExtension, ILocalExtension, IExtensionsControlManifest, InstallOptions,
 	UninstallOptions, Metadata, IExtensionManagementService, DidUninstallExtensionEvent, InstallExtensionEvent, InstallExtensionResult,
 	UninstallExtensionEvent, InstallOperation, InstallExtensionInfo, IProductVersion, DidUpdateExtensionMetadata, UninstallExtensionInfo,
-	IAllowedExtensionsService
+	IAllowedExtensionsService, InstallExtensionProgressEvent
 } from './extensionManagement.js';
 import { ExtensionType, IExtensionManifest, TargetPlatform } from '../../extensions/common/extensions.js';
 import { IProductService } from '../../product/common/productService.js';
@@ -48,6 +48,7 @@ function transformOutgoingExtension(extension: ILocalExtension, transformer: IUR
 export class ExtensionManagementChannel<TContext = RemoteAgentConnectionContext | string> implements IServerChannel<TContext> {
 
 	readonly onInstallExtension: Event<InstallExtensionEvent>;
+	readonly onInstallExtensionProgress: Event<InstallExtensionProgressEvent>;
 	readonly onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
 	readonly onUninstallExtension: Event<UninstallExtensionEvent>;
 	readonly onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
@@ -55,6 +56,7 @@ export class ExtensionManagementChannel<TContext = RemoteAgentConnectionContext 
 
 	constructor(private service: IExtensionManagementService, private getUriTransformer: (requestContext: TContext) => IURITransformer | null) {
 		this.onInstallExtension = Event.buffer(service.onInstallExtension, 'onInstallExtension', true);
+		this.onInstallExtensionProgress = Event.buffer(service.onInstallExtensionProgress, 'onInstallExtensionProgress', true);
 		this.onDidInstallExtensions = Event.buffer(service.onDidInstallExtensions, 'onDidInstallExtensions', true);
 		this.onUninstallExtension = Event.buffer(service.onUninstallExtension, 'onUninstallExtension', true);
 		this.onDidUninstallExtension = Event.buffer(service.onDidUninstallExtension, 'onDidUninstallExtension', true);
@@ -72,6 +74,12 @@ export class ExtensionManagementChannel<TContext = RemoteAgentConnectionContext 
 						profileLocation: e.profileLocation ? transformOutgoingURI(e.profileLocation, uriTransformer) : e.profileLocation
 					};
 				});
+			}
+			case 'onInstallExtensionProgress': {
+				return Event.map<InstallExtensionProgressEvent, InstallExtensionProgressEvent>(this.onInstallExtensionProgress, e => ({
+					...e,
+					profileLocation: transformOutgoingURI(e.profileLocation, uriTransformer)
+				}));
 			}
 			case 'onDidInstallExtensions': {
 				return Event.map<readonly InstallExtensionResult[], readonly InstallExtensionResult[]>(this.onDidInstallExtensions, results =>
@@ -194,6 +202,9 @@ export class ExtensionManagementChannelClient extends CommontExtensionManagement
 	protected readonly _onInstallExtension = this._register(new Emitter<InstallExtensionEvent>());
 	get onInstallExtension() { return this._onInstallExtension.event; }
 
+	protected readonly _onInstallExtensionProgress = this._register(new Emitter<InstallExtensionProgressEvent>());
+	get onInstallExtensionProgress() { return this._onInstallExtensionProgress.event; }
+
 	protected readonly _onDidInstallExtensions = this._register(new Emitter<readonly InstallExtensionResult[]>());
 	get onDidInstallExtensions() { return this._onDidInstallExtensions.event; }
 
@@ -213,6 +224,7 @@ export class ExtensionManagementChannelClient extends CommontExtensionManagement
 	) {
 		super(productService, allowedExtensionsService);
 		this._register(this.channel.listen<InstallExtensionEvent>('onInstallExtension')(e => this.onInstallExtensionEvent({ ...e, source: this.isUriComponents(e.source) ? URI.revive(e.source) : e.source, profileLocation: URI.revive(e.profileLocation) })));
+		this._register(this.channel.listen<InstallExtensionProgressEvent>('onInstallExtensionProgress')(e => this._onInstallExtensionProgress.fire({ ...e, profileLocation: URI.revive(e.profileLocation) })));
 		this._register(this.channel.listen<readonly InstallExtensionResult[]>('onDidInstallExtensions')(results => this.onDidInstallExtensionsEvent(results.map(e => ({ ...e, local: e.local ? transformIncomingExtension(e.local, null) : e.local, source: this.isUriComponents(e.source) ? URI.revive(e.source) : e.source, profileLocation: URI.revive(e.profileLocation) })))));
 		this._register(this.channel.listen<UninstallExtensionEvent>('onUninstallExtension')(e => this.onUninstallExtensionEvent({ ...e, profileLocation: URI.revive(e.profileLocation) })));
 		this._register(this.channel.listen<DidUninstallExtensionEvent>('onDidUninstallExtension')(e => this.onDidUninstallExtensionEvent({ ...e, profileLocation: URI.revive(e.profileLocation) })));

--- a/src/vs/platform/extensionManagement/node/extensionDownloader.ts
+++ b/src/vs/platform/extensionManagement/node/extensionDownloader.ts
@@ -15,7 +15,7 @@ import { Promises as FSPromises } from '../../../base/node/pfs.js';
 import { buffer, CorruptZipMessage } from '../../../base/node/zip.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { toExtensionManagementError } from '../common/abstractExtensionManagementService.js';
-import { ExtensionManagementError, ExtensionManagementErrorCode, ExtensionSignatureVerificationCode, IExtensionGalleryService, IGalleryExtension, InstallOperation } from '../common/extensionManagement.js';
+import { ExtensionDownloadProgress, ExtensionInstallStage, ExtensionManagementError, ExtensionManagementErrorCode, ExtensionSignatureVerificationCode, IExtensionGalleryService, IGalleryExtension, InstallExtensionProgressEvent, InstallOperation } from '../common/extensionManagement.js';
 import { ExtensionKey, groupByExtension } from '../common/extensionManagementUtil.js';
 import { fromExtractError } from './extensionManagementUtil.js';
 import { IExtensionSignatureVerificationService } from './extensionSignatureVerificationService.js';
@@ -61,10 +61,11 @@ export class ExtensionsDownloader extends Disposable {
 		this.cleanUpPromise = this.cleanUp();
 	}
 
-	async download(extension: IGalleryExtension, operation: InstallOperation, verifySignature: boolean, clientTargetPlatform?: TargetPlatform): Promise<{ readonly location: URI; readonly verificationStatus: ExtensionSignatureVerificationCode | undefined }> {
+	async download(extension: IGalleryExtension, operation: InstallOperation, verifySignature: boolean, clientTargetPlatform?: TargetPlatform, progress?: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void): Promise<{ readonly location: URI; readonly verificationStatus: ExtensionSignatureVerificationCode | undefined }> {
 		await this.cleanUpPromise;
 
-		const location = await this.downloadVSIX(extension, operation);
+		progress?.({ stage: ExtensionInstallStage.Downloading });
+		const location = await this.downloadVSIX(extension, operation, downloadProgress => progress?.({ stage: ExtensionInstallStage.Downloading, ...downloadProgress }));
 
 		if (!verifySignature) {
 			return { location, verificationStatus: undefined };
@@ -73,6 +74,7 @@ export class ExtensionsDownloader extends Disposable {
 		if (!extension.isSigned) {
 			return { location, verificationStatus: ExtensionSignatureVerificationCode.NotSigned };
 		}
+		progress?.({ stage: ExtensionInstallStage.Verifying });
 
 		let signatureArchiveLocation;
 		try {
@@ -108,11 +110,11 @@ export class ExtensionsDownloader extends Disposable {
 		}
 	}
 
-	private async downloadVSIX(extension: IGalleryExtension, operation: InstallOperation): Promise<URI> {
+	private async downloadVSIX(extension: IGalleryExtension, operation: InstallOperation, progress?: (progress: ExtensionDownloadProgress) => void): Promise<URI> {
 		try {
 			const location = joinPath(this.extensionsDownloadDir, this.getName(extension));
 			const attempts = await this.doDownload(extension, 'vsix', async () => {
-				await this.downloadFile(extension, location, location => this.extensionGalleryService.download(extension, location, operation));
+				await this.downloadFile(extension, location, location => this.extensionGalleryService.download(extension, location, operation, progress));
 				try {
 					await this.validate(location.fsPath, 'extension/package.json');
 				} catch (error) {

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -36,6 +36,8 @@ import {
 	IAllowedExtensionsService,
 	VerifyExtensionSignatureConfigKey,
 	shouldRequireRepositorySignatureFor,
+	ExtensionInstallStage,
+	InstallExtensionProgressEvent,
 } from '../common/extensionManagement.js';
 import { areSameExtensions, computeTargetPlatform, ExtensionKey, getGalleryExtensionId, groupByExtension } from '../common/extensionManagementUtil.js';
 import { IExtensionsProfileScannerService, IScannedProfileExtension } from '../common/extensionsProfileScannerService.js';
@@ -277,28 +279,30 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
 		return this.userDataProfilesService.defaultProfile.extensionsResource;
 	}
 
-	protected createInstallExtensionTask(manifest: IExtensionManifest, extension: URI | IGalleryExtension, options: InstallExtensionTaskOptions): IInstallExtensionTask {
+	protected createInstallExtensionTask(manifest: IExtensionManifest, extension: URI | IGalleryExtension, options: InstallExtensionTaskOptions, progress: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void): IInstallExtensionTask {
 		const extensionKey = extension instanceof URI ? new ExtensionKey({ id: getGalleryExtensionId(manifest.publisher, manifest.name) }, manifest.version) : ExtensionKey.create(extension);
 		return this.instantiationService.createInstance(InstallExtensionInProfileTask, extensionKey, manifest, extension, options, (operation, token) => {
 			if (extension instanceof URI) {
+				progress({ stage: ExtensionInstallStage.Extracting });
 				return this.extractVSIX(extensionKey, extension, options, token);
 			}
 			let promise = this.extractingGalleryExtensions.get(extensionKey.toString());
 			if (!promise) {
-				this.extractingGalleryExtensions.set(extensionKey.toString(), promise = this.downloadAndExtractGalleryExtension(extensionKey, extension, operation, options, token));
+				this.extractingGalleryExtensions.set(extensionKey.toString(), promise = this.downloadAndExtractGalleryExtension(extensionKey, extension, operation, options, token, progress));
 				promise.finally(() => this.extractingGalleryExtensions.delete(extensionKey.toString()));
 			}
 			return promise;
-		}, this.extensionsScanner);
+		}, progress, this.extensionsScanner);
 	}
 
 	protected createUninstallExtensionTask(extension: ILocalExtension, options: UninstallExtensionTaskOptions): IUninstallExtensionTask {
 		return new UninstallExtensionInProfileTask(extension, options, this.extensionsProfileScannerService);
 	}
 
-	private async downloadAndExtractGalleryExtension(extensionKey: ExtensionKey, gallery: IGalleryExtension, operation: InstallOperation, options: InstallExtensionTaskOptions, token: CancellationToken): Promise<ExtractExtensionResult> {
-		const { verificationStatus, location } = await this.downloadExtension(gallery, operation, !options.donotVerifySignature, options.context?.[EXTENSION_INSTALL_CLIENT_TARGET_PLATFORM_CONTEXT] as TargetPlatform | undefined);
+	private async downloadAndExtractGalleryExtension(extensionKey: ExtensionKey, gallery: IGalleryExtension, operation: InstallOperation, options: InstallExtensionTaskOptions, token: CancellationToken, progress: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void): Promise<ExtractExtensionResult> {
+		const { verificationStatus, location } = await this.downloadExtension(gallery, operation, !options.donotVerifySignature, options.context?.[EXTENSION_INSTALL_CLIENT_TARGET_PLATFORM_CONTEXT] as TargetPlatform | undefined, progress);
 		try {
+			progress({ stage: ExtensionInstallStage.Extracting });
 
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
@@ -337,12 +341,12 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
 		}
 	}
 
-	private async downloadExtension(extension: IGalleryExtension, operation: InstallOperation, verifySignature: boolean, clientTargetPlatform?: TargetPlatform): Promise<{ readonly location: URI; readonly verificationStatus: ExtensionSignatureVerificationCode | undefined }> {
+	private async downloadExtension(extension: IGalleryExtension, operation: InstallOperation, verifySignature: boolean, clientTargetPlatform?: TargetPlatform, progress?: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void): Promise<{ readonly location: URI; readonly verificationStatus: ExtensionSignatureVerificationCode | undefined }> {
 		if (verifySignature) {
 			const value = this.configurationService.getValue(VerifyExtensionSignatureConfigKey);
 			verifySignature = isBoolean(value) ? value : true;
 		}
-		const { location, verificationStatus } = await this.extensionsDownloader.download(extension, operation, verifySignature, clientTargetPlatform);
+		const { location, verificationStatus } = await this.extensionsDownloader.download(extension, operation, verifySignature, clientTargetPlatform, progress);
 		const shouldRequireSignature = shouldRequireRepositorySignatureFor(extension.private, await this.extensionGalleryManifestService.getExtensionGalleryManifest());
 
 		if (
@@ -1050,6 +1054,7 @@ class InstallExtensionInProfileTask extends AbstractExtensionTask<ILocalExtensio
 		readonly source: IGalleryExtension | URI,
 		readonly options: InstallExtensionTaskOptions,
 		private readonly extractExtensionFn: (operation: InstallOperation, token: CancellationToken) => Promise<ExtractExtensionResult>,
+		private readonly progress: (progress: Omit<InstallExtensionProgressEvent, 'identifier' | 'profileLocation'>) => void,
 		private readonly extensionsScanner: ExtensionsScanner,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService,
@@ -1149,6 +1154,7 @@ class InstallExtensionInProfileTask extends AbstractExtensionTask<ILocalExtensio
 			local = result.local;
 			this._verificationStatus = result.verificationStatus;
 		}
+		this.progress({ stage: ExtensionInstallStage.Installing });
 
 		if (this.uriIdentityService.extUri.isEqual(this.userDataProfilesService.defaultProfile.extensionsResource, this.options.profileLocation)) {
 			try {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -13,7 +13,7 @@ import { IContextMenuService } from '../../../../platform/contextview/browser/co
 import { disposeIfDisposable } from '../../../../base/common/lifecycle.js';
 import { IExtension, ExtensionState, IExtensionsWorkbenchService, IExtensionContainer, TOGGLE_IGNORE_EXTENSION_ACTION_ID, SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID, THEME_ACTIONS_GROUP, INSTALL_ACTIONS_GROUP, UPDATE_ACTIONS_GROUP, ExtensionEditorTab, ExtensionRuntimeActionType, IExtensionArg, AutoUpdateConfigurationKey } from '../common/extensions.js';
 import { ExtensionsConfigurationInitialContent } from '../common/extensionsFileTemplate.js';
-import { IGalleryExtension, IExtensionGalleryService, ILocalExtension, InstallOptions, InstallOperation, ExtensionManagementErrorCode, IAllowedExtensionsService, shouldRequireRepositorySignatureFor } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { ExtensionInstallStage, IGalleryExtension, IExtensionGalleryService, ILocalExtension, InstallOptions, InstallOperation, ExtensionManagementErrorCode, IAllowedExtensionsService, shouldRequireRepositorySignatureFor } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IWorkbenchExtensionEnablementService, EnablementState, IExtensionManagementServerService, IExtensionManagementServer, IWorkbenchExtensionManagementService } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { ExtensionRecommendationReason, IExtensionIgnoredRecommendationsService, IExtensionRecommendationsService } from '../../../services/extensionRecommendations/common/extensionRecommendations.js';
 import { areSameExtensions, getExtensionId } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
@@ -722,6 +722,27 @@ export class InstallingLabelAction extends ExtensionAction {
 
 	update(): void {
 		this.class = `${InstallingLabelAction.CLASS}${this.extension && this.extension.state === ExtensionState.Installing ? '' : ' hide'}`;
+		const progress = this.extension?.installProgress;
+		if (!progress) {
+			this.label = InstallingLabelAction.LABEL;
+			return;
+		}
+		switch (progress.stage) {
+			case ExtensionInstallStage.Downloading:
+				this.label = progress.totalBytes && progress.downloadedBytes !== undefined
+					? localize('downloadingExtensionWithProgress', "Downloading {0}%", Math.min(100, Math.floor(progress.downloadedBytes / progress.totalBytes * 100)))
+					: localize('downloadingExtension', "Downloading");
+				break;
+			case ExtensionInstallStage.Verifying:
+				this.label = localize('verifyingExtension', "Verifying");
+				break;
+			case ExtensionInstallStage.Extracting:
+				this.label = localize('extractingExtension', "Extracting");
+				break;
+			case ExtensionInstallStage.Installing:
+				this.label = InstallingLabelAction.LABEL;
+				break;
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -26,7 +26,8 @@ import {
 	ExtensionManagementErrorCode,
 	MaliciousExtensionInfo,
 	shouldRequireRepositorySignatureFor,
-	IGalleryExtensionVersion
+	IGalleryExtensionVersion,
+	InstallExtensionProgressEvent
 } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IWorkbenchExtensionEnablementService, EnablementState, IExtensionManagementServerService, IExtensionManagementServer, IWorkbenchExtensionManagementService, IResourceExtension } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData, areSameExtensions, groupByExtension, getGalleryExtensionId, findMatchingMaliciousEntry } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
@@ -95,6 +96,7 @@ type ExtensionsLoadClassification = {
 export class Extension implements IExtension {
 
 	public enablementState: EnablementState = EnablementState.EnabledGlobally;
+	public installProgress: InstallExtensionProgressEvent | undefined;
 
 	private galleryResourcesCache = new Map<string, any>();
 
@@ -616,6 +618,7 @@ class Extensions extends Disposable {
 	) {
 		super();
 		this._register(server.extensionManagementService.onInstallExtension(e => this.onInstallExtension(e)));
+		this._register(server.extensionManagementService.onInstallExtensionProgress(e => this.onInstallExtensionProgress(e)));
 		this._register(server.extensionManagementService.onDidInstallExtensions(e => this.onDidInstallExtensions(e)));
 		this._register(server.extensionManagementService.onUninstallExtension(e => this.onUninstallExtension(e.identifier)));
 		this._register(server.extensionManagementService.onDidUninstallExtension(e => this.onDidUninstallExtension(e)));
@@ -645,6 +648,14 @@ class Extensions extends Disposable {
 					this.onDidUninstallExtension(e);
 				}
 			}));
+		}
+	}
+
+	private onInstallExtensionProgress(event: InstallExtensionProgressEvent): void {
+		const extension = this.installing.find(extension => areSameExtensions(extension.identifier, event.identifier));
+		if (extension) {
+			extension.installProgress = event;
+			this._onChange.fire({ extension });
 		}
 	}
 

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -6,7 +6,7 @@
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { Event } from '../../../../base/common/event.js';
 import { IPager } from '../../../../base/common/paging.js';
-import { IQueryOptions, ILocalExtension, IGalleryExtension, IExtensionIdentifier, IExtensionInfo, IExtensionQueryOptions, IDeprecationInfo, InstallExtensionResult, InstallOptions } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IQueryOptions, ILocalExtension, IGalleryExtension, IExtensionIdentifier, IExtensionInfo, IExtensionQueryOptions, IDeprecationInfo, InstallExtensionProgressEvent, InstallExtensionResult, InstallOptions } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { EnablementState, IExtensionManagementServer, IResourceExtension } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
@@ -59,6 +59,7 @@ export interface IExtension {
 	readonly isBuiltin: boolean;
 	readonly isWorkspaceScoped: boolean;
 	readonly state: ExtensionState;
+	readonly installProgress?: InstallExtensionProgressEvent;
 	readonly name: string;
 	readonly displayName: string;
 	readonly identifier: IExtensionIdentifier;

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -10,7 +10,7 @@ import * as ExtensionsActions from '../../browser/extensionsActions.js';
 import { ExtensionsWorkbenchService } from '../../browser/extensionsWorkbenchService.js';
 import {
 	IExtensionManagementService, IExtensionGalleryService, ILocalExtension, IGalleryExtension,
-	DidUninstallExtensionEvent, InstallExtensionEvent, IExtensionIdentifier, InstallOperation, IExtensionTipsService, InstallExtensionResult, getTargetPlatform, IExtensionsControlManifest, UninstallExtensionEvent, Metadata
+	DidUninstallExtensionEvent, InstallExtensionEvent, IExtensionIdentifier, InstallOperation, IExtensionTipsService, InstallExtensionResult, getTargetPlatform, IExtensionsControlManifest, UninstallExtensionEvent, Metadata, ExtensionInstallStage
 } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IWorkbenchExtensionEnablementService, EnablementState, IExtensionManagementServerService, IExtensionManagementServer, ExtensionInstallLocation, IProfileAwareExtensionManagementService, IWorkbenchExtensionManagementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { IExtensionRecommendationsService } from '../../../../services/extensionRecommendations/common/extensionRecommendations.js';
@@ -210,6 +210,19 @@ suite('ExtensionsActions', () => {
 				assert.ok(!testObject.enabled);
 				assert.strictEqual('Installing', testObject.label);
 				assert.strictEqual('extension-action label install installing', testObject.class);
+
+				const extension = testObject.extension as Mutable<typeof testObject.extension>;
+				extension!.installProgress = { identifier: gallery.identifier, profileLocation: URI.file('profile'), stage: ExtensionInstallStage.Downloading, downloadedBytes: 50, totalBytes: 100 };
+				testObject.update();
+				assert.strictEqual('Downloading 50%', testObject.label);
+
+				extension!.installProgress = { identifier: gallery.identifier, profileLocation: URI.file('profile'), stage: ExtensionInstallStage.Verifying };
+				testObject.update();
+				assert.strictEqual('Verifying', testObject.label);
+
+				extension!.installProgress = { identifier: gallery.identifier, profileLocation: URI.file('profile'), stage: ExtensionInstallStage.Extracting };
+				testObject.update();
+				assert.strictEqual('Extracting', testObject.label);
 			});
 	});
 

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -12,6 +12,7 @@ import {
 	UninstallExtensionInfo,
 	IAllowedExtensionsService,
 	EXTENSION_INSTALL_SKIP_PUBLISHER_TRUST_CONTEXT,
+	InstallExtensionProgressEvent,
 } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { DidChangeProfileForServerEvent, DidUninstallExtensionOnServerEvent, IExtensionManagementServer, IExtensionManagementServerService, InstallExtensionOnServerEvent, IPublisherInfo, IResourceExtension, IWorkbenchExtensionManagementService, UninstallExtensionOnServerEvent } from './extensionManagement.js';
 import { ExtensionType, isLanguagePackExtension, IExtensionManifest, getWorkspaceSupportTypeMessage, TargetPlatform } from '../../../../platform/extensions/common/extensions.js';
@@ -64,6 +65,7 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 
 	private readonly _onInstallExtension = this._register(new Emitter<InstallExtensionOnServerEvent>());
 	readonly onInstallExtension: Event<InstallExtensionOnServerEvent>;
+	readonly onInstallExtensionProgress: Event<InstallExtensionProgressEvent>;
 
 	private readonly _onDidInstallExtensions = this._register(new Emitter<readonly InstallExtensionResult[]>());
 	readonly onDidInstallExtensions: Event<readonly InstallExtensionResult[]>;
@@ -132,6 +134,9 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 		this._register(onInstallExtensionEventMultiplexer.add(this._onInstallExtension.event));
 		this.onInstallExtension = onInstallExtensionEventMultiplexer.event;
 
+		const onInstallExtensionProgressEventMultiplexer = this._register(new EventMultiplexer<InstallExtensionProgressEvent>());
+		this.onInstallExtensionProgress = onInstallExtensionProgressEventMultiplexer.event;
+
 		const onDidInstallExtensionsEventMultiplexer = this._register(new EventMultiplexer<readonly InstallExtensionResult[]>());
 		this._register(onDidInstallExtensionsEventMultiplexer.add(this._onDidInstallExtensions.event));
 		this.onDidInstallExtensions = onDidInstallExtensionsEventMultiplexer.event;
@@ -163,6 +168,7 @@ export class ExtensionManagementService extends CommontExtensionManagementServic
 
 		for (const server of this.servers) {
 			this._register(onInstallExtensionEventMultiplexer.add(Event.map(server.extensionManagementService.onInstallExtension, e => ({ ...e, server }))));
+			this._register(onInstallExtensionProgressEventMultiplexer.add(server.extensionManagementService.onInstallExtensionProgress));
 			this._register(onDidInstallExtensionsEventMultiplexer.add(server.extensionManagementService.onDidInstallExtensions));
 			this._register(onDidProfileAwareInstallExtensionsEventMultiplexer.add(server.extensionManagementService.onProfileAwareDidInstallExtensions));
 			this._register(onUninstallExtensionEventMultiplexer.add(Event.map(server.extensionManagementService.onUninstallExtension, e => ({ ...e, server }))));

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -2009,6 +2009,7 @@ export class TestWorkbenchExtensionEnablementService implements IWorkbenchExtens
 export class TestWorkbenchExtensionManagementService implements IWorkbenchExtensionManagementService {
 	_serviceBrand: undefined;
 	onInstallExtension = Event.None;
+	onInstallExtensionProgress = Event.None;
 	onDidInstallExtensions = Event.None;
 	onUninstallExtension = Event.None;
 	onDidUninstallExtension = Event.None;


### PR DESCRIPTION
## Summary

Extension installation can appear to be stuck when downloading a large VSIX or when later installation steps take time. This change surfaces internal installation progress in the Extensions view so users can tell what VS Code is doing.

Fixes #328551

The extension card now reports the following stages:

- `Downloading N%` when the Marketplace response provides a valid content length
- `Downloading` when the total size is unknown
- `Verifying`
- `Extracting`
- `Installing`

## Implementation

- Count bytes while streaming Marketplace VSIX downloads and throttle progress notifications to avoid excessive UI updates.
- Propagate download progress and installation stages through the extension management service and remote IPC channel.
- Track progress per installing extension in the workbench and update the existing installing label with localized stage text.
- Keep the change internal; it does not add or change the public extension API.

## User impact

Users get immediate feedback during slow extension installs and can distinguish network download time from signature verification, extraction, and final profile installation.

## Verification

- `npm run typecheck-client -- --pretty false`
- Targeted ESLint validation for the modified extension management and workbench files
- `npm run gulp compile-client`
- Added coverage for downloading percentage, verification, and extraction labels in `InstallingLabelAction`

The targeted Electron UI test could not be executed in this environment because downloading the Electron test runtime from GitHub timed out. Type checking, linting, and core client compilation completed successfully.

## How to test

1. Open the Extensions view.
2. Install a large extension that is not already present in the download cache.
3. Confirm that its card transitions through the applicable progress labels.
4. Confirm that downloads without a valid `Content-Length` show `Downloading` without a fabricated percentage.
5. Repeat in a Remote window and confirm that progress from the remote extension host reaches the client UI.
