### PR TITLE
Add lm.removeLanguageModelsProviderGroup command

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatLanguageModelActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatLanguageModelActions.ts
@@ -248,6 +248,26 @@ class ConfigureLanguageModelsGroupAction extends Action2 {
 	}
 }
 
+class RemoveLanguageModelsGroupAction extends Action2 {
+	constructor() {
+		super({
+			id: 'lm.removeLanguageModelsProviderGroup',
+			title: localize('lm.removeGroup', 'Remove Language Models Group'),
+		});
+	}
+
+	async run(accessor: ServicesAccessor, languageModelsProviderGroup: ILanguageModelsProviderGroup): Promise<void> {
+		const languageModelsService = accessor.get(ILanguageModelsService);
+
+		if (!languageModelsProviderGroup) {
+			throw new Error('Language model group is required');
+		}
+
+		const { name, vendor } = languageModelsProviderGroup;
+		await languageModelsService.removeLanguageModelsProviderGroup(vendor, name);
+	}
+}
+
 class MigrateLanguageModelsGroupAction extends Action2 {
 	constructor() {
 		super({
@@ -270,5 +290,6 @@ class MigrateLanguageModelsGroupAction extends Action2 {
 export function registerLanguageModelActions() {
 	registerAction2(ManageLanguageModelAuthenticationAction);
 	registerAction2(ConfigureLanguageModelsGroupAction);
+	registerAction2(RemoveLanguageModelsGroupAction);
 	registerAction2(MigrateLanguageModelsGroupAction);
 }


### PR DESCRIPTION
Fixes #328577

Extensions that sync declarative configuration into language model provider groups can add groups via `lm.addLanguageModelsProviderGroup` but have no way to remove them when the corresponding configuration entry goes away, leaving orphaned groups in Manage Language Models.

This registers `lm.removeLanguageModelsProviderGroup` next to the existing add and migrate commands. It takes the same argument shape as add (only `name` and `vendor` are used, since they identify the group) and delegates to `ILanguageModelsService.removeLanguageModelsProviderGroup`, the same method the Manage Language Models editor's Delete action uses, including its cleanup of the group's stored secrets. Vendor and group existence are validated by the service, which throws before any mutation.

The command is unscoped, matching the add command and the native editor's removal path; the command layer has no caller identity to scope on.
