### PR TITLE
agentHost: detect workspace provenance from metadata

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -302,7 +302,6 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		const workspace = this._workspaceContextService.getWorkspace();
 		if (this._environmentService.isSessionsWindow
 			|| this._workspaceContextService.getWorkbenchState() !== WorkbenchState.WORKSPACE
-			|| workspace.folders.length < 2
 			|| !URI.isUri(workspace.configuration)) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -226,7 +226,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	});
 
 	test('getOrCreate includes Editor multi-root workspace metadata', async () => {
-		workspaceFolders = [URI.file('/workspace/one'), URI.file('/workspace/two')];
+		workspaceFolders = [URI.file('/workspace/one')];
 		workspaceConfiguration = URI.parse('vscode-remote://ssh-remote+host/work/demo.code-workspace');
 		workspaceName = 'Demo Workspace';
 		workbenchState = WorkbenchState.WORKSPACE;


### PR DESCRIPTION
## Summary

- identify `.code-workspace` session provenance from workspace metadata instead of current folder count
- preserve provenance when a multi-root workspace currently contains only one folder
- add focused regression coverage for a one-folder `.code-workspace`

## Audit

Other folder-count checks were reviewed. They control provider multi-directory runtime behavior, folder-picker UI, customization syncing, or unrelated generic workspace behavior; they do not classify Agent Host session provenance and remain unchanged.

## Validation

- `npm run transpile-client`
- focused `AgentHostUntitledProvisionalSessionService` unit test
- `npm run valid-layers-check`
- `npm run precommit`