### PR TITLE
agentHost: Track tool result size and model

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -154,6 +154,7 @@ export interface IAgentHostToolInvokedReport {
 	toolSourceKind: string;
 	result: ToolInvokedResult;
 	invocationTimeMs?: number;
+	resultSizeInCharacters: number;
 }
 
 export interface IAgentHostAskQuestionsToolInvokedEvent {
@@ -809,6 +810,7 @@ export class AgentHostTelemetryReporter {
 			toolSourceKind: report.toolSourceKind,
 			invocationTimeMs: report.invocationTimeMs,
 			provider: report.provider,
+			resultSizeInCharacters: report.resultSizeInCharacters,
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -143,6 +143,7 @@ export interface IAgentHostTurnCompletedReport {
 	result: AgentHostTurnResult;
 	model: string | undefined;
 	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+	modelSelectionKind: AgentHostModelSelectionKind;
 	permissionLevel: string | undefined;
 	failure: IAgentHostTurnFailure | undefined;
 }
@@ -150,11 +151,14 @@ export interface IAgentHostTurnCompletedReport {
 export interface IAgentHostToolInvokedReport {
 	provider: string;
 	session: string;
+	turnId: string;
 	toolId: string;
 	toolSourceKind: string;
 	result: ToolInvokedResult;
 	invocationTimeMs?: number;
 	resultSizeInCharacters: number;
+	model: string | undefined;
+	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 }
 
 export interface IAgentHostAskQuestionsToolInvokedEvent {
@@ -436,6 +440,16 @@ export interface IAgentHostStalledToolCallCompletedReport {
 	result: ToolInvokedResult;
 	totalTimeMs: number;
 	timeAfterStallMs: number;
+}
+
+function toTelemetryModel(model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined): string | TelemetryTrustedValue<string> | undefined {
+	if (model === undefined) {
+		return undefined;
+	}
+	if (modelTelemetryKind === 'trusted') {
+		return new TelemetryTrustedValue(model);
+	}
+	return modelTelemetryKind === 'byok' ? 'byokModel' : 'unknown';
 }
 
 export class AgentHostTelemetryReporter {
@@ -764,11 +778,7 @@ export class AgentHostTelemetryReporter {
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
-		const model = report.model === undefined
-			? undefined
-			: report.modelTelemetryKind === 'trusted'
-				? new TelemetryTrustedValue(report.model)
-				: report.modelTelemetryKind === 'byok' ? 'byokModel' : 'unknown';
+		const model = toTelemetryModel(report.model, report.modelTelemetryKind);
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,
 			agentSessionId: AgentSession.id(session),
@@ -777,7 +787,7 @@ export class AgentHostTelemetryReporter {
 			totalTime: report.totalTime,
 			result: report.result,
 			model,
-			modelSelectionKind: report.model === undefined ? 'default' : report.model === 'auto' ? 'auto' : 'explicit',
+			modelSelectionKind: report.modelSelectionKind,
 			permissionLevel: report.permissionLevel,
 			errorType: report.failure?.error.errorType,
 			failureStage: report.failure?.stage,
@@ -811,6 +821,8 @@ export class AgentHostTelemetryReporter {
 			invocationTimeMs: report.invocationTimeMs,
 			provider: report.provider,
 			resultSizeInCharacters: report.resultSizeInCharacters,
+			turnId: report.turnId,
+			model: toTelemetryModel(report.model, report.modelTelemetryKind),
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -8,7 +8,7 @@ import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import type { SessionToolAuthenticationRequest, SessionToolClientExecutionRequest, SessionToolConfirmationRequest } from '../common/state/protocol/state.js';
 import { ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../common/state/sessionState.js';
-import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter, IAgentHostToolInvokedReport } from './agentHostTelemetryReporter.js';
 
 export type ToolInvokedResult = 'success' | 'error' | 'userCancelled';
 
@@ -74,6 +74,7 @@ interface IToolCallTiming {
 	toolSourceKind: string;
 	model: string | undefined;
 	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+	modelResolvedFromUsage: boolean;
 }
 
 interface IStalledToolCall {
@@ -99,6 +100,7 @@ export class AgentHostToolCallTracker extends Disposable {
 
 	private readonly _toolCalls = new Map<string, IToolCallTiming>();
 	private readonly _turnModels = new Map<string, { model: string; modelTelemetryKind: AgentHostModelTelemetryKind }>();
+	private readonly _pendingToolReports = new Map<string, IAgentHostToolInvokedReport[]>();
 	private readonly _toolCallStallTimers = this._register(new DisposableMap<string>());
 	private readonly _stalledToolCalls = new Map<string, IStalledToolCall>();
 
@@ -118,15 +120,25 @@ export class AgentHostToolCallTracker extends Disposable {
 			toolSourceKind: toolSourceKindFromContributor(contributor),
 			model: resolvedModel?.model ?? model,
 			modelTelemetryKind: resolvedModel?.modelTelemetryKind ?? modelTelemetryKind,
+			modelResolvedFromUsage: resolvedModel !== undefined,
 		});
 	}
 
 	updateTurnModel(session: string, turnId: string, model: string, modelTelemetryKind: AgentHostModelTelemetryKind): void {
-		this._turnModels.set(this._turnKey(session, turnId), { model, modelTelemetryKind });
+		const turnKey = this._turnKey(session, turnId);
+		this._turnModels.set(turnKey, { model, modelTelemetryKind });
 		for (const timing of this._toolCalls.values()) {
 			if (timing.session === session && timing.turnId === turnId) {
 				timing.model = model;
 				timing.modelTelemetryKind = modelTelemetryKind;
+				timing.modelResolvedFromUsage = true;
+			}
+		}
+		const pending = this._pendingToolReports.get(turnKey);
+		if (pending) {
+			this._pendingToolReports.delete(turnKey);
+			for (const report of pending) {
+				this._reporter.toolInvoked({ ...report, model, modelTelemetryKind });
 			}
 		}
 	}
@@ -163,7 +175,7 @@ export class AgentHostToolCallTracker extends Disposable {
 		const totalTimeMs = timing.lifecycleStopWatch.elapsed();
 		const resultSizeInCharacters = JSON.stringify(result).length;
 
-		this._reporter.toolInvoked({
+		const report: IAgentHostToolInvokedReport = {
 			provider: timing.provider,
 			session: timing.session,
 			turnId: timing.turnId,
@@ -174,7 +186,15 @@ export class AgentHostToolCallTracker extends Disposable {
 			resultSizeInCharacters,
 			model: timing.model,
 			modelTelemetryKind: timing.modelTelemetryKind,
-		});
+		};
+		if (timing.modelResolvedFromUsage) {
+			this._reporter.toolInvoked(report);
+		} else {
+			const turnKey = this._turnKey(timing.session, timing.turnId);
+			const pending = this._pendingToolReports.get(turnKey) ?? [];
+			pending.push(report);
+			this._pendingToolReports.set(turnKey, pending);
+		}
 
 		const stalled = this._stalledToolCalls.get(key);
 		if (stalled) {
@@ -225,6 +245,14 @@ export class AgentHostToolCallTracker extends Disposable {
 	 */
 	clearSession(session: string): void {
 		const prefix = `${session}\0`;
+		for (const [key, reports] of this._pendingToolReports) {
+			if (key.startsWith(prefix)) {
+				this._pendingToolReports.delete(key);
+				for (const report of reports) {
+					this._reporter.toolInvoked(report);
+				}
+			}
+		}
 		for (const key of this._toolCalls.keys()) {
 			if (key.startsWith(prefix)) {
 				this._toolCalls.delete(key);
@@ -250,6 +278,7 @@ export class AgentHostToolCallTracker extends Disposable {
 	clear(): void {
 		this._toolCalls.clear();
 		this._turnModels.clear();
+		this._pendingToolReports.clear();
 		this._toolCallStallTimers.clearAndDisposeAll();
 		this._stalledToolCalls.clear();
 	}

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -143,6 +143,7 @@ export class AgentHostToolCallTracker extends Disposable {
 		this._toolCalls.delete(key);
 		const resultBucket = deriveToolInvokedResult(result);
 		const totalTimeMs = timing.lifecycleStopWatch.elapsed();
+		const resultSizeInCharacters = JSON.stringify(result).length;
 
 		this._reporter.toolInvoked({
 			provider: timing.provider,
@@ -151,6 +152,7 @@ export class AgentHostToolCallTracker extends Disposable {
 			toolSourceKind: timing.toolSourceKind,
 			result: resultBucket,
 			invocationTimeMs: timing.invocationStopWatch?.elapsed(),
+			resultSizeInCharacters,
 		});
 
 		const stalled = this._stalledToolCalls.get(key);

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -8,7 +8,7 @@ import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import type { SessionToolAuthenticationRequest, SessionToolClientExecutionRequest, SessionToolConfirmationRequest } from '../common/state/protocol/state.js';
 import { ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../common/state/sessionState.js';
-import type { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 
 export type ToolInvokedResult = 'success' | 'error' | 'userCancelled';
 
@@ -68,9 +68,12 @@ interface IToolCallTiming {
 	invocationStopWatch?: StopWatch;
 	readonly provider: string;
 	readonly session: string;
+	readonly turnId: string;
 	readonly toolId: string;
 	contributor: ToolCallContributor | undefined;
 	toolSourceKind: string;
+	model: string | undefined;
+	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 }
 
 interface IStalledToolCall {
@@ -95,6 +98,7 @@ interface IStalledToolCall {
 export class AgentHostToolCallTracker extends Disposable {
 
 	private readonly _toolCalls = new Map<string, IToolCallTiming>();
+	private readonly _turnModels = new Map<string, { model: string; modelTelemetryKind: AgentHostModelTelemetryKind }>();
 	private readonly _toolCallStallTimers = this._register(new DisposableMap<string>());
 	private readonly _stalledToolCalls = new Map<string, IStalledToolCall>();
 
@@ -102,15 +106,29 @@ export class AgentHostToolCallTracker extends Disposable {
 		super();
 	}
 
-	toolCallStarted(provider: string, session: string, toolCallId: string, toolName: string, contributor: ToolCallContributor | undefined): void {
+	toolCallStarted(provider: string, session: string, turnId: string, toolCallId: string, toolName: string, contributor: ToolCallContributor | undefined, model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined): void {
+		const resolvedModel = this._turnModels.get(this._turnKey(session, turnId));
 		this._toolCalls.set(this._key(session, toolCallId), {
 			lifecycleStopWatch: StopWatch.create(true),
 			provider,
 			session,
+			turnId,
 			toolId: toolName,
 			contributor,
 			toolSourceKind: toolSourceKindFromContributor(contributor),
+			model: resolvedModel?.model ?? model,
+			modelTelemetryKind: resolvedModel?.modelTelemetryKind ?? modelTelemetryKind,
 		});
+	}
+
+	updateTurnModel(session: string, turnId: string, model: string, modelTelemetryKind: AgentHostModelTelemetryKind): void {
+		this._turnModels.set(this._turnKey(session, turnId), { model, modelTelemetryKind });
+		for (const timing of this._toolCalls.values()) {
+			if (timing.session === session && timing.turnId === turnId) {
+				timing.model = model;
+				timing.modelTelemetryKind = modelTelemetryKind;
+			}
+		}
 	}
 
 	toolCallMetadataUpdated(session: string, toolCallId: string, contributor: ToolCallContributor | undefined): void {
@@ -148,11 +166,14 @@ export class AgentHostToolCallTracker extends Disposable {
 		this._reporter.toolInvoked({
 			provider: timing.provider,
 			session: timing.session,
+			turnId: timing.turnId,
 			toolId: timing.toolId,
 			toolSourceKind: timing.toolSourceKind,
 			result: resultBucket,
 			invocationTimeMs: timing.invocationStopWatch?.elapsed(),
 			resultSizeInCharacters,
+			model: timing.model,
+			modelTelemetryKind: timing.modelTelemetryKind,
 		});
 
 		const stalled = this._stalledToolCalls.get(key);
@@ -219,15 +240,25 @@ export class AgentHostToolCallTracker extends Disposable {
 				this._stalledToolCalls.delete(key);
 			}
 		}
+		for (const key of this._turnModels.keys()) {
+			if (key.startsWith(prefix)) {
+				this._turnModels.delete(key);
+			}
+		}
 	}
 
 	clear(): void {
 		this._toolCalls.clear();
+		this._turnModels.clear();
 		this._toolCallStallTimers.clearAndDisposeAll();
 		this._stalledToolCalls.clear();
 	}
 
 	private _key(session: string, toolCallId: string): string {
 		return `${session}\0${toolCallId}`;
+	}
+
+	private _turnKey(session: string, turnId: string): string {
+		return `${session}\0${turnId}`;
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -13,8 +13,9 @@ interface ITurnTiming {
 	readonly stopWatch: StopWatch;
 	readonly provider: string;
 	readonly session: string;
-	readonly model: string | undefined;
-	readonly modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+	model: string | undefined;
+	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+	readonly modelSelectionKind: 'default' | 'auto' | 'explicit';
 	readonly permissionLevel: string | undefined;
 	firstProgressMs: number | undefined;
 }
@@ -58,6 +59,7 @@ export class AgentHostTurnTracker extends Disposable {
 			session,
 			model,
 			modelTelemetryKind,
+			modelSelectionKind: model === undefined ? 'default' : model === 'auto' ? 'auto' : 'explicit',
 			permissionLevel,
 			firstProgressMs: undefined,
 		});
@@ -69,6 +71,19 @@ export class AgentHostTurnTracker extends Disposable {
 		if (timing && timing.firstProgressMs === undefined) {
 			timing.firstProgressMs = timing.stopWatch.elapsed();
 		}
+	}
+
+	updateModel(session: string, turnId: string, model: string, modelTelemetryKind: AgentHostModelTelemetryKind): void {
+		const timing = this._turnTimings.get(this._key(session, turnId));
+		if (timing) {
+			timing.model = model;
+			timing.modelTelemetryKind = modelTelemetryKind;
+		}
+	}
+
+	getModelTelemetryContext(session: string, turnId: string): { model: string | undefined; modelTelemetryKind: AgentHostModelTelemetryKind | undefined } | undefined {
+		const timing = this._turnTimings.get(this._key(session, turnId));
+		return timing ? { model: timing.model, modelTelemetryKind: timing.modelTelemetryKind } : undefined;
 	}
 
 	turnCompleted(session: string, turnId: string, result: AgentHostTurnResult, failure?: IAgentHostTurnFailure): void {
@@ -88,6 +103,7 @@ export class AgentHostTurnTracker extends Disposable {
 			result,
 			model: timing.model,
 			modelTelemetryKind: timing.modelTelemetryKind,
+			modelSelectionKind: timing.modelSelectionKind,
 			permissionLevel: timing.permissionLevel,
 			failure,
 		});

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1497,6 +1497,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const sessionKey = session.toString();
 		const provider = this._findProviderForSession(session);
 		this._sideEffects.clearQueuedMessageSenders(chat.toString());
+		this._sideEffects.cancelSubagentSessions(chat.toString());
+		this._sideEffects.clearToolCallTelemetry(chat.toString());
 		this._stateManager.removeChat(sessionKey, chat.toString());
 		// Drop the chat from the orchestrator-owned catalog so it isn't
 		// re-materialized on the next restore.
@@ -2043,6 +2045,10 @@ export class AgentService extends Disposable implements IAgentService {
 
 	async disposeSession(session: URI): Promise<void> {
 		this._logService.trace(`[AgentService] disposeSession: ${session.toString()}`);
+		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {
+			this._sideEffects.clearToolCallTelemetry(chat.resource);
+		}
+		this._sideEffects.clearToolCallTelemetry(session.toString());
 		// Resolve the working directories up front and pass them explicitly:
 		// the checkpoint and review services need them to locate the
 		// repositories holding this session's refs, and reading them from

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -782,15 +782,21 @@ export class AgentSideEffects extends Disposable {
 
 		if (action.type === ActionType.ChatToolCallStart && agent) {
 			this._toolCallAgents.set(`${sessionKey}:${action.toolCallId}`, agent.id);
+			const modelContext = this._turnTracker.getModelTelemetryContext(sessionKey, action.turnId);
 			// Stamp the tool call start for `languageModelToolInvoked` telemetry.
 			// Ready may refine the contributor once the complete tool metadata is
 			// available, so the tracker updates the source kind below when needed.
-			this._toolCallTracker.toolCallStarted(agent.id, sessionKey, action.toolCallId, action.toolName, action.contributor);
+			this._toolCallTracker.toolCallStarted(agent.id, sessionKey, action.turnId, action.toolCallId, action.toolName, action.contributor, modelContext?.model, modelContext?.modelTelemetryKind);
 		} else if (action.type === ActionType.ChatToolCallReady) {
 			this._toolCallTracker.toolCallMetadataUpdated(sessionKey, action.toolCallId, action.contributor);
 			if (action.confirmed) {
 				this._toolCallTracker.toolCallExecutionStarted(sessionKey, action.toolCallId);
 			}
+		}
+		if (action.type === ActionType.ChatUsage && action.usage.model && agent) {
+			const modelContext = this._getModelTelemetryContext(agent, action.usage.model);
+			this._turnTracker.updateModel(sessionKey, action.turnId, modelContext.model, modelContext.modelTelemetryKind);
+			this._toolCallTracker.updateTurnModel(sessionKey, action.turnId, modelContext.model, modelContext.modelTelemetryKind);
 		}
 
 		const sessionUri = isAhpChatChannel(sessionKey) ? parseRequiredSessionUriFromChatUri(sessionKey) : sessionKey;
@@ -1749,18 +1755,23 @@ export class AgentSideEffects extends Disposable {
 	private _getTurnTelemetryContext(agent: IAgent, state: SessionState | undefined, modelId: string | undefined): { model: string | undefined; modelTelemetryKind: AgentHostModelTelemetryKind | undefined; permissionLevel: string | undefined } {
 		const permissionValue = state?.config?.values[SessionConfigKey.AutoApprove];
 		const permissionLevel = typeof permissionValue === 'string' ? permissionValue : undefined;
-		const model = modelId === undefined ? undefined : agent.models.get().find(model => model.id === modelId);
-		let modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+		const modelContext = modelId === undefined
+			? { model: undefined, modelTelemetryKind: undefined }
+			: this._getModelTelemetryContext(agent, modelId);
+		return { ...modelContext, permissionLevel };
+	}
+
+	private _getModelTelemetryContext(agent: IAgent, modelId: string): { model: string; modelTelemetryKind: AgentHostModelTelemetryKind } {
+		const model = agent.models.get().find(model => model.id === modelId);
+		let modelTelemetryKind: AgentHostModelTelemetryKind;
 		if (modelId === 'auto') {
 			modelTelemetryKind = 'trusted';
-		} else if (modelId === undefined) {
-			modelTelemetryKind = undefined;
 		} else if (model === undefined) {
 			modelTelemetryKind = 'unknown';
 		} else {
 			modelTelemetryKind = readAgentModelByokIdentifier(model) === undefined ? 'trusted' : 'byok';
 		}
-		return { model: modelId, modelTelemetryKind, permissionLevel };
+		return { model: modelId, modelTelemetryKind };
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1133,6 +1133,8 @@ export class AgentSideEffects extends Disposable {
 				turnId,
 				duration: this._turnDuration(subagent.turnStopWatch),
 			});
+			this._turnTracker.turnCompleted(subagent.chatUri, turnId, 'success');
+			this._toolCallTracker.clearSession(subagent.chatUri);
 		}
 	}
 
@@ -1145,6 +1147,7 @@ export class AgentSideEffects extends Disposable {
 				this._cancelledTurnIds.delete(chatUri);
 			}
 		}
+
 		const parentChatURIs = new Set<ProtocolURI>();
 		for (const subagent of this._subagentChats.values()) {
 			if (subagent.sessionUri === parentSession) {
@@ -1157,6 +1160,10 @@ export class AgentSideEffects extends Disposable {
 			this._subagentChats.deleteAll(parentChatURI);
 			this._pendingSubagentSignals.deleteAll(parentChatURI);
 		}
+	}
+
+	clearToolCallTelemetry(channel: ProtocolURI): void {
+		this._toolCallTracker.clearSession(channel);
 	}
 
 	clearInputRequestsForSession(session: ProtocolURI): void {

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -132,6 +132,10 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		fire({ type: ActionType.ChatToolCallComplete, turnId, toolCallId, result });
 	}
 
+	function completeTurn(turnId: string): void {
+		fire({ type: ActionType.ChatTurnComplete, turnId, duration: 1000 });
+	}
+
 	function toolEvents(): { eventName: string; data: Record<string, unknown> }[] {
 		return telemetry.events
 			.filter(e => e.eventName === 'languageModelToolInvoked')
@@ -226,6 +230,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 			confirmed: ToolCallConfirmationReason.NotNeeded,
 		});
 		toolComplete('turn-1', 'tc-1', { success: true, pastTenseMessage: 'ran' });
+		completeTurn('turn-1');
 
 		assert.deepStrictEqual(toolEvents(), [{
 			eventName: 'languageModelToolInvoked',
@@ -250,6 +255,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 
 		toolStart('turn-1', 'tc-mcp', 'lookup', { kind: ToolCallContributorKind.MCP, customizationId: 'c1' });
 		toolComplete('turn-1', 'tc-mcp', { success: false, pastTenseMessage: 'denied', error: { message: 'denied', code: 'denied' } });
+		completeTurn('turn-1');
 
 		assert.deepStrictEqual(toolEvents(), [{
 			eventName: 'languageModelToolInvoked',
@@ -281,6 +287,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 			confirmed: ToolCallConfirmationReason.NotNeeded,
 		});
 		toolComplete('turn-1', 'tc-client', { success: true, pastTenseMessage: 'ran tests' });
+		completeTurn('turn-1');
 
 		assert.deepStrictEqual(toolEvents(), [{
 			eventName: 'languageModelToolInvoked',
@@ -337,6 +344,19 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		assert.deepStrictEqual(toolEvents()[0].data.model, { trusted: true, value: 'gpt-5.5' });
 	});
 
+	test('waits for a resolved usage model received after tool completion', () => {
+		setupSession();
+		agent.setModels([{ provider: 'mock', id: 'claude-sonnet', name: 'Claude Sonnet', supportsVision: false }]);
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-model', 'read_file');
+		toolComplete('turn-1', 'tc-model', { success: true, pastTenseMessage: 'read file' });
+		assert.strictEqual(toolEvents().length, 0);
+		fire({ type: ActionType.ChatUsage, turnId: 'turn-1', usage: { model: 'claude-sonnet' } });
+
+		assert.deepStrictEqual(toolEvents()[0].data.model, { trusted: true, value: 'claude-sonnet' });
+	});
+
 	test('includes result content in the serialized result size', () => {
 		setupSession();
 		startTurn('turn-1');
@@ -347,6 +367,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 			pastTenseMessage: 'read files',
 			content: [{ type: ToolResultContentType.Text, text: 'alpha\nbeta' }],
 		});
+		completeTurn('turn-1');
 
 		assert.deepStrictEqual(toolEvents()[0].data.resultSizeInCharacters, 97);
 	});
@@ -386,6 +407,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		await timeout(0);
 		toolComplete('turn-1', 'tc-mcp-ready', { success: true, pastTenseMessage: 'looked up metadata' });
 		toolComplete('turn-1', 'tc-late-client', { success: true, pastTenseMessage: 'ran tests' });
+		completeTurn('turn-1');
 
 		assert.deepStrictEqual(toolEvents().map(event => event.data.toolSourceKind), ['mcp', 'agentHost']);
 	});
@@ -415,6 +437,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 			sideEffects.handleAction(defaultChatUri, confirmed);
 			await timeout(25);
 			toolComplete('turn-1', 'tc-confirm-timing', { success: true, pastTenseMessage: 'wrote file' });
+			completeTurn('turn-1');
 		});
 
 		const event = telemetry.events.find(event => event.eventName === 'languageModelToolInvoked');
@@ -434,6 +457,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 
 		toolStart('turn-1', 'tc-err', 'bash');
 		toolComplete('turn-1', 'tc-err', { success: false, pastTenseMessage: 'boom', error: { message: 'boom' } });
+		completeTurn('turn-1');
 
 		assert.strictEqual(toolEvents()[0].data.result, 'error');
 	});
@@ -445,6 +469,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		toolStart('turn-1', 'tc-dup', 'bash');
 		toolComplete('turn-1', 'tc-dup', { success: true, pastTenseMessage: 'ran' });
 		toolComplete('turn-1', 'tc-dup', { success: true, pastTenseMessage: 'ran' });
+		completeTurn('turn-1');
 
 		assert.strictEqual(toolEvents().length, 1);
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -14,6 +14,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
 import { SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
@@ -108,12 +109,12 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
 	}
 
-	function startTurn(turnId: string, text = 'hello'): void {
+	function startTurn(turnId: string, text = 'hello', modelId?: string): void {
 		const action: ChatAction = {
 			type: ActionType.ChatTurnStarted,
 			turnId,
 			startedAt: '2025-01-01T00:00:00.000Z',
-			message: { text, origin: { kind: MessageKind.User } },
+			message: { text, origin: { kind: MessageKind.User }, model: modelId ? { id: modelId } : undefined },
 		};
 		stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
 		sideEffects.handleAction(defaultChatUri, action);
@@ -143,6 +144,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 						invocationTimeMs: data.invocationTimeMs === undefined
 							? undefined
 							: typeof data.invocationTimeMs === 'number' && data.invocationTimeMs >= 0,
+						model: data.model instanceof TelemetryTrustedValue ? { trusted: true, value: data.model.value } : data.model,
 					},
 				};
 			});
@@ -236,6 +238,8 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				provider: 'mock',
 				invocationTimeMs: true,
 				resultSizeInCharacters: 41,
+				turnId: 'turn-1',
+				model: undefined,
 			},
 		}]);
 	});
@@ -258,6 +262,8 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				provider: 'mock',
 				invocationTimeMs: undefined,
 				resultSizeInCharacters: 90,
+				turnId: 'turn-1',
+				model: undefined,
 			},
 		}]);
 	});
@@ -287,8 +293,48 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				provider: 'mock',
 				invocationTimeMs: true,
 				resultSizeInCharacters: 47,
+				turnId: 'turn-1',
+				model: undefined,
 			},
 		}]);
+	});
+
+	test('uses the resolved usage model for an in-flight tool call', () => {
+		setupSession();
+		agent.setModels([
+			{ provider: 'mock', id: 'auto', name: 'Auto', supportsVision: false },
+			{ provider: 'mock', id: 'gpt-5.5', name: 'GPT 5.5', supportsVision: false },
+		]);
+		startTurn('turn-1', 'hello', 'auto');
+
+		toolStart('turn-1', 'tc-model', 'read_file');
+		fire({ type: ActionType.ChatUsage, turnId: 'turn-1', usage: { model: 'gpt-5.5' } });
+		toolComplete('turn-1', 'tc-model', { success: true, pastTenseMessage: 'read file' });
+
+		assert.deepStrictEqual(toolEvents()[0].data, {
+			result: 'success',
+			chatSessionId: sessionKey,
+			toolId: 'read_file',
+			toolExtensionId: undefined,
+			toolSourceKind: 'agentHost',
+			invocationTimeMs: undefined,
+			provider: 'mock',
+			resultSizeInCharacters: 47,
+			turnId: 'turn-1',
+			model: { trusted: true, value: 'gpt-5.5' },
+		});
+	});
+
+	test('uses a resolved usage model received before the tool call starts', () => {
+		setupSession();
+		agent.setModels([{ provider: 'mock', id: 'gpt-5.5', name: 'GPT 5.5', supportsVision: false }]);
+		startTurn('turn-1');
+
+		fire({ type: ActionType.ChatUsage, turnId: 'turn-1', usage: { model: 'gpt-5.5' } });
+		toolStart('turn-1', 'tc-model', 'read_file');
+		toolComplete('turn-1', 'tc-model', { success: true, pastTenseMessage: 'read file' });
+
+		assert.deepStrictEqual(toolEvents()[0].data.model, { trusted: true, value: 'gpt-5.5' });
 	});
 
 	test('includes result content in the serialized result size', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -17,7 +17,7 @@ import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/tel
 import { AgentSession, IAgent } from '../../common/agentService.js';
 import { SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
-import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
@@ -235,6 +235,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				toolSourceKind: 'agentHost',
 				provider: 'mock',
 				invocationTimeMs: true,
+				resultSizeInCharacters: 41,
 			},
 		}]);
 	});
@@ -256,6 +257,7 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				toolSourceKind: 'mcp',
 				provider: 'mock',
 				invocationTimeMs: undefined,
+				resultSizeInCharacters: 90,
 			},
 		}]);
 	});
@@ -284,8 +286,23 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				toolSourceKind: 'client',
 				provider: 'mock',
 				invocationTimeMs: true,
+				resultSizeInCharacters: 47,
 			},
 		}]);
+	});
+
+	test('includes result content in the serialized result size', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-read', 'read_file');
+		toolComplete('turn-1', 'tc-read', {
+			success: true,
+			pastTenseMessage: 'read files',
+			content: [{ type: ToolResultContentType.Text, text: 'alpha\nbeta' }],
+		});
+
+		assert.deepStrictEqual(toolEvents()[0].data.resultSizeInCharacters, 97);
 	});
 
 	test('only accepts contributor refinements that preserve execution ownership', async () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -244,6 +244,27 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		]);
 	});
 
+	test('uses the resolved usage model while preserving Auto selection', () => {
+		setupSession();
+		agent.setModels([
+			{ provider: 'mock', id: 'auto', name: 'Auto', supportsVision: false },
+			{ provider: 'mock', id: 'gpt-5.5', name: 'GPT 5.5', supportsVision: false },
+		]);
+		startTurn('turn-auto', 'hello', 'auto');
+
+		fire({ type: ActionType.ChatUsage, turnId: 'turn-auto', usage: { model: 'gpt-5.5' } });
+		fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-auto', duration: 1000 });
+
+		const data = completedEvents()[0].data as Record<string, unknown>;
+		assert.deepStrictEqual({
+			model: capturedModel(data),
+			modelSelectionKind: data.modelSelectionKind,
+		}, {
+			model: { trusted: true, value: 'gpt-5.5' },
+			modelSelectionKind: 'auto',
+		});
+	});
+
 	test('timeToFirstProgress is undefined when no visible progress arrives before completion', () => {
 		setupSession();
 		startTurn('turn-1');

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1867,6 +1867,10 @@ suite('AgentSideEffects', () => {
 					result: { success: true, pastTenseMessage: 'Read file' },
 				},
 			});
+			agent.fireProgress({
+				kind: 'action', resource: URI.parse(defaultChatUri),
+				action: { type: ActionType.ChatTurnComplete, turnId: 'turn-2', duration: 1000 },
+			});
 
 			assert.deepStrictEqual(
 				telemetryService.events.filter(event => event.eventName === 'languageModelToolInvoked').map(event => event.eventName),

--- a/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
+++ b/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
@@ -22,6 +22,7 @@ export type LanguageModelToolInvokedEvent = LanguageModelToolTelemetryData & {
 	prepareTimeMs?: number;
 	invocationTimeMs?: number;
 	provider?: string;
+	resultSizeInCharacters?: number;
 };
 
 export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryClassification & {
@@ -29,6 +30,7 @@ export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryC
 	prepareTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in prepareToolInvocation method in milliseconds.' };
 	invocationTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in tool invoke method in milliseconds.' };
 	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilotcli, claude, codex), if applicable.' };
+	resultSizeInCharacters?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Length of the serialized Agent Host tool result in UTF-16 code units, if applicable.' };
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };

--- a/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
+++ b/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { TelemetryTrustedValue } from './telemetryUtils.js';
+
 export type LanguageModelToolTelemetryData = {
 	chatSessionId: string | undefined;
 	toolId: string;
@@ -23,6 +25,8 @@ export type LanguageModelToolInvokedEvent = LanguageModelToolTelemetryData & {
 	invocationTimeMs?: number;
 	provider?: string;
 	resultSizeInCharacters?: number;
+	turnId?: string;
+	model?: string | TelemetryTrustedValue<string>;
 };
 
 export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryClassification & {
@@ -31,6 +35,8 @@ export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryC
 	invocationTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in tool invoke method in milliseconds.' };
 	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilotcli, claude, codex), if applicable.' };
 	resultSizeInCharacters?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Length of the serialized Agent Host tool result in UTF-16 code units, if applicable.' };
+	turnId?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the Agent Host turn containing the tool invocation, if applicable.' };
+	model?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The trusted provider model identifier that produced the tool call, or a generic value for BYOK and unknown models, if applicable.' };
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };


### PR DESCRIPTION
## Overview

### What

Adds `resultSizeInCharacters`, `model`, and `turnId` to the canonical `languageModelToolInvoked` event for Agent Host tool completions. Result size is the serialized AHP `ToolCallResult` length in UTF-16 code units.

Model attribution comes directly from the turn's resolved `ChatUsage.model`. The tool tracker handles usage arriving before tool start, during execution, or after tool completion; a completed report waits for late usage and falls back to the selected model when the turn ends. Auto remains recorded as the selection kind on `agentHost.turnCompleted` while `model` carries the resolved model. Trusted provider model ids are emitted verbatim through `TelemetryTrustedValue`; BYOK and unknown models use `byokModel` and `unknown`.

The local `agent.tool.responseLength` emitter is unchanged. Follow-up work would be required only for tokenizer-aware result cost; no placeholder token count is emitted.

### Why

Tracked in https://github.com/microsoft/vscode-internalbacklog/issues/8247. The local event was observed in local sessions but had no Agent Host result-size counterpart. Without direct model attribution, the AH measurement could not reliably support model-segmented analysis: session-level joins are many-to-many. This change puts the resolved model and turn key on the tool row itself.

---

## Data parity

Legend: Exact = same analytical signal, Analogue = close analogue, Gap = AH data omits.

| Analytical signal | Local event / source | AH event / source | Parity |
|---|---|---|---|
| Tool identity | `agent.tool.responseLength.toolName` | `languageModelToolInvoked.toolId` | Exact after renaming |
| Successful result population | Event fires only after success | Filter `languageModelToolInvoked.result == "success"` | Exact after filtering |
| Relative result size | Tokenized `tokenCount` | Serialized `resultSizeInCharacters` | Analogue: different unit and envelope |
| Model | Invoked endpoint `model` | Resolved `ChatUsage.model` | Exact for trusted models; BYOK/unknown remain privacy-bucketed |
| Turn correlation | `requestId` | `turnId` | Analogue: native identifiers differ, but AH rows have a direct turn key |
| Model-normalized prompt cost | Endpoint tokenizer | Not available | Gap: requires tokenizer-aware SDK support |

---

## Row-count and dashboard implications

- **Historical rows:** `agent.tool.responseLength` remains success-only and token-based.
- **AH rows:** `languageModelToolInvoked` covers successful, failed, and user-cancelled completed tool calls; filter to `result == "success"` for population parity.
- **Query translation:** normalize `toolName = coalesce(toolName, toolId)` and retain an explicit size-unit dimension. Do not coalesce raw token and character counts into one numeric series.
- **Model analysis:** use `model` directly; no session-level join is required. `turnId` supports joins to other AH turn events when needed.
- **Privacy:** only the numeric serialized length is emitted; tool-result content is not added to telemetry. Model ids retain the existing trusted/BYOK/unknown treatment.

## Semantic-shift ledger

| Signal | Shift | Impact |
|---|---|---|
| Size unit | Model tokens become serialized UTF-16 code units | Compare distributions within one unit/population; raw values are not interchangeable |
| Counted payload | Rendered primitive result becomes the serialized AHP result envelope | AH values include fixed protocol/structured metadata overhead |
| Cadence | Success-only becomes all completed outcomes | Filter AH rows to successful outcomes for parity |
| Emission timing | AH may wait for late usage before emitting a completed tool row | Improves direct model attribution; unresolved turns flush on turn/chat/session cleanup |

## Validation

- Agent Host tool/turn telemetry suites: 31 passing
- AgentSideEffects suite: 184 passing
- AgentService disposal tests: 12 passing
- `npm run transpile-client` - passed
- `npm run precommit` - passed
- `npm run typecheck-client` was attempted but remains blocked by unrelated pre-existing Agent Host protocol/UI type errors.