### PR TITLE
Preserve spaces in rich text clipboard content

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -8,7 +8,6 @@ import { RunOnceScheduler } from '../../../base/common/async.js';
 import { Color } from '../../../base/common/color.js';
 import { Event } from '../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
-import * as platform from '../../../base/common/platform.js';
 import * as strings from '../../../base/common/strings.js';
 import { ConfigurationChangedEvent, EditorOption, filterValidationDecorations, filterFontDecorations, FindComputedEditorOptionValueById } from '../config/editorOptions.js';
 import { EDITOR_FONT_DEFAULTS } from '../config/fontInfo.js';
@@ -1126,7 +1125,7 @@ export class ViewModel extends Disposable implements IViewModel {
 			if (lineContent === '') {
 				result += '<br>';
 			} else {
-				result += tokenizeLineToHTML(lineContent, lineTokens.inflate(), colorMap, startOffset, endOffset, tabSize, platform.isWindows);
+				result += tokenizeLineToHTML(lineContent, lineTokens.inflate(), colorMap, startOffset, endOffset, tabSize, false);
 			}
 		}
 

--- a/src/vs/editor/test/browser/viewModel/viewModelImpl.test.ts
+++ b/src/vs/editor/test/browser/viewModel/viewModelImpl.test.ts
@@ -156,6 +156,15 @@ suite('ViewModel', () => {
 		});
 	}
 
+	test('issue #88178: getRichTextToCopy preserves consecutive spaces', () => {
+		testViewModel(['hello  world'], {}, (viewModel, model) => {
+			model.setLanguage('markdown');
+			const actual = viewModel.getRichTextToCopy([new Range(1, 1, 1, 13)], false);
+
+			assert.ok(actual && !actual.html.includes('&#160;'));
+		});
+	});
+
 	const USUAL_TEXT = [
 		'',
 		'line2',

--- a/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
+++ b/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
@@ -292,6 +292,24 @@ suite('Editor Modes - textToHtmlTokenizer', () => {
 		);
 	});
 
+	test('tokenizeLineToHTML preserves consecutive spaces when useNbsp is false', () => {
+		const text = 'hello  world';
+		const lineTokens = new TestLineTokens([
+			new TestLineToken(
+				text.length,
+				(
+					(1 << MetadataConsts.FOREGROUND_OFFSET)
+				) >>> 0
+			)
+		]);
+		const colorMap = [null!, '#000000'];
+
+		assert.strictEqual(
+			tokenizeLineToHTML(text, lineTokens, colorMap, 0, text.length, 4, false),
+			'<div><span style="color: #000000;">hello  world</span></div>'
+		);
+	});
+
 	test('tokenizeLineToHTML with tabs and non-zero startOffset #263387', () => {
 		// This test demonstrates the issue where tab padding is calculated incorrectly
 		// when startOffset is non-zero and there are tabs AFTER the start position.


### PR DESCRIPTION
Fixes #88178

Seeded by a VS Code Sweeper review: https://github.com/egamma/vscodesweeper-state/blob/state/records/microsoft/vscode/items/88178.md

Stops enabling non-breaking-space substitution when generating rich clipboard HTML. The clipboard wrapper already uses `white-space: pre`, so consecutive regular spaces remain preserved without changing the copied text. Adds regression coverage for both the rich-copy caller and the tokenizer parameter behavior.

Validation: `./scripts/test.sh --run src/vs/editor/test/browser/viewModel/viewModelImpl.test.ts --run src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts`