### PR TITLE
Fail loudly when tree-sitter grammars are unavailable

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -90,6 +90,10 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
+      - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+        condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify node_modules cache
+
       - script: |
           set -e
           # Set the private NPM registry to the global npmrc file

--- a/build/azure-pipelines/common/listNodeModules.ts
+++ b/build/azure-pipelines/common/listNodeModules.ts
@@ -26,11 +26,11 @@ function findNodeModulesFiles(location: string, inNodeModules: boolean, result: 
 		try {
 			stat = fs.statSync(path.join(ROOT, entryPath));
 		} catch (err) {
-			// A dangling symlink cannot be stat'ed and is safe to skip. Any
-			// other failure would silently drop files from the cache manifest,
-			// producing an incomplete node_modules archive that later fails in
-			// confusing ways, so surface it instead.
-			if (isDanglingSymbolicLink(entryPath)) {
+			// A symlink whose target does not exist cannot be stat'ed and is
+			// safe to skip. Any other failure would silently drop files from
+			// the cache manifest, producing an incomplete node_modules archive
+			// that later fails in confusing ways, so surface it instead.
+			if (isDanglingSymbolicLink(entryPath, err)) {
 				continue;
 			}
 			throw new Error(`Failed to stat '${entryPath}' while listing node_modules`, { cause: err });
@@ -46,7 +46,12 @@ function findNodeModulesFiles(location: string, inNodeModules: boolean, result: 
 	}
 }
 
-function isDanglingSymbolicLink(entryPath: string): boolean {
+function isDanglingSymbolicLink(entryPath: string, err: unknown): boolean {
+	// Only a missing target explains the failure; errors such as EACCES, EIO or
+	// ELOOP indicate a real problem even when the entry is a symlink.
+	if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+		return false;
+	}
 	try {
 		return fs.lstatSync(path.join(ROOT, entryPath)).isSymbolicLink();
 	} catch {

--- a/build/azure-pipelines/common/listNodeModules.ts
+++ b/build/azure-pipelines/common/listNodeModules.ts
@@ -26,7 +26,14 @@ function findNodeModulesFiles(location: string, inNodeModules: boolean, result: 
 		try {
 			stat = fs.statSync(path.join(ROOT, entryPath));
 		} catch (err) {
-			continue;
+			// A dangling symlink cannot be stat'ed and is safe to skip. Any
+			// other failure would silently drop files from the cache manifest,
+			// producing an incomplete node_modules archive that later fails in
+			// confusing ways, so surface it instead.
+			if (isDanglingSymbolicLink(entryPath)) {
+				continue;
+			}
+			throw new Error(`Failed to stat '${entryPath}' while listing node_modules`, { cause: err });
 		}
 
 		if (stat.isDirectory()) {
@@ -36,6 +43,14 @@ function findNodeModulesFiles(location: string, inNodeModules: boolean, result: 
 				result.push(entryPath.substr(1));
 			}
 		}
+	}
+}
+
+function isDanglingSymbolicLink(entryPath: string): boolean {
+	try {
+		return fs.lstatSync(path.join(ROOT, entryPath)).isSymbolicLink();
+	} catch {
+		return false;
 	}
 }
 

--- a/build/azure-pipelines/common/verifyNodeModulesCache.ts
+++ b/build/azure-pipelines/common/verifyNodeModulesCache.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Verifies that a `node_modules` tree restored from the pipeline cache is
+ * complete enough to build and test with.
+ *
+ * The cache is a plain tarball of every file under `node_modules`. When it is
+ * restored, `npm ci` is skipped entirely, so a truncated or partially written
+ * archive is never repaired: the build proceeds against an incomplete
+ * dependency tree. That failure mode is silent and extremely hard to diagnose
+ * downstream — a missing tree-sitter grammar, for example, surfaces only as
+ * dozens of unrelated-looking unit-test assertion mismatches.
+ *
+ * When verification fails this clears the pipeline's cache-hit variable (passed
+ * as the first argument) so the subsequent steps treat the run as a cache miss
+ * and reinstall from scratch.
+ */
+
+const ROOT = path.join(import.meta.dirname, '../../../');
+
+const cacheHitVariable = process.argv[2] ?? 'NODE_MODULES_RESTORED';
+
+/**
+ * Files that must exist and be non-empty. These are load-bearing assets that
+ * are consumed at runtime rather than imported as JS, so a missing one is not
+ * caught by module resolution.
+ */
+const REQUIRED_FILES = [
+	'node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter.wasm',
+	'node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-bash.wasm',
+	'node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-powershell.wasm',
+];
+
+function verify(): string[] {
+	const problems: string[] = [];
+
+	for (const relativePath of REQUIRED_FILES) {
+		const fullPath = path.join(ROOT, relativePath);
+		let stat: fs.Stats;
+		try {
+			stat = fs.statSync(fullPath);
+		} catch (err) {
+			problems.push(`missing: ${relativePath}`);
+			continue;
+		}
+		if (!stat.isFile() || stat.size === 0) {
+			problems.push(`empty or not a file: ${relativePath}`);
+		}
+	}
+
+	return problems;
+}
+
+function main(): void {
+	const problems = verify();
+
+	if (problems.length === 0) {
+		console.log(`node_modules cache verified (${REQUIRED_FILES.length} required files present)`);
+		return;
+	}
+
+	for (const problem of problems) {
+		console.error(`  ${problem}`);
+	}
+	console.error('node_modules cache is incomplete, falling back to a clean install');
+	// Signal a cache miss so the install steps, which are gated on the
+	// cache-hit variable, run and repair the tree.
+	console.log(`##vso[task.setvariable variable=${cacheHitVariable}]false`);
+}
+
+main();

--- a/build/azure-pipelines/copilot/setup-steps.yml
+++ b/build/azure-pipelines/copilot/setup-steps.yml
@@ -36,6 +36,10 @@ steps:
     condition: and(succeeded(), eq(variables.BUILD_CACHE_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
+  - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts BUILD_CACHE_RESTORED
+    condition: and(succeeded(), eq(variables.BUILD_CACHE_RESTORED, 'true'))
+    displayName: Verify node_modules cache
+
   - pwsh: |
       $ErrorActionPreference = 'Stop'
       # Set the private NPM registry to the global npmrc file

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -64,6 +64,10 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
+  - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+    condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+    displayName: Verify node_modules cache
+
   - script: |
       set -e
       # Set the private NPM registry to the global npmrc file

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -84,6 +84,10 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
+  - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+    condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+    displayName: Verify node_modules cache
+
   - script: |
       set -e
       # Set the private NPM registry to the global npmrc file

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -42,6 +42,10 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
+      - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+        condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify node_modules cache
+
       - script: |
           set -e
           npm config set registry "$NPM_REGISTRY"

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -52,6 +52,10 @@ jobs:
         condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Extract node_modules cache
 
+      - script: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+        condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify node_modules cache
+
       - script: |
           set -e
           # Set the private NPM registry to the global npmrc file

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -68,6 +68,10 @@ steps:
     condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Extract node_modules cache
 
+  - powershell: node build/azure-pipelines/common/verifyNodeModulesCache.ts
+    condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
+    displayName: Verify node_modules cache
+
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -74,6 +74,7 @@ import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostLocalCommands } from './localCommands/localChatCommand.js';
 import './localCommands/localChatCommands.contribution.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
+import type { ITreeSitterReadiness } from './commandAutoApprover.js';
 import type { ICopilotApiService } from './shared/copilotApiService.js';
 import { stripProxyErrorMarker, toChatErrorMeta, tryParseForwardedChatError } from './shared/forwardedChatError.js';
 import { persistSessionMetadata } from './shared/persistSessionMetadata.js';
@@ -596,9 +597,12 @@ export class AgentSideEffects extends Disposable {
 	 * Initializes async resources (tree-sitter WASM) used for command
 	 * auto-approval. Await this before any session events can arrive to
 	 * guarantee that auto-approval checks are fully synchronous.
+	 *
+	 * Resolves with which shells can actually be analyzed; an unavailable shell
+	 * fails closed (commands require confirmation) rather than blocking startup.
 	 */
-	initialize(): Promise<void> {
-		return this._permissionManager.initialize().then(() => undefined);
+	initialize(): Promise<ITreeSitterReadiness> {
+		return this._permissionManager.initialize();
 	}
 
 	// ---- Agent registration -------------------------------------------------

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -598,7 +598,7 @@ export class AgentSideEffects extends Disposable {
 	 * guarantee that auto-approval checks are fully synchronous.
 	 */
 	initialize(): Promise<void> {
-		return this._permissionManager.initialize();
+		return this._permissionManager.initialize().then(() => undefined);
 	}
 
 	// ---- Agent registration -------------------------------------------------

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -119,6 +119,23 @@ const pwshNoSpaceRedirectRegex = /^[0-9*]?>>?/;
  */
 export type CommandApprovalResult = 'approved' | 'denied' | 'noMatch';
 
+/**
+ * Which tree-sitter pieces actually loaded.
+ *
+ * A shell whose grammar is unavailable cannot be analyzed, so every command for
+ * it degrades to `noMatch` (fail-closed). That degradation is silent by design
+ * in production, which makes a packaging or dependency regression very hard to
+ * spot — see {@link CommandAutoApprover.initialize}.
+ */
+export interface ITreeSitterReadiness {
+	/** Whether the core tree-sitter runtime initialized. */
+	readonly parser: boolean;
+	/** Whether the bash grammar loaded and can analyze commands. */
+	readonly bash: boolean;
+	/** Whether the PowerShell grammar loaded and can analyze commands. */
+	readonly powershell: boolean;
+}
+
 /** Structured outcome of {@link CommandAutoApprover.evaluate}. */
 export interface ICommandApprovalEvaluation {
 	/** Final approval outcome, identical to {@link CommandAutoApprover.shouldAutoApprove}. */
@@ -195,7 +212,7 @@ export class CommandAutoApprover extends Disposable {
 	private _bashLanguage: Language | undefined;
 	private _powershellLanguage: Language | undefined;
 	private _queryClass: typeof Query | undefined;
-	private readonly _initPromise: Promise<void>;
+	private readonly _initPromise: Promise<ITreeSitterReadiness>;
 
 	constructor(
 		private readonly _logService: ILogService,
@@ -208,8 +225,14 @@ export class CommandAutoApprover extends Disposable {
 	 * Returns a promise that resolves once tree-sitter WASM has been loaded.
 	 * Await this before processing any events to guarantee that
 	 * {@link shouldAutoApprove} can parse commands synchronously.
+	 *
+	 * Resolves with which pieces are actually usable. Callers that only need to
+	 * await initialization can ignore the value; production stays fail-closed
+	 * when a grammar is missing. Tests and diagnostics should assert on it, as a
+	 * silently unavailable grammar turns into confusing `noMatch` results rather
+	 * than a clear error.
 	 */
-	initialize(): Promise<void> {
+	initialize(): Promise<ITreeSitterReadiness> {
 		return this._initPromise;
 	}
 
@@ -383,12 +406,24 @@ export class CommandAutoApprover extends Disposable {
 		}
 	}
 
-	private async _initTreeSitter(): Promise<void> {
+	/**
+	 * Reports readiness by actually analyzing a probe command per shell, rather
+	 * than by trusting that `Language.load()` resolved. A grammar can load
+	 * cleanly and still be the wrong grammar (or an incompatible ABI), which
+	 * yields no sub-commands and silently degrades every command to `noMatch`.
+	 */
+	private _probeShell(isPowerShell: boolean): boolean {
+		const parsed = this._extractSubCommands(isPowerShell ? 'Get-ChildItem' : 'ls', isPowerShell);
+		return parsed?.subCommands.length === 1;
+	}
+
+	private async _initTreeSitter(): Promise<ITreeSitterReadiness> {
+		const unavailable: ITreeSitterReadiness = { parser: false, bash: false, powershell: false };
 		try {
 			const { default: TreeSitter } = (await import('@vscode/tree-sitter-wasm'));
 
 			if (this._store.isDisposed) {
-				return;
+				return unavailable;
 			}
 
 			// Resolve WASM files from node_modules. In the desktop app the `.wasm`
@@ -405,7 +440,7 @@ export class CommandAutoApprover extends Disposable {
 			});
 
 			if (this._store.isDisposed) {
-				return;
+				return unavailable;
 			}
 
 			const parser = new TreeSitter.Parser();
@@ -430,7 +465,7 @@ export class CommandAutoApprover extends Disposable {
 			]);
 
 			if (this._store.isDisposed) {
-				return;
+				return unavailable;
 			}
 
 			this._parser = parser;
@@ -448,9 +483,16 @@ export class CommandAutoApprover extends Disposable {
 			} else {
 				this._logService.warn('[CommandAutoApprover] Failed to load the PowerShell grammar; PowerShell commands will require confirmation', powershellLanguage.reason);
 			}
-			this._logService.info(`[CommandAutoApprover] Tree-sitter initialized (bash=${this._bashLanguage ? 'available' : 'unavailable'}, powershell=${this._powershellLanguage ? 'available' : 'unavailable'})`);
+			const readiness: ITreeSitterReadiness = {
+				parser: true,
+				bash: this._probeShell(false),
+				powershell: this._probeShell(true),
+			};
+			this._logService.info(`[CommandAutoApprover] Tree-sitter initialized (bash=${readiness.bash ? 'available' : 'unavailable'}, powershell=${readiness.powershell ? 'available' : 'unavailable'})`);
+			return readiness;
 		} catch (err) {
 			this._logService.warn('[CommandAutoApprover] Failed to initialize tree-sitter', err);
+			return unavailable;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -32,7 +32,7 @@ import {
 } from '../common/state/sessionState.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
-import { CommandAutoApprover } from './commandAutoApprover.js';
+import { CommandAutoApprover, type ITreeSitterReadiness } from './commandAutoApprover.js';
 
 /**
  * Event fields needed for auto-approval decisions.
@@ -234,8 +234,11 @@ export class SessionPermissionManager extends Disposable {
 	 * Initializes async resources (tree-sitter WASM) used for shell command
 	 * auto-approval. Await this before any session events can arrive so that
 	 * shell command parsing within {@link getAutoApproval} is synchronous.
+	 *
+	 * Resolves with which shells can actually be analyzed; an unavailable shell
+	 * fails closed (commands require confirmation) rather than blocking startup.
 	 */
-	initialize(): Promise<void> {
+	initialize(): Promise<ITreeSitterReadiness> {
 		return this._commandAutoApprover.initialize();
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -47,6 +47,7 @@ import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { createNoopGitService, createNullSessionDataService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { MockAgent } from './mockAgent.js';
 import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
+import { assertTreeSitterReady } from './treeSitterReadinessTestUtils.js';
 
 // ---- Tests ------------------------------------------------------------------
 
@@ -3010,7 +3011,7 @@ suite('AgentSideEffects', () => {
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
 			// Rule resolvability requires a successful tree-sitter parse.
-			await sideEffects.initialize();
+			assertTreeSitterReady(await sideEffects.initialize());
 
 			const cases = [
 				['tc-shell-rules-1', { requestSandboxBypass: false, shellLanguage: 'bash' as const }],
@@ -3054,7 +3055,7 @@ suite('AgentSideEffects', () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
-			await sideEffects.initialize();
+			assertTreeSitterReady(await sideEffects.initialize());
 
 			// `get-childitem` only matches the default `Get-ChildItem` allow rule
 			// under PowerShell's case-insensitive matching. Missing language fails

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -16,7 +16,12 @@ suite('CommandAutoApprover', () => {
 
 	setup(async () => {
 		approver = disposables.add(new CommandAutoApprover(new NullLogService()));
-		await approver.initialize();
+		const readiness = await approver.initialize();
+		// Without a working parser and both grammars every command silently
+		// degrades to `noMatch`, which shows up as dozens of confusing
+		// assertion mismatches instead of one clear failure. Fail fast here so
+		// a packaging/dependency regression is obvious. See issue #328863.
+		assert.deepStrictEqual(readiness, { parser: true, bash: true, powershell: true }, 'tree-sitter must be fully available for these tests');
 	});
 
 	suite('shouldAutoApprove', () => {
@@ -284,6 +289,15 @@ suite('CommandAutoApprover', () => {
 		test('is not rule-resolvable while the parser is unavailable', () => {
 			const uninitialized = disposables.add(new CommandAutoApprover(new NullLogService()));
 			assert.deepStrictEqual(uninitialized.evaluate('ls'), { result: 'noMatch', autoApproveRuleResolvable: false });
+		});
+
+		test('initialize reports per-shell readiness by analyzing a probe command', async () => {
+			// Readiness must reflect whether a shell can actually be analyzed,
+			// not merely that the grammar file loaded: a wrong or incompatible
+			// grammar loads cleanly yet silently degrades everything to
+			// `noMatch`.
+			const probe = disposables.add(new CommandAutoApprover(new NullLogService()));
+			assert.deepStrictEqual(await probe.initialize(), { parser: true, bash: true, powershell: true });
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { CommandAutoApprover, type ICommandApprovalEvaluation } from '../../node/commandAutoApprover.js';
+import { assertTreeSitterReady } from './treeSitterReadinessTestUtils.js';
 
 suite('CommandAutoApprover', () => {
 
@@ -16,12 +17,7 @@ suite('CommandAutoApprover', () => {
 
 	setup(async () => {
 		approver = disposables.add(new CommandAutoApprover(new NullLogService()));
-		const readiness = await approver.initialize();
-		// Without a working parser and both grammars every command silently
-		// degrades to `noMatch`, which shows up as dozens of confusing
-		// assertion mismatches instead of one clear failure. Fail fast here so
-		// a packaging/dependency regression is obvious. See issue #328863.
-		assert.deepStrictEqual(readiness, { parser: true, bash: true, powershell: true }, 'tree-sitter must be fully available for these tests');
+		assertTreeSitterReady(await approver.initialize());
 	});
 
 	suite('shouldAutoApprove', () => {

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -19,6 +19,7 @@ import { SessionStatus, ToolCallConfirmationReason, type SessionSummary } from '
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { SessionPermissionManager, type IToolApprovalEvent } from '../../node/sessionPermissions.js';
+import { assertTreeSitterReady } from './treeSitterReadinessTestUtils.js';
 
 suite('SessionPermissionManager', () => {
 
@@ -82,7 +83,7 @@ suite('SessionPermissionManager', () => {
 		manager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));
 		permissions = disposables.add(new SessionPermissionManager(manager, {}, configService, new NullLogService()));
-		await permissions.initialize();
+		assertTreeSitterReady(await permissions.initialize());
 
 		manager.createSession(makeSummary(sessionUri, URI.file(workDir).toString()));
 	});

--- a/src/vs/platform/agentHost/test/node/treeSitterReadinessTestUtils.ts
+++ b/src/vs/platform/agentHost/test/node/treeSitterReadinessTestUtils.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type { ITreeSitterReadiness } from '../../node/commandAutoApprover.js';
+
+/**
+ * Asserts that tree-sitter is fully usable before running tests that depend on
+ * shell command analysis.
+ *
+ * Without a working parser and both grammars, every command silently degrades
+ * to `noMatch` (fail-closed). In a test suite that surfaces as many unrelated
+ * looking assertion mismatches rather than one actionable failure — see
+ * https://github.com/microsoft/vscode-engineering/issues/3484, where a single
+ * environment problem produced 37 of them across three suites.
+ */
+export function assertTreeSitterReady(readiness: ITreeSitterReadiness): void {
+	assert.deepStrictEqual(
+		readiness,
+		{ parser: true, bash: true, powershell: true },
+		'tree-sitter must be fully available for these tests');
+}


### PR DESCRIPTION
Fixes the macOS unit test failures reported in [vscode-engineering#3484](https://github.com/microsoft/vscode-engineering/issues/3484), **without reverting #328863** — that PR is innocent.

## Root cause

Build `20260804.3` (macOS, Electron unit tests) failed with 37 assertion mismatches across `CommandAutoApprover` (28), `SessionPermissionManager` (7) and `AgentSideEffects` (2). Every failure had the same cause: the **bash and PowerShell tree-sitter grammars could not be used**, so `_extractSubCommands` returned `undefined` and every command degraded to `noMatch`.

That degradation is deliberate and fail-closed in production, but it is **silent**: grammars load via `Promise.allSettled` and failures are only `_logService.warn`, which tests discard through `NullLogService`. One environment problem therefore surfaced as dozens of unrelated-looking assertion failures — and CI misattributed it to the unrelated commit at the head of the build.

`dce00340cb3` touches none of `commandAutoApprover.ts`, `sessionPermissions.ts`, or `agentSideEffects.ts`.

## Evidence

Deleting **only** the two grammar files (leaving core `tree-sitter.wasm` intact) reproduces CI exactly:

| Condition | Result | Console noise | Matches CI? |
|---|---|---|---|
| Baseline | 37 pass / 0 fail | none | — |
| **Both grammars unusable** | **9 pass / 28 fail** | **zero** | ✅ exact — counts **and** all 9 passing test names |
| Same, all three suites | 28 + **7** + **2** | zero | ✅ exact |
| Core `tree-sitter.wasm` missing | 2 pass / 1 fail, aborts | loud `ENOENT` | ❌ refuted |
| Bash grammar only | 17–20 fail | zero | ❌ no |
| Grammars **truncated** | 9 pass / 28 fail | zero | ✅ exact |
| Grammars replaced with a **valid but wrong** grammar | 9 pass / 28 fail | zero | ✅ exact |

The last row matters: the signature can arise even when `Language.load()` **succeeds**, so a file-existence check is not sufficient. Missing / truncated / corrupt / wrong-ABI are all indistinguishable from the failure alone.

## Changes

**Make it loud (source)**
- `CommandAutoApprover.initialize()` now resolves with `{ parser, bash, powershell }` readiness. Readiness is determined by **analyzing a probe command per shell**, not by trusting `Language.load()` — this catches the valid-but-wrong-grammar case above.
- The test suite asserts full readiness in `setup()`, collapsing **28 confusing failures into 1 clear one**.

**Stop an incomplete dependency tree reaching the tests (build)**
- When the pipeline restores its `node_modules` cache it **skips `npm ci` entirely**, so a truncated/partial archive is never repaired. Added `verifyNodeModulesCache.ts`, run after every cache extraction (7 pipelines), which clears the cache-hit variable so the install steps run and rebuild the tree.
- `listNodeModules.ts` swallowed `statSync` failures via `catch { continue }`, silently dropping files from the cache manifest. It now only skips dangling symlinks and throws otherwise.

Production behavior is unchanged: an unavailable grammar still fails closed and requires user confirmation rather than blocking startup.

## Verification

- ✅ `225 passing` across all three affected suites (was 224; +1 new readiness test)
- ✅ With grammars removed → **1** clear failure: `tree-sitter must be fully available for these tests` (was 28)
- ✅ Same single clear failure for the valid-but-wrong-grammar case
- ✅ `typecheck-client`: 7 errors before, 7 after — no regressions
- ✅ `build/` typecheck clean; ESLint clean on all changed files
- ✅ `verifyNodeModulesCache.ts` manually exercised: passes on a good tree, detects missing **and** zero-length files, honors the custom variable name used by the copilot pipeline

## Note on the caching hypothesis

The most plausible source is a poisoned Darwin `node_modules` cache (per-platform cache keys explain macOS-only). That remains **plausible but unproven** without the failed archive — which is precisely why this PR hardens detection at both layers rather than asserting a single physical cause. Recommend also invalidating the darwin cache entry.

<details>
<summary>Analysis methodology</summary>

The first root cause I proposed was **wrong** (I blamed the `product.commit` heuristic in `appNodeModules.ts`). It was falsified by experiment: that path produces loud Emscripten `ENOENT` errors and aborts after ~2 tests, and repo-root `product.json` is never stamped with a commit. A proposed `isBuilt` fix was also rejected — it would have *broken* the working test harness. Findings were independently re-derived and verified by two separate models before this PR.
</details>
