### PR TITLE
Remove stray merge conflict marker in sessionState.ts

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1169,7 +1169,6 @@ export interface ISessionGitHubState {
 	/** The URL of the GitHub pull request. */
 	readonly pullRequestUrl?: string;
 	/**
-<<<<<<< HEAD
 	 * URLs of the GitHub issues referenced by the session's user messages, in
 	 * order of first appearance.
 	 */


### PR DESCRIPTION
A `<<<<<<< HEAD` merge conflict marker was accidentally committed inside the JSDoc comment of `ISessionGitHubState.issueUrls` in `src/vs/platform/agentHost/common/state/sessionState.ts`. This removes it. No other markers or lost declarations remain.