### PR TITLE
Fix canonical URI cache invalidation on path casing changes

### DIFF
--- a/src/vs/platform/uriIdentity/common/uriIdentityService.ts
+++ b/src/vs/platform/uriIdentity/common/uriIdentityService.ts
@@ -60,7 +60,7 @@ export class UriIdentityService implements IUriIdentityService {
 			}
 			schemeIgnoresPathCasingCache.delete(e.scheme);
 			const newIgnorePathCasingValue = ignorePathCasing(URI.from({ scheme: e.scheme }));
-			if (newIgnorePathCasingValue === newIgnorePathCasingValue) {
+			if (oldIgnorePathCasingValue === newIgnorePathCasingValue) {
 				return;
 			}
 			for (const [key, entry] of this._canonicalUris.entries()) {

--- a/src/vs/platform/uriIdentity/test/common/uriIdentityService.test.ts
+++ b/src/vs/platform/uriIdentity/test/common/uriIdentityService.test.ts
@@ -6,17 +6,24 @@
 import assert from 'assert';
 import { UriIdentityService } from '../../common/uriIdentityService.js';
 import { mock } from '../../../../base/test/common/mock.js';
-import { IFileService, FileSystemProviderCapabilities } from '../../../files/common/files.js';
+import { IFileService, IFileSystemProvider, IFileSystemProviderCapabilitiesChangeEvent, FileSystemProviderCapabilities } from '../../../files/common/files.js';
 import { URI } from '../../../../base/common/uri.js';
-import { Event } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 suite('URI Identity', function () {
 
 	class FakeFileService extends mock<IFileService>() {
 
-		override onDidChangeFileSystemProviderCapabilities = Event.None;
+		private readonly _onDidChangeFileSystemProviderCapabilities = new Emitter<IFileSystemProviderCapabilitiesChangeEvent>();
+
+		override onDidChangeFileSystemProviderCapabilities = this._onDidChangeFileSystemProviderCapabilities.event;
 		override onDidChangeFileSystemProviderRegistrations = Event.None;
+
+		private readonly provider = new class extends mock<IFileSystemProvider>() {
+			override capabilities = FileSystemProviderCapabilities.None;
+			override onDidChangeCapabilities = Event.None;
+		};
 
 		constructor(readonly data: Map<string, FileSystemProviderCapabilities>) {
 			super();
@@ -28,19 +35,32 @@ suite('URI Identity', function () {
 			const mask = this.data.get(uri.scheme) ?? 0;
 			return Boolean(mask & flag);
 		}
+
+		changeCapabilities(scheme: string, capabilities: FileSystemProviderCapabilities): void {
+			this.data.set(scheme, capabilities);
+			this.provider.capabilities = capabilities;
+			this._onDidChangeFileSystemProviderCapabilities.fire({ provider: this.provider, scheme });
+		}
+
+		override dispose(): void {
+			this._onDidChangeFileSystemProviderCapabilities.dispose();
+		}
 	}
 
 	let _service: UriIdentityService;
+	let _fileService: FakeFileService;
 
 	setup(function () {
-		_service = new UriIdentityService(new FakeFileService(new Map([
+		_fileService = new FakeFileService(new Map([
 			['bar', FileSystemProviderCapabilities.PathCaseSensitive],
 			['foo', FileSystemProviderCapabilities.None]
-		])));
+		]));
+		_service = new UriIdentityService(_fileService);
 	});
 
 	teardown(function () {
 		_service.dispose();
+		_fileService.dispose();
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -76,6 +96,20 @@ suite('URI Identity', function () {
 
 		assertCanonical(b, b);
 		assertCanonical(b1, b1); // case sensitive
+	});
+
+	test('asCanonicalUri clears cache when provider path casing changes', function () {
+		const upper = URI.parse('foo://bar/BANG');
+		const lower = URI.parse('foo://bar/bang');
+
+		assert.strictEqual(_service.asCanonicalUri(upper).toString(), upper.toString());
+		assert.strictEqual(_service.asCanonicalUri(lower).toString(), upper.toString());
+		assert.strictEqual(_service.extUri.isEqual(upper, lower), true);
+
+		_fileService.changeCapabilities('foo', FileSystemProviderCapabilities.PathCaseSensitive);
+
+		assert.strictEqual(_service.extUri.isEqual(upper, lower), false);
+		assert.strictEqual(_service.asCanonicalUri(lower).toString(), lower.toString());
 	});
 
 	test('asCanonicalUri (normalization)', function () {


### PR DESCRIPTION
Fixes #328677

## Summary

Fix canonical URI cache invalidation when a filesystem provider's path-casing capability changes.

## Root Cause

`UriIdentityService` recomputes the new per-scheme `ignorePathCasing` value after a filesystem provider registration or capability-change event, but the existing implementation compares the newly computed value to itself.

Because this condition is always true, the listener returns before clearing cached canonical URI entries for the affected scheme.

As a result, direct URI comparisons can reflect the updated path-casing behavior while `asCanonicalUri()` continues returning URI values cached under the previous casing semantics.

## Change

Compare the previously cached path-casing value with the newly computed value:

```diff
- if (newIgnorePathCasingValue === newIgnorePathCasingValue) {
+ if (oldIgnorePathCasingValue === newIgnorePathCasingValue) {
````

This allows the existing canonical URI cache invalidation logic to run only when the provider's path-casing behavior has actually changed.

## Regression Test

Added a focused URI Identity regression test that:

* caches `foo://bar/BANG` while the provider scheme is case-insensitive;
* confirms `foo://bar/BANG` and `foo://bar/bang` initially resolve to the same canonical URI;
* changes the provider capability to `PathCaseSensitive`;
* emits the provider capability-change event;
* verifies direct URI comparison reflects the new case-sensitive behavior; and
* verifies `asCanonicalUri(foo://bar/bang)` no longer returns the stale uppercase URI.

The test fails on the previous implementation and passes after the fix.

## Validation

* `npm run compile`
* `.\scripts\test.bat --grep "asCanonicalUri clears cache when provider path casing changes"`

  * `1 passing`
* `.\scripts\test.bat --grep "URI Identity"`

  * `8 passing`
