### PR TITLE
Implement end-to-end BYOK image support and regression tests

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -25,9 +25,11 @@ export interface IByokLmTextPart {
 	readonly text: string;
 }
 
+export type ByokLmImageMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp' | 'image/bmp';
+
 export interface IByokLmImagePart {
 	readonly type: 'image';
-	readonly mimeType: string;
+	readonly mimeType: ByokLmImageMimeType;
 	readonly data: string;
 }
 

--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -25,10 +25,18 @@ export interface IByokLmTextPart {
 	readonly text: string;
 }
 
+export interface IByokLmImagePart {
+	readonly type: 'image';
+	readonly mimeType: string;
+	readonly data: string;
+}
+
+export type IByokLmContentPart = IByokLmTextPart | IByokLmImagePart;
+
 export interface IByokLmMessageItem {
 	readonly type: 'message';
 	readonly role: 'system' | 'developer' | 'user' | 'assistant';
-	readonly content: IByokLmTextPart[];
+	readonly content: IByokLmContentPart[];
 }
 
 export interface IByokLmReasoningItem {

--- a/src/vs/platform/agentHost/node/copilot/byokResponsesTranslation.ts
+++ b/src/vs/platform/agentHost/node/copilot/byokResponsesTranslation.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { decodeBase64 } from '../../../../base/common/buffer.js';
 import {
 	IByokLmChatRequest,
 	IByokLmChatResult,
+	IByokLmContentPart,
 	IByokLmInputItem,
 	IByokLmOutputItem,
 	IByokLmTool,
@@ -14,6 +16,7 @@ import {
 interface IResponsesContentPart {
 	readonly type?: string;
 	readonly text?: string;
+	readonly image_url?: string;
 }
 
 interface IResponsesSummaryPart {
@@ -71,7 +74,7 @@ function toBridgeRole(role: string | undefined): 'system' | 'developer' | 'user'
 	}
 }
 
-function toTextParts(content: string | IResponsesContentPart[] | undefined, itemIndex: number): Array<{ type: 'text'; text: string }> {
+function toContentParts(content: string | IResponsesContentPart[] | undefined, itemIndex: number): IByokLmContentPart[] {
 	if (typeof content === 'string') {
 		return content ? [{ type: 'text', text: content }] : [];
 	}
@@ -81,6 +84,22 @@ function toTextParts(content: string | IResponsesContentPart[] | undefined, item
 	return content.map((part, contentIndex) => {
 		if ((part.type === 'input_text' || part.type === 'output_text' || part.type === 'text') && typeof part.text === 'string') {
 			return { type: 'text' as const, text: part.text };
+		}
+		if (part.type === 'input_image' && typeof part.image_url === 'string') {
+			const match = /^data:(?<mimeType>image\/[^;,]+)(?:;[^,]*)?;base64,(?<data>.*)$/.exec(part.image_url);
+			if (match?.groups) {
+				try {
+					decodeBase64(match.groups.data);
+				} catch {
+					throw new ResponsesTranslationError(`Invalid input[${itemIndex}].content[${contentIndex}].image_url`);
+				}
+				return {
+					type: 'image' as const,
+					mimeType: match.groups.mimeType,
+					data: match.groups.data,
+				};
+			}
+			throw new ResponsesTranslationError(`Unsupported input[${itemIndex}].content[${contentIndex}].image_url`);
 		}
 		throw new ResponsesTranslationError(`Unsupported input[${itemIndex}].content[${contentIndex}] type '${part.type ?? ''}'`);
 	});
@@ -99,7 +118,7 @@ function toBridgeInputItem(item: IResponsesInputItem, index: number): IByokLmInp
 			return {
 				type: 'message',
 				role: toBridgeRole(item.role),
-				content: toTextParts(item.content, index),
+				content: toContentParts(item.content, index),
 			};
 		case 'reasoning':
 			return {

--- a/src/vs/platform/agentHost/node/copilot/byokResponsesTranslation.ts
+++ b/src/vs/platform/agentHost/node/copilot/byokResponsesTranslation.ts
@@ -5,6 +5,7 @@
 
 import { decodeBase64 } from '../../../../base/common/buffer.js';
 import {
+	ByokLmImageMimeType,
 	IByokLmChatRequest,
 	IByokLmChatResult,
 	IByokLmContentPart,
@@ -22,6 +23,19 @@ interface IResponsesContentPart {
 interface IResponsesSummaryPart {
 	readonly type?: string;
 	readonly text?: string;
+}
+
+function isSupportedImageMimeType(mimeType: string): mimeType is ByokLmImageMimeType {
+	switch (mimeType) {
+		case 'image/png':
+		case 'image/jpeg':
+		case 'image/gif':
+		case 'image/webp':
+		case 'image/bmp':
+			return true;
+		default:
+			return false;
+	}
 }
 
 interface IResponsesInputItem {
@@ -88,6 +102,9 @@ function toContentParts(content: string | IResponsesContentPart[] | undefined, i
 		if (part.type === 'input_image' && typeof part.image_url === 'string') {
 			const match = /^data:(?<mimeType>image\/[^;,]+)(?:;[^,]*)?;base64,(?<data>.*)$/.exec(part.image_url);
 			if (match?.groups) {
+				if (!isSupportedImageMimeType(match.groups.mimeType)) {
+					throw new ResponsesTranslationError(`Unsupported input[${itemIndex}].content[${contentIndex}].image_url MIME type '${match.groups.mimeType}'`);
+				}
 				try {
 					decodeBase64(match.groups.data);
 				} catch {

--- a/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
@@ -210,7 +210,7 @@ suite('ByokLmProxyService', () => {
 			async () => ({ output: [] }),
 			async handle => {
 				const responses: Array<{ status: number; body: unknown }> = [];
-				for (const imageUrl of ['https://example.com/image.png', 'data:image/png;base64,not valid']) {
+				for (const imageUrl of ['https://example.com/image.png', 'data:image/svg+xml;base64,PHN2Zz4=', 'data:image/png;base64,not valid']) {
 					const response = await fetch(responsesUrl(handle, 'gemini'), {
 						method: 'POST',
 						headers: authHeaders(handle),
@@ -232,6 +232,15 @@ suite('ByokLmProxyService', () => {
 						body: {
 							error: {
 								message: 'Unsupported input[0].content[0].image_url',
+								type: 'invalid_request_error',
+							},
+						},
+					},
+					{
+						status: 400,
+						body: {
+							error: {
+								message: 'Unsupported input[0].content[0].image_url MIME type \'image/svg+xml\'',
 								type: 'invalid_request_error',
 							},
 						},

--- a/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/byokLmProxyService.test.ts
@@ -138,6 +138,118 @@ suite('ByokLmProxyService', () => {
 		assert.deepStrictEqual(captured?.input, [{ type: 'message', role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
 	});
 
+	test('forwards image input on the initial and subsequent turns', async () => {
+		const captured: IByokLmChatRequest[] = [];
+		const statuses: number[] = [];
+		const imageMessage = {
+			type: 'message',
+			role: 'user',
+			content: [
+				{ type: 'input_text', text: 'What is in this image?' },
+				{ type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgo=' },
+			],
+		};
+
+		await withProxy(
+			async request => {
+				captured.push(request);
+				return { output: [] };
+			},
+			async handle => {
+				for (const input of [
+					[imageMessage],
+					[imageMessage, { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Try again without a new image.' }] }],
+				]) {
+					const response = await fetch(responsesUrl(handle, 'gemini'), {
+						method: 'POST',
+						headers: authHeaders(handle),
+						body: JSON.stringify({ model: 'gemini-3.6-flash', input }),
+					});
+					statuses.push(response.status);
+					await response.text();
+				}
+			},
+		);
+
+		assert.deepStrictEqual({ statuses, input: captured.map(request => request.input) }, {
+			statuses: [200, 200],
+			input: [
+				[
+					{
+						type: 'message',
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'What is in this image?' },
+							{ type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+						],
+					},
+				],
+				[
+					{
+						type: 'message',
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'What is in this image?' },
+							{ type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+						],
+					},
+					{
+						type: 'message',
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'Try again without a new image.' },
+						],
+					},
+				],
+			],
+		});
+	});
+
+	test('rejects image URLs that cannot be forwarded as inline data', async () => {
+		await withProxy(
+			async () => ({ output: [] }),
+			async handle => {
+				const responses: Array<{ status: number; body: unknown }> = [];
+				for (const imageUrl of ['https://example.com/image.png', 'data:image/png;base64,not valid']) {
+					const response = await fetch(responsesUrl(handle, 'gemini'), {
+						method: 'POST',
+						headers: authHeaders(handle),
+						body: JSON.stringify({
+							model: 'gemini-3.6-flash',
+							input: [{
+								type: 'message',
+								role: 'user',
+								content: [{ type: 'input_image', image_url: imageUrl }],
+							}],
+						}),
+					});
+					responses.push({ status: response.status, body: await response.json() });
+				}
+
+				assert.deepStrictEqual(responses, [
+					{
+						status: 400,
+						body: {
+							error: {
+								message: 'Unsupported input[0].content[0].image_url',
+								type: 'invalid_request_error',
+							},
+						},
+					},
+					{
+						status: 400,
+						body: {
+							error: {
+								message: 'Invalid input[0].content[0].image_url',
+								type: 'invalid_request_error',
+							},
+						},
+					},
+				]);
+			},
+		);
+	});
+
 	test('forwards custom tool call history with freeform input', async () => {
 		let captured: IByokLmChatRequest | undefined;
 		await withProxy(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
@@ -8,6 +8,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { decodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import {
+	ByokLmImageMimeType,
 	IAgentHostByokLmHandler,
 	IByokLmChatRequest,
 	IByokLmChatResult,
@@ -269,10 +270,25 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 					result.push({ type: 'text', value: part.text });
 				}
 			} else {
-				result.push({ type: 'image_url', value: { mimeType: part.mimeType as ChatImageMimeType, data: decodeBase64(part.data) } });
+				result.push({ type: 'image_url', value: { mimeType: this._toChatImageMimeType(part.mimeType), data: decodeBase64(part.data) } });
 			}
 		}
 		return result.length ? result : [{ type: 'text', value: '' }];
+	}
+
+	private _toChatImageMimeType(mimeType: ByokLmImageMimeType): ChatImageMimeType {
+		switch (mimeType) {
+			case 'image/png':
+				return ChatImageMimeType.PNG;
+			case 'image/jpeg':
+				return ChatImageMimeType.JPEG;
+			case 'image/gif':
+				return ChatImageMimeType.GIF;
+			case 'image/webp':
+				return ChatImageMimeType.WEBP;
+			case 'image/bmp':
+				return ChatImageMimeType.BMP;
+		}
 	}
 
 	private _appendTextOutput(output: IByokLmOutputItem[], value: string): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
@@ -6,11 +6,12 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { decodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import {
 	IAgentHostByokLmHandler,
 	IByokLmChatRequest,
 	IByokLmChatResult,
+	IByokLmContentPart,
 	IByokLmInputItem,
 	IByokLmModelInfo,
 	IByokLmOutputItem,
@@ -18,6 +19,7 @@ import {
 } from '../../../../../../platform/agentHost/common/agentHostByokLm.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import {
+	ChatImageMimeType,
 	ChatMessageRole,
 	IChatMessage,
 	IChatMessagePart,
@@ -207,7 +209,7 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 			case 'message':
 				return {
 					role: this._toChatRole(item.role),
-					content: [{ type: 'text', value: item.content.map(part => part.text).join('') }],
+					content: this._toChatMessageParts(item.content),
 				};
 			case 'reasoning': {
 				return {
@@ -254,6 +256,23 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 					}],
 				};
 		}
+	}
+
+	private _toChatMessageParts(parts: IByokLmContentPart[]): IChatMessagePart[] {
+		const result: IChatMessagePart[] = [];
+		for (const part of parts) {
+			if (part.type === 'text') {
+				const previous = result.at(-1);
+				if (previous?.type === 'text') {
+					previous.value += part.text;
+				} else {
+					result.push({ type: 'text', value: part.text });
+				}
+			} else {
+				result.push({ type: 'image_url', value: { mimeType: part.mimeType as ChatImageMimeType, data: decodeBase64(part.data) } });
+			}
+		}
+		return result.length ? result : [{ type: 'text', value: '' }];
 	}
 
 	private _appendTextOutput(output: IByokLmOutputItem[], value: string): void {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
@@ -251,7 +251,14 @@ suite('AgentHostByokLmHandler', () => {
 					{ type: 'custom_tool_call', callId: 't2', name: 'apply_patch', input: 'patch' },
 					{ type: 'function_call_output', callId: 't1', output: 'sunny' },
 					{ type: 'custom_tool_call_output', callId: 't2', output: 'Done!' },
-					{ type: 'message', role: 'user', content: [{ type: 'text', text: 'hi' }] },
+					{
+						type: 'message',
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'hi' },
+							{ type: 'image', mimeType: 'image/png', data: 'aW1hZ2U=' },
+						],
+					},
 				],
 			},
 			CancellationToken.None,
@@ -280,7 +287,13 @@ suite('AgentHostByokLmHandler', () => {
 				},
 				{ role: ChatMessageRole.User, content: [{ type: 'tool_result', toolCallId: 't1', value: [{ type: 'text', value: 'sunny' }] }] },
 				{ role: ChatMessageRole.User, content: [{ type: 'tool_result', toolCallId: 't2', value: [{ type: 'text', value: 'Done!' }] }] },
-				{ role: ChatMessageRole.User, content: [{ type: 'text', value: 'hi' }] },
+				{
+					role: ChatMessageRole.User,
+					content: [
+						{ type: 'text', value: 'hi' },
+						{ type: 'image_url', value: { mimeType: 'image/png', data: VSBuffer.fromString('image') } },
+					],
+				},
 			],
 			options: {
 				modelOptions: { temperature: 0.5 },


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/8710
This pull request implements end-to-end support for BYOK image handling in the Gemini provider, addressing the issue where image inputs were causing failures in conversation history. Key changes include:

- **Bridge DTO Extension**: The bridge now carries base64 image data, allowing it to be processed correctly.
- **Response Translation**: Adjustments ensure that `input_image` data URLs are translated into proper image parts.
- **Renderer Conversion**: The renderer decodes images into standard `image_url` chat parts, preserving resizing and limits.
- **Regression Tests**: Added tests to reproduce the initial HTTP 400 error for image requests and subsequent failures due to poisoned history.

Validation steps confirmed that all affected unit tests passed, and hygiene checks were successful. This implementation ensures that images can be handled correctly in conversations, preventing previous issues from recurring.