### PR TITLE
Stop empty-session GC from deleting restored Agent Host sessions

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -34,15 +34,17 @@ export interface IAgentHostStateManagerOptions {
 }
 
 /**
- * How a session's cached state came to exist in this process.
+ * Whether a session is still an unused draft: minted by this process and never
+ * used. Only such a session is safe to destroy automatically.
  *
- * This is about *origin*, not current contents: callers that are about to
- * destroy user data must key off this rather than off observable emptiness,
- * because an empty-looking state is also what a failed history load produces.
+ * Deliberately not derived from the current turn count. An empty session is
+ * also what a failed history load produces, and what a truncate-to-zero leaves
+ * behind — neither means the session is disposable. The flag latches to `false`
+ * on first use and never returns to `true`.
  */
-export const enum SessionProvenance {
-	Created = 'created',
-	Restored = 'restored',
+const enum SessionUse {
+	UnusedDraft,
+	Used,
 }
 
 /**
@@ -61,8 +63,8 @@ interface ISessionEntry {
 	modifiedAt: string;
 	/** Aggregate file-change counts for the session-wide changeset. Catalog-only. */
 	changes?: ChangesSummary;
-	/** How this entry came to exist. */
-	readonly provenance: SessionProvenance;
+	/** Whether this session is still an unused draft. Latches to `Used`. */
+	use: SessionUse;
 }
 
 /**
@@ -333,16 +335,28 @@ export class AgentHostStateManager extends Disposable {
 	}
 
 	/**
-	 * Returns how the cached state for a session came to exist, or `undefined`
-	 * when the session is not currently in state. Accepts either a session URI
-	 * or one of its chat channel URIs.
+	 * Whether a session is still an unused draft minted by this process, or
+	 * `undefined` when the session is not currently in state. Accepts either a
+	 * session URI or one of its chat channel URIs.
+	 *
+	 * Callers about to destroy durable data must use this rather than checking
+	 * whether the session currently looks empty.
 	 */
-	getSessionProvenance(sessionOrChat: URI): SessionProvenance | undefined {
+	isUnusedDraft(sessionOrChat: URI): boolean | undefined {
 		const session = this._resolveOwningSession(sessionOrChat);
 		if (session === undefined) {
 			return undefined;
 		}
-		return this._sessionStates.get(session)?.provenance;
+		const entry = this._sessionStates.get(session);
+		return entry && entry.use === SessionUse.UnusedDraft;
+	}
+
+	/** Permanently marks a session as used, so it is never auto-collected. */
+	private _markSessionUsed(session: URI): void {
+		const entry = this._sessionStates.get(session);
+		if (entry) {
+			entry.use = SessionUse.Used;
+		}
 	}
 
 	private _resolveOwningSession(sessionOrChat: URI): URI | undefined {
@@ -437,6 +451,9 @@ export class AgentHostStateManager extends Disposable {
 		const chatState = this._chatStates.get(buildDefaultChatUri(session));
 		if (chatState) {
 			chatState.turns = turns;
+		}
+		if (turns.length > 0) {
+			this._markSessionUsed(session);
 		}
 	}
 
@@ -587,7 +604,7 @@ export class AgentHostStateManager extends Disposable {
 		}
 
 		const state = createSessionState(summary);
-		this._sessionStates.set(key, this._newEntry(state, summary, SessionProvenance.Created));
+		this._sessionStates.set(key, this._newEntry(state, summary, SessionUse.UnusedDraft));
 		this._ensureDefaultChat(key, summary);
 
 		this._logService.trace(`[AgentHostStateManager] Created session: ${key}`);
@@ -609,8 +626,8 @@ export class AgentHostStateManager extends Disposable {
 	}
 
 	/** Builds the authoritative {@link ISessionEntry} for a freshly seeded state. */
-	private _newEntry(state: SessionState, summary: SessionSummary, provenance: SessionProvenance): ISessionEntry {
-		return { state, createdAt: summary.createdAt, modifiedAt: summary.modifiedAt, changes: summary.changes, provenance };
+	private _newEntry(state: SessionState, summary: SessionSummary, use: SessionUse): ISessionEntry {
+		return { state, createdAt: summary.createdAt, modifiedAt: summary.modifiedAt, changes: summary.changes, use };
 	}
 
 	/**
@@ -676,7 +693,7 @@ export class AgentHostStateManager extends Disposable {
 			...createSessionState(summary),
 			lifecycle: SessionLifecycle.Ready,
 		};
-		this._sessionStates.set(key, this._newEntry(state, summary, SessionProvenance.Restored));
+		this._sessionStates.set(key, this._newEntry(state, summary, SessionUse.Used));
 		this._ensureDefaultChat(key, summary, turns, options?.draft, options?.defaultChatTitle);
 		this._summaryNotifier.announce(key, summary);
 
@@ -1348,6 +1365,11 @@ export class AgentHostStateManager extends Disposable {
 	 *  - keep the session's `chats` catalog entry in sync.
 	 */
 	private _onChatStateChanged(sessionKey: string, chatUri: string, prev: ChatState, next: ChatState): void {
+		// Any turn activity permanently retires the session's unused-draft
+		// status, so a later truncate-to-zero cannot make it look collectable.
+		if (next.turns.length > 0 || next.activeTurn) {
+			this._markSessionUsed(sessionKey);
+		}
 		// Active turn tracking — derive from the reducer's view of state,
 		// never from raw action turn-ids, so out-of-order lifecycle actions
 		// can't desync the count from reality. Track active turns per chat so a

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -34,6 +34,18 @@ export interface IAgentHostStateManagerOptions {
 }
 
 /**
+ * How a session's cached state came to exist in this process.
+ *
+ * This is about *origin*, not current contents: callers that are about to
+ * destroy user data must key off this rather than off observable emptiness,
+ * because an empty-looking state is also what a failed history load produces.
+ */
+export const enum SessionProvenance {
+	Created = 'created',
+	Restored = 'restored',
+}
+
+/**
  * Authoritative per-session record held by the state manager. Bundles the flat
  * {@link SessionState} with the {@link SessionSummary} catalog-only fields that
  * do not live on the state. The session URI (catalog `resource`) is the map
@@ -49,6 +61,8 @@ interface ISessionEntry {
 	modifiedAt: string;
 	/** Aggregate file-change counts for the session-wide changeset. Catalog-only. */
 	changes?: ChangesSummary;
+	/** How this entry came to exist. */
+	readonly provenance: SessionProvenance;
 }
 
 /**
@@ -306,7 +320,7 @@ export class AgentHostStateManager extends Disposable {
 		// chat URI is given the conversation contents are taken from that chat,
 		// while the session summary/config come from the owning session.
 		const isChat = isAhpChatChannel(sessionOrChat);
-		const session = isChat ? parseDefaultChatUri(sessionOrChat) : sessionOrChat;
+		const session = this._resolveOwningSession(sessionOrChat);
 		if (session === undefined) {
 			return undefined;
 		}
@@ -316,6 +330,23 @@ export class AgentHostStateManager extends Disposable {
 		}
 		const chatUri = isChat ? sessionOrChat : buildDefaultChatUri(session);
 		return mergeSessionWithDefaultChat(entry.state, this._chatStates.get(chatUri));
+	}
+
+	/**
+	 * Returns how the cached state for a session came to exist, or `undefined`
+	 * when the session is not currently in state. Accepts either a session URI
+	 * or one of its chat channel URIs.
+	 */
+	getSessionProvenance(sessionOrChat: URI): SessionProvenance | undefined {
+		const session = this._resolveOwningSession(sessionOrChat);
+		if (session === undefined) {
+			return undefined;
+		}
+		return this._sessionStates.get(session)?.provenance;
+	}
+
+	private _resolveOwningSession(sessionOrChat: URI): URI | undefined {
+		return isAhpChatChannel(sessionOrChat) ? parseDefaultChatUri(sessionOrChat) : sessionOrChat;
 	}
 
 	/**
@@ -556,7 +587,7 @@ export class AgentHostStateManager extends Disposable {
 		}
 
 		const state = createSessionState(summary);
-		this._sessionStates.set(key, this._newEntry(state, summary));
+		this._sessionStates.set(key, this._newEntry(state, summary, SessionProvenance.Created));
 		this._ensureDefaultChat(key, summary);
 
 		this._logService.trace(`[AgentHostStateManager] Created session: ${key}`);
@@ -578,8 +609,8 @@ export class AgentHostStateManager extends Disposable {
 	}
 
 	/** Builds the authoritative {@link ISessionEntry} for a freshly seeded state. */
-	private _newEntry(state: SessionState, summary: SessionSummary): ISessionEntry {
-		return { state, createdAt: summary.createdAt, modifiedAt: summary.modifiedAt, changes: summary.changes };
+	private _newEntry(state: SessionState, summary: SessionSummary, provenance: SessionProvenance): ISessionEntry {
+		return { state, createdAt: summary.createdAt, modifiedAt: summary.modifiedAt, changes: summary.changes, provenance };
 	}
 
 	/**
@@ -645,7 +676,7 @@ export class AgentHostStateManager extends Disposable {
 			...createSessionState(summary),
 			lifecycle: SessionLifecycle.Ready,
 		};
-		this._sessionStates.set(key, this._newEntry(state, summary));
+		this._sessionStates.set(key, this._newEntry(state, summary, SessionProvenance.Restored));
 		this._ensureDefaultChat(key, summary, turns, options?.draft, options?.defaultChatTitle);
 		this._summaryNotifier.announce(key, summary);
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -42,7 +42,7 @@ import { AgentConfigurationService, IAgentConfigurationService } from './agentCo
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
-import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
+import { AgentHostStateManager, IAgentHostStateManager, SessionProvenance } from './agentHostStateManager.js';
 import { IAgentHostGitService, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
@@ -2200,6 +2200,12 @@ export class AgentService extends Disposable implements IAgentService {
 	 * existing {@link _maybeEvictIdleSession} path which only drops cached
 	 * state and lets the session be restored from disk later.
 	 *
+	 * GC is restricted to sessions this process minted
+	 * ({@link SessionProvenance.Created}). A session rehydrated from durable
+	 * storage is never a candidate however empty it looks, because an empty
+	 * restored state is indistinguishable from a session whose history failed
+	 * to load. This still covers the case GC exists for: never-used drafts.
+	 *
 	 * The delay ({@link SESSION_GC_GRACE_MS}) gives a disconnected client time
 	 * to reconnect or a workspace switch to settle. Any subsequent subscribe
 	 * (or createSession on the same URI) cancels the timer via
@@ -2222,6 +2228,10 @@ export class AgentService extends Disposable implements IAgentService {
 		if (state.turns.length > 0 || state.activeTurn !== undefined) {
 			return false;
 		}
+		if (this._stateManager.getSessionProvenance(key) !== SessionProvenance.Created) {
+			this._logService.trace(`[AgentService] Skipping GC for restored session: ${key}`);
+			return false;
+		}
 		this._pendingSessionGc.set(resource, disposableTimeout(() => {
 			this._pendingSessionGc.deleteAndDispose(resource);
 			this._runSessionGc(resource).catch(err => {
@@ -2237,9 +2247,9 @@ export class AgentService extends Disposable implements IAgentService {
 
 	/**
 	 * Fires {@link SESSION_GC_GRACE_MS} after a session lost its last
-	 * subscriber while empty. Re-checks both invariants (still no subscribers,
-	 * still empty) before tearing the session down via {@link disposeSession}.
-	 * The cached state may already have been evicted by
+	 * subscriber while empty. Re-checks the invariants (still no subscribers,
+	 * still empty, still not restored) before tearing the session down via
+	 * {@link disposeSession}. The cached state may already have been evicted by
 	 * {@link _maybeEvictIdleSession}; in that case we still proceed because
 	 * "evicted + no resubscribe" implies no client is observing the session.
 	 */
@@ -2250,6 +2260,13 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		const state = this._stateManager.getSessionState(key);
 		if (state && (state.turns.length > 0 || state.activeTurn !== undefined)) {
+			return;
+		}
+		// The session may have been evicted and rehydrated from disk during the
+		// grace window. An *absent* provenance means it was evicted and never
+		// came back, which is still a valid target — so only `Restored` aborts.
+		if (this._stateManager.getSessionProvenance(key) === SessionProvenance.Restored) {
+			this._logService.trace(`[AgentService] GC aborted, session was restored during grace window: ${key}`);
 			return;
 		}
 		this._logService.info(`[AgentService] GC: disposing empty unsubscribed session ${key}`);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -42,7 +42,7 @@ import { AgentConfigurationService, IAgentConfigurationService } from './agentCo
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
-import { AgentHostStateManager, IAgentHostStateManager, SessionProvenance } from './agentHostStateManager.js';
+import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentHostGitService, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
@@ -2200,11 +2200,10 @@ export class AgentService extends Disposable implements IAgentService {
 	 * existing {@link _maybeEvictIdleSession} path which only drops cached
 	 * state and lets the session be restored from disk later.
 	 *
-	 * GC is restricted to sessions this process minted
-	 * ({@link SessionProvenance.Created}). A session rehydrated from durable
-	 * storage is never a candidate however empty it looks, because an empty
-	 * restored state is indistinguishable from a session whose history failed
-	 * to load. This still covers the case GC exists for: never-used drafts.
+	 * GC is restricted to sessions that are still unused drafts. A session that
+	 * was restored from durable storage, or that has ever had a turn, is never
+	 * a candidate however empty it looks now — an empty state is also what a
+	 * failed history load and a truncate-to-zero leave behind.
 	 *
 	 * The delay ({@link SESSION_GC_GRACE_MS}) gives a disconnected client time
 	 * to reconnect or a workspace switch to settle. Any subsequent subscribe
@@ -2228,8 +2227,8 @@ export class AgentService extends Disposable implements IAgentService {
 		if (state.turns.length > 0 || state.activeTurn !== undefined) {
 			return false;
 		}
-		if (this._stateManager.getSessionProvenance(key) !== SessionProvenance.Created) {
-			this._logService.trace(`[AgentService] Skipping GC for restored session: ${key}`);
+		if (this._stateManager.isUnusedDraft(key) !== true) {
+			this._logService.trace(`[AgentService] Skipping GC for session that is not an unused draft: ${key}`);
 			return false;
 		}
 		this._pendingSessionGc.set(resource, disposableTimeout(() => {
@@ -2248,7 +2247,7 @@ export class AgentService extends Disposable implements IAgentService {
 	/**
 	 * Fires {@link SESSION_GC_GRACE_MS} after a session lost its last
 	 * subscriber while empty. Re-checks the invariants (still no subscribers,
-	 * still empty, still not restored) before tearing the session down via
+	 * still empty, still an unused draft) before tearing the session down via
 	 * {@link disposeSession}. The cached state may already have been evicted by
 	 * {@link _maybeEvictIdleSession}; in that case we still proceed because
 	 * "evicted + no resubscribe" implies no client is observing the session.
@@ -2262,11 +2261,11 @@ export class AgentService extends Disposable implements IAgentService {
 		if (state && (state.turns.length > 0 || state.activeTurn !== undefined)) {
 			return;
 		}
-		// The session may have been evicted and rehydrated from disk during the
-		// grace window. An *absent* provenance means it was evicted and never
-		// came back, which is still a valid target — so only `Restored` aborts.
-		if (this._stateManager.getSessionProvenance(key) === SessionProvenance.Restored) {
-			this._logService.trace(`[AgentService] GC aborted, session was restored during grace window: ${key}`);
+		// The session may have been rehydrated or used during the grace window.
+		// An *absent* entry means it was evicted and never came back, which is
+		// still a valid target — so only an explicit non-draft aborts.
+		if (this._stateManager.isUnusedDraft(key) === false) {
+			this._logService.trace(`[AgentService] GC aborted, session is no longer an unused draft: ${key}`);
 			return;
 		}
 		this._logService.info(`[AgentService] GC: disposing empty unsubscribed session ${key}`);

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -217,16 +217,10 @@ const RESUMABLE_HISTORY_ABSENT_PATTERNS = [
 
 /**
  * Decide whether a Copilot SDK `resumeSession` failure should fall back to
- * `createSession({ sessionId })`, which starts a fresh session under the same
- * id and therefore presents the session as having no history.
- *
- * This is an **allowlist**: anything that doesn't positively state the session
- * is empty propagates. The inverse is unsafe because the fallback is the first
- * half of a data-loss sequence — the session comes back with zero turns, and
- * `AgentService`'s empty-session GC then deletes the SDK session, its data
- * directory, and its worktree. A transient `network fetch failed` is also a
- * `-32603`, so a denylist of corruption keywords turned "briefly offline" into
- * "session and worktree deleted".
+ * `createSession({ sessionId })`, which presents the session as having no
+ * history. Deliberately an allowlist: a fallback on an unrelated failure (a
+ * transient `network fetch failed` is also `-32603`) discards a live session's
+ * history and leaves it exposed to empty-session GC.
  */
 function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
 	if (getCopilotSdkErrorCode(err) !== -32603) {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -205,18 +205,28 @@ function getErrorMessage(err: unknown): string {
 }
 
 /**
+ * Messages from a failed Copilot SDK `session.resume` that positively indicate
+ * the session has no events on disk, so there is no history to lose. Includes
+ * the post-"Start Over" case, where `truncateSession` leaves zero events.
+ */
+const RESUMABLE_HISTORY_ABSENT_PATTERNS = [
+	/\bSession not found\b/i,
+	/\bno events\b/i,
+	/\bempty session\b/i,
+];
+
+/**
  * Decide whether a Copilot SDK `resumeSession` failure should fall back to
- * `createSession({ sessionId })`. We want to preserve the original
- * recovery for empty / truncated sessions (e.g. after the user invoked
- * "Start Over", which calls `truncateSession` and leaves the on-disk
- * session with zero events - the SDK then refuses to resume it), but we
- * must NOT silently swallow corruption / schema-validation / parse
- * failures: those should surface so the user sees the real error and the
- * original session contents are not masked by a fresh empty session.
+ * `createSession({ sessionId })`, which starts a fresh session under the same
+ * id and therefore presents the session as having no history.
  *
- * Heuristic: any `-32603` Internal Error is treated as the empty-session
- * case UNLESS the message clearly indicates corruption, schema
- * validation, parse failure, or malformed input.
+ * This is an **allowlist**: anything that doesn't positively state the session
+ * is empty propagates. The inverse is unsafe because the fallback is the first
+ * half of a data-loss sequence — the session comes back with zero turns, and
+ * `AgentService`'s empty-session GC then deletes the SDK session, its data
+ * directory, and its worktree. A transient `network fetch failed` is also a
+ * `-32603`, so a denylist of corruption keywords turned "briefly offline" into
+ * "session and worktree deleted".
  */
 function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
 	if (getCopilotSdkErrorCode(err) !== -32603) {
@@ -224,7 +234,7 @@ function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
 	}
 
 	const message = getErrorMessage(err);
-	return !/\b(corrupt|corrupted|invalid|validation|schema|must be|parse|malformed|unexpected token)\b/i.test(message);
+	return RESUMABLE_HISTORY_ABSENT_PATTERNS.some(pattern => pattern.test(message));
 }
 
 function isCustomAgentNotFoundError(err: unknown): boolean {
@@ -421,14 +431,15 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 					this._logService.warn(`[Copilot:${plan.sessionId}] SDK resumeSession without custom agent failed: code=${getCopilotSdkErrorCode(retryErr)}, message=${getErrorMessage(retryErr)}`);
 				}
 			}
-			// The SDK fails to resume sessions that have no messages.
-			// Fall back to creating a new session with the same ID,
-			// seeding model & working directory from stored metadata.
+			// Only a session with no events on disk may fall back to creating a
+			// fresh one under the same ID (seeding model & working directory
+			// from stored metadata); every other failure propagates.
 			if (!shouldCreateEmptySessionAfterResumeError(resumeError)) {
+				this._logService.warn(`[Copilot:${plan.sessionId}] Resume failure does not indicate an empty session; surfacing it instead of replacing the session with an empty one`);
 				throw resumeError;
 			}
 
-			this._logService.warn(`[Copilot:${plan.sessionId}] Resume failed (code=-32603), falling back to createSession with same ID`);
+			this._logService.warn(`[Copilot:${plan.sessionId}] Resume reported no session history; falling back to createSession with same ID`);
 			const wrapper = await this._createSession({
 				...fallbackPlan,
 				kind: 'create',

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -12,7 +12,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { ActionType, NotificationType, type ActionEnvelope, type INotification } from '../../common/state/sessionActions.js';
 import { MessageKind, SessionSummary, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentSessionUri, buildSubagentSessionUriPrefix, isSubagentSession, mergeSessionWithDefaultChat, parseSubagentSessionUri, readHostBuildInfo, type ChatState, type MarkdownResponsePart, type SessionState } from '../../common/state/sessionState.js';
 import { type SessionSummaryChangedParams } from '../../common/state/protocol/notifications.js';
-import { AgentHostStateManager, SessionProvenance } from '../../node/agentHostStateManager.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { buildChangesetUri, buildSessionChangesetUri } from '../../common/changesetUri.js';
 import { withAgentCustomizationSettings } from '../../common/agentCustomizationSettings.js';
 
@@ -585,34 +585,75 @@ suite('AgentHostStateManager', () => {
 		assert.strictEqual(notifications.length, 0, 'should not emit notification for restored sessions');
 	});
 
-	suite('session provenance', () => {
+	suite('unused-draft tracking', () => {
 
-		test('reports how a session entered state, addressable by session or chat URI', () => {
+		test('reports draft status by origin, addressable by session or chat URI', () => {
 			const restoredUri = URI.from({ scheme: 'copilot', path: '/restored-session' }).toString();
 			manager.createSession(makeSessionSummary());
 			manager.restoreSession(makeSessionSummary(restoredUri), []);
 
 			assert.deepStrictEqual({
-				created: manager.getSessionProvenance(sessionUri),
-				createdViaChatUri: manager.getSessionProvenance(sessionChatUri),
-				restored: manager.getSessionProvenance(restoredUri),
-				restoredViaChatUri: manager.getSessionProvenance(buildDefaultChatUri(restoredUri)),
-				unknown: manager.getSessionProvenance(URI.from({ scheme: 'copilot', path: '/nope' }).toString()),
+				created: manager.isUnusedDraft(sessionUri),
+				createdViaChatUri: manager.isUnusedDraft(sessionChatUri),
+				restored: manager.isUnusedDraft(restoredUri),
+				restoredViaChatUri: manager.isUnusedDraft(buildDefaultChatUri(restoredUri)),
+				unknown: manager.isUnusedDraft(URI.from({ scheme: 'copilot', path: '/nope' }).toString()),
 			}, {
-				created: SessionProvenance.Created,
-				createdViaChatUri: SessionProvenance.Created,
-				restored: SessionProvenance.Restored,
-				restoredViaChatUri: SessionProvenance.Restored,
+				created: true,
+				createdViaChatUri: true,
+				restored: false,
+				restoredViaChatUri: false,
 				unknown: undefined,
 			});
 		});
 
-		test('a restored session that was first created keeps its Created provenance', () => {
+		test('a restored session that was first created is no longer a draft', () => {
 			// `restoreSession` short-circuits when the session is already in state.
 			manager.createSession(makeSessionSummary());
 			manager.restoreSession(makeSessionSummary(), []);
 
-			assert.strictEqual(manager.getSessionProvenance(sessionUri), SessionProvenance.Created);
+			assert.strictEqual(manager.isUnusedDraft(sessionUri), true);
+		});
+
+		test('draft status is retired by a turn and does not come back on truncate', () => {
+			manager.createSession(makeSessionSummary());
+			const observed: (boolean | undefined)[] = [manager.isUnusedDraft(sessionUri)];
+
+			manager.dispatchServerAction(sessionChatUri, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			});
+			observed.push(manager.isUnusedDraft(sessionUri));
+
+			manager.dispatchServerAction(sessionChatUri, { type: ActionType.ChatTurnComplete, turnId: 'turn-1', duration: 1 });
+			observed.push(manager.isUnusedDraft(sessionUri));
+
+			// Truncate-to-zero empties the chat but must not resurrect the draft.
+			manager.dispatchServerAction(sessionChatUri, { type: ActionType.ChatTruncated });
+			observed.push(manager.isUnusedDraft(sessionUri));
+
+			assert.deepStrictEqual({
+				observed,
+				turnsAfterTruncate: manager.getDefaultChatState(sessionUri)?.turns.length,
+			}, {
+				observed: [true, false, false, false],
+				turnsAfterTruncate: 0,
+			});
+		});
+
+		test('seeding turns for a fork retires draft status', () => {
+			manager.createSession(makeSessionSummary());
+			manager.seedDefaultChatTurns(sessionUri, [{
+				id: 'turn-1',
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+				responseParts: [],
+				usage: undefined,
+				state: TurnState.Complete,
+			}]);
+
+			assert.strictEqual(manager.isUnusedDraft(sessionUri), false);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -12,7 +12,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { ActionType, NotificationType, type ActionEnvelope, type INotification } from '../../common/state/sessionActions.js';
 import { MessageKind, SessionSummary, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentSessionUri, buildSubagentSessionUriPrefix, isSubagentSession, mergeSessionWithDefaultChat, parseSubagentSessionUri, readHostBuildInfo, type ChatState, type MarkdownResponsePart, type SessionState } from '../../common/state/sessionState.js';
 import { type SessionSummaryChangedParams } from '../../common/state/protocol/notifications.js';
-import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { AgentHostStateManager, SessionProvenance } from '../../node/agentHostStateManager.js';
 import { buildChangesetUri, buildSessionChangesetUri } from '../../common/changesetUri.js';
 import { withAgentCustomizationSettings } from '../../common/agentCustomizationSettings.js';
 
@@ -583,6 +583,37 @@ suite('AgentHostStateManager', () => {
 		manager.restoreSession(makeSessionSummary(), []);
 
 		assert.strictEqual(notifications.length, 0, 'should not emit notification for restored sessions');
+	});
+
+	suite('session provenance', () => {
+
+		test('reports how a session entered state, addressable by session or chat URI', () => {
+			const restoredUri = URI.from({ scheme: 'copilot', path: '/restored-session' }).toString();
+			manager.createSession(makeSessionSummary());
+			manager.restoreSession(makeSessionSummary(restoredUri), []);
+
+			assert.deepStrictEqual({
+				created: manager.getSessionProvenance(sessionUri),
+				createdViaChatUri: manager.getSessionProvenance(sessionChatUri),
+				restored: manager.getSessionProvenance(restoredUri),
+				restoredViaChatUri: manager.getSessionProvenance(buildDefaultChatUri(restoredUri)),
+				unknown: manager.getSessionProvenance(URI.from({ scheme: 'copilot', path: '/nope' }).toString()),
+			}, {
+				created: SessionProvenance.Created,
+				createdViaChatUri: SessionProvenance.Created,
+				restored: SessionProvenance.Restored,
+				restoredViaChatUri: SessionProvenance.Restored,
+				unknown: undefined,
+			});
+		});
+
+		test('a restored session that was first created keeps its Created provenance', () => {
+			// `restoreSession` short-circuits when the session is already in state.
+			manager.createSession(makeSessionSummary());
+			manager.restoreSession(makeSessionSummary(), []);
+
+			assert.strictEqual(manager.getSessionProvenance(sessionUri), SessionProvenance.Created);
+		});
 	});
 
 	test('emits sessionSummaryChanged when summary changes', () => {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -31,6 +31,7 @@ import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind,
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
+import { SessionProvenance } from '../../node/agentHostStateManager.js';
 import { AgentHostManagementService } from '../../node/agentHostManagementService.js';
 import { MockAgent, ScriptedMockAgent } from './mockAgent.js';
 import { mapSessionEventsToHistoryRecords } from './historyRecordFixtures.js';
@@ -5100,6 +5101,56 @@ suite('AgentService (node dispatcher)', () => {
 				// cancelled by createSession, dispose would have fired.
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'createSession on same URI must cancel pending GC');
+			});
+		});
+
+		test('a restored session that loaded zero turns is never GC-disposed', () => {
+			// Regression: GC used to key purely off "0 turns", but a restored
+			// session can present as empty because its history FAILED to load.
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				await copilotAgent.createSession();
+				const sessions = await copilotAgent.listSessions();
+				const sessionResource = sessions[0].session;
+
+				// No messages => restores with zero turns, exactly as a failed
+				// history load would look.
+				copilotAgent.sessionMessages = [];
+				await service.restoreSession(sessionResource);
+				service.addSubscriber(sessionResource, 'client-1');
+
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual({
+					disposed: copilotAgent.disposeSessionCalls.map(u => u.toString()),
+					released: copilotAgent.releaseSessionCalls.map(u => u.toString()),
+				}, {
+					// Nothing destroyed, but the non-destructive idle release still happens.
+					disposed: [],
+					released: [sessionResource.toString()],
+				});
+			});
+		});
+
+		test('a session restored during the grace window is not GC-disposed', () => {
+			// The rehydrated session is deliberately still empty, so that the
+			// turns check cannot be what saves it — only provenance can.
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 5_000));
+				service.stateManager.deleteSession(sessionResource.toString());
+				copilotAgent.sessionMessages = [];
+				await service.restoreSession(sessionResource);
+				assert.strictEqual(service.stateManager.getSessionProvenance(sessionResource.toString()), SessionProvenance.Restored, 'precondition: session is now durable state');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'a session restored mid-grace must not be GC-disposed');
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -31,7 +31,6 @@ import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind,
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
-import { SessionProvenance } from '../../node/agentHostStateManager.js';
 import { AgentHostManagementService } from '../../node/agentHostManagementService.js';
 import { MockAgent, ScriptedMockAgent } from './mockAgent.js';
 import { mapSessionEventsToHistoryRecords } from './historyRecordFixtures.js';
@@ -5135,7 +5134,7 @@ suite('AgentService (node dispatcher)', () => {
 
 		test('a session restored during the grace window is not GC-disposed', () => {
 			// The rehydrated session is deliberately still empty, so that the
-			// turns check cannot be what saves it — only provenance can.
+			// turns check cannot be what saves it — only draft status can.
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				service.registerProvider(copilotAgent);
 				const sessionResource = await service.createSession({ provider: 'copilot' });
@@ -5146,11 +5145,34 @@ suite('AgentService (node dispatcher)', () => {
 				service.stateManager.deleteSession(sessionResource.toString());
 				copilotAgent.sessionMessages = [];
 				await service.restoreSession(sessionResource);
-				assert.strictEqual(service.stateManager.getSessionProvenance(sessionResource.toString()), SessionProvenance.Restored, 'precondition: session is now durable state');
+				assert.strictEqual(service.stateManager.isUnusedDraft(sessionResource.toString()), false, 'precondition: session is now durable state');
 
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 
 				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'a session restored mid-grace must not be GC-disposed');
+			});
+		});
+
+		test('a session truncated back to zero turns is not GC-disposed', () => {
+			// A session created in this process that has been used is durable
+			// data — its worktree holds real work — even though a truncate
+			// (checkpoint restore / first-message edit) empties its turns.
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				const chatUri = buildDefaultChatUri(sessionResource.toString());
+				service.addSubscriber(sessionResource, 'client-1');
+				service.dispatchAction(chatUri, { type: ActionType.ChatTurnStarted, turnId: 'turn-1', startedAt: '2025-01-01T00:00:00.000Z', message: { text: 'hello', origin: { kind: MessageKind.User } } }, 'client-1', 1);
+				service.dispatchAction(chatUri, { type: ActionType.ChatTurnComplete, turnId: 'turn-1', duration: 1000 }, 'client-1', 2);
+
+				// Truncate every turn away, then drop the last subscriber.
+				service.dispatchAction(chatUri, { type: ActionType.ChatTruncated }, 'client-1', 3);
+				assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString())?.turns.length, 0, 'precondition: session now looks empty');
+
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.strictEqual(copilotAgent.disposeSessionCalls.length, 0, 'a used session must not be GC-disposed after truncation');
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -445,8 +445,8 @@ suite('CopilotSessionLauncher resume fallback', () => {
 		}
 	});
 
-	test('falls back to createSession for an unknown -32603 from resumeSession', async () => {
-		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed: something went wrong');
+	test('falls back to createSession when the SDK reports the session was not found', async () => {
+		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed with message: Session not found: session-1');
 
 		const sessions = new DisposableStore();
 		try {
@@ -454,6 +454,31 @@ suite('CopilotSessionLauncher resume fallback', () => {
 			assert.strictEqual(getCreateSessionCalls(), 1);
 		} finally {
 			sessions.dispose();
+			await launcher.disposeByokProxyHandle();
+		}
+	});
+
+	test('does not replace a session with an empty one after a transient network failure', async () => {
+		// Regression: this used to fall through to `createSession`, presenting a
+		// session with real history as having zero turns — which the empty-session
+		// GC then deleted along with its worktree.
+		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed with message: network fetch failed: request failed: error sending request for url (https://api.github.com/copilot_internal/user)');
+
+		try {
+			await assert.rejects(() => launcher.launch(plan, testRuntime), /network fetch failed/);
+			assert.strictEqual(getCreateSessionCalls(), 0);
+		} finally {
+			await launcher.disposeByokProxyHandle();
+		}
+	});
+
+	test('does not replace a session with an empty one for an unrecognized -32603', async () => {
+		const { launcher, plan, getCreateSessionCalls } = createResumeFailingLaunch('Request session.resume failed: something went wrong');
+
+		try {
+			await assert.rejects(() => launcher.launch(plan, testRuntime), /something went wrong/);
+			assert.strictEqual(getCreateSessionCalls(), 0);
+		} finally {
 			await launcher.disposeByokProxyHandle();
 		}
 	});


### PR DESCRIPTION
A transient network failure during the Copilot SDK's `session.resume` could permanently delete an Agent Host session, its data directory, and its isolated worktree. This was found by investigating a real lost session; two sessions on one machine were destroyed this way within two days.

## What happened

Reconstructed from `agenthost.log`:

| Time | Event |
|---|---|
| 17:50 | Last turn finishes, `Session idle` |
| 17:51 | `Releasing idle session from memory (durable state preserved)` — normal eviction |
| 18:03 | Re-subscribe → `_resumeSession called — session not in memory, resuming...` |
| 18:03 | ⚠️ `SDK resumeSession failed: code=-32603, message=... network fetch failed: request failed: error sending request for url (https://api.github.com/copilot_internal/user)` |
| 18:03 | ⚠️ `Resume failed (code=-32603), falling back to createSession with same ID` |
| 18:04 | `Fallback createSession succeeded` → `Restored session ... with 0 turns` |
| 18:42 | 💀 `GC: disposing empty unsubscribed session` |
| 18:42 | Worktree deleted (`Watcher shutdown because watched path got deleted`) |

## Root cause

Two individually-reasonable mechanisms that are jointly destructive.

**1. The resume fallback was too permissive.** `shouldCreateEmptySessionAfterResumeError` treated *any* `-32603` as "the SDK cannot resume an empty session" unless the message matched a corruption keyword (`corrupt|invalid|validation|schema|must be|parse|malformed|unexpected token`). A network failure is also `-32603` and matches none of those, so it fell through to `createSession({ sessionId })` — starting a fresh session over an intact event log and presenting it as having no history.

**2. The empty-session GC then reaped it.** `_maybeScheduleSessionGc` arms a 30s timer when a session loses its last subscriber with `turns.length === 0`; `_runSessionGc` then calls `disposeSession`, which does `client.deleteSession()`, `deleteSessionData()`, and `removeCreatedWorktree()` (a `git worktree remove --force`).

The underlying design flaw: **"0 turns" was being used as a proxy for "never-used draft", but it is also exactly what a failed history load looks like** — and what a truncate leaves behind. A destructive action must not be conditioned on a value that a failure path can produce.

## The fix

Both ends of the sequence, because neither alone is sufficient — fixing only the predicate leaves GC trusting a fabricable value, and fixing only GC still shows the user a blank session.

**Resume fallback is now an allowlist** (`copilotSessionLauncher.ts`). It fires only when the SDK positively reports no events on disk (`Session not found`, `no events`, `empty session`), which still covers the "Start Over" truncate case that the fallback exists for. Everything else propagates, so a recoverable error surfaces with the on-disk history untouched.

**GC is gated on an explicit unused-draft flag** (`agentHostStateManager.ts`, `agentService.ts`). The flag is set when this process mints a session and latches off permanently on restore, on any turn activity, and on fork/import turn seeding. GC arms only for sessions that are still unused drafts, and `_runSessionGc` re-checks when the timer fires. Once a session has been used it can never look collectable again, however empty its turns become.

This is host-local bookkeeping on `ISessionEntry`; there is no AHP/protocol change.

## Why a use flag rather than just widening the error regex

The allowlist fixes the one trigger we observed. The draft flag is categorical: it protects against *any* future cause of "empty-looking session with real durable state", not just this error string. Enumerating known-bad messages means every new SDK error text is a fresh data-loss bug.

It also doesn't weaken what GC is for. Of 39 GC-disposed sessions in local logs, 37 were genuine never-used drafts (correct) and 2 had real content — both being the ones that hit the network-caused resume fallback.

An earlier revision of this PR gated on creation *origin* (`Created` vs `Restored`). Code review correctly pointed out that origin is not the same as "never used": `ChatTruncated` with no `turnId` clears `turns`, and `agentHostSessionHandler` dispatches exactly that on a checkpoint restore or first-message edit — so a session created here, used for real work, then truncated would still have been collected. Tracking use monotonically is strictly stronger and is what landed.

## Validation

- Full agent host unit suite: **3853 passing, 0 failing**
- `npm run typecheck-client` clean; `eslint` clean on changed files
- The GC guards were **mutation-checked** — each guard disabled in turn, confirming the corresponding test fails. This mattered: the first two versions of the mid-grace test passed with the guard disabled (no GC was ever armed, then the *turns* check was doing the work) and only became meaningful once the rehydrated session was made to return zero turns.
- One existing test (`falls back to createSession for an unknown -32603`) encoded the unsafe contract and now asserts the error propagates.

## Not included

Follow-ups worth doing separately: refusing to force-remove a worktree with uncommitted changes or unpushed commits, and telemetry on both the fallback and the GC-dispose paths — this surfaced only because a user noticed one missing session by hand.

(Written by Copilot)
