### PR TITLE
Fix remote Agent Host diff compatibility

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -9,7 +9,8 @@ import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { createFileSystemProviderError, FileChangeType, FilePermission, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileSystemProvider, IFileSystemProviderWithFileRealpathCapability, IFileWriteOptions, IStat, IWatchOptions } from '../../files/common/files.js';
-import { fromAgentHostUri, toAgentHostUri } from './agentHostUri.js';
+import { fromAgentHostUri, LOCAL_AGENT_HOST_AUTHORITY, toAgentHostUri } from './agentHostUri.js';
+import { toLegacySessionDbUri } from './sessionDbUri.js';
 import { ContentEncoding, type CreateResourceWatchParams, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceRequestParams, type ResourceRequestResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWriteParams, type ResourceWriteResult } from './state/protocol/commands.js';
 import { AhpErrorCodes } from './state/protocol/errors.js';
 import { ProtocolError } from './state/sessionProtocol.js';
@@ -640,7 +641,13 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
  */
 export class AgentHostFileSystemProvider extends AHPFileSystemProvider {
 	protected _decodeUri(resource: URI): URI {
-		return fromAgentHostUri(resource);
+		const originalUri = fromAgentHostUri(resource);
+		// A remote Agent Host can be older than the client. Current-layout
+		// session-db URIs were introduced after the legacy wire format, while
+		// all Agent Host versions that produce file-edit snapshots understand
+		// legacy references. Keep the canonical outer path for labels, but send
+		// the backward-compatible reference over AHP.
+		return resource.authority === LOCAL_AGENT_HOST_AUTHORITY ? originalUri : toLegacySessionDbUri(originalUri);
 	}
 
 	protected _encodeUri(resource: URI, authority: string): URI {

--- a/src/vs/platform/agentHost/common/sessionDbUri.ts
+++ b/src/vs/platform/agentHost/common/sessionDbUri.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { decodeHex } from '../../../base/common/buffer.js';
+import { decodeHex, encodeHex, VSBuffer } from '../../../base/common/buffer.js';
+import { basename } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
 
 const SESSION_DB_SCHEME = 'session-db';
@@ -74,6 +75,30 @@ export function canonicalizeSessionDbUri(uri: URI, fileUri: URI): URI {
 		return uri;
 	}
 	return sessionDbUri(fileUri.path, fields);
+}
+
+/**
+ * Rewrites a current-layout `session-db:` URI to the legacy wire format.
+ *
+ * Remote agent hosts may be older than the client and only understand the
+ * legacy hex-encoded layout. The path component of the current URI is only
+ * used for display, so converting it before an AHP resource request preserves
+ * the canonical client-side label while keeping the request backward
+ * compatible. Legacy, malformed, and foreign URIs are returned unchanged.
+ */
+export function toLegacySessionDbUri(uri: URI): URI {
+	if (uri.scheme !== SESSION_DB_SCHEME || !uri.query) {
+		return uri;
+	}
+	const fields = parseSessionDbUriQuery(uri.query);
+	if (!fields) {
+		return uri;
+	}
+	return URI.from({
+		scheme: SESSION_DB_SCHEME,
+		authority: encodeHex(VSBuffer.fromString(fields.sessionUri)).toString(),
+		path: `/${encodeURIComponent(fields.toolCallId)}/${encodeHex(VSBuffer.fromString(fields.filePath))}/${fields.part}/${basename(uri.path)}`,
+	});
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../base/common/async.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
+import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -162,6 +162,32 @@ suite('toAgentHostUri / fromAgentHostUri', () => {
 			wrappedPath: original.path,
 			wrappedFragment: original.fragment,
 			unwrapped: original.toString(),
+		});
+	});
+
+	test('round-trips a canonical session-db URI', () => {
+		const original = URI.from({
+			scheme: 'session-db',
+			path: '/c:/src/vscode/file.ts',
+			query: JSON.stringify({
+				sessionUri: 'copilot:/session-1',
+				toolCallId: 'call-1',
+				filePath: 'C:\\src\\vscode\\file.ts',
+				part: 'before',
+			}),
+		});
+
+		const wrapped = toAgentHostUri(original, 'remote-host');
+		const unwrapped = fromAgentHostUri(wrapped);
+
+		assert.deepStrictEqual({
+			wrappedPath: wrapped.path,
+			unwrappedPath: unwrapped.path,
+			unwrappedQuery: unwrapped.query,
+		}, {
+			wrappedPath: '/c:/src/vscode/file.ts',
+			unwrappedPath: original.path,
+			unwrappedQuery: original.query,
 		});
 	});
 
@@ -431,6 +457,37 @@ suite('AgentHostFileSystemProvider - synthetic content schemes', () => {
 
 		assert.strictEqual(VSBuffer.wrap(bytes).toString(), 'stub-content');
 		assert.deepStrictEqual(connection.readCalls.map(u => u.toString()), [inner.toString()]);
+	});
+
+	test('readFile keeps the canonical session-db path for labels but sends the legacy wire format to a remote host', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider());
+		const connection = new StubConnection();
+		disposables.add(provider.registerAuthority('remote', connection));
+		const inner = URI.from({
+			scheme: 'session-db',
+			path: '/c:/src/vscode/file.ts',
+			query: JSON.stringify({
+				sessionUri: 'copilot:/session-1',
+				toolCallId: 'call-1',
+				filePath: 'C:\\src\\vscode\\file.ts',
+				part: 'before',
+			}),
+		});
+		const wrapped = toAgentHostUri(inner, 'remote');
+
+		await provider.readFile(wrapped);
+
+		assert.deepStrictEqual({
+			wrappedPath: wrapped.path,
+			remoteReads: connection.readCalls.map(uri => uri.toString()),
+		}, {
+			wrappedPath: '/c:/src/vscode/file.ts',
+			remoteReads: [URI.from({
+				scheme: 'session-db',
+				authority: encodeHex(VSBuffer.fromString('copilot:/session-1')).toString(),
+				path: `/call-1/${encodeHex(VSBuffer.fromString('C:\\src\\vscode\\file.ts'))}/before/file.ts`,
+			}).toString()],
+		});
 	});
 
 	test('full stat-then-read round-trip mirrors the diff editor flow', async () => {

--- a/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
+++ b/src/vs/platform/agentHost/test/common/sessionDbUri.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { buildSessionDbUri, canonicalizeSessionDbUri, parseSessionDbUri } from '../../common/sessionDbUri.js';
+import { buildSessionDbUri, canonicalizeSessionDbUri, parseSessionDbUri, toLegacySessionDbUri } from '../../common/sessionDbUri.js';
 
 const hex = (value: string) => encodeHex(VSBuffer.fromString(value)).toString();
 
@@ -142,6 +142,32 @@ suite('canonicalizeSessionDbUri', () => {
 		assert.deepStrictEqual(
 			[canonical, unparseable, foreign].map(uri => canonicalizeSessionDbUri(uri, fileUri).toString()),
 			[canonical.toString(), unparseable.toString(), foreign.toString()],
+		);
+	});
+});
+
+suite('toLegacySessionDbUri', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('rewrites the current layout to the backward-compatible wire format', () => {
+		const canonical = URI.parse(buildSessionDbUri('copilot:/abc-123', 'call_1', 'C:\\Code\\repo\\file.ts', 'before'));
+		const legacy = toLegacySessionDbUri(canonical);
+
+		assert.deepStrictEqual(
+			[legacy.query, parseSessionDbUri(legacy.toString())],
+			['', { sessionUri: 'copilot:/abc-123', toolCallId: 'call_1', filePath: 'C:\\Code\\repo\\file.ts', part: 'before' }],
+		);
+	});
+
+	test('leaves legacy, malformed and foreign URIs untouched', () => {
+		const legacy = legacyUri('copilot:/abc-123', 'call_1', '/workspace/file.ts', 'before', 'file.ts');
+		const malformed = URI.from({ scheme: 'session-db', path: '/file.ts', query: '{}' });
+		const foreign = URI.file('/workspace/file.ts');
+
+		assert.deepStrictEqual(
+			[legacy, malformed, foreign].map(uri => toLegacySessionDbUri(uri).toString()),
+			[legacy.toString(), malformed.toString(), foreign.toString()],
 		);
 	});
 });


### PR DESCRIPTION
Fixes #328249

Newer clients canonicalize `session-db:` content URIs so diff labels use the edited file path. When connected through a tunnel to an older Agent Host, sending that canonical URI back over AHP fails because the older host only understands the legacy hex-encoded layout.

This change:
- keeps canonical `session-db:` paths on the client for readable diff labels
- translates current-layout URIs to the backward-compatible legacy wire format only for remote Agent Hosts
- adds coverage for URI conversion and the remote provider read path

Validation:
- `npm run compile`
- focused Electron unit suites for session-db URI parsing/canonicalization and AgentHostFileSystemProvider: 29 passing
- `git diff --check`