### PR TITLE
fix: show plan.md in Agents markdown preview pills

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -314,14 +314,16 @@ visible slot into the sent chat — see _Adding a Chat to an Existing Session_
 below.
 
 For agent-host sessions, the floating turn-status pills above the chat input read
-the viewed chat's `lastTurnChanges` while the turn streams. They remain visible
-when the chat transitions from `InProgress` to `NeedsInput`, since tool or input
-confirmation does not end the active turn. The changes count, diff, and preview
-list are scoped to files under the session workspace folder or its working
-directory/worktree; edits outside those roots are treated as external files and
-do not inflate the pill or show as preview candidates. The preview pill itself
-stays a compact resource label (file icon + name); preview wording is kept to
-tooltips and actions, not rendered as visible pill text.
+the viewed chat's last-turn change streams while the turn streams. They remain
+visible when the chat transitions from `InProgress` to `NeedsInput`, since tool
+or input confirmation does not end the active turn. The changes count and multi-
+diff stay scoped to files under the session workspace folder or its working
+directory/worktree (`lastTurnChanges`); edits outside those roots do not inflate
+that pill. Preview pills prefer `lastTurnPreviewChanges` when present, so
+out-of-workspace markdown such as session-state `plan.md` can still appear as
+preview candidates without affecting the workspace-scoped count. The preview
+pill itself stays a compact resource label (file icon + name); preview wording
+is kept to tooltips and actions, not rendered as visible pill text.
 
 Explicit user-initiated "new session" gestures (Ctrl/Cmd+N, the **New** button,
 the mobile titlebar "+" button, and the sessions quick picker's "New Session"

--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -36,24 +36,31 @@ const EMPTY_TURN_DATA: ITurnData = { stats: EMPTY_DIFF_STATS, previewFiles: [] }
 
 /**
  * Compute the current turn's diff stats and previewable files from the chat's
- * last-turn changes ({@link IChat.lastTurnChanges}), which the provider derives
- * from the live output stream. Files are classified as created vs. edited with
- * the same rules as the Changes view (an addition has no original; a deletion
- * has no modified resource). Created files are listed before edited ones so the
- * primary (first) file is the first created one, falling back to the first
- * edited one. Returns {@link EMPTY_TURN_DATA} when the chat exposes no last-turn
- * changes (e.g. before its first turn, or a provider that can't determine them).
+ * last-turn changes. Diff stats come from {@link IChat.lastTurnChanges}
+ * (workspace/worktree scoped). Previewable files prefer
+ * {@link IChat.lastTurnPreviewChanges} when present so out-of-workspace
+ * markdown such as session-state `plan.md` still gets a preview pill, then
+ * fall back to the scoped stream. Files are classified as created vs. edited
+ * with the same rules as the Changes view (an addition has no original; a
+ * deletion has no modified resource). Created files are listed before edited
+ * ones so the primary (first) file is the first created one, falling back to
+ * the first edited one. Returns {@link EMPTY_TURN_DATA} when the chat exposes
+ * no last-turn changes (e.g. before its first turn, or a provider that can't
+ * determine them).
  */
 function computeTurnData(chat: IChat, reader: IReader): ITurnData {
 	const changes = chat.lastTurnChanges?.read(reader) ?? [];
+	const previewChanges = chat.lastTurnPreviewChanges?.read(reader) ?? changes;
 
 	let insertions = 0, deletions = 0;
-	const created: IPreviewFile[] = [];
-	const edited: IPreviewFile[] = [];
 	for (const change of changes) {
 		insertions += change.insertions;
 		deletions += change.deletions;
+	}
 
+	const created: IPreviewFile[] = [];
+	const edited: IPreviewFile[] = [];
+	for (const change of previewChanges) {
 		if (change.modifiedUri === undefined) {
 			continue; // a deletion has nothing to preview
 		}

--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -26,7 +26,7 @@ import type { ISessionChatPillsDebugData } from './sessionChatInputToolbarDebug.
 import './media/sessionChatInputToolbar.css';
 
 /** The per-turn data both pills reflect. */
-interface ITurnData {
+export interface ITurnData {
 	readonly stats: IDiffStats;
 	/** Previewable files changed in the turn, primary (first) first. */
 	readonly previewFiles: readonly IPreviewFile[];
@@ -35,20 +35,10 @@ interface ITurnData {
 const EMPTY_TURN_DATA: ITurnData = { stats: EMPTY_DIFF_STATS, previewFiles: [] };
 
 /**
- * Compute the current turn's diff stats and previewable files from the chat's
- * last-turn changes. Diff stats come from {@link IChat.lastTurnChanges}
- * (workspace/worktree scoped). Previewable files prefer
- * {@link IChat.lastTurnPreviewChanges} when present so out-of-workspace
- * markdown such as session-state `plan.md` still gets a preview pill, then
- * fall back to the scoped stream. Files are classified as created vs. edited
- * with the same rules as the Changes view (an addition has no original; a
- * deletion has no modified resource). Created files are listed before edited
- * ones so the primary (first) file is the first created one, falling back to
- * the first edited one. Returns {@link EMPTY_TURN_DATA} when the chat exposes
- * no last-turn changes (e.g. before its first turn, or a provider that can't
- * determine them).
+ * Diff stats from {@link IChat.lastTurnChanges}; preview files from
+ * {@link IChat.lastTurnPreviewChanges} when present, else the scoped stream.
  */
-function computeTurnData(chat: IChat, reader: IReader): ITurnData {
+export function computeTurnData(chat: IChat, reader: IReader): ITurnData {
 	const changes = chat.lastTurnChanges?.read(reader) ?? [];
 	const previewChanges = chat.lastTurnPreviewChanges?.read(reader) ?? changes;
 

--- a/src/vs/sessions/contrib/chat/test/browser/sessionChatInputToolbar.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionChatInputToolbar.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { constObservable, derived } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChat } from '../../../../services/sessions/common/session.js';
+import { computeTurnData } from '../../browser/sessionChatInputToolbar.js';
+
+suite('sessionChatInputToolbar', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('preview files include session-state plan.md while stats stay workspace-scoped', () => {
+		const workspaceMd = URI.file('/repo/NOTES.md');
+		const planFile = URI.file('/home/user/.copilot/session-state/abc/plan.md');
+
+		const workspaceChange: IChatSessionFileChange2 = {
+			uri: workspaceMd,
+			modifiedUri: workspaceMd,
+			originalUri: URI.file('/repo/NOTES.md.before'),
+			insertions: 2,
+			deletions: 1,
+		};
+		const planChange: IChatSessionFileChange2 = {
+			uri: planFile,
+			modifiedUri: planFile,
+			insertions: 12,
+			deletions: 0,
+		};
+
+		const chat = new class extends mock<IChat>() {
+			override readonly lastTurnChanges = constObservable([workspaceChange]);
+			override readonly lastTurnPreviewChanges = constObservable([workspaceChange, planChange]);
+		}();
+
+		const turnData = derived(reader => computeTurnData(chat, reader)).get();
+
+		assert.deepStrictEqual(turnData.stats, { files: 1, insertions: 2, deletions: 1 });
+		assert.deepStrictEqual(turnData.previewFiles.map(f => ({ path: f.uri.path, kind: f.kind, created: f.created })), [
+			{ path: planFile.path, kind: 'markdown', created: true },
+			{ path: workspaceMd.path, kind: 'markdown', created: false },
+		]);
+	});
+
+	test('falls back to lastTurnChanges for preview when preview stream is omitted', () => {
+		const md = URI.file('/repo/README.md');
+		const change: IChatSessionFileChange2 = {
+			uri: md,
+			modifiedUri: md,
+			insertions: 3,
+			deletions: 0,
+		};
+		const chat = new class extends mock<IChat>() {
+			override readonly lastTurnChanges = constObservable([change]);
+		}();
+
+		const turnData = derived(reader => computeTurnData(chat, reader)).get();
+		assert.strictEqual(turnData.stats.files, 1);
+		assert.deepStrictEqual(turnData.previewFiles.map(f => f.uri.path), [md.path]);
+	});
+});

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
@@ -68,6 +68,13 @@ export interface ISessionOutputObs {
 	 * recent request produced.
 	 */
 	getLastTurnChanges(chatUri: URI): IObservable<readonly ISessionFileChange[]>;
+	/**
+	 * Like {@link getLastTurnChanges}, but **without** the workspace/worktree
+	 * filter. Used by markdown preview pills so session-state files such as
+	 * `plan.md` (written under `~/.copilot/session-state/`) still surface as
+	 * preview candidates without inflating the workspace-scoped changes count.
+	 */
+	getLastTurnPreviewChanges(chatUri: URI): IObservable<readonly ISessionFileChange[]>;
 }
 
 /**
@@ -85,6 +92,9 @@ export interface ISessionOutputObs {
  *   chat's last turn's in-workspace/worktree edits reduced per file into
  *   {@link ISessionFileChange | changes} (with diff stats), mirroring the
  *   "Last Turn Changes" changeset without depending on it.
+ * - {@link ISessionOutputObs.getLastTurnPreviewChanges}: same as
+ *   {@link ISessionOutputObs.getLastTurnChanges} but including out-of-workspace
+ *   edits (e.g. session-state `plan.md`) for markdown preview pills.
  * Computation only happens for the active, non-archived session: archived
  * sessions never open a live chat-state subscription, so no parsing work is
  * done for them.
@@ -183,7 +193,20 @@ export function createSessionOutputObs(
 			return [];
 		});
 
-	return { externalFiles, getLastTurnChanges };
+	const getLastTurnPreviewChanges = (chatUri: URI): IObservable<readonly ISessionFileChange[]> =>
+		derivedOpts<readonly ISessionFileChange[]>({ equalsFn: sessionFileChangesEqual }, reader => {
+			for (const chatEditsObs of editsPerChatObs.read(reader)) {
+				const chatEdits = chatEditsObs.read(reader);
+				if (isEqual(chatEdits.chatUri, chatUri)) {
+					// No folderRoots: include session-state plan.md and other
+					// out-of-workspace markdown so preview pills can show them.
+					return reduceTurnChanges(chatEdits.lastTurnEdits);
+				}
+			}
+			return [];
+		});
+
+	return { externalFiles, getLastTurnChanges, getLastTurnPreviewChanges };
 }
 
 /**

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -339,7 +339,7 @@ class AdditionalChat extends Disposable {
 	private readonly _interactivity: ISettableObservable<ChatInteractivity>;
 	private readonly _isNew: ISettableObservable<boolean>;
 
-	constructor(resource: URI, summary: ChatSummary, isNew: boolean = false, parentChat?: URI, sessionIsArchived: IObservable<boolean> = constObservable(false), lastTurnChanges?: IObservable<readonly ISessionFileChange[]>) {
+	constructor(resource: URI, summary: ChatSummary, isNew: boolean = false, parentChat?: URI, sessionIsArchived: IObservable<boolean> = constObservable(false), lastTurnChanges?: IObservable<readonly ISessionFileChange[]>, lastTurnPreviewChanges?: IObservable<readonly ISessionFileChange[]>) {
 		super();
 		const modifiedAt = summary.modifiedAt ? new Date(summary.modifiedAt) : new Date();
 		this._title = observableValue('chatTitle', summary.title || localize('newChatTab', "New Chat"));
@@ -359,6 +359,7 @@ class AdditionalChat extends Disposable {
 			status: derived(reader => this._isNew.read(reader) ? SessionStatus.Untitled : this._status.read(reader)),
 			changes: constObservable([]),
 			lastTurnChanges,
+			lastTurnPreviewChanges,
 			checkpoints: observableValue(this, undefined),
 			modelId: this._modelId,
 			mode: this._mode,
@@ -766,6 +767,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			status: derived(this, reader => this._defaultChatStatusOverride.read(reader) ?? this.status.read(reader)),
 			changes: this.changes,
 			lastTurnChanges: sessionOutput.getLastTurnChanges(URI.parse(buildDefaultChatUri(this.backendUri))),
+			lastTurnPreviewChanges: sessionOutput.getLastTurnPreviewChanges(URI.parse(buildDefaultChatUri(this.backendUri))),
 			checkpoints: observableValue(this, undefined),
 			modelId: this.modelId,
 			mode: this.mode,
@@ -909,8 +911,10 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 
 	private _createAdditionalChat(chatId: string, summary: ChatSummary): AdditionalChat {
 		const resource = URI.from({ scheme: this._resourceScheme, path: `/${this._rawId}`, fragment: chatId });
-		const lastTurnChanges = this._sessionOutput.getLastTurnChanges(URI.parse(summary.resource));
-		return new AdditionalChat(resource, summary, this._newChatIds.has(chatId), this._resolveParentChatResource(summary.origin), this.isArchived, lastTurnChanges);
+		const chatUri = URI.parse(summary.resource);
+		const lastTurnChanges = this._sessionOutput.getLastTurnChanges(chatUri);
+		const lastTurnPreviewChanges = this._sessionOutput.getLastTurnPreviewChanges(chatUri);
+		return new AdditionalChat(resource, summary, this._newChatIds.has(chatId), this._resolveParentChatResource(summary.origin), this.isArchived, lastTurnChanges, lastTurnPreviewChanges);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
@@ -290,6 +290,31 @@ suite('agentHostSessionFiles', () => {
 		]);
 	});
 
+	test('reduceTurnChanges keeps session-state plan.md when unfiltered for preview pills', () => {
+		const edits: IParsedFileEdit[] = [
+			parsedEdit(FileEditKind.Edit, { after: '/repo/src/app.ts', beforeContent: '/repo/src/app.ts.before' }, { insertions: 2 }),
+			parsedEdit(FileEditKind.Create, { after: '/home/user/.copilot/session-state/abc/plan.md' }, { insertions: 12 }),
+			parsedEdit(FileEditKind.Edit, { after: '/home/user/.config/tool.json', beforeContent: '/home/user/.config/tool.json.before' }, { insertions: 1 }),
+		];
+		const folderRoots = [URI.file('/repo')];
+
+		const workspaceChanges = reduceTurnChanges(edits, folderRoots).map(c => c.uri.path);
+		assert.deepStrictEqual(workspaceChanges, ['/repo/src/app.ts'], 'workspace-scoped last-turn changes must drop session-state plan.md');
+
+		const previewChanges = reduceTurnChanges(edits).map(c => ({
+			uri: c.uri.path,
+			modified: c.modifiedUri?.path,
+			original: c.originalUri?.path,
+			insertions: c.insertions,
+			deletions: c.deletions,
+		}));
+		assert.deepStrictEqual(previewChanges, [
+			{ uri: '/repo/src/app.ts', modified: '/repo/src/app.ts', original: '/repo/src/app.ts.before', insertions: 2, deletions: 0 },
+			{ uri: '/home/user/.copilot/session-state/abc/plan.md', modified: '/home/user/.copilot/session-state/abc/plan.md', original: undefined, insertions: 12, deletions: 0 },
+			{ uri: '/home/user/.config/tool.json', modified: '/home/user/.config/tool.json', original: '/home/user/.config/tool.json.before', insertions: 1, deletions: 0 },
+		], 'unfiltered preview stream must keep session-state plan.md');
+	});
+
 	test('reduceTurnChanges nets out a file created and then deleted in the same turn', () => {
 		const edits: IParsedFileEdit[] = [
 			parsedEdit(FileEditKind.Create, { after: '/repo/scratch.tmp' }, { insertions: 5 }),

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -473,6 +473,14 @@ export interface IChat {
 	 * this omit the observable.
 	 */
 	readonly lastTurnChanges?: IObservable<readonly ISessionFileChange[]>;
+	/**
+	 * Like {@link lastTurnChanges}, but including files outside the
+	 * workspace/worktree (e.g. session-state `plan.md`). Used by markdown
+	 * preview pills so those files remain discoverable without inflating the
+	 * workspace-scoped changes count. Providers that cannot determine this omit
+	 * the observable; consumers then fall back to {@link lastTurnChanges}.
+	 */
+	readonly lastTurnPreviewChanges?: IObservable<readonly ISessionFileChange[]>;
 	/** Checkpoints associated with the chat. */
 	readonly checkpoints: IObservable<IChatCheckpoints | undefined>;
 	/** Currently selected model identifier. */


### PR DESCRIPTION
## Summary

- Found while testing #328631 — when a session creates a plan, there's no `plan.md` preview pill above the Agents input (and same for follow-up turns that touch it). Tracked in #328857.
- Root cause is that `plan.md` lives under `~/.copilot/session-state/`, which is outside the workspace, and the floating pills only look at workspace-scoped `lastTurnChanges`.
- This keeps the "N files changed" count / multi-diff scoped to the workspace, but feeds preview pills from an unfiltered last-turn stream so session-state markdown (like `plan.md`) can show up.

## Test plan

- [ ] Start an Agents session that creates a plan → confirm a `plan.md` markdown preview pill appears above the input
- [ ] Click the pill → opens the markdown preview for the plan file
- [ ] Confirm the changes-count pill still only reflects workspace/worktree edits (session-state files don't inflate it)
- [ ] Edit a normal workspace `.md` during a turn → preview pill still works as before
- [ ] Unit: `agentHostSessionFiles` test covering filtered vs unfiltered `reduceTurnChanges` for session-state `plan.md`

Fixes #328857