### PR TITLE
fix: memory leak in PerfModelContentProvider

### DIFF
--- a/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
+++ b/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
@@ -99,7 +99,7 @@ export class PerfviewInput extends TextResourceEditorInput {
 	}
 }
 
-class PerfModelContentProvider implements ITextModelContentProvider {
+export class PerfModelContentProvider implements ITextModelContentProvider {
 
 	private _model: ITextModel | undefined;
 	private _modelDisposables: IDisposable[] = [];
@@ -119,7 +119,7 @@ class PerfModelContentProvider implements ITextModelContentProvider {
 	provideTextContent(resource: URI): Promise<ITextModel> {
 
 		if (!this._model || this._model.isDisposed()) {
-			dispose(this._modelDisposables);
+			this._modelDisposables = dispose(this._modelDisposables);
 			const langId = this._languageService.createById('markdown');
 			this._model = this._modelService.getModel(resource) || this._modelService.createModel('Loading...', langId, resource);
 

--- a/src/vs/workbench/contrib/performance/test/browser/perfviewEditor.test.ts
+++ b/src/vs/workbench/contrib/performance/test/browser/perfviewEditor.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { dispose } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+import { ILanguageSelection, ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
+import { ITimerService } from '../../../../services/timer/browser/timerService.js';
+import { ITerminalService } from '../../../terminal/browser/terminal.js';
+import { PerfModelContentProvider } from '../../browser/perfviewEditor.js';
+
+suite('PerfModelContentProvider', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('discards listeners for a disposed model', async () => {
+		const modelStates: Array<{ disposed: boolean }> = [];
+		const modelService = {
+			getModel: () => null,
+			createModel: () => {
+				const state = { disposed: false };
+				modelStates.push(state);
+				return {
+					isDisposed: () => state.disposed,
+					setLanguage: () => { }
+				} as unknown as ITextModel;
+			}
+		} as unknown as IModelService;
+		const languageService = {
+			createById: () => {
+				const emitter = store.add(new Emitter<string>());
+				return { languageId: 'markdown', onDidChange: emitter.event } as ILanguageSelection;
+			}
+		} as unknown as ILanguageService;
+		const extensionStatusEmitter = store.add(new Emitter());
+		const extensionService = {
+			onDidChangeExtensionsStatus: extensionStatusEmitter.event,
+			whenInstalledExtensionsRegistered: () => Promise.resolve(true)
+		} as unknown as IExtensionService;
+		const neverReady = new Promise<boolean>(() => { });
+		const provider = new PerfModelContentProvider(
+			modelService,
+			languageService,
+			{ setTransientModelProperty: () => { } } as unknown as ICodeEditorService,
+			{ when: () => Promise.resolve() } as unknown as ILifecycleService,
+			{ whenReady: () => neverReady } as unknown as ITimerService,
+			extensionService,
+			{} as IProductService,
+			{ getConnection: () => undefined } as unknown as IRemoteAgentService,
+			{ whenConnected: Promise.resolve() } as unknown as ITerminalService,
+		);
+
+		try {
+			await provider.provideTextContent(URI.parse('perf:Startup Performance'));
+			assert.strictEqual(provider['_modelDisposables'].length, 2);
+
+			modelStates[0].disposed = true;
+			await provider.provideTextContent(URI.parse('perf:Startup Performance'));
+			assert.strictEqual(provider['_modelDisposables'].length, 2);
+		} finally {
+			dispose(provider['_modelDisposables']);
+		}
+	});
+});


### PR DESCRIPTION
### Details

When the Startup Performance text model is recreated, disposed language and extension-status listeners stay reachable because `_modelDisposables` keeps their disposable wrappers.

### Change

Use the empty array returned by `dispose` so only listeners for the current model remain reachable.

### Before

When running `startup-performance-view-open` 37 times, the language selection and content-provider callbacks grow:

<img width="1400" height="80" alt="startup-performance-view-open before" src="https://github.com/user-attachments/assets/d5944f92-e1b8-40bd-b5ec-1bf4a2c755c6" />

### After

No more matching leak is detected.

### Test Video

[startup-performance-view-open.webm](https://github.com/user-attachments/assets/cb9890d8-030e-4d6b-bc33-f7d8a9ba9534)
