### PR TITLE
chat: respect BYOK group names in agent host picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
@@ -70,7 +70,11 @@ export function getProviderGroupForModel(
 	languageModelsService: ILanguageModelsService,
 ): IProviderGroupInfo {
 	if (model.metadata.modelGroup) {
-		return { vendor: model.metadata.vendor, groupName: getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id) };
+		const byokGroup = model.metadata.byokModelIdentifier ? modelToGroup.get(model.metadata.byokModelIdentifier) : undefined;
+		return {
+			vendor: model.metadata.vendor,
+			groupName: byokGroup?.groupName ?? getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id),
+		};
 	}
 	return modelToGroup.get(model.identifier) ?? {
 		vendor: model.metadata.vendor,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
@@ -71,9 +71,9 @@ export function getProviderGroupForModel(
 ): IProviderGroupInfo {
 	if (model.metadata.modelGroup) {
 		const byokGroup = model.metadata.byokModelIdentifier ? modelToGroup.get(model.metadata.byokModelIdentifier) : undefined;
-		return {
+		return byokGroup ?? {
 			vendor: model.metadata.vendor,
-			groupName: byokGroup?.groupName ?? getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id),
+			groupName: getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id),
 		};
 	}
 	return modelToGroup.get(model.identifier) ?? {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -964,6 +964,27 @@ suite('buildModelPickerItems', () => {
 		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'GoogleBYOK']);
 	});
 
+	test('Other Models keeps identically named agent-host BYOK groups from different providers separate', () => {
+		const auto = createAutoModel();
+		const googleModelIdentifier = 'google/Default/gemini-2.5-pro';
+		const openaiModelIdentifier = 'openai/Default/gpt-5';
+		const google = createAgentHostModel('google/gemini-2.5-pro', 'Gemini 2.5 Pro', { id: 'google' });
+		const openai = createAgentHostModel('openai/gpt-5', 'GPT-5', { id: 'openai' });
+		const service = createLanguageModelsServiceStub([
+			{ vendor: 'google', displayName: 'Google', groups: [{ name: 'Default', modelIdentifiers: [googleModelIdentifier] }] },
+			{ vendor: 'openai', displayName: 'OpenAI', groups: [{ name: 'Default', modelIdentifiers: [openaiModelIdentifier] }] },
+		]);
+
+		const items = callBuild([
+			auto,
+			{ ...google, metadata: { ...google.metadata, byokModelIdentifier: googleModelIdentifier } },
+			{ ...openai, metadata: { ...openai.metadata, byokModelIdentifier: openaiModelIdentifier } },
+		], { languageModelsService: service });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Default', 'Default']);
+	});
+
 	test('Other Models keeps a single section when agent-host models share one modelGroup', () => {
 		const auto = createAutoModel();
 		const a = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -944,6 +944,26 @@ suite('buildModelPickerItems', () => {
 		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'Hugging Face', 'OpenAI']);
 	});
 
+	test('Other Models respects the configured BYOK group name for agent-host models', () => {
+		const auto = createAutoModel();
+		const cli = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });
+		const googleModelIdentifier = 'google/GoogleBYOK/gemini-2.5-pro';
+		const google = createAgentHostModel('google/gemini-2.5-pro', 'Gemini 2.5 Pro', { id: 'google' });
+		const googleWithByokIdentifier = {
+			...google,
+			metadata: { ...google.metadata, byokModelIdentifier: googleModelIdentifier },
+		};
+		const service = createLanguageModelsServiceStub([
+			{ vendor: 'copilotcli', displayName: 'Copilot CLI', groups: [] },
+			{ vendor: 'google', displayName: 'Google', groups: [{ name: 'GoogleBYOK', modelIdentifiers: [googleModelIdentifier] }] },
+		]);
+
+		const items = callBuild([auto, cli, googleWithByokIdentifier], { languageModelsService: service });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'GoogleBYOK']);
+	});
+
 	test('Other Models keeps a single section when agent-host models share one modelGroup', () => {
 		const auto = createAutoModel();
 		const a = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });


### PR DESCRIPTION
## Summary

- resolve agent-host BYOK models against their configured provider group
- preserve the generic vendor label as a fallback
- add regression coverage for custom group names

Fixes microsoft/vscode-internalbacklog#8709