### PR TITLE
agentHost: complete Auto router telemetry mapping

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -280,6 +280,15 @@ export interface IAgentHostAutoModeRouterDecisionReport {
 	confidence: number | undefined;
 	candidateModels: readonly string[] | undefined;
 	categoryScores: Readonly<Record<string, number | undefined>> | undefined;
+	routingMethod: string | undefined;
+	availableModels: readonly string[] | undefined;
+	fallback: boolean | undefined;
+	fallbackReason: string | undefined;
+	stickyOverride: boolean | undefined;
+	routerLatencyMs: number | undefined;
+	endToEndLatencyMs: number | undefined;
+	chosenShortfall: number | undefined;
+	hasImage: boolean | undefined;
 }
 
 export interface IAgentHostSkillContentReadReport {
@@ -592,11 +601,7 @@ export class AgentHostTelemetryReporter {
 		});
 	}
 
-	/**
-	 * Emits the subset of the extension's restricted `automode.routerDecisionRestricted` event
-	 * available from the SDK's `session.auto_mode_resolved` event. Router-only fields that the SDK
-	 * does not expose are omitted rather than synthesized.
-	 */
+	/** Emits the extension's restricted `automode.routerDecisionRestricted` event from authoritative SDK fields. */
 	autoModeRouterDecision(report: IAgentHostAutoModeRouterDecisionReport): void {
 		const restricted = this._restricted;
 		if (!restricted) {
@@ -612,15 +617,25 @@ export class AgentHostTelemetryReporter {
 			vscodeRequestId: report.turnId,
 			initiatorClientType: report.clientType,
 			...(report.predictedLabel !== undefined ? { predictedLabel: report.predictedLabel } : {}),
+			...(report.routingMethod !== undefined ? { routingMethod: report.routingMethod } : {}),
+			...(report.fallback !== undefined ? { fallback: String(report.fallback) } : {}),
+			...(report.fallbackReason !== undefined ? { fallbackReason: report.fallbackReason } : {}),
 			candidateModel: candidateModels[0] ?? '',
 			chosenModel: report.chosenModel,
 			candidateModels: JSON.stringify(candidateModels),
+			...(report.availableModels !== undefined ? { availableModels: JSON.stringify(report.availableModels) } : {}),
+			...(report.stickyOverride !== undefined ? { stickyOverrideStr: String(report.stickyOverride) } : {}),
+			...(report.hasImage !== undefined ? { hasImage: String(report.hasImage) } : {}),
 			...(scoreKeys.length > 0 ? {
 				[isBinary ? 'binaryScores' : 'hydraScores']: JSON.stringify(categoryScores),
 			} : {}),
 		};
 		const measurements = {
 			...(report.confidence !== undefined ? { confidence: report.confidence } : {}),
+			...(report.routerLatencyMs !== undefined ? { latencyMs: report.routerLatencyMs } : {}),
+			...(report.endToEndLatencyMs !== undefined ? { e2eLatencyMs: report.endToEndLatencyMs } : {}),
+			...(report.stickyOverride !== undefined ? { stickyOverride: report.stickyOverride ? 1 : 0 } : {}),
+			...(report.chosenShortfall !== undefined ? { chosenShortfall: report.chosenShortfall } : {}),
 			...(categoryScores.needs_reasoning !== undefined ? { scoreNeedsReasoning: categoryScores.needs_reasoning } : {}),
 			...(categoryScores.no_reasoning !== undefined ? { scoreNoReasoning: categoryScores.no_reasoning } : {}),
 		};

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4222,6 +4222,15 @@ export class CopilotAgentSession extends Disposable {
 					confidence: e.data.confidence,
 					candidateModels: e.data.candidateModels,
 					categoryScores: e.data.categoryScores,
+					routingMethod: e.data.routingMethod,
+					availableModels: e.data.availableModels,
+					fallback: e.data.fallback,
+					fallbackReason: e.data.fallbackReason,
+					stickyOverride: e.data.stickyOverride,
+					routerLatencyMs: e.data.routerLatencyMs,
+					endToEndLatencyMs: e.data.endToEndLatencyMs,
+					chosenShortfall: e.data.chosenShortfall,
+					hasImage: e.data.hasImage,
 				});
 			}
 			autoModeResolved = { turnId, data: e.data };

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -317,7 +317,7 @@ suite('AgentHostTelemetryReporter', () => {
 		}]);
 	});
 
-	test('autoModeRouterDecision maps the SDK Hydra and binary score shapes without inventing unavailable fields', () => {
+	test('autoModeRouterDecision maps authoritative SDK router fields and score shapes without deriving values', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
@@ -330,6 +330,15 @@ suite('AgentHostTelemetryReporter', () => {
 			confidence: 0.9,
 			candidateModels: ['gpt-5', 'gpt-4.1'],
 			categoryScores: { reasoning: 0.8, code_gen: 0.7, debugging: 0.6, tool_use: 0.5 },
+			routingMethod: 'hydra',
+			availableModels: ['gpt-5', 'gpt-4.1', 'gpt-5-mini'],
+			fallback: false,
+			fallbackReason: 'not-needed',
+			stickyOverride: true,
+			routerLatencyMs: 25,
+			endToEndLatencyMs: 40,
+			chosenShortfall: 0.05,
+			hasImage: true,
 		});
 		reporter.autoModeRouterDecision({
 			session,
@@ -340,6 +349,15 @@ suite('AgentHostTelemetryReporter', () => {
 			confidence: undefined,
 			candidateModels: undefined,
 			categoryScores: { needs_reasoning: 0.2, no_reasoning: 0.8 },
+			routingMethod: undefined,
+			availableModels: undefined,
+			fallback: undefined,
+			fallbackReason: undefined,
+			stickyOverride: undefined,
+			routerLatencyMs: undefined,
+			endToEndLatencyMs: undefined,
+			chosenShortfall: undefined,
+			hasImage: undefined,
 		});
 
 		assert.deepStrictEqual({ events: service.enhancedEvents, measurements: service.enhancedMeasurements }, {
@@ -350,9 +368,15 @@ suite('AgentHostTelemetryReporter', () => {
 					vscodeRequestId: 'turn-hydra',
 					initiatorClientType: 'editor_window',
 					predictedLabel: 'high',
+					routingMethod: 'hydra',
+					fallback: 'false',
+					fallbackReason: 'not-needed',
 					candidateModel: 'gpt-5',
 					chosenModel: 'gpt-5',
 					candidateModels: JSON.stringify(['gpt-5', 'gpt-4.1']),
+					availableModels: JSON.stringify(['gpt-5', 'gpt-4.1', 'gpt-5-mini']),
+					stickyOverrideStr: 'true',
+					hasImage: 'true',
 					hydraScores: JSON.stringify({ reasoning: 0.8, code_gen: 0.7, debugging: 0.6, tool_use: 0.5 }),
 				},
 			}, {
@@ -368,7 +392,7 @@ suite('AgentHostTelemetryReporter', () => {
 					binaryScores: JSON.stringify({ needs_reasoning: 0.2, no_reasoning: 0.8 }),
 				},
 			}],
-			measurements: [{ confidence: 0.9 }, { scoreNeedsReasoning: 0.2, scoreNoReasoning: 0.8 }],
+			measurements: [{ confidence: 0.9, latencyMs: 25, e2eLatencyMs: 40, stickyOverride: 1, chosenShortfall: 0.05 }, { scoreNeedsReasoning: 0.2, scoreNoReasoning: 0.8 }],
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -377,7 +377,7 @@ class CapturingRestrictedTelemetryService implements ITelemetryService, IAgentHo
 	readonly sqmId = 'sqmId';
 	readonly devDeviceId = 'devDeviceId';
 	readonly firstSessionDate = 'firstSessionDate';
-	readonly events: Array<{ destination: 'enhanced' | 'internal'; eventName: string; properties: TelemetryProps | undefined }> = [];
+	readonly events: Array<{ destination: 'enhanced' | 'internal'; eventName: string; properties: TelemetryProps | undefined; measurements?: TelemetryMeasurements }> = [];
 
 	publicLog(): void { }
 	publicLog2(): void { }
@@ -386,17 +386,17 @@ class CapturingRestrictedTelemetryService implements ITelemetryService, IAgentHo
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
 	sendGHTelemetryEvent(): void { }
-	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, _measurements?: TelemetryMeasurements): void {
-		this.events.push({ destination: 'enhanced', eventName, properties });
+	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this.events.push({ destination: 'enhanced', eventName, properties, ...(measurements ? { measurements } : {}) });
 	}
-	sendEnhancedGHTelemetryEventForContext(_context: IAgentHostRestrictedTelemetryContext, eventName: string, properties?: TelemetryProps): void {
-		this.events.push({ destination: 'enhanced', eventName, properties });
+	sendEnhancedGHTelemetryEventForContext(_context: IAgentHostRestrictedTelemetryContext, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this.events.push({ destination: 'enhanced', eventName, properties, ...(measurements ? { measurements } : {}) });
 	}
-	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, _measurements?: TelemetryMeasurements): void {
-		this.events.push({ destination: 'internal', eventName, properties });
+	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this.events.push({ destination: 'internal', eventName, properties, ...(measurements ? { measurements } : {}) });
 	}
-	sendInternalMSFTTelemetryEventForContext(_context: IAgentHostInternalTelemetryContext, eventName: string, properties?: TelemetryProps): void {
-		this.events.push({ destination: 'internal', eventName, properties });
+	sendInternalMSFTTelemetryEventForContext(_context: IAgentHostInternalTelemetryContext, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this.events.push({ destination: 'internal', eventName, properties, ...(measurements ? { measurements } : {}) });
 	}
 	setCopilotTrackingId(): void { }
 	setRestrictedTelemetryEndpoint(): void { }

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -8561,21 +8561,45 @@ suite('CopilotAgentSession', () => {
 				confidence: 0.91,
 				candidateModels: ['gpt-5', 'gpt-4.1'],
 				categoryScores: { needs_reasoning: 0.9, no_reasoning: 0.1 },
+				routingMethod: 'binary',
+				availableModels: ['gpt-5', 'gpt-4.1', 'gpt-5-mini'],
+				fallback: false,
+				fallbackReason: 'not-needed',
+				stickyOverride: true,
+				routerLatencyMs: 25,
+				endToEndLatencyMs: 40,
+				chosenShortfall: 0.05,
+				hasImage: true,
 			} as SessionEventPayload<'session.auto_mode_resolved'>['data']);
 
 			assert.deepStrictEqual(telemetryService.events
 				.filter(event => event.eventName === 'automode.routerDecisionRestricted')
-				.map(event => ({ destination: event.destination, properties: event.properties })), [{
+				.map(event => ({ destination: event.destination, properties: event.properties, measurements: event.measurements })), [{
 					destination: 'enhanced',
 					properties: {
 						conversationId: 'test-session-1',
 						vscodeRequestId: 'turn-auto',
 						initiatorClientType: 'agents_window',
 						predictedLabel: 'needs_reasoning',
+						routingMethod: 'binary',
+						fallback: 'false',
+						fallbackReason: 'not-needed',
 						candidateModel: 'gpt-5',
 						chosenModel: 'gpt-5',
 						candidateModels: JSON.stringify(['gpt-5', 'gpt-4.1']),
+						availableModels: JSON.stringify(['gpt-5', 'gpt-4.1', 'gpt-5-mini']),
+						stickyOverrideStr: 'true',
+						hasImage: 'true',
 						binaryScores: JSON.stringify({ needs_reasoning: 0.9, no_reasoning: 0.1 }),
+					},
+					measurements: {
+						confidence: 0.91,
+						latencyMs: 25,
+						e2eLatencyMs: 40,
+						stickyOverride: 1,
+						chosenShortfall: 0.05,
+						scoreNeedsReasoning: 0.9,
+						scoreNoReasoning: 0.1,
 					},
 				}]);
 		});


### PR DESCRIPTION
## Overview

Complete Agent Host parity for the restricted `automode.routerDecisionRestricted` event now that VS Code has adopted SDK 1.0.9-preview.1/runtime 1.0.77.

Maps the authoritative `session.auto_mode_resolved` fields directly:

- routing method and available models
- fallback state and reason
- sticky override
- router and end-to-end latency
- chosen-model shortfall
- image presence

`routingMethod` is never derived from score shape. Existing candidate/model and Hydra/binary score mappings remain unchanged.

Runtime/SDK support:

- [github/copilot-agent-runtime#13904](https://github.com/github/copilot-agent-runtime/pull/13904)
- [github/copilot-agent-runtime#14004](https://github.com/github/copilot-agent-runtime/pull/14004)

Validation:

- full `npm run compile`
- full node unit suite (13,202 passing; 192 pending)
- targeted ESLint for all changed files
- pre-commit hygiene

Related to [microsoft/vscode-internalbacklog#8247](https://github.com/microsoft/vscode-internalbacklog/issues/8247) and follows [microsoft/vscode#327738](https://github.com/microsoft/vscode/pull/327738).
