### PR TITLE
Fix Windows-style path handling in getDiagnostics test's Uri.parse mock

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/vscode-node/test/getDiagnostics.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/vscode-node/test/getDiagnostics.spec.ts
@@ -4,12 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
 import { TestLogService } from '../../../../../platform/testing/common/testLogService';
 import { MockMcpServer, parseToolResult, createMockUri, createMockDiagnostic } from './testHelpers';
 
 const { mockGetDiagnostics } = vi.hoisted(() => ({
 	mockGetDiagnostics: vi.fn(),
 }));
+
+// Fixtures are POSIX-style URIs, but a fixture can also be a drive-letter
+// path — detect which from the URL itself, not fileURLToPath()'s host-OS default.
+function uriToFsPath(str: string): string {
+	const isWindowsPath = /^file:\/\/\/[A-Za-z]:\//.test(str);
+	return fileURLToPath(str, { windows: isWindowsPath });
+}
 
 vi.mock('vscode', () => {
 	const DiagnosticSeverity = {
@@ -27,7 +35,7 @@ vi.mock('vscode', () => {
 		Uri: {
 			parse: (str: string) => ({
 				toString: () => str,
-				fsPath: str.replace('file://', ''),
+				fsPath: uriToFsPath(str),
 				scheme: 'file',
 			}),
 		},
@@ -79,6 +87,16 @@ describe('getDiagnostics tool', () => {
 		expect(result).toHaveLength(1);
 		expect(result[0].uri).toBe('file:///test/file.ts');
 		expect(result[0].diagnostics).toHaveLength(1);
+	});
+
+	it('should resolve filePath correctly for a Windows drive-letter URI', async () => {
+		const mockDiag = createMockDiagnostic('Test error', 0, 0, 0, 0, 10, 'test-source', 'TEST001');
+		mockGetDiagnostics.mockReturnValue([mockDiag]);
+
+		const handler = server.getToolHandler('get_diagnostics')!;
+		const result = parseToolResult<DiagnosticsFileResult[]>(await handler({ uri: 'file:///C:/Users/test/file.ts' }));
+
+		expect(result[0].filePath).toBe('C:\\Users\\test\\file.ts');
 	});
 
 	it('should return empty array when no diagnostics exist for URI', async () => {


### PR DESCRIPTION
# Fix Windows-style path handling in getDiagnostics test's Uri.parse mock

## The problem

The mocked `Uri.parse()` converts a file URL into a filesystem path incorrectly for Windows. E.g, `file:///C:/Users/test.ts` turns into `/C:/Users/test.ts`. 
Then it just fails **silently**, no error or crash, just a wrong value.

The bug is currently dormant: all the existing fixtures are POSIX-style, so the 8 existing tests pass. 
Adding a drive-letter test exposes it: `fsPath` resolves to `"/C:/Users/test/file.ts"` instead of `C:\Users\test\file.ts`.

A plain `fileURLToPath(str)` isn't a safe fix either — it resolves by host OS, so on Windows it throws on the existing POSIX-style fixtures, 5 of 9 tests failing:
```
TypeError: File URL path must be absolute
 ❯ Object.parse .../getDiagnostics.spec.ts:38:13
     fsPath: fileURLToPath(str),
Test Files  1 failed (1)
     Tests  5 failed | 4 passed (9)
```

## The fix

Detect the URI's own convention instead of relying on the host OS: if the path looks like a drive letter, parse it as Windows; otherwise as POSIX.

Also added a test asserting the resolved `filePath` for a drive-letter URI, since no existing test covered that case.

## How to test

```bash
cd extensions/copilot
npx vitest run src/extension/chatSessions/copilotcli/vscode-node/test/getDiagnostics.spec.ts
```
Expect `9 passed`.

This specifically needs to run **on Windows** to be meaningful — on Linux/macOS, `fileURLToPath()`'s host-OS default already matches the POSIX-style fixtures, so the regression this PR fixes never surfaces there. 

The new drive-letter test passes on any OS, since the fix no longer depends on the host at all.
