### PR TITLE
agentHost: refresh provisionals on folder changes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1408,7 +1408,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				const model = imported?.model ?? this._createModelSelection(request.userSelectedModelId, request.modelConfiguration);
 				const initialConfig = {
 					...this._provisionalService.getInitialSessionConfig(),
-					...this._provisionalService.getSessionConfig(request.sessionResource),
 					...request.agentHostSessionConfig,
 				};
 				await this._createAndSubscribe(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1408,6 +1408,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				const model = imported?.model ?? this._createModelSelection(request.userSelectedModelId, request.modelConfiguration);
 				const initialConfig = {
 					...this._provisionalService.getInitialSessionConfig(),
+					...this._provisionalService.getSessionConfig(request.sessionResource),
 					...request.agentHostSessionConfig,
 				};
 				await this._createAndSubscribe(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -81,7 +81,7 @@ import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../com
 import { ChatInputStateOrigin, reviveSerializableInputState, type IChatModel, type IChatModelInputState, type IChatRequestVariableData, type IInputModel, type ISerializableChatModelInputState } from '../../../common/model/chatModel.js';
 import { ChatElicitationRequestPart } from '../../../common/model/chatProgressTypes/chatElicitationRequestPart.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
-import { getChatSessionType } from '../../../common/model/chatUri.js';
+import { getChatSessionType, isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ILanguageModelToolsService, IToolInvocation, IToolResult, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { IChatWidgetService } from '../../chat.js';
@@ -930,7 +930,20 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	}
 
 	async provideChatInputCompletions(sessionResource: URI, params: IChatInputCompletionsParams, token: CancellationToken): Promise<IChatInputCompletionsResult | undefined> {
-		const backendSession = this._resolveSessionUri(sessionResource);
+		let backendSession: URI;
+		if (isUntitledChatSession(sessionResource)) {
+			// Provisional URIs are opaque; wait for the current generation instead of deriving one.
+			const provisionalSession = await raceCancellation(this._provisionalService.waitForPending(sessionResource), token);
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+			if (!provisionalSession) {
+				return undefined;
+			}
+			backendSession = provisionalSession;
+		} else {
+			backendSession = this._resolveSessionUri(sessionResource);
+		}
 		// Note: we don't forward `token` across IPC \u2014 cancellation tokens
 		// don't round-trip through the proxy channel today. The post-await
 		// `isCancellationRequested` check below is enough to drop a stale

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1360,9 +1360,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		let failureStage: AgentHostInvocationFailureStage = 'resolveSession';
 
 		try {
-			const resolvedSession = this._resolveSessionUri(request.sessionResource);
-			const sessionKey = resolvedSession.toString();
-
 			failureStage = 'provisionalSession';
 			// The chat-input picker may have pre-created a provisional session
 			// against this resource (`IAgentHostUntitledProvisionalSessionService.getOrCreate`).
@@ -1373,6 +1370,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			if (cancellationToken.isCancellationRequested) {
 				return {};
 			}
+			const resolvedSession = this._resolveSessionUri(request.sessionResource);
+			const sessionKey = resolvedSession.toString();
 			const provisionalBackend = this._provisionalService.get(request.sessionResource);
 			if (provisionalBackend) {
 				this._ensureSessionSubscription(sessionKey);
@@ -4013,6 +4012,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	/** Maps a UI session resource to a backend provider URI. */
 	private _resolveSessionUri(sessionResource: URI): URI {
+		const provisionalSession = this._provisionalService.get(sessionResource);
+		if (provisionalSession) {
+			return provisionalSession;
+		}
 		const rawId = sessionResource.path.substring(1);
 		return AgentSession.uri(this._config.backendSessionScheme ?? this._config.provider, rawId);
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -96,9 +96,8 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		// resource. The provisional service is the source of truth for the
 		// `state.config.values` the user picked via chips; copying them
 		// here means the agent's `_materializeProvisional` will see them on
-		// first send. Best-effort — if no provisional exists or the rebind
-		// fails, the handler falls through to its standard
-		// `_createAndSubscribe` path with no user selections.
+		// first send. Recoverable failure falls through to the handler's standard
+		// create path; ambiguous final-URI cleanup rejects to prevent unsafe reuse.
 		if (request.untitledResource) {
 			const workingDirectory = this._newSessionFolderService.getFolder(request.untitledResource)
 				?? this._newSessionFolderService.getDefaultFolder()

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -389,7 +389,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 
 	/**
 	 * Ensures the published generation realizes the draft's current folder and config.
-	 * It discards stale unpublished candidates, then publishes the valid candidate and retires the previous generation.
+	 * It keeps the previous generation hidden until a valid candidate can replace it, discarding stale candidates along the way.
 	 */
 	private async _reconcileGeneration(sessionResource: URI, entry: IEntry): Promise<URI | undefined> {
 		while (this._entries.get(sessionResource) === entry && !entry.disposed) {
@@ -403,7 +403,6 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			const config = { ...entry.config };
 
 			if (!await this._isTargetFolderTrusted(workingDirectory)) {
-				await this._retireGeneration(sessionResource, entry);
 				return undefined;
 			}
 
@@ -419,7 +418,6 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				});
 			} catch (err) {
 				this._logService.warn(`[AgentHostProvisional] Failed to create provisional session for ${sessionResource.toString()}: ${err instanceof Error ? err.message : String(err)}`);
-				await this._retireGeneration(sessionResource, entry);
 				return undefined;
 			}
 
@@ -437,18 +435,6 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			return created;
 		}
 		return undefined;
-	}
-
-	private async _retireGeneration(sessionResource: URI, entry: IEntry): Promise<void> {
-		const generation = entry.generation;
-		if (!generation) {
-			return;
-		}
-		entry.generation = undefined;
-		if (this._entries.get(sessionResource) === entry) {
-			this._onDidChange.fire(sessionResource);
-		}
-		await this._disposeBackend(generation.backendSession, 'retired provisional generation');
 	}
 
 	private async _disposeBackend(backendSession: URI, reason: string): Promise<void> {
@@ -680,8 +666,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		if (!entry) {
 			return undefined;
 		}
+		// Fresh entries already contain defaults; apply the user's partial on top.
+		// Mutate before queueing so a racing tryRebind sees the latest config.
 		Object.assign(entry.config, partial);
 		entry.configVersion++;
+		// Keep overlay values current while schema re-resolution is pending.
 		if (entry.resolvedConfig) {
 			entry.resolvedConfig = {
 				...entry.resolvedConfig,
@@ -689,6 +678,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			};
 		}
 
+		// Serialize dispatch and re-resolution so racing chip changes settle in order.
 		return this._queue(sessionResource, async () => {
 			if (this._entries.get(sessionResource) !== entry || entry.disposed) {
 				return undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -555,8 +555,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		entry.workingDirectory = newWorkingDirectory;
 		entry.configVersion++;
 		entry.resolvedConfig = undefined;
-		this._onDidChange.fire(sessionResource);
-		return this._queue(sessionResource, async () => {
+		const work = this._queue(sessionResource, async () => {
 			if (this._entries.get(sessionResource) !== entry || entry.disposed) {
 				return;
 			}
@@ -582,6 +581,9 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			}
 			this._onDidChange.fire(sessionResource);
 		});
+		// Register pending work before notifying because listeners can synchronously wait or reacquire.
+		this._onDidChange.fire(sessionResource);
+		return work;
 	}
 
 	disposeSession(sessionResource: URI): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -71,7 +71,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatConfiguration, getChatPermissionLevelFromDefaultConfiguration, type IChatDefaultConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IAgentHostNewSessionFolderService, computeWorkingDirectories } from './agentHostNewSessionFolderService.js';
-import { type IAgentHostImportConversation, IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
+import { IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
 	createDecorator<IAgentHostUntitledProvisionalSessionService>('agentHostUntitledProvisionalSessionService');
@@ -105,9 +105,6 @@ export interface IAgentHostUntitledProvisionalSessionService {
 	 * the initial config supplied on the request.
 	 */
 	getInitialSessionConfig(): Record<string, unknown> | undefined;
-
-	/** Workbench-owned config for an existing logical provisional record. */
-	getSessionConfig(sessionResource: URI): Record<string, unknown> | undefined;
 
 	/**
 	 * Ensure a backend provisional exists for an untitled chat UI resource.
@@ -299,11 +296,6 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return this._getInitialConfig();
 	}
 
-	getSessionConfig(sessionResource: URI): Record<string, unknown> | undefined {
-		const entry = this._entries.get(sessionResource);
-		return entry && !entry.disposed ? { ...entry.config } : undefined;
-	}
-
 	async waitForPending(sessionResource: URI): Promise<URI | undefined> {
 		while (true) {
 			const pending = this._pending.get(sessionResource);
@@ -487,43 +479,14 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			}
 
 			const newBackendSession = this._toBackendUri(newSessionResource, provider);
-			let imported: IAgentHostImportConversation | undefined;
-			let importedRead = false;
+			// Imports materialize eagerly, so carry their history and model into the rebound session.
+			const imported = this._importConversationStore.take(newSessionResource);
 
 			while (this._entries.get(oldSessionResource) === oldEntry && !oldEntry.disposed) {
 				// The workbench cache is authoritative; backend state can lag synchronous chip edits.
 				const config = { ...oldEntry.config };
 				const configVersion = oldEntry.configVersion;
 				const targetWorkingDirectory = oldEntry.workingDirectory ?? workingDirectory;
-				const trusted = await this._isTargetFolderTrusted(targetWorkingDirectory);
-				if (this._entries.get(oldSessionResource) !== oldEntry || oldEntry.disposed) {
-					return undefined;
-				}
-				if (oldEntry.configVersion !== configVersion || !this._sameUri(oldEntry.workingDirectory ?? workingDirectory, targetWorkingDirectory)) {
-					continue;
-				}
-				if (!trusted) {
-					if (imported) {
-						this._importConversationStore.set(newSessionResource, imported);
-					}
-					const oldGeneration = oldEntry.generation;
-					oldEntry.generation = undefined;
-					this._entries.set(newSessionResource, oldEntry);
-					this._entries.delete(oldSessionResource);
-					this._resolvedConfigs.delete(oldSessionResource);
-					this._resolvedConfigRequestSeq.delete(oldSessionResource);
-					this._rebound.add(oldSessionResource);
-					this._onDidChange.fire(newSessionResource);
-					if (oldGeneration) {
-						await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
-					}
-					return undefined;
-				}
-				if (!importedRead) {
-					// Imports materialize eagerly, so carry their history and model into the rebound session.
-					imported = this._importConversationStore.take(newSessionResource);
-					importedRead = true;
-				}
 				let created: URI;
 				try {
 					created = await this._agentHostService.createSession({

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -13,7 +13,7 @@
  *
  * Resource identities:
  * - chat UI resource: `agent-host-PROVIDER:/untitled-<uuid>` before first Send.
- * - backend resource: `PROVIDER:/untitled-<uuid>` for the provisional state.
+ * - backend resource: an opaque `PROVIDER:/<uuid>` for provisional state.
  * - real chat resource: `agent-host-PROVIDER:/<uuid>` after
  *   `chatServiceImpl.acceptInput` calls `createNewChatSessionItem`.
  * - real backend resource: `PROVIDER:/<uuid>` after `tryRebind`.
@@ -25,10 +25,10 @@
  * 2. On first Send, `AgentHostSessionListController.newChatSessionItem`
  *    receives both `request.untitledResource` and the newly generated real
  *    resource. It must call `tryRebind` before the handler invokes the agent.
- * 3. `tryRebind` snapshots `state.config.values` from the untitled backend
- *    provisional, creates a new provisional for the real backend resource with
- *    that config, swaps `_entries`, fires `onDidChange` for both resources,
- *    then best-effort disposes the untitled backend provisional.
+ * 3. `tryRebind` snapshots the workbench-owned config from the untitled
+ *    provisional record, creates a new provisional for the real backend
+ *    resource, swaps `_entries`, fires `onDidChange`, then best-effort disposes
+ *    the untitled backend provisional.
  * 4. `AgentHostSessionHandler._invokeAgent` calls `get(realResource)`. When a
  *    rebound provisional exists, it takes a refcounted subscription on that
  *    backend state up front so the rest of the handler observes the preserved
@@ -53,6 +53,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { equals } from '../../../../../../base/common/objects.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -140,10 +141,9 @@ export interface IAgentHostUntitledProvisionalSessionService {
 
 	/**
 	 * Bridge the untitled chat UI resource to the real chat UI resource created
-	 * for first Send. Must copy `state.config.values` from the old backend
-	 * provisional into the new backend provisional before the handler invokes the
-	 * agent. No-op when no old mapping exists; idempotent when the new mapping is
-	 * already present.
+	 * for first Send. Must copy the workbench-owned config into the real backend
+	 * provisional before the handler invokes the agent. No-op when no old mapping
+	 * exists; idempotent when the new mapping is already present.
 	 */
 	tryRebind(
 		oldSessionResource: URI,
@@ -181,8 +181,14 @@ export interface IAgentHostUntitledProvisionalSessionService {
 	): Promise<void>;
 }
 
-interface IEntry {
+interface IProvisionalGeneration {
 	readonly backendSession: URI;
+	readonly workingDirectory: URI | undefined;
+}
+
+interface IEntry {
+	readonly provider: string;
+	generation: IProvisionalGeneration | undefined;
 	/**
 	 * Workbench-owned snapshot of session-config values for this provisional.
 	 * Seeded from {@link _getInitialConfig} at create time and mutated
@@ -191,26 +197,28 @@ interface IEntry {
 	 * `state.config.values`.
 	 */
 	config: Record<string, unknown>;
+	configVersion: number;
 	/**
 	 * Working directory the provisional backend session was created with. A
 	 * created session's cwd is immutable, so when the user picks a different
 	 * folder the entry is recreated; this lets a folder change no-op when the
 	 * cwd is unchanged.
 	 */
-	workingDirectory?: URI;
+	workingDirectory: URI | undefined;
 	/**
 	 * Latest re-resolved config (schema + values) for this provisional, set
 	 * by {@link applyConfigChange} after each value change. Cleared when the
 	 * entry is rebound or disposed.
 	 */
 	resolvedConfig?: ResolveSessionConfigResult;
+	disposed: boolean;
 }
 
 export class AgentHostUntitledProvisionalSessionService extends Disposable implements IAgentHostUntitledProvisionalSessionService {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _entries = new ResourceMap<IEntry>();
-	private readonly _pending = new ResourceMap<Promise<URI | undefined>>();
+	private readonly _pending = new ResourceMap<Promise<unknown>>();
 	private readonly _resolvedConfigs = new ResourceMap<ResolveSessionConfigResult>();
 	private readonly _resolvedConfigRequestSeq = new ResourceMap<number>();
 	// URIs that were the source of a successful `tryRebind`. The chat widget
@@ -267,7 +275,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	}
 
 	get(sessionResource: URI): URI | undefined {
-		return this._entries.get(sessionResource)?.backendSession;
+		const entry = this._entries.get(sessionResource);
+		if (!entry || entry.disposed || !this._generationMatchesDesiredState(entry)) {
+			return undefined;
+		}
+		return entry.generation?.backendSession;
 	}
 
 	private _computeWorkingDirectories(primary: URI | undefined, provider: string): readonly URI[] | undefined {
@@ -279,11 +291,16 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	}
 
 	async waitForPending(sessionResource: URI): Promise<URI | undefined> {
-		const inflight = this._pending.get(sessionResource);
-		if (inflight) {
-			await inflight;
+		while (true) {
+			const pending = this._pending.get(sessionResource);
+			if (!pending) {
+				return this.get(sessionResource);
+			}
+			await pending;
+			if (this._pending.get(sessionResource) === pending) {
+				return this.get(sessionResource);
+			}
 		}
-		return this.get(sessionResource);
 	}
 
 	getOrCreate(
@@ -300,49 +317,130 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		}
 		const inflight = this._pending.get(sessionResource);
 		if (inflight) {
-			return inflight;
+			return inflight.then(() => this.get(sessionResource));
 		}
 
-		const work = this._sequencer.queue(sessionResource.toString(), async () => {
-			// Re-check inside the sequencer — another caller may have raced
-			// us and populated the entry while we were queued.
+		const entry = this._ensureEntry(sessionResource, provider, workingDirectory);
+		if (!entry) {
+			return Promise.resolve(undefined);
+		}
+		return this._queue(sessionResource, async () => {
 			const settled = this.get(sessionResource);
 			if (settled) {
 				return settled;
 			}
-			// Don't eagerly spawn a provisional backend session in an
-			// untrusted target folder — that would start an agent in the
-			// folder before the user has opted in. This pre-warm is a silent
-			// optimization; trust is requested interactively on first Send
-			// (see AgentHostSessionHandler).
-			if (!await this._isTargetFolderTrusted(workingDirectory)) {
-				return undefined;
-			}
-			const backendSession = this._toBackendUri(sessionResource, provider);
-			const initialConfig = this._getInitialConfig();
-			try {
-				const created = await this._agentHostService.createSession({
-					provider,
-					session: backendSession,
-					workingDirectories: this._computeWorkingDirectories(workingDirectory, provider),
-					config: initialConfig,
-					progressToken: generateUuid(),
-				});
-				this._entries.set(sessionResource, { backendSession: created, config: { ...(initialConfig ?? {}) }, workingDirectory });
-				this._onDidChange.fire(sessionResource);
-				return created;
-			} catch (err) {
-				this._logService.warn(`[AgentHostProvisional] Failed to create provisional session for ${sessionResource.toString()}: ${err instanceof Error ? err.message : String(err)}`);
-				return undefined;
-			}
+			return this._reconcileGeneration(sessionResource, entry);
 		});
+	}
+
+	private _ensureEntry(sessionResource: URI, provider: string, workingDirectory: URI | undefined): IEntry | undefined {
+		const existing = this._entries.get(sessionResource);
+		if (existing) {
+			return existing;
+		}
+		if (this._rebound.has(sessionResource)) {
+			return undefined;
+		}
+		const entry: IEntry = {
+			provider,
+			generation: undefined,
+			config: { ...(this._getInitialConfig() ?? {}) },
+			configVersion: 0,
+			workingDirectory,
+			disposed: false,
+		};
+		this._entries.set(sessionResource, entry);
+		return entry;
+	}
+
+	private _queue<T>(sessionResource: URI, task: () => Promise<T>): Promise<T> {
+		const work = this._sequencer.queue(sessionResource.toString(), task);
 		this._pending.set(sessionResource, work);
-		work.finally(() => {
+		void work.finally(() => {
 			if (this._pending.get(sessionResource) === work) {
 				this._pending.delete(sessionResource);
 			}
-		});
+		}).catch(() => { });
 		return work;
+	}
+
+	private _generationMatchesDesiredState(entry: IEntry): boolean {
+		return !!entry.generation && this._sameUri(entry.generation.workingDirectory, entry.workingDirectory);
+	}
+
+	private _sameUri(first: URI | undefined, second: URI | undefined): boolean {
+		return first === undefined || second === undefined ? first === second : isEqual(first, second);
+	}
+
+	private _newProvisionalUri(provider: string): URI {
+		return URI.from({ scheme: provider, path: `/${generateUuid()}` });
+	}
+
+	private async _reconcileGeneration(sessionResource: URI, entry: IEntry): Promise<URI | undefined> {
+		while (this._entries.get(sessionResource) === entry && !entry.disposed) {
+			if (this._generationMatchesDesiredState(entry)) {
+				return entry.generation!.backendSession;
+			}
+
+			const workingDirectory = entry.workingDirectory;
+			const configVersion = entry.configVersion;
+			const config = { ...entry.config };
+
+			if (!await this._isTargetFolderTrusted(workingDirectory)) {
+				await this._retireGeneration(sessionResource, entry);
+				return undefined;
+			}
+
+			const candidate = this._newProvisionalUri(entry.provider);
+			let created: URI;
+			try {
+				created = await this._agentHostService.createSession({
+					provider: entry.provider,
+					session: candidate,
+					workingDirectories: this._computeWorkingDirectories(workingDirectory, entry.provider),
+					config,
+					progressToken: generateUuid(),
+				});
+			} catch (err) {
+				this._logService.warn(`[AgentHostProvisional] Failed to create provisional session for ${sessionResource.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+				await this._retireGeneration(sessionResource, entry);
+				return undefined;
+			}
+
+			if (this._entries.get(sessionResource) !== entry || entry.disposed || entry.configVersion !== configVersion || !this._sameUri(entry.workingDirectory, workingDirectory)) {
+				await this._disposeBackend(created, 'obsolete provisional candidate');
+				continue;
+			}
+
+			const previous = entry.generation;
+			entry.generation = { backendSession: created, workingDirectory };
+			this._onDidChange.fire(sessionResource);
+			if (previous) {
+				await this._disposeBackend(previous.backendSession, 'replaced provisional generation');
+			}
+			return created;
+		}
+		return undefined;
+	}
+
+	private async _retireGeneration(sessionResource: URI, entry: IEntry): Promise<void> {
+		const generation = entry.generation;
+		if (!generation) {
+			return;
+		}
+		entry.generation = undefined;
+		if (this._entries.get(sessionResource) === entry) {
+			this._onDidChange.fire(sessionResource);
+		}
+		await this._disposeBackend(generation.backendSession, 'retired provisional generation');
+	}
+
+	private async _disposeBackend(backendSession: URI, reason: string): Promise<void> {
+		try {
+			await this._agentHostService.disposeSession(backendSession);
+		} catch (err) {
+			this._logService.warn(`[AgentHostProvisional] Failed to dispose ${reason} ${backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	/**
@@ -359,138 +457,102 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return this._workspaceTrustManagementService.isWorkspaceTrusted();
 	}
 
-	async tryRebind(
+	tryRebind(
 		oldSessionResource: URI,
 		newSessionResource: URI,
 		provider: string,
 		workingDirectory: URI | undefined,
 	): Promise<URI | undefined> {
-		// If the new resource already has a provisional (e.g. tryRebind was
-		// called twice), short-circuit.
-		const alreadyBound = this.get(newSessionResource);
-		if (alreadyBound) {
-			return alreadyBound;
-		}
+		return this._queue(oldSessionResource, async () => {
+			const alreadyBound = this.get(newSessionResource);
+			if (alreadyBound) {
+				return alreadyBound;
+			}
 
-		// Make sure any in-flight create for the old resource settles before
-		// we read its state — otherwise we may not see the user's most
-		// recent dispatch.
-		await this.waitForPending(oldSessionResource);
+			const oldEntry = this._entries.get(oldSessionResource);
+			if (!oldEntry || oldEntry.disposed) {
+				return undefined;
+			}
 
-		const oldEntry = this._entries.get(oldSessionResource);
-		if (!oldEntry) {
-			return undefined;
-		}
+			const config = { ...oldEntry.config };
+			const newBackendSession = this._toBackendUri(newSessionResource, provider);
+			const imported = this._importConversationStore.take(newSessionResource);
 
-		// The workbench owns the source of truth for provisional config: it
-		// was seeded by `_getInitialConfig()` at create time and updated
-		// synchronously by `applyConfigChange` for any picker chip changes.
-		// Read straight from the entry; do NOT round-trip through the agent's
-		// `state.config.values`, which lags behind by a server echo.
-		const config = oldEntry.config;
-		const newBackendSession = this._toBackendUri(newSessionResource, provider);
+			let created: URI;
+			try {
+				created = await this._agentHostService.createSession({
+					provider,
+					session: newBackendSession,
+					workingDirectories: this._computeWorkingDirectories(workingDirectory, provider),
+					config,
+					...(imported ? { model: imported.model, importConversation: { turns: imported.turns, model: imported.model } } : {}),
+					progressToken: generateUuid(),
+				});
+			} catch (err) {
+				this._logService.warn(`[AgentHostProvisional] Failed to create rebound provisional: ${err instanceof Error ? err.message : String(err)}`);
+				return undefined;
+			}
 
-		// If a conversation was imported ("Continue in…") into this session, seed
-		// it as real editable history on the rebound (real) session. The stash was
-		// moved from the untitled resource to `newSessionResource` at graduation.
-		// Carry the source session's model so the imported session resumes on the
-		// same model instead of the host default (the normal per-turn model path
-		// is skipped for imports, which materialize eagerly at create time).
-		const imported = this._importConversationStore.take(newSessionResource);
-
-		let created: URI;
-		try {
-			created = await this._agentHostService.createSession({
+			const oldGeneration = oldEntry.generation;
+			this._entries.set(newSessionResource, {
 				provider,
-				session: newBackendSession,
-				workingDirectories: this._computeWorkingDirectories(workingDirectory, provider),
+				generation: { backendSession: created, workingDirectory },
 				config,
-				...(imported ? { model: imported.model, importConversation: { turns: imported.turns, model: imported.model } } : {}),
-				progressToken: generateUuid(),
+				configVersion: oldEntry.configVersion,
+				workingDirectory,
+				resolvedConfig: oldEntry.resolvedConfig,
+				disposed: false,
 			});
-		} catch (err) {
-			this._logService.warn(`[AgentHostProvisional] Failed to create rebound provisional: ${err instanceof Error ? err.message : String(err)}`);
-			return undefined;
-		}
+			this._entries.delete(oldSessionResource);
+			oldEntry.disposed = true;
+			this._resolvedConfigs.delete(oldSessionResource);
+			this._resolvedConfigRequestSeq.delete(oldSessionResource);
+			this._rebound.add(oldSessionResource);
+			this._onDidChange.fire(newSessionResource);
 
-		// Atomically swap entries: insert the new entry, drop the old one.
-		// Order matters — the old entry's `dispose` below must not race with
-		// the picker's `onDidChange` re-render reading the new entry.
-		this._entries.set(newSessionResource, { backendSession: created, config: { ...config }, workingDirectory, resolvedConfig: oldEntry.resolvedConfig });
-		this._entries.delete(oldSessionResource);
-		this._resolvedConfigs.delete(oldSessionResource);
-		this._resolvedConfigRequestSeq.delete(oldSessionResource);
-		this._rebound.add(oldSessionResource);
-		// Only notify for the new resource. Firing for `oldSessionResource`
-		// would race the chat widget's `onDidChangeViewModel`: the picker is
-		// still bound to the old URI and would re-enter `getOrCreate`,
-		// spinning up an orphan provisional session on the agent.
-		this._onDidChange.fire(newSessionResource);
-
-		// Dispose the temporary provisional. Best-effort; the agent treats
-		// it as an in-memory drop (no SDK/worktree to tear down).
-		this._agentHostService.disposeSession(oldEntry.backendSession).catch(err => {
-			this._logService.warn(`[AgentHostProvisional] Failed to dispose temporary provisional ${oldEntry.backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+			if (oldGeneration) {
+				await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
+			}
+			return created;
 		});
-
-		return created;
 	}
 
 	/**
 	 * Recreate the provisional backend session for `sessionResource` at a new
 	 * working directory, preserving the user's config choices. A created
 	 * session's cwd is immutable, so the only way to honor a folder change is to
-	 * dispose and recreate. Reuses the same deterministic backend URI so the
-	 * chat-resource-to-backend mapping stays stable. Sequencer-queued so it
-	 * settles in order with config-chip changes for the same resource.
+	 * dispose and recreate. The replacement uses a fresh backend URI so existing
+	 * subscribers acquire an authoritative snapshot for the new incarnation.
 	 */
 	private _changeWorkingDirectory(sessionResource: URI, newWorkingDirectory: URI): Promise<void> {
-		return this._sequencer.queue(sessionResource.toString(), async () => {
-			const entry = this._entries.get(sessionResource);
-			if (!entry) {
+		const entry = this._entries.get(sessionResource);
+		if (!entry || entry.disposed || this._sameUri(entry.workingDirectory, newWorkingDirectory)) {
+			return Promise.resolve();
+		}
+		entry.workingDirectory = newWorkingDirectory;
+		entry.configVersion++;
+		entry.resolvedConfig = undefined;
+		this._onDidChange.fire(sessionResource);
+		return this._queue(sessionResource, async () => {
+			if (this._entries.get(sessionResource) !== entry || entry.disposed) {
 				return;
 			}
-			if (entry.workingDirectory?.toString() === newWorkingDirectory.toString()) {
+			const backend = await this._reconcileGeneration(sessionResource, entry);
+			if (!backend) {
 				return;
 			}
-			// Read the stripped backend provider scheme (e.g. `copilot`), not
-			// the full `agent-host-*` chat-resource scheme.
-			const provider = entry.backendSession.scheme;
-			const config = { ...entry.config };
-			try {
-				await this._agentHostService.disposeSession(entry.backendSession);
-			} catch (err) {
-				this._logService.warn(`[AgentHostProvisional] Failed to dispose provisional before cwd change ${entry.backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
-			}
-			let created: URI;
-			try {
-				created = await this._agentHostService.createSession({
-					provider,
-					session: entry.backendSession,
-					workingDirectories: this._computeWorkingDirectories(newWorkingDirectory, provider),
-					config,
-					progressToken: generateUuid(),
-				});
-			} catch (err) {
-				this._logService.warn(`[AgentHostProvisional] Failed to recreate provisional at new cwd: ${err instanceof Error ? err.message : String(err)}`);
-				// The old provisional is gone; drop the entry so the next
-				// getOrCreate rebuilds it from scratch.
-				this._entries.delete(sessionResource);
-				this._onDidChange.fire(sessionResource);
-				return;
-			}
-			this._entries.set(sessionResource, { backendSession: created, config, workingDirectory: newWorkingDirectory, resolvedConfig: entry.resolvedConfig });
 			// Re-resolve config against the new cwd so chip schemas refresh.
+			const configVersion = entry.configVersion;
+			const workingDirectory = entry.workingDirectory;
 			try {
 				const resolved = await this._agentHostService.resolveSessionConfig({
-					provider,
-					workingDirectory: newWorkingDirectory,
-					config: { ...config },
+					provider: entry.provider,
+					workingDirectory,
+					config: { ...entry.config },
 				});
-				const current = this._entries.get(sessionResource);
-				if (current && current.backendSession.toString() === created.toString()) {
-					current.config = { ...current.config, ...resolved.values };
-					current.resolvedConfig = resolved;
+				if (this._entries.get(sessionResource) === entry && !entry.disposed && entry.configVersion === configVersion && this._sameUri(entry.workingDirectory, workingDirectory)) {
+					entry.config = { ...entry.config, ...resolved.values };
+					entry.resolvedConfig = resolved;
 				}
 			} catch (err) {
 				this._logService.warn(`[AgentHostProvisional] schema re-resolve after cwd change failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -499,28 +561,32 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		});
 	}
 
-	async disposeSession(sessionResource: URI): Promise<void> {
-		await this.waitForPending(sessionResource);
+	disposeSession(sessionResource: URI): Promise<void> {
 		const entry = this._entries.get(sessionResource);
 		this._resolvedConfigs.delete(sessionResource);
 		this._resolvedConfigRequestSeq.delete(sessionResource);
 		if (!entry) {
-			return;
+			return Promise.resolve();
 		}
+		entry.disposed = true;
 		this._entries.delete(sessionResource);
 		this._onDidChange.fire(sessionResource);
-		try {
-			await this._agentHostService.disposeSession(entry.backendSession);
-		} catch (err) {
-			this._logService.warn(`[AgentHostProvisional] Failed to dispose provisional ${entry.backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
-		}
+		return this._queue(sessionResource, async () => {
+			if (entry.generation) {
+				await this._disposeBackend(entry.generation.backendSession, 'provisional generation');
+				entry.generation = undefined;
+			}
+		});
 	}
 
 	override dispose(): void {
 		// Fire-and-forget cleanup for any provisionals still tracked. Avoid
 		// awaiting in `dispose()` to keep workbench teardown synchronous.
 		for (const [, entry] of this._entries) {
-			this._agentHostService.disposeSession(entry.backendSession).catch(() => { /* swallow on shutdown */ });
+			entry.disposed = true;
+			if (entry.generation) {
+				this._agentHostService.disposeSession(entry.generation.backendSession).catch(() => { /* swallow on shutdown */ });
+			}
 		}
 		this._entries.clear();
 		this._pending.clear();
@@ -579,68 +645,52 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		workingDirectory: URI | undefined,
 		partial: Record<string, unknown>,
 	): Promise<URI | undefined> {
-		// SYNCHRONOUS pre-await mutation: a `tryRebind` racing during
-		// `getOrCreate` only awaits `_pending` (not this service's
-		// `_sequencer`), so the rebound entry must observe the latest
-		// `entry.config` even if the user clicks Send the very next tick.
-		const preExisting = this._entries.get(sessionResource);
-		if (preExisting) {
-			Object.assign(preExisting.config, partial);
-			// Keep overlay values in sync with the cache so the picker (which
-			// prefers `overlay.values`) doesn't render a stale value during the
-			// re-resolve round-trip. Schema is left as-is; the queued resolve
-			// replaces both atomically below.
-			if (preExisting.resolvedConfig) {
-				preExisting.resolvedConfig = {
-					...preExisting.resolvedConfig,
-					values: { ...preExisting.resolvedConfig.values, ...partial },
-				};
-			}
-		}
-		const backend = await this.getOrCreate(sessionResource, provider, workingDirectory);
-		if (!backend) {
+		const entry = this._ensureEntry(sessionResource, provider, workingDirectory);
+		if (!entry) {
 			return undefined;
 		}
-		if (!preExisting) {
-			// Fresh entry just created by getOrCreate; apply partial on top.
-			// No `resolvedConfig` exists yet on a newly-created entry, so
-			// there's nothing to merge into.
-			const entry = this._entries.get(sessionResource);
-			if (entry) {
-				Object.assign(entry.config, partial);
-			}
+		Object.assign(entry.config, partial);
+		entry.configVersion++;
+		if (entry.resolvedConfig) {
+			entry.resolvedConfig = {
+				...entry.resolvedConfig,
+				values: { ...entry.resolvedConfig.values, ...partial },
+			};
 		}
-		this._agentHostService.dispatch(backend.toString(), {
-			type: ActionType.SessionConfigChanged,
-			config: partial,
-		});
 
-		// Sequence ONLY the re-resolve so racing chip clicks settle in order
-		// (e.g. worktree → folder issued before the first resolve returns).
-		return this._sequencer.queue(sessionResource.toString(), async () => {
-			const current = this._entries.get(sessionResource);
-			if (!current) {
-				return backend;
+		return this._queue(sessionResource, async () => {
+			if (this._entries.get(sessionResource) !== entry || entry.disposed) {
+				return undefined;
 			}
+			const backend = await this._reconcileGeneration(sessionResource, entry);
+			if (!backend || this._entries.get(sessionResource) !== entry || entry.disposed) {
+				return undefined;
+			}
+			this._agentHostService.dispatch(backend.toString(), {
+				type: ActionType.SessionConfigChanged,
+				config: partial,
+			});
+			const configVersion = entry.configVersion;
+			const resolvedWorkingDirectory = entry.workingDirectory;
 			try {
 				const resolved = await this._agentHostService.resolveSessionConfig({
 					provider,
-					workingDirectory,
-					config: { ...current.config },
+					workingDirectory: resolvedWorkingDirectory,
+					config: { ...entry.config },
 				});
 				const stillCurrent = this._entries.get(sessionResource);
-				if (stillCurrent === current) {
+				if (stillCurrent === entry && !entry.disposed && entry.configVersion === configVersion && this._sameUri(entry.workingDirectory, resolvedWorkingDirectory)) {
 					const resolvedValues = { ...resolved.values };
 					// Merge resolved values into entry.config so a later `tryRebind`
 					// materializes the backend session with the validated configuration
 					// the UI is displaying. Merge (not replace) so any keys the schema
 					// doesn't know about survive.
-					const mergedConfig = { ...stillCurrent.config, ...resolvedValues };
-					const configChanged = !equals(stillCurrent.config, mergedConfig);
-					const resolvedChanged = !equals(stillCurrent.resolvedConfig, resolved);
+					const mergedConfig = { ...entry.config, ...resolvedValues };
+					const configChanged = !equals(entry.config, mergedConfig);
+					const resolvedChanged = !equals(entry.resolvedConfig, resolved);
 					if (configChanged || resolvedChanged) {
-						stillCurrent.config = mergedConfig;
-						stillCurrent.resolvedConfig = resolved;
+						entry.config = mergedConfig;
+						entry.resolvedConfig = resolved;
 						this._onDidChange.fire(sessionResource);
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -386,6 +386,10 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return URI.from({ scheme: provider, path: `/${generateUuid()}` });
 	}
 
+	/**
+	 * Ensures the published generation realizes the draft's current folder and config.
+	 * It discards stale unpublished candidates, then publishes the valid candidate and retires the previous generation.
+	 */
 	private async _reconcileGeneration(sessionResource: URI, entry: IEntry): Promise<URI | undefined> {
 		while (this._entries.get(sessionResource) === entry && !entry.disposed) {
 			if (this._generationMatchesDesiredState(entry)) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -71,7 +71,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatConfiguration, getChatPermissionLevelFromDefaultConfiguration, type IChatDefaultConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IAgentHostNewSessionFolderService, computeWorkingDirectories } from './agentHostNewSessionFolderService.js';
-import { IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
+import { type IAgentHostImportConversation, IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
 	createDecorator<IAgentHostUntitledProvisionalSessionService>('agentHostUntitledProvisionalSessionService');
@@ -105,6 +105,9 @@ export interface IAgentHostUntitledProvisionalSessionService {
 	 * the initial config supplied on the request.
 	 */
 	getInitialSessionConfig(): Record<string, unknown> | undefined;
+
+	/** Workbench-owned config for an existing logical provisional record. */
+	getSessionConfig(sessionResource: URI): Record<string, unknown> | undefined;
 
 	/**
 	 * Ensure a backend provisional exists for an untitled chat UI resource.
@@ -296,6 +299,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return this._getInitialConfig();
 	}
 
+	getSessionConfig(sessionResource: URI): Record<string, unknown> | undefined {
+		const entry = this._entries.get(sessionResource);
+		return entry && !entry.disposed ? { ...entry.config } : undefined;
+	}
+
 	async waitForPending(sessionResource: URI): Promise<URI | undefined> {
 		while (true) {
 			const pending = this._pending.get(sessionResource);
@@ -479,14 +487,43 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			}
 
 			const newBackendSession = this._toBackendUri(newSessionResource, provider);
-			// Imports materialize eagerly, so carry their history and model into the rebound session.
-			const imported = this._importConversationStore.take(newSessionResource);
+			let imported: IAgentHostImportConversation | undefined;
+			let importedRead = false;
 
 			while (this._entries.get(oldSessionResource) === oldEntry && !oldEntry.disposed) {
 				// The workbench cache is authoritative; backend state can lag synchronous chip edits.
 				const config = { ...oldEntry.config };
 				const configVersion = oldEntry.configVersion;
 				const targetWorkingDirectory = oldEntry.workingDirectory ?? workingDirectory;
+				const trusted = await this._isTargetFolderTrusted(targetWorkingDirectory);
+				if (this._entries.get(oldSessionResource) !== oldEntry || oldEntry.disposed) {
+					return undefined;
+				}
+				if (oldEntry.configVersion !== configVersion || !this._sameUri(oldEntry.workingDirectory ?? workingDirectory, targetWorkingDirectory)) {
+					continue;
+				}
+				if (!trusted) {
+					if (imported) {
+						this._importConversationStore.set(newSessionResource, imported);
+					}
+					const oldGeneration = oldEntry.generation;
+					oldEntry.generation = undefined;
+					this._entries.set(newSessionResource, oldEntry);
+					this._entries.delete(oldSessionResource);
+					this._resolvedConfigs.delete(oldSessionResource);
+					this._resolvedConfigRequestSeq.delete(oldSessionResource);
+					this._rebound.add(oldSessionResource);
+					this._onDidChange.fire(newSessionResource);
+					if (oldGeneration) {
+						await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
+					}
+					return undefined;
+				}
+				if (!importedRead) {
+					// Imports materialize eagerly, so carry their history and model into the rebound session.
+					imported = this._importConversationStore.take(newSessionResource);
+					importedRead = true;
+				}
 				let created: URI;
 				try {
 					created = await this._agentHostService.createSession({

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -474,46 +474,60 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				return undefined;
 			}
 
-			const config = { ...oldEntry.config };
 			const newBackendSession = this._toBackendUri(newSessionResource, provider);
 			const imported = this._importConversationStore.take(newSessionResource);
 
-			let created: URI;
-			try {
-				created = await this._agentHostService.createSession({
+			while (this._entries.get(oldSessionResource) === oldEntry && !oldEntry.disposed) {
+				const config = { ...oldEntry.config };
+				const configVersion = oldEntry.configVersion;
+				const targetWorkingDirectory = oldEntry.workingDirectory ?? workingDirectory;
+				let created: URI;
+				try {
+					created = await this._agentHostService.createSession({
+						provider,
+						session: newBackendSession,
+						workingDirectories: this._computeWorkingDirectories(targetWorkingDirectory, provider),
+						config,
+						...(imported ? { model: imported.model, importConversation: { turns: imported.turns, model: imported.model } } : {}),
+						progressToken: generateUuid(),
+					});
+				} catch (err) {
+					this._logService.warn(`[AgentHostProvisional] Failed to create rebound provisional: ${err instanceof Error ? err.message : String(err)}`);
+					return undefined;
+				}
+
+				if (this._entries.get(oldSessionResource) !== oldEntry || oldEntry.disposed) {
+					await this._disposeBackend(created, 'retired rebound candidate');
+					return undefined;
+				}
+				if (oldEntry.configVersion !== configVersion || !this._sameUri(oldEntry.workingDirectory ?? workingDirectory, targetWorkingDirectory)) {
+					await this._disposeBackend(created, 'obsolete rebound candidate');
+					continue;
+				}
+
+				const oldGeneration = oldEntry.generation;
+				this._entries.set(newSessionResource, {
 					provider,
-					session: newBackendSession,
-					workingDirectories: this._computeWorkingDirectories(workingDirectory, provider),
+					generation: { backendSession: created, workingDirectory: targetWorkingDirectory },
 					config,
-					...(imported ? { model: imported.model, importConversation: { turns: imported.turns, model: imported.model } } : {}),
-					progressToken: generateUuid(),
+					configVersion,
+					workingDirectory: targetWorkingDirectory,
+					resolvedConfig: oldEntry.resolvedConfig,
+					disposed: false,
 				});
-			} catch (err) {
-				this._logService.warn(`[AgentHostProvisional] Failed to create rebound provisional: ${err instanceof Error ? err.message : String(err)}`);
-				return undefined;
-			}
+				this._entries.delete(oldSessionResource);
+				oldEntry.disposed = true;
+				this._resolvedConfigs.delete(oldSessionResource);
+				this._resolvedConfigRequestSeq.delete(oldSessionResource);
+				this._rebound.add(oldSessionResource);
+				this._onDidChange.fire(newSessionResource);
 
-			const oldGeneration = oldEntry.generation;
-			this._entries.set(newSessionResource, {
-				provider,
-				generation: { backendSession: created, workingDirectory },
-				config,
-				configVersion: oldEntry.configVersion,
-				workingDirectory,
-				resolvedConfig: oldEntry.resolvedConfig,
-				disposed: false,
-			});
-			this._entries.delete(oldSessionResource);
-			oldEntry.disposed = true;
-			this._resolvedConfigs.delete(oldSessionResource);
-			this._resolvedConfigRequestSeq.delete(oldSessionResource);
-			this._rebound.add(oldSessionResource);
-			this._onDidChange.fire(newSessionResource);
-
-			if (oldGeneration) {
-				await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
+				if (oldGeneration) {
+					await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
+				}
+				return created;
 			}
-			return created;
+			return undefined;
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -402,6 +402,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			const configVersion = entry.configVersion;
 			const config = { ...entry.config };
 
+			// Prewarming is silent; first Send owns interactive trust, so never create in an untrusted target.
 			if (!await this._isTargetFolderTrusted(workingDirectory)) {
 				return undefined;
 			}
@@ -478,9 +479,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			}
 
 			const newBackendSession = this._toBackendUri(newSessionResource, provider);
+			// Imports materialize eagerly, so carry their history and model into the rebound session.
 			const imported = this._importConversationStore.take(newSessionResource);
 
 			while (this._entries.get(oldSessionResource) === oldEntry && !oldEntry.disposed) {
+				// The workbench cache is authoritative; backend state can lag synchronous chip edits.
 				const config = { ...oldEntry.config };
 				const configVersion = oldEntry.configVersion;
 				const targetWorkingDirectory = oldEntry.workingDirectory ?? workingDirectory;
@@ -509,6 +512,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				}
 
 				const oldGeneration = oldEntry.generation;
+				// Publish the real mapping before retiring the untitled entry so consumers never observe a partial swap.
 				this._entries.set(newSessionResource, {
 					provider,
 					generation: { backendSession: created, workingDirectory: targetWorkingDirectory },
@@ -523,9 +527,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				this._resolvedConfigs.delete(oldSessionResource);
 				this._resolvedConfigRequestSeq.delete(oldSessionResource);
 				this._rebound.add(oldSessionResource);
+				// Notify only the real resource; notifying the old URI can recreate an orphan while the widget still uses it.
 				this._onDidChange.fire(newSessionResource);
 
 				if (oldGeneration) {
+					// The temporary generation is in-memory only, so disposal is best-effort.
 					await this._disposeBackend(oldGeneration.backendSession, 'temporary provisional generation');
 				}
 				return created;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -282,10 +282,10 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 
 	get(sessionResource: URI): URI | undefined {
 		const entry = this._entries.get(sessionResource);
-		if (!entry || entry.disposed || !this._generationMatchesDesiredState(entry)) {
+		if (!entry || entry.disposed) {
 			return undefined;
 		}
-		return entry.generation?.backendSession;
+		return this._generationMatchingDesiredState(entry)?.backendSession;
 	}
 
 	private _computeWorkingDirectories(primary: URI | undefined, provider: string): readonly URI[] | undefined {
@@ -374,8 +374,9 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return work;
 	}
 
-	private _generationMatchesDesiredState(entry: IEntry): boolean {
-		return !!entry.generation && this._sameUri(entry.generation.workingDirectory, entry.workingDirectory);
+	private _generationMatchingDesiredState(entry: IEntry): IProvisionalGeneration | undefined {
+		const generation = entry.generation;
+		return generation && this._sameUri(generation.workingDirectory, entry.workingDirectory) ? generation : undefined;
 	}
 
 	private _sameUri(first: URI | undefined, second: URI | undefined): boolean {
@@ -392,8 +393,9 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	 */
 	private async _reconcileGeneration(sessionResource: URI, entry: IEntry): Promise<URI | undefined> {
 		while (this._entries.get(sessionResource) === entry && !entry.disposed) {
-			if (this._generationMatchesDesiredState(entry)) {
-				return entry.generation!.backendSession;
+			const currentGeneration = this._generationMatchingDesiredState(entry);
+			if (currentGeneration) {
+				return currentGeneration.backendSession;
 			}
 
 			const workingDirectory = entry.workingDirectory;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -186,6 +186,8 @@ interface IProvisionalGeneration {
 	readonly workingDirectory: URI | undefined;
 }
 
+type ProvisionalOperationResult = URI | void;
+
 interface IEntry {
 	readonly provider: string;
 	generation: IProvisionalGeneration | undefined;
@@ -197,6 +199,10 @@ interface IEntry {
 	 * `state.config.values`.
 	 */
 	config: Record<string, unknown>;
+	/**
+	 * Monotonic revision of {@link config}. Async generation creation snapshots
+	 * this value, discarding and recreating its candidate after a newer edit.
+	 */
 	configVersion: number;
 	/**
 	 * Working directory the provisional backend session was created with. A
@@ -218,7 +224,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _entries = new ResourceMap<IEntry>();
-	private readonly _pending = new ResourceMap<Promise<unknown>>();
+	private readonly _pending = new ResourceMap<Promise<ProvisionalOperationResult>>();
 	private readonly _resolvedConfigs = new ResourceMap<ResolveSessionConfigResult>();
 	private readonly _resolvedConfigRequestSeq = new ResourceMap<number>();
 	// URIs that were the source of a successful `tryRebind`. The chat widget
@@ -353,7 +359,11 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return entry;
 	}
 
-	private _queue<T>(sessionResource: URI, task: () => Promise<T>): Promise<T> {
+	/**
+	 * Serializes lifecycle work for one logical draft and records its latest tail
+	 * so external callers can wait for a stable current generation.
+	 */
+	private _queue<T extends ProvisionalOperationResult>(sessionResource: URI, task: () => Promise<T>): Promise<T> {
 		const work = this._sequencer.queue(sessionResource.toString(), task);
 		this._pending.set(sessionResource, work);
 		void work.finally(() => {
@@ -463,6 +473,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		provider: string,
 		workingDirectory: URI | undefined,
 	): Promise<URI | undefined> {
+		// Graduation must run after any queued folder or config reconciliation.
 		return this._queue(oldSessionResource, async () => {
 			const alreadyBound = this.get(newSessionResource);
 			if (alreadyBound) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -39,8 +39,8 @@
  * Invariants to preserve:
  * - `_entries` is keyed by chat UI resources and stores backend resources.
  * - `getOrCreate` is serialized per chat UI resource; chip instances may race.
- * - `tryRebind` is best-effort. Failure must degrade to the handler's normal
- *   create path rather than blocking Send.
+ * - Recoverable `tryRebind` failure degrades to the handler's normal create
+ *   path. It rejects only when an ambiguous final URI cannot be retired safely.
  * - Abandoned untitled chats must dispose their backend provisional state when
  *   `IChatService.onDidDisposeSession` reports the chat UI resource.
  * - Callers own provider and working-directory consistency. Derive them from
@@ -71,7 +71,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatConfiguration, getChatPermissionLevelFromDefaultConfiguration, type IChatDefaultConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IAgentHostNewSessionFolderService, computeWorkingDirectories } from './agentHostNewSessionFolderService.js';
-import { IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
+import { type IAgentHostImportConversation, IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
 	createDecorator<IAgentHostUntitledProvisionalSessionService>('agentHostUntitledProvisionalSessionService');
@@ -227,6 +227,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	private readonly _pending = new ResourceMap<Promise<ProvisionalOperationResult>>();
 	private readonly _resolvedConfigs = new ResourceMap<ResolveSessionConfigResult>();
 	private readonly _resolvedConfigRequestSeq = new ResourceMap<number>();
+	private readonly _pendingBackendDisposals = new ResourceSet();
 	// URIs that were the source of a successful `tryRebind`. The chat widget
 	// briefly reattaches to the old untitled URI before its viewModel switches
 	// to the new real URI; without this tombstone the picker would call
@@ -278,6 +279,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				void this._changeWorkingDirectory(sessionResource, folder);
 			}
 		}));
+		this._register(this._agentHostService.onAgentHostStart(() => this._retryPendingBackendDisposals()));
 	}
 
 	get(sessionResource: URI): URI | undefined {
@@ -302,7 +304,12 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			if (!pending) {
 				return this.get(sessionResource);
 			}
-			await pending;
+			try {
+				await pending;
+			} catch {
+				// The operation caller owns its error; observers only re-read stable state.
+				return undefined;
+			}
 			if (this._pending.get(sessionResource) === pending) {
 				return this.get(sessionResource);
 			}
@@ -404,6 +411,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 
 			// Prewarming is silent; first Send owns interactive trust, so never create in an untrusted target.
 			if (!await this._isTargetFolderTrusted(workingDirectory)) {
+				await this._retireGeneration(sessionResource, entry);
 				return undefined;
 			}
 
@@ -419,6 +427,8 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				});
 			} catch (err) {
 				this._logService.warn(`[AgentHostProvisional] Failed to create provisional session for ${sessionResource.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+				await this._disposeBackend(candidate, 'failed provisional candidate');
+				await this._retireGeneration(sessionResource, entry);
 				return undefined;
 			}
 
@@ -438,11 +448,33 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		return undefined;
 	}
 
-	private async _disposeBackend(backendSession: URI, reason: string): Promise<void> {
+	private async _retireGeneration(sessionResource: URI, entry: IEntry): Promise<void> {
+		const generation = entry.generation;
+		if (!generation) {
+			return;
+		}
+		entry.generation = undefined;
+		if (this._entries.get(sessionResource) === entry) {
+			this._onDidChange.fire(sessionResource);
+		}
+		await this._disposeBackend(generation.backendSession, 'retired provisional generation');
+	}
+
+	private async _disposeBackend(backendSession: URI, reason: string): Promise<boolean> {
+		this._pendingBackendDisposals.add(backendSession);
 		try {
 			await this._agentHostService.disposeSession(backendSession);
+			this._pendingBackendDisposals.delete(backendSession);
+			return true;
 		} catch (err) {
 			this._logService.warn(`[AgentHostProvisional] Failed to dispose ${reason} ${backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+			return false;
+		}
+	}
+
+	private _retryPendingBackendDisposals(): void {
+		for (const backendSession of this._pendingBackendDisposals) {
+			void this._disposeBackend(backendSession, 'pending provisional cleanup');
 		}
 	}
 
@@ -499,15 +531,28 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 					});
 				} catch (err) {
 					this._logService.warn(`[AgentHostProvisional] Failed to create rebound provisional: ${err instanceof Error ? err.message : String(err)}`);
+					this._restoreImportedConversation(newSessionResource, imported);
+					const disposed = await this._disposeBackend(newBackendSession, 'failed rebound candidate');
+					if (!disposed) {
+						throw new Error(`Cannot safely recover rebound session ${newBackendSession.toString()} until its candidate is retired`);
+					}
 					return undefined;
 				}
 
 				if (this._entries.get(oldSessionResource) !== oldEntry || oldEntry.disposed) {
-					await this._disposeBackend(created, 'retired rebound candidate');
+					const disposed = await this._disposeBackend(created, 'retired rebound candidate');
+					this._restoreImportedConversation(newSessionResource, imported);
+					if (!disposed) {
+						throw new Error(`Cannot safely recover rebound session ${newBackendSession.toString()} until its candidate is retired`);
+					}
 					return undefined;
 				}
 				if (oldEntry.configVersion !== configVersion || !this._sameUri(oldEntry.workingDirectory ?? workingDirectory, targetWorkingDirectory)) {
-					await this._disposeBackend(created, 'obsolete rebound candidate');
+					const disposed = await this._disposeBackend(created, 'obsolete rebound candidate');
+					if (!disposed) {
+						this._restoreImportedConversation(newSessionResource, imported);
+						throw new Error(`Cannot safely retry rebound session ${newBackendSession.toString()} until its stale candidate is retired`);
+					}
 					continue;
 				}
 
@@ -536,8 +581,15 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				}
 				return created;
 			}
+			this._restoreImportedConversation(newSessionResource, imported);
 			return undefined;
 		});
+	}
+
+	private _restoreImportedConversation(sessionResource: URI, imported: IAgentHostImportConversation | undefined): void {
+		if (imported) {
+			this._importConversationStore.set(sessionResource, imported);
+		}
 	}
 
 	/**
@@ -613,8 +665,12 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				this._agentHostService.disposeSession(entry.generation.backendSession).catch(() => { /* swallow on shutdown */ });
 			}
 		}
+		for (const backendSession of this._pendingBackendDisposals) {
+			this._agentHostService.disposeSession(backendSession).catch(() => { /* swallow on shutdown */ });
+		}
 		this._entries.clear();
 		this._pending.clear();
+		this._pendingBackendDisposals.clear();
 		this._resolvedConfigs.clear();
 		this._resolvedConfigRequestSeq.clear();
 		this._rebound.clear();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -860,6 +860,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		onDidChange: Event.None,
 		get: () => undefined,
 		getInitialSessionConfig: () => undefined,
+		getSessionConfig: () => undefined,
 		waitForPending: async () => undefined,
 		getOrCreate: async () => undefined,
 		tryRebind: async () => undefined,
@@ -3547,6 +3548,20 @@ suite('AgentHostChatContribution', () => {
 			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: dispatch.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
 			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: { type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', turnId: action.turnId } as ChatAction, serverSeq: 2, origin: undefined });
 			await turnPromise;
+		}));
+
+		test('preserves logical provisional config in the fallback creation path', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				provisionalServiceOverride: {
+					getSessionConfig: () => ({ isolation: 'worktree' }),
+				},
+			});
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
+			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.createSessionCalls[0].config?.['isolation'], 'worktree');
 		}));
 
 		test('recovers from stale failed subscription before first send', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3512,6 +3512,43 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(AgentSession.id(URI.parse(parentSession)), 'existing-session-42');
 		}));
 
+		test('waits for provisional replacement before resolving first-send backend', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-replacement' });
+			const oldBackend = AgentSession.uri('copilot', 'old-provisional');
+			const newBackend = AgentSession.uri('copilot', 'new-provisional');
+			const pending = new DeferredPromise<void>();
+			disposables.add({ dispose: () => pending.cancel() });
+			let currentBackend = oldBackend;
+			const { agentHostService, chatAgentService } = createContribution(disposables, {
+				provisionalServiceOverride: {
+					get: resource => resource.toString() === sessionResource.toString() ? currentBackend : undefined,
+					waitForPending: async () => {
+						await pending.p;
+						return currentBackend;
+					},
+				},
+			});
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+			const turnPromise = registered.impl.invoke(
+				makeRequest({ message: 'Use new backend', sessionResource }),
+				() => { }, [], CancellationToken.None,
+			);
+			await timeout(0);
+			assert.strictEqual(agentHostService.turnActions.length, 0);
+
+			currentBackend = newBackend;
+			pending.complete();
+			await timeout(10);
+
+			const dispatch = agentHostService.turnActions[0];
+			const action = dispatch.action as ITurnStartedAction;
+			const parentSession = parseDefaultChatUri(dispatch.channel.toString());
+			assert.strictEqual(parentSession, newBackend.toString());
+			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: dispatch.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: { type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', turnId: action.turnId } as ChatAction, serverSeq: 2, origin: undefined });
+			await turnPromise;
+		}));
+
 		test('recovers from stale failed subscription before first send', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/existing-subscribe-retry' });
 			const backendSession = AgentSession.uri('copilot', 'existing-subscribe-retry');
@@ -10972,6 +11009,29 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(result?.items[0].label, '/yolo on');
 			assert.strictEqual(result?.items[0].insertText, '');
+		});
+
+		test('routes untitled completions to the current opaque provisional backend', async () => {
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-completions' });
+			const backendSession = AgentSession.uri('copilot', 'opaque-provisional');
+			const { sessionHandler, agentHostService } = createContribution(disposables, {
+				provisionalServiceOverride: {
+					get: resource => resource.toString() === sessionResource.toString() ? backendSession : undefined,
+				},
+			});
+			let request: CompletionsParams | undefined;
+			(agentHostService as unknown as { completions: (params: CompletionsParams) => Promise<CompletionsResult> }).completions = async params => {
+				request = params;
+				return { items: [] };
+			};
+
+			await sessionHandler.provideChatInputCompletions(
+				sessionResource,
+				{ text: '/', offset: 1 },
+				CancellationToken.None,
+			);
+
+			assert.strictEqual(request?.channel, backendSession.toString());
 		});
 
 		test('surfaces a chat completion backend URI verbatim on the completion attachment', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -860,7 +860,6 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		onDidChange: Event.None,
 		get: () => undefined,
 		getInitialSessionConfig: () => undefined,
-		getSessionConfig: () => undefined,
 		waitForPending: async () => undefined,
 		getOrCreate: async () => undefined,
 		tryRebind: async () => undefined,
@@ -3548,20 +3547,6 @@ suite('AgentHostChatContribution', () => {
 			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: dispatch.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
 			agentHostService.fireAction({ channel: dispatch.channel.toString(), action: { type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', turnId: action.turnId } as ChatAction, serverSeq: 2, origin: undefined });
 			await turnPromise;
-		}));
-
-		test('preserves logical provisional config in the fallback creation path', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
-				provisionalServiceOverride: {
-					getSessionConfig: () => ({ isolation: 'worktree' }),
-				},
-			});
-
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
-			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
-			await turnPromise;
-
-			assert.strictEqual(agentHostService.createSessionCalls[0].config?.['isolation'], 'worktree');
 		}));
 
 		test('recovers from stale failed subscription before first send', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -11017,6 +11017,7 @@ suite('AgentHostChatContribution', () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables, {
 				provisionalServiceOverride: {
 					get: resource => resource.toString() === sessionResource.toString() ? backendSession : undefined,
+					waitForPending: async () => backendSession,
 				},
 			});
 			let request: CompletionsParams | undefined;
@@ -11032,6 +11033,54 @@ suite('AgentHostChatContribution', () => {
 			);
 
 			assert.strictEqual(request?.channel, backendSession.toString());
+		});
+
+		test('waits for a pending provisional before requesting untitled completions', async () => {
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-pending-completions' });
+			const backendSession = AgentSession.uri('copilot', 'replacement-provisional');
+			const pending = new DeferredPromise<void>();
+			disposables.add({ dispose: () => pending.cancel() });
+			const currentBackend: { value: URI | undefined } = { value: undefined };
+			const { sessionHandler, agentHostService } = createContribution(disposables, {
+				provisionalServiceOverride: {
+					get: () => currentBackend.value,
+					waitForPending: async () => {
+						await pending.p;
+						return currentBackend.value;
+					},
+				},
+			});
+			const requests: CompletionsParams[] = [];
+			(agentHostService as unknown as { completions: (params: CompletionsParams) => Promise<CompletionsResult> }).completions = async params => {
+				requests.push(params);
+				return { items: [] };
+			};
+
+			const completions = sessionHandler.provideChatInputCompletions(sessionResource, { text: '/', offset: 1 }, CancellationToken.None);
+			await timeout(0);
+			assert.strictEqual(requests.length, 0);
+			currentBackend.value = backendSession;
+			pending.complete();
+			await completions;
+
+			assert.strictEqual(requests[0]?.channel, backendSession.toString());
+		});
+
+		test('returns no untitled completions when there is no current generation', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+			let requests = 0;
+			(agentHostService as unknown as { completions: (_params: CompletionsParams) => Promise<CompletionsResult> }).completions = async () => {
+				requests++;
+				return { items: [] };
+			};
+
+			const result = await sessionHandler.provideChatInputCompletions(
+				URI.from({ scheme: 'agent-host-copilot', path: '/untitled-no-generation' }),
+				{ text: '/', offset: 1 },
+				CancellationToken.None,
+			);
+
+			assert.deepStrictEqual({ result, requests }, { result: undefined, requests: 0 });
 		});
 
 		test('surfaces a chat completion backend URI verbatim on the completion attachment', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -569,7 +569,6 @@ suite('AgentHostClientTools', () => {
 				onDidChange: Event.None,
 				get: () => undefined,
 				getInitialSessionConfig: () => undefined,
-				getSessionConfig: () => undefined,
 				waitForPending: async () => undefined,
 				getOrCreate: async () => undefined,
 				applyConfigChange: async () => undefined,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -569,6 +569,7 @@ suite('AgentHostClientTools', () => {
 				onDidChange: Event.None,
 				get: () => undefined,
 				getInitialSessionConfig: () => undefined,
+				getSessionConfig: () => undefined,
 				waitForPending: async () => undefined,
 				getOrCreate: async () => undefined,
 				applyConfigChange: async () => undefined,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -48,6 +48,7 @@ import { IAgentSubscription } from '../../../../../../platform/agentHost/common/
 import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHostTerminalService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult, ToolAndToolSetEnablementMap, ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ICustomizationHarnessService } from '../../../common/customizationHarnessService.js';
@@ -564,6 +565,18 @@ suite('AgentHostClientTools', () => {
 				resolve: () => undefined,
 				isNewSession: () => false,
 			});
+			instantiationService.stub(IAgentHostUntitledProvisionalSessionService, {
+				onDidChange: Event.None,
+				get: () => undefined,
+				getInitialSessionConfig: () => undefined,
+				waitForPending: async () => undefined,
+				getOrCreate: async () => undefined,
+				applyConfigChange: async () => undefined,
+				tryRebind: async () => undefined,
+				disposeSession: async () => { },
+				getResolvedConfig: () => undefined,
+				refreshResolvedConfig: async () => { },
+			} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService);
 			instantiationService.stub(ILanguageModelToolsService, toolsService);
 			instantiationService.stub(IAgentHostToolSetEnablementService, {
 				observe: () => constObservable<IToolEnablementState>({ toolSets: new Map(), tools: new Map() }),

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostGenericConfigChips.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostGenericConfigChips.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { IReference } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
+import { type ComponentToState, StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IChatWidget } from '../../../browser/chat.js';
+import { AgentHostGenericConfigChips } from '../../../browser/agentSessions/agentHost/agentHostGenericConfigChips.js';
+import { IAgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
+
+function createSubscription<T>(): IAgentSubscription<T> {
+	return {
+		value: undefined,
+		verifiedValue: undefined,
+		onDidChange: Event.None,
+		onWillApplyAction: Event.None,
+		onDidApplyAction: Event.None,
+	};
+}
+
+suite('AgentHostGenericConfigChips', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('moves its subscription when the provisional generation changes', () => {
+		const sessionResource = URI.parse('agent-host-copilot:/untitled-test');
+		const firstBackend = URI.parse('copilot:/first-generation');
+		const secondBackend = URI.parse('copilot:/second-generation');
+		const provisionalChanged = disposables.add(new Emitter<URI>());
+		let currentBackend = firstBackend;
+		const provisionalService = {
+			onDidChange: provisionalChanged.event,
+			get: () => currentBackend,
+		} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService;
+		const acquired: string[] = [];
+		const released: string[] = [];
+		const agentHostService = new class extends mock<IAgentHostService>() {
+			declare readonly _serviceBrand: undefined;
+
+			override getSubscription<T extends StateComponents>(_kind: T, resource: URI, _owner: string): IReference<IAgentSubscription<ComponentToState[T]>> {
+				acquired.push(resource.toString());
+				return {
+					object: createSubscription<ComponentToState[T]>(),
+					dispose: () => released.push(resource.toString()),
+				};
+			}
+		}();
+		const widget = {
+			viewModel: { sessionResource },
+			onDidChangeViewModel: Event.None,
+		} as Partial<IChatWidget> as IChatWidget;
+		const chips = disposables.add(new AgentHostGenericConfigChips(
+			widget,
+			disposables.add(new TestInstantiationService()),
+			agentHostService,
+			provisionalService,
+			{} as IAgentHostSessionWorkingDirectoryResolver,
+			{} as IWorkspaceContextService,
+			{} as IAgentHostNewSessionFolderService,
+		));
+
+		currentBackend = secondBackend;
+		provisionalChanged.fire(sessionResource);
+
+		assert.deepStrictEqual({
+			acquired,
+			released,
+		}, {
+			acquired: [firstBackend.toString(), secondBackend.toString()],
+			released: [firstBackend.toString()],
+		});
+
+		chips.dispose();
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -607,7 +607,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 	});
 
-	test('untrusted folder change retires the previous generation and can retry', async () => {
+	test('untrusted folder change hides the previous generation and reuses it on rollback', async () => {
 		const folderA = URI.file('/repoA');
 		const folderB = URI.file('/repoB');
 		const ui = untitledChatUri('trust-change');
@@ -625,22 +625,25 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			createCount: agentHost.createCalls.length,
 		}, {
 			current: undefined,
-			disposed: [original.toString()],
+			disposed: [],
 			createCount: 1,
 		});
 
-		untrustedFolders.delete(folderB.toString());
-		const retried = await provisional.getOrCreate(ui, 'copilot', folderB);
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'folder' } }];
+		folderService.setFolder(ui, folderA);
+		await flush();
 		assert.deepStrictEqual({
-			retried: retried?.toString(),
-			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+			current: provisional.get(ui)?.toString(),
+			createCount: agentHost.createCalls.length,
+			disposed: agentHost.disposed.map(uri => uri.toString()),
 		}, {
-			retried: agentHost.createCalls.at(-1)?.session?.toString(),
-			latestCwd: folderB.toString(),
+			current: original.toString(),
+			createCount: 1,
+			disposed: [],
 		});
 	});
 
-	test('failed folder replacement retires the previous generation and can retry', async () => {
+	test('failed folder replacement retains the previous generation until retry succeeds', async () => {
 		const folderA = URI.file('/repoA');
 		const folderB = URI.file('/repoB');
 		const ui = untitledChatUri('failed-change');
@@ -658,7 +661,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			createCount: agentHost.createCalls.length,
 		}, {
 			current: undefined,
-			disposed: [original.toString()],
+			disposed: [],
 			createCount: 2,
 		});
 
@@ -666,9 +669,11 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.deepStrictEqual({
 			retried: retried?.toString(),
 			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
 		}, {
 			retried: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: folderB.toString(),
+			disposed: [original.toString()],
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -21,7 +21,7 @@ import type { ConfigSchema } from '../../../../../../platform/agentHost/common/s
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IWorkspaceContextService, IWorkspace, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
-import type { AgentInfo, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { MessageKind, TurnState, type AgentInfo, type RootState, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostUntitledProvisionalSessionService, IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
@@ -138,6 +138,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	let agentHost: MockAgentHostService;
 	let provisional: IAgentHostUntitledProvisionalSessionService;
 	let folderService: IAgentHostNewSessionFolderService;
+	let importStore: AgentHostImportConversationStore;
 	let cleanup: DisposableStore;
 	let workspaceTrusted: boolean;
 	let untrustedFolders: Set<string>;
@@ -165,7 +166,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 		folderService = ds.add(insta.createInstance(AgentHostNewSessionFolderService));
 		insta.stub(IAgentHostNewSessionFolderService, folderService);
-		insta.stub(IAgentHostImportConversationStore, new AgentHostImportConversationStore());
+		importStore = new AgentHostImportConversationStore();
+		insta.stub(IAgentHostImportConversationStore, importStore);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());
 	});
@@ -488,6 +490,61 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 				URI.from({ scheme: 'copilot', path: '/real-dispose-race' }).toString(),
 			].sort(),
 		});
+	});
+
+	test('tryRebind does not create an untrusted rebound and preserves logical config', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('rebind-untrusted');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-untrusted' });
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
+		await provisional.applyConfigChange(ui, 'copilot', folderA, { isolation: 'worktree' });
+		const oldBackend = provisional.get(ui);
+		assert.ok(oldBackend);
+		untrustedFolders.add(folderB.toString());
+		folderService.setFolder(ui, folderB);
+		await flush();
+
+		const rebound = await provisional.tryRebind(ui, realUi, 'copilot', folderB);
+
+		assert.deepStrictEqual({
+			rebound,
+			createCount: agentHost.createCalls.length,
+			oldConfig: provisional.getSessionConfig(ui),
+			realConfig: provisional.getSessionConfig(realUi),
+			realBackend: provisional.get(realUi),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+		}, {
+			rebound: undefined,
+			createCount: 1,
+			oldConfig: undefined,
+			realConfig: { isolation: 'worktree' },
+			realBackend: undefined,
+			disposed: [oldBackend.toString()],
+		});
+	});
+
+	test('tryRebind restores an import when the target becomes untrusted during creation', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('rebind-import-race');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-import-race' });
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		const turn: Turn = { id: 'turn', message: { text: 'hello', origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined, state: TurnState.Complete };
+		const imported = { turns: [turn], model: { id: 'test-model' } };
+		importStore.set(realUi, imported);
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+
+		const rebind = provisional.tryRebind(ui, realUi, 'copilot', folderA);
+		await timeout(0);
+		untrustedFolders.add(folderB.toString());
+		folderService.setFolder(ui, folderB);
+		gate.complete();
+		await rebind;
+
+		assert.deepStrictEqual(importStore.take(realUi), imported);
 	});
 
 	test('disposeSession drops the entry and its overlay', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -564,6 +564,34 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 	});
 
+	test('folder change listeners can wait for the queued replacement', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('cwd-listener');
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'folder' } }];
+		let pendingReplacement: Promise<URI | undefined> | undefined;
+		cleanup.add(provisional.onDidChange(resource => {
+			if (!pendingReplacement && resource.toString() === ui.toString()) {
+				pendingReplacement = provisional.waitForPending(ui);
+			}
+		}));
+
+		folderService.setFolder(ui, folderB);
+		assert.ok(pendingReplacement);
+		const replacement = await pendingReplacement;
+
+		assert.deepStrictEqual({
+			replacement: replacement?.toString(),
+			current: provisional.get(ui)?.toString(),
+			cwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+		}, {
+			replacement: agentHost.createCalls.at(-1)?.session?.toString(),
+			current: agentHost.createCalls.at(-1)?.session?.toString(),
+			cwd: folderB.toString(),
+		});
+	});
+
 	test('folder change to the same folder is a no-op', async () => {
 		const folderA = URI.file('/repoA');
 		const ui = untitledChatUri('cwd2');

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -43,6 +43,8 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	readonly disposed: URI[] = [];
 	readonly dispatched: IDispatchedAction[] = [];
 	readonly resolveCalls: IAgentResolveSessionConfigParams[] = [];
+	createGate: DeferredPromise<void> | undefined;
+	failNextCreate = false;
 
 	/** Agents advertised by the (stubbed) root state; drives capability gating. */
 	rootStateAgents: AgentInfo[] = [];
@@ -65,6 +67,15 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 
 	override async createSession(config?: IAgentCreateSessionConfig): Promise<URI> {
 		this.createCalls.push(config!);
+		if (this.failNextCreate) {
+			this.failNextCreate = false;
+			throw new Error('create failed');
+		}
+		const gate = this.createGate;
+		this.createGate = undefined;
+		if (gate) {
+			await gate.p;
+		}
 		return config!.session!;
 	}
 
@@ -118,10 +129,6 @@ function untitledChatUri(id: string): URI {
 	return URI.from({ scheme: 'agent-host-copilot', path: `/untitled-${id}` });
 }
 
-function expectedBackendUri(id: string): URI {
-	return URI.from({ scheme: 'copilot', path: `/untitled-${id}` });
-}
-
 // ---- Tests -----------------------------------------------------------------
 
 suite('AgentHostUntitledProvisionalSessionService', () => {
@@ -165,12 +172,23 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	test('getOrCreate creates one backend provisional and returns the same URI on repeat calls', async () => {
 		agentHost.resolveQueue = [];
 		const ui = untitledChatUri('a');
-		const a = await provisional.getOrCreate(ui, 'copilot', undefined);
-		const b = await provisional.getOrCreate(ui, 'copilot', undefined);
-		assert.strictEqual(a?.toString(), expectedBackendUri('a').toString());
-		assert.strictEqual(b?.toString(), a.toString());
-		assert.strictEqual(agentHost.createCalls.length, 1);
-		assert.deepStrictEqual(agentHost.createCalls[0].config, { isolation: 'folder' });
+		const [a, b] = await Promise.all([
+			provisional.getOrCreate(ui, 'copilot', undefined),
+			provisional.getOrCreate(ui, 'copilot', undefined),
+		]);
+		assert.deepStrictEqual({
+			provider: a?.scheme,
+			isOpaque: a?.path !== ui.path,
+			reused: b?.toString() === a?.toString(),
+			createCount: agentHost.createCalls.length,
+			config: agentHost.createCalls[0].config,
+		}, {
+			provider: 'copilot',
+			isOpaque: true,
+			reused: true,
+			createCount: 1,
+			config: { isolation: 'folder' },
+		});
 	});
 
 	test('getOrCreate does not spawn a backend provisional in an untrusted workspace', async () => {
@@ -199,8 +217,15 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		const workingDirectory = URI.from({ scheme: 'file', path: '/trusted-folder' });
 		const ui = untitledChatUri('trusted-folder');
 		const result = await provisional.getOrCreate(ui, 'copilot', workingDirectory);
-		assert.strictEqual(result?.toString(), expectedBackendUri('trusted-folder').toString());
-		assert.strictEqual(agentHost.createCalls.length, 1);
+		assert.deepStrictEqual({
+			provider: result?.scheme,
+			isOpaque: result?.path !== ui.path,
+			createCount: agentHost.createCalls.length,
+		}, {
+			provider: 'copilot',
+			isOpaque: true,
+			createCount: 1,
+		});
 	});
 
 	test('applyConfigChange dispatches SessionConfigChanged synchronously after mutating entry.config', async () => {
@@ -225,7 +250,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.strictEqual(agentHost.dispatched.length, 1, 'dispatched before re-resolve await');
 		assert.strictEqual(agentHost.dispatched[0].type, ActionType.SessionConfigChanged);
 		assert.deepStrictEqual(agentHost.dispatched[0].config, { isolation: 'worktree' });
-		assert.strictEqual(agentHost.dispatched[0].channel, expectedBackendUri('b').toString());
+		assert.strictEqual(agentHost.dispatched[0].channel, agentHost.createCalls[0].session?.toString());
 
 		// Unblock so the queued re-resolve completes and the outer promise settles.
 		blocked.complete({ schema: makeSchema(false), values: { isolation: 'worktree' } });
@@ -389,13 +414,14 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		// up-to-date config the user just set — proving entry.config was mutated
 		// synchronously, not deferred behind the (still-blocked) re-resolve.
 		const newUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-g' });
-		await provisional.tryRebind(ui, newUi, 'copilot', undefined);
+		const rebind = provisional.tryRebind(ui, newUi, 'copilot', undefined);
+		assert.strictEqual(agentHost.createCalls.some(c => c.session?.path === '/real-g'), false);
+		blocked.complete({ schema: makeSchema(false), values: { isolation: 'worktree' } });
+		await rebind;
 
 		const reboundCreate = agentHost.createCalls.find(c => c.session?.path === '/real-g');
 		assert.ok(reboundCreate, 'rebind triggered a createSession');
 		assert.strictEqual(reboundCreate!.config?.['isolation'], 'worktree');
-
-		blocked.complete({ schema: makeSchema(false), values: { isolation: 'worktree' } });
 	});
 
 	test('disposeSession drops the entry and its overlay', async () => {
@@ -446,6 +472,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
 		await provisional.applyConfigChange(ui, 'copilot', folderA, { isolation: 'worktree' });
 		assert.strictEqual(agentHost.createCalls.length, 1);
+		const original = agentHost.createCalls[0].session;
+		assert.ok(original);
 
 		// Re-resolve response for the recreation at the new cwd.
 		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
@@ -455,14 +483,16 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		const recreate = agentHost.createCalls[agentHost.createCalls.length - 1];
 		assert.deepStrictEqual({
 			createCount: agentHost.createCalls.length,
-			disposedOld: agentHost.disposed.some(d => d.toString() === expectedBackendUri('cwd1').toString()),
-			recreatedSession: recreate.session?.toString(),
+			disposedOld: agentHost.disposed.some(d => d.toString() === original.toString()),
+			recreatedWithFreshUri: recreate.session?.toString() !== original.toString(),
+			currentSession: provisional.get(ui)?.toString(),
 			recreatedCwd: recreate.workingDirectories?.[0]?.toString(),
 			recreatedConfig: recreate.config?.['isolation'],
 		}, {
 			createCount: 2,
 			disposedOld: true,
-			recreatedSession: expectedBackendUri('cwd1').toString(),
+			recreatedWithFreshUri: true,
+			currentSession: recreate.session?.toString(),
 			recreatedCwd: folderB.toString(),
 			recreatedConfig: 'worktree',
 		});
@@ -479,6 +509,161 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 
 		assert.strictEqual(agentHost.createCalls.length, 1, 'no recreate for unchanged folder');
 		assert.strictEqual(agentHost.disposed.length, 0);
+	});
+
+	test('rapid folder changes converge on the latest folder', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const folderC = URI.file('/repoC');
+		const ui = untitledChatUri('rapid');
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		const original = provisional.get(ui);
+		assert.ok(original);
+		agentHost.resolveQueue = [
+			{ schema: makeSchema(false), values: { isolation: 'folder' } },
+			{ schema: makeSchema(false), values: { isolation: 'folder' } },
+		];
+
+		folderService.setFolder(ui, folderB);
+		folderService.setFolder(ui, folderC);
+		await flush();
+
+		assert.deepStrictEqual({
+			createCount: agentHost.createCalls.length,
+			current: provisional.get(ui)?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+		}, {
+			createCount: 2,
+			current: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: folderC.toString(),
+			disposed: [original.toString()],
+		});
+	});
+
+	test('untrusted folder change retires the previous generation and can retry', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('trust-change');
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		const original = provisional.get(ui);
+		assert.ok(original);
+		untrustedFolders.add(folderB.toString());
+
+		folderService.setFolder(ui, folderB);
+		await flush();
+
+		assert.deepStrictEqual({
+			current: provisional.get(ui),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+			createCount: agentHost.createCalls.length,
+		}, {
+			current: undefined,
+			disposed: [original.toString()],
+			createCount: 1,
+		});
+
+		untrustedFolders.delete(folderB.toString());
+		const retried = await provisional.getOrCreate(ui, 'copilot', folderB);
+		assert.deepStrictEqual({
+			retried: retried?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+		}, {
+			retried: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: folderB.toString(),
+		});
+	});
+
+	test('failed folder replacement retires the previous generation and can retry', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('failed-change');
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		const original = provisional.get(ui);
+		assert.ok(original);
+		agentHost.failNextCreate = true;
+
+		folderService.setFolder(ui, folderB);
+		await flush();
+
+		assert.deepStrictEqual({
+			current: provisional.get(ui),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+			createCount: agentHost.createCalls.length,
+		}, {
+			current: undefined,
+			disposed: [original.toString()],
+			createCount: 2,
+		});
+
+		const retried = await provisional.getOrCreate(ui, 'copilot', folderB);
+		assert.deepStrictEqual({
+			retried: retried?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
+		}, {
+			retried: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
+			latestCwd: folderB.toString(),
+		});
+	});
+
+	test('config changed during creation retires the stale candidate', async () => {
+		const folder = URI.file('/repo');
+		const ui = untitledChatUri('config-race');
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+		const initialCreate = provisional.getOrCreate(ui, 'copilot', folder);
+		await timeout(0);
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
+
+		const configChange = provisional.applyConfigChange(ui, 'copilot', folder, { isolation: 'worktree' });
+		gate.complete();
+		await Promise.all([initialCreate, configChange]);
+
+		const stale = agentHost.createCalls[0].session;
+		const current = agentHost.createCalls.at(-1)?.session;
+		assert.deepStrictEqual({
+			createCount: agentHost.createCalls.length,
+			staleDisposed: agentHost.disposed.map(uri => uri.toString()),
+			current: provisional.get(ui)?.toString(),
+			currentConfig: agentHost.createCalls.at(-1)?.config,
+			dispatchChannel: agentHost.dispatched.at(-1)?.channel,
+		}, {
+			createCount: 2,
+			staleDisposed: stale ? [stale.toString()] : [],
+			current: current?.toString(),
+			currentConfig: { isolation: 'worktree' },
+			dispatchChannel: current?.toString(),
+		});
+	});
+
+	test('dispose queued behind creation cannot publish or deadlock', async () => {
+		const ui = untitledChatUri('dispose-race');
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+		const creation = provisional.getOrCreate(ui, 'copilot', URI.file('/repo'));
+		await timeout(0);
+
+		const disposal = provisional.disposeSession(ui);
+		gate.complete();
+		await Promise.all([creation, disposal]);
+
+		assert.deepStrictEqual({
+			current: provisional.get(ui),
+			createCount: agentHost.createCalls.length,
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+		}, {
+			current: undefined,
+			createCount: 1,
+			disposed: agentHost.createCalls[0].session ? [agentHost.createCalls[0].session!.toString()] : [],
+		});
 	});
 
 	test('folder change with no provisional entry is a no-op', async () => {
@@ -508,8 +693,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		await provisional.getOrCreate(singleRoot, 'copilot', folderA);
 
 		assert.deepStrictEqual({
-			multiRoot: agentHost.createCalls.find(c => c.session?.toString() === expectedBackendUri('multi').toString())?.workingDirectories?.map(d => d.toString()),
-			singleRoot: agentHost.createCalls.find(c => c.session?.toString() === expectedBackendUri('single').toString())?.workingDirectories?.map(d => d.toString()),
+			multiRoot: agentHost.createCalls[0].workingDirectories?.map(d => d.toString()),
+			singleRoot: agentHost.createCalls[1].workingDirectories?.map(d => d.toString()),
 		}, {
 			multiRoot: [folderB.toString(), folderA.toString(), folderC.toString()],
 			singleRoot: [folderA.toString()],
@@ -534,8 +719,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		await provisional.getOrCreate(single, 'copilot', folderB);
 
 		assert.deepStrictEqual({
-			advertising: agentHost.createCalls.find(c => c.session?.toString() === expectedBackendUri('cap-multi').toString())?.workingDirectories?.map(d => d.toString()),
-			nonAdvertising: agentHost.createCalls.find(c => c.session?.toString() === expectedBackendUri('cap-single').toString())?.workingDirectories?.map(d => d.toString()),
+			advertising: agentHost.createCalls[0].workingDirectories?.map(d => d.toString()),
+			nonAdvertising: agentHost.createCalls[1].workingDirectories?.map(d => d.toString()),
 		}, {
 			advertising: [folderB.toString(), folderA.toString(), folderC.toString()],
 			nonAdvertising: [folderB.toString()],

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -424,6 +424,72 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.strictEqual(reboundCreate!.config?.['isolation'], 'worktree');
 	});
 
+	test('tryRebind retries when config changes during final session creation', async () => {
+		const ui = untitledChatUri('rebind-config-race');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-config-race' });
+		await provisional.getOrCreate(ui, 'copilot', undefined);
+		const oldBackend = provisional.get(ui);
+		assert.ok(oldBackend);
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+
+		const rebind = provisional.tryRebind(ui, realUi, 'copilot', undefined);
+		await timeout(0);
+		const configChange = provisional.applyConfigChange(ui, 'copilot', undefined, { isolation: 'worktree' });
+		gate.complete();
+		const [rebound] = await Promise.all([rebind, configChange]);
+
+		const finalCreates = agentHost.createCalls.filter(call => call.session?.path === '/real-config-race');
+		assert.deepStrictEqual({
+			finalCreateCount: finalCreates.length,
+			firstCandidateDisposed: agentHost.disposed.filter(uri => uri.path === '/real-config-race').length,
+			oldBackendDisposed: agentHost.disposed.some(uri => uri.toString() === oldBackend.toString()),
+			rebound: rebound?.toString(),
+			current: provisional.get(realUi)?.toString(),
+			finalConfig: finalCreates.at(-1)?.config,
+		}, {
+			finalCreateCount: 2,
+			firstCandidateDisposed: 1,
+			oldBackendDisposed: true,
+			rebound: URI.from({ scheme: 'copilot', path: '/real-config-race' }).toString(),
+			current: URI.from({ scheme: 'copilot', path: '/real-config-race' }).toString(),
+			finalConfig: { isolation: 'worktree' },
+		});
+	});
+
+	test('tryRebind disposes its candidate when the old entry is retired during creation', async () => {
+		const ui = untitledChatUri('rebind-dispose-race');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-dispose-race' });
+		await provisional.getOrCreate(ui, 'copilot', undefined);
+		const oldBackend = provisional.get(ui);
+		assert.ok(oldBackend);
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+
+		const rebind = provisional.tryRebind(ui, realUi, 'copilot', undefined);
+		await timeout(0);
+		const disposal = provisional.disposeSession(ui);
+		gate.complete();
+		const [rebound] = await Promise.all([rebind, disposal]);
+
+		assert.deepStrictEqual({
+			rebound,
+			oldMapping: provisional.get(ui),
+			newMapping: provisional.get(realUi),
+			disposed: agentHost.disposed.map(uri => uri.toString()).sort(),
+		}, {
+			rebound: undefined,
+			oldMapping: undefined,
+			newMapping: undefined,
+			disposed: [
+				oldBackend.toString(),
+				URI.from({ scheme: 'copilot', path: '/real-dispose-race' }).toString(),
+			].sort(),
+		});
+	});
+
 	test('disposeSession drops the entry and its overlay', async () => {
 		const ui = untitledChatUri('h');
 		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -228,7 +228,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 	});
 
-	test('applyConfigChange dispatches SessionConfigChanged synchronously after mutating entry.config', async () => {
+	test('applyConfigChange dispatches SessionConfigChanged before schema re-resolution completes', async () => {
 		const ui = untitledChatUri('b');
 		// Resolve never returns — proves mutate+dispatch happen before the
 		// re-resolve await.
@@ -395,7 +395,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.strictEqual(changeFires, 0, 'no onDidChange fire when overlay is unchanged');
 	});
 
-	test('tryRebind sees latest entry.config from a synchronously-completed applyConfigChange', async () => {
+	test('tryRebind waits for pending config reconciliation', async () => {
 		const ui = untitledChatUri('g');
 		// Block the re-resolve so it does NOT run before tryRebind's read.
 		const blocked = new DeferredPromise<ResolveSessionConfigResult>();
@@ -410,9 +410,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		await Promise.resolve();
 		await timeout(0);
 
-		// Now perform a rebind. The new backend session must be created with the
-		// up-to-date config the user just set — proving entry.config was mutated
-		// synchronously, not deferred behind the (still-blocked) re-resolve.
+		// Rebind must wait behind the config operation rather than graduating
+		// with a partially reconciled draft.
 		const newUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-g' });
 		const rebind = provisional.tryRebind(ui, newUi, 'copilot', undefined);
 		assert.strictEqual(agentHost.createCalls.some(c => c.session?.path === '/real-g'), false);
@@ -597,13 +596,11 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.deepStrictEqual({
 			createCount: agentHost.createCalls.length,
 			current: provisional.get(ui)?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
 			disposed: agentHost.disposed.map(uri => uri.toString()),
 		}, {
 			createCount: 2,
 			current: agentHost.createCalls.at(-1)?.session?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: folderC.toString(),
 			disposed: [original.toString()],
 		});
@@ -635,11 +632,9 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		const retried = await provisional.getOrCreate(ui, 'copilot', folderB);
 		assert.deepStrictEqual({
 			retried: retried?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
 		}, {
 			retried: agentHost.createCalls.at(-1)?.session?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: folderB.toString(),
 		});
 	});
@@ -669,11 +664,9 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		const retried = await provisional.getOrCreate(ui, 'copilot', folderB);
 		assert.deepStrictEqual({
 			retried: retried?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: agentHost.createCalls.at(-1)?.workingDirectories?.[0]?.toString(),
 		}, {
 			retried: agentHost.createCalls.at(-1)?.session?.toString(),
-			latestCreated: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: folderB.toString(),
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -66,7 +66,8 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	resolveQueue: (Promise<ResolveSessionConfigResult> | ResolveSessionConfigResult)[] = [];
 
 	override async createSession(config?: IAgentCreateSessionConfig): Promise<URI> {
-		this.createCalls.push(config!);
+		assert.ok(config?.session);
+		this.createCalls.push(config);
 		if (this.failNextCreate) {
 			this.failNextCreate = false;
 			throw new Error('create failed');
@@ -76,7 +77,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		if (gate) {
 			await gate.p;
 		}
-		return config!.session!;
+		return config.session;
 	}
 
 	override async disposeSession(session: URI): Promise<void> {
@@ -420,7 +421,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 
 		const reboundCreate = agentHost.createCalls.find(c => c.session?.path === '/real-g');
 		assert.ok(reboundCreate, 'rebind triggered a createSession');
-		assert.strictEqual(reboundCreate!.config?.['isolation'], 'worktree');
+		assert.strictEqual(reboundCreate.config?.['isolation'], 'worktree');
 	});
 
 	test('tryRebind retries when config changes during final session creation', async () => {
@@ -713,6 +714,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		const disposal = provisional.disposeSession(ui);
 		gate.complete();
 		await Promise.all([creation, disposal]);
+		const createdSession = agentHost.createCalls[0].session;
+		assert.ok(createdSession);
 
 		assert.deepStrictEqual({
 			current: provisional.get(ui),
@@ -721,7 +724,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		}, {
 			current: undefined,
 			createCount: 1,
-			disposed: agentHost.createCalls[0].session ? [agentHost.createCalls[0].session!.toString()] : [],
+			disposed: [createdSession.toString()],
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -21,7 +21,7 @@ import type { ConfigSchema } from '../../../../../../platform/agentHost/common/s
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IWorkspaceContextService, IWorkspace, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
-import { MessageKind, TurnState, type AgentInfo, type RootState, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import type { AgentInfo, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostUntitledProvisionalSessionService, IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
@@ -138,7 +138,6 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	let agentHost: MockAgentHostService;
 	let provisional: IAgentHostUntitledProvisionalSessionService;
 	let folderService: IAgentHostNewSessionFolderService;
-	let importStore: AgentHostImportConversationStore;
 	let cleanup: DisposableStore;
 	let workspaceTrusted: boolean;
 	let untrustedFolders: Set<string>;
@@ -166,8 +165,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 		folderService = ds.add(insta.createInstance(AgentHostNewSessionFolderService));
 		insta.stub(IAgentHostNewSessionFolderService, folderService);
-		importStore = new AgentHostImportConversationStore();
-		insta.stub(IAgentHostImportConversationStore, importStore);
+		insta.stub(IAgentHostImportConversationStore, new AgentHostImportConversationStore());
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());
 	});
@@ -490,61 +488,6 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 				URI.from({ scheme: 'copilot', path: '/real-dispose-race' }).toString(),
 			].sort(),
 		});
-	});
-
-	test('tryRebind does not create an untrusted rebound and preserves logical config', async () => {
-		const folderA = URI.file('/repoA');
-		const folderB = URI.file('/repoB');
-		const ui = untitledChatUri('rebind-untrusted');
-		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-untrusted' });
-		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
-		await provisional.applyConfigChange(ui, 'copilot', folderA, { isolation: 'worktree' });
-		const oldBackend = provisional.get(ui);
-		assert.ok(oldBackend);
-		untrustedFolders.add(folderB.toString());
-		folderService.setFolder(ui, folderB);
-		await flush();
-
-		const rebound = await provisional.tryRebind(ui, realUi, 'copilot', folderB);
-
-		assert.deepStrictEqual({
-			rebound,
-			createCount: agentHost.createCalls.length,
-			oldConfig: provisional.getSessionConfig(ui),
-			realConfig: provisional.getSessionConfig(realUi),
-			realBackend: provisional.get(realUi),
-			disposed: agentHost.disposed.map(uri => uri.toString()),
-		}, {
-			rebound: undefined,
-			createCount: 1,
-			oldConfig: undefined,
-			realConfig: { isolation: 'worktree' },
-			realBackend: undefined,
-			disposed: [oldBackend.toString()],
-		});
-	});
-
-	test('tryRebind restores an import when the target becomes untrusted during creation', async () => {
-		const folderA = URI.file('/repoA');
-		const folderB = URI.file('/repoB');
-		const ui = untitledChatUri('rebind-import-race');
-		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-import-race' });
-		await provisional.getOrCreate(ui, 'copilot', folderA);
-		const turn: Turn = { id: 'turn', message: { text: 'hello', origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined, state: TurnState.Complete };
-		const imported = { turns: [turn], model: { id: 'test-model' } };
-		importStore.set(realUi, imported);
-		const gate = new DeferredPromise<void>();
-		cleanup.add({ dispose: () => gate.cancel() });
-		agentHost.createGate = gate;
-
-		const rebind = provisional.tryRebind(ui, realUi, 'copilot', folderA);
-		await timeout(0);
-		untrustedFolders.add(folderB.toString());
-		folderService.setFolder(ui, folderB);
-		gate.complete();
-		await rebind;
-
-		assert.deepStrictEqual(importStore.take(realUi), imported);
 	});
 
 	test('disposeSession drops the entry and its overlay', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../../base/common/async.js';
-import { Event } from '../../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
@@ -21,7 +21,7 @@ import type { ConfigSchema } from '../../../../../../platform/agentHost/common/s
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IWorkspaceContextService, IWorkspace, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
-import type { AgentInfo, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { MessageKind, TurnState, type AgentInfo, type RootState, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostUntitledProvisionalSessionService, IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
@@ -43,8 +43,12 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	readonly disposed: URI[] = [];
 	readonly dispatched: IDispatchedAction[] = [];
 	readonly resolveCalls: IAgentResolveSessionConfigParams[] = [];
+	readonly disposeAttempts: URI[] = [];
 	createGate: DeferredPromise<void> | undefined;
 	failNextCreate = false;
+	failNextDispose = false;
+	private readonly _onAgentHostStart = new Emitter<void>();
+	override readonly onAgentHostStart = this._onAgentHostStart.event;
 
 	/** Agents advertised by the (stubbed) root state; drives capability gating. */
 	rootStateAgents: AgentInfo[] = [];
@@ -81,7 +85,20 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	}
 
 	override async disposeSession(session: URI): Promise<void> {
+		this.disposeAttempts.push(session);
+		if (this.failNextDispose) {
+			this.failNextDispose = false;
+			throw new Error('dispose failed');
+		}
 		this.disposed.push(session);
+	}
+
+	fireAgentHostStart(): void {
+		this._onAgentHostStart.fire();
+	}
+
+	dispose(): void {
+		this._onAgentHostStart.dispose();
 	}
 
 	override dispatch(channel: Parameters<IAgentHostService['dispatch']>[0], action: Parameters<IAgentHostService['dispatch']>[1]): void {
@@ -136,6 +153,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	const ds = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let agentHost: MockAgentHostService;
+	let importStore: AgentHostImportConversationStore;
 	let provisional: IAgentHostUntitledProvisionalSessionService;
 	let folderService: IAgentHostNewSessionFolderService;
 	let cleanup: DisposableStore;
@@ -144,7 +162,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	let workspaceFolders: URI[];
 
 	setup(async () => {
-		agentHost = new MockAgentHostService();
+		agentHost = ds.add(new MockAgentHostService());
 		workspaceTrusted = true;
 		untrustedFolders = new Set<string>();
 		workspaceFolders = [];
@@ -165,7 +183,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 		folderService = ds.add(insta.createInstance(AgentHostNewSessionFolderService));
 		insta.stub(IAgentHostNewSessionFolderService, folderService);
-		insta.stub(IAgentHostImportConversationStore, new AgentHostImportConversationStore());
+		importStore = new AgentHostImportConversationStore();
+		insta.stub(IAgentHostImportConversationStore, importStore);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());
 	});
@@ -490,6 +509,60 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 	});
 
+	test('tryRebind restores an imported conversation when final creation fails', async () => {
+		const ui = untitledChatUri('rebind-import-failure');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-import-failure' });
+		await provisional.getOrCreate(ui, 'copilot', undefined);
+		const turn: Turn = { id: 'turn', message: { text: 'hello', origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined, state: TurnState.Complete };
+		const imported = { turns: [turn], model: { id: 'test-model' } };
+		importStore.set(realUi, imported);
+		agentHost.failNextCreate = true;
+
+		const rebound = await provisional.tryRebind(ui, realUi, 'copilot', undefined);
+
+		assert.deepStrictEqual({
+			rebound,
+			imported: importStore.take(realUi),
+			disposed: agentHost.disposed.map(uri => uri.toString()),
+		}, {
+			rebound: undefined,
+			imported,
+			disposed: [URI.from({ scheme: 'copilot', path: '/real-import-failure' }).toString()],
+		});
+	});
+
+	test('tryRebind blocks deterministic URI reuse until failed disposal is retried', async () => {
+		const ui = untitledChatUri('rebind-dispose-failure');
+		const realUi = URI.from({ scheme: 'agent-host-copilot', path: '/real-dispose-failure' });
+		await provisional.getOrCreate(ui, 'copilot', undefined);
+		const gate = new DeferredPromise<void>();
+		cleanup.add({ dispose: () => gate.cancel() });
+		agentHost.createGate = gate;
+		const rebind = provisional.tryRebind(ui, realUi, 'copilot', undefined);
+		const pendingRead = provisional.waitForPending(ui);
+		await timeout(0);
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
+		const configChange = provisional.applyConfigChange(ui, 'copilot', undefined, { isolation: 'worktree' });
+		agentHost.failNextDispose = true;
+		gate.complete();
+
+		await assert.rejects(rebind, /Cannot safely retry rebound session/);
+		assert.strictEqual(await pendingRead, undefined);
+		await configChange;
+		const reboundUri = URI.from({ scheme: 'copilot', path: '/real-dispose-failure' });
+		assert.deepStrictEqual({
+			attempts: agentHost.disposeAttempts.filter(uri => uri.toString() === reboundUri.toString()).length,
+			disposed: agentHost.disposed.filter(uri => uri.toString() === reboundUri.toString()).length,
+		}, {
+			attempts: 1,
+			disposed: 0,
+		});
+
+		agentHost.fireAgentHostStart();
+		await timeout(0);
+		assert.strictEqual(agentHost.disposed.filter(uri => uri.toString() === reboundUri.toString()).length, 1);
+	});
+
 	test('disposeSession drops the entry and its overlay', async () => {
 		const ui = untitledChatUri('h');
 		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
@@ -635,7 +708,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		});
 	});
 
-	test('untrusted folder change hides the previous generation and reuses it on rollback', async () => {
+	test('untrusted folder change retires the hidden generation and recreates on rollback', async () => {
 		const folderA = URI.file('/repoA');
 		const folderB = URI.file('/repoB');
 		const ui = untitledChatUri('trust-change');
@@ -653,7 +726,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			createCount: agentHost.createCalls.length,
 		}, {
 			current: undefined,
-			disposed: [],
+			disposed: [original.toString()],
 			createCount: 1,
 		});
 
@@ -664,14 +737,16 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			current: provisional.get(ui)?.toString(),
 			createCount: agentHost.createCalls.length,
 			disposed: agentHost.disposed.map(uri => uri.toString()),
+			recreated: provisional.get(ui)?.toString() !== original.toString(),
 		}, {
-			current: original.toString(),
-			createCount: 1,
-			disposed: [],
+			current: agentHost.createCalls.at(-1)?.session?.toString(),
+			createCount: 2,
+			disposed: [original.toString()],
+			recreated: true,
 		});
 	});
 
-	test('failed folder replacement retains the previous generation until retry succeeds', async () => {
+	test('failed folder replacement cleans up its candidate and recreates on retry', async () => {
 		const folderA = URI.file('/repoA');
 		const folderB = URI.file('/repoB');
 		const ui = untitledChatUri('failed-change');
@@ -682,6 +757,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 
 		folderService.setFolder(ui, folderB);
 		await flush();
+		const failedCandidate = agentHost.createCalls[1].session;
+		assert.ok(failedCandidate);
 
 		assert.deepStrictEqual({
 			current: provisional.get(ui),
@@ -689,7 +766,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			createCount: agentHost.createCalls.length,
 		}, {
 			current: undefined,
-			disposed: [],
+			disposed: [failedCandidate.toString(), original.toString()],
 			createCount: 2,
 		});
 
@@ -701,7 +778,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		}, {
 			retried: agentHost.createCalls.at(-1)?.session?.toString(),
 			latestCwd: folderB.toString(),
-			disposed: [original.toString()],
+			disposed: [failedCandidate.toString(), original.toString()],
 		});
 	});
 


### PR DESCRIPTION
Fixes #327804
For https://github.com/microsoft/vscode/issues/321651

## Summary

- give each Editor Window provisional backend incarnation a unique URI
- serialize provisional creation, folder/config reconciliation, rebind, and disposal
- resolve live provisional backends through the provisional service
- add coverage for folder/config races, trust and failure cleanup, first-send routing, completions, and subscription movement

## Validation

- client type-check
- 26 provisional lifecycle and consumer tests
- 282 Agent Host chat contribution tests
- targeted hygiene checks

The local design Markdown files are intentionally excluded from this PR.