### PR TITLE
agentHost: filter repo telemetry through content exclusion

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
@@ -294,17 +294,22 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		if (paths.length === 0) {
 			return [];
 		}
-		const result = await checkContentExclusion(paths);
-		if (!result.available || result.checks.length !== paths.length) {
+		let result: Awaited<ReturnType<RepoInfoContentExclusionChecker>>;
+		try {
+			result = await checkContentExclusion(paths);
+		} catch {
+			return [];
+		}
+		if (result.available !== true || !Array.isArray(result.checks) || result.checks.length !== paths.length) {
 			return [];
 		}
 		const allowedPaths = new Set<string>();
 		for (let index = 0; index < paths.length; index++) {
 			const check = result.checks[index];
-			if (check.path !== paths[index]) {
+			if (!check || typeof check.path !== 'string' || check.path !== paths[index] || typeof check.excluded !== 'boolean') {
 				return [];
 			}
-			if (!check.excluded) {
+			if (check.excluded === false) {
 				allowedPaths.add(check.path);
 			}
 		}

--- a/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts
@@ -5,7 +5,7 @@
 
 import { Limiter } from '../../../base/common/async.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { relativePath } from '../../../base/common/resources.js';
+import { joinPath, relativePath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
 import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
@@ -38,6 +38,10 @@ interface IRepoInfoFileDescriptor {
 }
 
 type RepoInfoTelemetryReporter = Pick<AgentHostTelemetryReporter, 'reportRepoInfo'>;
+export type RepoInfoContentExclusionChecker = (paths: readonly string[]) => Promise<{
+	readonly available: boolean;
+	readonly checks: readonly { readonly path: string; readonly excluded: boolean }[];
+}>;
 
 export interface IResolvedRepoInfoRemote {
 	readonly remoteUrl: string;
@@ -126,19 +130,19 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		super();
 	}
 
-	async reportBegin(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
+	async reportBegin(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean, checkContentExclusion?: RepoInfoContentExclusionChecker): Promise<void> {
 		let begin = this._beginResults.get(telemetryMessageId);
 		if (!begin) {
 			begin = {
 				clientType,
-				result: this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'begin', workingDirectory, baseBranch, isContextCurrent),
+				result: this._captureSafely(context, sessionUri, telemetryMessageId, clientType, 'begin', workingDirectory, baseBranch, isContextCurrent, checkContentExclusion),
 			};
 			this._beginResults.set(telemetryMessageId, begin);
 		}
 		await begin.result;
 	}
 
-	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<void> {
+	async reportEnd(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean, checkContentExclusion?: RepoInfoContentExclusionChecker): Promise<void> {
 		const begin = this._beginResults.get(telemetryMessageId);
 		if (!begin) {
 			return;
@@ -146,7 +150,7 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		try {
 			const beginResult = await begin.result;
 			if (beginResult === 'success' || beginResult === 'noChanges') {
-				await this._captureSafely(context, sessionUri, telemetryMessageId, begin.clientType, 'end', workingDirectory, baseBranch, isContextCurrent);
+				await this._captureSafely(context, sessionUri, telemetryMessageId, begin.clientType, 'end', workingDirectory, baseBranch, isContextCurrent, checkContentExclusion);
 			}
 		} finally {
 			this._beginResults.delete(telemetryMessageId);
@@ -163,16 +167,16 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		super.dispose();
 	}
 
-	private async _captureSafely(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
+	private async _captureSafely(context: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, baseBranch: string | undefined, isContextCurrent: () => boolean, checkContentExclusion?: RepoInfoContentExclusionChecker): Promise<AgentHostRepoInfoResult | undefined> {
 		try {
-			return await this._capture(context, sessionUri, telemetryMessageId, clientType, location, workingDirectory, baseBranch, isContextCurrent);
+			return await this._capture(context, sessionUri, telemetryMessageId, clientType, location, workingDirectory, baseBranch, isContextCurrent, checkContentExclusion);
 		} catch (error) {
 			this._logService.warn(`[AgentHostRepoInfoTelemetry] Failed to capture ${location} repo info: ${error instanceof Error ? error.message : String(error)}`);
 			return undefined;
 		}
 	}
 
-	private async _capture(telemetryContext: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, persistedBaseBranch: string | undefined, isContextCurrent: () => boolean): Promise<AgentHostRepoInfoResult | undefined> {
+	private async _capture(telemetryContext: IAgentHostRestrictedTelemetryContext, sessionUri: string, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', workingDirectory: URI | undefined, persistedBaseBranch: string | undefined, isContextCurrent: () => boolean, checkContentExclusion?: RepoInfoContentExclusionChecker): Promise<AgentHostRepoInfoResult | undefined> {
 		if (!workingDirectory || !isContextCurrent() || (!telemetryContext.restrictedTelemetryEnabled && !telemetryContext.isInternal)) {
 			return undefined;
 		}
@@ -242,15 +246,15 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 			return undefined;
 		}
 		const resolvedDescriptors = descriptors as IRepoInfoFileDescriptor[];
-		const fileRelativePaths = JSON.stringify([...new Set(resolvedDescriptors.map(descriptor => descriptor.newPath ?? descriptor.oldPath).filter((path): path is string => path !== undefined))]);
-		// The SDK does not expose per-path exclusion decisions yet, so withhold patch content unless exclusion is explicitly disabled.
+		let allowedDescriptors = resolvedDescriptors;
 		if (telemetryContext.copilotIgnoreEnabled !== false) {
-			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, 0, fileRelativePaths);
+			allowedDescriptors = await this._filterContentExclusionAllowedDescriptors(repositoryRoot, resolvedDescriptors, checkContentExclusion);
 		}
+		const fileRelativePaths = JSON.stringify([...new Set(allowedDescriptors.map(descriptor => descriptor.newPath ?? descriptor.oldPath).filter((path): path is string => path !== undefined))]);
 		let patchTooLarge = false;
 		const limiter = new Limiter<{ readonly uri: string; readonly originalUri: string; readonly renameUri: string | undefined; readonly status: string; readonly diff: string }>(DIFF_PATCH_CONCURRENCY);
-		const diffs = await Promise.all(resolvedDescriptors.map(descriptor => limiter.queue(async () => {
-			const paths = [descriptor.oldPath, descriptor.newPath].filter((path): path is string => path !== undefined);
+		const diffs = await Promise.all(allowedDescriptors.map(descriptor => limiter.queue(async () => {
+			const paths = [...new Set([descriptor.oldPath, descriptor.newPath].filter((path): path is string => path !== undefined))];
 			const result = await this._gitService.getDiffPatchBetweenRefs(workingDirectory, { fromRef: headCommitHash, toRef: tree, paths, maxBuffer: MAX_DIFFS_JSON_BYTES });
 			if (!result) {
 				throw new Error(`Failed to compute diff for ${paths.join(', ')}`);
@@ -269,12 +273,44 @@ export class AgentHostRepoInfoTelemetry extends Disposable {
 		if (patchTooLarge) {
 			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, MAX_DIFFS_JSON_BYTES + 1, fileRelativePaths);
 		}
-		const diffsJSON = JSON.stringify(diffs);
+		const diffsJSON = diffs.length > 0 ? JSON.stringify(diffs) : undefined;
+		if (!diffsJSON) {
+			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, 0, fileRelativePaths);
+		}
 		const measurement = measureRepoInfoDiffsJSON(diffsJSON);
 		if (measurement.tooLarge) {
 			return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'diffTooLarge', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths);
 		}
 		return await this._reportIfTreeUnchanged(telemetryContext, isContextCurrent, telemetryMessageId, clientType, location, repoInfo, workingDirectory, tree, 'success', safety.workspaceFileCount, fileDiffs.length, measurement.diffSizeBytes, fileRelativePaths, diffsJSON);
+	}
+
+	private async _filterContentExclusionAllowedDescriptors(repositoryRoot: URI, descriptors: readonly IRepoInfoFileDescriptor[], checkContentExclusion: RepoInfoContentExclusionChecker | undefined): Promise<IRepoInfoFileDescriptor[]> {
+		if (!checkContentExclusion) {
+			return [];
+		}
+		const paths = [...new Set(descriptors.flatMap(descriptor => [descriptor.oldPath, descriptor.newPath]
+			.filter((path): path is string => path !== undefined)
+			.map(path => joinPath(repositoryRoot, path).fsPath)))];
+		if (paths.length === 0) {
+			return [];
+		}
+		const result = await checkContentExclusion(paths);
+		if (!result.available || result.checks.length !== paths.length) {
+			return [];
+		}
+		const allowedPaths = new Set<string>();
+		for (let index = 0; index < paths.length; index++) {
+			const check = result.checks[index];
+			if (check.path !== paths[index]) {
+				return [];
+			}
+			if (!check.excluded) {
+				allowedPaths.add(check.path);
+			}
+		}
+		return descriptors.filter(descriptor => [descriptor.oldPath, descriptor.newPath]
+			.filter((path): path is string => path !== undefined)
+			.every(path => allowedPaths.has(joinPath(repositoryRoot, path).fsPath)));
 	}
 
 	private async _reportIfTreeUnchanged(telemetryContext: IAgentHostRestrictedTelemetryContext, isContextCurrent: () => boolean, telemetryMessageId: string, clientType: AgentHostClientType, location: 'begin' | 'end', repoInfo: IRepoInfoContext, workingDirectory: URI, capturedTree: string, stableResult: 'success' | 'noChanges' | 'diffTooLarge', workspaceFileCount: number, changedFileCount: number, diffSizeBytes: number, fileRelativePaths?: string, diffsJSON?: string): Promise<AgentHostRepoInfoResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3465,7 +3465,7 @@ export class CopilotAgentSession extends Disposable {
 		if (!resolved || this._store.isDisposed || !isCurrent()) {
 			return undefined;
 		}
-		await this._repoInfoTelemetry.reportBegin(resolved.context, this.sessionUri.toString(), telemetryMessageId, clientType, this._workingDirectory, resolved.baseBranch, isCurrent);
+		await this._repoInfoTelemetry.reportBegin(resolved.context, this.sessionUri.toString(), telemetryMessageId, clientType, this._workingDirectory, resolved.baseBranch, isCurrent, paths => this._wrapper.session.rpc.contentExclusion.checkPaths({ paths: [...paths] }));
 		return resolved;
 	}
 
@@ -3473,7 +3473,7 @@ export class CopilotAgentSession extends Disposable {
 		if (!resolved || this._store.isDisposed || !isCurrent()) {
 			return;
 		}
-		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, this._workingDirectory, resolved.baseBranch, isCurrent);
+		await this._repoInfoTelemetry.reportEnd(resolved.context, this.sessionUri.toString(), telemetryMessageId, this._workingDirectory, resolved.baseBranch, isCurrent, paths => this._wrapper.session.rpc.contentExclusion.checkPaths({ paths: [...paths] }));
 	}
 
 	private _completeActiveRepoInfoTelemetry(): void {

--- a/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
@@ -211,6 +211,8 @@ suite('AgentHostRepoInfoTelemetry', () => {
 
 		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: true }, 'agent-session://copilot/s1', 'turn-0', AgentHostClientType.Unknown, root, undefined, () => true, async () => ({ available: false, checks: [] }));
 		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: undefined }, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.Unknown, root, undefined, () => true);
+		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: true }, 'agent-session://copilot/s1', 'turn-2', AgentHostClientType.Unknown, root, undefined, () => true, async () => { throw new Error('policy unavailable'); });
+		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: true }, 'agent-session://copilot/s1', 'turn-3', AgentHostClientType.Unknown, root, undefined, () => true, async () => ({ available: 'yes', checks: [{ path: '/repo/new.txt', excluded: null }] }) as never);
 
 		assert.deepStrictEqual({
 			patchCalls,
@@ -232,6 +234,16 @@ suite('AgentHostRepoInfoTelemetry', () => {
 				fileRelativePaths: JSON.stringify([]),
 				diffsJSON: undefined,
 				result: 'success',
+			}, {
+				repoId: 'microsoft/vscode',
+				fileRelativePaths: JSON.stringify([]),
+				diffsJSON: undefined,
+				result: 'success',
+			}, {
+				repoId: 'microsoft/vscode',
+				fileRelativePaths: JSON.stringify([]),
+				diffsJSON: undefined,
+				result: 'success',
 			}],
 		});
 	});
@@ -239,7 +251,8 @@ suite('AgentHostRepoInfoTelemetry', () => {
 	test('emits paths and patches only when every path for a change is allowed', async () => {
 		const root = URI.file('/repo');
 		const allowedUri = URI.joinPath(root, 'allowed.txt');
-		const excludedUri = URI.joinPath(root, 'excluded.txt');
+		const excludedOldUri = URI.joinPath(root, 'excluded-old.txt');
+		const excludedNewUri = URI.joinPath(root, 'excluded-new.txt');
 		const checkedPaths: string[][] = [];
 		const patchPaths: string[][] = [];
 		const reports: IAgentHostRepoInfoReport[] = [];
@@ -256,8 +269,8 @@ suite('AgentHostRepoInfoTelemetry', () => {
 				after: { uri: allowedUri.toString(), content: { uri: 'git-blob://allowed-after' } },
 				diff: { added: 1, removed: 1 },
 			}, {
-				before: { uri: excludedUri.toString(), content: { uri: 'git-blob://excluded-before' } },
-				after: { uri: excludedUri.toString(), content: { uri: 'git-blob://excluded-after' } },
+				before: { uri: excludedOldUri.toString(), content: { uri: 'git-blob://excluded-before' } },
+				after: { uri: excludedNewUri.toString(), content: { uri: 'git-blob://excluded-after' } },
 				diff: { added: 1, removed: 1 },
 			}],
 			getDiffPatchBetweenRefs: async (_cwd, options) => {
@@ -271,7 +284,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 			checkedPaths.push([...paths]);
 			return {
 				available: true,
-				checks: paths.map(path => ({ path, excluded: path === excludedUri.fsPath })),
+				checks: paths.map(path => ({ path, excluded: path === excludedOldUri.fsPath })),
 			};
 		});
 
@@ -281,7 +294,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 			fileRelativePaths: reports[0].fileRelativePaths,
 			diffs: JSON.parse(reports[0].diffsJSON ?? '[]').map((diff: { uri: string; diff: string }) => ({ uri: diff.uri, diff: diff.diff })),
 		}, {
-			checkedPaths: [[allowedUri.fsPath, excludedUri.fsPath]],
+			checkedPaths: [[allowedUri.fsPath, excludedOldUri.fsPath, excludedNewUri.fsPath]],
 			patchPaths: [['allowed.txt']],
 			fileRelativePaths: JSON.stringify(['allowed.txt']),
 			diffs: [{ uri: allowedUri.toString(), diff: 'allowed-patch' }],

--- a/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRepoInfoTelemetry.test.ts
@@ -188,7 +188,7 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		assert.deepStrictEqual({ snapshots, results: reports.map(report => report.result) }, { snapshots: 1, results: ['tooManyChanges'] });
 	});
 
-	test('withholds diff content when content exclusion is enabled or unknown', async () => {
+	test('fails closed when content exclusion is unavailable or no checker is provided', async () => {
 		const root = URI.file('/repo');
 		let patchCalls = 0;
 		const gitService: IAgentHostGitService = {
@@ -209,9 +209,8 @@ suite('AgentHostRepoInfoTelemetry', () => {
 		const reports: IAgentHostRepoInfoReport[] = [];
 		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
 
-		for (const [index, copilotIgnoreEnabled] of [true, undefined].entries()) {
-			await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled }, 'agent-session://copilot/s1', `turn-${index}`, AgentHostClientType.Unknown, root, undefined, () => true);
-		}
+		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: true }, 'agent-session://copilot/s1', 'turn-0', AgentHostClientType.Unknown, root, undefined, () => true, async () => ({ available: false, checks: [] }));
+		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: undefined }, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.Unknown, root, undefined, () => true);
 
 		assert.deepStrictEqual({
 			patchCalls,
@@ -225,15 +224,67 @@ suite('AgentHostRepoInfoTelemetry', () => {
 			patchCalls: 0,
 			reports: [{
 				repoId: 'microsoft/vscode',
-				fileRelativePaths: JSON.stringify(['new.txt']),
+				fileRelativePaths: JSON.stringify([]),
 				diffsJSON: undefined,
 				result: 'success',
 			}, {
 				repoId: 'microsoft/vscode',
-				fileRelativePaths: JSON.stringify(['new.txt']),
+				fileRelativePaths: JSON.stringify([]),
 				diffsJSON: undefined,
 				result: 'success',
 			}],
+		});
+	});
+
+	test('emits paths and patches only when every path for a change is allowed', async () => {
+		const root = URI.file('/repo');
+		const allowedUri = URI.joinPath(root, 'allowed.txt');
+		const excludedUri = URI.joinPath(root, 'excluded.txt');
+		const checkedPaths: string[][] = [];
+		const patchPaths: string[][] = [];
+		const reports: IAgentHostRepoInfoReport[] = [];
+		const gitService: IAgentHostGitService = {
+			...createNoopGitService(),
+			getRepositoryRoot: async () => root,
+			getSessionGitState: async () => ({ branchName: 'feature', baseBranchName: 'main' }),
+			getFetchRemoteUrls: async () => ['https://github.com/microsoft/vscode'],
+			resolveBranchBaselineCommit: async () => 'base',
+			getBranchDiffSafetyInfo: async () => ({ hasVirtualFileSystem: false, baselineCommitTimestamp: Date.now(), commitCount: 1, workspaceFileCount: 2 }),
+			captureWorkingTreeAsTree: async () => 'tree',
+			computeFileDiffsBetweenRefs: async () => [{
+				before: { uri: allowedUri.toString(), content: { uri: 'git-blob://allowed-before' } },
+				after: { uri: allowedUri.toString(), content: { uri: 'git-blob://allowed-after' } },
+				diff: { added: 1, removed: 1 },
+			}, {
+				before: { uri: excludedUri.toString(), content: { uri: 'git-blob://excluded-before' } },
+				after: { uri: excludedUri.toString(), content: { uri: 'git-blob://excluded-after' } },
+				diff: { added: 1, removed: 1 },
+			}],
+			getDiffPatchBetweenRefs: async (_cwd, options) => {
+				patchPaths.push([...options.paths]);
+				return { patch: 'allowed-patch', tooLarge: false };
+			},
+		};
+		const collector = disposables.add(new AgentHostRepoInfoTelemetry({ reportRepoInfo: async (_context, report) => { reports.push(report); } }, gitService, createTestGitHubEndpointService(), new NullLogService()));
+
+		await collector.reportBegin({ ...restrictedContext, copilotIgnoreEnabled: true }, 'agent-session://copilot/s1', 'turn-1', AgentHostClientType.EditorWindow, root, undefined, () => true, async paths => {
+			checkedPaths.push([...paths]);
+			return {
+				available: true,
+				checks: paths.map(path => ({ path, excluded: path === excludedUri.fsPath })),
+			};
+		});
+
+		assert.deepStrictEqual({
+			checkedPaths,
+			patchPaths,
+			fileRelativePaths: reports[0].fileRelativePaths,
+			diffs: JSON.parse(reports[0].diffsJSON ?? '[]').map((diff: { uri: string; diff: string }) => ({ uri: diff.uri, diff: diff.diff })),
+		}, {
+			checkedPaths: [[allowedUri.fsPath, excludedUri.fsPath]],
+			patchPaths: [['allowed.txt']],
+			fileRelativePaths: JSON.stringify(['allowed.txt']),
+			diffs: [{ uri: allowedUri.toString(), diff: 'allowed-patch' }],
 		});
 	});
 


### PR DESCRIPTION
## Overview

Restore content-exclusion-safe `fileRelativePaths` and `diffsJSON` in Agent Host `request.repoInfo` telemetry now that VS Code has adopted the runtime's batch path-check API.

For content exclusion enabled/unknown sessions, this change:

- sends one batch of absolute old/new file paths to `session.rpc.contentExclusion.checkPaths`
- fails closed when the checker or policy service is unavailable, returns a malformed/misaligned result, or rejects
- includes a change only when every old/new path for that change is allowed
- computes patches only for allowed changes
- preserves the existing commit-age, change-count, payload-size, per-diff truncation, and working-tree stability safeguards

When content exclusion is explicitly disabled, behavior remains unchanged.

Runtime support: [github/copilot-agent-runtime#13345](https://github.com/github/copilot-agent-runtime/pull/13345), adopted in VS Code through SDK 1.0.9-preview.1/runtime 1.0.77.

Validation:

- full `npm run compile`
- targeted ESLint
- `AgentHostRepoInfoTelemetry` tests (9 passing)
- `CopilotAgentSession` repo-info tests (4 passing)
- pre-commit hygiene

Related to [microsoft/vscode-internalbacklog#8247](https://github.com/microsoft/vscode-internalbacklog/issues/8247) and follows [microsoft/vscode#326424](https://github.com/microsoft/vscode/pull/326424).
