### PR TITLE
Fix multilingual dictation model labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -287,11 +287,11 @@ configurationRegistry.registerConfiguration({
 				'mai',
 			],
 			enumItemLabels: [
-				nls.localize('dictation.model.nemotronStreaming.label', "Nemotron 3.5 ASR (Multilingual) — On-Device"),
+				nls.localize('dictation.model.nemotronMultilingual.label', "Nemotron 3.5 ASR (Multilingual) — On-Device"),
 				nls.localize('dictation.model.mai.label', "MAI — Cloud"),
 			],
 			markdownEnumDescriptions: [
-				nls.localize('dictation.model.nemotronStreaming', "NVIDIA Nemotron 3.5 multilingual streaming RNN-T, run on-device through Microsoft Foundry Local. Works offline; no audio leaves the device. Automatic language selection follows the Voice Mode language setting and system or browser locale, with model detection as a fallback. Downloaded on first use and cached on disk."),
+				nls.localize('dictation.model.nemotronMultilingual', "NVIDIA Nemotron 3.5 multilingual streaming RNN-T, run on-device through Microsoft Foundry Local. Works offline; no audio leaves the device. Automatic language selection follows the Voice Mode language setting and system or browser locale, with model detection as a fallback. Downloaded on first use and cached on disk."),
 				nls.localize('dictation.model.mai', "Cloud transcription through the same Microsoft AI voice service used by Voice Mode. Requires a network connection and GitHub sign-in; audio is streamed to the service."),
 			],
 			markdownDescription: nls.localize('dictation.model', "The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service."),

--- a/src/vs/workbench/contrib/chat/browser/speechToText/micButtonHovers.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/micButtonHovers.ts
@@ -7,6 +7,7 @@ import { IManagedHoverContent } from '../../../../../base/browser/ui/hover/hover
 import { escapeMarkdownSyntaxTokens, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../../platform/localTranscription/common/localTranscription.js';
 import { DICTATION_MAI_MODEL_ID, DICTATION_MODEL_SETTING } from './chatSpeechToTextService.js';
 
 /**
@@ -33,9 +34,13 @@ function asHoverContent(title: string, description: string): IManagedHoverConten
  */
 function getDictationDescription(configurationService: IConfigurationService): string {
 	const modelId = configurationService.getValue<string>(DICTATION_MODEL_SETTING)?.trim();
-	return modelId === DICTATION_MAI_MODEL_ID
-		? localize('dictation.hover.cloud', "Types what you say into the input. Transcribes in the cloud with the MAI speech model.")
-		: localize('dictation.hover.onDevice', "Types what you say into the input. Transcribes on-device with {0}.", modelId || localize('dictation.hover.defaultModel', "the dictation model"));
+	if (modelId === DICTATION_MAI_MODEL_ID) {
+		return localize('dictation.hover.cloud', "Types what you say into the input. Transcribes in the cloud with the MAI speech model.");
+	}
+	if (!modelId || modelId === DEFAULT_LOCAL_TRANSCRIPTION_MODEL) {
+		return localize('dictation.hover.nemotronMultilingual', "Types what you say into the input. Transcribes on-device with the Nemotron 3.5 ASR multilingual model.");
+	}
+	return localize('dictation.hover.onDevice', "Types what you say into the input. Transcribes on-device with {0}.", modelId);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/micButtonHovers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/micButtonHovers.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../../platform/localTranscription/common/localTranscription.js';
+import { DICTATION_MAI_MODEL_ID, DICTATION_MODEL_SETTING } from '../../browser/speechToText/chatSpeechToTextService.js';
+import { getDictationHoverMarkdown } from '../../browser/speechToText/micButtonHovers.js';
+
+suite('MicButtonHovers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses user-facing names for supported dictation models', () => {
+		const onDevice = new TestConfigurationService({ [DICTATION_MODEL_SETTING]: DEFAULT_LOCAL_TRANSCRIPTION_MODEL });
+		const cloud = new TestConfigurationService({ [DICTATION_MODEL_SETTING]: DICTATION_MAI_MODEL_ID });
+
+		assert.deepStrictEqual({
+			onDevice: getDictationHoverMarkdown('Dictate', onDevice).value,
+			cloud: getDictationHoverMarkdown('Dictate', cloud).value,
+		}, {
+			onDevice: '**Dictate**\n\nTypes what you say into the input. Transcribes on-device with the Nemotron 3.5 ASR multilingual model.',
+			cloud: '**Dictate**\n\nTypes what you say into the input. Transcribes in the cloud with the MAI speech model.',
+		});
+	});
+});


### PR DESCRIPTION
Use fresh localization keys for the multilingual Nemotron setting metadata so stale English-only translations cannot override the updated label and description. The dictation action hover now displays the supported models’ user-facing names instead of exposing the raw Nemotron model ID.

Fixes #328737

Tests: `./scripts/test.sh --grep MicButtonHovers`
Lint: file-scoped ESLint