### PR TITLE
fix(webview): increase focus retry count for copyImage

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -271,7 +271,7 @@ function addCodeBlockCopyButtons() {
 	}
 }
 
-async function copyImage(image: HTMLImageElement, retries = 5) {
+async function copyImage(image: HTMLImageElement, retries = 50) {
 	if (!document.hasFocus() && retries > 0) {
 		// copyImage is called at the same time as webview.reveal, which means this function is running whilst the webview is gaining focus.
 		// Since navigator.clipboard.write requires the document to be focused, we need to wait for focus.

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1587,7 +1587,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		});
 	};
 
-	const copyOutputImage = async (outputId: string, altOutputId: string, textAlternates?: { mimeType: string; content: string }[], retries = 5) => {
+	const copyOutputImage = async (outputId: string, altOutputId: string, textAlternates?: { mimeType: string; content: string }[], retries = 50) => {
 		if (!window.document.hasFocus() && retries > 0) {
 			// copyImage can be called from outside of the webview, which means this function may be running whilst the webview is gaining focus.
 			// Since navigator.clipboard.write requires the document to be focused, we need to wait for focus.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #199981

### Description

This PR addresses the long-standing issue where users are unable to copy images to their system clipboard via the right-click context menu inside webviews (such as Markdown Previews and Notebook outputs). 

**Root Cause:**
When the VS Code custom context menu is invoked via a right-click, the webview `iframe` loses document focus. Because `navigator.clipboard.write()` strictly requires an active, focused document, it fails with a `NotAllowedError` if invoked while the context menu still holds focus. The existing code attempted to wait for focus to return, but the retry limit was set to only `5` retries at very short intervals (100-250ms total), which is frequently insufficient for the UI to return focus to the webview.

**Proposed Changes:**
- Increased the `retries` parameter in `webviewPreloads.ts` (Notebooks) from 5 to 50.
- Increased the `retries` parameter in `preview-src/index.ts` (Markdown) from 5 to 50.

This gives the webview up to 1 - 2.5 seconds to regain focus before executing the clipboard write operation, completely mitigating the timing race condition without introducing any blocking delays.

### How to test
1. Open a Markdown file with an embedded image, or a Notebook with an image output.
2. Right-click the image to open the context menu.
3. Select "Copy Image".
4. Paste the image into an external program (like Paint or a browser).
5. The image should successfully paste instead of failing silently.

