### PR TITLE
agentHost: separate agent selection and execution mode telemetry

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -28,6 +28,8 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 - **Do not conflate custom-agent selection with Agent Host execution mode**: `chat.modeChange` describes workbench mode/custom-agent picker selections, while `interactive`, `plan`, and `autopilot` are Agent Host execution modes and belong in `agentHost.executionModeChanged`. Preserve the SDK-native mode event as a peer rather than reshaping either axis into the other.
 
+- **Picker telemetry must use the scoped session and active chat**: Agents Window action view items can belong to a non-active visible session or peer chat. Resolve previous selection and request counts from scoped `ISessionContext.session.activeChat`, never a window-global picker model or parent session resource.
+
 - **A sash element's `left`/`top` is the hit-area edge, not the split boundary**: `SplitView.getSashPosition` returns the exact boundary after the preceding view, then `Sash.layout` subtracts half the sash size so the draggable element is centered on that boundary. Align the Sessions/Editor and bottom-Panel grid sash hit areas to `agents.layout.floatingPanelGap`; do not apply that token to independent geometry such as the Auxiliary Bar's leading padding.
 - **Wrong menu IDs**: Never use `MenuId.*` from `vs/platform/actions` for Agents window UI. Always use `Menus.*` from `browser/menus.ts`.
 - **Durable chat source/origin references**: Store only `turnId` in durable fork/side-chat references. Active versus historical is mutable lifecycle state that consumers must resolve against the current `activeTurn` and retained `turns` when needed; do not encode lifecycle state in the reference type.

--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -26,6 +26,8 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 ## Common Pitfalls
 
+- **Do not conflate custom-agent selection with Agent Host execution mode**: `chat.modeChange` describes workbench mode/custom-agent picker selections, while `interactive`, `plan`, and `autopilot` are Agent Host execution modes and belong in `agentHost.executionModeChanged`. Preserve the SDK-native mode event as a peer rather than reshaping either axis into the other.
+
 - **A sash element's `left`/`top` is the hit-area edge, not the split boundary**: `SplitView.getSashPosition` returns the exact boundary after the preceding view, then `Sash.layout` subtracts half the sash size so the draggable element is centered on that boundary. Align the Sessions/Editor and bottom-Panel grid sash hit areas to `agents.layout.floatingPanelGap`; do not apply that token to independent geometry such as the Auxiliary Bar's leading padding.
 - **Wrong menu IDs**: Never use `MenuId.*` from `vs/platform/actions` for Agents window UI. Always use `Menus.*` from `browser/menus.ts`.
 - **Durable chat source/origin references**: Store only `turnId` in durable fork/side-chat references. Active versus historical is mutable lifecycle state that consumers must resolve against the current `activeTurn` and retained `turns` when needed; do not encode lifecycle state in the reference type.

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -8,6 +8,7 @@ import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
 import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
+import type { SessionMode } from '../common/agentHostSchema.js';
 import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
 import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
@@ -16,26 +17,24 @@ import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
 
 export type AgentHostUserMessageSentSource = 'direct' | 'queued';
 
-export interface IAgentHostChatModeChangeEvent {
+export interface IAgentHostExecutionModeChangedEvent {
 	provider: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
-	fromMode: string;
-	mode: string;
-	requestCount: number;
-	storage: 'builtin';
+	previousMode: SessionMode;
+	newMode: SessionMode;
+	turnCount: number;
 }
 
-export type IAgentHostChatModeChangeClassification = {
+export type IAgentHostExecutionModeChangedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the mode change belongs to a subagent session.' };
-	fromMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent host execution mode.' };
-	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent host execution mode.' };
-	requestCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of completed turns in the agent host chat.' };
-	storage: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Source of the target mode.' };
-	owner: 'digitarald';
-	comment: 'Reports agent host execution mode changes under the workbench chat mode event for telemetry continuity.';
+	previousMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent host execution mode.' };
+	newMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent host execution mode.' };
+	turnCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of completed turns in the agent host chat.' };
+	owner: 'amunger';
+	comment: 'Reports agent host execution mode changes.';
 };
 
 export interface IAgentHostUserMessageSentEvent {
@@ -448,15 +447,14 @@ export class AgentHostTelemetryReporter {
 		return typeof ts.sendEnhancedGHTelemetryEvent === 'function' ? ts as IAgentHostRestrictedTelemetry : undefined;
 	}
 
-	chatModeChanged(provider: string, session: string, fromMode: string, mode: string, requestCount: number): void {
-		this._telemetryService.publicLog2<IAgentHostChatModeChangeEvent, IAgentHostChatModeChangeClassification>('chat.modeChange', {
+	executionModeChanged(provider: string, session: string, previousMode: SessionMode, newMode: SessionMode, turnCount: number): void {
+		this._telemetryService.publicLog2<IAgentHostExecutionModeChangedEvent, IAgentHostExecutionModeChangedClassification>('agentHost.executionModeChanged', {
 			provider,
 			agentSessionId: AgentSession.id(session),
 			isSubagentSession: isSubagentSession(session),
-			fromMode,
-			mode,
-			requestCount,
-			storage: 'builtin',
+			previousMode,
+			newMode,
+			turnCount,
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -253,7 +253,7 @@ export class AgentSideEffects extends Disposable {
 				return;
 			}
 
-			this._telemetryReporter.chatModeChanged(agent.id, e.session, previousMode, currentMode, sessionState.turns.length);
+			this._telemetryReporter.executionModeChanged(agent.id, e.session, previousMode, currentMode, sessionState.turns.length);
 		}));
 
 		// Whenever the agents observable changes, publish to root state.

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -4218,7 +4218,7 @@ suite('AgentSideEffects', () => {
 			assert.deepStrictEqual(JSON.parse(persisted), { mode: 'interactive', autoApprove: 'default' });
 		});
 
-		test('SessionConfigChanged emits chat.modeChange for effective mode transitions without duplicate echoes', () => {
+		test('SessionConfigChanged emits agentHost.executionModeChanged for effective mode transitions without duplicate echoes', () => {
 			setupSession();
 			stateManager.setSessionConfig(sessionUri.toString(), {
 				schema: platformSessionSchema.toProtocol(),
@@ -4249,38 +4249,35 @@ suite('AgentSideEffects', () => {
 				replace: true,
 			});
 
-			assert.deepStrictEqual(telemetryService.events.filter(event => event.eventName === 'chat.modeChange'), [{
-				eventName: 'chat.modeChange',
+			assert.deepStrictEqual(telemetryService.events.filter(event => event.eventName === 'agentHost.executionModeChanged'), [{
+				eventName: 'agentHost.executionModeChanged',
 				data: {
 					provider: 'mock',
 					agentSessionId: 'session-1',
 					isSubagentSession: false,
-					fromMode: 'interactive',
-					mode: 'plan',
-					requestCount: 1,
-					storage: 'builtin',
+					previousMode: 'interactive',
+					newMode: 'plan',
+					turnCount: 1,
 				},
 			}, {
-				eventName: 'chat.modeChange',
+				eventName: 'agentHost.executionModeChanged',
 				data: {
 					provider: 'mock',
 					agentSessionId: 'session-1',
 					isSubagentSession: false,
-					fromMode: 'plan',
-					mode: 'autopilot',
-					requestCount: 1,
-					storage: 'builtin',
+					previousMode: 'plan',
+					newMode: 'autopilot',
+					turnCount: 1,
 				},
 			}, {
-				eventName: 'chat.modeChange',
+				eventName: 'agentHost.executionModeChanged',
 				data: {
 					provider: 'mock',
 					agentSessionId: 'session-1',
 					isSubagentSession: false,
-					fromMode: 'autopilot',
-					mode: 'interactive',
-					requestCount: 1,
-					storage: 'builtin',
+					previousMode: 'autopilot',
+					newMode: 'interactive',
+					turnCount: 1,
 				},
 			}]);
 		});

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -83,6 +83,8 @@ focus a slot:   part.onDidFocusSession → view.setActive → updates active vis
 
 The Agents-window chat surface also registers the workbench chat pre-submit handlers. These handlers can consume provider-specific client-side commands before the normal send path, while the actual send still routes through the sessions provider model.
 
+User selections in the Agents-window mode picker report the shared `chat.modeChange` telemetry event. Agent Host execution-mode transitions (`interactive`, `plan`, and `autopilot`) are reported separately as `agentHost.executionModeChanged`.
+
 The `sessions.showSessionsPicker` command globally prioritizes non-archived sessions that need input, followed by other unread sessions. Each priority group preserves the picker's existing recent-first order, and sessions in neither group remain in the existing "recently opened" and "other sessions" sections. Archived-session exclusion is owned by the picker grouping helper so archived sessions cannot enter any section regardless of status or read state. The picker initially selects the first session rather than the preceding New Session item or the active session.
 
 The Agents-window composer uses the shared dictation toggle semantics: activating dictation again while the speech-to-text model is downloading or loading cancels preparation, while activating it during recording stops and transcribes. The new-session composer also renders the shared chat-tip content above its input; because it is not an `IChatWidget`, the chat-tip service treats an Agents window with zero registered foreground chat widgets as this single composer surface.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker.ts
@@ -141,7 +141,7 @@ class AgentHostAgentPickerContribution extends Disposable implements IWorkbenchC
 
 		const factory = (_action: IAction, _options: IActionViewItemOptions, scopedInstantiationService: IInstantiationService) => {
 			const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
-			const picker = scopedInstantiationService.createInstance(ModePicker, modePickerModel);
+			const picker = scopedInstantiationService.createInstance(ModePicker, modePickerModel, session);
 			const disposableStore = new DisposableStore();
 
 			disposableStore.add(picker.onDidSelect(mode => {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -170,16 +170,17 @@ class CopilotPickerActionViewItemContribution extends Disposable implements IWor
 		this._register(actionViewItemService.register(
 			Menus.NewSessionConfig, 'sessions.defaultCopilot.modePicker',
 			(_action, _options, scopedInstantiationService) => {
-				const picker = scopedInstantiationService.createInstance(ModePicker, modePickerModel);
+				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
+				const picker = scopedInstantiationService.createInstance(ModePicker, modePickerModel, session);
 				const disposableStore = new DisposableStore();
 				disposableStore.add(picker.onDidSelect(mode => {
-					const session = sessionsService.activeSession.get();
-					if (!session) {
+					const scopedSession = session.get();
+					if (!scopedSession) {
 						return;
 					}
-					const provider = sessionsProvidersService.getProvider(session.providerId);
+					const provider = sessionsProvidersService.getProvider(scopedSession.providerId);
 					if (provider instanceof CopilotChatSessionsProvider) {
-						provider.getSession(session.sessionId)?.setMode(mode);
+						provider.getSession(scopedSession.sessionId)?.setMode(mode);
 					}
 				}));
 				return new PickerActionViewItem(picker, disposableStore);

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker.ts
@@ -8,6 +8,7 @@ import { Gesture, EventType as TouchEventType } from '../../../../../base/browse
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { IObservable } from '../../../../../base/common/observable.js';
 import { localize } from '../../../../../nls.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
@@ -23,6 +24,7 @@ import { Target } from '../../../../../workbench/contrib/chat/common/promptSynta
 import { AICustomizationManagementCommands } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementSection } from '../../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import type { ISession } from '../../../../services/sessions/common/session.js';
+import type { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
 import { CopilotCLISessionType } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -59,10 +61,6 @@ export class ModePickerModel extends Disposable {
 
 	get selectedModeId(): string | undefined {
 		return this._selectedModeId;
-	}
-
-	get sessionResource(): URI | undefined {
-		return this._sessionResource;
 	}
 
 	constructor(
@@ -166,6 +164,7 @@ export class ModePicker extends Disposable {
 
 	constructor(
 		modePickerModel: ModePickerModel,
+		private readonly session: IObservable<IActiveSession | undefined>,
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -233,11 +232,13 @@ export class ModePicker extends Disposable {
 		const items = this._buildItems(modes);
 
 		const triggerElement = this._triggerElement;
-		const previousMode = this._modePickerModel.selectedMode;
 		const delegate: IActionListDelegate<ModePickerItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
 				if (item.kind === 'mode') {
+					const activeChat = this.session.get()?.activeChat.get();
+					const previousModeId = activeChat?.mode.get()?.id;
+					const previousMode = modes.find(mode => mode.id === previousModeId) ?? ChatMode.Agent;
 					reportNewChatPickerClosed(this.telemetryService, {
 						id: 'NewChatModePicker',
 						optionIdBefore: previousMode.id,
@@ -246,8 +247,7 @@ export class ModePicker extends Disposable {
 						optionLabelAfter: item.mode.label.get(),
 						isPII: true,
 					});
-					const sessionResource = this._modePickerModel.sessionResource;
-					const requestCount = sessionResource ? this.chatService.getSession(sessionResource)?.getRequests().length ?? 0 : 0;
+					const requestCount = activeChat ? this.chatService.getSession(activeChat.resource)?.getRequests().length ?? 0 : 0;
 					reportChatModeChange(this.telemetryService, previousMode, item.mode, requestCount);
 					this._selectMode(item.mode);
 				} else {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker.ts
@@ -14,6 +14,8 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { ChatMode, IChatMode, IChatModes, IChatModeService } from '../../../../../workbench/contrib/chat/common/chatModes.js';
+import { reportChatModeChange } from '../../../../../workbench/contrib/chat/common/chatModeTelemetry.js';
+import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -57,6 +59,10 @@ export class ModePickerModel extends Disposable {
 
 	get selectedModeId(): string | undefined {
 		return this._selectedModeId;
+	}
+
+	get sessionResource(): URI | undefined {
+		return this._sessionResource;
 	}
 
 	constructor(
@@ -163,6 +169,7 @@ export class ModePicker extends Disposable {
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IChatService private readonly chatService: IChatService,
 	) {
 		super();
 
@@ -239,6 +246,9 @@ export class ModePicker extends Disposable {
 						optionLabelAfter: item.mode.label.get(),
 						isPII: true,
 					});
+					const sessionResource = this._modePickerModel.sessionResource;
+					const requestCount = sessionResource ? this.chatService.getSession(sessionResource)?.getRequests().length ?? 0 : 0;
+					reportChatModeChange(this.telemetryService, previousMode, item.mode, requestCount);
 					this._selectMode(item.mode);
 				} else {
 					this.commandService.executeCommand(AICustomizationManagementCommands.OpenEditor, AICustomizationManagementSection.Agents);

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modePicker.test.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { hash } from '../../../../../../base/common/hash.js';
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IActionListDelegate, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { NullTelemetryServiceShape } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IChatModeService, IChatModes, ChatMode, CustomChatMode } from '../../../../../../workbench/contrib/chat/common/chatModes.js';
+import { IChatService } from '../../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatSessionsService } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChatModel, IChatRequestModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { PromptsStorage } from '../../../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { Target } from '../../../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { ISession } from '../../../../../services/sessions/common/session.js';
+import { ModePicker, ModePickerModel } from '../../browser/modePicker.js';
+
+class TestTelemetryService extends NullTelemetryServiceShape {
+	readonly events: { readonly name: string; readonly data: unknown }[] = [];
+
+	override publicLog2(eventName?: string, data?: unknown): void {
+		if (eventName) {
+			this.events.push({ name: eventName, data });
+		}
+	}
+}
+
+suite('ModePicker', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reports chat.modeChange when selecting a custom agent', () => {
+		const telemetryService = new TestTelemetryService();
+		const sessionResource = URI.parse('agent-host-copilotcli:/session-1');
+		const customAgent = new CustomChatMode({
+			id: 'reviewer',
+			uri: URI.parse('file:///workspace/.github/agents/reviewer.agent.md'),
+			name: 'Reviewer',
+			agentInstructions: { content: '', toolReferences: [] },
+			source: { storage: PromptsStorage.local },
+			target: Target.Undefined,
+			visibility: { userInvocable: true, agentInvocable: true },
+			enabled: true,
+			tools: ['read'],
+		});
+		const modes: IChatModes & IDisposable = {
+			onDidChange: Event.None,
+			builtin: [ChatMode.Agent],
+			custom: [customAgent],
+			findModeById: id => id === customAgent.id ? customAgent : ChatMode.Agent.id === id ? ChatMode.Agent : undefined,
+			findModeByName: name => name === customAgent.name.get() ? customAgent : undefined,
+			waitForPendingUpdates: async () => { },
+			dispose: () => { },
+		};
+		const model = store.add(new ModePickerModel(
+			new class extends mock<IChatSessionsService>() {
+				override getCustomAgentTargetForSessionType(): Target {
+					return Target.Undefined;
+				}
+			}(),
+			new class extends mock<IChatModeService>() {
+				override createModes(): IChatModes & IDisposable {
+					return modes;
+				}
+			}(),
+		));
+		model.setSession({ resource: sessionResource } as ISession, undefined);
+
+		let selectCustomAgent: (() => void) | undefined;
+		const picker = store.add(new ModePicker(
+			model,
+			new class extends mock<IActionWidgetService>() {
+				override readonly isVisible = false;
+				override show<T>(_user: string, _supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>): void {
+					const item = items.find(item => {
+						if (!item.item) {
+							return false;
+						}
+						const value = item.item as { readonly kind?: string; readonly mode?: { readonly id: string } };
+						return value.kind === 'mode' && value.mode?.id === customAgent.id;
+					});
+					assert.ok(item?.item);
+					const modeItem = item.item;
+					selectCustomAgent = () => delegate.onSelect(modeItem);
+				}
+				override hide(): void { }
+			}(),
+			new class extends mock<ICommandService>() { }(),
+			telemetryService,
+			new class extends mock<IChatService>() {
+				override getSession(): IChatModel {
+					return new class extends mock<IChatModel>() {
+						override getRequests(): IChatRequestModel[] {
+							return [
+								new class extends mock<IChatRequestModel>() { }(),
+								new class extends mock<IChatRequestModel>() { }(),
+								new class extends mock<IChatRequestModel>() { }(),
+							];
+						}
+					}();
+				}
+			}(),
+		));
+		const container = document.createElement('div');
+		picker.render(container);
+		container.querySelector<HTMLElement>('a.action-label')?.click();
+		assert.ok(selectCustomAgent);
+		selectCustomAgent();
+
+		assert.deepStrictEqual(telemetryService.events.filter(event => event.name === 'chat.modeChange'), [{
+			name: 'chat.modeChange',
+			data: {
+				fromMode: 'agent',
+				mode: String(hash(customAgent.name.get())),
+				requestCount: 3,
+				storage: 'local',
+				extensionId: undefined,
+				toolsCount: 1,
+				handoffsCount: 0,
+				isClaudeAgent: false,
+			},
+		}]);
+	});
+});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modePicker.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { Event } from '../../../../../../base/common/event.js';
 import { hash } from '../../../../../../base/common/hash.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -20,7 +21,8 @@ import { IChatSessionsService } from '../../../../../../workbench/contrib/chat/c
 import { IChatModel, IChatRequestModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { PromptsStorage } from '../../../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { Target } from '../../../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { ISession } from '../../../../../services/sessions/common/session.js';
+import { IChat, ISession } from '../../../../../services/sessions/common/session.js';
+import { IActiveSession } from '../../../../../services/sessions/common/sessionsManagement.js';
 import { ModePicker, ModePickerModel } from '../../browser/modePicker.js';
 
 class TestTelemetryService extends NullTelemetryServiceShape {
@@ -36,9 +38,10 @@ class TestTelemetryService extends NullTelemetryServiceShape {
 suite('ModePicker', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('reports chat.modeChange when selecting a custom agent', () => {
+	test('reports chat.modeChange for the scoped active chat', () => {
 		const telemetryService = new TestTelemetryService();
 		const sessionResource = URI.parse('agent-host-copilotcli:/session-1');
+		const chatResource = sessionResource.with({ fragment: 'peer-chat' });
 		const customAgent = new CustomChatMode({
 			id: 'reviewer',
 			uri: URI.parse('file:///workspace/.github/agents/reviewer.agent.md'),
@@ -71,11 +74,22 @@ suite('ModePicker', () => {
 				}
 			}(),
 		));
-		model.setSession({ resource: sessionResource } as ISession, undefined);
+		model.setSession(new class extends mock<ISession>() {
+			override readonly resource = sessionResource;
+		}(), customAgent.id);
+		const activeChat = new class extends mock<IChat>() {
+			override readonly resource = chatResource;
+			override readonly mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>('mode', { id: ChatMode.Agent.id, kind: ChatMode.Agent.kind });
+		}();
+		const scopedSession = observableValue<IActiveSession | undefined>('session', new class extends mock<IActiveSession>() {
+			override readonly activeChat = observableValue<IChat>('activeChat', activeChat);
+		}());
 
 		let selectCustomAgent: (() => void) | undefined;
+		const requestedChatResources: string[] = [];
 		const picker = store.add(new ModePicker(
 			model,
+			scopedSession,
 			new class extends mock<IActionWidgetService>() {
 				override readonly isVisible = false;
 				override show<T>(_user: string, _supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>): void {
@@ -95,7 +109,8 @@ suite('ModePicker', () => {
 			new class extends mock<ICommandService>() { }(),
 			telemetryService,
 			new class extends mock<IChatService>() {
-				override getSession(): IChatModel {
+				override getSession(resource: URI): IChatModel {
+					requestedChatResources.push(resource.toString());
 					return new class extends mock<IChatModel>() {
 						override getRequests(): IChatRequestModel[] {
 							return [
@@ -114,18 +129,24 @@ suite('ModePicker', () => {
 		assert.ok(selectCustomAgent);
 		selectCustomAgent();
 
-		assert.deepStrictEqual(telemetryService.events.filter(event => event.name === 'chat.modeChange'), [{
-			name: 'chat.modeChange',
-			data: {
-				fromMode: 'agent',
-				mode: String(hash(customAgent.name.get())),
-				requestCount: 3,
-				storage: 'local',
-				extensionId: undefined,
-				toolsCount: 1,
-				handoffsCount: 0,
-				isClaudeAgent: false,
-			},
-		}]);
+		assert.deepStrictEqual({
+			events: telemetryService.events.filter(event => event.name === 'chat.modeChange'),
+			requestedChatResources,
+		}, {
+			events: [{
+				name: 'chat.modeChange',
+				data: {
+					fromMode: 'agent',
+					mode: String(hash(customAgent.name.get())),
+					requestCount: 3,
+					storage: 'local',
+					extensionId: undefined,
+					toolsCount: 1,
+					handoffsCount: 0,
+					isClaudeAgent: false,
+				},
+			}],
+			requestedChatResources: [chatResource.toString()],
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -24,13 +24,13 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { getModeNameForTelemetry, buildCustomAgentHandoffsInfo, getHandoffId, IChatMode, IChatModeService, IChatModes } from '../../common/chatModes.js';
+import { buildCustomAgentHandoffsInfo, getHandoffId, IChatMode, IChatModeService, IChatModes } from '../../common/chatModes.js';
+import { reportChatModeChange } from '../../common/chatModeTelemetry.js';
 import { chatVariableLeader } from '../../common/requestParser/chatParserTypes.js';
 import { ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatService } from '../../common/chatService/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
 import { ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
-import { isInClaudeAgentsFolder } from '../../common/promptSyntax/config/promptFileLocations.js';
 import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
 import { type IChatAcceptInputOptions, IChatWidget, IChatWidgetService } from '../chat.js';
 import { getAgentSessionProvider, AgentSessionProviders, AgentSessionTarget } from '../agentSessions/agentSessions.js';
@@ -252,30 +252,6 @@ export interface IToggleChatModeArgs {
 	sessionResource: URI | undefined;
 }
 
-type ChatModeChangeClassification = {
-	owner: 'digitarald';
-	comment: 'Reporting when agent is switched between different modes';
-	fromMode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent name' };
-	mode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent name' };
-	requestCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of requests in the current chat session'; 'isMeasurement': true };
-	storage?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Source of the target mode (builtin, local, user, extension)' };
-	extensionId?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Extension ID if the target mode is from an extension' };
-	toolsCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of custom tools in the target mode'; 'isMeasurement': true };
-	handoffsCount?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of handoffs in the target mode'; 'isMeasurement': true };
-	isClaudeAgent?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the target mode is a Claude agent file from .claude/agents/' };
-};
-
-type ChatModeChangeEvent = {
-	fromMode: string;
-	mode: string;
-	requestCount: number;
-	storage?: string;
-	extensionId?: string;
-	toolsCount?: number;
-	handoffsCount?: number;
-	isClaudeAgent?: boolean;
-};
-
 class ToggleChatModeAction extends Action2 {
 
 	static readonly ID = ToggleAgentModeActionId;
@@ -325,25 +301,7 @@ class ToggleChatModeAction extends Action2 {
 			return;
 		}
 
-		// Send telemetry for mode change
-		const storage = switchToMode.source?.storage ?? 'builtin';
-		const extensionId = switchToMode.source?.storage === 'extension' ? switchToMode.source.extensionId.value : undefined;
-		const toolsCount = switchToMode.customTools?.get()?.length ?? 0;
-		const handoffsCount = switchToMode.handOffs?.get()?.length ?? 0;
-
-		const modeUri = switchToMode.uri?.get();
-		const isClaudeAgent = modeUri ? isInClaudeAgentsFolder(modeUri) : undefined;
-
-		telemetryService.publicLog2<ChatModeChangeEvent, ChatModeChangeClassification>('chat.modeChange', {
-			fromMode: getModeNameForTelemetry(currentMode),
-			mode: getModeNameForTelemetry(switchToMode),
-			requestCount: requestCount,
-			storage,
-			extensionId,
-			toolsCount,
-			handoffsCount,
-			isClaudeAgent
-		});
+		reportChatModeChange(telemetryService, currentMode, switchToMode, requestCount);
 
 		widget.input.setChatMode(switchToMode.id, true, true);
 

--- a/src/vs/workbench/contrib/chat/common/chatModeTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModeTelemetry.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IChatMode, getModeNameForTelemetry } from './chatModes.js';
+import { isInClaudeAgentsFolder } from './promptSyntax/config/promptFileLocations.js';
+
+type ChatModeChangeClassification = {
+	owner: 'digitarald';
+	comment: 'Reporting when agent is switched between different modes';
+	fromMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent name' };
+	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The new agent name' };
+	requestCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of requests in the current chat session'; isMeasurement: true };
+	storage: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Source of the target mode (builtin, local, user, extension)' };
+	extensionId?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Extension ID if the target mode is from an extension' };
+	toolsCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of custom tools in the target mode'; isMeasurement: true };
+	handoffsCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Number of handoffs in the target mode'; isMeasurement: true };
+	isClaudeAgent?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the target mode is a Claude agent file from .claude/agents/' };
+};
+
+type ChatModeChangeEvent = {
+	fromMode: string;
+	mode: string;
+	requestCount: number;
+	storage: string;
+	extensionId?: string;
+	toolsCount: number;
+	handoffsCount: number;
+	isClaudeAgent?: boolean;
+};
+
+export function reportChatModeChange(telemetryService: ITelemetryService, currentMode: IChatMode, targetMode: IChatMode, requestCount: number): void {
+	if (currentMode.id === targetMode.id) {
+		return;
+	}
+
+	const storage = targetMode.source?.storage ?? 'builtin';
+	const extensionId = targetMode.source?.storage === 'extension' ? targetMode.source.extensionId.value : undefined;
+	const modeUri = targetMode.uri?.get();
+
+	telemetryService.publicLog2<ChatModeChangeEvent, ChatModeChangeClassification>('chat.modeChange', {
+		fromMode: getModeNameForTelemetry(currentMode),
+		mode: getModeNameForTelemetry(targetMode),
+		requestCount,
+		storage,
+		extensionId,
+		toolsCount: targetMode.customTools?.get()?.length ?? 0,
+		handoffsCount: targetMode.handOffs?.get()?.length ?? 0,
+		isClaudeAgent: modeUri ? isInClaudeAgentsFolder(modeUri) : undefined,
+	});
+}

--- a/src/vs/workbench/contrib/chat/test/common/chatModeTelemetry.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModeTelemetry.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { hash } from '../../../../../base/common/hash.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { ChatMode, CustomChatMode } from '../../common/chatModes.js';
+import { reportChatModeChange } from '../../common/chatModeTelemetry.js';
+import { Target } from '../../common/promptSyntax/promptTypes.js';
+import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+
+class TestTelemetryService extends NullTelemetryServiceShape {
+	readonly events: { readonly name: string; readonly data: unknown }[] = [];
+
+	override publicLog2(eventName?: string, data?: unknown): void {
+		if (eventName) {
+			this.events.push({ name: eventName, data });
+		}
+	}
+}
+
+suite('ChatModeTelemetry', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reports custom agent selections with their picker metadata', () => {
+		const telemetryService = new TestTelemetryService();
+		const targetMode = new CustomChatMode({
+			id: 'reviewer',
+			uri: URI.file('/workspace/.claude/agents/reviewer.md'),
+			name: 'Reviewer',
+			agentInstructions: { content: '', toolReferences: [] },
+			source: { storage: PromptsStorage.local },
+			target: Target.Undefined,
+			visibility: { userInvocable: true, agentInvocable: true },
+			enabled: true,
+			tools: ['read', 'search'],
+		});
+
+		reportChatModeChange(telemetryService, ChatMode.Agent, targetMode, 4);
+
+		assert.deepStrictEqual(telemetryService.events, [{
+			name: 'chat.modeChange',
+			data: {
+				fromMode: 'agent',
+				mode: String(hash('Reviewer')),
+				requestCount: 4,
+				storage: 'local',
+				extensionId: undefined,
+				toolsCount: 2,
+				handoffsCount: 0,
+				isClaudeAgent: true,
+			},
+		}]);
+	});
+
+	test('does not report selecting the current mode', () => {
+		const telemetryService = new TestTelemetryService();
+
+		reportChatModeChange(telemetryService, ChatMode.Agent, ChatMode.Agent, 0);
+
+		assert.deepStrictEqual(telemetryService.events, []);
+	});
+});


### PR DESCRIPTION
## Overview

This follows up #328504 by keeping two distinct telemetry concepts separate:

- `chat.modeChange` tracks user selections of chat modes and custom agents.
- `agentHost.executionModeChanged` tracks Agent Host execution modes: `interactive`, `plan`, and `autopilot`.

The SDK-native `session.mode.changed` event remains unchanged as a peer signal.

## Before

| Event | Coverage |
|---|---|
| `chat.modeChange` | Regular workbench chat-mode and custom-agent picker selections |
| SDK `session.mode.changed` | Copilot SDK execution-mode transitions |

Agent Host custom-agent selections made through the Agents Window picker were not reported by `chat.modeChange`. Agent Host execution-mode transitions also lacked a consistent VS Code-owned event.

## After

| Event | Coverage |
|---|---|
| `chat.modeChange` | Chat-mode and custom-agent selections from both regular workbench chat and the Agents Window |
| `agentHost.executionModeChanged` | Effective Agent Host execution-mode transitions |
| SDK `session.mode.changed` | Existing SDK-native execution-mode transitions, unchanged |

### `chat.modeChange`

Retains the picker-oriented shape:

- `fromMode`
- `mode`
- `requestCount`
- `storage`
- `extensionId`
- `toolsCount`
- `handoffsCount`
- `isClaudeAgent`

Custom-agent names retain their existing privacy treatment.

### `agentHost.executionModeChanged`

Reports:

- `provider`
- `agentSessionId`
- `isSubagentSession`
- `previousMode`
- `newMode`
- `turnCount`

Repeated SDK echoes of an already-applied mode transition remain suppressed.

## Changes

- Extract the existing `chat.modeChange` reporting into a shared helper.
- Use the helper from both the regular chat picker and Agents Window picker.
- Move Agent Host execution-mode reporting to `agentHost.executionModeChanged`.
- Add focused coverage for custom-agent selections, metadata/privacy handling, execution-mode transitions, default resets, and SDK-echo deduplication.

## Dashboard implications

- `chat.modeChange` remains a coherent user-selection event instead of mixing custom-agent and execution-mode value domains.
- Agents Window custom-agent selections add new `chat.modeChange` rows.
- Agent Host execution transitions move to `agentHost.executionModeChanged`; they remain distinguishable by `provider`, `agentSessionId`, and `isSubagentSession`.

## Validation

- Pre-commit hygiene passes.
- Four focused unit tests pass.
- Full typecheck and layer validation are currently blocked by unrelated errors on `main` in `copilotAgentSession.ts`, `copilotSystemNotification.ts`, and `fixtureUtils.ts`.