### PR TITLE
chat: batch subagent reconstruction updates

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
@@ -160,6 +160,8 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 
 	/** Per-tool-invocation autoruns observing tool state; each is disposed once its tool reaches a terminal state so listeners don't accumulate for the widget's lifetime. */
 	private readonly _toolStateTracking = this._register(new DisposableStore());
+	private _toolPresentationBatchDepth = 0;
+	private _toolPresentationDirty = false;
 
 	// Working spinner elements for expanded state
 	private workingSpinnerElement: HTMLElement | undefined;
@@ -698,6 +700,30 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 		return this.toolsWaitingForConfirmation > 0;
 	}
 
+	public beginToolPresentationBatch(): void {
+		this._toolPresentationBatchDepth++;
+	}
+
+	public endToolPresentationBatch(): void {
+		if (this._toolPresentationBatchDepth === 0) {
+			return;
+		}
+		this._toolPresentationBatchDepth--;
+		if (this._toolPresentationBatchDepth === 0 && this._toolPresentationDirty) {
+			this._toolPresentationDirty = false;
+			this._updateToolPresentation();
+		}
+	}
+
+	private _updateToolPresentation(): void {
+		if (this._toolPresentationBatchDepth > 0) {
+			this._toolPresentationDirty = true;
+			return;
+		}
+		this._updateOpenChatToolbarContext();
+		this.updateTitle();
+	}
+
 	/** Routes this subagent's initial confirmations to the input carousel. */
 	public enableCarouselMode(
 		navigateToCarousel: (subAgentInvocationId: string) => void,
@@ -976,8 +1002,10 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 			this.currentRunningToolMessage = this.getToolLabel(toolInvocation, initialState);
 			this.currentRunningToolIcon = this.currentRunningToolMessage ? getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon) : undefined;
 			this.updateActiveToolPresentation(toolInvocation.toolCallId, this.currentRunningToolMessage, this.currentRunningToolIcon, initialState);
-			this._updateOpenChatToolbarContext();
-			this.updateTitle();
+			this._updateToolPresentation();
+		}
+		if (initialState.type === IChatToolInvocation.StateKind.Completed || initialState.type === IChatToolInvocation.StateKind.Cancelled) {
+			return;
 		}
 		const addToolToCarousel = this._addToolToCarousel;
 		const shouldUseCarouselForTool = this._shouldUseCarouselForTool;
@@ -992,8 +1020,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 				this.currentRunningToolMessage = this.getToolLabel(toolInvocation, state);
 				this.currentRunningToolIcon = this.currentRunningToolMessage ? getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon) : undefined;
 				this.updateActiveToolPresentation(toolInvocation.toolCallId, this.currentRunningToolMessage, this.currentRunningToolIcon, state);
-				this._updateOpenChatToolbarContext();
-				this.updateTitle();
+				this._updateToolPresentation();
 			}
 			if (this.currentRunningToolCallId === toolInvocation.toolCallId) {
 				const toolLabel = this.getToolLabel(toolInvocation, state);
@@ -1001,8 +1028,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 					this.currentRunningToolMessage = toolLabel;
 					this.currentRunningToolIcon = getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon);
 					this.updateActiveToolPresentation(toolInvocation.toolCallId, this.currentRunningToolMessage, this.currentRunningToolIcon, state);
-					this._updateOpenChatToolbarContext();
-					this.updateTitle();
+					this._updateToolPresentation();
 				}
 			}
 
@@ -1034,12 +1060,12 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 
 			if (isWaitingForCarouselConfirmation && !wasWaitingForCarouselConfirmation) {
 				this.toolsWaitingForCarouselConfirmation++;
-				this._updateOpenChatToolbarContext();
+				this._updateToolPresentation();
 				addToolToCarousel(toolInvocation);
 				this.showConfirmationPlaceholder();
 			} else if (!isWaitingForCarouselConfirmation && wasWaitingForCarouselConfirmation) {
 				this.toolsWaitingForCarouselConfirmation--;
-				this._updateOpenChatToolbarContext();
+				this._updateToolPresentation();
 				if (this.toolsWaitingForCarouselConfirmation === 0) {
 					this.hideConfirmationPlaceholder();
 				} else {
@@ -1053,7 +1079,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 			// On terminal state, dispose this autorun (deferred so we don't dispose it mid-run) to avoid leaking a listener per tool invocation.
 			if (state.type === IChatToolInvocation.StateKind.Completed || state.type === IChatToolInvocation.StateKind.Cancelled) {
 				if (this.activeToolPresentations.delete(toolInvocation.toolCallId)) {
-					this._updateOpenChatToolbarContext();
+					this._updateToolPresentation();
 				}
 				queueMicrotask(() => this._toolStateTracking.delete(toolStateAutorun));
 			}
@@ -1406,8 +1432,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 		this.currentRunningToolMessage = hookMessage;
 		this.currentRunningToolCallId = undefined;
 		this.currentRunningToolIcon = hookPart.stopReason ? Codicon.error : Codicon.warning;
-		this._updateOpenChatToolbarContext();
-		this.updateTitle();
+		this._updateToolPresentation();
 
 		if (this.isExpanded() || this.hasExpandedOnce) {
 			const result = factory();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2209,10 +2209,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const renderedParts = templateData.renderedParts ?? [];
 		templateData.renderedParts = renderedParts;
 		templateData.renderedContent = contentForThisTurn;
+		const batchedSubagentParts = new Set<ChatSubagentContentPart>();
 		let codeBlockStartIndex = 0;
 		let treeStartIndex = 0;
 		let displacedWorkingPart: ChatWorkingProgressContentPart | undefined;
-		partsToRender.forEach((partToRender, contentIndex) => {
+		const renderParts = () => partsToRender.forEach((partToRender, contentIndex) => {
 			// Accumulate counts from the part that ended up at the previous index
 			if (contentIndex > 0) {
 				const prevPart = renderedParts[contentIndex - 1];
@@ -2307,7 +2308,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 					lastThinking.removeEditPillByPartId(alreadyRenderedPart.codeblocksPartId);
 				}
 
-				const newPart = this.renderChatContentPart(partToRender, templateData, context);
+				const newPart = this.renderChatContentPart(partToRender, templateData, context, batchedSubagentParts);
 				if (newPart) {
 					renderedParts[contentIndex] = newPart;
 					alreadyRenderedPart?.domNode?.remove();
@@ -2315,7 +2316,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return;
 			}
 
-			const newPart = this.renderChatContentPart(partToRender, templateData, context);
+			const newPart = this.renderChatContentPart(partToRender, templateData, context, batchedSubagentParts);
 			if (newPart) {
 				renderedParts[contentIndex] = newPart;
 				// Maybe the part can't be rendered in this context, but this shouldn't really happen
@@ -2344,6 +2345,17 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				alreadyRenderedPart?.domNode?.remove();
 			}
 		});
+		try {
+			renderParts();
+		} finally {
+			for (const subagentPart of batchedSubagentParts) {
+				try {
+					subagentPart.endToolPresentationBatch();
+				} catch (error) {
+					this.logService.error('ChatListItemRenderer#renderChatContentDiff: error flushing subagent presentation', error);
+				}
+			}
+		}
 		displacedWorkingPart?.dispose();
 		displacedWorkingPart?.domNode?.remove();
 
@@ -2819,12 +2831,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 	}
 
-	private handleSubagentToolGrouping(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, subagentId: string, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate, codeBlockStartIndex: number): IChatContentPart {
+	private handleSubagentToolGrouping(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, subagentId: string, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate, codeBlockStartIndex: number, batchedSubagentParts?: Set<ChatSubagentContentPart>): IChatContentPart {
 		// Finalize any active thinking part since subagent tools have their own grouping
 		this.finalizeCurrentThinkingPart(context, templateData);
 
 		const lastSubagent = this.getSubagentPart(templateData.renderedParts, subagentId);
 		if (lastSubagent) {
+			this.beginSubagentToolPresentationBatch(lastSubagent, batchedSubagentParts);
 			// Enable carousel mode before appendToolInvocation creates an inline part.
 			this.maybeRouteSubagentToolToCarousel(toolInvocation, lastSubagent, context, templateData, codeBlockStartIndex);
 
@@ -2851,6 +2864,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			() => this._currentLayoutWidth.get(),
 			this._announcedToolProgressKeys,
 		);
+		this.beginSubagentToolPresentationBatch(subagentPart, batchedSubagentParts);
 		// Enable carousel mode before appendToolInvocation creates an inline part.
 		this.maybeRouteSubagentToolToCarousel(toolInvocation, subagentPart, context, templateData, codeBlockStartIndex);
 
@@ -2861,6 +2875,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		return subagentPart;
+	}
+
+	private beginSubagentToolPresentationBatch(subagentPart: ChatSubagentContentPart, batchedSubagentParts: Set<ChatSubagentContentPart> | undefined): void {
+		if (batchedSubagentParts && !batchedSubagentParts.has(subagentPart)) {
+			batchedSubagentParts.add(subagentPart);
+			subagentPart.beginToolPresentationBatch();
+		}
 	}
 
 	/** Routes subagent confirmations to the input carousel and leaves a placeholder inline. */
@@ -2957,7 +2978,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		lastThinking.markAsInactive();
 	}
 
-	private renderChatContentPart(content: IChatRendererContent, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext): IChatContentPart | undefined {
+	private renderChatContentPart(content: IChatRendererContent, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext, batchedSubagentParts?: Set<ChatSubagentContentPart>): IChatContentPart | undefined {
 		try {
 			// if we get an empty thinking part, mark thinking as finished
 			if (content.kind === 'thinking' && (Array.isArray(content.value) ? content.value.length === 0 : content.value === '')) {
@@ -3019,7 +3040,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'info') {
 				return this.instantiationService.createInstance(ChatErrorContentPart, ChatErrorLevel.Info, content.content, content, this.chatContentMarkdownRenderer);
 			} else if (content.kind === 'hook') {
-				return this.renderHookPart(content, context, templateData);
+				return this.renderHookPart(content, context, templateData, batchedSubagentParts);
 			} else if (content.kind === 'markdownContent') {
 				return this.renderMarkdown(content, templateData, context);
 			} else if (content.kind === 'references') {
@@ -3031,7 +3052,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'codeCitations') {
 				return this.renderCodeCitations(content, context, templateData);
 			} else if (content.kind === 'toolInvocation' || content.kind === 'toolInvocationSerialized') {
-				return this.renderToolInvocation(content, context, templateData);
+				return this.renderToolInvocation(content, context, templateData, batchedSubagentParts);
 			} else if (content.kind === 'extensions') {
 				return this.renderExtensionsContent(content, context, templateData);
 			} else if (content.kind === 'pullRequest') {
@@ -3220,7 +3241,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	}
 
-	private renderToolInvocation(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart | undefined {
+	private renderToolInvocation(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate, batchedSubagentParts?: Set<ChatSubagentContentPart>): IChatContentPart | undefined {
 		// Skip rendering completed tool invocations that are hidden and have no meaningful content - ie, autopilot "task complete".
 		// We intentionally only short-circuit when the invocation's presentation is hidden, otherwise extension-contributed
 		// tools that don't supply a `pastTenseMessage` (proposed API) get filtered out incorrectly.
@@ -3286,7 +3307,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// Check for subagent grouping before creating tool part - subagent part handles lazy creation
 		const subagentId = getSubagentId(toolInvocation);
 		if (subagentId && isResponseVM(context.element) && !IChatToolInvocation.isEffectivelyHidden(toolInvocation)) {
-			return this.handleSubagentToolGrouping(toolInvocation, subagentId, context, templateData, codeBlockStartIndex);
+			return this.handleSubagentToolGrouping(toolInvocation, subagentId, context, templateData, codeBlockStartIndex, batchedSubagentParts);
 		}
 
 		// For cases not handled above (no thinking part, no subagent, etc.), create the part now
@@ -3504,7 +3525,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return part;
 	}
 
-	private renderHookPart(hookPart: IChatHookPart, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart {
+	private renderHookPart(hookPart: IChatHookPart, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate, batchedSubagentParts?: Set<ChatSubagentContentPart>): IChatContentPart {
 		if (!(hookPart.stopReason || hookPart.systemMessage)) {
 			return this.renderNoContent(other => other.kind === 'hook' && other.hookType === hookPart.hookType);
 		}
@@ -3512,6 +3533,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (hookPart.subAgentInvocationId) {
 			const subagentPart = this.getSubagentPart(templateData.renderedParts, hookPart.subAgentInvocationId);
 			if (subagentPart) {
+				this.beginSubagentToolPresentationBatch(subagentPart, batchedSubagentParts);
 				subagentPart.appendHookItem(() => {
 					const part = this.instantiationService.createInstance(ChatHookContentPart, hookPart, context);
 					return { domNode: part.domNode, disposable: part };

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
@@ -21,7 +21,7 @@ import { TestMenuService, workbenchInstantiationService } from '../../../../../.
 import { IChatWidgetService } from '../../../../browser/chat.js';
 import { ChatCollapsibleContentPart } from '../../../../browser/widget/chatContentParts/chatCollapsibleContentPart.js';
 import { ChatSubagentContentPart } from '../../../../browser/widget/chatContentParts/chatSubagentContentPart.js';
-import { IChatMarkdownContent, IChatSubagentToolInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
+import { IChatHookPart, IChatMarkdownContent, IChatSubagentToolInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
 import { IChatResponseViewModel } from '../../../../common/model/chatViewModel.js';
 import { ChatResponseModelChangeReason } from '../../../../common/model/chatModel.js';
@@ -123,6 +123,7 @@ suite('ChatSubagentContentPart', () => {
 	let announcedToolProgressKeys: Set<string>;
 	let actionViewItemService: TestActionViewItemService;
 	let menuService: TestSubagentMenuService;
+	let markdownRenderCount: number;
 
 	function createMockRenderContext(isComplete: boolean = false, sessionResource: URI = URI.parse('chat-session://test/session1')): IChatContentPartRenderContext {
 		const mockElement: Partial<IChatResponseViewModel> = {
@@ -287,10 +288,12 @@ suite('ChatSubagentContentPart', () => {
 	setup(() => {
 		disposables = store.add(new DisposableStore());
 		instantiationService = workbenchInstantiationService(undefined, store);
+		markdownRenderCount = 0;
 
 		// Create a mock markdown renderer
 		mockMarkdownRenderer = {
 			render: (_markdown: IMarkdownString, _options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown => {
+				markdownRenderCount++;
 				const element = outElement ?? mainWindow.document.createElement('div');
 				const content = typeof _markdown === 'string' ? _markdown : (_markdown.value ?? '');
 				element.textContent = content;
@@ -1812,6 +1815,99 @@ suite('ChatSubagentContentPart', () => {
 	});
 
 	suite('Current running tool in title', () => {
+		test('batches presentation while reconstructing terminal tool history', () => {
+			const parentTool = createMockToolInvocation({
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const part = createPart(parentTool, createMockRenderContext(false));
+			markdownRenderCount = 0;
+
+			part.beginToolPresentationBatch();
+			for (let index = 0; index < 128; index++) {
+				const tool = createMockToolInvocation({
+					toolId: 'readFile',
+					toolCallId: `child-${index}`,
+					subAgentInvocationId: parentTool.toolCallId,
+					stateType: IChatToolInvocation.StateKind.Completed,
+					invocationMessage: `Completed tool ${index}`
+				});
+				part.appendToolInvocation(tool, index);
+			}
+
+			const rendersDuringBatch = markdownRenderCount;
+			part.endToolPresentationBatch();
+			const rendersAfterBatch = markdownRenderCount;
+			const button = getCollapseButton(part);
+			assert.ok(button);
+			const titleAfterBatch = getCollapseButtonLabel(button)?.textContent ?? button.textContent ?? '';
+			const toolStateTracking = (part as unknown as { _toolStateTracking: { _toDispose: Set<object> } })._toolStateTracking;
+			const trackedTerminalToolCount = toolStateTracking._toDispose.size;
+
+			const liveTool = createMockToolInvocation({
+				toolId: 'searchFiles',
+				toolCallId: 'live-child',
+				subAgentInvocationId: parentTool.toolCallId,
+				stateType: IChatToolInvocation.StateKind.Executing,
+				invocationMessage: 'Searching live files'
+			});
+			part.appendToolInvocation(liveTool, 128);
+			const titleAfterLiveTool = getCollapseButtonLabel(button)?.textContent ?? button.textContent ?? '';
+
+			assert.deepStrictEqual({
+				rendersDuringBatch,
+				rendersAfterBatch,
+				trackedTerminalToolCount,
+				rendersAfterLiveTool: markdownRenderCount,
+				titleAfterBatchIncludesLatestTool: titleAfterBatch.includes('Completed tool 127'),
+				titleAfterLiveToolIncludesLatestTool: titleAfterLiveTool.includes('Searching live files'),
+			}, {
+				rendersDuringBatch: 0,
+				rendersAfterBatch: 1,
+				trackedTerminalToolCount: 0,
+				rendersAfterLiveTool: 2,
+				titleAfterBatchIncludesLatestTool: true,
+				titleAfterLiveToolIncludesLatestTool: true,
+			});
+		});
+
+		test('batches grouped hook presentation updates', () => {
+			const parentTool = createMockToolInvocation({
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const part = createPart(parentTool, createMockRenderContext(false));
+			const hookPart: IChatHookPart = {
+				kind: 'hook',
+				hookType: 'PreToolUse',
+				systemMessage: 'Warning',
+				toolDisplayName: 'Search',
+				subAgentInvocationId: parentTool.toolCallId,
+			};
+			markdownRenderCount = 0;
+
+			part.beginToolPresentationBatch();
+			for (let index = 0; index < 32; index++) {
+				part.appendHookItem(() => ({ domNode: mainWindow.document.createElement('div') }), hookPart);
+			}
+			const rendersDuringBatch = markdownRenderCount;
+			part.endToolPresentationBatch();
+
+			assert.deepStrictEqual({
+				rendersDuringBatch,
+				rendersAfterBatch: markdownRenderCount,
+			}, {
+				rendersDuringBatch: 0,
+				rendersAfterBatch: 1,
+			});
+		});
+
 		test('should update title with current running tool invocation message', () => {
 			const toolInvocation = createMockToolInvocation({
 				toolSpecificData: {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -19,6 +19,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import { buildPlanReviewProgressContent, ChatListItemRenderer, endsWithActiveSubagentContent, endsWithCompletedQuestionInteraction, formatCompletedResponseDisclosureLabel, formatResponseTokenStats, getCompletedResponseCollapseEndIndex, getFinalResponseStartIndex, getVisibleCompletedResponseItemCount, getWorkingProgressRelevantParts, IChatListItemTemplate, isWaitingForMcpServers, reconcileChatItemHeight, renderChatRequestTimestamp, renderChatResponseDetails, shouldCollapseCompletedResponsePart, shouldCreateGroupedThinkingPart, shouldHideChatUserIdentity, shouldPinToolInvocationToThinking, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange, shouldShowFileChangesSummaryForSettings, shouldShowPillsSummaryForSettings, shouldStartNewCollapsedThinkingGroup } from '../../../browser/widget/chatListRenderer.js';
 import { ChatWidget } from '../../../browser/widget/chatWidget.js';
 import { isChatTurnStatusPillsEnabled } from '../../../browser/widget/chatTurnPills.js';
+import { ChatSubagentContentPart } from '../../../browser/widget/chatContentParts/chatSubagentContentPart.js';
 import { ChatRequestQueueKind, IChatMcpServersStartingSlow, IChatQuestionCarousel, IChatService, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { formatChatRequestTimestamp, formatChatResponseDetails, formatElapsedTime } from '../../../common/chatProgressFormatting.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../../common/constants.js';
@@ -909,6 +910,105 @@ suite('ChatListRenderer', () => {
 		}, {
 			mountedWhileStreaming: true,
 			mountedAfterCompletion: true,
+		});
+
+		disposables.dispose();
+	});
+
+	test('reconstructs a large collapsed subagent history through one renderer batch', async () => {
+		const disposables = store.add(new DisposableStore());
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('chat.agent.thinking.collapsedTools', CollapsedToolsDisplayMode.Off);
+		configurationService.setUserConfiguration(ChatConfiguration.SubagentsUseRichRendering, false);
+		configurationService.setUserConfiguration('chat.checkpoints.enabled', false);
+		configurationService.setUserConfiguration('chat.checkpoints.showFileChanges', false);
+		configurationService.setUserConfiguration(ChatConfiguration.TurnStatusPills, false);
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(IChatService, new MockChatService());
+		instantiationService.stub(IChatAgentService, disposables.add(instantiationService.createInstance(ChatAgentService)));
+
+		const model = disposables.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
+		const viewModel = disposables.add(instantiationService.createInstance(ChatViewModel, model, undefined));
+		model.addRequest({
+			text: 'test',
+			parts: [new ChatRequestTextPart(new OffsetRange(0, 4), new Range(1, 1, 1, 5), 'test')]
+		}, { variables: [] }, 0);
+		const response = viewModel.getItems().find(isResponseVM);
+		assert.ok(response);
+
+		const parentSubagent: IChatToolInvocationSerialized = {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'subagent-1',
+			toolId: 'task',
+			source: ToolDataSource.Internal,
+			invocationMessage: 'Running subagent',
+			originMessage: undefined,
+			pastTenseMessage: undefined,
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: false,
+			presentation: undefined,
+			toolSpecificData: { kind: 'subagent', description: 'Investigate', isActive: true },
+		};
+		const toolData = {
+			id: 'search',
+			displayName: 'Search',
+			modelDescription: 'Search files',
+			source: ToolDataSource.Internal,
+		};
+		const childTools: ChatToolInvocation[] = Array.from({ length: 128 }, (_, index) => new ChatToolInvocation(
+			{
+				invocationMessage: `Completed tool ${index}`,
+				pastTenseMessage: `Completed tool ${index}`,
+			},
+			toolData,
+			`child-${index}`,
+			parentSubagent.toolCallId,
+			{},
+		));
+		await Promise.all(childTools.map(tool => tool.didExecuteTool(undefined)));
+		const content: IChatRendererContent[] = [parentSubagent, ...childTools];
+
+		const container = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+		disposables.add(toDisposable(() => container.remove()));
+		const renderer = disposables.add(instantiationService.createInstance(
+			ChatListItemRenderer,
+			{} as ChatEditorOptions,
+			{},
+			{
+				getListLength: () => 1,
+				onDidScroll: () => toDisposable(() => { }),
+				container,
+				currentChatMode: () => ChatModeKind.Agent,
+			},
+			undefined,
+			viewModel,
+		));
+		const template = renderer.renderTemplate(container);
+		disposables.add(toDisposable(() => renderer.disposeTemplate(template)));
+		const privateRenderer = renderer as unknown as {
+			renderChatContentDiff(partsToRender: ReadonlyArray<IChatRendererContent | null>, contentForThisTurn: ReadonlyArray<IChatRendererContent>, element: IChatResponseViewModel, elementIndex: number, templateData: IChatListItemTemplate): void;
+			clearRenderedParts(templateData: IChatListItemTemplate): void;
+		};
+
+		privateRenderer.renderChatContentDiff(content, content, response, 0, template);
+		privateRenderer.clearRenderedParts(template);
+		privateRenderer.renderChatContentDiff(content, content, response, 0, template);
+
+		const subagentPart = template.renderedParts?.find(part => part instanceof ChatSubagentContentPart);
+		assert.ok(subagentPart);
+		const titleBeforeExpansion = subagentPart.domNode.textContent ?? '';
+		const expandButton = subagentPart.domNode.querySelector<HTMLElement>('.chat-used-context-label > .monaco-button');
+		assert.ok(expandButton);
+		expandButton.click();
+
+		assert.deepStrictEqual({
+			titleIncludesLatestTool: titleBeforeExpansion.includes('Completed tool 127'),
+			renderedToolCount: subagentPart.domNode.querySelectorAll('.chat-thinking-tool-wrapper').length,
+		}, {
+			titleIncludesLatestTool: true,
+			renderedToolCount: 128,
 		});
 
 		disposables.dispose();


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/329117

- batch subagent title, toolbar, ARIA, and active-tool presentation updates while virtualized chat rows reconstruct historical activity
- avoid transient state observers and microtasks for already-terminal child tools
- include grouped hook activity in the same renderer batch and isolate per-subagent flush failures
- add deterministic high-volume component and renderer recycling regressions

## Root cause

Scrolling a collapsed active subagent row reconstructed every historical child tool synchronously. Each child repeatedly sanitized the title Markdown and reset open-chat duration state, producing a ~280 ms wheel handler for a 112-tool history even though the content was hidden.

## Validation

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts --run src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts` (118 passing, 1 pre-existing skipped)
- `node --experimental-strip-types build/hygiene.ts <changed files>`