### PR TITLE
chat: shorten tab labels when opening edit pill diffs

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
@@ -12,7 +12,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Iterable } from '../../../../../../base/common/iterator.js';
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
+import { basename, isEqual } from '../../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../../nls.js';
@@ -37,6 +37,7 @@ import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
 import { ChatTreeItem } from '../../chat.js';
 import { ResourcePool } from './chatCollections.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+import { getChatChangesDiffEditorLabel } from './chatDiffEditorLabel.js';
 
 const CHANGES_SUMMARY_ELEMENT_HEIGHT = 22;
 const CHANGES_SUMMARY_MAX_ITEMS_SHOWN = 6;
@@ -91,9 +92,11 @@ export function renderChangesSummaryFileList(
 			// fall back to the diff editor.
 		}
 
+		const fileURI = ChatEditingSnapshotTextModelContentProvider.getOriginalFileURI(diff.modifiedURI);
 		editorService.openEditor({
 			original: { resource: diff.originalURI },
 			modified: { resource: diff.modifiedURI },
+			label: getChatChangesDiffEditorLabel(basename(fileURI ?? diff.modifiedURI)),
 			options: { preserveFocus: true }
 		});
 	}));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffEditorLabel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffEditorLabel.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../../../nls.js';
+
+/**
+ * Short tab title for chat/agent diff editors. Passing this as `label` to
+ * `openEditor` prevents {@link DiffEditorInput} from forcing a long
+ * snapshot/agent-host path into the tab description (#326790).
+ */
+export function getChatChangesDiffEditorLabel(fileBasename: string): string {
+	return localize('diff.generic', '{0} (changes from chat)', fileBasename);
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart.ts
@@ -20,6 +20,7 @@ import { IEditSessionDiffStats } from '../../../common/editing/chatEditingServic
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
 import { ChatEditPillElement, isResourceContentEmpty } from './chatEditPillElement.js';
+import { getChatChangesDiffEditorLabel } from './chatDiffEditorLabel.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 
 /**
@@ -120,12 +121,17 @@ export class ChatExternalEditContentPart extends ChatEditPillElement implements 
 			this.editorService.openEditor({
 				original: { resource: this.edit.beforeContentUri },
 				modified: { resource: this.edit.afterContentUri },
+				label: getChatChangesDiffEditorLabel(this.labelService.getUriBasenameLabel(this.edit.uri)),
 				options,
 			}, group);
 		} else if (this.edit.editKind === 'delete' && this.edit.beforeContentUri) {
 			// The file no longer exists on disk; show the pre-deletion
 			// content from the snapshot instead of opening the missing URI.
-			this.editorService.openEditor({ resource: this.edit.beforeContentUri, options }, group);
+			this.editorService.openEditor({
+				resource: this.edit.beforeContentUri,
+				label: this.labelService.getUriBasenameLabel(this.edit.uri),
+				options,
+			}, group);
 		} else if (this.edit.editKind !== 'delete') {
 			this.editorService.openEditor({ resource: this.edit.uri, options }, group);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -62,6 +62,7 @@ import { IDisposableReference } from './chatCollections.js';
 import { EditorPool } from './chatContentCodePools.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { ChatEditPillElement, isResourceContentEmpty } from './chatEditPillElement.js';
+import { getChatChangesDiffEditorLabel } from './chatDiffEditorLabel.js';
 import { ChatExtensionsContentPart } from './chatExtensionsContentPart.js';
 import { ChatProgressSubPart } from './chatProgressContentPart.js';
 import { IncrementalDOMMorpher } from './chatIncrementalRendering/chatIncrementalRendering.js';
@@ -896,9 +897,11 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 				this.editorService.openEditor({ resource: this.uri, options }, group);
 				return;
 			}
+			const labelUri = this.uri ?? this.currentDiff.modifiedURI;
 			this.editorService.openEditor({
 				original: { resource: this.currentDiff.originalURI },
 				modified: { resource: this.currentDiff.modifiedURI },
+				label: getChatChangesDiffEditorLabel(this.labelService.getUriBasenameLabel(labelUri)),
 				options
 			}, group);
 		} else if (this.uri) {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatDiffEditorLabel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatDiffEditorLabel.test.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { getChatChangesDiffEditorLabel } from '../../../../browser/widget/chatContentParts/chatDiffEditorLabel.js';
+
+suite('chatDiffEditorLabel', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('getChatChangesDiffEditorLabel returns a short chat-scoped tab title', () => {
+		assert.strictEqual(getChatChangesDiffEditorLabel('file.ts'), 'file.ts (changes from chat)');
+		assert.strictEqual(getChatChangesDiffEditorLabel('README.md'), 'README.md (changes from chat)');
+	});
+});

--- a/src/vs/workbench/test/browser/parts/editor/diffEditorInput.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/diffEditorInput.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { workbenchInstantiationService } from '../../workbenchTestServices.js';
-import { EditorResourceAccessor, isDiffEditorInput, isResourceDiffEditorInput, isResourceSideBySideEditorInput, IUntypedEditorInput } from '../../../../common/editor.js';
+import { EditorResourceAccessor, EditorInputCapabilities, isDiffEditorInput, isResourceDiffEditorInput, isResourceSideBySideEditorInput, IUntypedEditorInput } from '../../../../common/editor.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -113,6 +113,31 @@ suite('Diff editor input', () => {
 
 		otherInput.dispose();
 		assert.strictEqual(counter, 2);
+	});
+
+	test('preferred name avoids forced description when both sides share a name', () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+
+		class NamedEditorInput extends MyEditorInput {
+			constructor(resource: URI, private readonly name: string) {
+				super(resource);
+			}
+
+			override getName(): string {
+				return this.name;
+			}
+		}
+
+		const original = disposables.add(new NamedEditorInput(URI.file('/tmp/agent-host/snapshots/before/very/long/path/file.ts'), 'file.ts'));
+		const modified = disposables.add(new NamedEditorInput(URI.file('/tmp/agent-host/snapshots/after/very/long/path/file.ts'), 'file.ts'));
+
+		const unlabeled = disposables.add(instantiationService.createInstance(DiffEditorInput, undefined, undefined, original, modified, undefined));
+		assert.strictEqual(unlabeled.getName(), 'file.ts ↔ file.ts');
+		assert.ok(unlabeled.capabilities & EditorInputCapabilities.ForceDescription);
+
+		const labeled = disposables.add(instantiationService.createInstance(DiffEditorInput, 'file.ts (changes from chat)', undefined, original, modified, undefined));
+		assert.strictEqual(labeled.getName(), 'file.ts (changes from chat)');
+		assert.strictEqual(labeled.capabilities & EditorInputCapabilities.ForceDescription, 0);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Opening an edit pill from chat builds a `DiffEditorInput` without a preferred label. When both sides share a basename, that force-shows the long snapshot / agent-host path in the tab description and makes the close button hard to hit.

Pass a short label (`filename (changes from chat)`) — same pattern we already use from the chat editing integration — when opening these diffs from edit pills, collapsed code blocks, and the changes summary list. Deleted files opened from a snapshot get a basename label as well.

fixes https://github.com/microsoft/vscode/issues/326790