### PR TITLE
Fix workspaceContains glob search ignores

### DIFF
--- a/src/vs/workbench/services/extensions/common/workspaceContains.ts
+++ b/src/vs/workbench/services/extensions/common/workspaceContains.ts
@@ -122,6 +122,8 @@ export function checkGlobFileExists(
 	const query = queryBuilder.file(folders.map(folder => toWorkspaceFolder(URI.revive(folder))), {
 		_reason: 'checkExists',
 		includePattern: includes,
+		disregardIgnoreFiles: true,
+		disregardExcludeSettings: true,
 		exists: true
 	});
 

--- a/src/vs/workbench/services/extensions/test/browser/workspaceContains.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/workspaceContains.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { checkGlobFileExists } from '../../common/workspaceContains.js';
+import { IFileQuery, ISearchService } from '../../../search/common/search.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+
+suite('Workspace Contains', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('glob search disregards ignore files and exclude settings', async () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables) as TestInstantiationService;
+		const configurationService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+		configurationService.setUserConfiguration('search', { useIgnoreFiles: true });
+		configurationService.setUserConfiguration('files', { exclude: { '**/Content': true } });
+
+		instantiationService.stub(ISearchService, {
+			fileSearch(query: IFileQuery) {
+				assert.deepStrictEqual({
+					disregardIgnoreFiles: query.folderQueries[0].disregardIgnoreFiles,
+					excludePattern: query.folderQueries[0].excludePattern
+				}, {
+					disregardIgnoreFiles: true,
+					excludePattern: []
+				});
+
+				return Promise.resolve({ limitHit: true, results: [], messages: [] });
+			}
+		});
+
+		const exists = await instantiationService.invokeFunction(
+			checkGlobFileExists,
+			[URI.file('/workspace')],
+			['**/Content/test123.json'],
+			CancellationToken.None
+		);
+
+		assert.strictEqual(exists, true);
+	});
+});


### PR DESCRIPTION
Fixes #323964

Seeded by a VS Code Sweeper review: https://github.com/egamma/vscodesweeper-state/blob/state/records/microsoft/vscode/items/323964.md

Glob-based `workspaceContains` activation searches now disregard ignore files and exclude settings, ensuring ignored or excluded files can still activate extensions. Added a regression test that verifies the generated file query ignores both filters.

Validation: `./scripts/test.sh --run src/vs/workbench/services/extensions/test/browser/workspaceContains.test.ts`