### PR TITLE
agentHost: graduate enablement setting

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -42,7 +42,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: true,
-			tags: ['experimental', 'advanced'],
+			tags: ['advanced'],
 			experiment: { mode: 'startup' },
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {


### PR DESCRIPTION
## Summary

- remove the experimental classification from `chat.agentHost.enabled`
- keep the setting classified as advanced