### PR TITLE
Dialogs: Preserve arrow keys in editable controls

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -5,7 +5,7 @@
 
 import './dialog.css';
 import { localize } from '../../../../nls.js';
-import { $, addDisposableListener, addStandardDisposableListener, clearNode, EventHelper, EventType, getWindow, hide, isActiveElement, isAncestor, show } from '../../dom.js';
+import { $, addDisposableListener, addStandardDisposableListener, clearNode, EventHelper, EventType, getWindow, hide, isActiveElement, isAncestor, isEditableElement, isHTMLElement, show } from '../../dom.js';
 import { StandardKeyboardEvent } from '../../keyboardEvent.js';
 import { ActionBar } from '../actionbar/actionbar.js';
 import { ButtonBar, ButtonBarAlignment, ButtonWithDescription, ButtonWithDropdown, IButton, IButtonStyles, IButtonWithDropdownOptions } from '../button/button.js';
@@ -386,7 +386,9 @@ export class Dialog extends Disposable {
 				let eventHandled = false;
 
 				// Focus: Next / Previous
-				if (evt.equals(KeyCode.Tab) || evt.equals(KeyCode.RightArrow) || evt.equals(KeyMod.Shift | KeyCode.Tab) || evt.equals(KeyCode.LeftArrow)) {
+				const isArrowNavigation = evt.equals(KeyCode.RightArrow) || evt.equals(KeyCode.LeftArrow);
+				const isEditableTarget = isHTMLElement(e.target) && isEditableElement(e.target);
+				if (evt.equals(KeyCode.Tab) || evt.equals(KeyMod.Shift | KeyCode.Tab) || isArrowNavigation && !isEditableTarget) {
 
 					// Build a list of focusable elements in their visual order
 					const focusableElements: { focus: () => void }[] = [];

--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -387,7 +387,7 @@ export class Dialog extends Disposable {
 
 				// Focus: Next / Previous
 				const isArrowNavigation = evt.equals(KeyCode.RightArrow) || evt.equals(KeyCode.LeftArrow);
-				const isEditableTarget = isHTMLElement(e.target) && isEditableElement(e.target);
+				const isEditableTarget = isHTMLElement(e.target) && (isEditableElement(e.target) || e.target.isContentEditable);
 				if (evt.equals(KeyCode.Tab) || evt.equals(KeyMod.Shift | KeyCode.Tab) || isArrowNavigation && !isEditableTarget) {
 
 					// Build a list of focusable elements in their visual order

--- a/src/vs/base/test/browser/ui/dialog/dialog.test.ts
+++ b/src/vs/base/test/browser/ui/dialog/dialog.test.ts
@@ -38,9 +38,12 @@ suite('Dialog', () => {
 		const container = append(document.body, $('.test-dialog-container'));
 		disposables.add(toDisposable(() => container.remove()));
 		let textarea!: HTMLTextAreaElement;
+		let contentEditable!: HTMLDivElement;
 		const dialog = disposables.add(new Dialog(container, 'Message', ['Save', 'Cancel'], {
 			renderBody: body => {
 				textarea = append(body, $('textarea'));
+				contentEditable = append(body, $('div'));
+				contentEditable.contentEditable = 'true';
 			},
 			buttonStyles: unthemedButtonStyles,
 			checkboxStyles: unthemedCheckboxStyles,
@@ -48,17 +51,23 @@ suite('Dialog', () => {
 			dialogStyles: unthemedDialogStyles,
 		}));
 		const result = dialog.show();
-		textarea.focus();
 
-		const event = new (getWindow(textarea).KeyboardEvent)('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-		textarea.dispatchEvent(event);
+		const dispatchArrowRight = (target: HTMLElement) => {
+			target.focus();
+			const event = new (getWindow(target).KeyboardEvent)('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+			target.dispatchEvent(event);
+			return {
+				activeElement: getWindow(target).document.activeElement,
+				defaultPrevented: event.defaultPrevented,
+			};
+		};
 
 		assert.deepStrictEqual({
-			activeElement: getWindow(textarea).document.activeElement,
-			defaultPrevented: event.defaultPrevented,
+			textarea: dispatchArrowRight(textarea),
+			contentEditable: dispatchArrowRight(contentEditable),
 		}, {
-			activeElement: textarea,
-			defaultPrevented: false,
+			textarea: { activeElement: textarea, defaultPrevented: false },
+			contentEditable: { activeElement: contentEditable, defaultPrevented: false },
 		});
 
 		dialog.dispose();

--- a/src/vs/base/test/browser/ui/dialog/dialog.test.ts
+++ b/src/vs/base/test/browser/ui/dialog/dialog.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { $, append, getWindow } from '../../../../browser/dom.js';
+import { unthemedButtonStyles } from '../../../../browser/ui/button/button.js';
+import { Dialog, IDialogStyles } from '../../../../browser/ui/dialog/dialog.js';
+import { unthemedInboxStyles } from '../../../../browser/ui/inputbox/inputBox.js';
+import { ICheckboxStyles } from '../../../../browser/ui/toggle/toggle.js';
+import { toDisposable } from '../../../../common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
+
+const unthemedDialogStyles: IDialogStyles = {
+	dialogForeground: undefined,
+	dialogBackground: undefined,
+	dialogShadow: undefined,
+	dialogBorder: undefined,
+	errorIconForeground: undefined,
+	warningIconForeground: undefined,
+	infoIconForeground: undefined,
+	textLinkForeground: undefined,
+};
+
+const unthemedCheckboxStyles: ICheckboxStyles = {
+	checkboxBackground: undefined,
+	checkboxBorder: undefined,
+	checkboxForeground: undefined,
+	checkboxDisabledBackground: undefined,
+	checkboxDisabledForeground: undefined,
+};
+
+suite('Dialog', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('keeps horizontal arrow keys in editable custom body controls', async () => {
+		const container = append(document.body, $('.test-dialog-container'));
+		disposables.add(toDisposable(() => container.remove()));
+		let textarea!: HTMLTextAreaElement;
+		const dialog = disposables.add(new Dialog(container, 'Message', ['Save', 'Cancel'], {
+			renderBody: body => {
+				textarea = append(body, $('textarea'));
+			},
+			buttonStyles: unthemedButtonStyles,
+			checkboxStyles: unthemedCheckboxStyles,
+			inputBoxStyles: unthemedInboxStyles,
+			dialogStyles: unthemedDialogStyles,
+		}));
+		const result = dialog.show();
+		textarea.focus();
+
+		const event = new (getWindow(textarea).KeyboardEvent)('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+		textarea.dispatchEvent(event);
+
+		assert.deepStrictEqual({
+			activeElement: getWindow(textarea).document.activeElement,
+			defaultPrevented: event.defaultPrevented,
+		}, {
+			activeElement: textarea,
+			defaultPrevented: false,
+		});
+
+		dialog.dispose();
+		await result;
+	});
+});


### PR DESCRIPTION
Prevent dialog focus navigation from consuming horizontal arrow keys when focus is inside an editable control (e.g. `<textarea>` or `<input>`) rendered in the dialog body, so users can move the caret within the field instead of jumping between buttons.

Required for the automation dialog to allow arrow key support for text fields within the dialog

Fixes #328743
Fixes #328732