### PR TITLE
Remove trailing parenthesis from BYOK model footers

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -692,12 +692,16 @@ export function getLanguageModelDisplayNameWithProvider(model: ILanguageModelCha
 	const originalMetadata = metadata.byokModelIdentifier ? languageModelsService.lookupLanguageModel(originalIdentifier) : metadata;
 	const providerVendor = originalMetadata?.vendor ?? metadata.modelGroup?.id ?? metadata.vendor;
 	const providerName = getLanguageModelProviderDisplayName(languageModelsService, providerVendor);
+	const identifierSuffix = originalMetadata?.id;
+	const modelName = identifierSuffix && metadata.name.endsWith(` (${identifierSuffix})`)
+		? metadata.name.slice(0, -identifierSuffix.length - 3)
+		: metadata.name;
 	const groupName = languageModelsService.getLanguageModelGroups(providerVendor)
 		.find(group => group.modelIdentifiers.includes(originalIdentifier))
 		?.group?.name;
 	return groupName && groupName !== providerName
-		? localize('chat.languageModelNameWithProviderAndGroup', "{0}/{1}/{2}", providerName, groupName, metadata.name)
-		: localize('chat.languageModelNameWithProvider', "{0}/{1}", providerName, metadata.name);
+		? localize('chat.languageModelNameWithProviderAndGroup', "{0}/{1}/{2}", providerName, groupName, modelName)
+		: localize('chat.languageModelNameWithProvider', "{0}/{1}", providerName, modelName);
 }
 
 export interface IModelControlEntry {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -4004,7 +4004,7 @@ suite('AgentHostChatContribution', () => {
 
 			const result = await turnPromise;
 
-			assert.strictEqual(result.details, 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1) • 1.5 credits');
+			assert.strictEqual(result.details, 'OpenRouter/Amazon: Nova Micro 1.0 • 1.5 credits');
 		}));
 
 		test('live BYOK turn includes a configured group between provider and model', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -4189,7 +4189,7 @@ suite('AgentHostChatContribution', () => {
 				modelName: subagentData.modelName,
 			}, {
 				credits: 5.0,
-				modelName: 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
+				modelName: 'OpenRouter/Amazon: Nova Micro 1.0',
 			});
 		}));
 
@@ -6777,7 +6777,7 @@ suite('AgentHostChatContribution', () => {
 				kind: 'subagent',
 				description: 'Review agentHost changes',
 				chatResource: childChatUri,
-				modelName: 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
+				modelName: 'OpenRouter/Amazon: Nova Micro 1.0',
 				isActive: true,
 			});
 			assert.deepStrictEqual(activeToolPart && {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -286,11 +286,11 @@ suite('LanguageModels', function () {
 			gemini: getLanguageModelDisplayNameWithProvider(geminiModel, createService()),
 			native: getLanguageModelDisplayNameWithProvider(nativeModel, createService('OpenRouter 2')),
 		}, {
-			direct: 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
-			bridged: 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
-			grouped: 'OpenRouter/OpenRouter 2/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
-			duplicateGroup: 'OpenRouter/Amazon: Nova Micro 1.0 (amazon/nova-micro-v1)',
-			gemini: 'Gemini/Gemini 3.1 Pro Preview (models/gemini-3.1-pro-preview)',
+			direct: 'OpenRouter/Amazon: Nova Micro 1.0',
+			bridged: 'OpenRouter/Amazon: Nova Micro 1.0',
+			grouped: 'OpenRouter/OpenRouter 2/Amazon: Nova Micro 1.0',
+			duplicateGroup: 'OpenRouter/Amazon: Nova Micro 1.0',
+			gemini: 'Gemini/Gemini 3.1 Pro Preview',
 			native: 'Claude Sonnet 4.6',
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -266,6 +266,13 @@ suite('LanguageModels', function () {
 				vendor: 'gemini',
 			},
 		};
+		const meaningfulParenthesesModel: ILanguageModelChatMetadataAndIdentifier = {
+			identifier: 'openrouter/amazon/nova-micro-v1',
+			metadata: {
+				...originalModel.metadata,
+				name: 'Amazon: Nova Micro 1.0 (Preview)',
+			},
+		};
 		const createService = (groupName?: string): ILanguageModelsService => ({
 			getVendors: () => [
 				{ vendor: 'openrouter', displayName: 'OpenRouter' },
@@ -284,6 +291,7 @@ suite('LanguageModels', function () {
 			grouped: getLanguageModelDisplayNameWithProvider(bridgedModel, createService('OpenRouter 2')),
 			duplicateGroup: getLanguageModelDisplayNameWithProvider(bridgedModel, createService('OpenRouter')),
 			gemini: getLanguageModelDisplayNameWithProvider(geminiModel, createService()),
+			meaningfulParentheses: getLanguageModelDisplayNameWithProvider(meaningfulParenthesesModel, createService()),
 			native: getLanguageModelDisplayNameWithProvider(nativeModel, createService('OpenRouter 2')),
 		}, {
 			direct: 'OpenRouter/Amazon: Nova Micro 1.0',
@@ -291,6 +299,7 @@ suite('LanguageModels', function () {
 			grouped: 'OpenRouter/OpenRouter 2/Amazon: Nova Micro 1.0',
 			duplicateGroup: 'OpenRouter/Amazon: Nova Micro 1.0',
 			gemini: 'Gemini/Gemini 3.1 Pro Preview',
+			meaningfulParentheses: 'OpenRouter/Amazon: Nova Micro 1.0 (Preview)',
 			native: 'Claude Sonnet 4.6',
 		});
 	});


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/8716

This pull request addresses the issue of trailing parenthetical text in the footer for BYOK (Bring Your Own Key) models. The changes made include:

- **Code Updates**:
  - Modified the `languageModels.ts` file to remove trailing parenthetical segments from BYOK model names, ensuring that only redundant identifiers are stripped while preserving meaningful parentheses.
  - Updated the regression test in `agentHostChatContribution.test.ts` to reflect the changes made to the footer formatting.

- **Testing**:
  - Verified that the changes do not affect non-BYOK model names or the Auto-routing suffix.
  - All targeted tests and hygiene checks have passed successfully.

This change enhances the clarity of BYOK model footers by eliminating unnecessary information while maintaining the integrity of other model displays.