### PR TITLE
editor: Dispose moved block overlay actions

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/movedBlocksLinesFeature.ts
@@ -349,15 +349,15 @@ class MovedBlockOverlayWidget extends ViewZoneOverlayWidget {
 			highlightToggledItems: true,
 		}));
 
-		const caption = new Action(
+		const caption = this._register(new Action(
 			'',
 			text,
 			'',
 			false,
-		);
+		));
 		actionBar.push(caption, { icon: false, label: true });
 
-		const actionCompare = new Action(
+		const actionCompare = this._register(new Action(
 			'',
 			'Compare',
 			ThemeIcon.asClassName(Codicon.compareChanges),
@@ -366,7 +366,7 @@ class MovedBlockOverlayWidget extends ViewZoneOverlayWidget {
 				this._editor.focus();
 				this._diffModel.movedTextToCompare.set(this._diffModel.movedTextToCompare.get() === _move ? undefined : this._move, undefined);
 			},
-		);
+		));
 		this._register(autorun(reader => {
 			const isActive = this._diffModel.movedTextToCompare.read(reader) === _move;
 			actionCompare.checked = isActive;


### PR DESCRIPTION
fyi @hediet 

## Problem

Each `MovedBlockOverlayWidget` creates a disabled caption action and a compare action. The overlay registered its `ActionBar`, but the action bar owns only the action view items and their subscriptions; it does not dispose the underlying `Action` instances.

When diff state changed and the overlay widgets were recreated, the actions became unreachable without being disposed. Disposable tracking reported `[LEAKED DISPOSABLE]` warnings for both actions from `MovedBlockOverlayWidget`.

This was primarily a lifecycle-contract violation rather than significant retained-memory growth: disposing the action bar released its listeners, allowing the actions to be collected. Explicitly disposing the actions still avoids the warnings and correctly tears down their emitters.

## Fix

Register both actions with their owning `MovedBlockOverlayWidget`, whose existing lifecycle already follows the moved-block overlay recreation.

## Validation

- `npm run compile`
- `npm run precommit`

(Written by Copilot)