### PR TITLE
Fix Agent Host checkpoint restore failures

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
@@ -13,7 +13,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { FileEditKind, ToolCallStatus, type ToolCallState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IChatProgress, IChatWorkspaceEdit } from '../../../common/chatService/chatService.js';
 import { ChatEditingSessionState, IChatEditingSession, IEditSessionDiffStats, IEditSessionEntryDiff, IModifiedFileEntry, IStreamingEdits } from '../../../common/editing/chatEditingService.js';
@@ -30,6 +30,13 @@ interface IAgentHostCheckpoint {
 	readonly edits: IToolCallFileEdit[];
 	/** Tool-call IDs whose edits have already been folded into `edits`. */
 	readonly seenToolCallIds: Set<string>;
+}
+
+interface IPendingCheckpointWrite {
+	readonly checkpoint: IAgentHostCheckpoint;
+	readonly direction: 'before' | 'after';
+	readonly edits: readonly IToolCallFileEdit[];
+	nextIndex: number;
 }
 
 /**
@@ -85,6 +92,7 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 	private readonly _checkpoints: IAgentHostCheckpoint[] = [];
 	private readonly _currentCheckpointIndex = observableValue<number>(this, -1);
 	private readonly _undoRedoSequencer = new Sequencer();
+	private _pendingCheckpointWrite: IPendingCheckpointWrite | undefined;
 
 	constructor(
 		readonly chatSessionResource: URI,
@@ -167,11 +175,9 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 			// Multiple tool calls in one request may touch the same file
 			// (e.g. create→edit, edit→delete). Fold each new edit into the
 			// prior one for the same resource so the checkpoint stores a
-			// single net before/after pair per file. Otherwise
-			// _writeCheckpointContent would apply duplicate writes in
-			// parallel and race to leave the file in an undefined state.
+			// single net before/after pair per file.
 			const existingIdx = cp.edits.findIndex(e => e.resource.toString() === resource.toString());
-			if (existingIdx < 0) {
+			if (existingIdx < 0 || entry.kind === FileEditKind.Rename || cp.edits[existingIdx].kind === FileEditKind.Rename) {
 				cp.edits.push(entry);
 			} else {
 				cp.edits[existingIdx] = mergeFileEdit(cp.edits[existingIdx], entry);
@@ -241,16 +247,20 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 			// Undo forward checkpoints
 			for (let i = currentIdx; i > targetIdx; i--) {
 				await this._writeCheckpointContent(this._checkpoints[i], 'before');
+				this._setCheckpointIndex(i - 1);
 			}
 		} else if (targetIdx > currentIdx) {
 			// Redo to reach the target
 			for (let i = currentIdx + 1; i <= targetIdx; i++) {
 				await this._writeCheckpointContent(this._checkpoints[i], 'after');
+				this._setCheckpointIndex(i);
 			}
 		}
+	}
 
+	private _setCheckpointIndex(index: number): void {
 		transaction(tx => {
-			this._currentCheckpointIndex.set(targetIdx, tx);
+			this._currentCheckpointIndex.set(index, tx);
 		});
 	}
 
@@ -349,13 +359,29 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 	// ---- Private helpers ----------------------------------------------------
 
 	private async _writeCheckpointContent(checkpoint: IAgentHostCheckpoint, direction: 'before' | 'after'): Promise<void> {
-		const ops = checkpoint.edits.map(async edit => {
+		let progress = this._pendingCheckpointWrite;
+		if (progress) {
+			if (progress.checkpoint !== checkpoint || progress.direction !== direction) {
+				throw new Error(`Cannot change checkpoints while ${progress.direction === 'before' ? 'undoing' : 'redoing'} request '${progress.checkpoint.requestId}'`);
+			}
+		} else {
+			progress = {
+				checkpoint,
+				direction,
+				edits: direction === 'before' ? checkpoint.edits.slice().reverse() : checkpoint.edits.slice(),
+				nextIndex: 0,
+			};
+			this._pendingCheckpointWrite = progress;
+		}
+
+		for (; progress.nextIndex < progress.edits.length; progress.nextIndex++) {
+			const edit = progress.edits[progress.nextIndex];
 			try {
 				if (direction === 'before') {
 					// Undoing this edit
 					switch (edit.kind) {
 						case FileEditKind.Create:
-							await this._fileService.del(edit.resource);
+							await this._deleteIfExists(edit.resource);
 							break;
 						case FileEditKind.Delete:
 							if (edit.beforeContentUri) {
@@ -364,11 +390,9 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 							}
 							break;
 						case FileEditKind.Rename:
-							if (edit.originalResource) {
-								await this._fileService.move(edit.resource, edit.originalResource, true);
-							}
 							if (edit.beforeContentUri && edit.originalResource) {
 								const content = await this._fileService.readFile(edit.beforeContentUri);
+								await this._moveIfNeeded(edit.resource, edit.originalResource);
 								await this._fileService.writeFile(edit.originalResource, content.value);
 							}
 							break;
@@ -389,14 +413,12 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 							}
 							break;
 						case FileEditKind.Delete:
-							await this._fileService.del(edit.resource);
+							await this._deleteIfExists(edit.resource);
 							break;
 						case FileEditKind.Rename:
-							if (edit.originalResource) {
-								await this._fileService.move(edit.originalResource, edit.resource, true);
-							}
-							if (edit.afterContentUri) {
+							if (edit.afterContentUri && edit.originalResource) {
 								const content = await this._fileService.readFile(edit.afterContentUri);
+								await this._moveIfNeeded(edit.originalResource, edit.resource);
 								await this._fileService.writeFile(edit.resource, content.value);
 							}
 							break;
@@ -410,9 +432,31 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 				}
 			} catch (err) {
 				this._logService.warn(`[AgentHostSnapshotController] Failed to ${direction === 'before' ? 'undo' : 'redo'} ${edit.kind} for ${edit.resource.toString()}`, err);
+				throw err;
 			}
-		});
-		await Promise.all(ops);
+		}
+		this._pendingCheckpointWrite = undefined;
+	}
+
+	private async _moveIfNeeded(source: URI, target: URI): Promise<void> {
+		try {
+			await this._fileService.move(source, target, true);
+		} catch (error) {
+			if (toFileOperationResult(error) !== FileOperationResult.FILE_NOT_FOUND) {
+				throw error;
+			}
+			await this._fileService.readFile(target);
+		}
+	}
+
+	private async _deleteIfExists(resource: URI): Promise<void> {
+		try {
+			await this._fileService.del(resource);
+		} catch (error) {
+			if (toFileOperationResult(error) !== FileOperationResult.FILE_NOT_FOUND) {
+				throw error;
+			}
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
@@ -11,7 +11,7 @@ import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import type { ToolCallCompletedState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
-import { IFileContent, IFileService } from '../../../../../../platform/files/common/files.js';
+import { FileOperationError, FileOperationResult, IFileContent, IFileService } from '../../../../../../platform/files/common/files.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IChatResponseModel } from '../../../common/model/chatModel.js';
 import { AgentHostSnapshotController } from '../../../browser/agentSessions/agentHost/agentHostSnapshotController.js';
@@ -52,40 +52,79 @@ function makeToolCall(opts: {
 	};
 }
 
-function makeMockFileService(contentMap: Map<string, string>): IFileService {
+function makeRenameToolCall(opts: {
+	toolCallId: string;
+	originalFile: URI;
+	renamedFile: URI;
+	beforeURI: string;
+	afterURI: string;
+}): ToolCallCompletedState {
+	return {
+		status: ToolCallStatus.Completed,
+		toolCallId: opts.toolCallId,
+		toolName: 'rename',
+		displayName: 'Rename File',
+		invocationMessage: 'Renaming file',
+		toolInput: '{}',
+		success: true,
+		pastTenseMessage: 'Renamed file',
+		confirmed: ToolCallConfirmationReason.NotNeeded,
+		content: [{
+			type: ToolResultContentType.FileEdit,
+			before: {
+				uri: opts.originalFile.toString(),
+				content: { uri: opts.beforeURI },
+			},
+			after: {
+				uri: opts.renamedFile.toString(),
+				content: { uri: opts.afterURI },
+			},
+		}],
+	};
+}
+
+function makeMockFileService(contentMap: Map<string, string>, beforeWrite?: () => void, comparisonKey: (uri: URI) => string = uri => uri.toString()): IFileService {
 	return new class extends mock<IFileService>() {
 		override async readFile(uri: URI) {
-			const data = contentMap.get(uri.toString());
+			const data = contentMap.get(comparisonKey(uri));
 			if (data === undefined) {
 				throw new Error(`Content not found: ${uri.toString()}`);
 			}
 			return { value: VSBuffer.fromString(data) } as IFileContent;
 		}
 		override async writeFile(uri: URI, content: VSBuffer): Promise<any> {
-			contentMap.set(uri.toString(), content.toString());
+			beforeWrite?.();
+			contentMap.set(comparisonKey(uri), content.toString());
 			return {};
 		}
 		override async del(uri: URI) {
-			contentMap.delete(uri.toString());
+			if (!contentMap.delete(comparisonKey(uri))) {
+				throw new FileOperationError('File not found', FileOperationResult.FILE_NOT_FOUND);
+			}
 		}
 		override async move(source: URI, target: URI): Promise<any> {
-			const data = contentMap.get(source.toString());
-			if (data !== undefined) {
-				contentMap.set(target.toString(), data);
-				contentMap.delete(source.toString());
+			const sourceKey = comparisonKey(source);
+			const targetKey = comparisonKey(target);
+			const data = contentMap.get(sourceKey);
+			if (data === undefined) {
+				throw new FileOperationError('File not found', FileOperationResult.FILE_NOT_FOUND);
+			}
+			contentMap.set(targetKey, data);
+			if (sourceKey !== targetKey) {
+				contentMap.delete(sourceKey);
 			}
 			return {};
 		}
 	};
 }
 
-function createController(store: DisposableStore, contentMap: Map<string, string>): AgentHostSnapshotController {
+function createController(store: DisposableStore, contentMap: Map<string, string>, fileService: IFileService = makeMockFileService(contentMap)): AgentHostSnapshotController {
 	const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/test-session' });
 	const controller = new AgentHostSnapshotController(
 		sessionResource,
 		'local',
 		new NullLogService(),
-		makeMockFileService(contentMap),
+		fileService,
 	);
 	store.add(controller);
 	return controller;
@@ -267,8 +306,7 @@ suite('AgentHostSnapshotController', () => {
 	test('multiple tool calls editing the same file collapse to one net edit', async () => {
 		// Two sequential edits to /file.ts within the same request: the
 		// second edit's after-content must win on redo, and the first
-		// edit's before-content must win on undo. Without merging, the
-		// two edits would race when applied in parallel.
+		// edit's before-content must win on undo.
 		const beforeA = URI.file('/snap/before-a').toString();
 		const afterA = URI.file('/snap/after-a').toString();
 		const beforeB = URI.file('/snap/before-b').toString();
@@ -290,6 +328,208 @@ suite('AgentHostSnapshotController', () => {
 		}));
 		await controller.restoreSnapshot('req-1', undefined);
 		assert.strictEqual(contentMap.get(file), 'v0');
+	});
+
+	test('partial restore failure does not advance the cursor and can be retried', async () => {
+		const editBefore = URI.file('/snap/edit-before').toString();
+		const editAfter = URI.file('/snap/edit-after').toString();
+		const firstRenameBefore = URI.file('/snap/first-rename-before').toString();
+		const firstRenameAfter = URI.file('/snap/first-rename-after').toString();
+		const secondRenameBefore = URI.file('/snap/second-rename-before').toString();
+		const secondRenameAfter = URI.file('/snap/second-rename-after').toString();
+		const originalFile = URI.file('/a.ts');
+		const firstRenamedFile = URI.file('/b.ts');
+		const secondRenamedFile = URI.file('/c.ts');
+		const contentMap = new Map([
+			[editBefore, 'v0'],
+			[editAfter, 'v1'],
+			[firstRenameBefore, 'v1'],
+			[firstRenameAfter, 'v1'],
+			[secondRenameBefore, 'v1'],
+			[secondRenameAfter, 'v1'],
+			[secondRenamedFile.toString(), 'v1'],
+		]);
+		let writeCount = 0;
+		const fileService = makeMockFileService(contentMap, () => {
+			if (++writeCount === 2) {
+				throw new Error('write failed');
+			}
+		});
+		const controller = createController(store, contentMap, fileService);
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-edit',
+			filePath: originalFile.path,
+			beforeURI: editBefore,
+			afterURI: editAfter,
+		}));
+		controller.addToolCallEdits('req-1', makeRenameToolCall({
+			toolCallId: 'tc-rename',
+			originalFile,
+			renamedFile: firstRenamedFile,
+			beforeURI: firstRenameBefore,
+			afterURI: firstRenameAfter,
+		}));
+		controller.addToolCallEdits('req-1', makeRenameToolCall({
+			toolCallId: 'tc-second-rename',
+			originalFile: firstRenamedFile,
+			renamedFile: secondRenamedFile,
+			beforeURI: secondRenameBefore,
+			afterURI: secondRenameAfter,
+		}));
+
+		await assert.rejects(controller.restoreSnapshot('req-1', undefined), /write failed/);
+		assert.deepStrictEqual({
+			originalAfterFailure: contentMap.get(originalFile.toString()),
+			firstRenameAfterFailure: contentMap.get(firstRenamedFile.toString()),
+			secondRenameAfterFailure: contentMap.get(secondRenamedFile.toString()),
+			canUndo: controller.canUndo.get(),
+			canRedo: controller.canRedo.get(),
+			disabledRequests: controller.requestDisablement.get(),
+		}, {
+			originalAfterFailure: 'v1',
+			firstRenameAfterFailure: undefined,
+			secondRenameAfterFailure: undefined,
+			canUndo: true,
+			canRedo: false,
+			disabledRequests: [],
+		});
+
+		await controller.restoreSnapshot('req-1', undefined);
+		assert.deepStrictEqual({
+			original: contentMap.get(originalFile.toString()),
+			firstRename: contentMap.get(firstRenamedFile.toString()),
+			secondRename: contentMap.get(secondRenamedFile.toString()),
+		}, {
+			original: 'v0',
+			firstRename: undefined,
+			secondRename: undefined,
+		});
+	});
+
+	test('undo replays an edit followed by a rename in reverse order', async () => {
+		const editBefore = URI.file('/snap/edit-before').toString();
+		const editAfter = URI.file('/snap/edit-after').toString();
+		const renameBefore = URI.file('/snap/rename-before').toString();
+		const renameAfter = URI.file('/snap/rename-after').toString();
+		const originalFile = URI.file('/a.ts');
+		const renamedFile = URI.file('/b.ts');
+		const contentMap = new Map([
+			[editBefore, 'v0'],
+			[editAfter, 'v1'],
+			[renameBefore, 'v1'],
+			[renameAfter, 'v1'],
+			[renamedFile.toString(), 'v1'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-edit',
+			filePath: originalFile.path,
+			beforeURI: editBefore,
+			afterURI: editAfter,
+		}));
+		controller.addToolCallEdits('req-1', makeRenameToolCall({
+			toolCallId: 'tc-rename',
+			originalFile,
+			renamedFile,
+			beforeURI: renameBefore,
+			afterURI: renameAfter,
+		}));
+
+		await controller.restoreSnapshot('req-1', undefined);
+		assert.deepStrictEqual({
+			original: contentMap.get(originalFile.toString()),
+			renamed: contentMap.get(renamedFile.toString()),
+		}, {
+			original: 'v0',
+			renamed: undefined,
+		});
+	});
+
+	test('rename followed by an edit preserves the rename during undo and redo', async () => {
+		const renameBefore = URI.file('/snap/rename-before').toString();
+		const renameAfter = URI.file('/snap/rename-after').toString();
+		const editBefore = URI.file('/snap/edit-before').toString();
+		const editAfter = URI.file('/snap/edit-after').toString();
+		const originalFile = URI.file('/a.ts');
+		const renamedFile = URI.file('/b.ts');
+		const contentMap = new Map([
+			[renameBefore, 'v0'],
+			[renameAfter, 'v0'],
+			[editBefore, 'v0'],
+			[editAfter, 'v1'],
+			[renamedFile.toString(), 'v1'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeRenameToolCall({
+			toolCallId: 'tc-rename',
+			originalFile,
+			renamedFile,
+			beforeURI: renameBefore,
+			afterURI: renameAfter,
+		}));
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-edit',
+			filePath: renamedFile.path,
+			beforeURI: editBefore,
+			afterURI: editAfter,
+		}));
+
+		await controller.restoreSnapshot('req-1', undefined);
+		const afterUndo = {
+			original: contentMap.get(originalFile.toString()),
+			renamed: contentMap.get(renamedFile.toString()),
+		};
+		await controller.redoInteraction();
+
+		assert.deepStrictEqual({
+			afterUndo,
+			afterRedo: {
+				original: contentMap.get(originalFile.toString()),
+				renamed: contentMap.get(renamedFile.toString()),
+			},
+		}, {
+			afterUndo: {
+				original: 'v0',
+				renamed: undefined,
+			},
+			afterRedo: {
+				original: undefined,
+				renamed: 'v1',
+			},
+		});
+	});
+
+	test('case-only rename restore preserves the file on a case-insensitive file system', async () => {
+		const before = URI.file('/snap/before');
+		const after = URI.file('/snap/after');
+		const originalFile = URI.file('/foo.ts');
+		const renamedFile = URI.file('/Foo.ts');
+		const comparisonKey = (uri: URI) => uri.toString().toLowerCase();
+		const contentMap = new Map([
+			[comparisonKey(before), 'v0'],
+			[comparisonKey(after), 'v1'],
+			[comparisonKey(renamedFile), 'v1'],
+		]);
+		const controller = createController(store, contentMap, makeMockFileService(contentMap, undefined, comparisonKey));
+		controller.addToolCallEdits('req-1', makeRenameToolCall({
+			toolCallId: 'tc-rename',
+			originalFile,
+			renamedFile,
+			beforeURI: before.toString(),
+			afterURI: after.toString(),
+		}));
+
+		await controller.restoreSnapshot('req-1', undefined);
+		const afterUndo = contentMap.get(comparisonKey(originalFile));
+		await controller.redoInteraction();
+
+		assert.deepStrictEqual({
+			afterUndo,
+			afterRedo: contentMap.get(comparisonKey(renamedFile)),
+		}, {
+			afterUndo: 'v0',
+			afterRedo: 'v1',
+		});
 	});
 
 	test('hasEditsInRequest reflects added tool call edits', () => {


### PR DESCRIPTION
## Summary

- restore checkpoint edits in dependency-safe order
- keep checkpoint state unchanged after filesystem failures and allow safe retries
- preserve rename chains, rename/edit combinations, and case-only renames
- add focused regression coverage

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts`
- `npm run typecheck-client`
- `npm run precommit`

(Written by Copilot)