### PR TITLE
fix: guard null visible range in indent guides (fixes #244370)

### DIFF
--- a/src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts
+++ b/src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts
@@ -136,7 +136,7 @@ export class IndentGuidesOverlay extends DynamicViewOverlay {
 						? leftOffset + (guide.visibleColumn - 1) * this._spaceWidth
 						: ctx.visibleRangeForPosition(
 							new Position(lineNumber, guide.column)
-						)!.left;
+						)?.left ?? leftOffset;
 
 				if (left > scrollWidth || (this._maxIndentLeft > 0 && left > this._maxIndentLeft)) {
 					break;


### PR DESCRIPTION
### Summary

`IndentGuidesOverlay.prepareRender` computes the horizontal `left` offset for each bracket/indent guide by calling `ctx.visibleRangeForPosition(...)`. For guides anchored to a model column (`guide.column !== -1`) the result was dereferenced with a non-null assertion (`!.left`). `RenderingContext.visibleRangeForPosition` is declared to return `HorizontalPosition | null` and legitimately returns `null` when the requested position is not part of the currently rendered viewport (e.g. the line/column is outside the rendered range or not yet laid out). When that happens the `!` bypasses the type system and `.left` throws `TypeError: Cannot read properties of null (reading 'left')`.

The two sibling calls in the very same method (the per-line `leftOffset` on line 132 and the horizontal-guide `width` calculation on line 148) already handle the nullable return with `?.left ?? <fallback>`. The column-anchored branch was the sole spot that asserted non-null, so this is a localized oversight rather than an invalid value produced upstream.

Fixes microsoft/vscode#244370
Recommended reviewer: `@hediet`

### Culprit Commit

`78cb0b490a6` — "Fixes \#136474, fixes \#136475. Rewrites bracket guides." by `@hediet` (Henning Dieterichs, 2022-04-01). This commit replaced the previous unconditional `left = leftOffset + (guide.visibleColumn - 1) * this._spaceWidth` with the `guide.column === -1 ? ... : ctx.visibleRangeForPosition(...)!.left` branch, introducing the non-null assertion on a nullable return. The commit is an ancestor of the shipped build `2fc07b811f760549dab9be9d2bedd06c51dfcb9a` (2022 << 2025).

### Code Flow

```mermaid
flowchart TD
  A[view.ts prepareRender loop] --> B[viewOverlays.ts prepareRender]
  B --> C[IndentGuidesOverlay.prepareRender]
  C --> D[loop over guides on line]
  D --> E{guide.column === -1 ?}
  E -- yes --> F[left = leftOffset + visibleColumn math]
  E -- no --> G[ctx.visibleRangeForPosition position]
  G --> H{returns HorizontalPosition or null}
  H -- null --> I[!.left throws TypeError]
```

### Affected Files

- `src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts` (crash site, line 138) — the `!.left` non-null assertion. This is the file changed.
- `src/vs/editor/browser/view/renderingContext.ts` (supporting) — declares `visibleRangeForPosition(position: Position): HorizontalPosition | null`, confirming `null` is a valid, expected return value.

### Repro Steps

Hard to reproduce deterministically; the null return depends on transient viewport/layout timing. Conceptually: an editor with bracket-pair or indentation guides enabled renders a frame in which a guide is anchored to a model column whose position is not currently in the rendered/laid-out visible range (e.g. during rapid scrolling, folding, or layout churn). `visibleRangeForPosition` returns `null` for that position and the `!.left` dereference throws.

### How the Fix Works

**Chosen approach** — `src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts`: replace the non-null assertion `)!.left;` with `)?.left ?? leftOffset;`. `visibleRangeForPosition`'s declared type is already nullable (`HorizontalPosition | null`), so `null` is a legitimate contract-conforming value, not an invalid value injected by some upstream producer — there is no type-system bypass to chase further up. The correct fix therefore lives at the consumer that failed to honor the nullable contract. The fallback mirrors the existing pattern in the same function: line 132 already computes `leftOffset` as the line's left position with an identical `?.left ?? 0`-style guard, so falling back to `leftOffset` yields a sensible horizontal origin for the guide when the precise column position is not yet renderable, instead of crashing. This is not an error being silenced — `visibleRangeForPosition` returning `null` is a normal render-timing outcome that the surrounding code already treats as expected, and no `logService.error`/throw/telemetry path is being removed.

**Alternatives considered**:
- Wrapping the loop body in try/catch — rejected: hides a normal nullable-return case behind exception handling instead of honoring the already-nullable contract at the point of use.
- Skipping the guide entirely (`continue`) when the range is null — rejected: produces intermittently missing guides during scroll; the `?? leftOffset` fallback keeps the guide visible at a sensible position, consistent with the sibling `?? (left + this._spaceWidth)` fallback on the width calculation.

### Recommended Owner

`@hediet` (Henning Dieterichs) — authored the culprit commit `78cb0b490a6` that introduced the non-null assertion, is the current assignee of the issue, and owns the bracket/indent guides rendering code.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/30709253851) · opus48 · 218.2 AIC · ⌖ 17.7 AIC · ⊞ 18.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-id%3A+errors-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30709253851, workflow_id: errors-fix, run: https://github.com/microsoft/vscode-engineering/actions/runs/30709253851 -->

<!-- gh-aw-workflow-id: errors-fix -->
<!-- gh-aw-workflow-call-id: microsoft/vscode-engineering/errors-fix -->