### PR TITLE
Automations: Make cards fully clickable

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -100,6 +100,8 @@
 	border: 1px solid var(--vscode-widget-border);
 	border-radius: 6px;
 	height: 100%;
+	cursor: pointer;
+	touch-action: manipulation;
 }
 
 .automations-card:hover {

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
@@ -27,7 +27,7 @@ class AutomationsCustomViewAccessibilityHelp implements IAccessibleViewImplement
 		const restoreFocus = createFocusRestorer(layoutService);
 		const content = [
 			localize('automationsCustomView.help.overview', "You are in the Automations view. It contains automation cards followed by run history."),
-			localize('automationsCustomView.help.cards', "Tab between each card's Edit, Run now, and Delete controls. Edit opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation."),
+			localize('automationsCustomView.help.cards', "Tab between each card's Edit, Run now, and Delete controls. Edit, or clicking anywhere else on the card, opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation."),
 			localize('automationsCustomView.help.history', "Run history is grouped by date. Each run reports its Pending, Running, Completed, or Failed status. Runs with an available session can be opened with Enter or Space."),
 			localize('automationsCustomView.help.read', "Completed and failed runs that have not been opened are announced as unread. Use Mark all as read to clear all available unread runs."),
 			localize('automationsCustomView.help.accessibleView', "Use Open Accessible View to read the current automations and run history as text."),

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -31,7 +31,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { createPixelSpinner } from '../../../../../base/browser/ui/pixelSpinner/pixelSpinner.js';
-import { Gesture, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
+import { Gesture, GestureEvent, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../../services/sessions/common/session.js';
@@ -168,13 +168,11 @@ class AutomationCardsSection extends Disposable {
 		const card = DOM.append(wrapper, $('.automations-card'));
 		card.setAttribute('role', 'group');
 		card.setAttribute('aria-label', localize('automationCard', "{0} — {1}", automation.name, formatSchedule(automation)));
+		this.disposables.add(Gesture.addTarget(card));
 
 		const main = DOM.append(card, $('button.automations-card-main', {
 			type: 'button',
 			'aria-label': localize('editAutomationNamed', "Edit automation {0}", automation.name),
-		}));
-		this.disposables.add(DOM.addDisposableListener(main, DOM.EventType.CLICK, () => {
-			void this.openEditDialog(automation);
 		}));
 
 		// Name row with disabled badge
@@ -216,6 +214,16 @@ class AutomationCardsSection extends Disposable {
 		this.disposables.add(deleteBtn.onDidClick(() => {
 			void this.confirmDelete(automation);
 		}));
+
+		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap]) {
+			this.disposables.add(DOM.addDisposableListener(card, eventType, event => {
+				const target = (event as GestureEvent).initialTarget ?? event.target;
+				if (target instanceof Node && DOM.isAncestor(target, actions)) {
+					return;
+				}
+				void this.openEditDialog(automation);
+			}));
+		}
 	}
 
 	private createIconButton(container: HTMLElement, icon: ThemeIcon, tooltip: string, disabled: boolean): Button {

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -187,8 +187,10 @@ class FakeDialogService extends mock<IDialogService>() {
 
 class FakeRunner extends mock<IAutomationRunner>() {
 	whenDispatched: Promise<IAutomationRunDispatch> = Promise.resolve({ kind: 'notStarted', reason: 'targetUnavailable' });
+	runCalls = 0;
 
 	override runOnce(_automation: IAutomation, _trigger: AutomationRunTrigger, _leaderWindowId: number, _token?: CancellationToken): IAutomationRunOperation {
+		this.runCalls++;
 		return { whenDispatched: this.whenDispatched, whenCompleted: Promise.resolve() };
 	}
 }
@@ -346,8 +348,8 @@ suite('AutomationsCardsWidget', () => {
 		});
 	});
 
-	test('clicking the card opens edit without intercepting card actions', async () => {
-		const { automationDialogService, automationService, widget } = setup();
+	test('clicking the card opens edit without intercepting action clicks', async () => {
+		const { automationDialogService, automationService, runner, widget } = setup();
 		const item = automation();
 		automationService.setAutomations([item]);
 
@@ -357,17 +359,46 @@ suite('AutomationsCardsWidget', () => {
 		assert.ok(actionButton);
 		actionButton.click();
 		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			showCalls: automationDialogService.showCalls,
+			existing: automationDialogService.lastOptions?.existing,
+			runCalls: runner.runCalls,
+		}, {
+			showCalls: 1,
+			existing: item,
+			runCalls: 1,
+		});
+	});
+
+	test('tapping the card opens edit without intercepting action taps', async () => {
+		const { automationDialogService, automationService, runner, widget } = setup();
+		const item = automation();
+		automationService.setAutomations([item]);
+		const card = widget.element.querySelector<HTMLElement>('.automations-card');
+		const actionButton = widget.element.querySelector<HTMLButtonElement>('.automations-card-action-button');
+		assert.ok(card);
+		assert.ok(actionButton);
+
 		const tapEvent = new MouseEvent(TouchEventType.Tap, { cancelable: true }) as GestureEvent;
 		tapEvent.initialTarget = actionButton;
-		widget.element.querySelector<HTMLElement>('.automations-card')?.dispatchEvent(tapEvent);
+		actionButton.dispatchEvent(tapEvent);
+		card.dispatchEvent(tapEvent);
+		await Promise.resolve();
+
+		const cardTapEvent = new MouseEvent(TouchEventType.Tap, { cancelable: true }) as GestureEvent;
+		cardTapEvent.initialTarget = card;
+		card.dispatchEvent(cardTapEvent);
 		await Promise.resolve();
 
 		assert.deepStrictEqual({
 			showCalls: automationDialogService.showCalls,
 			existing: automationDialogService.lastOptions?.existing,
+			runCalls: runner.runCalls,
 		}, {
 			showCalls: 1,
 			existing: item,
+			runCalls: 1,
 		});
 	});
 

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { DeferredPromise } from '../../../../../base/common/async.js';
+import { GestureEvent, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { toDisposable } from '../../../../../base/common/lifecycle.js';
@@ -156,8 +157,12 @@ class FakeAutomationService extends mock<IAutomationService>() {
 class FakeAutomationDialogService extends mock<IAutomationDialogService>() {
 	result: IAutomationDialogResult | undefined;
 	beforeReturn: (() => void) | undefined;
+	showCalls = 0;
+	lastOptions: IShowAutomationDialogOptions | undefined;
 
-	override async showAutomationDialog(_options: IShowAutomationDialogOptions): Promise<IAutomationDialogResult | undefined> {
+	override async showAutomationDialog(options: IShowAutomationDialogOptions): Promise<IAutomationDialogResult | undefined> {
+		this.showCalls++;
+		this.lastOptions = options;
 		this.beforeReturn?.();
 		return this.result;
 	}
@@ -338,6 +343,31 @@ suite('AutomationsCardsWidget', () => {
 		}, {
 			activeElement: widget.element,
 			cardFocused: false,
+		});
+	});
+
+	test('clicking the card opens edit without intercepting card actions', async () => {
+		const { automationDialogService, automationService, widget } = setup();
+		const item = automation();
+		automationService.setAutomations([item]);
+
+		widget.element.querySelector<HTMLElement>('.automations-card')?.click();
+		await Promise.resolve();
+		const actionButton = widget.element.querySelector<HTMLButtonElement>('.automations-card-action-button');
+		assert.ok(actionButton);
+		actionButton.click();
+		await Promise.resolve();
+		const tapEvent = new MouseEvent(TouchEventType.Tap, { cancelable: true }) as GestureEvent;
+		tapEvent.initialTarget = actionButton;
+		widget.element.querySelector<HTMLElement>('.automations-card')?.dispatchEvent(tapEvent);
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			showCalls: automationDialogService.showCalls,
+			existing: automationDialogService.lastOptions?.existing,
+		}, {
+			showCalls: 1,
+			existing: item,
 		});
 	});
 


### PR DESCRIPTION
## Summary

- open the automation edit dialog when clicking or tapping anywhere on an automation card
- preserve the existing Run and Delete actions, including synthesized touch events
- update accessibility help and add click/tap regression coverage

## Testing

- `npm run compile-client`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- targeted hygiene checks
- `scripts/test.bat --run src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts`