### PR TITLE
chore: bump @github/copilot-sdk to 1.0.9-preview.2 and @github/copilot to 1.0.78-2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@github/copilot": "^1.0.78-2",
-        "@github/copilot-sdk": "^1.0.9-preview.2",
+        "@github/copilot": "1.0.78-2",
+        "@github/copilot-sdk": "1.0.9-preview.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
         "@microsoft/dev-tunnels-connections": "^1.3.41",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@github/copilot": "^1.0.77",
-        "@github/copilot-sdk": "^1.0.9-preview.1",
+        "@github/copilot": "^1.0.78-2",
+        "@github/copilot-sdk": "^1.0.9-preview.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
         "@microsoft/dev-tunnels-connections": "^1.3.41",
@@ -1113,6 +1113,151 @@
       }
     },
     "node_modules/@github/copilot": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.78-2.tgz",
+      "integrity": "sha512-9MrssRFvYWFPnePZ8BFgMGv735awQ19KrKMZYr14u7Kp9j8l3jyUiSMKa5oCJD5V0mR52+1YE2jy4TCfF/mqlA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.78-2",
+        "@github/copilot-darwin-x64": "1.0.78-2",
+        "@github/copilot-linux-arm64": "1.0.78-2",
+        "@github/copilot-linux-x64": "1.0.78-2",
+        "@github/copilot-linuxmusl-arm64": "1.0.78-2",
+        "@github/copilot-linuxmusl-x64": "1.0.78-2",
+        "@github/copilot-win32-arm64": "1.0.78-2",
+        "@github/copilot-win32-x64": "1.0.78-2"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-tZ+53pbjdFzyIJHBhRhjbKTZZjBT2gJ2RF+MRqJKE9uv774rNxtWb3a9T3Yfu78smjusKjFf0dfJp2rabhxAKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.78-2.tgz",
+      "integrity": "sha512-DpCSlK8u+k5bHeLpbYjJpDaIMlPulpDoTi5zJOcmKIBcxBUx5/RjPogq6DjumNSyLC09Fm9ddMPQgitvMxhDUw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-ERhA6MoAL3yYRdYXN6IielJ8MJheSq7AnchCG92LWq7bRuFwmdQf0mQZzhZd/W6xHsistAQ9dByeVH/UAFB5mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.78-2.tgz",
+      "integrity": "sha512-lbHfY2NrgPxhpJTnvbMWmtxDwSwkgIb9wqJGCQ50ofeX4RuONmBb1960rtmkECtGyN6zDUzIatX7MNBRRBFIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-xXHza3RpX/RbTY7/DDK8Bt7kDU0pDEn1Nf1T08X9o06FhUjTeh7wTMUh/Ogfq9ocG5K4v8fuk1ONv63viQVeIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.78-2.tgz",
+      "integrity": "sha512-ihWyNGlyJHs1iAZsG+BLYzRxpKzRX+OV7E5HVIlAAxL6fxw2ymkgrfSAfx5FR8D2ZXWloY14ZKttFUbizAyJkg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.9-preview.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.9-preview.2.tgz",
+      "integrity": "sha512-PG2RmoKF7jVxrYKBkiLJb4MKUlDcOpsKY0mOqo9gbudw5h1yqJJR0FAhywTtJ4IJxJxZO6Ym/pl/+9zT918RrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.76-5",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.77.tgz",
       "integrity": "sha512-nkTtDPKvsClAByPPqnD/57vK7YIBK1dgiv7aVc9uO3rxKCyqiqYaBqwi8pMzesvGP3yl+//+iMzaBXNWEcZVWQ==",
@@ -1134,7 +1279,7 @@
         "@github/copilot-win32-x64": "1.0.77"
       }
     },
-    "node_modules/@github/copilot-darwin-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.77.tgz",
       "integrity": "sha512-sCWSH5+Flm/OxFe7dzsBfyj7ADBkzkR54Sz5NGw7dtcVVEOnVUkZLjEtNmZ1t5QRD4Sf1+g/DiwgJEbsR9xR1w==",
@@ -1150,7 +1295,7 @@
         "copilot-darwin-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-darwin-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.77.tgz",
       "integrity": "sha512-ReNlB+g+OBiqHwmY5leJBIyvHZQcjyWL/OY8aVimHyESn2ToPKP3eUNTzSUJvvbPM6+0LXwEpijLedkRd2Cn1g==",
@@ -1166,7 +1311,7 @@
         "copilot-darwin-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linux-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.77.tgz",
       "integrity": "sha512-A8j/WBPFvV5WfLbgnIIQLUVuFRAR7kLyc5WgId6XLCu1ARbkRM7353zz9mEXXwjc6LqotHVg80ooANJjNtmSPg==",
@@ -1185,7 +1330,7 @@
         "copilot-linux-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linux-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.77.tgz",
       "integrity": "sha512-2eefKkdUnQ1Y8oxyRyexHBXVpuSmrfEM8XJauquVjPc0JqF5nab9axwpFPzrRSF1GB+25F9tUK2sDQRyp08wag==",
@@ -1204,7 +1349,7 @@
         "copilot-linux-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linuxmusl-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.77.tgz",
       "integrity": "sha512-YtltOZQp8plytSKSGTWWKbOx3QD8iZH04sLtKTrYs6nu5UalIgFPoMkwamy1gh7h5EBkeVxD2s3epVrlvP4X4w==",
@@ -1223,7 +1368,7 @@
         "copilot-linuxmusl-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linuxmusl-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.77.tgz",
       "integrity": "sha512-owINwPgHU/ZZBwFhVPgkgGjLkF6e4QbdofADvKMdKJWV2+7oWjXUIlPA4/PwraD2Gkuu583l7m0XLL27TN8oUA==",
@@ -1242,22 +1387,7 @@
         "copilot-linuxmusl-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-sdk": {
-      "version": "1.0.9-preview.1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.9-preview.1.tgz",
-      "integrity": "sha512-/hUYdxpa4HL57uKmRCLmcg31wWjZPKGBbBfIhVqJdWXkp4/E6lbtHoiIbT5SLCPpf4c8Ka5zw356z+k4Nn/diA==",
-      "license": "MIT",
-      "dependencies": {
-        "@github/copilot": "^1.0.76-5",
-        "koffi": "^3.1.0",
-        "vscode-jsonrpc": "^8.2.1",
-        "zod": "^4.3.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@github/copilot-win32-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.77.tgz",
       "integrity": "sha512-l5oQaMLCRup0nmmpbqOAYEAJ5YWgNlaoO0psNaKDzvTbdzEJRZqib2t7+p3bgoDpK7SB/m8m1uxFC4XT3hlprg==",
@@ -1273,10 +1403,42 @@
         "copilot-win32-arm64": "copilot.exe"
       }
     },
-    "node_modules/@github/copilot-win32-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.77.tgz",
       "integrity": "sha512-8Mo9y3/8CVU2w35WqwSiRMTGH1kKHR3URPSJYF4J4OG8L7NOEy2fafXR9Tuq3H21Srg3OzFkl/A+Taunqz9KcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-5rzE6ysT8ZMCZ8zhcgtExaaZ05UFo6KOCQZNYi+YGx8xpObR92vruZKKhBZH2vE51DM47dT1JQ9o0jS6eP7/dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.78-2.tgz",
+      "integrity": "sha512-10bTnLdDXiLcjWTMAoEmSuqkmf8Q+no9B5pL3u5ks3WiFLGx/r9oDo8CeyYV965CEsfoRkBIxWaLUTMra1tlxQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@github/copilot": "^1.0.77",
-    "@github/copilot-sdk": "^1.0.9-preview.1",
+    "@github/copilot": "^1.0.78-2",
+    "@github/copilot-sdk": "^1.0.9-preview.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
     "@microsoft/dev-tunnels-connections": "^1.3.41",

--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@github/copilot": "^1.0.78-2",
-    "@github/copilot-sdk": "^1.0.9-preview.2",
+    "@github/copilot": "1.0.78-2",
+    "@github/copilot-sdk": "1.0.9-preview.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
     "@microsoft/dev-tunnels-connections": "^1.3.41",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vscode-reh",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "^1.0.77",
-        "@github/copilot-sdk": "^1.0.9-preview.1",
+        "@github/copilot": "^1.0.78-2",
+        "@github/copilot-sdk": "^1.0.9-preview.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
         "@microsoft/mxc-sdk": "0.6.1",
@@ -61,6 +61,151 @@
       }
     },
     "node_modules/@github/copilot": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.78-2.tgz",
+      "integrity": "sha512-9MrssRFvYWFPnePZ8BFgMGv735awQ19KrKMZYr14u7Kp9j8l3jyUiSMKa5oCJD5V0mR52+1YE2jy4TCfF/mqlA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.78-2",
+        "@github/copilot-darwin-x64": "1.0.78-2",
+        "@github/copilot-linux-arm64": "1.0.78-2",
+        "@github/copilot-linux-x64": "1.0.78-2",
+        "@github/copilot-linuxmusl-arm64": "1.0.78-2",
+        "@github/copilot-linuxmusl-x64": "1.0.78-2",
+        "@github/copilot-win32-arm64": "1.0.78-2",
+        "@github/copilot-win32-x64": "1.0.78-2"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-tZ+53pbjdFzyIJHBhRhjbKTZZjBT2gJ2RF+MRqJKE9uv774rNxtWb3a9T3Yfu78smjusKjFf0dfJp2rabhxAKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.78-2.tgz",
+      "integrity": "sha512-DpCSlK8u+k5bHeLpbYjJpDaIMlPulpDoTi5zJOcmKIBcxBUx5/RjPogq6DjumNSyLC09Fm9ddMPQgitvMxhDUw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-ERhA6MoAL3yYRdYXN6IielJ8MJheSq7AnchCG92LWq7bRuFwmdQf0mQZzhZd/W6xHsistAQ9dByeVH/UAFB5mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.78-2.tgz",
+      "integrity": "sha512-lbHfY2NrgPxhpJTnvbMWmtxDwSwkgIb9wqJGCQ50ofeX4RuONmBb1960rtmkECtGyN6zDUzIatX7MNBRRBFIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-xXHza3RpX/RbTY7/DDK8Bt7kDU0pDEn1Nf1T08X9o06FhUjTeh7wTMUh/Ogfq9ocG5K4v8fuk1ONv63viQVeIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.78-2.tgz",
+      "integrity": "sha512-ihWyNGlyJHs1iAZsG+BLYzRxpKzRX+OV7E5HVIlAAxL6fxw2ymkgrfSAfx5FR8D2ZXWloY14ZKttFUbizAyJkg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.9-preview.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.9-preview.2.tgz",
+      "integrity": "sha512-PG2RmoKF7jVxrYKBkiLJb4MKUlDcOpsKY0mOqo9gbudw5h1yqJJR0FAhywTtJ4IJxJxZO6Ym/pl/+9zT918RrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.76-5",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.77.tgz",
       "integrity": "sha512-nkTtDPKvsClAByPPqnD/57vK7YIBK1dgiv7aVc9uO3rxKCyqiqYaBqwi8pMzesvGP3yl+//+iMzaBXNWEcZVWQ==",
@@ -82,7 +227,7 @@
         "@github/copilot-win32-x64": "1.0.77"
       }
     },
-    "node_modules/@github/copilot-darwin-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.77.tgz",
       "integrity": "sha512-sCWSH5+Flm/OxFe7dzsBfyj7ADBkzkR54Sz5NGw7dtcVVEOnVUkZLjEtNmZ1t5QRD4Sf1+g/DiwgJEbsR9xR1w==",
@@ -98,7 +243,7 @@
         "copilot-darwin-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-darwin-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.77.tgz",
       "integrity": "sha512-ReNlB+g+OBiqHwmY5leJBIyvHZQcjyWL/OY8aVimHyESn2ToPKP3eUNTzSUJvvbPM6+0LXwEpijLedkRd2Cn1g==",
@@ -114,7 +259,7 @@
         "copilot-darwin-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linux-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.77.tgz",
       "integrity": "sha512-A8j/WBPFvV5WfLbgnIIQLUVuFRAR7kLyc5WgId6XLCu1ARbkRM7353zz9mEXXwjc6LqotHVg80ooANJjNtmSPg==",
@@ -133,7 +278,7 @@
         "copilot-linux-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linux-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.77.tgz",
       "integrity": "sha512-2eefKkdUnQ1Y8oxyRyexHBXVpuSmrfEM8XJauquVjPc0JqF5nab9axwpFPzrRSF1GB+25F9tUK2sDQRyp08wag==",
@@ -152,7 +297,7 @@
         "copilot-linux-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linuxmusl-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.77.tgz",
       "integrity": "sha512-YtltOZQp8plytSKSGTWWKbOx3QD8iZH04sLtKTrYs6nu5UalIgFPoMkwamy1gh7h5EBkeVxD2s3epVrlvP4X4w==",
@@ -171,7 +316,7 @@
         "copilot-linuxmusl-arm64": "copilot"
       }
     },
-    "node_modules/@github/copilot-linuxmusl-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linuxmusl-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.77.tgz",
       "integrity": "sha512-owINwPgHU/ZZBwFhVPgkgGjLkF6e4QbdofADvKMdKJWV2+7oWjXUIlPA4/PwraD2Gkuu583l7m0XLL27TN8oUA==",
@@ -190,22 +335,7 @@
         "copilot-linuxmusl-x64": "copilot"
       }
     },
-    "node_modules/@github/copilot-sdk": {
-      "version": "1.0.9-preview.1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.9-preview.1.tgz",
-      "integrity": "sha512-/hUYdxpa4HL57uKmRCLmcg31wWjZPKGBbBfIhVqJdWXkp4/E6lbtHoiIbT5SLCPpf4c8Ka5zw356z+k4Nn/diA==",
-      "license": "MIT",
-      "dependencies": {
-        "@github/copilot": "^1.0.76-5",
-        "koffi": "^3.1.0",
-        "vscode-jsonrpc": "^8.2.1",
-        "zod": "^4.3.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@github/copilot-win32-arm64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.77.tgz",
       "integrity": "sha512-l5oQaMLCRup0nmmpbqOAYEAJ5YWgNlaoO0psNaKDzvTbdzEJRZqib2t7+p3bgoDpK7SB/m8m1uxFC4XT3hlprg==",
@@ -221,10 +351,42 @@
         "copilot-win32-arm64": "copilot.exe"
       }
     },
-    "node_modules/@github/copilot-win32-x64": {
+    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.77.tgz",
       "integrity": "sha512-8Mo9y3/8CVU2w35WqwSiRMTGH1kKHR3URPSJYF4J4OG8L7NOEy2fafXR9Tuq3H21Srg3OzFkl/A+Taunqz9KcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.78-2.tgz",
+      "integrity": "sha512-5rzE6ysT8ZMCZ8zhcgtExaaZ05UFo6KOCQZNYi+YGx8xpObR92vruZKKhBZH2vE51DM47dT1JQ9o0jS6eP7/dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.78-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.78-2.tgz",
+      "integrity": "sha512-10bTnLdDXiLcjWTMAoEmSuqkmf8Q+no9B5pL3u5ks3WiFLGx/r9oDo8CeyYV965CEsfoRkBIxWaLUTMra1tlxQ==",
       "cpu": [
         "x64"
       ],

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vscode-reh",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "^1.0.78-2",
-        "@github/copilot-sdk": "^1.0.9-preview.2",
+        "@github/copilot": "1.0.78-2",
+        "@github/copilot-sdk": "1.0.9-preview.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
         "@microsoft/mxc-sdk": "0.6.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@github/copilot": "^1.0.77",
-    "@github/copilot-sdk": "^1.0.9-preview.1",
+    "@github/copilot": "^1.0.78-2",
+    "@github/copilot-sdk": "^1.0.9-preview.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
     "@microsoft/mxc-sdk": "0.6.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@github/copilot": "^1.0.78-2",
-    "@github/copilot-sdk": "^1.0.9-preview.2",
+    "@github/copilot": "1.0.78-2",
+    "@github/copilot-sdk": "1.0.9-preview.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
     "@microsoft/mxc-sdk": "0.6.1",

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3026,7 +3026,6 @@ suite('CopilotAgentSession', () => {
 					accessKind: 'read',
 					paths: ['/workspace/src/file.ts'],
 					toolCallId: 'tc-managed',
-					managedApprovalRequired: true,
 					autoApproval: { recommendation: 'approve', reason: 'Low risk' },
 				},
 			});


### PR DESCRIPTION
- Bump `@github/copilot-sdk` from `^1.0.9-preview.1` to `^1.0.9-preview.2` in root and `remote/`.
- Bump `@github/copilot` from `^1.0.77` to `^1.0.78-2` alongside the SDK (matched validated bot bump pair).
- Drop `managedApprovalRequired` from the path `promptRequest` fixture in `copilotAgentSession` tests; SDK 1.0.9-preview.2 removed that field from `PermissionPromptRequestPath`.

Supersedes the bot draft after rebase onto current `main`: https://github.com/microsoft/vscode/pull/328553

-----------------------------------------
Inspirations from:

- Version pair and packaging surface come from the validated bot bump in https://github.com/microsoft/vscode/pull/328553.
- Path prompt fixture cleanup comes from the bot fix commit on that PR (`managedApprovalRequired` no longer exists on `PermissionPromptRequestPath`).