### PR TITLE
Enable tool search and prefer-long-context by default

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3418,7 +3418,7 @@
           },
           "github.copilot.chat.preferLongContext.enabled": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%github.copilot.config.preferLongContext.enabled%"
           },
           "github.copilot.enable": {

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -56,7 +56,6 @@ const experimentalAutoModelHintMarkers = ['minimax', 'mp3yn0h7', 'yaqq2gxh'];
  * Builds a configurationSchema for the model picker based on the endpoint's supported capabilities.
  * Models that support reasoning_effort get a "Thinking Effort" dropdown in the model picker UI.
  */
-// Returns the available context size options for a model, or undefined if the model has no configurable context sizes. With a long_context surcharge, offers the default tier and the full window as an opt-in. Without a surcharge, `chat.preferLongContext.enabled` decides: enabled shows only the full window, disabled (default) still shows both so the smaller window stays selectable.
 function getContextSizeOptions(endpoint: IChatEndpoint, preferLongContext: boolean): { value: number; description: string; isDefault: boolean }[] | undefined {
 	const pricing = endpoint.tokenPricing;
 

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1055,8 +1055,7 @@ export namespace ConfigKey {
 	export const SummarizeAgentConversationHistory = defineSetting<boolean>('chat.summarizeAgentConversationHistory.enabled', ConfigType.Simple, true);
 	export const VirtualToolThreshold = defineSetting<number>('chat.virtualTools.threshold', ConfigType.ExperimentBased, HARD_TOOL_LIMIT);
 	export const CurrentEditorAgentContext = defineSetting<boolean>('chat.agent.currentEditorContext.enabled', ConfigType.Simple, true);
-	// When enabled, models with a free long context window only show the long context option in the picker. Disabled (default) keeps the smaller option. Gates behavior introduced in microsoft/vscode#322950 and microsoft/vscode#323116.
-	export const PreferLongContext = defineSetting<boolean>('chat.preferLongContext.enabled', ConfigType.Simple, false);
+	export const PreferLongContext = defineSetting<boolean>('chat.preferLongContext.enabled', ConfigType.Simple, true);
 	/** BYOK  */
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', ConfigType.ExperimentBased, false);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', ConfigType.Simple, false);

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -740,8 +740,8 @@ export const platformRootSchema = createSchema({
 	[AgentHostPreferLongContextEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',
 		title: localize('agentHost.config.preferLongContextEnabled.title', "Prefer Long Context"),
-		description: localize('agentHost.config.preferLongContextEnabled.description', "Whether Copilot Chat's prefer-long-context setting is enabled. When `true`, models with a free long context window only show the long context option in the picker. When `false` (default), the smaller default context option stays selectable."),
-		default: false,
+		description: localize('agentHost.config.preferLongContextEnabled.description', "Whether Copilot Chat's prefer-long-context setting is enabled. When `true` (default), models with a free long context window only show the long context option in the picker. When `false`, the smaller default context option stays selectable."),
+		default: true,
 	}),
 	[AgentHostSystemProxyEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',

--- a/src/vs/platform/agentHost/common/copilotCliConfig.ts
+++ b/src/vs/platform/agentHost/common/copilotCliConfig.ts
@@ -101,7 +101,7 @@ export const copilotCliConfigSchema = createSchema({
 		type: 'boolean',
 		title: localize('agentHost.config.toolSearchEnabled.title', "Agent Host Tool Search"),
 		description: localize('agentHost.config.toolSearchEnabled.description', "When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front."),
-		default: false,
+		default: true,
 	}),
 	[CopilotCliConfigKey.ToolSearchDeferThreshold]: schemaProperty<number>({
 		type: 'number',

--- a/src/vs/platform/agentHost/common/copilotCliConfig.ts
+++ b/src/vs/platform/agentHost/common/copilotCliConfig.ts
@@ -21,7 +21,7 @@ export const enum CopilotCliConfigKey {
 	RubberDuck = 'rubberDuck',
 	/** Apply Opus 4.8-tuned system-prompt overrides on Opus 4.8 models. Off by default. */
 	Opus48Prompt = 'opus48Prompt',
-	/** Enable runtime tool search (deferred-tool loading) for Copilot SDK sessions. Off by default. */
+	/** Enable runtime tool search (deferred-tool loading) for Copilot SDK sessions. On by default. */
 	ToolSearchEnabled = 'toolSearchEnabled',
 	/** Minimum tool count before MCP/external tools are deferred behind tool search. 0 = always defer. */
 	ToolSearchDeferThreshold = 'toolSearchDeferThreshold',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1515,7 +1515,7 @@ configurationRegistry.registerConfiguration({
 		[AgentHostToolSearchEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.copilot.toolSearch.enabled', "When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front."),
-			default: false,
+			default: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostToolSearchDeferThresholdSettingId]: {


### PR DESCRIPTION
Flips the defaults for two settings that have been baking behind an opt-in flag:

- `chat.agentHost.copilot.toolSearch.enabled` → `true`
- `github.copilot.chat.preferLongContext.enabled` → `true`

### Why the diff touches more than two lines

Each setting's default lives in more than one place, and the pairs have to stay in sync:

**Tool search**
- `chat.shared.contribution.ts` — the user-facing workbench setting registration.
- `copilotCliConfig.ts` — the agent-host schema default the renderer forwards the value into.

**Prefer long context**
- `extensions/copilot/package.json` — the contributed setting default.
- `configurationService.ts` — `ConfigKey.PreferLongContext`. The extension throws a `BugIndicatingError` at load time if the code default drifts from `package.json`, so these two must change together.
- `agentHostSchema.ts` — the forwarded `preferLongContextEnabled` root-config default, plus its description, which stated `false` was the default.

### Note on schema defaults

`getRootValue` returns `undefined` for unset keys rather than falling back to the schema `default`, so the effective defaults come from the VS Code / extension setting registrations that the renderer forwards on startup. The `default` fields in the agent-host schemas are advertised metadata and were updated to match so the two don't disagree.

### Validation

- `vitest` on `contextSizeOverride.spec.ts` and `chatSessionInitializer.spec.ts` — 38 passed. This also exercises the `package.json` ↔ code default-consistency assertion.
- `tsc --noEmit -p src/tsconfig.json` — no new errors (two pre-existing failures in `copilotAgentSession.ts` / `copilotSystemNotification.ts` from local SDK type drift are untouched by this change).