### PR TITLE
build: harden validation script contracts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,8 @@ Run a targeted type check or build when you are not fully confident in the chang
 - `npm run gulp compile-extensions` for built-in extensions
 - `npm run typecheck` from the `build` folder for build tooling
 
+Development compile tasks already type-check their inputs. Do not run `npm run typecheck-client` immediately before `npm run compile` or `npm run compile-client`; choose the command that covers the required validation. When tests only need fresh output files, use the fast one-shot `npm run transpile-client` instead of compiling.
+
 Use `scripts/test.sh` (or `scripts\test.bat` on Windows) for unit tests and `scripts/test-integration.sh` (or `scripts\test-integration.bat` on Windows) for integration tests. Add a targeted selector such as `--grep` whenever possible. Run `npm run valid-layers-check` only when a change may affect module layering.
 
 ## Coding Guidelines

--- a/build/eslint.ts
+++ b/build/eslint.ts
@@ -19,6 +19,10 @@ export function shouldErrorOnUnmatchedPattern(args: readonly string[]): boolean 
 }
 
 async function eslint(args: readonly string[]): Promise<void> {
+	const started = Date.now();
+	console.log(args.length > 0
+		? `ESLint: checking ${args.length} requested target${args.length === 1 ? '' : 's'}.`
+		: 'ESLint: checking the full repository.');
 	const linter = new ESLint({
 		cache: true,
 		cacheLocation: '.eslintcache',
@@ -33,6 +37,7 @@ async function eslint(args: readonly string[]): Promise<void> {
 	if (message) {
 		console.log(message);
 	}
+	console.log(`ESLint: checked ${results.length} file${results.length === 1 ? '' : 's'} in ${Date.now() - started}ms.`);
 
 	let warningCount = 0;
 	let errorCount = 0;

--- a/build/hygiene.ts
+++ b/build/hygiene.ts
@@ -205,35 +205,39 @@ export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, run
 	const snapshotFilter = filter(['**', '!**/*.snap', '!**/*.snap.actual']);
 	const yarnLockFilter = filter(['**', '!**/yarn.lock']);
 	const unicodeFilterStream = filter(Array.from(unicodeFilter), { restore: true });
-	let inputFileCount = 0;
+	const checkedFiles = new Set<string>();
+	const trackCheckedFile = () => es.through(function (file: VinylFile) {
+		checkedFiles.add(file.relative);
+		this.emit('data', file);
+	});
 
 	const result = input
 		.pipe(filter((f) => Boolean(f.stat && !f.stat.isDirectory())))
 		.pipe(snapshotFilter)
 		.pipe(yarnLockFilter)
-		.pipe(es.through(function (file: VinylFile) {
-			inputFileCount++;
-			this.emit('data', file);
-		}))
 		.pipe(productJsonFilter)
-		.pipe(process.env['BUILD_SOURCEVERSION'] ? es.through() : productJson)
+		.pipe(process.env['BUILD_SOURCEVERSION'] ? es.through() : trackCheckedFile().pipe(productJson))
 		.pipe(productJsonFilter.restore)
 		.pipe(unicodeFilterStream)
+		.pipe(trackCheckedFile())
 		.pipe(unicode)
 		.pipe(unicodeFilterStream.restore)
 		.pipe(filter(Array.from(indentationFilter)))
+		.pipe(trackCheckedFile())
 		.pipe(indentation)
 		.pipe(filter(Array.from(copyrightFilter)))
+		.pipe(trackCheckedFile())
 		.pipe(copyrights);
 
 	const streams: NodeJS.ReadWriteStream[] = [
-		result.pipe(filter(Array.from(tsFormattingFilter))).pipe(formatting)
+		result.pipe(filter(Array.from(tsFormattingFilter))).pipe(trackCheckedFile()).pipe(formatting)
 	];
 
 	if (runEslint) {
 		streams.push(
 			result
 				.pipe(filter(Array.from(eslintFilter)))
+				.pipe(trackCheckedFile())
 				.pipe(
 					eslint((results) => {
 						errorCount += results.warningCount;
@@ -244,7 +248,7 @@ export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, run
 	}
 
 	streams.push(
-		result.pipe(filter(Array.from(stylelintFilter))).pipe(gulpstylelint(((message: string, isError: boolean) => {
+		result.pipe(filter(Array.from(stylelintFilter))).pipe(trackCheckedFile()).pipe(gulpstylelint(((message: string, isError: boolean) => {
 			if (isError) {
 				console.error(message);
 				errorCount++;
@@ -266,8 +270,8 @@ export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, run
 			},
 			function () {
 				process.stdout.write('\n');
-				console.log(`Hygiene checked ${inputFileCount} file${inputFileCount === 1 ? '' : 's'} in ${Date.now() - started}ms.`);
-				if (requestedPaths && inputFileCount === 0) {
+				console.log(`Hygiene checked ${checkedFiles.size} file${checkedFiles.size === 1 ? '' : 's'} in ${Date.now() - started}ms.`);
+				if (requestedPaths && checkedFiles.size === 0) {
 					this.emit('error', `No hygiene-eligible files matched the requested paths: ${requestedPaths.join(', ')}`);
 				} else if (errorCount > 0) {
 					this.emit(

--- a/build/hygiene.ts
+++ b/build/hygiene.ts
@@ -83,7 +83,10 @@ export function checkNoNewJavaScriptFiles(repoRoot: string): string | undefined 
  * Main hygiene function that runs checks on files
  */
 export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, runEslint = true): NodeJS.ReadWriteStream {
-	console.log('Starting hygiene...');
+	const started = Date.now();
+	const requestedPaths = Array.isArray(some) ? some : undefined;
+	const scope = requestedPaths ? `${requestedPaths.length} requested path${requestedPaths.length === 1 ? '' : 's'}` : some ? 'provided file stream' : 'full repository';
+	console.log(`Starting hygiene (${scope})...`);
 	let errorCount = 0;
 
 	const productJson = es.through(function (file: VinylFile) {
@@ -202,11 +205,16 @@ export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, run
 	const snapshotFilter = filter(['**', '!**/*.snap', '!**/*.snap.actual']);
 	const yarnLockFilter = filter(['**', '!**/yarn.lock']);
 	const unicodeFilterStream = filter(Array.from(unicodeFilter), { restore: true });
+	let inputFileCount = 0;
 
 	const result = input
 		.pipe(filter((f) => Boolean(f.stat && !f.stat.isDirectory())))
 		.pipe(snapshotFilter)
 		.pipe(yarnLockFilter)
+		.pipe(es.through(function (file: VinylFile) {
+			inputFileCount++;
+			this.emit('data', file);
+		}))
 		.pipe(productJsonFilter)
 		.pipe(process.env['BUILD_SOURCEVERSION'] ? es.through() : productJson)
 		.pipe(productJsonFilter.restore)
@@ -258,7 +266,10 @@ export function hygiene(some: NodeJS.ReadWriteStream | string[] | undefined, run
 			},
 			function () {
 				process.stdout.write('\n');
-				if (errorCount > 0) {
+				console.log(`Hygiene checked ${inputFileCount} file${inputFileCount === 1 ? '' : 's'} in ${Date.now() - started}ms.`);
+				if (requestedPaths && inputFileCount === 0) {
+					this.emit('error', `No hygiene-eligible files matched the requested paths: ${requestedPaths.join(', ')}`);
+				} else if (errorCount > 0) {
 					this.emit(
 						'error',
 						'Hygiene failed with ' +
@@ -356,7 +367,7 @@ if (import.meta.main) {
 						}
 					}
 
-					console.log('Reading git index versions...');
+					console.log(`Reading ${some.length} git index version${some.length === 1 ? '' : 's'}...`);
 
 					createGitIndexVinyls(some)
 						.then(
@@ -373,6 +384,9 @@ if (import.meta.main) {
 							console.error(err);
 							process.exit(1);
 						});
+				} else {
+					console.error('No staged files found. Pass file paths to check unstaged files.');
+					process.exit(1);
 				}
 			}
 		);

--- a/build/lib/test/hygiene.test.ts
+++ b/build/lib/test/hygiene.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { suite, test } from 'node:test';
+
+suite('hygiene', () => {
+
+	test('rejects requested files that enter no hygiene checker', () => {
+		const repositoryRoot = path.join(import.meta.dirname, '../../..');
+		const result = spawnSync(process.execPath, [
+			'--experimental-strip-types',
+			'build/hygiene.ts',
+			'src/vs/editor/contrib/colorPicker/browser/images/opacity-background.png',
+		], {
+			cwd: repositoryRoot,
+			encoding: 'utf8',
+		});
+
+		assert.deepStrictEqual({
+			status: result.status,
+			hasNoMatchError: result.stderr.includes('No hygiene-eligible files matched the requested paths'),
+		}, {
+			status: 1,
+			hasNoMatchError: true,
+		});
+	});
+});

--- a/build/lib/test/stylelint.test.ts
+++ b/build/lib/test/stylelint.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import { stylelintFilter } from '../../filters.ts';
+import { resolveStylelintMatches, resolveStylelintSources } from '../../stylelint.ts';
+
+suite('stylelint', () => {
+
+	test('uses the full filter without positional arguments', () => {
+		assert.deepStrictEqual(resolveStylelintSources(['node', 'build/stylelint.ts']), {
+			sources: Array.from(stylelintFilter),
+			explicit: false,
+		});
+	});
+
+	test('resolves multiple positional and path arguments', () => {
+		assert.deepStrictEqual(resolveStylelintSources([
+			'node',
+			'build/stylelint.ts',
+			'src/vs/base',
+			'--path=src/vs/editor/**/*.css',
+			'-p',
+			'src/vs/platform/example.css',
+		]), {
+			sources: [
+				'src/vs/base/**/*.css',
+				'src/vs/editor/**/*.css',
+				'src/vs/platform/example.css',
+			],
+			explicit: true,
+		});
+	});
+
+	test('rejects missing path argument values', () => {
+		assert.throws(() => resolveStylelintSources([
+			'node',
+			'build/stylelint.ts',
+			'--path',
+		]), /Missing value for --path/);
+	});
+
+	test('rejects unmatched source patterns', () => {
+		assert.throws(() => resolveStylelintMatches([
+			'does-not-exist/**/*.css',
+		]), /No CSS files matched the requested path/);
+	});
+});

--- a/build/stylelint.ts
+++ b/build/stylelint.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import es from 'event-stream';
+import glob from 'glob';
 import vfs from 'vinyl-fs';
 import { stylelintFilter } from './filters.ts';
 import { findRootAnchoredHas } from './lib/stylelint/validateHasSelectors.ts';
@@ -137,9 +138,14 @@ function lineNumberAtOffset(contents: string, offset: number): number {
 }
 
 function stylelint(sources: string[] = Array.from(stylelintFilter), explicit = false): NodeJS.ReadWriteStream {
+	const started = Date.now();
+	const resolvedSources = explicit ? resolveStylelintMatches(sources) : sources;
 	let fileCount = 0;
+	console.info(explicit
+		? `Stylelint: checking ${resolvedSources.length} CSS file${resolvedSources.length === 1 ? '' : 's'} matched by ${sources.length} requested path${sources.length === 1 ? '' : 's'}.`
+		: 'Stylelint: checking all CSS files under src.');
 	return vfs
-		.src(sources, { base: '.', follow: true, allowEmpty: true })
+		.src(resolvedSources, { base: '.', follow: true, allowEmpty: !explicit })
 		.pipe(gulpstylelint((message, isError) => {
 			if (isError) {
 				console.error(message);
@@ -151,52 +157,80 @@ function stylelint(sources: string[] = Array.from(stylelintFilter), explicit = f
 			fileCount++;
 			this.emit('data', file);
 		}, function () {
-			// When the caller targeted an explicit path that matched no CSS files,
-			// say so - otherwise a typo'd path looks like a clean run.
-			if (explicit && fileCount === 0) {
-				console.info('No CSS files matched the requested path: ' + sources.join(', '));
-			}
+			console.info(`Stylelint: checked ${fileCount} CSS file${fileCount === 1 ? '' : 's'} in ${Date.now() - started}ms.`);
 			this.emit('end');
 		}));
 }
 
 /**
- * Resolves the source globs to lint from the CLI argument, if any. Accepts a
- * single file, a folder, or a glob (passed via `npm run stylelint -- <path>` or
+ * Resolves the source globs to lint from the CLI arguments, if any. Accepts
+ * files, folders, or globs (passed via `npm run stylelint -- <path>...` or
  * `--path=<path>`). A `.css` file or an explicit glob is used as-is; a folder is
- * expanded to `<folder>/**\/*.css`. With no argument the default
+ * expanded to `<folder>/**\/*.css`. With no arguments the default
  * `src/**\/*.css` set is linted. Returns the resolved globs plus whether an
  * explicit path was given (used to widen the design-token checks beyond the
  * default `src/vs/sessions` scope to follow the requested path).
  */
-function resolveSources(argv: string[]): { sources: string[]; explicit: boolean } {
-	const args = argv.slice(2);
-	let target: string | undefined;
-	for (const arg of args) {
+export function resolveStylelintSources(argv: readonly string[]): { sources: string[]; explicit: boolean } {
+	const targets: string[] = [];
+	for (let index = 2; index < argv.length; index++) {
+		const arg = argv[index];
 		if (arg.startsWith('--path=')) {
-			target = arg.slice('--path='.length);
+			targets.push(arg.slice('--path='.length));
 		} else if (arg === '--path' || arg === '-p') {
-			continue; // value is the next positional arg
+			const target = argv[++index];
+			if (!target || target.startsWith('-')) {
+				throw new Error(`Missing value for ${arg}.`);
+			}
+			targets.push(target);
 		} else if (!arg.startsWith('-')) {
-			target = arg;
+			targets.push(arg);
 		}
 	}
-	if (!target) {
+	if (targets.length === 0) {
 		return { sources: Array.from(stylelintFilter), explicit: false };
 	}
-	// Normalise separators and trim any trailing slash.
-	const normalized = target.replace(/\\/g, '/').replace(/\/+$/, '');
-	if (/[*?[\]{}]/.test(normalized) || /\.css$/i.test(normalized)) {
-		return { sources: [normalized], explicit: true };
+
+	return {
+		sources: targets.map(target => {
+			const normalized = target.replace(/\\/g, '/').replace(/\/+$/, '');
+			if (!normalized) {
+				throw new Error('Stylelint paths cannot be empty.');
+			}
+			if (/[*?[\]{}]/.test(normalized) || /\.css$/i.test(normalized)) {
+				return normalized;
+			}
+			return normalized + '/**/*.css';
+		}),
+		explicit: true,
+	};
+}
+
+export function resolveStylelintMatches(sources: readonly string[]): string[] {
+	const matches = new Set<string>();
+	for (const source of sources) {
+		const sourceMatches = glob.sync(source, { follow: true, nodir: true });
+		if (sourceMatches.length === 0) {
+			throw new Error(`No CSS files matched the requested path: ${source}`);
+		}
+		for (const match of sourceMatches) {
+			matches.add(match);
+		}
 	}
-	return { sources: [normalized + '/**/*.css'], explicit: true };
+	return Array.from(matches);
 }
 
 if (import.meta.main) {
-	const { sources, explicit } = resolveSources(process.argv);
-	stylelint(sources, explicit).on('error', (err: Error) => {
+	try {
+		const { sources, explicit } = resolveStylelintSources(process.argv);
+		stylelint(sources, explicit).on('error', (err: Error) => {
+			console.error();
+			console.error(err);
+			process.exit(1);
+		});
+	} catch (err) {
 		console.error();
 		console.error(err);
 		process.exit(1);
-	});
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "echo Please run any of the test scripts from the scripts folder.",
+    "test": "node -e \"console.error('Run a test script from the scripts folder, for example: ./scripts/test.sh --run <file>.'); process.exit(1)\"",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",
     "test-browser-no-install": "node test/unit/browser/index.js",
     "test-node": "mocha test/unit/node/index.js --delay --ui=tdd --timeout=5000 --exit",


### PR DESCRIPTION
## Summary

- fail root `npm test` instead of succeeding without running tests
- fail explicit hygiene and stylelint requests when they match no eligible files
- fail `npm run precommit` when there are no staged files
- support multiple positional and `--path` stylelint targets
- report scope, matched-file count, and elapsed time from validation wrappers
- document that compile tasks already type-check and recommend one-shot transpilation when tests only need fresh output

## Motivation

A 30-day audit of local agent sessions found several validation commands that could report success without checking the intended files. It also found repeated typechecking immediately before compile tasks that already type-check. These changes make accidental no-ops visible and give agents clearer feedback about the scope and cost of validation.

This follows [#328531](https://github.com/microsoft/vscode/pull/328531), which added positional targets to the ESLint wrapper.

## Validation

- `cd build && node --test lib/test/eslint.test.ts lib/test/stylelint.test.ts`
- `npm run typecheck --prefix build`
- targeted ESLint and hygiene checks for all changed build files
- successful stylelint invocation with two explicit CSS files
- verified unmatched hygiene and stylelint targets exit nonzero
- verified unstaged `npm run precommit` and root `npm test` exit nonzero with actionable messages
- staged `npm run precommit`

(Written by Copilot)