### PR TITLE
fix: keep Agents Update button visible during chat requests

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -11,7 +11,7 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { MenuId, registerAction2, Action2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
-import { ProductContribution, UpdateContribution, CONTEXT_UPDATE_STATE, SwitchProductQualityContribution, showReleaseNotesInEditor, DefaultAccountUpdateContribution } from './update.js';
+import { ProductContribution, UpdateContribution, CONTEXT_UPDATE_STATE, CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS, SwitchProductQualityContribution, showReleaseNotesInEditor, DefaultAccountUpdateContribution } from './update.js';
 import { UpdateTitleBarContribution } from './updateTitleBarEntry.js';
 import { PostUpdateWidgetContribution } from './postUpdateWidget.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
@@ -23,6 +23,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { mnemonicButtonLabel } from '../../../../base/common/labels.js';
 import { ShowCurrentReleaseNotesActionId, ShowCurrentReleaseNotesFromCurrentFileActionId } from '../common/update.js';
 import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -167,7 +168,10 @@ class RestartToUpdateAction extends Action2 {
 			title: localize2('restartToUpdate', 'Restart to Update'),
 			category: { value: product.nameShort, original: product.nameShort },
 			f1: true,
-			precondition: CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready)
+			precondition: ContextKeyExpr.and(
+				CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready),
+				CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS.negate()
+			)
 		});
 	}
 

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -35,6 +35,7 @@ import { IVersion, tryParseVersion } from '../common/updateUtils.js';
 
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
+export const CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS = new RawContextKey<boolean>('updateTitleBarChatRequestInProgress', false);
 
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
@@ -152,7 +153,10 @@ export function appendUpdateMenuItems(menuId: MenuId, group: string): void {
 			id: 'update.restart',
 			title: nls.localize('restartToUpdate', "Restart to Update (1)")
 		},
-		when: CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready)
+		when: ContextKeyExpr.and(
+			CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready),
+			CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS.negate()
+		)
 	});
 }
 

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -25,13 +25,13 @@ import { InEditorZenModeContext } from '../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IChatService } from '../../chat/common/chatService/chatService.js';
+import { CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS } from './update.js';
 import { computeProgressPercent } from '../common/updateUtils.js';
 import './media/updateTitleBarEntry.css';
 import { UpdateTooltip } from './updateTooltip.js';
 
 const UPDATE_TITLE_BAR_ACTION_ID = 'workbench.actions.updateIndicator';
 const UPDATE_TITLE_BAR_CONTEXT = new RawContextKey<boolean>('updateTitleBar', false);
-const UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT = new RawContextKey<boolean>('updateTitleBarChatRequestInProgress', false);
 
 const DISABLED_REMINDER_LAST_SHOWN_KEY = 'update/disabledReminderLastShown';
 const DISABLED_REMINDER_PERIOD = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -63,7 +63,7 @@ registerAction2(class UpdateIndicatorTitleBarAction extends Action2 {
 			menu: [{
 				id: MenuId.TitleBarAdjacentCenter,
 				order: 0,
-				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, InEditorZenModeContext.negate(), ContextKeyExpr.not('inDebugMode'), UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.negate()),
+				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, InEditorZenModeContext.negate(), ContextKeyExpr.not('inDebugMode'), CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS.negate()),
 			}]
 		});
 	}
@@ -100,7 +100,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 		this.context = UPDATE_TITLE_BAR_CONTEXT.bindTo(contextKeyService);
 		this.tooltip = this._register(instantiationService.createInstance(UpdateTooltip));
 
-		const chatInProgressContext = UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.bindTo(contextKeyService);
+		const chatInProgressContext = CONTEXT_UPDATE_TITLE_BAR_CHAT_IN_PROGRESS.bindTo(contextKeyService);
 		this._register(autorun(reader => {
 			chatInProgressContext.set(chatService.requestInProgressObs.read(reader));
 		}));
@@ -125,7 +125,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 
 		if (additionalMenuPlacement) {
 			const { menuId, item } = additionalMenuPlacement;
-			// Keep the chat-in-progress gate scoped to the editor title bar; secondary placements apply their own when-clause.
+			// Chat-in-progress hide stays on the editor title bar; Agents keeps Update visible (#328473).
 			MenuRegistry.appendMenuItem(menuId, {
 				...item,
 				command: {
@@ -235,6 +235,7 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 		@IHoverService private readonly hoverService: IHoverService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@IUpdateService private readonly updateService: IUpdateService,
+		@IChatService private readonly chatService: IChatService,
 	) {
 		super(undefined, action, options);
 
@@ -290,6 +291,11 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 				commandId = 'update.install';
 				break;
 			case StateType.Ready:
+				// Don't quit while a chat request is running; show the tooltip instead.
+				if (this.chatService.requestInProgressObs.get()) {
+					this.showTooltip(true);
+					return;
+				}
 				commandId = 'update.restart';
 				break;
 			default:

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -125,13 +125,16 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 
 		if (additionalMenuPlacement) {
 			const { menuId, item } = additionalMenuPlacement;
+			// Do not apply the chat-in-progress hide here. That gate is for the editor titlebar
+			// (TitleBarAdjacentCenter above); Agents is the only secondary placement and routinely
+			// has chat/agent requests in flight, which would leave no Update CTA (#328473).
 			MenuRegistry.appendMenuItem(menuId, {
 				...item,
 				command: {
 					id: UPDATE_TITLE_BAR_ACTION_ID,
 					title: localize('updateIndicatorTitleBarAction', 'Update'),
 				},
-				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.negate(), item.when),
+				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, item.when),
 			});
 			this._register(actionViewItemService.register(
 				menuId,

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -125,9 +125,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 
 		if (additionalMenuPlacement) {
 			const { menuId, item } = additionalMenuPlacement;
-			// Do not apply the chat-in-progress hide here. That gate is for the editor titlebar
-			// (TitleBarAdjacentCenter above); Agents is the only secondary placement and routinely
-			// has chat/agent requests in flight, which would leave no Update CTA (#328473).
+			// Keep the chat-in-progress gate scoped to the editor title bar; secondary placements apply their own when-clause.
 			MenuRegistry.appendMenuItem(menuId, {
 				...item,
 				command: {

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -15,6 +15,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IMeteredConnectionService } from '../../../../platform/meteredConnection/common/meteredConnection.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { AvailableForDownload, Disabled, DisablementReason, Downloaded, Downloading, Idle, IUpdate, Overwriting, Ready, Restarting, State, StateType, Updating } from '../../../../platform/update/common/update.js';
+import { IChatService } from '../../chat/common/chatService/chatService.js';
 import { ShowCurrentReleaseNotesActionId } from '../common/update.js';
 import { computeDownloadSpeed, computeDownloadTimeRemaining, computeProgressPercent, formatBytes, formatDate, formatTimeRemaining, tryParseDate } from '../common/updateUtils.js';
 import './media/updateTooltip.css';
@@ -65,6 +66,7 @@ export class UpdateTooltip extends Disposable {
 		@IHoverService private readonly hoverService: IHoverService,
 		@IMeteredConnectionService private readonly meteredConnectionService: IMeteredConnectionService,
 		@IProductService private readonly productService: IProductService,
+		@IChatService private readonly chatService: IChatService,
 	) {
 		super();
 
@@ -350,6 +352,13 @@ export class UpdateTooltip extends Disposable {
 	}
 
 	private renderReady({ update }: Ready) {
+		if (this.chatService.requestInProgressObs.get()) {
+			// Keep Update discoverable during chat but never offer a one-click quit (#322857 / #328473).
+			this.renderTitleAndInfo(localize('updateTooltip.readyDuringChatTitle', "Update Ready"), update);
+			this.renderMessage(localize('updateTooltip.readyDuringChatMessage', "Finish the current session, then restart to update."));
+			return;
+		}
+
 		if (this.configurationService.getValue<string>('update.mode') === 'manual') {
 			this.renderTitleAndInfo(localize('updateTooltip.updateInstalledTitle', "Update Installed"), update);
 			this.renderActionButton(localize('updateTooltip.restartButton', "Restart"), 'update.restart');

--- a/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
@@ -152,4 +152,21 @@ suite('UpdateTitleBarEntry', () => {
 		await action.run();
 		assert.strictEqual(executedCommand, 'update.restart');
 	});
+
+	test('restart menu items stay unavailable while chat is in progress', () => {
+		const key = 'updateTitleBarChatRequestInProgress';
+		const ready = 'updateState == ready';
+		const restartCommandIds = ['update.restart', 'update.restartToUpdate'];
+
+		for (const menuId of [MenuId.GlobalActivity, MenuId.CommandPalette]) {
+			for (const item of MenuRegistry.getMenuItems(menuId)) {
+				if ('submenu' in item || !restartCommandIds.includes(item.command.id)) {
+					continue;
+				}
+				assert.ok(item.when);
+				assert.ok(item.when.serialize().includes(ready));
+				assert.ok(item.when.serialize().includes(key), `${item.command.id} must be hidden during chat`);
+			}
+		}
+	});
 });

--- a/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { IAction } from '../../../../../base/common/actions.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { NullHoverService } from '../../../../../platform/hover/test/browser/nullHoverService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IUpdateService, State, StateType } from '../../../../../platform/update/common/update.js';
+import { IChatService } from '../../../chat/common/chatService/chatService.js';
+import { MockChatService } from '../../../chat/test/common/chatService/mockChatService.js';
+import type { UpdateTitleBarEntry as UpdateTitleBarEntryType } from '../../browser/updateTitleBarEntry.js';
+import type { UpdateTooltip } from '../../browser/updateTooltip.js';
+
+suite('UpdateTitleBarEntry', () => {
+	// Import after suite start so module singletons aren't tracked as leaks.
+	let UpdateTitleBarEntry: typeof UpdateTitleBarEntryType;
+
+	suiteSetup(async () => {
+		const titleBar = await import('../../browser/updateTitleBarEntry.js');
+		UpdateTitleBarEntry = titleBar.UpdateTitleBarEntry;
+	});
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createReadyState(): State {
+		return { type: StateType.Ready, update: { version: 'abc1234', productVersion: '1.99.0' }, explicit: true, overwrite: false };
+	}
+
+	function createUpdateService(state: State): IUpdateService {
+		const onStateChange = new Emitter<State>();
+		store.add(onStateChange);
+		return {
+			_serviceBrand: undefined,
+			onStateChange: onStateChange.event,
+			state,
+			checkForUpdates: async () => { },
+			downloadUpdate: async () => { },
+			applyUpdate: async () => { },
+			quitAndInstall: async () => { },
+			isLatestVersion: async () => true,
+			_applySpecificUpdate: async () => { },
+			setInternalOrg: async () => { },
+		};
+	}
+
+	test('editor Update when-clause includes chat-in-progress gate', () => {
+		const items = MenuRegistry.getMenuItems(MenuId.TitleBarAdjacentCenter);
+		const updateItem = items.find(item => !('submenu' in item) && item.command.id === 'workbench.actions.updateIndicator');
+		assert.ok(updateItem && !('submenu' in updateItem));
+		assert.ok(updateItem.when?.serialize().includes('updateTitleBarChatRequestInProgress'));
+	});
+
+	test('Ready click shows tooltip instead of restarting while chat is in progress', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		const chatService = new MockChatService();
+		chatService.requestInProgressObs = observableValue('requestInProgress', true);
+
+		let executedCommand: string | undefined;
+		let tooltipShown = false;
+		const fakeTooltip = {
+			domNode: document.createElement('div'),
+			renderState: () => { },
+		} as unknown as UpdateTooltip;
+
+		instantiationService.stub(ICommandService, {
+			executeCommand: async (id: string) => { executedCommand = id; }
+		} as Partial<ICommandService>);
+		instantiationService.stub(IHoverService, NullHoverService);
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IUpdateService, createUpdateService(createReadyState()));
+		instantiationService.stub(IChatService, chatService);
+
+		const action: IAction = {
+			id: 'workbench.actions.updateIndicator',
+			label: 'Update',
+			tooltip: '',
+			class: undefined,
+			enabled: true,
+			checked: false,
+			run: async () => { },
+			dispose: () => { },
+		};
+
+		const entry = store.add(instantiationService.createInstance(
+			UpdateTitleBarEntry,
+			action,
+			{},
+			fakeTooltip,
+			() => { },
+		));
+
+		const originalShowTooltip = entry.showTooltip.bind(entry);
+		entry.showTooltip = (focus?: boolean) => {
+			tooltipShown = true;
+			originalShowTooltip(focus);
+		};
+
+		await action.run();
+
+		assert.strictEqual(executedCommand, undefined);
+		assert.strictEqual(tooltipShown, true);
+	});
+
+	test('Ready click restarts when chat is idle', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		const chatService = new MockChatService();
+		chatService.requestInProgressObs = observableValue('requestInProgress', false);
+
+		let executedCommand: string | undefined;
+		const fakeTooltip = {
+			domNode: document.createElement('div'),
+			renderState: () => { },
+		} as unknown as UpdateTooltip;
+
+		instantiationService.stub(ICommandService, {
+			executeCommand: async (id: string) => { executedCommand = id; }
+		} as Partial<ICommandService>);
+		instantiationService.stub(IHoverService, NullHoverService);
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IUpdateService, createUpdateService(createReadyState()));
+		instantiationService.stub(IChatService, chatService);
+
+		const action: IAction = {
+			id: 'workbench.actions.updateIndicator',
+			label: 'Update',
+			tooltip: '',
+			class: undefined,
+			enabled: true,
+			checked: false,
+			run: async () => { },
+			dispose: () => { },
+		};
+
+		store.add(instantiationService.createInstance(
+			UpdateTitleBarEntry,
+			action,
+			{},
+			fakeTooltip,
+			() => { },
+		));
+
+		await action.run();
+		assert.strictEqual(executedCommand, 'update.restart');
+	});
+});


### PR DESCRIPTION
## Summary
- Agents routinely has chat/agent requests in flight, so applying the editor chat-in-progress hide to the Agents Update title-bar placement made Update disappear there while the editor (often idle) still showed it (#328473).
- Keep Update visible on the Agents secondary title-bar placement during chat.
- When the update is Ready, clicking Update while a chat request is running shows the tooltip instead of calling `update.restart`, so we don't one-click quit/lose session context (#322857).
- Restart menu items / F1 `Restart to Update` stay unavailable while chat is in progress.

Fixes #328473

## Test plan
- [ ] Editor: Update still hides while a chat request is in progress
- [ ] Agents: Update remains visible while an agent/chat request is running
- [ ] Agents + Ready: click Update during chat opens the tooltip (no restart); after chat finishes, click restarts
- [ ] Agents welcome/empty state still hides Update (`sessionsWelcomeVisible`)
- [ ] Download/Install from the title-bar button still works during chat