### PR TITLE
Add component fixture rendering controls

### DIFF
--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -8,7 +8,7 @@
 import { defineFixture, defineFixtureGroup, defineFixtureVariants } from '@vscode/component-explorer';
 // eslint-disable-next-line local/code-import-patterns, local/code-amd-node-module
 import { z } from 'zod';
-import { DisposableStore, DisposableTracker, IDisposable, IReference, setDisposableTracker, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, DisposableTracker, IDisposable, IReference, MutableDisposable, setDisposableTracker, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 // eslint-disable-next-line local/code-import-patterns
@@ -335,8 +335,12 @@ export async function setupTheme(container: HTMLElement, theme: ColorThemeData, 
  * flag), parsed once into a typed shape by {@link parseFixtureInput}.
  */
 interface FixtureRenderInput {
-	/** See {@link ReverseStylesheetsOption}; `false` when no reversal is requested. */
-	readonly reverseStylesheets: ReverseStylesheetsOption;
+	/** Whether all stylesheet documents should be reversed. */
+	readonly reverseStylesheets: boolean;
+	/** The stylesheet document range to reverse, when set. */
+	readonly reverseStylesheetsRange: Exclude<ReverseStylesheetsOption, boolean> | undefined;
+	/** Whether CSS animations and transitions are enabled. */
+	readonly enableAnimations: boolean;
 	/** Whether the render should return its virtual-time trace as `output`. */
 	readonly outputTimeTrace: boolean;
 	/** Whether the render should return the bundled stylesheet files as `output`. */
@@ -349,43 +353,41 @@ interface FixtureRenderInput {
  */
 function parseFixtureInput(input: unknown): FixtureRenderInput {
 	if (!input || typeof input !== 'object') {
-		return { reverseStylesheets: false, outputTimeTrace: false, outputStylesheetFiles: false };
+		return { reverseStylesheets: false, reverseStylesheetsRange: undefined, enableAnimations: false, outputTimeTrace: false, outputStylesheetFiles: false };
 	}
 	const record = input as Record<string, unknown>;
 	return {
-		reverseStylesheets: parseReverseOption(record.reverseStylesheets),
+		reverseStylesheets: record.reverseStylesheets === true,
+		reverseStylesheetsRange: parseReverseStylesheetsRange(record.reverseStylesheetsRange),
+		enableAnimations: record.enableAnimations === true,
 		outputTimeTrace: !!record.outputTimeTrace,
 		outputStylesheetFiles: !!record.outputStylesheetFiles,
 	};
 }
 
-/**
- * Validates a `reverseStylesheets` input value: `true` (reverse all stylesheet
- * documents), `{ fromIndex, toIndex }` (reverse only that index window, used by
- * the order-dependency bisection), or `false` when absent/unrecognized.
- */
-function parseReverseOption(value: unknown): ReverseStylesheetsOption {
-	if (value === true) {
-		return true;
-	}
+function parseReverseStylesheetsRange(value: unknown): Exclude<ReverseStylesheetsOption, boolean> | undefined {
 	if (value && typeof value === 'object') {
 		const range = value as Record<string, unknown>;
 		if (typeof range.fromIndex === 'number' && typeof range.toIndex === 'number') {
 			return { fromIndex: range.fromIndex, toIndex: range.toIndex };
 		}
 	}
-	return false;
+	return undefined;
+}
+
+function getReverseStylesheetsOption(input: unknown): ReverseStylesheetsOption {
+	const parsedInput = parseFixtureInput(input);
+	return parsedInput.reverseStylesheetsRange ?? parsedInput.reverseStylesheets;
 }
 
 /** Inputs exposed as Component Explorer controls. */
 const fixtureInputSchema = z.object({
-	reverseStylesheets: z.union([
-		z.boolean(),
-		z.object({
-			fromIndex: z.number(),
-			toIndex: z.number(),
-		}),
-	]).default(false).describe('Reverse the order of the bundled CSS documents to surface cascade-order dependencies.'),
+	reverseStylesheets: z.boolean().default(false).describe('Reverse the order of the bundled CSS documents to surface cascade-order dependencies.'),
+	reverseStylesheetsRange: z.object({
+		fromIndex: z.number(),
+		toIndex: z.number(),
+	}).optional().describe('Reverse the bundled CSS documents in this half-open index range.'),
+	enableAnimations: z.boolean().default(false).describe('Enable CSS animations and transitions.'),
 	outputTimeTrace: z.boolean().default(false).describe('Return the render\'s virtual-time trace as its output.'),
 	outputStylesheetFiles: z.boolean().default(false).describe('Return the bundled stylesheet files as the render output.'),
 });
@@ -897,6 +899,10 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 		displayMode: { type: 'component' },
 		background: themeVariant.background,
 		inputSchema: fixtureInputSchema,
+		inputControls: {
+			reverseStylesheets: { placement: 'toolbar', label: 'Reverse Stylesheets' },
+			enableAnimations: { placement: 'toolbar', label: 'Enable Animations' },
+		},
 		render: async (container: HTMLElement, context) => {
 			const disposableStore = new DisposableStore();
 			const input = parseFixtureInput(context.input);
@@ -999,12 +1005,19 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 			async function actualRender() {
 				await setupTheme(container, theme, scopeThemingParticipants);
 
-				// The order-dependency fuzzer reorders the bundled CSS for just
-				// this render; the override is scoped to the fixture's lifetime
-				// (disposed at teardown, where it is also leak-checked).
-				if (input.reverseStylesheets !== false) {
-					disposableStore.add(overrideStylesheetOrder(input.reverseStylesheets));
-				}
+				const stylesheetOrderOverride = disposableStore.add(new MutableDisposable<IDisposable>());
+				const updateStylesheetOrder = (input: unknown) => {
+					const option = getReverseStylesheetsOption(input);
+					stylesheetOrderOverride.clear();
+					if (option !== false) {
+						stylesheetOrderOverride.value = overrideStylesheetOrder(option);
+					}
+				};
+				context.watchInput('reverseStylesheets', (_value, input) => updateStylesheetOrder(input));
+				context.watchInput('reverseStylesheetsRange', (_value, input) => updateStylesheetOrder(input));
+				context.watchInput('enableAnimations', value => {
+					container.classList.toggle('disable-animations', !value);
+				});
 
 				let renderTimeApi: IDisposable | undefined;
 				if (virtualTimeEnabled) {

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
@@ -18,7 +18,12 @@ let overlaySheet: CSSStyleSheet | undefined;
 let baseStylesInstalledPromise: Promise<void> | undefined;
 let bundlePromise: Promise<Bundle> | undefined;
 let bundle: Bundle | undefined;
-let activeOverride: object | undefined;
+const activeOverrides: {
+	readonly option: Exclude<ReverseStylesheetsOption, false>;
+	readonly overlay: CSSStyleSheet;
+	readonly bundle: Bundle;
+}[] = [];
+let originalDisabledStates: readonly boolean[] | undefined;
 let iconsStyleSheetCache: CSSStyleSheet | undefined;
 const themeStyleSheetCache = new WeakMap<ColorThemeData, CSSStyleSheet>();
 const installedThemes = new WeakSet<ColorThemeData>();
@@ -151,7 +156,7 @@ function readBundle(): Promise<Bundle> {
 
 /**
  * The repo-relative source files of the bundled stylesheet documents, in product
- * order. Index `i` is the document that a `reverseStylesheets` window refers to,
+ * order. Index `i` is the document that a `reverseStylesheetsRange` refers to,
  * so the bisection driver uses this to name a conflicting document — keeping all
  * knowledge of the bundle format inside the runtime.
  */
@@ -236,37 +241,37 @@ export async function ensureGlobalStylesInstalled(theme: ColorThemeData, scopeTh
  * are disabled and replaced wholesale by the reordered copy in the overlay, so
  * the originals cannot contribute competing declarations.
  *
- * Exclusive and stack-like: throws if another override is already active (two
- * fixtures must not render against the shared page concurrently), and the
- * returned disposable throws if disposed out of order.
+ * Concurrent fixtures share the document stylesheets. The most recently applied
+ * override wins until it is disposed.
  * {@link ensureGlobalStylesInstalled} must have resolved first.
  */
 export function overrideStylesheetOrder(option: Exclude<ReverseStylesheetsOption, false>): IDisposable {
 	if (!overlaySheet || !bundle) {
 		throw new Error('ensureGlobalStylesInstalled() must resolve before overriding the stylesheet order.');
 	}
-	if (activeOverride) {
-		throw new Error('A stylesheet-order override is already active; fixtures must render sequentially.');
+	const override = { option, overlay: overlaySheet, bundle };
+	if (activeOverrides.length === 0) {
+		originalDisabledStates = bundle.sheets.map(sheet => sheet.disabled);
+		for (const sheet of bundle.sheets) {
+			sheet.disabled = true;
+		}
 	}
-	const overlay = overlaySheet;
-	const sheets = bundle.sheets;
-	const token = activeOverride = {};
-
-	// Disable the bundled product sheets and reproduce them, reordered, in the
-	// overlay. The overlay alone then defines the product cascade, so the disabled
-	// originals can't win (or tie) against it.
-	const wasDisabled = sheets.map(sheet => sheet.disabled);
-	for (const sheet of sheets) {
-		sheet.disabled = true;
-	}
-	overlay.replaceSync(reverseDocuments(bundle.rawSources, option));
+	overlaySheet.replaceSync(reverseDocuments(bundle.rawSources, option));
+	activeOverrides.push(override);
 
 	return toDisposable(() => {
-		if (activeOverride !== token) {
-			throw new Error('Stylesheet-order override disposed out of order.');
+		const index = activeOverrides.indexOf(override);
+		if (index === -1) {
+			return;
 		}
-		overlay.replaceSync('');
-		sheets.forEach((sheet, i) => { sheet.disabled = wasDisabled[i]; });
-		activeOverride = undefined;
+		activeOverrides.splice(index, 1);
+		const activeOverride = activeOverrides.at(-1);
+		if (activeOverride) {
+			activeOverride.overlay.replaceSync(reverseDocuments(activeOverride.bundle.rawSources, activeOverride.option));
+			return;
+		}
+		override.overlay.replaceSync('');
+		override.bundle.sheets.forEach((sheet, i) => { sheet.disabled = originalDisabledStates![i]; });
+		originalDisabledStates = undefined;
 	});
 }

--- a/test/componentFixtures/cssOrderShared.mts
+++ b/test/componentFixtures/cssOrderShared.mts
@@ -48,7 +48,7 @@ export interface RenderResult {
 	readonly targetDir: string;
 }
 
-/** Options accepted by a `reverseStylesheets` input value. */
+/** Options accepted by the `reverseStylesheetsRange` input value. */
 export interface ReverseWindow {
 	readonly fromIndex: number;
 	readonly toIndex: number;
@@ -118,7 +118,7 @@ export class Renderer {
 
 	/** Renders a single fixture with the given reversal window and returns its image hash. */
 	async hash(fixtureRegex: string, window: ReverseWindow): Promise<string> {
-		const { entries } = await this.render(fixtureRegex, { reverseStylesheets: window });
+		const { entries } = await this.render(fixtureRegex, { reverseStylesheetsRange: window });
 		const hash = entries[0]?.imageHash;
 		if (!hash) {
 			throw new Error(`Render produced no image hash for ${fixtureRegex}`);


### PR DESCRIPTION
Adds explicit Component Explorer controls for fixture rendering without changing screenshot defaults.

- Declares toolbar toggles for normal/reversed stylesheet order and CSS animations
- Keeps animations disabled by default
- Splits ranged stylesheet reversal into `reverseStylesheetsRange` so the Explorer does not need to render a union input
- Updates the scheduled CSS order scanner's bisection probes to use the range input
- Supports shared live controls when multiple theme variants are mounted

Validation:
- Component Explorer Playwright tests: 13 passed
- Ranged render through Component Explorer CLI: passed
- Pre-commit hygiene: passed
- `npm run typecheck-client`: blocked by pre-existing `AuthenticationResponseDetails.firstAuthAttempt` error in `src/vs/platform/native/electron-main/auth.ts`