### PR TITLE
agentHost: preserve duplicate BYOK registrations

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -149,6 +149,18 @@ export interface IByokLmModelInfo {
 	readonly defaultReasoningEffort?: string;
 }
 
+/**
+ * Returns the provider-local selection id used by the agent host. Configured
+ * provider groups remain part of the id so models with the same vendor and
+ * provider-local id do not collide.
+ */
+export function getByokLmSelectionModelId(model: IByokLmModelInfo): string {
+	const vendorPrefix = `${model.vendor}/`;
+	return model.modelIdentifier?.startsWith(vendorPrefix)
+		? model.modelIdentifier.slice(vendorPrefix.length)
+		: model.id;
+}
+
 export const IAgentHostByokLmHandler = createDecorator<IAgentHostByokLmHandler>('agentHostByokLmHandler');
 
 /**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -53,6 +53,7 @@ import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from 
 import { ProtectedResourceMetadata, type AgentSelection, type ChildCustomizationType, type ConfigPropertySchema, type ConfigSchema, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type SessionAction } from '../../common/state/sessionActions.js';
 import { AgentCustomization, CustomizationLoadStatus, CustomizationType, RuleCustomization, ChatInputResponseKind, SkillCustomization, customizationId, buildChatUri, buildDefaultChatUri, isDefaultChatUri, parseChatUri, parseRequiredSessionUriFromChatUri, parseSubagentSessionUri, AH_META_WORKSPACELESS_DB_KEY, type ChildCustomization, type ClientPluginCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type MessageAttachment, type PendingMessage, type PluginCustomization, type PolicyState, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
+import { getByokLmSelectionModelId } from '../../common/agentHostByokLm.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
@@ -1082,7 +1083,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * connect-time retry) and caches the serving window's models, so this is a
 	 * cheap synchronous read of that cache.
 	 *
-	 * Each model is surfaced under the provider-qualified id `vendor/id` so a
+	 * Each model is surfaced under the provider-qualified id `vendor/[group/]id` so a
 	 * selection round-trips to the per-session provider config synthesized by
 	 * `resolveByokSessionConfig`.
 	 */
@@ -1097,7 +1098,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const thinkingLevel = this._createThinkingLevelConfigSchemaProperty(supportedReasoningEfforts, defaultReasoningEffort);
 			return {
 				provider: this.id,
-				id: `${m.vendor}/${m.id}`,
+				id: `${m.vendor}/${getByokLmSelectionModelId(m)}`,
 				name: m.name ?? m.id,
 				maxContextWindow: m.maxContextWindowTokens,
 				supportsVision: m.supportsVision ?? false,

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -17,7 +17,7 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
 import { IByokLmProxyService, type IByokLmProxyHandle } from './byokLmProxyService.js';
-import type { IByokLmModelInfo } from '../../common/agentHostByokLm.js';
+import { getByokLmSelectionModelId, type IByokLmModelInfo } from '../../common/agentHostByokLm.js';
 import type { ModelSelection, ToolDefinition } from '../../common/state/protocol/state.js';
 import type { ActiveClientToolSet } from '../activeClientState.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
@@ -303,7 +303,7 @@ export function getCopilotContextTier(model: ModelSelection | undefined, longCon
  * Each vendor maps to one `type: 'openai'` / `wireApi: 'responses'` provider
  * whose `baseUrl` points at the proxy and authenticates with the session-scoped
  * `Bearer <nonce>.<sessionId>`; each model is surfaced under the
- * provider-qualified selection id `vendor/id`, matching what the renderer's
+ * provider-qualified selection id `vendor/[group/]id`, matching what the renderer's
  * `AgentHostByokLmHandler` resolves.
  *
  * Extracted from {@link CopilotSessionLauncher} so the synthesis and gating are
@@ -329,14 +329,14 @@ export async function resolveByokSessionConfig(
 	if (byokModels.length === 0) {
 		return {};
 	}
-	// Deduplicate by selection id (`vendor/id`). The same BYOK model can be
+	// Deduplicate by group-qualified selection id (`vendor/[group/]id`). The same BYOK model can be
 	// reported more than once — e.g. when two renderer bridges are transiently
 	// serving during a window hand-off (continuing a chat into a new session) —
 	// and the runtime rejects a session config with duplicate BYOK model
 	// selection ids ("Duplicate BYOK model selection id ...").
 	const seenSelectionIds = new Set<string>();
 	byokModels = byokModels.filter(m => {
-		const selectionId = `${m.vendor}/${m.id}`;
+		const selectionId = `${m.vendor}/${getByokLmSelectionModelId(m)}`;
 		if (seenSelectionIds.has(selectionId)) {
 			return false;
 		}
@@ -361,7 +361,7 @@ export async function resolveByokSessionConfig(
 		bearerToken: `${handle.nonce}.${sessionId}`,
 	}));
 	const models: ProviderModelConfig[] = byokModels.map(m => ({
-		id: m.id,
+		id: getByokLmSelectionModelId(m),
 		provider: m.vendor,
 		...(m.name !== undefined ? { name: m.name } : {}),
 		...(m.maxContextWindowTokens !== undefined ? { maxContextWindowTokens: m.maxContextWindowTokens } : {}),

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -2190,6 +2190,42 @@ suite('CopilotAgent', () => {
 		}
 	});
 
+	test('BYOK models from multiple Gemini provider groups have unique picker identifiers', async () => {
+		const byokBridgeRegistry = new ByokLmBridgeRegistry();
+		const agent = createTestAgent(disposables, { byokBridgeRegistry });
+		const modelSnapshots = disposables.add(new Emitter<IByokLmModelInfo[]>());
+		const connection: IByokLmBridgeConnection = {
+			chat: async () => ({ output: [] }),
+			onDidChangeModels: modelSnapshots.event,
+		};
+		disposables.add(byokBridgeRegistry.register('renderer', connection));
+
+		try {
+			modelSnapshots.fire([
+				{
+					vendor: 'google',
+					id: 'gemini-2.5-pro',
+					name: 'Gemini 2.5 Pro',
+					modelIdentifier: 'google/Gemini Personal/gemini-2.5-pro',
+				},
+				{
+					vendor: 'google',
+					id: 'gemini-2.5-pro',
+					name: 'Gemini 2.5 Pro',
+					modelIdentifier: 'google/Gemini Work/gemini-2.5-pro',
+				},
+			]);
+			const models = await waitForState(agent.models, models => models.length === 2);
+
+			assert.deepStrictEqual(models.map(model => model.id), [
+				'google/Gemini Personal/gemini-2.5-pro',
+				'google/Gemini Work/gemini-2.5-pro',
+			]);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
 	test('configSchema emits a numeric contextSize property when long_context tier exceeds default', async () => {
 		const agent = createTestAgent(disposables, {
 			copilotClient: new TestCopilotClient([], [{

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -158,6 +158,23 @@ suite('resolveByokSessionConfig', () => {
 		});
 	});
 
+	test('preserves provider groups when models share a vendor and id', async () => {
+		const registry = new ByokLmBridgeRegistry();
+		const registration = registry.register('client-1', connectionOf([
+			{ vendor: 'google', id: 'gemini-2.5-pro', modelIdentifier: 'google/Gemini Personal/gemini-2.5-pro' },
+			{ vendor: 'google', id: 'gemini-2.5-pro', modelIdentifier: 'google/Gemini Work/gemini-2.5-pro' },
+		]));
+		const proxy = countingProxy();
+
+		const config = await resolveByokSessionConfig(sessionId, registry, proxy.startProxy, log);
+		registration.dispose();
+
+		assert.deepStrictEqual(config.models, [
+			{ id: 'Gemini Personal/gemini-2.5-pro', provider: 'google' },
+			{ id: 'Gemini Work/gemini-2.5-pro', provider: 'google' },
+		]);
+	});
+
 	test('synthesized provider config routes through a live proxy to the bridge', async () => {
 		const registry = new ByokLmBridgeRegistry();
 		let captured: IByokLmChatRequest | undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
@@ -160,6 +160,11 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 	 * provider-local id (the `provider/id` selection id the picker surfaced).
 	 */
 	private _resolveModelIdentifier(vendor: string, modelId: string): string | undefined {
+		const exactIdentifier = `${vendor}/${modelId}`;
+		const exactMetadata = this._languageModelsService.lookupLanguageModel(exactIdentifier);
+		if (exactMetadata?.isBYOK && exactMetadata.vendor === vendor) {
+			return exactIdentifier;
+		}
 		for (const identifier of this._languageModelsService.getLanguageModelIds()) {
 			const metadata = this._languageModelsService.lookupLanguageModel(identifier);
 			if (metadata?.isBYOK && metadata.vendor === vendor && metadata.id === modelId) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -157,7 +157,7 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 
 	/**
 	 * Derives the picker group id for a model — the vendor its models are bucketed
-	 * under. BYOK models are surfaced by the agent host under the `vendor/id` selection
+	 * under. BYOK models are surfaced by the agent host under the `vendor/[group/]id` selection
 	 * id (see `resolveByokSessionConfig`), so their upstream vendor is the id prefix;
 	 * native harness models have no prefix and group under their `provider` (the harness,
 	 * e.g. `copilotcli`). The picker resolves the display name from the vendor registry —

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
@@ -180,6 +180,26 @@ suite('AgentHostByokLmHandler', () => {
 		]);
 	});
 
+	test('chat resolves the configured provider group when models share a vendor and id', async () => {
+		const workIdentifier = 'google/Gemini Work/gemini-2.5-pro';
+		const service = new TestLanguageModelsService(
+			new Map([
+				['google/Gemini Personal/gemini-2.5-pro', byokModel('google', 'gemini-2.5-pro')],
+				[workIdentifier, byokModel('google', 'gemini-2.5-pro')],
+			]),
+			() => responseOf([]),
+		);
+		const handler = createHandler(service);
+
+		await handler.chat({
+			vendor: 'google',
+			modelId: 'Gemini Work/gemini-2.5-pro',
+			input: [],
+		}, CancellationToken.None);
+
+		assert.strictEqual(service.captured?.modelId, workIdentifier);
+	});
+
 	test('buffers ordered thinking, text, tool calls, continuation and usage', async () => {
 		const service = new TestLanguageModelsService(
 			new Map([['id-acme-claude', byokModel('acme', 'claude')]]),


### PR DESCRIPTION
## Summary

- preserve configured BYOK provider group identity in agent-host model selection IDs
- keep models with the same vendor and provider-local ID distinct in the model picker
- route requests back to the exact renderer-side provider registration
- add regression coverage for catalog publication, session configuration, and request routing

Fixes microsoft/vscode-internalbacklog#8712