### PR TITLE
fix sliced last row in inline chat terminal output

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1569,6 +1569,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		}
 		const mirror = this._register(this._instantiationService.createInstance(DetachedTerminalCommandMirror, liveTerminalInstance.xterm, command));
 		this._mirror = mirror;
+		this._register(mirror.onDidFirstRender(() => this._handleMirrorFirstRender()));
 		this._register(mirror.onDidUpdate(result => {
 			// Hide empty message as soon as we get output
 			if (result.lineCount && result.lineCount > 0) {
@@ -1640,6 +1641,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		}
 		dom.clearNode(this._terminalContainer);
 		this._snapshotMirror = this._register(this._instantiationService.createInstance(DetachedTerminalSnapshotMirror, snapshot, this._getStoredTheme));
+		this._register(this._snapshotMirror.onDidFirstRender(() => this._handleMirrorFirstRender()));
 		await this._snapshotMirror.attach(this._terminalContainer);
 		this._snapshotMirror.setOutput(snapshot);
 		await this._layoutMirrorWidth(this._snapshotMirror);
@@ -1689,10 +1691,20 @@ class ChatTerminalToolOutputSection extends Disposable {
 	}
 
 	private _scheduleOutputRelayout(): void {
-		dom.getActiveWindow().requestAnimationFrame(() => {
+		dom.getWindow(this.domNode).requestAnimationFrame(() => {
 			this._layoutOutput();
 			this._scrollOutputToBottom();
 		});
+	}
+
+	/**
+	 * The first render initializes the renderer and with it the actual cell metrics, which
+	 * can differ from the pre-render font estimate; re-run layout so the box height and
+	 * wrap width match what xterm actually painted.
+	 */
+	private _handleMirrorFirstRender(): void {
+		void this._layoutMirrorWidth();
+		this._layoutOutput();
 	}
 
 	private _handleResize(): void {
@@ -1795,7 +1807,14 @@ class ChatTerminalToolOutputSection extends Disposable {
 	}
 
 	private _computeRowHeightPx(): number {
-		const window = dom.getActiveWindow();
+		// Prefer the mirror's own row height: once its renderer has initialized this is the
+		// exact cell height xterm paints, so the box ends on a whole row instead of slicing
+		// the last one via the config-based estimate below.
+		const mirrorRowHeight = (this._snapshotMirror ?? this._mirror)?.getRowHeightPx();
+		if (mirrorRowHeight !== undefined) {
+			return mirrorRowHeight;
+		}
+		const window = dom.getWindow(this.domNode);
 		const font = this._terminalConfigurationService.getFont(window);
 		const hasCharHeight = isNumber(font.charHeight) && font.charHeight > 0;
 		const hasFontSize = isNumber(font.fontSize) && font.fontSize > 0;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1312,7 +1312,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
  * - Accessibility: proper ARIA labels and accessible view support
  * - Theme-aware background color that adapts to panel vs editor context
  */
-class ChatTerminalToolOutputSection extends Disposable {
+export class ChatTerminalToolOutputSection extends Disposable {
 	public readonly domNode: HTMLElement;
 
 	public get isExpanded(): boolean {
@@ -1569,7 +1569,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		}
 		const mirror = this._register(this._instantiationService.createInstance(DetachedTerminalCommandMirror, liveTerminalInstance.xterm, command));
 		this._mirror = mirror;
-		this._register(mirror.onDidFirstRender(() => this._handleMirrorFirstRender()));
+		this._register(mirror.onDidChangeRowHeight(() => this._handleMirrorRowHeightChange()));
 		this._register(mirror.onDidUpdate(result => {
 			// Hide empty message as soon as we get output
 			if (result.lineCount && result.lineCount > 0) {
@@ -1641,7 +1641,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		}
 		dom.clearNode(this._terminalContainer);
 		this._snapshotMirror = this._register(this._instantiationService.createInstance(DetachedTerminalSnapshotMirror, snapshot, this._getStoredTheme));
-		this._register(this._snapshotMirror.onDidFirstRender(() => this._handleMirrorFirstRender()));
+		this._register(this._snapshotMirror.onDidChangeRowHeight(() => this._handleMirrorRowHeightChange()));
 		await this._snapshotMirror.attach(this._terminalContainer);
 		this._snapshotMirror.setOutput(snapshot);
 		await this._layoutMirrorWidth(this._snapshotMirror);
@@ -1698,11 +1698,11 @@ class ChatTerminalToolOutputSection extends Disposable {
 	}
 
 	/**
-	 * The first render initializes the renderer and with it the actual cell metrics, which
-	 * can differ from the pre-render font estimate; re-run layout so the box height and
-	 * wrap width match what xterm actually painted.
+	 * The mirror's painted cell metrics changed: the first render replaces the pre-render
+	 * font estimate, and later renders can reflect DPR changes. Re-run layout so the box
+	 * height and wrap width match what xterm actually painted.
 	 */
-	private _handleMirrorFirstRender(): void {
+	private _handleMirrorRowHeightChange(): void {
 		void this._layoutMirrorWidth();
 		this._layoutOutput();
 	}
@@ -1759,17 +1759,22 @@ class ChatTerminalToolOutputSection extends Disposable {
 		const scrollableDomNode = this._scrollableContainer.getDomNode();
 		const rowHeight = this._computeRowHeightPx();
 		const padding = this._getOutputPadding();
-		const maxHeight = rowHeight * MAX_OUTPUT_ROWS + padding;
-		const contentHeight = this._getOutputContentHeight(lineCount, rowHeight, padding);
-		const clampedHeight = Math.min(contentHeight, maxHeight);
+		// The container carries a CSS max-height with overflow: hidden; keep the row cap
+		// under it so the CSS limit can never slice a row that the height math allowed.
+		let maxRows = MAX_OUTPUT_ROWS;
+		const containerMaxHeight = Number.parseFloat(dom.getComputedStyle(this.domNode).maxHeight);
+		if (!Number.isNaN(containerMaxHeight)) {
+			maxRows = Math.max(Math.min(maxRows, Math.floor((containerMaxHeight - padding) / rowHeight)), MIN_OUTPUT_ROWS);
+		}
+		const contentRows = Math.min(Math.max(lineCount, MIN_OUTPUT_ROWS), maxRows);
 		// Use the line-count-based calculation directly rather than constraining by
 		// _outputBody.clientHeight. The DOM measurement races with xterm's async
 		// rendering — when new lines arrive, clientHeight reflects the stale
 		// (pre-render) size, causing the viewport to be too short and clipping the
-		// last line. The calculated height still has enough headroom because it
-		// includes the output padding and may round slightly differently from
-		// xterm's actual rendered cell height.
-		scrollableDomNode.style.height = clampedHeight < maxHeight ? `${clampedHeight}px` : '';
+		// last line. The height is an exact multiple of the mirror's painted row
+		// height (plus the output padding) with no rounding slack, so the box always
+		// ends on a whole row.
+		scrollableDomNode.style.height = `${contentRows * rowHeight + padding}px`;
 		this._scrollableContainer.scanDomNode();
 	}
 
@@ -1792,11 +1797,6 @@ class ChatTerminalToolOutputSection extends Disposable {
 		const dimensions = this._scrollableContainer.getScrollDimensions();
 		this._scrollableContainer.setScrollPosition({ scrollTop: dimensions.scrollHeight });
 		this._isProgrammaticScroll = false;
-	}
-
-	private _getOutputContentHeight(lineCount: number, rowHeight: number, padding: number): number {
-		const contentRows = Math.max(lineCount, MIN_OUTPUT_ROWS);
-		return (contentRows * rowHeight) + padding;
 	}
 
 	private _getOutputPadding(): number {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatTerminalToolProgressPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatTerminalToolProgressPart.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type { Terminal } from '@xterm/xterm';
+import { importAMDNodeModule } from '../../../../../../../amdX.js';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../../base/common/observable.js';
@@ -12,12 +14,17 @@ import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../../../../base/test/common/timeTravelScheduler.js';
 import { timeout } from '../../../../../../../base/common/async.js';
+import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IAccessibleViewService } from '../../../../../../../platform/accessibility/browser/accessibleView.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
 import { DiffEditorPool, EditorPool } from '../../../../browser/widget/chatContentParts/chatContentCodePools.js';
-import { ChatTerminalThinkingCollapsibleWrapper } from '../../../../browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.js';
+import { ChatTerminalThinkingCollapsibleWrapper, ChatTerminalToolOutputSection } from '../../../../browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.js';
 import { IChatResponseViewModel } from '../../../../common/model/chatViewModel.js';
 import { TerminalToolAutoExpand, TerminalToolAutoExpandTimeout } from '../../../../browser/widget/chatContentParts/toolInvocationParts/terminalToolAutoExpand.js';
+import { ITerminalConfigurationService, ITerminalService, type IDetachedXTermOptions } from '../../../../../terminal/browser/terminal.js';
+import type { ITerminalFont } from '../../../../../terminal/common/terminal.js';
+import { createFakeDetachedTerminal } from '../../../../../terminal/test/browser/chatTerminalMirrorTestUtils.js';
 
 suite('ChatTerminalToolProgressPart Auto-Expand Logic', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -327,4 +334,110 @@ suite('ChatTerminalToolProgressPart Auto-Expand Logic', () => {
 		assert.strictEqual(isExpanded, true, 'Should expand exactly once after first data');
 		onCommandFinished.fire(undefined);
 	}));
+});
+
+suite('ChatTerminalToolOutputSection layout', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	// Mounts the real section with the real snapshot mirror over a faked detached terminal,
+	// so the asserted heights are what actually reaches the DOM. Regression coverage for the
+	// sliced-last-row symptom of #328299: the box height must derive from the mirror's
+	// painted cell height, not the configuration-font estimate.
+	let instantiationService: TestInstantiationService;
+	let XTermBaseCtor: typeof Terminal;
+	let fakes: ReturnType<typeof createFakeDetachedTerminal>[];
+	let mirrorFont: ITerminalFont;
+	let container: HTMLElement;
+
+	setup(async () => {
+		instantiationService = workbenchInstantiationService(undefined, store);
+		XTermBaseCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
+		fakes = [];
+		// Mirror metrics deliberately differ from the config estimate below so the tests can
+		// tell which source the layout used
+		mirrorFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 20 };
+		instantiationService.stub(ITerminalService, {
+			createDetachedTerminal: async (options: IDetachedXTermOptions) => {
+				const fake = createFakeDetachedTerminal(XTermBaseCtor, options, mirrorFont);
+				fakes.push(fake);
+				return fake.instance;
+			}
+		} as Partial<ITerminalService>);
+		instantiationService.stub(ITerminalConfigurationService, {
+			getFont: () => ({ fontFamily: 'monospace', fontSize: 10, letterSpacing: 0, lineHeight: 1, charWidth: 6, charHeight: 10 })
+		} as Partial<ITerminalConfigurationService>);
+		instantiationService.stub(IAccessibleViewService, {
+			getOpenAriaHint: () => null
+		} as Partial<IAccessibleViewService>);
+		container = mainWindow.document.createElement('div');
+		container.style.width = '800px';
+		mainWindow.document.body.appendChild(container);
+		store.add(toDisposable(() => container.remove()));
+	});
+
+	function createSection(output: { text: string } | undefined): ChatTerminalToolOutputSection {
+		const section = store.add(instantiationService.createInstance(
+			ChatTerminalToolOutputSection,
+			async () => undefined,
+			() => undefined,
+			() => undefined,
+			() => output,
+			() => 'echo test',
+			() => undefined,
+			() => false,
+			false,
+		));
+		container.appendChild(section.domNode);
+		return section;
+	}
+
+	function boxHeight(section: ChatTerminalToolOutputSection): string {
+		const scrollable = section.domNode.querySelector('.monaco-scrollable-element') as HTMLElement | null;
+		return scrollable?.style.height ?? '';
+	}
+
+	/** The expected box height for `rows` rows: rows × rowHeight plus the body's real padding. */
+	function expectedHeight(section: ChatTerminalToolOutputSection, rows: number, rowHeight: number): string {
+		const body = section.domNode.querySelector('.chat-terminal-output-body') as HTMLElement;
+		const style = mainWindow.getComputedStyle(body);
+		const padding = (Number.parseFloat(style.paddingTop) || 0) + (Number.parseFloat(style.paddingBottom) || 0);
+		return `${rows * rowHeight + padding}px`;
+	}
+
+	test('box height uses the mirror row height, not the config estimate', async () => {
+		const section = createSection({ text: 'l1\r\nl2\r\nl3' });
+		await section.toggle(true);
+		assert.strictEqual(boxHeight(section), expectedHeight(section, 3, 20));
+	});
+
+	test('falls back to the config-font estimate while mirror metrics are unavailable', async () => {
+		mirrorFont = { ...mirrorFont, charHeight: 0 };
+		const section = createSection({ text: 'l1\r\nl2\r\nl3' });
+		await section.toggle(true);
+		assert.strictEqual(boxHeight(section), expectedHeight(section, 3, 10));
+	});
+
+	test('relayouts when the mirror announces changed cell metrics', async () => {
+		const section = createSection({ text: 'l1\r\nl2\r\nl3' });
+		await section.toggle(true);
+		assert.strictEqual(boxHeight(section), expectedHeight(section, 3, 20));
+
+		// Simulate the renderer reporting different metrics (first render replacing the
+		// estimate, or a DPR change): mutate the font the fake reports, then open the raw
+		// terminal so xterm fires a real render event
+		mirrorFont.charHeight = 30;
+		const fake = fakes[0];
+		const renderFired = new Promise<void>(resolve => {
+			const listener = fake.raw.onRender(() => {
+				listener.dispose();
+				resolve();
+			});
+		});
+		const host = mainWindow.document.createElement('div');
+		container.appendChild(host);
+		fake.raw.open(host);
+		await renderFired;
+
+		assert.strictEqual(boxHeight(section), expectedHeight(section, 3, 30));
+	});
 });

--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -102,8 +102,10 @@ interface IDetachedTerminalCommandMirror {
 	attach(container: HTMLElement): Promise<void>;
 	renderCommand(): Promise<IDetachedTerminalCommandMirrorRenderResult | undefined>;
 	layout(widthPx: number): Promise<IDetachedTerminalCommandMirrorRenderResult | undefined>;
+	getRowHeightPx(): number | undefined;
 	onDidUpdate: Event<IDetachedTerminalCommandMirrorRenderResult>;
 	onDidInput: Event<string>;
+	onDidFirstRender: Event<void>;
 }
 
 const enum ChatTerminalMirrorMetrics {
@@ -179,6 +181,21 @@ function measureMirrorHorizontalChrome(detached: IDetachedTerminalInstance): num
 	const style = getWindow(element).getComputedStyle(element);
 	const chrome = parseInt(style.paddingLeft) + parseInt(style.paddingRight);
 	return isNaN(chrome) ? undefined : Math.max(chrome, 0);
+}
+
+/**
+ * Computes the height in CSS pixels of one rendered row from the mirror's font. Once the
+ * renderer has initialized, {@link XtermTerminal.getFont} reports its actual cell metrics,
+ * so the value matches what xterm paints; before that it is the configuration-based
+ * estimate. Returns undefined while the terminal or its metrics are unavailable.
+ */
+function getMirrorRowHeightPx(detached: IDetachedTerminalInstance | undefined): number | undefined {
+	const font = detached?.xterm.getFont();
+	if (!font?.charHeight || font.charHeight <= 0) {
+		return undefined;
+	}
+	const lineHeight = font.lineHeight > 0 ? font.lineHeight : 1;
+	return font.charHeight * lineHeight;
 }
 
 /**
@@ -314,6 +331,9 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 	public readonly onDidUpdate: Event<IDetachedTerminalCommandMirrorRenderResult> = this._onDidUpdateEmitter.event;
 	private readonly _onDidInputEmitter = this._register(new Emitter<string>());
 	public readonly onDidInput: Event<string> = this._onDidInputEmitter.event;
+	private readonly _onDidFirstRenderEmitter = this._register(new Emitter<void>());
+	public readonly onDidFirstRender: Event<void> = this._onDidFirstRenderEmitter.event;
+	private _firstRenderListenerInstalled = false;
 
 	private _lastVT = '';
 	private _lineCount = 0;
@@ -358,6 +378,24 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 			terminal.attachToElement(container, { enableGpu: false });
 			this._attachedContainer = container;
 		}
+		this._installFirstRenderListener(terminal);
+	}
+
+	/**
+	 * The height in CSS pixels of one rendered row of this mirror, or undefined until the
+	 * detached terminal exists. Reflects the renderer's actual cell metrics once it has
+	 * rendered, so box-height math matches what xterm paints.
+	 */
+	getRowHeightPx(): number | undefined {
+		return getMirrorRowHeightPx(this._detachedTerminal);
+	}
+
+	private _installFirstRenderListener(detached: IDetachedTerminalInstance): void {
+		if (this._firstRenderListenerInstalled) {
+			return;
+		}
+		this._firstRenderListenerInstalled = true;
+		this._register(Event.once(getMirrorRaw(detached).onRender)(() => this._onDidFirstRenderEmitter.fire()));
 	}
 
 	async renderCommand(): Promise<IDetachedTerminalCommandMirrorRenderResult | undefined> {
@@ -732,6 +770,7 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
  */
 export class DetachedTerminalSnapshotMirror extends Disposable {
 	private _detachedTerminal: Promise<IDetachedTerminalInstance> | undefined;
+	private _resolvedTerminal: IDetachedTerminalInstance | undefined;
 	private _attachedContainer: HTMLElement | undefined;
 
 	private _output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined;
@@ -742,6 +781,9 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 	private _lastRenderedLineCount: number | undefined;
 	private _lastRenderedMaxColumnWidth: number | undefined;
 	private _lastRenderedText = '';
+	private readonly _onDidFirstRenderEmitter = this._register(new Emitter<void>());
+	public readonly onDidFirstRender: Event<void> = this._onDidFirstRenderEmitter.event;
+	private _firstRenderListenerInstalled = false;
 
 	constructor(
 		output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined,
@@ -771,8 +813,18 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 				return terminal;
 			}
 			enableCursorLineReflow(terminal);
+			this._resolvedTerminal = terminal;
 			return this._register(terminal);
 		});
+	}
+
+	/**
+	 * The height in CSS pixels of one rendered row of this mirror, or undefined until the
+	 * detached terminal exists. Reflects the renderer's actual cell metrics once it has
+	 * rendered, so box-height math matches what xterm paints.
+	 */
+	public getRowHeightPx(): number | undefined {
+		return getMirrorRowHeightPx(this._resolvedTerminal);
 	}
 
 	private async _getTerminal(): Promise<IDetachedTerminalInstance> {
@@ -797,6 +849,10 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 		if (needsAttach) {
 			terminal.attachToElement(container, { enableGpu: false });
 			this._attachedContainer = container;
+		}
+		if (!this._firstRenderListenerInstalled) {
+			this._firstRenderListenerInstalled = true;
+			this._register(Event.once(getMirrorRaw(terminal).onRender)(() => this._onDidFirstRenderEmitter.fire()));
 		}
 
 		this._container = container;

--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -105,7 +105,7 @@ interface IDetachedTerminalCommandMirror {
 	getRowHeightPx(): number | undefined;
 	onDidUpdate: Event<IDetachedTerminalCommandMirrorRenderResult>;
 	onDidInput: Event<string>;
-	onDidFirstRender: Event<void>;
+	onDidChangeRowHeight: Event<void>;
 }
 
 const enum ChatTerminalMirrorMetrics {
@@ -331,9 +331,10 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 	public readonly onDidUpdate: Event<IDetachedTerminalCommandMirrorRenderResult> = this._onDidUpdateEmitter.event;
 	private readonly _onDidInputEmitter = this._register(new Emitter<string>());
 	public readonly onDidInput: Event<string> = this._onDidInputEmitter.event;
-	private readonly _onDidFirstRenderEmitter = this._register(new Emitter<void>());
-	public readonly onDidFirstRender: Event<void> = this._onDidFirstRenderEmitter.event;
-	private _firstRenderListenerInstalled = false;
+	private readonly _onDidChangeRowHeightEmitter = this._register(new Emitter<void>());
+	public readonly onDidChangeRowHeight: Event<void> = this._onDidChangeRowHeightEmitter.event;
+	private _renderListenerInstalled = false;
+	private _lastObservedRowHeight: number | undefined;
 
 	private _lastVT = '';
 	private _lineCount = 0;
@@ -387,15 +388,30 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 	 * rendered, so box-height math matches what xterm paints.
 	 */
 	getRowHeightPx(): number | undefined {
+		if (this._store.isDisposed) {
+			return undefined;
+		}
 		return getMirrorRowHeightPx(this._detachedTerminal);
 	}
 
 	private _installFirstRenderListener(detached: IDetachedTerminalInstance): void {
-		if (this._firstRenderListenerInstalled) {
+		if (this._renderListenerInstalled) {
 			return;
 		}
-		this._firstRenderListenerInstalled = true;
-		this._register(Event.once(getMirrorRaw(detached).onRender)(() => this._onDidFirstRenderEmitter.fire()));
+		this._renderListenerInstalled = true;
+		// Renders can change the cell metrics: the first render replaces the measured font
+		// estimate with the renderer's actual dimensions, and later ones can reflect DPR
+		// changes (e.g. the window moving to a differently scaled monitor). Only the
+		// changes are announced, so the per-frame cost is one number comparison.
+		this._register(getMirrorRaw(detached).onRender(() => this._notifyRowHeightIfChanged()));
+	}
+
+	private _notifyRowHeightIfChanged(): void {
+		const rowHeight = this.getRowHeightPx();
+		if (rowHeight !== undefined && rowHeight !== this._lastObservedRowHeight) {
+			this._lastObservedRowHeight = rowHeight;
+			this._onDidChangeRowHeightEmitter.fire();
+		}
 	}
 
 	async renderCommand(): Promise<IDetachedTerminalCommandMirrorRenderResult | undefined> {
@@ -781,9 +797,10 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 	private _lastRenderedLineCount: number | undefined;
 	private _lastRenderedMaxColumnWidth: number | undefined;
 	private _lastRenderedText = '';
-	private readonly _onDidFirstRenderEmitter = this._register(new Emitter<void>());
-	public readonly onDidFirstRender: Event<void> = this._onDidFirstRenderEmitter.event;
-	private _firstRenderListenerInstalled = false;
+	private readonly _onDidChangeRowHeightEmitter = this._register(new Emitter<void>());
+	public readonly onDidChangeRowHeight: Event<void> = this._onDidChangeRowHeightEmitter.event;
+	private _renderListenerInstalled = false;
+	private _lastObservedRowHeight: number | undefined;
 
 	constructor(
 		output: IChatTerminalToolInvocationData['terminalCommandOutput'] | undefined,
@@ -824,6 +841,9 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 	 * rendered, so box-height math matches what xterm paints.
 	 */
 	public getRowHeightPx(): number | undefined {
+		if (this._store.isDisposed) {
+			return undefined;
+		}
 		return getMirrorRowHeightPx(this._resolvedTerminal);
 	}
 
@@ -850,9 +870,19 @@ export class DetachedTerminalSnapshotMirror extends Disposable {
 			terminal.attachToElement(container, { enableGpu: false });
 			this._attachedContainer = container;
 		}
-		if (!this._firstRenderListenerInstalled) {
-			this._firstRenderListenerInstalled = true;
-			this._register(Event.once(getMirrorRaw(terminal).onRender)(() => this._onDidFirstRenderEmitter.fire()));
+		if (!this._renderListenerInstalled) {
+			this._renderListenerInstalled = true;
+			// Renders can change the cell metrics: the first render replaces the measured font
+			// estimate with the renderer's actual dimensions, and later ones can reflect DPR
+			// changes (e.g. the window moving to a differently scaled monitor). Only the
+			// changes are announced, so the per-frame cost is one number comparison.
+			this._register(getMirrorRaw(terminal).onRender(() => {
+				const rowHeight = this.getRowHeightPx();
+				if (rowHeight !== undefined && rowHeight !== this._lastObservedRowHeight) {
+					this._lastObservedRowHeight = rowHeight;
+					this._onDidChangeRowHeightEmitter.fire();
+				}
+			}));
 		}
 
 		this._container = container;

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -6,6 +6,8 @@
 import type { Terminal } from '@xterm/xterm';
 import { deepStrictEqual, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../amdX.js';
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { toDisposable } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import type { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -941,7 +943,7 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 		});
 	});
 
-	suite('getRowHeightPx', () => {
+	suite('row height metrics', () => {
 		let instantiationService: TestInstantiationService;
 		let XTermBaseCtor: typeof Terminal;
 		let fakes: ReturnType<typeof createFakeDetachedTerminal>[];
@@ -1017,6 +1019,87 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 		test('command mirror reports the mirror cell height', async () => {
 			const mirror = await createLaidOutCommandMirror();
 			strictEqual(mirror.getRowHeightPx(), 14);
+		});
+
+		function createHost(): HTMLElement {
+			const host = mainWindow.document.createElement('div');
+			mainWindow.document.body.appendChild(host);
+			store.add(toDisposable(() => host.remove()));
+			return host;
+		}
+
+		function nextRender(raw: Terminal): Promise<void> {
+			return new Promise<void>(resolve => {
+				const listener = raw.onRender(() => {
+					listener.dispose();
+					resolve();
+				});
+			});
+		}
+
+		function write(raw: Terminal, data: string): Promise<void> {
+			return new Promise<void>(resolve => raw.write(data, resolve));
+		}
+
+		test('snapshot mirror onDidChangeRowHeight fires once per metrics change, only after attach', async () => {
+			nextFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 };
+			const mirror = createSnapshotMirror({ text: 'hello' });
+			let fires = 0;
+			store.add(mirror.onDidChangeRowHeight(() => fires++));
+			await mirror.render();
+			strictEqual(fires, 0, 'rendering content alone must not fire before attach');
+
+			const host = createHost();
+			await mirror.attach(host);
+			strictEqual(fires, 0, 'attach alone must not fire without a render');
+
+			const raw = fakes[0].raw;
+			let rendered = nextRender(raw);
+			raw.open(host);
+			await rendered;
+			strictEqual(fires, 1, 'the first real render announces the metrics');
+
+			rendered = nextRender(raw);
+			await write(raw, 'more');
+			await rendered;
+			strictEqual(fires, 1, 'renders with unchanged metrics must not re-fire');
+
+			nextFont.charHeight = 21;
+			rendered = nextRender(raw);
+			await write(raw, '!');
+			await rendered;
+			strictEqual(fires, 2, 'a metrics change fires exactly once more');
+		});
+
+		test('command mirror onDidChangeRowHeight fires once per metrics change, only after attach', async () => {
+			nextFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 };
+			const mirror = await createLaidOutCommandMirror();
+			let fires = 0;
+			store.add(mirror.onDidChangeRowHeight(() => fires++));
+
+			const host = createHost();
+			const raw = fakes[0].raw;
+			let rendered = nextRender(raw);
+			raw.open(host);
+			await rendered;
+			strictEqual(fires, 0, 'renders before attach must not fire');
+
+			await mirror.attach(host);
+			rendered = nextRender(raw);
+			await write(raw, 'output');
+			await rendered;
+			strictEqual(fires, 1, 'the first render after attach announces the metrics');
+
+			rendered = nextRender(raw);
+			await write(raw, 'more');
+			await rendered;
+			strictEqual(fires, 1, 'renders with unchanged metrics must not re-fire');
+
+			nextFont.charHeight = 21;
+			rendered = nextRender(raw);
+			await write(raw, '!');
+			await rendered;
+			strictEqual(fires, 2, 'a metrics change fires exactly once more');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -6,7 +6,6 @@
 import type { Terminal } from '@xterm/xterm';
 import { deepStrictEqual, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../amdX.js';
-import { Event } from '../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import type { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -14,9 +13,10 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import type { ITerminalCommand } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
 import type { ITerminalFont } from '../../common/terminal.js';
-import { ITerminalService, type IDetachedTerminalInstance, type IDetachedXTermOptions } from '../../browser/terminal.js';
+import { ITerminalService, type IDetachedXTermOptions } from '../../browser/terminal.js';
 import { XtermTerminal } from '../../browser/xterm/xtermTerminal.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { createFakeDetachedTerminal } from './chatTerminalMirrorTestUtils.js';
 import { TestXtermAddonImporter } from './xterm/xtermTestUtils.js';
 import { computeChatTerminalMirrorCols, computeMaxBufferColumnWidth, computeSnapshotLineCount, DetachedTerminalCommandMirror, DetachedTerminalSnapshotMirror, vtBoundaryMatches } from '../../browser/chatTerminalCommandMirror.js';
 
@@ -30,37 +30,6 @@ const defaultTerminalConfig = {
 	mouseWheelScrollSensitivity: 1,
 	unicodeVersion: '6'
 };
-
-/**
- * Creates a fake detached terminal instance backed by a real raw xterm.js terminal so mirror
- * tests can inspect the resulting buffer and count resize/write calls. The fixed font metrics
- * (charWidth 10, letterSpacing 0) make width-to-cols math deterministic on any machine.
- */
-function createFakeDetachedTerminal(RawCtor: typeof Terminal, options: IDetachedXTermOptions, font: ITerminalFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 }) {
-	const raw = new RawCtor({ cols: options.cols, rows: options.rows });
-	const counters = { resizeCalls: 0, writeCalls: 0 };
-	const instance = {
-		xterm: {
-			raw,
-			get cols() { return raw.cols; },
-			get rows() { return raw.rows; },
-			get buffer() { return raw.buffer; },
-			getFont: () => font,
-			write: (data: string, callback?: () => void) => {
-				counters.writeCalls++;
-				raw.write(data, callback);
-			},
-			resize: (columns: number, rows: number) => {
-				counters.resizeCalls++;
-				raw.resize(columns, rows);
-			}
-		},
-		onData: Event.None,
-		attachToElement: () => { },
-		dispose: () => raw.dispose()
-	} as unknown as IDetachedTerminalInstance;
-	return { raw, counters, instance };
-}
 
 suite('Workbench - ChatTerminalCommandMirror', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -36,10 +36,9 @@ const defaultTerminalConfig = {
  * tests can inspect the resulting buffer and count resize/write calls. The fixed font metrics
  * (charWidth 10, letterSpacing 0) make width-to-cols math deterministic on any machine.
  */
-function createFakeDetachedTerminal(RawCtor: typeof Terminal, options: IDetachedXTermOptions) {
+function createFakeDetachedTerminal(RawCtor: typeof Terminal, options: IDetachedXTermOptions, font: ITerminalFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 }) {
 	const raw = new RawCtor({ cols: options.cols, rows: options.rows });
 	const counters = { resizeCalls: 0, writeCalls: 0 };
-	const font: ITerminalFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 };
 	const instance = {
 		xterm: {
 			raw,
@@ -970,6 +969,85 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 			const { resizeCalls, writeCalls } = { ...fakes[0].counters };
 			await mirror.layout(1224);
 			deepStrictEqual(fakes[0].counters, { resizeCalls, writeCalls });
+		});
+	});
+
+	suite('getRowHeightPx', () => {
+		let instantiationService: TestInstantiationService;
+		let XTermBaseCtor: typeof Terminal;
+		let fakes: ReturnType<typeof createFakeDetachedTerminal>[];
+		let nextFont: ITerminalFont | undefined;
+
+		setup(async () => {
+			const configurationService = new TestConfigurationService({
+				editor: {
+					fastScrollSensitivity: 2,
+					mouseWheelScrollSensitivity: 1
+				} as Partial<IEditorOptions>,
+				files: {},
+				terminal: {
+					integrated: defaultTerminalConfig
+				},
+			});
+			instantiationService = workbenchInstantiationService({
+				configurationService: () => configurationService
+			}, store);
+			XTermBaseCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
+			fakes = [];
+			nextFont = undefined;
+			instantiationService.stub(ITerminalService, {
+				createDetachedTerminal: async (options: IDetachedXTermOptions) => {
+					const fake = createFakeDetachedTerminal(XTermBaseCtor, options, nextFont);
+					fakes.push(fake);
+					return fake.instance;
+				}
+			} as Partial<ITerminalService>);
+		});
+
+		function createSnapshotMirror(output: { text: string } | undefined): DetachedTerminalSnapshotMirror {
+			return store.add(instantiationService.createInstance(DetachedTerminalSnapshotMirror, output, () => undefined));
+		}
+
+		async function createLaidOutCommandMirror(): Promise<DetachedTerminalCommandMirror> {
+			const capabilities = store.add(new TerminalCapabilityStore());
+			const source = store.add(instantiationService.createInstance(XtermTerminal, undefined, XTermBaseCtor, {
+				cols: 80,
+				rows: 10,
+				xtermColorProvider: { getBackgroundColor: () => undefined },
+				capabilities,
+				disableShellIntegrationReporting: true,
+				xtermAddonImporter: new TestXtermAddonImporter(),
+			}, undefined));
+			const mirror = store.add(instantiationService.createInstance(DetachedTerminalCommandMirror, source, {} as ITerminalCommand));
+			// layout creates the detached terminal without needing a rendered command
+			await mirror.layout(1224);
+			return mirror;
+		}
+
+		test('snapshot mirror reports the mirror cell height once the terminal exists', async () => {
+			const mirror = createSnapshotMirror({ text: 'hello' });
+			await mirror.render();
+			// charHeight 14 × lineHeight 1 from the fake font
+			strictEqual(mirror.getRowHeightPx(), 14);
+		});
+
+		test('snapshot mirror reports undefined before the detached terminal resolves', () => {
+			const mirror = createSnapshotMirror({ text: 'hello' });
+			strictEqual(mirror.getRowHeightPx(), undefined);
+		});
+
+		test('uses the exact fractional cell height without per-row rounding', async () => {
+			// The DOM renderer paints each row at the exact css cell height; ceiling the
+			// per-row value would accumulate across rows and slice the last row
+			nextFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1.1, charWidth: 10, charHeight: 14.4 };
+			const mirror = createSnapshotMirror({ text: 'hello' });
+			await mirror.render();
+			strictEqual(mirror.getRowHeightPx(), 14.4 * 1.1);
+		});
+
+		test('command mirror reports the mirror cell height', async () => {
+			const mirror = await createLaidOutCommandMirror();
+			strictEqual(mirror.getRowHeightPx(), 14);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalMirrorTestUtils.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalMirrorTestUtils.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Terminal } from '@xterm/xterm';
+import { Event } from '../../../../../base/common/event.js';
+import type { ITerminalFont } from '../../common/terminal.js';
+import type { IDetachedTerminalInstance, IDetachedXTermOptions } from '../../browser/terminal.js';
+
+/**
+ * Creates a fake detached terminal instance backed by a real raw xterm.js terminal so mirror
+ * tests can inspect the resulting buffer and count resize/write calls. The fixed font metrics
+ * (charWidth 10, letterSpacing 0) make width-to-cols math deterministic on any machine; pass
+ * a custom font to model renderer metrics that differ from the configuration estimate.
+ */
+export function createFakeDetachedTerminal(RawCtor: typeof Terminal, options: IDetachedXTermOptions, font: ITerminalFont = { fontFamily: 'monospace', fontSize: 12, letterSpacing: 0, lineHeight: 1, charWidth: 10, charHeight: 14 }) {
+	const raw = new RawCtor({ cols: options.cols, rows: options.rows });
+	const counters = { resizeCalls: 0, writeCalls: 0 };
+	// eslint-disable-next-line local/code-no-dangerous-type-assertions
+	const instance = {
+		xterm: {
+			raw,
+			get cols() { return raw.cols; },
+			get rows() { return raw.rows; },
+			get buffer() { return raw.buffer; },
+			getFont: () => font,
+			write: (data: string, callback?: () => void) => {
+				counters.writeCalls++;
+				raw.write(data, callback);
+			},
+			resize: (columns: number, rows: number) => {
+				counters.resizeCalls++;
+				raw.resize(columns, rows);
+			}
+		},
+		onData: Event.None,
+		attachToElement: () => { },
+		dispose: () => raw.dispose()
+	} as unknown as IDetachedTerminalInstance;
+	return { raw, counters, instance };
+}


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/328299

- Add `getRowHeightPx()` to both detached terminal mirrors: the renderer's actual painted cell height (`charHeight × lineHeight` from the mirror's own `getFont()`) once it has rendered, the measured font estimate before that, and undefined until the detached terminal exists or after disposal.
- Size the output box from the mirror's row height without per-row `Math.ceil`, so the box height lands on a whole painted row instead of slicing the last one via `overflow: hidden`.
- Keep the row cap under the container's measured CSS `max-height` (minus padding) and always set an explicit row-multiple height, so the 300px cap can never slice a row the height math allowed.
- Fall back to the config-font estimate only while the mirror has no metrics, and read it from the part's owning window instead of `getActiveWindow()`, which can be a different window with different zoom/DPR; schedule the post-expand relayout on the owning window's `requestAnimationFrame` for the same reason.
- Add `onDidChangeRowHeight` to both mirrors — a persistent `onRender` listener with change detection (one number comparison per frame) — and re-run width and height layout when it fires, covering both the first render replacing the estimate and later metrics changes such as moving the window to a differently scaled monitor.
- Export `ChatTerminalToolOutputSection` and assert the fix at the DOM level: the scrollable element's height must come from the mirror row height (not the config estimate), fall back when metrics are unavailable, and relayout on announced metrics changes, using a shared fake detached terminal helper (`chatTerminalMirrorTestUtils.ts`).
- Cover the event contract for both mirror classes with real xterm render events: no firing before attach or from attach alone, exactly once on the first render, silent across renders with unchanged metrics, and exactly once more per metrics change.

-----------------------------------------
Inspirations from:

- Preferring the renderer's actual cell dimensions over the measured estimate comes from [`TerminalFontMetrics.getFont`](https://github.com/microsoft/vscode/blob/1b2f25580d1eaaeea7d18a3968565c818177d8e1/src/vs/workbench/contrib/terminal/browser/terminalConfigurationService.ts#L172-L186).
- Using the mirror's own font metrics for layout math is the same move #328313 made for columns: [`DetachedTerminalCommandMirror.layout`](https://github.com/microsoft/vscode/blob/1b2f25580d1eaaeea7d18a3968565c818177d8e1/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts#L459) and [`computeChatTerminalMirrorCols`](https://github.com/microsoft/vscode/blob/1b2f25580d1eaaeea7d18a3968565c818177d8e1/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts#L137-L145); this PR applies it to row height.
- Resolving font metrics against the terminal's own window comes from [`XtermTerminal.getFont`](https://github.com/microsoft/vscode/blob/1b2f25580d1eaaeea7d18a3968565c818177d8e1/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L711-L713).
- The painted row height being the DPR-rounded `css.cell.height` (which diverges from a `Math.ceil(charHeight × lineHeight)` estimate) is xterm.js's [`DomRenderer._updateDimensions`](https://github.com/xtermjs/xterm.js/blob/f33f502267455f40e64a89a6a554b8d6beae6284/src/browser/renderer/dom/DomRenderer.ts) — used as behavioral evidence, no code copied.
- Exporting a part-internal class for direct test mounting follows `ChatTerminalThinkingCollapsibleWrapper` in the same file, exercised the same way by [`chatTerminalToolProgressPart.test.ts`](https://github.com/microsoft/vscode/blob/1b2f25580d1eaaeea7d18a3968565c818177d8e1/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatTerminalToolProgressPart.test.ts#L67-L89).
