### PR TITLE
fix(terminal): allow shell integration in powershell audit mode

### DIFF
--- a/extensions/copilot/test/simulation/fixtures/fix/issue-7894/shellIntegration.ps1
+++ b/extensions/copilot/test/simulation/fixtures/fix/issue-7894/shellIntegration.ps1
@@ -8,9 +8,19 @@ if (Test-Path variable:global:__VSCodeOriginalPrompt) {
 	return;
 }
 
-# Disable shell integration when the language mode is restricted
+# Disable shell integration when the language mode is restricted, unless it's just an audit policy (PowerShell 7.4+)
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
-	return;
+	$isAudit = $false
+	try {
+		$policy = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+		if ($policy -eq 'Audit') {
+			$isAudit = $true
+		}
+	} catch { }
+
+	if (-not $isAudit) {
+		return;
+	}
 }
 
 $Global:__VSCodeOriginalPrompt = $function:Prompt

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -8,9 +8,19 @@ if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeSta
 	return;
 }
 
-# Disable shell integration when the language mode is restricted
+# Disable shell integration when the language mode is restricted, unless it's just an audit policy (PowerShell 7.4+)
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
-	return;
+	$isAudit = $false
+	try {
+		$policy = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+		if ($policy -eq 'Audit') {
+			$isAudit = $true
+		}
+	} catch { }
+
+	if (-not $isAudit) {
+		return;
+	}
 }
 
 $Global:__VSCodeState = @{


### PR DESCRIPTION
Fixes #283151

### Description

This PR allows VS Code's Terminal Shell Integration to initialize correctly when PowerShell 7.4+ is operating in the new `ConstrainedLanguage` Audit mode.

**Root Cause:**
PowerShell 7.4 introduced a security audit mode. When a system (such as modern Windows 11 machines) has a Windows Defender Application Control (WDAC) audit-only policy active, PowerShell reports its `$ExecutionContext.SessionState.LanguageMode` as `ConstrainedLanguage`. However, it functions with full, unrestricted semantics because it is only logging actions, not blocking them. The `shellIntegration.ps1` script historically bailed out immediately if the language mode was not `FullLanguage`, incorrectly breaking terminal features (prompt tracking, command decorations) for these users.

**Proposed Changes:**
- Updated the language mode guard in `shellIntegration.ps1` to query `[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()` when a restricted language mode is detected.
- If the lockdown policy explicitly returns `Audit`, we safely bypass the bailout and allow shell integration to initialize. 
- Included a `try...catch` wrapper to ensure this check safely fails open on older PowerShell versions that do not support this API.
- Replicated the logic in the Copilot simulation test fixture to ensure consistency.

### How to test
1. On a Windows 11 machine, enable a WDAC / App Control **audit-only** policy.
2. Launch PowerShell 7.4+. Verify that `$ExecutionContext.SessionState.LanguageMode` reports `ConstrainedLanguage` and `[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()` reports `Audit`.
3. Open the integrated terminal in VS Code using the `pwsh` profile.
4. Verify that terminal shell integration (prompt tracking and command boundaries) successfully initializes instead of silently aborting.
