### PR TITLE
agentHost: Warn when worktree creation fails

### DIFF
--- a/src/vs/platform/agentHost/common/meta/agentSystemNotificationMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentSystemNotificationMeta.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const enum AgentSystemNotificationKind {
+	WorktreeCreationFailure = 'worktreeCreationFailure',
+}
+
+export const enum AgentSystemNotificationSeverity {
+	Warning = 'warning',
+}
+
+interface IHasSystemNotificationMeta {
+	readonly _meta?: Record<string, unknown>;
+}
+
+export interface IAgentSystemNotificationMeta {
+	readonly kind?: AgentSystemNotificationKind;
+	readonly severity?: AgentSystemNotificationSeverity;
+}
+
+/** Reads recognized Agent Host system-notification metadata. */
+export function readAgentSystemNotificationMeta(source: IHasSystemNotificationMeta): IAgentSystemNotificationMeta {
+	const meta = source._meta;
+	if (!meta) {
+		return {};
+	}
+	return {
+		kind: meta['kind'] === AgentSystemNotificationKind.WorktreeCreationFailure ? meta['kind'] : undefined,
+		severity: meta['severity'] === AgentSystemNotificationSeverity.Warning ? meta['severity'] : undefined,
+	};
+}
+
+/** Serializes Agent Host system-notification metadata for the open protocol bag. */
+export function toAgentSystemNotificationMeta(meta: IAgentSystemNotificationMeta): Record<string, unknown> {
+	return { ...meta };
+}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -50,7 +50,7 @@ import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
 import { type IChatContextSnapshot, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 
-import { WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService } from '../common/agentHostCheckpointService.js';
@@ -638,7 +638,7 @@ export class AgentService extends Disposable implements IAgentService {
 	 * Creates the session's isolated worktree on the first send (deferred so the
 	 * user's prompt can name the branch), reports creation progress as the chat's
 	 * activity, surfaces the "Created isolated worktree" announcement as the first
-	 * markdown response part of the turn, and returns the created worktree URI.
+	 * markdown response part or a durable fallback warning, and returns the created worktree URI.
 	 * Idempotent; safe to call once the worktree exists. Returns `undefined` when
 	 * worktree creation failed. Only invoked for sessions whose worktree is still
 	 * pending (see {@link _resolveWorkingDirectoryBeforeSend}).
@@ -650,6 +650,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return undefined;
 		}
 		let reportedActivity = false;
+		let failureDiagnostic: string | undefined;
 		try {
 			await worktree.resolveOnFirstSend({
 				sessionUri: URI.parse(params.session),
@@ -667,12 +668,27 @@ export class AgentService extends Disposable implements IAgentService {
 				},
 			});
 		} catch (err) {
-			this._logService.warn(`[AgentService] worktree resolution failed for ${params.session}: ${toErrorMessage(err)}`);
+			failureDiagnostic = toErrorMessage(err);
+			this._logService.warn(`[AgentService] worktree resolution failed for ${params.session}: ${failureDiagnostic}`);
 		}
 		// Clear on every exit path so a failed creation can't strand the chat
 		// on a stale "Creating isolated worktree" activity.
 		if (reportedActivity) {
 			this._stateManager.dispatchServerAction(params.chat, { type: ActionType.ChatActivityChanged, activity: undefined });
+		}
+		const resolvedWorktree = worktree.getResolvedWorktree(sessionId);
+		if (!resolvedWorktree) {
+			try {
+				await worktree.persistCreationFailure(URI.parse(params.session), sessionId, failureDiagnostic);
+			} catch (err) {
+				this._logService.warn(`[AgentService] failed to persist worktree creation failure for ${params.session}: ${toErrorMessage(err)}`);
+			}
+			this._stateManager.dispatchServerAction(params.chat, {
+				type: ActionType.ChatResponsePart,
+				turnId: params.turnId,
+				part: buildWorktreeFailureNotification(failureDiagnostic),
+			});
+			return undefined;
 		}
 		const announcement = worktree.takePendingAnnouncement(sessionId);
 		if (announcement !== undefined) {
@@ -682,7 +698,7 @@ export class AgentService extends Disposable implements IAgentService {
 				part: { kind: ResponsePartKind.Markdown, id: generateUuid(), content: announcement },
 			});
 		}
-		return worktree.getResolvedWorktree(sessionId);
+		return resolvedWorktree;
 	}
 
 	registerProvider(provider: IAgent): void {

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -13,8 +13,9 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
-import { IAgentSessionProjectInfo } from '../../common/agentService.js';
+import { AgentSession, IAgentSessionProjectInfo } from '../../common/agentService.js';
 import { getBranchCompletions, IAgentHostGitService, IDefaultBranch, IWorktreeFileProgress, META_DIFF_BASE_BRANCH, tryResolvePrimaryWorktreeRoot } from '../../common/agentHostGitService.js';
+import { AgentSystemNotificationKind, AgentSystemNotificationSeverity, toAgentSystemNotificationMeta } from '../../common/meta/agentSystemNotificationMeta.js';
 import { ISchemaProperty, schemaProperty } from '../../common/agentHostSchema.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
@@ -34,6 +35,8 @@ import { ICopilotApiService } from './copilotApiService.js';
 const WORKTREE_META_BRANCH = 'copilot.worktree.branchName';
 const WORKTREE_META_PATH = 'copilot.worktree.path';
 export const WORKTREE_META_REPOSITORY_ROOT = 'copilot.worktree.repositoryRoot';
+const WORKTREE_META_CREATION_FAILURE = 'copilot.worktree.creationFailure';
+const MAX_WORKTREE_FAILURE_DIAGNOSTIC_LENGTH = 200;
 
 /** Thrown when a persisted session working directory is missing and cannot be repaired. */
 export class SessionWorkingDirectoryMissingError extends Error {
@@ -93,6 +96,40 @@ export function buildWorktreeAnnouncementText(branchName: string): string {
 		"Created isolated worktree for branch {0}",
 		appendEscapedMarkdownInlineCode(branchName)
 	) + '\n\n';
+}
+
+/** Builds the warning shown when worktree isolation falls back to the original folder. */
+export function buildWorktreeFailureNotification(diagnostic?: string): Extract<ResponsePart, { kind: ResponsePartKind.SystemNotification }> {
+	const normalizedDiagnostic = normalizeWorktreeFailureDiagnostic(diagnostic);
+	const content = normalizedDiagnostic
+		? localize(
+			'agentHost.worktreeCreationFailedWithDiagnostic',
+			"Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n{0}",
+			appendEscapedMarkdownInlineCode(normalizedDiagnostic)
+		)
+		: localize(
+			'agentHost.worktreeCreationFailed',
+			"Couldn't create the isolated worktree. This session is continuing in the original folder."
+		);
+	return {
+		kind: ResponsePartKind.SystemNotification,
+		content,
+		_meta: toAgentSystemNotificationMeta({
+			kind: AgentSystemNotificationKind.WorktreeCreationFailure,
+			severity: AgentSystemNotificationSeverity.Warning,
+		}),
+	};
+}
+
+/** Normalizes an arbitrary worktree failure into a bounded single-line diagnostic. */
+export function normalizeWorktreeFailureDiagnostic(diagnostic: string | undefined): string | undefined {
+	const normalized = diagnostic?.replace(/\s+/g, ' ').trim();
+	if (!normalized) {
+		return undefined;
+	}
+	return normalized.length > MAX_WORKTREE_FAILURE_DIAGNOSTIC_LENGTH
+		? `${normalized.slice(0, MAX_WORKTREE_FAILURE_DIAGNOSTIC_LENGTH - 3)}...`
+		: normalized;
 }
 
 /**
@@ -197,6 +234,19 @@ export function prependAnnouncementToFirstTurn(turns: readonly Turn[], announcem
 	return result;
 }
 
+function prependWorktreeFailureToFirstTurn(turns: readonly Turn[], diagnostic: string | undefined): readonly Turn[] {
+	if (turns.length === 0) {
+		return turns;
+	}
+	const result = turns.slice();
+	const first = result[0];
+	result[0] = {
+		...first,
+		responseParts: [buildWorktreeFailureNotification(diagnostic), ...first.responseParts],
+	};
+	return result;
+}
+
 /** Parameters for {@link WorktreeIsolation.resolveIsolationConfig}. */
 export interface IResolveIsolationConfigRequest {
 	readonly workingDirectory: URI | undefined;
@@ -257,9 +307,7 @@ export interface IResolveWorkingDirectoryRequest {
  * - completing branch names for the branch picker ({@link branchCompletions});
  * - creating the worktree on materialization and persisting its metadata
  *   ({@link resolveWorkingDirectory});
- * - surfacing the "Created isolated worktree" announcement live on the first
- *   turn ({@link takePendingAnnouncement}) and on restore
- *   ({@link applyRestoreAnnouncement});
+ * - surfacing worktree creation success/failure notices live and on restore;
  * - cleaning up / recreating the worktree on dispose, archive, and unarchive.
  *
  * A single host-owned instance serves every agent: the orchestrator
@@ -647,21 +695,34 @@ export class WorktreeIsolation extends Disposable {
 		return announcement;
 	}
 
+	async persistCreationFailure(sessionUri: URI, sessionId: string, diagnostic: string | undefined): Promise<void> {
+		const dbRef = this._sessionDataService.openDatabase(sessionUri);
+		try {
+			await dbRef.object.setMetadata(WORKTREE_META_CREATION_FAILURE, JSON.stringify({
+				sessionId,
+				diagnostic: normalizeWorktreeFailureDiagnostic(diagnostic),
+			}));
+		} finally {
+			dbRef.dispose();
+		}
+	}
+
 	/**
-	 * Re-injects the worktree announcement into a restored transcript by
-	 * prepending it to the first turn. No-op when the session was not worktree
-	 * isolated. Callers forward the turns returned from their history-read path.
+	 * Re-injects the applicable worktree notice into the first restored turn.
 	 *
 	 * The live path ({@link takePendingAnnouncement}) handles the very first
 	 * turn while the session is fresh; this path takes over on subsequent loads
 	 * (where the synthetic announcement is not part of the agent transcript).
 	 */
 	async applyRestoreAnnouncement(sessionUri: URI, turns: readonly Turn[]): Promise<readonly Turn[]> {
-		const worktreeMeta = await this._readWorktreeMetadata(sessionUri).catch(() => undefined);
-		if (!worktreeMeta?.branchName) {
+		const notice = await this._readWorktreeNotice(sessionUri).catch(() => undefined);
+		if (notice?.kind === 'failure') {
+			return prependWorktreeFailureToFirstTurn(turns, notice.diagnostic);
+		}
+		if (notice?.kind !== 'success') {
 			return turns;
 		}
-		return prependAnnouncementToFirstTurn(turns, buildWorktreeAnnouncementText(worktreeMeta.branchName));
+		return prependAnnouncementToFirstTurn(turns, buildWorktreeAnnouncementText(notice.branchName));
 	}
 
 	/**
@@ -891,6 +952,7 @@ export class WorktreeIsolation extends Disposable {
 		if (!ref) {
 			return undefined;
 		}
+
 		try {
 			const [branchName, worktreePathRaw, repositoryRootRaw] = await Promise.all([
 				ref.object.getMetadata(WORKTREE_META_BRANCH),
@@ -915,6 +977,39 @@ export class WorktreeIsolation extends Disposable {
 				}
 			}
 			return { branchName, worktreePath, repositoryRoot };
+		} finally {
+			ref.dispose();
+		}
+	}
+
+	private async _readWorktreeNotice(sessionUri: URI): Promise<{ kind: 'success'; branchName: string } | { kind: 'failure'; diagnostic?: string } | undefined> {
+		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);
+		if (!ref) {
+			return undefined;
+		}
+		try {
+			const [branchName, failureRaw] = await Promise.all([
+				ref.object.getMetadata(WORKTREE_META_BRANCH),
+				ref.object.getMetadata(WORKTREE_META_CREATION_FAILURE),
+			]);
+			if (branchName) {
+				return { kind: 'success', branchName };
+			}
+			if (!failureRaw) {
+				return undefined;
+			}
+			const failure = JSON.parse(failureRaw);
+			if (!failure || typeof failure !== 'object' || Array.isArray(failure)) {
+				return undefined;
+			}
+			const raw = failure as Record<string, unknown>;
+			if (raw['sessionId'] !== AgentSession.id(sessionUri)) {
+				return undefined;
+			}
+			return {
+				kind: 'failure',
+				diagnostic: typeof raw['diagnostic'] === 'string' ? normalizeWorktreeFailureDiagnostic(raw['diagnostic']) : undefined,
+			};
 		} finally {
 			ref.dispose();
 		}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5473,11 +5473,11 @@ suite('AgentService (node dispatcher)', () => {
 				modifiedAt: new Date().toISOString(),
 				project: undefined,
 				workingDirectories: [sourceDir.toString()],
-				config: {
-					schema: { type: 'object', properties: {} },
-					values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-				},
 			}, []);
+			localService.stateManager.setSessionConfig(sessionResource, {
+				schema: { type: 'object', properties: {} },
+				values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			});
 			localService.stateManager.dispatchServerAction(chat, {
 				type: ActionType.ChatTurnStarted,
 				turnId: 'turn-1',
@@ -5540,11 +5540,11 @@ suite('AgentService (node dispatcher)', () => {
 				modifiedAt: new Date().toISOString(),
 				project: undefined,
 				workingDirectories: [sourceDir.toString()],
-				config: {
-					schema: { type: 'object', properties: {} },
-					values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-				},
 			}, []);
+			localService.stateManager.setSessionConfig(sessionResource, {
+				schema: { type: 'object', properties: {} },
+				values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			});
 			localService.stateManager.dispatchServerAction(chat, {
 				type: ActionType.ChatTurnStarted,
 				turnId: 'turn-1',

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5473,11 +5473,11 @@ suite('AgentService (node dispatcher)', () => {
 				modifiedAt: new Date().toISOString(),
 				project: undefined,
 				workingDirectories: [sourceDir.toString()],
+				config: {
+					schema: { type: 'object', properties: {} },
+					values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+				},
 			}, []);
-			localService.stateManager.dispatchServerAction(sessionResource, {
-				type: ActionType.SessionConfigChanged,
-				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-			});
 			localService.stateManager.dispatchServerAction(chat, {
 				type: ActionType.ChatTurnStarted,
 				turnId: 'turn-1',
@@ -5502,7 +5502,7 @@ suite('AgentService (node dispatcher)', () => {
 				activity: undefined,
 				responseParts: [{
 					kind: ResponsePartKind.SystemNotification,
-					content: "Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found`",
+					content: 'Couldn\'t create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found`',
 					_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
 				}],
 				persistedFailure: {
@@ -5540,11 +5540,11 @@ suite('AgentService (node dispatcher)', () => {
 				modifiedAt: new Date().toISOString(),
 				project: undefined,
 				workingDirectories: [sourceDir.toString()],
+				config: {
+					schema: { type: 'object', properties: {} },
+					values: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+				},
 			}, []);
-			localService.stateManager.dispatchServerAction(sessionResource, {
-				type: ActionType.SessionConfigChanged,
-				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
-			});
 			localService.stateManager.dispatchServerAction(chat, {
 				type: ActionType.ChatTurnStarted,
 				turnId: 'turn-1',
@@ -5566,7 +5566,7 @@ suite('AgentService (node dispatcher)', () => {
 				resolved: [sourceDir.toString()],
 				responseParts: [{
 					kind: ResponsePartKind.SystemNotification,
-					content: "Couldn't create the isolated worktree. This session is continuing in the original folder.",
+					content: 'Couldn\'t create the isolated worktree. This session is continuing in the original folder.',
 					_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
 				}],
 				persistedFailure: { sessionId: 'worktree-fallback' },

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -38,7 +38,7 @@ import { type ISessionEvent } from './copilotTestEvents.js';
 import { createNoopGitService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT } from '../../node/shared/worktreeIsolation.js';
+import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 
@@ -5435,6 +5435,142 @@ suite('AgentService (node dispatcher)', () => {
 				[toStrings(await resolve(multi)), toStrings(await resolve(single)), toStrings(await resolve(none))],
 				[[a, b, c].map(d => d.toString()), [a.toString()], undefined],
 			);
+		});
+
+		test('first-send worktree failure warns and falls back to the original folder', async () => {
+			const sourceDir = URI.file(mkdtempSync(`${tmpdir()}/agent-worktree-failure-`));
+			disposables.add(toDisposable(() => {
+				rmSync(sourceDir.fsPath, { recursive: true, force: true });
+				rmSync(getWorktreesRoot(sourceDir).fsPath, { recursive: true, force: true });
+			}));
+			const database = new TestSessionDatabase();
+			const sessionDataService = createSessionDataService(database);
+			const gitService = createNoopGitService();
+			gitService.getRepositoryRoot = async () => sourceDir;
+			gitService.getDefaultBranch = async () => ({ name: 'main', startPoint: 'main' });
+			gitService.addWorktree = async () => {
+				throw new Error('git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found');
+			};
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			const isolation = disposables.add(new WorktreeIsolation(
+				{ generateBranchName: async () => 'agents/failure' },
+				gitService,
+				new TestCopilotApiService(),
+				sessionDataService,
+				new NullLogService(),
+			));
+			localService.setWorktreeIsolation(isolation);
+
+			const session = AgentSession.uri('copilot', 'worktree-failure');
+			const sessionResource = session.toString();
+			const chat = buildDefaultChatUri(sessionResource);
+			localService.stateManager.restoreSession({
+				resource: sessionResource,
+				provider: 'copilot',
+				title: 'Worktree failure',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+				project: undefined,
+				workingDirectories: [sourceDir.toString()],
+			}, []);
+			localService.stateManager.dispatchServerAction(sessionResource, {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			});
+			localService.stateManager.dispatchServerAction(chat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'test', origin: { kind: MessageKind.User } },
+			});
+			isolation.notePending(AgentSession.id(session));
+
+			const resolver = localService as unknown as {
+				_resolveWorkingDirectoryBeforeSend: (params: { session: string; chat: string; turnId: string; prompt: string }) => Promise<readonly URI[] | undefined>;
+			};
+			const resolved = await resolver._resolveWorkingDirectoryBeforeSend({ session: sessionResource, chat, turnId: 'turn-1', prompt: 'test' });
+			const chatState = localService.stateManager.getChatState(chat);
+
+			assert.deepStrictEqual({
+				resolved: resolved?.map(uri => uri.toString()),
+				activity: chatState?.activity,
+				responseParts: chatState?.activeTurn?.responseParts,
+				persistedFailure: JSON.parse((await database.getMetadata('copilot.worktree.creationFailure'))!),
+			}, {
+				resolved: [sourceDir.toString()],
+				activity: undefined,
+				responseParts: [{
+					kind: ResponsePartKind.SystemNotification,
+					content: "Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found`",
+					_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
+				}],
+				persistedFailure: {
+					sessionId: 'worktree-failure',
+					diagnostic: 'git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found',
+				},
+			});
+		});
+
+		test('first-send worktree fallback warns when no repository root is resolved', async () => {
+			const sourceDir = URI.file('/source/repo');
+			const database = new TestSessionDatabase();
+			const sessionDataService = createSessionDataService(database);
+			const gitService = createNoopGitService();
+			gitService.getRepositoryRoot = async () => undefined;
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			const isolation = disposables.add(new WorktreeIsolation(
+				{ generateBranchName: async () => 'agents/fallback' },
+				gitService,
+				new TestCopilotApiService(),
+				sessionDataService,
+				new NullLogService(),
+			));
+			localService.setWorktreeIsolation(isolation);
+
+			const session = AgentSession.uri('copilot', 'worktree-fallback');
+			const sessionResource = session.toString();
+			const chat = buildDefaultChatUri(sessionResource);
+			localService.stateManager.restoreSession({
+				resource: sessionResource,
+				provider: 'copilot',
+				title: 'Worktree fallback',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+				project: undefined,
+				workingDirectories: [sourceDir.toString()],
+			}, []);
+			localService.stateManager.dispatchServerAction(sessionResource, {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+			});
+			localService.stateManager.dispatchServerAction(chat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'test', origin: { kind: MessageKind.User } },
+			});
+			isolation.notePending(AgentSession.id(session));
+
+			const resolver = localService as unknown as {
+				_resolveWorkingDirectoryBeforeSend: (params: { session: string; chat: string; turnId: string; prompt: string }) => Promise<readonly URI[] | undefined>;
+			};
+			const resolved = await resolver._resolveWorkingDirectoryBeforeSend({ session: sessionResource, chat, turnId: 'turn-1', prompt: 'test' });
+
+			assert.deepStrictEqual({
+				resolved: resolved?.map(uri => uri.toString()),
+				responseParts: localService.stateManager.getChatState(chat)?.activeTurn?.responseParts,
+				persistedFailure: JSON.parse((await database.getMetadata('copilot.worktree.creationFailure'))!),
+			}, {
+				resolved: [sourceDir.toString()],
+				responseParts: [{
+					kind: ResponsePartKind.SystemNotification,
+					content: "Couldn't create the isolated worktree. This session is continuing in the original folder.",
+					_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
+				}],
+				persistedFailure: { sessionId: 'worktree-fallback' },
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -18,7 +18,7 @@ import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, MessageKind, ResponsePartKind, TurnState, type Turn } from '../../../common/state/sessionState.js';
 import { AgentBranchNameGenerator, IAgentBranchNameGenerator } from '../../../node/shared/agentBranchNameGenerator.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
-import { SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../../common/sessionTestHelpers.js';
 
 /**
@@ -702,6 +702,53 @@ suite('WorktreeIsolation', () => {
 			unchangedWhenNoMeta: 0,
 			firstPartKind: ResponsePartKind.Markdown,
 			firstPartHasBranch: true,
+		});
+	});
+
+	test('worktree failure notification bounds and escapes diagnostics', () => {
+		const diagnostic = `git-lfs \`filter\`\n${'x'.repeat(250)}`;
+		const notification = buildWorktreeFailureNotification(diagnostic);
+
+		assert.deepStrictEqual({
+			normalizedLength: normalizeWorktreeFailureDiagnostic(diagnostic)?.length,
+			kind: notification.kind,
+			content: notification.content,
+			meta: notification._meta,
+		}, {
+			normalizedLength: 200,
+			kind: ResponsePartKind.SystemNotification,
+			content: `Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n\`\`git-lfs \`filter\` ${'x'.repeat(180)}...\`\``,
+			meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
+		});
+	});
+
+	test('applyRestoreAnnouncement restores a worktree failure only for its originating session', async () => {
+		const isolation = createIsolation(disposables);
+		const turn: Turn = {
+			id: 't1',
+			message: { text: 'hi', origin: { kind: MessageKind.User } },
+			responseParts: [],
+			usage: undefined,
+			state: TurnState.Complete,
+		};
+		await isolation.persistCreationFailure(sessionUri, sessionId, 'git worktree exited with code 128');
+
+		const matching = await isolation.applyRestoreAnnouncement(sessionUri, [turn]);
+		const copied = await isolation.applyRestoreAnnouncement(URI.parse('agent-session://test/copied'), [turn]);
+		const empty = await isolation.applyRestoreAnnouncement(sessionUri, []);
+
+		assert.deepStrictEqual({
+			matching: matching[0].responseParts[0],
+			copiedPartCount: copied[0].responseParts.length,
+			emptyTurnCount: empty.length,
+		}, {
+			matching: {
+				kind: ResponsePartKind.SystemNotification,
+				content: "Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128`",
+				_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
+			},
+			copiedPartCount: 0,
+			emptyTurnCount: 0,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -744,7 +744,7 @@ suite('WorktreeIsolation', () => {
 		}, {
 			matching: {
 				kind: ResponsePartKind.SystemNotification,
-				content: "Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128`",
+				content: 'Couldn\'t create the isolated worktree. This session is continuing in the original folder.\n\n`git worktree exited with code 128`',
 				_meta: { kind: 'worktreeCreationFailure', severity: 'warning' },
 			},
 			copiedPartCount: 0,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2260,7 +2260,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					case ResponsePartKind.SystemNotification:
 						// System notifications don't have an id, so we have to identify it by index
 						if (responseParts$.get().indexOf(initial) >= (opts.initialResponsePartCount ?? 0) && opts.subAgentInvocationId === undefined) {
-							const progress = systemNotificationToChatPart(initial.content, this._config.connectionAuthority);
+							const progress = systemNotificationToChatPart(initial.content, this._config.connectionAuthority, initial._meta);
 							if (progress) {
 								opts.sink([progress]);
 							}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -22,6 +22,7 @@ import { AgentHostElementAttachmentDisplayKind, getElementAttachmentCorrelationI
 import { AgentHostAutoReplyAnswer } from '../../../../../../platform/agentHost/common/agentHostSchema.js';
 import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAnnotationsAttachment, isAgentFeedbackAttachment } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { getBrowserViewAttachmentMetadata, isBrowserViewAttachment } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
+import { AgentSystemNotificationKind, AgentSystemNotificationSeverity, readAgentSystemNotificationMeta } from '../../../../../../platform/agentHost/common/meta/agentSystemNotificationMeta.js';
 import { isViewUnreviewedCommentsTool, isAddCommentTool } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAnnotations.js';
 import { isCreateChatTool, isCreateSessionTool, isSendMessageTool, parseOpenSessionLinkChatId, parseOpenSessionLinkUri } from '../../../../../../platform/agentHost/common/openSessionLink.js';
 import { parsePartialToolInputForDisplay } from '../../../../../../platform/agentHost/common/partialToolInput.js';
@@ -436,12 +437,16 @@ export function isSubagentToolName(toolName: string): boolean {
 	return SUBAGENT_TOOL_NAMES.has(toolName);
 }
 
-export function systemNotificationToChatPart(content: StringOrMarkdown | undefined, connectionAuthority: string): IChatProgress | undefined {
+export function systemNotificationToChatPart(content: StringOrMarkdown | undefined, connectionAuthority: string, _meta?: Record<string, unknown>): IChatProgress | undefined {
 	if (!content) {
 		return undefined;
 	}
 	const value = stringOrMarkdownToString(content, connectionAuthority);
-	return { kind: 'systemNotification', content: typeof value === 'string' ? new MarkdownString(value) : value };
+	const markdown = typeof value === 'string' ? new MarkdownString(value) : value;
+	const meta = readAgentSystemNotificationMeta({ _meta });
+	return meta.kind === AgentSystemNotificationKind.WorktreeCreationFailure && meta.severity === AgentSystemNotificationSeverity.Warning
+		? { kind: 'warning', content: markdown }
+		: { kind: 'systemNotification', content: markdown };
 }
 
 /**
@@ -865,7 +870,7 @@ export function turnsToHistory(backendSession: URI, turns: readonly Turn[], part
 					break;
 				case ResponsePartKind.SystemNotification:
 					{
-						const progress = systemNotificationToChatPart(rp.content, connectionAuthority);
+						const progress = systemNotificationToChatPart(rp.content, connectionAuthority, rp._meta);
 						if (progress) {
 							parts.push(progress);
 						}
@@ -1211,7 +1216,7 @@ export function activeTurnToProgress(sessionResource: URI, activeTurn: ActiveTur
 			}
 			case ResponsePartKind.SystemNotification:
 				{
-					const progress = systemNotificationToChatPart(rp.content, connectionAuthority);
+					const progress = systemNotificationToChatPart(rp.content, connectionAuthority, rp._meta);
 					if (progress) {
 						parts.push(progress);
 					}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -27,6 +27,7 @@ import type { ChatInputRequestWithPlanReview } from '../../../../../../platform/
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { getElementAttachmentCorrelationId } from '../../../../../../platform/agentHost/common/meta/agentElementAttachments.js';
 import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/browserViewAttachments.js';
+import { AgentSystemNotificationKind, AgentSystemNotificationSeverity, toAgentSystemNotificationMeta } from '../../../../../../platform/agentHost/common/meta/agentSystemNotificationMeta.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { ProtocolError, type IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { ChatInteractivity, ConfirmationOptionKind, CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ProtectedResourceMetadata, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -3868,6 +3869,30 @@ suite('AgentHostChatContribution', () => {
 
 			const notifications = collected.flat().filter(part => part.kind === 'systemNotification');
 			assert.deepStrictEqual(notifications.map(part => part.content.value), ['Background command completed']);
+		}));
+
+		test('worktree failure response parts become live warnings', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
+
+			fire({
+				type: 'chat/responsePart',
+				session,
+				turnId,
+				part: {
+					kind: ResponsePartKind.SystemNotification,
+					content: 'Worktree creation failed',
+					_meta: toAgentSystemNotificationMeta({
+						kind: AgentSystemNotificationKind.WorktreeCreationFailure,
+						severity: AgentSystemNotificationSeverity.Warning,
+					}),
+				},
+			} as ChatAction);
+			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
+			await turnPromise;
+
+			const warnings = collected.flat().filter(part => part.kind === 'warning');
+			assert.deepStrictEqual(warnings.map(part => part.content.value), ['Worktree creation failed']);
 		}));
 
 		test('Auto model routing metadata becomes a live resolution part', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -7,9 +7,10 @@ import assert from 'assert';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import type { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { AgentHostAutoReplyAnswer } from '../../../../../../platform/agentHost/common/agentHostSchema.js';
+import { AgentSystemNotificationKind, AgentSystemNotificationSeverity, toAgentSystemNotificationMeta } from '../../../../../../platform/agentHost/common/meta/agentSystemNotificationMeta.js';
 import { McpAuthRequiredReason } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { fromAgentHostUri, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { buildSubagentChatUri, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, MessageKind, ToolCallContributorKind, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, readUsageInfoMeta, type ActiveTurn, type ICompletedToolCall, type ToolCallPendingConfirmationState, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason, type Message, type ToolResultContent } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -258,6 +259,28 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(progress.kind, 'systemNotification');
 			if (progress.kind !== 'systemNotification') { return; }
 			assert.strictEqual(progress.content.value, 'Shell command completed');
+		});
+
+		test('worktree failure notification restores as warning', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.SystemNotification,
+					content: 'Worktree creation failed',
+					_meta: toAgentSystemNotificationMeta({
+						kind: AgentSystemNotificationKind.WorktreeCreationFailure,
+						severity: AgentSystemNotificationSeverity.Warning,
+					}),
+				}],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'participant-1');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			assert.deepStrictEqual(response.parts[0], {
+				kind: 'warning',
+				content: new MarkdownString('Worktree creation failed'),
+			});
 		});
 
 		test('reasoning response part restores as thinking progress carrying its id', () => {
@@ -1898,6 +1921,22 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(result[0].kind, 'systemNotification');
 			if (result[0].kind !== 'systemNotification') { return; }
 			assert.strictEqual(result[0].content.value, 'Shell command completed');
+		});
+
+		test('produces warning for active worktree failure notification', () => {
+			const result = activeTurnToProgress(URI.file('/'), createActiveTurnState([{
+				kind: ResponsePartKind.SystemNotification,
+				content: 'Worktree creation failed',
+				_meta: toAgentSystemNotificationMeta({
+					kind: AgentSystemNotificationKind.WorktreeCreationFailure,
+					severity: AgentSystemNotificationSeverity.Warning,
+				}),
+			}]), undefined);
+
+			assert.deepStrictEqual(result[0], {
+				kind: 'warning',
+				content: new MarkdownString('Worktree creation failed'),
+			});
 		});
 
 		test('produces thinking progress for reasoning', () => {


### PR DESCRIPTION
## Summary

- surface a warning in the first chat turn when isolated worktree creation fails
- continue in the original folder while preserving a bounded Git diagnostic
- persist and restore the warning without leaking it into forked sessions
- render live and restored failures through the existing chat warning presentation

Fixes #328652

## Validation

- `git diff --check`
- independent code review and rubber-duck review
- targeted tests added for thrown and non-throwing failures, restoration, fork isolation, and live/history rendering
- automated tests, typecheck, valid-layers, and hygiene were not run because Node/npm are unavailable in the current environment


We will now display error messages that prevented the creation of the worktree
<img width="674" height="408" alt="image" src="https://github.com/user-attachments/assets/7f172b36-f8f1-46aa-93e0-eefaeeea4c2b" />
