### PR TITLE
agentHost: support Codex custom agents and runtime enablement

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -151,7 +151,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[AgentHostCodexAgentEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. Enabling takes effect without restarting the agent host; disabling takes effect after a restart."),
+			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. Enabling takes effect without restarting the agent host."),
 			default: false,
 			tags: ['experimental', 'advanced'],
 			// Allow the default to be overridden by an experiment. Uses `startup`

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -151,12 +151,11 @@ configurationRegistry.registerConfiguration({
 		},
 		[AgentHostCodexAgentEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
+			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. Enabling takes effect without restarting the agent host; disabling takes effect after a restart."),
 			default: false,
 			tags: ['experimental', 'advanced'],
 			// Allow the default to be overridden by an experiment. Uses `startup`
-			// (matching the sibling agent-host settings) since the agent host
-			// process must be restarted for a change to take effect anyway.
+			// to match the sibling agent-host provider settings.
 			experiment: { mode: 'startup' },
 			// Owns the `Codex3PIntegration` policy; gating here disables Codex across all agent-host surfaces.
 			policy: {

--- a/src/vs/platform/agentHost/common/meta/agentCustomizationMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentCustomizationMeta.ts
@@ -27,11 +27,10 @@ export interface IAgentCustomizationMeta {
  */
 export function readAgentCustomizationMeta(agent: AgentCustomization): IAgentCustomizationMeta {
 	const meta = agent._meta;
-	if (!meta) {
-		return {};
-	}
 	const result: Mutable<IAgentCustomizationMeta> = {};
-	if (typeof meta['userInvocable'] === 'boolean') {
+	if (agent.disableUserInvocation === true) {
+		result.userInvocable = false;
+	} else if (typeof meta?.['userInvocable'] === 'boolean') {
 		result.userInvocable = meta['userInvocable'];
 	}
 	return result;

--- a/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
+++ b/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
@@ -76,6 +76,27 @@ export class AgentHostAuthenticationService {
 		return { authenticated };
 	}
 
+	async replay(provider: IAgent): Promise<void> {
+		const protectedResources = new Set(provider.getProtectedResources().map(resource => resource.resource));
+		for (const stored of this._tokens.values()) {
+			const params: AuthenticateParams = { resource: stored.resource, scopes: stored.scopes, token: stored.token };
+			if (protectedResources.has(stored.resource)) {
+				try {
+					await provider.authenticate(stored.resource, stored.token);
+				} catch (error) {
+					this._logService.error(error, `[AgentHostAuthenticationService] Provider '${provider.id}' rejected replayed authentication for resource=${stored.resource}`);
+				}
+			}
+			if (provider.handleAuthenticationToken) {
+				try {
+					await provider.handleAuthenticationToken(params);
+				} catch (error) {
+					this._logService.error(error, `[AgentHostAuthenticationService] Provider '${provider.id}' rejected replayed session authentication for resource=${stored.resource}`);
+				}
+			}
+		}
+	}
+
 	getAuthToken(request: IAgentHostAuthTokenRequest): string | undefined {
 		const scopes = this._normalizeScopes(request.scopes);
 		const exact = this._tokens.get(this._key(request.resource, scopes));

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -50,6 +50,7 @@ import { CodexProxyService, ICodexProxyService } from './codex/codexProxyService
 import { AgentSdkDownloader, IAgentSdkDownloader, type IAgentSdkDownloadProgress } from './agentSdkDownloader.js';
 import { IAgentHostOTelService } from '../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService } from './otel/agentHostOTelService.js';
+import { AgentHostCodexEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
 import { AgentModelRefreshScheduler, MODEL_REFRESH_INTERVAL_MS } from './agentModelRefreshScheduler.js';
 import { AgentService } from './agentService.js';
 import { IAgentHostStateManager } from './agentHostStateManager.js';
@@ -336,10 +337,24 @@ async function main(): Promise<void> {
 			agentService.registerProvider(claudeAgent);
 			log('ClaudeAgent registered');
 		}
-		if (isAgentEnabled(process.env[AgentHostCodexAgentEnabledEnvVar], false) && (!environmentService.isBuilt || agentSdkDownloader.isAvailable(CodexSdkPackage))) {
-			const codexAgent = disposables.add(instantiationService.createInstance(CodexAgent));
-			agentService.registerProvider(codexAgent);
-			log('CodexAgent registered');
+		if (!environmentService.isBuilt || agentSdkDownloader.isAvailable(CodexSdkPackage)) {
+			const agentConfigurationService = agentService.configurationService;
+			let codexRegistered = false;
+			const registerCodexIfEnabled = () => {
+				if (codexRegistered) {
+					return;
+				}
+				const enabledByEnv = isAgentEnabled(process.env[AgentHostCodexAgentEnabledEnvVar], false);
+				const enabledByRootConfig = agentConfigurationService.getRootValue(platformRootSchema, AgentHostCodexEnabledConfigKey) === true;
+				if (enabledByEnv || enabledByRootConfig) {
+					codexRegistered = true;
+					const codexAgent = disposables.add(instantiationService.createInstance(CodexAgent));
+					agentService.registerProvider(codexAgent);
+					log('CodexAgent registered');
+				}
+			};
+			registerCodexIfEnabled();
+			disposables.add(agentConfigurationService.onDidRootConfigChange(() => registerCodexIfEnabled()));
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -717,6 +717,7 @@ export class AgentService extends Disposable implements IAgentService {
 		this._logService.info(`Registering agent provider: ${provider.id}`);
 		this._providers.set(provider.id, provider);
 		provider.setServerToolHost?.(this._serverToolHost);
+		void this._authService.replay(provider);
 		// Deterministic subagent membership ordering: apply a spawned subagent's
 		// catalog membership (via the spawn-channel handlers) BEFORE
 		// AgentSideEffects — registered next — handles the same signal and starts

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1179,6 +1179,23 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		this._logService.trace(`[AgentService] createSession returned: ${session.toString()}`);
 
+		// Provisional sessions deliberately suppress their `sessionAdded`
+		// notification until materialization, so it is safe — and important — to
+		// create their in-memory state before asking the provider for its initial
+		// customization snapshot. Providers may publish incremental plugin load
+		// updates while resolving that snapshot; without a state entry those
+		// actions are rejected as targeting an unknown session and custom agents
+		// can disappear from the picker permanently.
+		const provisionalState = created.provisional && !config?.fork && !config?.importConversation
+			? (() => {
+				const summary = this._buildInitialSummary(provider, session, config, created, '');
+				const state = this._stateManager.createSession(summary, { emitNotification: false });
+				state.config = sessionConfig;
+				state.activeClients = config?.activeClient ? [config.activeClient] : [];
+				return state;
+			})()
+			: undefined;
+
 		// Resolve config and seed the initial customization set in parallel so
 		// both are available before we register the session in the state
 		// manager. Seeding `state.customizations` directly (instead of
@@ -1274,9 +1291,11 @@ export class AgentService extends Disposable implements IAgentService {
 			// clients can subscribe and stream config / model changes that
 			// the agent will pick up at materialization time.
 			const summary = this._buildInitialSummary(provider, session, config, created, '');
-			const state = this._stateManager.createSession(summary, { emitNotification: !created.provisional });
-			state.config = sessionConfig;
-			state.activeClients = config?.activeClient ? [config.activeClient] : [];
+			const state = provisionalState ?? this._stateManager.createSession(summary, { emitNotification: true });
+			if (!provisionalState) {
+				state.config = sessionConfig;
+				state.activeClients = config?.activeClient ? [config.activeClient] : [];
+			}
 			if (initialCustomizations && initialCustomizations.length > 0) {
 				state.customizations = [...initialCustomizations];
 			}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -38,7 +38,7 @@ import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
 import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpToolsChanged, codexStartupErrorNeedsAuth, injectCodexMcpAuthTokens, inventoryToSdkServers, normalizeCodexMcpResourceUrl, translateCodexMcpStartupState, type ICodexMcpServerConfigJson, type ICodexMcpServerEntry } from './codexMcpServers.js';
 import { codexHooksToContainers, codexSelectedCapabilityRootCandidates, codexSkillsToContainers } from './codexCustomizations.js';
-import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
+import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfigFromPlugins, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import { McpAuthRequiredReason, McpServerStatus, type AhpMcpUiHostCapabilities, type Customization, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -527,9 +527,13 @@ interface ICodexSession {
 	 * restarted to pick them up. `undefined` until materialized.
 	 */
 	materializedMcpSig: string | undefined;
+	/** Signature of custom agents, instructions, and skill capability roots applied to the thread. */
+	materializedCustomizationsSig: string | undefined;
 	/** True once a turn has been started on the (materialized) thread. */
 	firstTurnSent: boolean;
 	model: ModelSelection | undefined;
+	agent: AgentSelection | undefined;
+	customizationDirectory: URI | undefined;
 	/** Workbench-facing turn id for the active turn. */
 	currentTurnId: string | undefined;
 	/** Local monotonic timer for the active workbench-facing turn. */
@@ -940,6 +944,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		session.materializePromise = undefined;
 		session.materializedToolsSig = undefined;
 		session.materializedMcpSig = undefined;
+		session.materializedCustomizationsSig = undefined;
 		session.needsResume = false;
 		session.hostTurnIdByAppTurnId.clear();
 		session.codexTurnIdByHostTurnId.clear();
@@ -1289,6 +1294,47 @@ export class CodexAgent extends Disposable implements IAgent {
 		return resolved.filter(candidate => candidate !== undefined);
 	}
 
+	private async _buildCustomizationLaunch(session: ICodexSession): Promise<{
+		readonly config: Record<string, JsonValue>;
+		readonly developerInstructions?: string;
+		readonly selectedCapabilityRoots: SelectedCapabilityRoot[];
+		readonly signature: string;
+	}> {
+		const plugins = session.clientCustomizations.enabledPlugins();
+		const customization = await codexCustomizationConfigFromPlugins(plugins, session.agent, this._fileService);
+		const config: Record<string, JsonValue> = {};
+		if (customization.agentRoles.length > 0) {
+			const root = join(os.tmpdir(), 'vscode-agent-codex-customizations', session.sessionId);
+			const agentsDirectory = join(root, 'agents');
+			await fs.promises.mkdir(agentsDirectory, { recursive: true });
+			const agents: Record<string, JsonValue> = {};
+			for (const [index, role] of customization.agentRoles.entries()) {
+				const rolePath = join(agentsDirectory, `${index}.toml`);
+				await fs.promises.writeFile(rolePath, codexAgentRoleToml(role), 'utf8');
+				agents[role.name] = { description: role.description, config_file: rolePath };
+			}
+			config.agents = agents;
+			session.customizationDirectory = URI.file(root);
+		}
+
+		const selectedCapabilityRoots = codexSkillCapabilityRoots(plugins).map((uri, index): SelectedCapabilityRoot => ({
+			id: `client-plugin-skills-${index}-${uri.fsPath}`,
+			location: { type: 'environment', environmentId: 'local', path: uri.fsPath },
+		}));
+		const signature = JSON.stringify({
+			agent: session.agent?.uri,
+			agentRoles: customization.agentRoles,
+			developerInstructions: customization.developerInstructions,
+			selectedCapabilityRoots: selectedCapabilityRoots.map(root => root.location.path),
+		});
+		return {
+			config,
+			...(customization.developerInstructions ? { developerInstructions: customization.developerInstructions } : {}),
+			selectedCapabilityRoots,
+			signature,
+		};
+	}
+
 	private async _refreshModels(): Promise<void> {
 		const usageSource = this._usageSource;
 		if (usageSource === 'openai') {
@@ -1388,19 +1434,27 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * — concurrent callers share the same promise.
 	 */
 	private async _ensureConnection(skipUsageSourceValidation = false): Promise<IConnectionReady> {
-		if (this._connection.kind === 'ready') {
-			return Promise.resolve(this._connection);
-		}
-		if (this._connection.kind === 'starting') {
-			return this._connection.promise;
-		}
-		if (!skipUsageSourceValidation && this._usageSource === 'openai') {
-			let validation = this._usageSourceValidation;
-			await validation;
-			while (validation !== this._usageSourceValidation) {
-				validation = this._usageSourceValidation;
-				await validation;
+		while (true) {
+			if (this._connection.kind === 'ready') {
+				return Promise.resolve(this._connection);
 			}
+			if (this._connection.kind === 'starting') {
+				return this._connection.promise;
+			}
+			if (!skipUsageSourceValidation && this._usageSource === 'openai') {
+				let validation = this._usageSourceValidation;
+				await validation;
+				while (validation !== this._usageSourceValidation) {
+					validation = this._usageSourceValidation;
+					await validation;
+				}
+				// Validation may itself establish the shared app-server connection.
+				// Loop back after the await so a caller that observed `idle` before
+				// validation does not start a second process and replace it.
+				skipUsageSourceValidation = true;
+				continue;
+			}
+			break;
 		}
 		const token = this._ensureAuthenticated();
 		const usageSource = this._usageSource;
@@ -2296,8 +2350,11 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
 			materializedMcpSig: undefined,
+			materializedCustomizationsSig: undefined,
 			firstTurnSent: true,
 			model: parent.model,
+			agent: parent.agent,
+			customizationDirectory: undefined,
 			currentTurnId: undefined,
 			turnStopWatch: undefined,
 			currentAppTurnId: undefined,
@@ -2764,14 +2821,31 @@ export class CodexAgent extends Disposable implements IAgent {
 		changeModel: (chat: URI, model: ModelSelection): Promise<void> => {
 			return this._changeModel(chat, model);
 		},
-		changeAgent: (_chat: URI, _agent: AgentSelection | undefined): Promise<void> => {
-			// Codex does not support selecting a custom agent.
-			return Promise.resolve();
-		},
+		changeAgent: (chat: URI, agent: AgentSelection | undefined): Promise<void> => this._changeAgent(chat, agent),
 		getMessages: (chat: URI): Promise<readonly Turn[]> => {
 			return this.getSessionMessages(chat);
 		},
 	};
+
+	private async _changeAgent(chat: URI, agent: AgentSelection | undefined): Promise<void> {
+		const sessionUri = this._sessionUriFromChat(chat);
+		const session = this._sessions.get(AgentSession.id(sessionUri));
+		if (!session) {
+			await this._metadataStore.write(sessionUri, { agent: agent ?? null });
+			return;
+		}
+		session.agent = agent;
+		await this._metadataStore.write(sessionUri, { agent: agent ?? null });
+		if (session.threadId === undefined) {
+			return;
+		}
+		if (!session.firstTurnSent) {
+			await this._restartThreadWithCurrentTools(session);
+			this._persistMaterializedSession(session);
+		} else {
+			session.needsResume = true;
+		}
+	}
 
 	async createSession(config: IAgentCreateSessionConfig = {}): Promise<IAgentCreateSessionResult> {
 		this._logService.info(`[Codex DEBUG] createSession usageSource=${this._usageSource} accountStatus=${codexAccountStateForUsageSource(this._usageSource, this._openAIAccountState).status} session=${config.session?.toString() ?? '(none)'} model=${config.model?.id ?? '(none)'} cwd=${config.workingDirectories?.[0]?.toString() ?? '(none)'}`);
@@ -2811,6 +2885,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		const existing = this._sessions.get(sessionId);
 		if (existing) {
 			existing.model = effectiveModel ?? existing.model;
+			existing.agent = config.agent ?? existing.agent;
 			const cwd = existing.workingDirectory ?? config.workingDirectories?.[0];
 			return {
 				session: sessionUri,
@@ -2839,8 +2914,11 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
 			materializedMcpSig: undefined,
+			materializedCustomizationsSig: undefined,
 			firstTurnSent: false,
 			model: effectiveModel,
+			agent: config.agent,
+			customizationDirectory: undefined,
 			currentTurnId: undefined,
 			turnStopWatch: undefined,
 			currentAppTurnId: undefined,
@@ -2873,7 +2951,7 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * `thread/resume` (`needsResume: true`) — so the prewarm/first-turn flags
 	 * are pre-set to their post-materialization values.
 	 */
-	private _createResumedSessionEntry(sessionId: string, threadId: string, sessionUri: URI, workingDirectory: URI | undefined, model: ModelSelection | undefined, workingDirectories?: readonly URI[], multiRootEnabled?: boolean): ICodexSession {
+	private _createResumedSessionEntry(sessionId: string, threadId: string, sessionUri: URI, workingDirectory: URI | undefined, model: ModelSelection | undefined, workingDirectories?: readonly URI[], multiRootEnabled?: boolean, agent?: AgentSelection): ICodexSession {
 		const clientToolSet = new ActiveClientToolSet();
 		const effectiveWorkingDirectories = distinctWorkingDirectories(workingDirectories);
 		return {
@@ -2895,8 +2973,11 @@ export class CodexAgent extends Disposable implements IAgent {
 			pendingUserInputs: new PendingRequestRegistry<ICodexUserInputResult>(),
 			materializedToolsSig: undefined,
 			materializedMcpSig: undefined,
+			materializedCustomizationsSig: undefined,
 			firstTurnSent: true,
 			model,
+			agent,
+			customizationDirectory: undefined,
 			currentTurnId: undefined,
 			turnStopWatch: undefined,
 			currentAppTurnId: undefined,
@@ -3022,7 +3103,16 @@ export class CodexAgent extends Disposable implements IAgent {
 			)
 			: undefined;
 
-		const session = this._createResumedSessionEntry(newThreadId, newThreadId, newSessionUri, workingDirectory, model, forkWorkingDirectories, multiRootEnabled);
+		const session = this._createResumedSessionEntry(
+			newThreadId,
+			newThreadId,
+			newSessionUri,
+			workingDirectory,
+			model,
+			forkWorkingDirectories,
+			multiRootEnabled,
+			config.agent ?? sourceSession?.agent,
+		);
 		this._sessions.set(newThreadId, session);
 		this._sessionIdByThreadId.set(newThreadId, newThreadId);
 		// Forked threads skip materialization (the thread already exists), so
@@ -3125,8 +3215,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		// merged with this session's enabled client-plugin servers. Passing them
 		// per-thread means a new session always reflects the current root config.
 		const mcpServers = this._buildSessionMcpServers(session);
+		const customizationLaunch = await this._buildCustomizationLaunch(session);
 		const threadConfig: Record<string, JsonValue> = {
 			web_search: narrowWebSearchMode(config[CodexSessionConfigKey.WebSearchMode]) ?? codexSessionConfigDefaults[CodexSessionConfigKey.WebSearchMode],
+			...customizationLaunch.config,
 		};
 		const mcpServerNames = Object.keys(mcpServers);
 		if (mcpServerNames.length > 0) {
@@ -3135,7 +3227,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		const multiRootActive = this._isMultiRootActive(session);
 		const runtimeWorkspaceRoots = multiRootActive ? this._runtimeWorkspaceRoots(session) : undefined;
-		const selectedCapabilityRoots = multiRootActive ? await this._selectedCapabilityRoots(session) : [];
+		const selectedCapabilityRoots = [
+			...(multiRootActive ? await this._selectedCapabilityRoots(session) : []),
+			...customizationLaunch.selectedCapabilityRoots,
+		];
 		const startResult = await conn.client.request<'thread/start', ThreadStartResponse>('thread/start', {
 			cwd: session.workingDirectory.fsPath,
 			...(runtimeWorkspaceRoots?.length ? { runtimeWorkspaceRoots } : {}),
@@ -3145,6 +3240,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sandbox: sandboxMode,
 			approvalsReviewer,
 			config: threadConfig,
+			developerInstructions: customizationLaunch.developerInstructions,
 			dynamicTools: this._buildDynamicTools(session),
 		}, this._traceContext(session));
 		const threadId = startResult.thread.id;
@@ -3162,6 +3258,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		session.threadId = threadId;
 		session.materializedMcpSig = mcpServersSignature(mcpServers);
+		session.materializedCustomizationsSig = customizationLaunch.signature;
 		session.materializedToolsSig = toolsSignature(session.clientToolSet.merged());
 		this._logService.info(`[Codex DEBUG] materialized session=${session.sessionUri.toString()} threadId=${session.threadId}`);
 		this._sessionIdByThreadId.set(session.threadId, session.sessionId);
@@ -3282,6 +3379,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			threadId: session.threadId,
 			cwd: session.workingDirectory,
 			modelId: session.model?.id,
+			agent: session.agent,
 			workingDirectories: multiRootActive ? session.workingDirectories : undefined,
 		};
 		void this._metadataStore.write(session.sessionUri, fields);
@@ -3410,7 +3508,9 @@ export class CodexAgent extends Disposable implements IAgent {
 		// `dynamicTools` and the servers in `config.mcp_servers`.
 		const toolsChanged = toolsSignature(session.clientToolSet.merged()) !== session.materializedToolsSig;
 		const mcpChanged = mcpServersSignature(this._buildSessionMcpServers(session)) !== session.materializedMcpSig;
-		if (!session.firstTurnSent && !session.needsResume && (toolsChanged || mcpChanged)) {
+		const customizationLaunch = await this._buildCustomizationLaunch(session);
+		const customizationsChanged = customizationLaunch.signature !== session.materializedCustomizationsSig;
+		if (!session.firstTurnSent && !session.needsResume && (toolsChanged || mcpChanged || customizationsChanged)) {
 			try {
 				await this._restartThreadWithCurrentTools(session);
 				this._persistMaterializedSession(session);
@@ -3435,11 +3535,19 @@ export class CodexAgent extends Disposable implements IAgent {
 				// so a resumed thread reconnects auth-gated servers, matching
 				// the config a fresh `thread/start` would apply.
 				const mcpServers = this._buildSessionMcpServers(session);
+				const customizationLaunch = await this._buildCustomizationLaunch(session);
 				const multiRootActive = this._isMultiRootActive(session);
 				const runtimeWorkspaceRoots = multiRootActive ? this._runtimeWorkspaceRoots(session) : undefined;
 				const resumeResult = await conn.client.request<'thread/resume', ThreadResumeResponse>(
 					'thread/resume',
-					buildCodexResumeParams(this._usageSource, threadId, mcpServers, runtimeWorkspaceRoots),
+					buildCodexResumeParams(
+						this._usageSource,
+						threadId,
+						mcpServers,
+						runtimeWorkspaceRoots,
+						customizationLaunch.config,
+						customizationLaunch.developerInstructions,
+					),
 					this._traceContext(session),
 				);
 				if (multiRootActive && !session.workingDirectories && resumeResult.runtimeWorkspaceRoots?.length) {
@@ -3447,6 +3555,7 @@ export class CodexAgent extends Disposable implements IAgent {
 					session.workingDirectory = session.workingDirectories[0];
 				}
 				session.materializedMcpSig = mcpServersSignature(mcpServers);
+				session.materializedCustomizationsSig = customizationLaunch.signature;
 				session.needsResume = false;
 			} catch (err) {
 				const duration = this._clearTurnStopWatch(session);
@@ -3665,6 +3774,12 @@ export class CodexAgent extends Disposable implements IAgent {
 				this._logService.info(`[Codex] failed to remove managed temp folder ${dir}: ${err instanceof Error ? err.message : String(err)}`);
 			});
 		}
+		if (session.customizationDirectory) {
+			const dir = session.customizationDirectory.fsPath;
+			fs.promises.rm(dir, { recursive: true, force: true }).catch(err => {
+				this._logService.info(`[Codex] failed to remove customization folder ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+			});
+		}
 		if (session.threadId !== undefined) {
 			this._sessionIdByThreadId.delete(session.threadId);
 		}
@@ -3833,7 +3948,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (!this._sessions.has(sessionId)) {
 			const workingDirectory = read.thread.cwd ? URI.file(read.thread.cwd) : undefined;
 			const threadId = read.thread.id;
-			const restored = this._createResumedSessionEntry(sessionId, threadId, session, workingDirectory, undefined, metadata.workingDirectories);
+			const overlay = await this._metadataStore.read(session);
+			const restored = this._createResumedSessionEntry(sessionId, threadId, session, workingDirectory, undefined, metadata.workingDirectories, undefined, overlay.agent);
 			this._sessions.set(sessionId, restored);
 			this._sessionIdByThreadId.set(threadId, sessionId);
 			if (!isCodexThreadProviderCompatible(this._usageSource, read.thread.modelProvider)) {
@@ -3978,6 +4094,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (sess?.clientCustomizations.removeClient(clientId)) {
 			// A departing client's skills may drop out of the process-global union.
 			void this._refreshSkillExtraRoots();
+			void this._reconcileMaterializedCustomizations(sess);
 		}
 	}
 
@@ -4020,6 +4137,23 @@ export class CodexAgent extends Disposable implements IAgent {
 		session.clientCustomizations.setClient(clientId, plugins);
 		this._publishClientCustomizations(session);
 		await this._refreshSkillExtraRoots();
+		await this._reconcileMaterializedCustomizations(session);
+	}
+
+	private async _reconcileMaterializedCustomizations(session: ICodexSession): Promise<void> {
+		if (session.threadId === undefined) {
+			return;
+		}
+		const launch = await this._buildCustomizationLaunch(session);
+		if (launch.signature === session.materializedCustomizationsSig) {
+			return;
+		}
+		if (!session.firstTurnSent) {
+			await this._restartThreadWithCurrentTools(session);
+			this._persistMaterializedSession(session);
+		} else {
+			session.needsResume = true;
+		}
 	}
 
 	/** Parse one synced plugin directory into its components (best-effort). */

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -1235,7 +1235,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		};
 	}
 
-	private _turnStartOptions(session: ICodexSession, modelId: string): Pick<TurnStartParams, 'approvalPolicy' | 'sandboxPolicy' | 'approvalsReviewer' | 'effort' | 'runtimeWorkspaceRoots' | 'personality' | 'summary' | 'collaborationMode'> {
+	private _turnStartOptions(session: ICodexSession, modelId: string, developerInstructions?: string): Pick<TurnStartParams, 'approvalPolicy' | 'sandboxPolicy' | 'approvalsReviewer' | 'effort' | 'runtimeWorkspaceRoots' | 'personality' | 'summary' | 'collaborationMode'> {
 		const config = this._readSessionConfig(session);
 		const { approvalPolicy, sandboxMode, approvalsReviewer } = this._resolveSessionPermissions(session);
 		const sandboxPolicy = this._sandboxPolicy(session, config, sandboxMode);
@@ -1253,7 +1253,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		const mode = collaborationModeKind(config[SessionConfigKey.Mode]);
 		const collaborationMode: TurnStartParams['collaborationMode'] = {
 			mode,
-			settings: { model: modelId, reasoning_effort: effort ?? null, developer_instructions: null },
+			settings: { model: modelId, reasoning_effort: effort ?? null, developer_instructions: developerInstructions ?? null },
 		};
 		return {
 			approvalPolicy,
@@ -3601,7 +3601,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		this._startTurnStopWatch(session);
 		try {
 			const model = await this._resolveModel(session);
-			const turnOptions = this._turnStartOptions(session, model.id);
+			const turnOptions = this._turnStartOptions(session, model.id, customizationLaunch.developerInstructions);
 			await conn.client.request<'turn/start'>('turn/start', {
 				threadId,
 				input: input.slice(),

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -1304,7 +1304,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		const customization = await codexCustomizationConfigFromPlugins(plugins, session.agent, this._fileService);
 		const config: Record<string, JsonValue> = {};
 		if (customization.agentRoles.length > 0) {
-			const root = join(os.tmpdir(), 'vscode-agent-codex-customizations', session.sessionId);
+			const root = session.customizationDirectory?.fsPath
+				?? await fs.promises.mkdtemp(join(os.tmpdir(), 'vscode-agent-codex-customizations-'));
 			const agentsDirectory = join(root, 'agents');
 			await fs.promises.mkdir(agentsDirectory, { recursive: true });
 			const agents: Record<string, JsonValue> = {};
@@ -1314,7 +1315,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				agents[role.name] = { description: role.description, config_file: rolePath };
 			}
 			config.agents = agents;
-			session.customizationDirectory = URI.file(root);
+			session.customizationDirectory ??= URI.file(root);
 		}
 
 		const selectedCapabilityRoots = codexSkillCapabilityRoots(plugins).map((uri, index): SelectedCapabilityRoot => ({
@@ -2886,6 +2887,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		if (existing) {
 			existing.model = effectiveModel ?? existing.model;
 			existing.agent = config.agent ?? existing.agent;
+			await this._seedEagerActiveClient(sessionUri, config.activeClient);
 			const cwd = existing.workingDirectory ?? config.workingDirectories?.[0];
 			return {
 				session: sessionUri,
@@ -2936,12 +2938,31 @@ export class CodexAgent extends Disposable implements IAgent {
 			clientCustomizations: new CodexClientCustomizationStore(),
 		};
 		this._sessions.set(sessionId, session);
+		await this._seedEagerActiveClient(sessionUri, config.activeClient);
 		this._schedulePrewarm(session);
 		return {
 			session: sessionUri,
 			resolvedWorkingDirectory: config.workingDirectories?.[0],
 			provisional: true,
 		};
+	}
+
+	/**
+	 * Seed the active client supplied with `createSession` before the agent host
+	 * asks for the initial customization snapshot. The initial state is assigned
+	 * directly rather than dispatched as `session/activeClientSet`, so without
+	 * this step Codex would not receive the client's tools or customizations until
+	 * a later turn happened to re-register the client.
+	 */
+	private async _seedEagerActiveClient(sessionUri: URI, activeClient: IAgentCreateSessionConfig['activeClient']): Promise<void> {
+		if (!activeClient) {
+			return;
+		}
+		const handle = this.getOrCreateActiveClient(sessionUri, { clientId: activeClient.clientId, displayName: activeClient.displayName });
+		handle.tools = activeClient.tools;
+		if (activeClient.customizations !== undefined) {
+			await this._syncClientCustomizations(sessionUri, activeClient.clientId, activeClient.customizations, { quiet: true });
+		}
 	}
 
 	/**
@@ -4117,7 +4138,7 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * and refresh the process-global skill roots. MCP servers are attached
 	 * per-thread at the next {@link _materialize}.
 	 */
-	private async _syncClientCustomizations(sessionUri: URI, clientId: string, customizations: readonly ClientPluginCustomization[]): Promise<void> {
+	private async _syncClientCustomizations(sessionUri: URI, clientId: string, customizations: readonly ClientPluginCustomization[], options?: { readonly quiet?: boolean }): Promise<void> {
 		const session = this._sessions.get(AgentSession.id(sessionUri));
 		if (!session) {
 			return;
@@ -4125,7 +4146,11 @@ export class CodexAgent extends Disposable implements IAgent {
 		const synced = await this._pluginManager.syncCustomizations(
 			clientId,
 			[...customizations],
-			status => this._fire(sessionUri, { type: ActionType.SessionCustomizationUpdated, customization: status }),
+			status => {
+				if (!options?.quiet) {
+					this._fire(sessionUri, { type: ActionType.SessionCustomizationUpdated, customization: status });
+				}
+			},
 		);
 		if (session.disposed) {
 			return;
@@ -4135,7 +4160,9 @@ export class CodexAgent extends Disposable implements IAgent {
 			return;
 		}
 		session.clientCustomizations.setClient(clientId, plugins);
-		this._publishClientCustomizations(session);
+		if (!options?.quiet) {
+			this._publishClientCustomizations(session);
+		}
 		await this._refreshSkillExtraRoots();
 		await this._reconcileMaterializedCustomizations(session);
 	}

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -4,8 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { dirname } from '../../../../base/common/path.js';
+import { extUri, joinPath, relativePath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { parseFrontMatter } from '../../../../base/common/yaml.js';
+import { IFileService } from '../../../files/common/files.js';
 import type { IMcpServerDefinition, IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
+import type { AgentSelection } from '../../common/state/protocol/state.js';
 import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
 import { toCodexMcpServerJson, type ICodexMcpServerConfigJson } from './codexMcpServers.js';
 
@@ -32,6 +37,18 @@ import { toCodexMcpServerJson, type ICodexMcpServerConfigJson } from './codexMcp
 export interface ICodexClientPlugin {
 	readonly synced: ISyncedCustomization;
 	readonly parsed: IParsedPlugin | undefined;
+}
+
+export interface ICodexAgentRoleSource {
+	readonly name: string;
+	readonly description: string;
+	readonly instructions: string;
+	readonly model?: string;
+}
+
+export interface ICodexCustomizationConfig {
+	readonly agentRoles: readonly ICodexAgentRoleSource[];
+	readonly developerInstructions?: string;
 }
 
 /**
@@ -176,4 +193,87 @@ export function codexSkillRootsFromPlugins(plugins: readonly ICodexClientPlugin[
 		}
 	}
 	return [...roots].sort();
+}
+
+export async function codexCustomizationConfigFromPlugins(
+	plugins: readonly ICodexClientPlugin[],
+	selectedAgent: AgentSelection | undefined,
+	fileService: IFileService,
+): Promise<ICodexCustomizationConfig> {
+	const agentRoles = new Map<string, ICodexAgentRoleSource>();
+	const pluginInstructions: string[] = [];
+	let selectedAgentInstructions: string | undefined;
+	const selectedAgentUri = selectedAgent?.uri;
+
+	for (const plugin of plugins) {
+		for (const agent of plugin.parsed?.agents ?? []) {
+			try {
+				const content = (await fileService.readFile(agent.uri)).value.toString();
+				const frontmatter = parseFrontMatter(content);
+				const name = frontmatter?.getStringValue('name')?.trim() || agent.name;
+				const description = frontmatter?.getStringValue('description')?.trim() || agent.description || name;
+				const instructions = frontmatter?.body ?? content;
+				const model = frontmatter?.getStringValue('model')?.trim() || undefined;
+				if (!agentRoles.has(name)) {
+					agentRoles.set(name, { name, description, instructions, ...(model ? { model } : {}) });
+				}
+				if (selectedAgentUri && isSelectedAgent(plugin, agent.uri, selectedAgentUri)) {
+					selectedAgentInstructions = instructions;
+				}
+			} catch { }
+		}
+
+		for (const instruction of plugin.parsed?.instructions ?? []) {
+			try {
+				const content = (await fileService.readFile(instruction.uri)).value.toString();
+				const frontmatter = parseFrontMatter(content);
+				const body = frontmatter?.body ?? content;
+				if (body.trim()) {
+					pluginInstructions.push(body.trim());
+				}
+			} catch { }
+		}
+	}
+
+	const developerInstructions = [
+		...pluginInstructions,
+		...(selectedAgentInstructions ? [selectedAgentInstructions.trim()] : []),
+	].filter(Boolean).join('\n\n');
+
+	return {
+		agentRoles: [...agentRoles.values()],
+		...(developerInstructions ? { developerInstructions } : {}),
+	};
+}
+
+function isSelectedAgent(plugin: ICodexClientPlugin, agentUri: URI, selectedAgentUri: string): boolean {
+	const selectedUri = URI.parse(selectedAgentUri);
+	if (extUri.isEqual(agentUri, selectedUri)) {
+		return true;
+	}
+	const pluginDir = plugin.synced.pluginDir;
+	if (!pluginDir) {
+		return false;
+	}
+	const relativeAgentPath = relativePath(pluginDir, agentUri);
+	if (relativeAgentPath === undefined) {
+		return false;
+	}
+	const sourcePluginUri = URI.parse(plugin.synced.customization.uri);
+	const sourceAgentUri = relativeAgentPath ? joinPath(sourcePluginUri, relativeAgentPath) : sourcePluginUri;
+	return extUri.isEqual(sourceAgentUri, selectedUri);
+}
+
+export function codexAgentRoleToml(role: ICodexAgentRoleSource): string {
+	return [
+		`name = ${JSON.stringify(role.name)}`,
+		`description = ${JSON.stringify(role.description)}`,
+		`developer_instructions = ${JSON.stringify(role.instructions)}`,
+		...(role.model ? [`model = ${JSON.stringify(role.model)}`] : []),
+		'',
+	].join('\n');
+}
+
+export function codexSkillCapabilityRoots(plugins: readonly ICodexClientPlugin[]): URI[] {
+	return codexSkillRootsFromPlugins(plugins).map(path => URI.file(path));
 }

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { dirname } from '../../../../base/common/path.js';
-import { extUri, joinPath, relativePath } from '../../../../base/common/resources.js';
+import { basename, extUri, joinPath, relativePath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { parseFrontMatter } from '../../../../base/common/yaml.js';
+import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
 import { IFileService } from '../../../files/common/files.js';
 import { parseRuleFile, type IMcpServerDefinition, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
@@ -203,6 +204,7 @@ export async function codexCustomizationConfigFromPlugins(
 	const agentRoles = new Map<string, ICodexAgentRoleSource>();
 	const pluginInstructions: string[] = [];
 	let selectedAgentInstructions: string | undefined;
+	let selectedAgentMatch = SelectedAgentMatch.None;
 	const selectedAgentUri = selectedAgent?.uri;
 
 	for (const plugin of plugins) {
@@ -217,8 +219,10 @@ export async function codexCustomizationConfigFromPlugins(
 				if (!agentRoles.has(name)) {
 					agentRoles.set(name, { name, description, instructions, ...(model ? { model } : {}) });
 				}
-				if (selectedAgentUri && isSelectedAgent(plugin, agent.uri, selectedAgentUri)) {
+				const match = selectedAgentUri ? matchSelectedAgent(plugin, agent.uri, selectedAgentUri) : SelectedAgentMatch.None;
+				if (match > selectedAgentMatch) {
 					selectedAgentInstructions = instructions;
+					selectedAgentMatch = match;
 				}
 			} catch { }
 		}
@@ -257,22 +261,44 @@ function isAlwaysOnRule(globs: readonly string[] | undefined, alwaysApply: boole
 	return globs.some(glob => glob.trim() === '**' || glob.trim() === '**/*');
 }
 
-function isSelectedAgent(plugin: ICodexClientPlugin, agentUri: URI, selectedAgentUri: string): boolean {
+const enum SelectedAgentMatch {
+	None,
+	SyntheticBundleSource,
+	Exact,
+}
+
+function matchSelectedAgent(plugin: ICodexClientPlugin, agentUri: URI, selectedAgentUri: string): SelectedAgentMatch {
 	const selectedUri = URI.parse(selectedAgentUri);
 	if (extUri.isEqual(agentUri, selectedUri)) {
-		return true;
+		return SelectedAgentMatch.Exact;
 	}
 	const pluginDir = plugin.synced.pluginDir;
 	if (!pluginDir) {
-		return false;
+		return SelectedAgentMatch.None;
 	}
 	const relativeAgentPath = relativePath(pluginDir, agentUri);
 	if (relativeAgentPath === undefined) {
-		return false;
+		return SelectedAgentMatch.None;
 	}
 	const sourcePluginUri = URI.parse(plugin.synced.customization.uri);
 	const sourceAgentUri = relativeAgentPath ? joinPath(sourcePluginUri, relativeAgentPath) : sourcePluginUri;
-	return extUri.isEqual(sourceAgentUri, selectedUri);
+	if (extUri.isEqual(sourceAgentUri, selectedUri)) {
+		return SelectedAgentMatch.Exact;
+	}
+
+	// The workbench's synthetic bundle flattens loose custom agents into its
+	// `agents/` directory, while the Agents window intentionally exposes each
+	// agent's original workspace/user URI. The host cannot reconstruct that
+	// original parent path, but the filename remains stable and is unique in
+	// the flattened bundle. Keep this as a lower-priority fallback so an exact
+	// match from another plugin always wins.
+	if (sourcePluginUri.scheme === SYNCED_CUSTOMIZATION_SCHEME
+		&& relativeAgentPath.startsWith('agents/')
+		&& basename(agentUri) === basename(selectedUri)) {
+		return SelectedAgentMatch.SyntheticBundleSource;
+	}
+
+	return SelectedAgentMatch.None;
 }
 
 export function codexAgentRoleToml(role: ICodexAgentRoleSource): string {

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -8,7 +8,7 @@ import { extUri, joinPath, relativePath } from '../../../../base/common/resource
 import { URI } from '../../../../base/common/uri.js';
 import { parseFrontMatter } from '../../../../base/common/yaml.js';
 import { IFileService } from '../../../files/common/files.js';
-import type { IMcpServerDefinition, IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
+import { parseRuleFile, type IMcpServerDefinition, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import type { AgentSelection } from '../../common/state/protocol/state.js';
 import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
@@ -225,6 +225,10 @@ export async function codexCustomizationConfigFromPlugins(
 
 		for (const instruction of plugin.parsed?.instructions ?? []) {
 			try {
+				const rule = await parseRuleFile(instruction.uri, fileService);
+				if (!isAlwaysOnRule(rule.globs, rule.alwaysApply)) {
+					continue;
+				}
 				const content = (await fileService.readFile(instruction.uri)).value.toString();
 				const frontmatter = parseFrontMatter(content);
 				const body = frontmatter?.body ?? content;
@@ -244,6 +248,13 @@ export async function codexCustomizationConfigFromPlugins(
 		agentRoles: [...agentRoles.values()],
 		...(developerInstructions ? { developerInstructions } : {}),
 	};
+}
+
+function isAlwaysOnRule(globs: readonly string[] | undefined, alwaysApply: boolean | undefined): boolean {
+	if (!globs?.length) {
+		return alwaysApply !== false;
+	}
+	return globs.some(glob => glob.trim() === '**' || glob.trim() === '**/*');
 }
 
 function isSelectedAgent(plugin: ICodexClientPlugin, agentUri: URI, selectedAgentUri: string): boolean {

--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -24,7 +24,18 @@ export function isCodexThreadProviderCompatible(usageSource: CodexUsageSource, m
 }
 
 /** Explicitly bind a compatible resumed thread to the current global usage source. */
-export function buildCodexResumeParams(usageSource: CodexUsageSource, threadId: string, mcpServers: Readonly<Record<string, unknown>>, workingDirectories?: readonly string[]): ThreadResumeParams {
+export function buildCodexResumeParams(
+	usageSource: CodexUsageSource,
+	threadId: string,
+	mcpServers: Readonly<Record<string, unknown>>,
+	workingDirectories?: readonly string[],
+	configOverrides: Readonly<Record<string, JsonValue>> = {},
+	developerInstructions?: string,
+): ThreadResumeParams {
+	const config = {
+		...configOverrides,
+		...(Object.keys(mcpServers).length > 0 ? { mcp_servers: mcpServers as JsonValue } : {}),
+	};
 	return {
 		threadId,
 		modelProvider: usageSource === 'copilot' ? 'vscode-proxy' : 'openai',
@@ -32,7 +43,8 @@ export function buildCodexResumeParams(usageSource: CodexUsageSource, threadId: 
 			cwd: workingDirectories[0],
 			runtimeWorkspaceRoots: [...workingDirectories],
 		} : {}),
-		...(Object.keys(mcpServers).length > 0 ? { config: { mcp_servers: mcpServers as JsonValue } } : {}),
+		...(Object.keys(config).length > 0 ? { config } : {}),
+		...(developerInstructions ? { developerInstructions } : {}),
 	};
 }
 

--- a/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
+++ b/src/vs/platform/agentHost/node/codex/codexSessionMetadataStore.ts
@@ -6,6 +6,7 @@
 import { URI } from '../../../../base/common/uri.js';
 import { ILogService } from '../../../log/common/log.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
+import type { AgentSelection } from '../../common/state/protocol/state.js';
 
 /**
  * Per-session bookkeeping codex needs to persist across agent host
@@ -32,6 +33,7 @@ export interface ICodexSessionOverlay {
 	readonly threadId?: string;
 	readonly cwd?: URI;
 	readonly modelId?: string;
+	readonly agent?: AgentSelection;
 	readonly workingDirectories?: readonly URI[];
 }
 
@@ -39,6 +41,7 @@ export interface ICodexSessionOverlayUpdate {
 	readonly threadId?: string;
 	readonly cwd?: URI;
 	readonly modelId?: string;
+	readonly agent?: AgentSelection | null;
 	readonly workingDirectories?: readonly URI[];
 }
 
@@ -47,6 +50,7 @@ export class CodexSessionMetadataStore {
 	private static readonly KEY_THREAD_ID = 'codex.threadId';
 	private static readonly KEY_CWD = 'codex.cwd';
 	private static readonly KEY_MODEL = 'codex.model';
+	private static readonly KEY_AGENT = 'codex.agent';
 	constructor(
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@ILogService private readonly _logService: ILogService,
@@ -76,6 +80,12 @@ export class CodexSessionMetadataStore {
 				if (fields.modelId !== undefined) {
 					work.push(db.setMetadata(CodexSessionMetadataStore.KEY_MODEL, fields.modelId));
 				}
+				if (fields.agent !== undefined) {
+					work.push(db.setMetadata(
+						CodexSessionMetadataStore.KEY_AGENT,
+						fields.agent === null ? '' : JSON.stringify({ uri: fields.agent.uri }),
+					));
+				}
 				await Promise.all(work);
 			} finally {
 				ref.dispose();
@@ -97,16 +107,18 @@ export class CodexSessionMetadataStore {
 				return {};
 			}
 			try {
-				const [threadId, cwdRaw, modelId] = await Promise.all([
+				const [threadId, cwdRaw, modelId, agentRaw] = await Promise.all([
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_THREAD_ID),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_CWD),
 					ref.object.getMetadata(CodexSessionMetadataStore.KEY_MODEL),
+					ref.object.getMetadata(CodexSessionMetadataStore.KEY_AGENT),
 				]);
 				const cwd = parseCwd(cwdRaw);
 				return {
 					threadId: threadId ?? undefined,
 					cwd: cwd.cwd,
 					modelId: modelId ?? undefined,
+					agent: parseAgentSelection(agentRaw),
 					workingDirectories: cwd.workingDirectories,
 				};
 			} finally {
@@ -118,6 +130,18 @@ export class CodexSessionMetadataStore {
 		}
 	}
 
+}
+
+function parseAgentSelection(raw: string | undefined): AgentSelection | undefined {
+	if (!raw) {
+		return undefined;
+	}
+	try {
+		const value: { uri?: unknown } = JSON.parse(raw);
+		return typeof value.uri === 'string' ? { uri: value.uri } : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function serializeCwd(cwd: URI, workingDirectories: readonly URI[] | undefined): string {

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -86,6 +86,7 @@ suite('Agent host _meta readers', () => {
 			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization(undefined)), {});
 			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization({ userInvocable: 'yes' })), {});
 			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization({ userInvocable: false })), { userInvocable: false });
+			assert.deepStrictEqual(readAgentCustomizationMeta({ ...agentCustomization({ userInvocable: true }), disableUserInvocation: true }), { userInvocable: false });
 			assert.strictEqual(toAgentCustomizationMeta({}), undefined);
 			assert.deepStrictEqual(toAgentCustomizationMeta({ userInvocable: true }), { userInvocable: true });
 		});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1201,6 +1201,32 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(AgentSession.provider(session), 'copilot');
 		});
 
+		test('accepts customization updates while creating a provisional session', async () => {
+			const customization = { type: CustomizationType.Plugin, id: customizationId('file:///plugin'), uri: 'file:///plugin', name: 'Plugin', enabled: true } as const;
+			class ProvisionalCustomizationAgent extends MockAgent {
+				override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+					return { ...await super.createSession(config), provisional: true };
+				}
+
+				override getSessionCustomizations = async (session: URI) => {
+					this.fireProgress({
+						kind: 'action',
+						resource: session,
+						action: { type: ActionType.SessionCustomizationUpdated, customization },
+					});
+					return [];
+				};
+			}
+
+			const agent = new ProvisionalCustomizationAgent('codex');
+			disposables.add(toDisposable(() => agent.dispose()));
+			service.registerProvider(agent);
+
+			const session = await service.createSession({ provider: agent.id });
+
+			assert.deepStrictEqual(service.stateManager.getSessionState(session.toString())?.customizations, [customization]);
+		});
+
 		test('truncates working directories for a provider without multipleWorkingDirectories', async () => {
 			class CapturingAgent extends MockAgent {
 				lastConfig: IAgentCreateSessionConfig | undefined;

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2536,6 +2536,21 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('replays stored authentication to a provider registered later', async () => {
+			service.registerProvider(copilotAgent);
+			await service.authenticate({ resource: 'https://api.github.com', token: 'tok' });
+			const lateAgent = new MockAgent('codex');
+			lateAgent.getProtectedResources = () => [{ resource: 'https://api.github.com', authorization_servers: ['https://github.com/login/oauth'], required: true }];
+			disposables.add(toDisposable(() => lateAgent.dispose()));
+
+			service.registerProvider(lateAgent);
+			for (let attempt = 0; attempt < 20 && lateAgent.authenticateCalls.length === 0; attempt++) {
+				await new Promise(resolve => setTimeout(resolve, 5));
+			}
+
+			assert.deepStrictEqual(lateAgent.authenticateCalls, [{ resource: 'https://api.github.com', token: 'tok' }]);
+		});
+
 		test('isolates a provider that throws — others still authenticate', async () => {
 			// Regression: if any provider's authenticate() rejects, the
 			// fan-out must NOT sink the others. Previously the call used

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -158,6 +158,23 @@ suite('codexClientCustomizations', () => {
 		].join('\n'));
 	});
 
+	test('does not promote path-scoped plugin instructions to thread-global instructions', async () => {
+		const globalInstructionUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/rules/global.instructions.md' });
+		const scopedInstructionUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/rules/typescript.instructions.md' });
+		await fileService.writeFile(globalInstructionUri, VSBuffer.fromString(`---\napplyTo: "**/*"\n---\nApply globally.`));
+		await fileService.writeFile(scopedInstructionUri, VSBuffer.fromString(`---\napplyTo: "**/*.ts"\n---\nApply only to TypeScript.`));
+		const plugins = [plugin('p', undefined, parsed({
+			instructions: [
+				instructionDef(globalInstructionUri, 'global'),
+				instructionDef(scopedInstructionUri, 'typescript'),
+			],
+		}))];
+
+		const config = await codexCustomizationConfigFromPlugins(plugins, undefined, fileService);
+
+		assert.strictEqual(config.developerInstructions, 'Apply globally.');
+	});
+
 	test('matches a selected source agent to its host-synced plugin copy', async () => {
 		const sourcePluginUri = URI.from({ scheme: Schemas.inMemory, path: '/source/plugin' });
 		const syncedPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/synced/plugin' });

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -4,15 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { PluginFormat, type IMcpServerDefinition, type IParsedPlugin, type IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
+import { FileService } from '../../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../log/common/log.js';
+import { PluginFormat, type IMcpServerDefinition, type IParsedAgent, type IParsedPlugin, type IParsedRule, type IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
 import { McpServerType, type IMcpServerConfiguration } from '../../../../mcp/common/mcpPlatformTypes.js';
 import type { ISyncedCustomization } from '../../../common/agentPluginManager.js';
 import { CustomizationType, McpServerStatus, type PluginCustomization } from '../../../common/state/protocol/channels-session/state.js';
-import { CodexClientCustomizationStore, codexMcpServersFromPlugins, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
+import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfigFromPlugins, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
 
 suite('codexClientCustomizations', () => {
+	const disposables = new DisposableStore();
+	let fileService: FileService;
+
+	setup(() => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+	});
+
+	teardown(() => disposables.clear());
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -28,6 +43,14 @@ suite('codexClientCustomizations', () => {
 	function skillDef(pluginDir: string, name: string): IParsedSkill {
 		const uri = URI.file(`${pluginDir}/skills/${name}/SKILL.md`);
 		return { uri, name, description: `${name} desc`, customization: { type: CustomizationType.Skill, id: `skill:${name}`, uri: uri.toString(), name } };
+	}
+
+	function agentDef(uri: URI, name: string): IParsedAgent {
+		return { uri, name, customization: { type: CustomizationType.Agent, id: `agent:${name}`, uri: uri.toString(), name } };
+	}
+
+	function instructionDef(uri: URI, name: string): IParsedRule {
+		return { uri, name, customization: { type: CustomizationType.Rule, id: `rule:${name}`, uri: uri.toString(), name } };
 	}
 
 	function parsed(overrides: Partial<IParsedPlugin> = {}): IParsedPlugin {
@@ -102,6 +125,63 @@ suite('codexClientCustomizations', () => {
 		// hardcoded posix path.
 		const skillsRoot = (pluginDir: string) => URI.file(`${pluginDir}/skills`).fsPath;
 		assert.deepStrictEqual(codexSkillRootsFromPlugins(plugins), [skillsRoot('/plugins/p'), skillsRoot('/plugins/q')]);
+		assert.deepStrictEqual(codexSkillCapabilityRoots(plugins).map(root => root.fsPath), [skillsRoot('/plugins/p'), skillsRoot('/plugins/q')]);
+	});
+
+	test('converts agent markdown and plugin instructions into codex launch configuration', async () => {
+		const agentUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/agents/reviewer.agent.md' });
+		const instructionUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/rules/repo.instructions.md' });
+		await fileService.writeFile(agentUri, VSBuffer.fromString(`---\nname: Reviewer\ndescription: Reviews carefully\nmodel: gpt-test\n---\nReview the change and report risks.`));
+		await fileService.writeFile(instructionUri, VSBuffer.fromString(`---\ndescription: Repository rules\n---\nAlways run focused tests.`));
+		const plugins = [plugin('p', undefined, parsed({
+			agents: [agentDef(agentUri, 'reviewer')],
+			instructions: [instructionDef(instructionUri, 'repo')],
+		}))];
+
+		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: agentUri.toString() }, fileService);
+
+		assert.deepStrictEqual(config, {
+			agentRoles: [{
+				name: 'Reviewer',
+				description: 'Reviews carefully',
+				instructions: 'Review the change and report risks.',
+				model: 'gpt-test',
+			}],
+			developerInstructions: 'Always run focused tests.\n\nReview the change and report risks.',
+		});
+		assert.strictEqual(codexAgentRoleToml(config.agentRoles[0]), [
+			'name = "Reviewer"',
+			'description = "Reviews carefully"',
+			'developer_instructions = "Review the change and report risks."',
+			'model = "gpt-test"',
+			'',
+		].join('\n'));
+	});
+
+	test('matches a selected source agent to its host-synced plugin copy', async () => {
+		const sourcePluginUri = URI.from({ scheme: Schemas.inMemory, path: '/source/plugin' });
+		const syncedPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/synced/plugin' });
+		const sourceAgentUri = URI.joinPath(sourcePluginUri, 'agents', 'reviewer.agent.md');
+		const syncedAgentUri = URI.joinPath(syncedPluginUri, 'agents', 'reviewer.agent.md');
+		await fileService.writeFile(syncedAgentUri, VSBuffer.fromString(`---\nname: Reviewer\ndescription: Reviews carefully\n---\nApply synced reviewer instructions.`));
+		const synced: ISyncedCustomization = {
+			customization: {
+				type: CustomizationType.Plugin,
+				id: 'synced-plugin',
+				uri: sourcePluginUri.toString(),
+				name: 'Synced Plugin',
+				enabled: true,
+			},
+			pluginDir: syncedPluginUri,
+		};
+		const plugins: ICodexClientPlugin[] = [{
+			synced,
+			parsed: parsed({ agents: [agentDef(syncedAgentUri, 'reviewer')] }),
+		}];
+
+		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: sourceAgentUri.toString() }, fileService);
+
+		assert.strictEqual(config.developerInstructions, 'Apply synced reviewer instructions.');
 	});
 
 	test('removeClient drops a client and setEnabled reports whether it changed', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -14,6 +14,7 @@ import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFil
 import { NullLogService } from '../../../../log/common/log.js';
 import { PluginFormat, type IMcpServerDefinition, type IParsedAgent, type IParsedPlugin, type IParsedRule, type IParsedSkill } from '../../../../agentPlugins/common/pluginParsers.js';
 import { McpServerType, type IMcpServerConfiguration } from '../../../../mcp/common/mcpPlatformTypes.js';
+import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../common/agentHostFileSystemService.js';
 import type { ISyncedCustomization } from '../../../common/agentPluginManager.js';
 import { CustomizationType, McpServerStatus, type PluginCustomization } from '../../../common/state/protocol/channels-session/state.js';
 import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfigFromPlugins, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
@@ -199,6 +200,62 @@ suite('codexClientCustomizations', () => {
 		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: sourceAgentUri.toString() }, fileService);
 
 		assert.strictEqual(config.developerInstructions, 'Apply synced reviewer instructions.');
+	});
+
+	test('matches an original loose-agent URI to its synthetic bundle copy', async () => {
+		const sourceAgentUri = URI.file('/workspace/.github/agents/reviewer.agent.md');
+		const syncedPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/synced/plugin' });
+		const syncedAgentUri = URI.joinPath(syncedPluginUri, 'agents', 'reviewer.agent.md');
+		await fileService.writeFile(syncedAgentUri, VSBuffer.fromString(`---\nname: Reviewer\ndescription: Reviews carefully\n---\nApply loose reviewer instructions.`));
+		const synced: ISyncedCustomization = {
+			customization: {
+				type: CustomizationType.Plugin,
+				id: 'synthetic-plugin',
+				uri: `${SYNCED_CUSTOMIZATION_SCHEME}:/agent-host-codex`,
+				name: 'VS Code Synced Data',
+				enabled: true,
+			},
+			pluginDir: syncedPluginUri,
+		};
+		const plugins: ICodexClientPlugin[] = [{
+			synced,
+			parsed: parsed({ agents: [agentDef(syncedAgentUri, 'reviewer')] }),
+		}];
+
+		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: sourceAgentUri.toString() }, fileService);
+
+		assert.strictEqual(config.developerInstructions, 'Apply loose reviewer instructions.');
+	});
+
+	test('prefers an exact selected agent over a synthetic filename fallback', async () => {
+		const selectedPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/source/plugin' });
+		const selectedSyncedPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/synced/selected-plugin' });
+		const selectedAgentUri = URI.joinPath(selectedPluginUri, 'agents', 'reviewer.agent.md');
+		const selectedSyncedAgentUri = URI.joinPath(selectedSyncedPluginUri, 'agents', 'reviewer.agent.md');
+		const syntheticPluginUri = URI.from({ scheme: Schemas.inMemory, path: '/synced/synthetic-plugin' });
+		const syntheticAgentUri = URI.joinPath(syntheticPluginUri, 'agents', 'reviewer.agent.md');
+		await fileService.writeFile(selectedSyncedAgentUri, VSBuffer.fromString('Apply exact reviewer instructions.'));
+		await fileService.writeFile(syntheticAgentUri, VSBuffer.fromString('Do not apply synthetic reviewer instructions.'));
+		const plugins: ICodexClientPlugin[] = [
+			{
+				synced: {
+					customization: { type: CustomizationType.Plugin, id: 'selected-plugin', uri: selectedPluginUri.toString(), name: 'Selected Plugin', enabled: true },
+					pluginDir: selectedSyncedPluginUri,
+				},
+				parsed: parsed({ agents: [agentDef(selectedSyncedAgentUri, 'selected-reviewer')] }),
+			},
+			{
+				synced: {
+					customization: { type: CustomizationType.Plugin, id: 'synthetic-plugin', uri: `${SYNCED_CUSTOMIZATION_SCHEME}:/agent-host-codex`, name: 'VS Code Synced Data', enabled: true },
+					pluginDir: syntheticPluginUri,
+				},
+				parsed: parsed({ agents: [agentDef(syntheticAgentUri, 'synthetic-reviewer')] }),
+			},
+		];
+
+		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: selectedAgentUri.toString() }, fileService);
+
+		assert.strictEqual(config.developerInstructions, 'Apply exact reviewer instructions.');
 	});
 
 	test('removeClient drops a client and setEnabled reports whether it changed', () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -81,6 +81,14 @@ suite('CodexLaunchConfig', () => {
 			modelProvider: 'vscode-proxy',
 			config: { mcp_servers: { GitHub: { url: 'https://api.githubcopilot.com/mcp/' } } },
 		});
+		assert.deepStrictEqual(buildCodexResumeParams('openai', 'thread-c', {}, undefined, {
+			agents: { Reviewer: { description: 'Reviews', config_file: '/tmp/reviewer.toml' } },
+		}, 'Use the selected reviewer instructions.'), {
+			threadId: 'thread-c',
+			modelProvider: 'openai',
+			config: { agents: { Reviewer: { description: 'Reviews', config_file: '/tmp/reviewer.toml' } } },
+			developerInstructions: 'Use the selected reviewer instructions.',
+		});
 		assert.deepStrictEqual(buildCodexResumeParams('openai', 'thread-c', {}, ['/repo-a', '/repo-b']), {
 			threadId: 'thread-c',
 			modelProvider: 'openai',

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -66,6 +66,32 @@ suite('CodexAgent model refresh', () => {
 		assert.deepStrictEqual(agent.models.get().map(model => model.id), ['gpt-5.5']);
 	});
 
+	test('reuses a connection created while OpenAI usage-source validation is pending', async () => {
+		const agent = createAgent(disposables, async () => []);
+		await Promise.resolve();
+
+		let resolveValidation!: () => void;
+		agent['_usageSource'] = 'openai';
+		agent['_usageSourceValidation'] = new Promise<void>(resolve => resolveValidation = resolve);
+		agent['_connection'] = { kind: 'idle' };
+
+		let startCount = 0;
+		agent['_startConnection'] = async () => {
+			startCount++;
+			return { client: { dispose() { } }, child: { kill() { return true; } }, usageSource: 'openai' } as never;
+		};
+
+		const connectionPromise = agent['_ensureConnection']();
+		await Promise.resolve();
+		const existingConnection = { kind: 'ready', client: { dispose() { } }, child: { kill() { return true; } }, usageSource: 'openai' } as const;
+		agent['_connection'] = existingConnection as never;
+		resolveValidation();
+
+		const connection = await connectionPromise;
+		assert.strictEqual(connection, existingConnection);
+		assert.strictEqual(startCount, 0);
+	});
+
 	test('advertises multiple working directories only while enabled', () => {
 		const agent = createAgent(disposables, async () => []);
 		const disabledByDefault = agent.getDescriptor().capabilities?.multipleWorkingDirectories;

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -7,12 +7,13 @@ import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import { PassThrough } from 'stream';
 import * as fs from 'fs';
+import * as os from 'os';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { sep } from '../../../../../base/common/path.js';
+import { join, sep } from '../../../../../base/common/path.js';
 import { isWindows } from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { INativeEnvironmentService } from '../../../../../platform/environment/common/environment.js';
@@ -317,7 +318,8 @@ suite('CodexAgent prewarm eviction', () => {
 				customization: { type: CustomizationType.McpServer, id: 'mcp', uri: 'file:///plugin/.mcp.json', name: 'local', enabled: true, state: { kind: McpServerStatus.Starting } },
 			}],
 		};
-		const { session } = await agent.createSession({ workingDirectories: [repo], model: { id: 'gpt-test' }, agent: { uri: agentUri.toString() } });
+		const unsafeSession = URI.from({ scheme: 'codex', path: '/../../codex-customization-victim' });
+		const { session } = await agent.createSession({ session: unsafeSession, workingDirectories: [repo], model: { id: 'gpt-test' }, agent: { uri: agentUri.toString() } });
 		const entry = agent['_sessions'].get(AgentSession.id(session))!;
 		entry.clientCustomizations.setClient('test', [{
 			synced: { customization: { type: CustomizationType.Plugin, id: 'plugin', uri: pluginDir.toString(), name: 'plugin', enabled: true }, pluginDir },
@@ -339,12 +341,14 @@ suite('CodexAgent prewarm eviction', () => {
 			developerInstructions: start.params.developerInstructions,
 			capabilityPaths: start.params.selectedCapabilityRoots?.map(root => root.location.path),
 			roleFile,
+			roleFileUsesHostGeneratedRoot: agents.Reviewer.config_file.startsWith(join(os.tmpdir(), 'vscode-agent-codex-customizations-')),
 		}, {
 			mcp: { local: { command: 'node', args: ['server.js'] } },
 			agentDescription: 'Reviews changes',
 			developerInstructions: 'Run focused tests.\n\nReview carefully.',
 			capabilityPaths: [URI.file('/plugin/skills').fsPath],
 			roleFile: 'name = "Reviewer"\ndescription = "Reviews changes"\ndeveloper_instructions = "Review carefully."\n',
+			roleFileUsesHostGeneratedRoot: true,
 		});
 		peer.exit();
 	});

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -56,6 +56,7 @@ interface ITestWireRequest {
 		readonly sandboxPolicy?: SandboxPolicy;
 		readonly config?: Record<string, unknown>;
 		readonly developerInstructions?: string;
+		readonly collaborationMode?: { readonly settings: { readonly developer_instructions: string | null } };
 	};
 }
 
@@ -339,6 +340,7 @@ suite('CodexAgent prewarm eviction', () => {
 			mcp: start.params.config?.['mcp_servers'],
 			agentDescription: agents.Reviewer.description,
 			developerInstructions: start.params.developerInstructions,
+			turnDeveloperInstructions: turn.params.collaborationMode?.settings.developer_instructions,
 			capabilityPaths: start.params.selectedCapabilityRoots?.map(root => root.location.path),
 			roleFile,
 			roleFileUsesHostGeneratedRoot: agents.Reviewer.config_file.startsWith(join(os.tmpdir(), 'vscode-agent-codex-customizations-')),
@@ -346,6 +348,7 @@ suite('CodexAgent prewarm eviction', () => {
 			mcp: { local: { command: 'node', args: ['server.js'] } },
 			agentDescription: 'Reviews changes',
 			developerInstructions: 'Run focused tests.\n\nReview carefully.',
+			turnDeveloperInstructions: 'Run focused tests.\n\nReview carefully.',
 			capabilityPaths: [URI.file('/plugin/skills').fsPath],
 			roleFile: 'name = "Reviewer"\ndescription = "Reviews changes"\ndeveloper_instructions = "Review carefully."\n',
 			roleFileUsesHostGeneratedRoot: true,

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -6,6 +6,8 @@
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import { PassThrough } from 'stream';
+import * as fs from 'fs';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -20,8 +22,11 @@ import { InMemoryFileSystemProvider } from '../../../../../platform/files/common
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { PluginFormat, type IParsedPlugin } from '../../../../agentPlugins/common/pluginParsers.js';
+import { McpServerType } from '../../../../mcp/common/mcpPlatformTypes.js';
 import { AgentSession } from '../../../common/agentService.js';
 import { buildDefaultChatUri } from '../../../common/state/sessionState.js';
+import { CustomizationType, McpServerStatus } from '../../../common/state/protocol/channels-session/state.js';
 import { ISessionDataService } from '../../../common/sessionDataService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
@@ -48,6 +53,8 @@ interface ITestWireRequest {
 		readonly runtimeWorkspaceRoots?: readonly string[];
 		readonly selectedCapabilityRoots?: readonly SelectedCapabilityRoot[];
 		readonly sandboxPolicy?: SandboxPolicy;
+		readonly config?: Record<string, unknown>;
+		readonly developerInstructions?: string;
 	};
 }
 
@@ -274,6 +281,72 @@ suite('CodexAgent prewarm eviction', () => {
 
 	test('waits for and evicts an in-flight folder prewarm when the first send resolves to a worktree', async () => {
 		await assertPrewarmEvictedOnSend(disposables, false);
+	});
+
+	test('thread start receives custom agents, instructions, skills, and MCP from client plugins', async () => {
+		const agent = await createAgent(disposables);
+		agent['_schedulePrewarm'] = () => { };
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const peer = disposables.add(createTestPeer());
+		agent['_connection'] = {
+			kind: 'ready',
+			client: new CodexAppServerClient(peer.transport),
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+
+		const repo = URI.file('/repo');
+		const pluginDir = URI.file('/plugin');
+		const agentUri = URI.file('/plugin/agents/reviewer.agent.md');
+		const instructionUri = URI.file('/plugin/rules/repo.instructions.md');
+		const skillUri = URI.file('/plugin/skills/greet/SKILL.md');
+		await agent['_fileService'].writeFile(agentUri, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews changes\n---\nReview carefully.'));
+		await agent['_fileService'].writeFile(instructionUri, VSBuffer.fromString('---\ndescription: Repo rules\n---\nRun focused tests.'));
+		await agent['_fileService'].writeFile(skillUri, VSBuffer.fromString('---\nname: greet\ndescription: Greets\n---\nSay hello.'));
+		const parsed: IParsedPlugin = {
+			format: PluginFormat.OpenPlugin,
+			hooks: [],
+			agents: [{ uri: agentUri, name: 'Reviewer', description: 'Reviews changes', customization: { type: CustomizationType.Agent, id: 'agent', uri: agentUri.toString(), name: 'Reviewer' } }],
+			instructions: [{ uri: instructionUri, name: 'repo', customization: { type: CustomizationType.Rule, id: 'rule', uri: instructionUri.toString(), name: 'repo' } }],
+			skills: [{ uri: skillUri, name: 'greet', description: 'Greets', customization: { type: CustomizationType.Skill, id: 'skill', uri: skillUri.toString(), name: 'greet' } }],
+			mcpServers: [{
+				name: 'local',
+				uri: URI.file('/plugin/.mcp.json'),
+				configuration: { type: McpServerType.LOCAL, command: 'node', args: ['server.js'] },
+				customization: { type: CustomizationType.McpServer, id: 'mcp', uri: 'file:///plugin/.mcp.json', name: 'local', enabled: true, state: { kind: McpServerStatus.Starting } },
+			}],
+		};
+		const { session } = await agent.createSession({ workingDirectories: [repo], model: { id: 'gpt-test' }, agent: { uri: agentUri.toString() } });
+		const entry = agent['_sessions'].get(AgentSession.id(session))!;
+		entry.clientCustomizations.setClient('test', [{
+			synced: { customization: { type: CustomizationType.Plugin, id: 'plugin', uri: pluginDir.toString(), name: 'plugin', enabled: true }, pluginDir },
+			parsed,
+		}]);
+
+		const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', [repo], undefined, 'turn-1');
+		const start = await readNextRequest(peer.outbound);
+		const agents = start.params.config?.['agents'] as Record<string, { description: string; config_file: string }>;
+		const roleFile = await fs.promises.readFile(agents.Reviewer.config_file, 'utf8');
+		peer.push({ id: start.id, result: { thread: { id: 'thread-custom' } } });
+		const turn = await readNextRequest(peer.outbound);
+		peer.push({ id: turn.id, result: {} });
+		await send;
+
+		assert.deepStrictEqual({
+			mcp: start.params.config?.['mcp_servers'],
+			agentDescription: agents.Reviewer.description,
+			developerInstructions: start.params.developerInstructions,
+			capabilityPaths: start.params.selectedCapabilityRoots?.map(root => root.location.path),
+			roleFile,
+		}, {
+			mcp: { local: { command: 'node', args: ['server.js'] } },
+			agentDescription: 'Reviews changes',
+			developerInstructions: 'Run focused tests.\n\nReview carefully.',
+			capabilityPaths: [URI.file('/plugin/skills').fsPath],
+			roleFile: 'name = "Reviewer"\ndescription = "Reviews changes"\ndeveloper_instructions = "Review carefully."\n',
+		});
+		peer.exit();
 	});
 
 	test('fresh multi-root start selects only existing secondary skill directories', async () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionMetadataStore.test.ts
@@ -18,18 +18,28 @@ suite('CodexSessionMetadataStore', () => {
 		const session = URI.parse('codex:/session');
 		const workingDirectories = [URI.file('/repo-a'), URI.file('/repo-b')];
 
-		await store.write(session, { threadId: 'thread', cwd: workingDirectories[0], workingDirectories });
+		await store.write(session, { threadId: 'thread', cwd: workingDirectories[0], workingDirectories, agent: { uri: 'file:///agents/reviewer.agent.md' } });
 
 		const overlay = await store.read(session);
 		assert.deepStrictEqual({
 			threadId: overlay.threadId,
 			cwd: overlay.cwd?.toString(),
 			workingDirectories: overlay.workingDirectories?.map(directory => directory.toString()),
+			agent: overlay.agent,
 		}, {
 			threadId: 'thread',
 			cwd: workingDirectories[0].toString(),
 			workingDirectories: workingDirectories.map(directory => directory.toString()),
+			agent: { uri: 'file:///agents/reviewer.agent.md' },
 		});
+	});
+
+	test('clears a persisted agent selection', async () => {
+		const store = new CodexSessionMetadataStore(createSessionDataService(), new NullLogService());
+		const session = URI.parse('codex:/session');
+		await store.write(session, { agent: { uri: 'file:///agents/reviewer.agent.md' } });
+		await store.write(session, { agent: null });
+		assert.strictEqual((await store.read(session)).agent, undefined);
 	});
 
 	test('ignores malformed working directory metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -15,9 +15,9 @@ import { join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ActionType } from '../../../common/state/sessionActions.js';
+import { AgentHostCodexEnabledConfigKey } from '../../../common/agentHostSchema.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
 import { type SubscribeResult } from '../../../common/state/protocol/commands.js';
-import { McpServerStatus } from '../../../common/state/protocol/state.js';
 import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification, type IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 import { CODEX_SDK_ROOT } from '../e2e/providers/codexTestConfiguration.js';
@@ -35,23 +35,22 @@ interface ICapturedRequest {
 
 async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: string, pluginUri: string): Promise<PluginCustomization> {
 	const deadline = Date.now() + 60_000;
+	let lastPlugin: PluginCustomization | undefined;
 	while (Date.now() < deadline) {
 		const session = await fetchSessionWithChat(client, sessionUri);
 		const plugin = session.customizations?.find((customization): customization is PluginCustomization =>
 			customization.type === CustomizationType.Plugin
 			&& customization.uri === pluginUri
-			&& (customization.children?.length ?? 0) >= 4
-			&& customization.children?.some((child): child is McpServerCustomization =>
-				child.type === CustomizationType.McpServer
-				&& child.state.kind === McpServerStatus.Ready
-			) === true
 		);
-		if (plugin) {
+		lastPlugin = plugin;
+		if (plugin
+			&& (plugin.children?.length ?? 0) >= 4
+			&& plugin.children?.some((child): child is McpServerCustomization => child.type === CustomizationType.McpServer) === true) {
 			return plugin;
 		}
 		await new Promise<void>(resolve => setTimeout(resolve, 100));
 	}
-	throw new Error(`Timed out waiting for parsed plugin ${pluginUri}`);
+	throw new Error(`Timed out waiting for parsed plugin ${pluginUri}; last state: ${JSON.stringify(lastPlugin)}`);
 }
 
 suite('Agent Host Provider Integration — Codex Customizations', function () {
@@ -166,19 +165,6 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 		const clientId = 'codex-customizations-client';
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId }, 30_000);
 		await client.call('authenticate', { channel: ROOT_STATE_URI, resource: 'https://api.github.com', token: 'not-a-real-token' }, 30_000);
-
-		const sessionUri = URI.from({ scheme: 'codex', path: `/${generateUuid()}` }).toString();
-		await client.call('createSession', {
-			channel: sessionUri,
-			provider: 'codex',
-			workingDirectories: [URI.file(workspaceDir).toString()],
-			config: { isolation: 'folder' },
-		}, 30_000);
-		createdSessions.push(sessionUri);
-		await client.call<SubscribeResult>('subscribe', { channel: sessionUri });
-		await client.call<SubscribeResult>('subscribe', { channel: buildDefaultChatUri(sessionUri) });
-		client.clearReceived();
-
 		const pluginCustomization: ClientPluginCustomization = {
 			type: CustomizationType.Plugin,
 			id: customizationId(pluginUri),
@@ -187,18 +173,23 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 			nonce: '1',
 			enabled: true,
 		};
-		client.dispatch({
+
+		const sessionUri = URI.from({ scheme: 'codex', path: `/${generateUuid()}` }).toString();
+		await client.call('createSession', {
 			channel: sessionUri,
-			clientSeq: 1,
-			action: {
-				type: ActionType.SessionActiveClientSet,
-				activeClient: {
-					clientId,
-					tools: [],
-					customizations: [pluginCustomization],
-				},
+			provider: 'codex',
+			workingDirectories: [URI.file(workspaceDir).toString()],
+			config: { isolation: 'folder' },
+			activeClient: {
+				clientId,
+				tools: [],
+				customizations: [pluginCustomization],
 			},
-		});
+		}, 30_000);
+		createdSessions.push(sessionUri);
+		await client.call<SubscribeResult>('subscribe', { channel: sessionUri });
+		await client.call<SubscribeResult>('subscribe', { channel: buildDefaultChatUri(sessionUri) });
+		client.clearReceived();
 
 		const parsedPlugin = await waitForParsedPlugin(client, sessionUri, pluginUri);
 		assert.deepStrictEqual(
@@ -209,7 +200,7 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 		const turnId = 'turn-codex-customizations';
 		client.dispatch({
 			channel: buildDefaultChatUri(sessionUri),
-			clientSeq: 2,
+			clientSeq: 1,
 			action: {
 				type: ActionType.ChatTurnStarted,
 				turnId,
@@ -236,5 +227,42 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 		assert.ok(requestText.includes(RULE_MARKER), 'plugin instructions must reach the Codex model request');
 		assert.ok(requestText.includes(SKILL_MARKER), 'plugin skills must be advertised in the Codex model request');
 		assert.ok(requestText.includes(MCP_MARKER), 'plugin MCP tools must be advertised in the Codex model request');
+	});
+
+	test('standalone host registers Codex after runtime enablement', async function () {
+		this.timeout(120_000);
+		const runtimeServer = await startRealServer({ mockLlm: true, codexSdkRoot: CODEX_SDK_ROOT, codexAgentEnabled: false });
+		const runtimeClient = new TestProtocolClient(runtimeServer.port);
+		const workspaceDir = await mkdtemp(join(tmpdir(), 'codex-runtime-enablement-'));
+		try {
+			await runtimeClient.connect();
+			await runtimeClient.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'codex-runtime-enablement-client' }, 30_000);
+			await runtimeClient.call('authenticate', { channel: ROOT_STATE_URI, resource: 'https://api.github.com', token: 'not-a-real-token' }, 30_000);
+			await runtimeClient.call<SubscribeResult>('subscribe', { channel: ROOT_STATE_URI });
+			runtimeClient.clearReceived();
+			runtimeClient.dispatch({
+				channel: ROOT_STATE_URI,
+				clientSeq: 1,
+				action: { type: ActionType.RootConfigChanged, config: { [AgentHostCodexEnabledConfigKey]: true } },
+			});
+			await runtimeClient.waitForNotification(notification =>
+				isActionNotification(notification, ActionType.RootConfigChanged)
+				&& (getActionEnvelope(notification).action as { readonly config?: Readonly<Record<string, boolean>> }).config?.[AgentHostCodexEnabledConfigKey] === true,
+				30_000,
+			);
+
+			const sessionUri = URI.from({ scheme: 'codex', path: `/${generateUuid()}` }).toString();
+			await runtimeClient.call('createSession', {
+				channel: sessionUri,
+				provider: 'codex',
+				workingDirectories: [URI.file(workspaceDir).toString()],
+				config: { isolation: 'folder' },
+			}, 30_000);
+		} finally {
+			runtimeClient.close();
+			runtimeServer.process.kill();
+			await runtimeServer.mockLlm?.close();
+			await rm(workspaceDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -17,7 +17,7 @@ import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ActionType } from '../../../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
 import { type SubscribeResult } from '../../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
+import { buildDefaultChatUri, customizationId, CustomizationType, McpServerStatus, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification, type IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 import { CODEX_SDK_ROOT } from '../e2e/providers/codexTestConfiguration.js';
 
@@ -40,6 +40,10 @@ async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: strin
 			customization.type === CustomizationType.Plugin
 			&& customization.uri === pluginUri
 			&& (customization.children?.length ?? 0) >= 4
+			&& customization.children?.some((child): child is McpServerCustomization =>
+				child.type === CustomizationType.McpServer
+				&& child.state.kind === McpServerStatus.Ready
+			) === true
 		);
 		if (plugin) {
 			return plugin;

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -33,6 +33,13 @@ interface ICapturedRequest {
 	readonly body: unknown;
 }
 
+function developerInputText(body: unknown): string {
+	const input = (body as { readonly input?: unknown } | undefined)?.input;
+	return Array.isArray(input)
+		? JSON.stringify(input.filter(item => item && typeof item === 'object' && (item as { readonly role?: unknown }).role === 'developer'))
+		: '';
+}
+
 async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: string, pluginUri: string): Promise<PluginCustomization> {
 	const deadline = Date.now() + 60_000;
 	let lastPlugin: PluginCustomization | undefined;
@@ -155,8 +162,9 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 			writeFile(mcpConfigFile, JSON.stringify({
 				mcpServers: {
 					customization_test: {
-						command: 'node',
+						command: process.execPath,
 						args: [mcpScript],
+						env: { ELECTRON_RUN_AS_NODE: '1' },
 					},
 				},
 			})),
@@ -223,8 +231,9 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 		const responsesRequest = [...requests].reverse().find(request => request.path.includes('/responses'));
 		assert.ok(responsesRequest, `expected a Codex /responses request; got paths: ${requests.map(request => request.path).join(', ')}`);
 		const requestText = JSON.stringify(responsesRequest.body);
-		assert.ok(requestText.includes(AGENT_MARKER), 'selected custom-agent instructions must reach the Codex model request');
-		assert.ok(requestText.includes(RULE_MARKER), 'plugin instructions must reach the Codex model request');
+		const developerText = developerInputText(responsesRequest.body);
+		assert.ok(developerText.includes(AGENT_MARKER), 'selected custom-agent instructions must reach the Codex developer message');
+		assert.ok(developerText.includes(RULE_MARKER), 'plugin instructions must reach the Codex developer message');
 		assert.ok(requestText.includes(SKILL_MARKER), 'plugin skills must be advertised in the Codex model request');
 		assert.ok(requestText.includes(MCP_MARKER), 'plugin MCP tools must be advertised in the Codex model request');
 	});

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -17,7 +17,8 @@ import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ActionType } from '../../../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
 import { type SubscribeResult } from '../../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, customizationId, CustomizationType, McpServerStatus, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
+import { McpServerStatus } from '../../../common/state/protocol/state.js';
+import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification, type IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 import { CODEX_SDK_ROOT } from '../e2e/providers/codexTestConfiguration.js';
 

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Agent Host integration tests using the real Codex App Server and a synthetic local LLM.
+ */
+
+import assert from 'assert';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { createRequire } from 'module';
+import { tmpdir } from 'os';
+import { join } from '../../../../../base/common/path.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { ActionType } from '../../../common/state/sessionActions.js';
+import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
+import { type SubscribeResult } from '../../../common/state/protocol/commands.js';
+import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
+import { fetchSessionWithChat, getActionEnvelope, isActionNotification, type IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
+import { CODEX_SDK_ROOT } from '../e2e/providers/codexTestConfiguration.js';
+
+const AGENT_MARKER = 'CODEX_CUSTOM_AGENT_INSTRUCTION_MARKER';
+const RULE_MARKER = 'CODEX_PLUGIN_RULE_MARKER';
+const SKILL_MARKER = 'CODEX_PLUGIN_SKILL_DESCRIPTION_MARKER';
+const MCP_MARKER = 'CODEX_PLUGIN_MCP_TOOL_MARKER';
+const nodeRequire = createRequire(import.meta.url);
+
+interface ICapturedRequest {
+	readonly path: string;
+	readonly body: unknown;
+}
+
+async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: string, pluginUri: string): Promise<PluginCustomization> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		const session = await fetchSessionWithChat(client, sessionUri);
+		const plugin = session.customizations?.find((customization): customization is PluginCustomization =>
+			customization.type === CustomizationType.Plugin
+			&& customization.uri === pluginUri
+			&& (customization.children?.length ?? 0) >= 4
+		);
+		if (plugin) {
+			return plugin;
+		}
+		await new Promise<void>(resolve => setTimeout(resolve, 100));
+	}
+	throw new Error(`Timed out waiting for parsed plugin ${pluginUri}`);
+}
+
+suite('Agent Host Provider Integration — Codex Customizations', function () {
+
+	let server: IServerHandle;
+	let client: TestProtocolClient;
+	const createdSessions: string[] = [];
+	const tempDirs: string[] = [];
+
+	suiteSetup(async function () {
+		this.timeout(120_000);
+		if (!CODEX_SDK_ROOT) {
+			this.skip();
+		}
+		server = await startRealServer({ mockLlm: true, codexSdkRoot: CODEX_SDK_ROOT });
+	});
+
+	suiteTeardown(function () {
+		server?.process.kill();
+	});
+
+	setup(async function () {
+		this.timeout(120_000);
+		client = new TestProtocolClient(server.port);
+		await client.connect();
+	});
+
+	teardown(async function () {
+		for (const session of createdSessions) {
+			try {
+				await client.call('disposeSession', { session }, 5000);
+			} catch { /* best-effort */ }
+		}
+		createdSessions.length = 0;
+		client.close();
+
+		for (const dir of tempDirs) {
+			try {
+				await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+			} catch { /* best-effort */ }
+		}
+		tempDirs.length = 0;
+	});
+
+	test('client plugin agents, instructions, skills, and MCP reach Codex', async function () {
+		this.timeout(180_000);
+
+		const workspaceDir = await mkdtemp(join(tmpdir(), 'codex-customizations-workspace-'));
+		const pluginDir = await mkdtemp(join(tmpdir(), 'codex-customizations-plugin-'));
+		tempDirs.push(workspaceDir, pluginDir);
+
+		const agentFile = join(pluginDir, 'agents', 'reviewer.agent.md');
+		const skillFile = join(pluginDir, 'skills', 'customization-skill', 'SKILL.md');
+		const instructionFile = join(pluginDir, 'rules', 'customization.instructions.md');
+		const mcpScript = join(pluginDir, 'customization-mcp.cjs');
+		const mcpConfigFile = join(pluginDir, '.mcp.json');
+		const pluginUri = URI.file(pluginDir).toString();
+
+		await Promise.all([
+			mkdir(join(pluginDir, '.plugin'), { recursive: true }),
+			mkdir(join(pluginDir, 'agents'), { recursive: true }),
+			mkdir(join(pluginDir, 'skills', 'customization-skill'), { recursive: true }),
+			mkdir(join(pluginDir, 'rules'), { recursive: true }),
+		]);
+
+		const mcpServerModule = nodeRequire.resolve('@modelcontextprotocol/sdk/server/index.js');
+		const mcpStdioModule = nodeRequire.resolve('@modelcontextprotocol/sdk/server/stdio.js');
+		const mcpTypesModule = nodeRequire.resolve('@modelcontextprotocol/sdk/types.js');
+		await Promise.all([
+			writeFile(join(pluginDir, '.plugin', 'plugin.json'), JSON.stringify({ name: 'Codex Customizations Test Plugin' })),
+			writeFile(agentFile, [
+				'---',
+				'name: Codex Custom Reviewer',
+				'description: Reviews changes using the integration-test policy.',
+				'---',
+				`Always follow ${AGENT_MARKER}.`,
+			].join('\n')),
+			writeFile(instructionFile, [
+				'---',
+				'name: Codex Integration Rule',
+				'applyTo:',
+				'  - "**/*"',
+				'---',
+				`Always follow ${RULE_MARKER}.`,
+			].join('\n')),
+			writeFile(skillFile, [
+				'---',
+				'name: customization-skill',
+				`description: ${SKILL_MARKER}`,
+				'---',
+				'Use this skill when validating Codex customization propagation.',
+			].join('\n')),
+			writeFile(mcpScript, [
+				`const { Server } = require(${JSON.stringify(mcpServerModule)});`,
+				`const { StdioServerTransport } = require(${JSON.stringify(mcpStdioModule)});`,
+				`const { CallToolRequestSchema, ListToolsRequestSchema } = require(${JSON.stringify(mcpTypesModule)});`,
+				`const server = new Server({ name: "codex-customization-test", version: "1.0.0" }, { capabilities: { tools: {} } });`,
+				`server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [{ name: "customization_probe", description: ${JSON.stringify(MCP_MARKER)}, inputSchema: { type: "object", properties: {} } }] }));`,
+				`server.setRequestHandler(CallToolRequestSchema, async () => ({ content: [{ type: "text", text: "customization MCP response" }] }));`,
+				'void server.connect(new StdioServerTransport());',
+			].join('\n')),
+			writeFile(mcpConfigFile, JSON.stringify({
+				mcpServers: {
+					customization_test: {
+						command: process.execPath,
+						args: [mcpScript],
+					},
+				},
+			})),
+		]);
+
+		const clientId = 'codex-customizations-client';
+		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId }, 30_000);
+		await client.call('authenticate', { channel: ROOT_STATE_URI, resource: 'https://api.github.com', token: 'not-a-real-token' }, 30_000);
+
+		const sessionUri = URI.from({ scheme: 'codex', path: `/${generateUuid()}` }).toString();
+		await client.call('createSession', {
+			channel: sessionUri,
+			provider: 'codex',
+			workingDirectories: [URI.file(workspaceDir).toString()],
+			config: { isolation: 'folder' },
+		}, 30_000);
+		createdSessions.push(sessionUri);
+		await client.call<SubscribeResult>('subscribe', { channel: sessionUri });
+		await client.call<SubscribeResult>('subscribe', { channel: buildDefaultChatUri(sessionUri) });
+		client.clearReceived();
+
+		const pluginCustomization: ClientPluginCustomization = {
+			type: CustomizationType.Plugin,
+			id: customizationId(pluginUri),
+			uri: pluginUri as ProtocolURI,
+			name: 'Codex Customizations Test Plugin',
+			nonce: '1',
+			enabled: true,
+		};
+		client.dispatch({
+			channel: sessionUri,
+			clientSeq: 1,
+			action: {
+				type: ActionType.SessionActiveClientSet,
+				activeClient: {
+					clientId,
+					tools: [],
+					customizations: [pluginCustomization],
+				},
+			},
+		});
+
+		const parsedPlugin = await waitForParsedPlugin(client, sessionUri, pluginUri);
+		assert.deepStrictEqual(
+			new Set(parsedPlugin.children?.map(child => child.type)),
+			new Set([CustomizationType.Agent, CustomizationType.Rule, CustomizationType.Skill, CustomizationType.McpServer]),
+		);
+
+		const turnId = 'turn-codex-customizations';
+		client.dispatch({
+			channel: buildDefaultChatUri(sessionUri),
+			clientSeq: 2,
+			action: {
+				type: ActionType.ChatTurnStarted,
+				turnId,
+				startedAt: '2026-08-04T00:00:00.000Z',
+				message: {
+					text: 'Reply with exactly CODEX_CUSTOMIZATIONS_OK.',
+					origin: { kind: MessageKind.User },
+					agent: { uri: URI.file(agentFile).toString() },
+				},
+			},
+		});
+		await client.waitForNotification(notification =>
+			isActionNotification(notification, 'chat/turnComplete')
+			&& getActionEnvelope(notification).channel === buildDefaultChatUri(sessionUri)
+			&& (getActionEnvelope(notification).action as { turnId?: string }).turnId === turnId,
+			120_000,
+		);
+
+		const requests = (server.mockLlm?.getRequests?.() ?? []) as readonly ICapturedRequest[];
+		const responsesRequest = [...requests].reverse().find(request => request.path.includes('/responses'));
+		assert.ok(responsesRequest, `expected a Codex /responses request; got paths: ${requests.map(request => request.path).join(', ')}`);
+		const requestText = JSON.stringify(responsesRequest.body);
+		assert.ok(requestText.includes(AGENT_MARKER), 'selected custom-agent instructions must reach the Codex model request');
+		assert.ok(requestText.includes(RULE_MARKER), 'plugin instructions must reach the Codex model request');
+		assert.ok(requestText.includes(SKILL_MARKER), 'plugin skills must be advertised in the Codex model request');
+		assert.ok(requestText.includes(MCP_MARKER), 'plugin MCP tools must be advertised in the Codex model request');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -34,7 +34,7 @@ interface ICapturedRequest {
 }
 
 async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: string, pluginUri: string): Promise<PluginCustomization> {
-	const deadline = Date.now() + 30_000;
+	const deadline = Date.now() + 60_000;
 	while (Date.now() < deadline) {
 		const session = await fetchSessionWithChat(client, sessionUri);
 		const plugin = session.customizations?.find((customization): customization is PluginCustomization =>
@@ -156,7 +156,7 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 			writeFile(mcpConfigFile, JSON.stringify({
 				mcpServers: {
 					customization_test: {
-						command: process.execPath,
+						command: 'node',
 						args: [mcpScript],
 					},
 				},

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -779,7 +779,7 @@ export async function startServer(options?: { readonly quiet?: boolean; readonly
  * Start the agent host server with the Copilot SDK agent with either a real or mocked LLM.
  * The server is started with logging enabled so the CopilotAgent is registered.
  */
-export async function startRealServer(options?: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly mockLlm?: boolean; readonly homeDir?: string; readonly userDataDir?: string; readonly logLevel?: string; readonly env?: NodeJS.ProcessEnv; readonly capiReplay?: { readonly fixturePath: string; readonly mode?: CapiReplayMode; readonly workDir?: string; readonly real?: boolean; readonly allowPosixCommands?: boolean; readonly allowStaleRecordedRequest?: boolean }; readonly mockScenarios?: readonly IMockScenario[] }): Promise<IServerHandle> {
+export async function startRealServer(options?: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string; readonly codexAgentEnabled?: boolean; readonly mockLlm?: boolean; readonly homeDir?: string; readonly userDataDir?: string; readonly logLevel?: string; readonly env?: NodeJS.ProcessEnv; readonly capiReplay?: { readonly fixturePath: string; readonly mode?: CapiReplayMode; readonly workDir?: string; readonly real?: boolean; readonly allowPosixCommands?: boolean; readonly allowStaleRecordedRequest?: boolean }; readonly mockScenarios?: readonly IMockScenario[] }): Promise<IServerHandle> {
 	// `capiReplay` records/replays in front of the mock LLM server, so it implies
 	// a mock upstream even when `mockLlm` was not explicitly requested — unless
 	// `real` is set, in which case the proxy forwards to real CAPI/GitHub.
@@ -847,7 +847,7 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			} : {}),
 			// Codex defaults to disabled; opt it in for the agent host e2e suite when a
 			// codex SDK root is supplied so the provider actually registers.
-			...(options?.codexSdkRoot ? { [AgentHostCodexAgentEnabledEnvVar]: 'true' } : {}),
+			...(options?.codexSdkRoot ? { [AgentHostCodexAgentEnabledEnvVar]: String(options.codexAgentEnabled ?? true) } : {}),
 			// Fixtures use Codex's unified exec tool, so keep record and replay on the same shell protocol.
 			...(options?.codexSdkRoot && options.capiReplay ? { [AgentHostCodexAgentBinaryArgsEnvVar]: JSON.stringify(['-c', 'features.unified_exec=true']) } : {}),
 			...(realCapture ? {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1454,6 +1454,18 @@ class NewSession extends Disposable {
 	private _selectedModelId: string | undefined;
 	private _selectedAgent: ISessionAgentRef | undefined;
 
+	observeClientCustomAgents(customAgents: IObservable<readonly AgentCustomization[]>, onDidChange: () => void): void {
+		let previous = customAgents.get();
+		this._register(autorun(reader => {
+			const current = customAgents.read(reader);
+			if (current === previous) {
+				return;
+			}
+			previous = current;
+			onDidChange();
+		}));
+	}
+
 	/**
 	 * Latest resolved config. Replaces what used to live in `_newSessionConfigs`.
 	 * `undefined` indicates the most recent {@link resolveConfig} failed and no
@@ -2564,6 +2576,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			...this._adapterOptions(),
 		} satisfies IAgentHostAdapterOptions);
 		this._newSessions.set(newSession.sessionId, newSession);
+		newSession.observeClientCustomAgents(this._activeClientService.getCustomAgents(resourceScheme), () => {
+			this._onDidChangeCustomAgents.fire();
+			this._onDidChangeCustomizations.fire();
+		});
 		this._onDidChangeSessionConfig.fire(newSession.sessionId);
 
 		// Kick off the initial config resolve and the eager backend session
@@ -3235,7 +3251,20 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	getCustomAgents(sessionId: string): readonly AgentCustomization[] {
 		const sessionState = this._lastSessionStates.get(sessionId);
-		return getEffectiveAgents(sessionState?.customizations);
+		const stateAgents = getEffectiveAgents(sessionState?.customizations);
+		const newSession = this._newSessions.get(sessionId);
+		if (!newSession) {
+			return stateAgents;
+		}
+		const clientAgents = this._activeClientService.getCustomAgents(newSession.session.resource.scheme).get();
+		if (clientAgents.length === 0) {
+			return stateAgents;
+		}
+		const agentsByUri = new Map(stateAgents.map(agent => [agent.uri.toString(), agent]));
+		for (const agent of clientAgents) {
+			agentsByUri.set(agent.uri.toString(), agent);
+		}
+		return [...agentsByUri.values()].sort((a, b) => a.name.localeCompare(b.name) || a.uri.toString().localeCompare(b.uri.toString()));
 	}
 
 	getCustomizations(sessionId: string): Customization[] {

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -16,7 +16,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { AgentHostCodexAgentEnabledSettingId, AgentSession, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, IAgentHostService, type IAgentCreateChatOptions, type IAgentCreateSessionConfig, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import type { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, CustomizationLoadStatus, CustomizationType, McpServerStatus, MessageKind, SessionLifecycle, type AgentInfo, type ChangesSummary, type Customization, type RootState, type SessionActiveClient, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, CustomizationLoadStatus, CustomizationType, McpServerStatus, MessageKind, SessionLifecycle, type AgentCustomization, type AgentInfo, type ChangesSummary, type Customization, type RootState, type SessionActiveClient, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { buildChatUri, buildDefaultChatUri, buildSubagentChatUri, ChangesetStatus, SessionStatus as ProtocolSessionStatus, StateComponents, withSessionGitState, withSessionMultiRootMetadata, withSessionWorkspaceless, type ChangesetState, type ChatState, type ChatSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, NotificationType, type ActionEnvelope, type IRootConfigChangedAction, type ChatAction, type SessionAction, type TerminalAction, type INotification, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
@@ -399,7 +399,7 @@ function createSchemaDefaultConfigurationService(): TestConfigurationService {
 
 function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = [
 	{ type: 'agent-host-copilotcli', name: 'copilot', displayName: 'Copilot', description: 'test', icon: undefined },
-], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService; agentHostEnabled?: boolean }): LocalAgentHostSessionsProvider {
+], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; activeClientAgents?: IObservable<readonly AgentCustomization[]>; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService; agentHostEnabled?: boolean }): LocalAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -448,6 +448,7 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 	}());
 	instantiationService.stub(IAgentHostActiveClientService, new class extends mock<IAgentHostActiveClientService>() {
 		override getActiveClient = (_sessionType: string, clientId: string) => ({ clientId, ...(options?.activeClient ?? { tools: [], customizations: [] }) });
+		override getCustomAgents = (_sessionType: string) => options?.activeClientAgents ?? constObservable([]);
 	}());
 
 	return disposables.add(instantiationService.createInstance(LocalAgentHostSessionsProvider));
@@ -2051,6 +2052,34 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.ok(session);
 
 		assert.deepStrictEqual(provider.getCustomAgents(session!.sessionId), []);
+	});
+
+	test('new session exposes client custom agents before SessionState and updates the picker', () => {
+		const activeClientAgents = observableValue<readonly AgentCustomization[]>('activeClientAgents', []);
+		const provider = createProvider(disposables, agentHost, undefined, { activeClientAgents });
+		const session = provider.createNewSession(URI.parse('file:///home/user/proj'), provider.sessionTypes[0].id);
+		let fired = 0;
+		disposables.add(provider.onDidChangeCustomAgents(() => fired++));
+
+		activeClientAgents.set([{
+			type: CustomizationType.Agent,
+			id: 'inbox',
+			uri: 'file:///plugins/github-inbox/agents/inbox.agent.md',
+			name: 'Inbox',
+		}], undefined);
+
+		assert.deepStrictEqual({
+			agents: provider.getCustomAgents(session.sessionId),
+			fired,
+		}, {
+			agents: [{
+				type: CustomizationType.Agent,
+				id: 'inbox',
+				uri: 'file:///plugins/github-inbox/agents/inbox.agent.md',
+				name: 'Inbox',
+			}],
+			fired: 1,
+		});
 	});
 
 	test('onDidChangeCustomAgents fires on root state and session state changes', async () => {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -6,11 +6,12 @@
 import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, isSessionAction, type ActionEnvelope, type INotification, type StateAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
-import { CustomizationLoadStatus, CustomizationType, type AgentInfo, type Customization, type RootState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationLoadStatus, CustomizationType, type AgentCustomization, type AgentInfo, type Customization, type RootState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { StateComponents, type ComponentToState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { sessionReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
@@ -244,6 +245,33 @@ suite('RemoteAgentHostCustomizationHarness', () => {
 		const items = await provider.provideChatSessionCustomizations(testSessionResource, CancellationToken.None);
 		assert.strictEqual(items.length, 2);
 		assert.notStrictEqual(items[0].itemKey, items[1].itemKey);
+	});
+
+	test('provider uses draft agents before session customizations hydrate', async () => {
+		const connection = disposables.add(new MockAgentConnection());
+		const fileService = new class extends mock<IFileService>() { };
+		const provider = disposables.add(new AgentCustomizationItemProvider(
+			'test-authority',
+			undefined,
+			undefined,
+			fileService,
+			new NullLogService(),
+			createTestCustomAgentsService(connection, []),
+		));
+		provider.setDraftCustomAgents(observableValue<readonly AgentCustomization[]>('draftAgents', [{
+			type: CustomizationType.Agent,
+			id: 'file:///workspace/.github/agents/reviewer.agent.md',
+			uri: 'file:///workspace/.github/agents/reviewer.agent.md',
+			name: 'Reviewer',
+			description: 'Review workspace changes',
+		}]));
+
+		const agents = await provider.provideCustomAgents(testSessionResource);
+
+		assert.deepStrictEqual(agents.map(agent => ({ name: agent.name, description: agent.description })), [{
+			name: 'Reviewer',
+			description: 'Review workspace changes',
+		}]);
 	});
 
 	test('provider keeps client-synced entries distinct from host-owned entries', async () => {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -232,6 +232,7 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 	}());
 	instantiationService.stub(IAgentHostActiveClientService, new class extends mock<IAgentHostActiveClientService>() {
 		override getActiveClient = (_sessionType: string, clientId: string) => ({ clientId, tools: [], customizations: [] });
+		override getCustomAgents = () => constObservable([]);
 	}());
 
 	const config: IRemoteAgentHostSessionsProviderConfig = {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -42,6 +42,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; pluginLabel: string | undefined; children: readonly ICustomizationItem[] }>();
 	private readonly _contentExpander: AgentCustomizationContentExpander;
 	private _draftCustomAgents: IObservable<readonly AgentCustomization[]> | undefined;
+	private _draftCustomizations: IObservable<readonly ClientPluginCustomization[]> | undefined;
 
 	constructor(
 		private readonly _connectionAuthority: string,
@@ -63,6 +64,14 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		this._draftCustomAgents = customAgents;
 		this._register(autorun(reader => {
 			customAgents.read(reader);
+			this._onDidChange.fire();
+		}));
+	}
+
+	setDraftCustomizations(customizations: IObservable<readonly ClientPluginCustomization[]>): void {
+		this._draftCustomizations = customizations;
+		this._register(autorun(reader => {
+			customizations.read(reader);
 			this._onDidChange.fire();
 		}));
 	}
@@ -246,7 +255,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		const expandPromises: Promise<readonly ICustomizationItem[]>[] = [];
 
 
-		const customizations = this._customAgentsService.getCustomizations(sessionResource);
+		const customizations = this.getCustomizations(sessionResource);
 
 		const directoryCustomizations = [];
 		for (const sessionCustomization of customizations) {
@@ -303,7 +312,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 				// location) so the item reflects where it actually came from.
 				const enriched = p.isBundleItem ? this._applySyncedOrigin(child) : child;
 				// Children inherit the parent plugin's status/enabled state.
-				items.set(`${p.item.itemKey ?? p.item.uri.toString()}::${enriched.type}::${enriched.name}`, {
+				items.set(enriched.uri.toString(), {
 					...enriched,
 					status: p.status,
 					statusMessage: p.statusMessage,
@@ -330,6 +339,20 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	private getCustomAgents(sessionResource: URI): readonly AgentCustomization[] {
 		const sessionAgents = this._customAgentsService.getCustomAgents(sessionResource);
 		return sessionAgents.length > 0 ? sessionAgents : this._draftCustomAgents?.get() ?? [];
+	}
+
+	private getCustomizations(sessionResource: URI): readonly Customization[] {
+		const sessionCustomizations = this._customAgentsService.getCustomizations(sessionResource);
+		const draftCustomizations = this._draftCustomizations?.get() ?? [];
+		if (draftCustomizations.length === 0) {
+			return sessionCustomizations;
+		}
+
+		const sessionKeys = new Set(sessionCustomizations.map(customization => `${customization.type}:${customization.uri}`));
+		return [
+			...sessionCustomizations,
+			...draftCustomizations.filter(customization => !sessionKeys.has(`${customization.type}:${customization.uri}`)),
+		];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -7,9 +7,10 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
+import { autorun, type IObservable } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
-import { CustomizationLoadStatus, CustomizationType, type ChildCustomization, type ClientPluginCustomization, type Customization, type CustomizationLoadState, type DirectoryCustomization, PluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CustomizationLoadStatus, CustomizationType, type AgentCustomization, type ChildCustomization, type ClientPluginCustomization, type Customization, type CustomizationLoadState, type DirectoryCustomization, PluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { ICustomizationItem, ICustomizationItemAction, ICustomizationItemProvider, ICustomizationSourceFolder } from '../../../common/customizationHarnessService.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../../../services/agentHost/common/agentHostFileSystemService.js';
@@ -40,6 +41,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	/** Cache: pluginUri → last expansion (keyed by nonce and label so we re-fetch on content or display-name changes). */
 	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; pluginLabel: string | undefined; children: readonly ICustomizationItem[] }>();
 	private readonly _contentExpander: AgentCustomizationContentExpander;
+	private _draftCustomAgents: IObservable<readonly AgentCustomization[]> | undefined;
 
 	constructor(
 		private readonly _connectionAuthority: string,
@@ -53,6 +55,14 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		this._contentExpander = new AgentCustomizationContentExpander(this._fileService, this._logService);
 
 		this._register(this._customAgentsService.onDidChangeCustomizations(() => {
+			this._onDidChange.fire();
+		}));
+	}
+
+	setDraftCustomAgents(customAgents: IObservable<readonly AgentCustomization[]>): void {
+		this._draftCustomAgents = customAgents;
+		this._register(autorun(reader => {
+			customAgents.read(reader);
 			this._onDidChange.fire();
 		}));
 	}
@@ -183,7 +193,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	}
 
 	async provideCustomAgents(sessionResource: URI): Promise<readonly ICustomAgent[]> {
-		const agents = this._customAgentsService.getCustomAgents(sessionResource);
+		const agents = this.getCustomAgents(sessionResource);
 		const sessionTypes = [getChatSessionType(sessionResource)];
 		return agents.map(agent => ({
 			id: agent.uri,
@@ -213,6 +223,23 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 
 	async provideChatSessionCustomizations(sessionResource: URI, token: CancellationToken): Promise<ICustomizationItem[]> {
 		const items = new Map<string, ICustomizationItem>();
+		const workingDirectories = this._customAgentsService.getWorkingDirectories(sessionResource);
+
+		for (const agent of this.getCustomAgents(sessionResource)) {
+			const source = isUnderAnyRoot(workingDirectories, agent.uri) ? AICustomizationSources.local : AICustomizationSources.user;
+			items.set(agent.id, {
+				itemKey: agent.id,
+				uri: this.toRemoteUri(agent.uri),
+				type: PromptsType.agent,
+				name: agent.name,
+				description: agent.description,
+				source,
+				extensionId: undefined,
+				pluginUri: undefined,
+				enabled: agent.enabled !== false,
+				userInvocable: readAgentCustomizationMeta(agent).userInvocable !== false,
+			});
+		}
 
 		// Build parent plugin items keyed by customization ref
 		const plugins: PluginMeta[] = [];
@@ -285,8 +312,6 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			}
 		}
 
-		const workingDirectories = this._customAgentsService.getWorkingDirectories(sessionResource);
-
 		for (const sessionCustomization of directoryCustomizations) {
 			const source = isUnderAnyRoot(workingDirectories, sessionCustomization.uri) ? AICustomizationSources.local : AICustomizationSources.user;
 			const isRemote = sessionCustomization.clientId !== undefined;
@@ -300,6 +325,11 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			}
 		}
 		return [...items.values()];
+	}
+
+	private getCustomAgents(sessionResource: URI): readonly AgentCustomization[] {
+		const sessionAgents = this._customAgentsService.getCustomAgents(sessionResource);
+		return sessionAgents.length > 0 ? sessionAgents : this._draftCustomAgents?.get() ?? [];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
@@ -15,7 +15,7 @@ import { IStorageService } from '../../../../../../platform/storage/common/stora
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { AgentHostCopilotMultiRootEnabledSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
-import type { SessionActiveClient, ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import type { AgentCustomization, SessionActiveClient, ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import type { ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
 import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
@@ -24,7 +24,7 @@ import { ILanguageModelToolsService, IToolData, IToolSet } from '../../../common
 import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 import { IConfigurationResolverService } from '../../../../../services/configurationResolver/common/configurationResolver.js';
 import { AgentCustomizationSyncProvider } from './agentCustomizationSyncProvider.js';
-import { type ILocalCustomizationSyncOptions, resolveCustomizationRefs, shouldSyncWorkspaceDotMcp } from './agentHostLocalCustomizations.js';
+import { type ILocalCustomizationSyncOptions, resolveCustomizationRefs, resolveLocalCustomAgents, shouldSyncWorkspaceDotMcp } from './agentHostLocalCustomizations.js';
 import { toolDataToDefinition } from './agentHostToolUtils.js';
 import { IAgentHostToolSetEnablementService, isToolEnabledInSet } from './agentHostToolSetEnablementService.js';
 import { SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
@@ -65,6 +65,9 @@ export interface IAgentHostActiveClientService {
 
 	getCustomizations(sessionType: string): IObservable<readonly ClientPluginCustomization[]>;
 
+	/** Selectable local agents available before the host has parsed the customization refs. */
+	getCustomAgents(sessionType: string): IObservable<readonly AgentCustomization[]>;
+
 	/**
 	 * Returns the tools this client advertises to the agent host for `sessionType`.
 	 *
@@ -80,6 +83,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _customizationsByType: ISettableObservable<ReadonlyMap<string, IObservable<readonly ClientPluginCustomization[]>>>;
+	private readonly _customAgentsByType: ISettableObservable<ReadonlyMap<string, IObservable<readonly AgentCustomization[]>>>;
 
 	private readonly _allToolsObs: IObservable<readonly IToolData[]>;
 	private readonly _allToolSetsObs: IObservable<Iterable<IToolSet>>;
@@ -102,6 +106,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 	) {
 		super();
 		this._customizationsByType = observableValue('agentHostCustomizationsByType', new Map());
+		this._customAgentsByType = observableValue('agentHostCustomAgentsByType', new Map());
 
 		// Pass `undefined` for the model: agent-host sessions use server-side model selection.
 		this._allToolsObs = this._toolsService.observeTools(undefined);
@@ -113,6 +118,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 		const syncProvider = store.add(new AgentCustomizationSyncProvider(sessionType, this._storageService));
 		const bundler = store.add(this._instantiationService.createInstance(SyncedCustomizationBundler, sessionType));
 		const customizations = observableValue<readonly ClientPluginCustomization[]>('agentCustomizations', []);
+		const customAgents = observableValue<readonly AgentCustomization[]>('agentCustomAgents', []);
 		// Gate for seeding folder-root `.mcp.json` servers from every workspace
 		// folder (not just the session's primary). Evaluated fresh on each sync
 		// so folder/setting changes are reflected. See `shouldSyncWorkspaceDotMcp`.
@@ -125,14 +131,19 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 		const updateCustomizations = async () => {
 			const seq = ++updateSeq;
 			try {
-				const refs = await resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, this._mcpService, this._configurationResolverService, bundler, sessionType, shouldIncludeWorkspaceDotMcp(), options);
+				const [refs, agents] = await Promise.all([
+					resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, this._mcpService, this._configurationResolverService, bundler, sessionType, shouldIncludeWorkspaceDotMcp(), options),
+					resolveLocalCustomAgents(this._fileService, syncProvider, this._agentPluginService),
+				]);
 				if (seq !== updateSeq) {
 					return;
 				}
-				if (equals(customizations.get(), refs)) {
-					return;
+				if (!equals(customizations.get(), refs)) {
+					customizations.set(refs, undefined);
 				}
-				customizations.set(refs, undefined);
+				if (!equals(customAgents.get(), agents)) {
+					customAgents.set(agents, undefined);
+				}
 			} catch (err) {
 				onUnexpectedError(err);
 			}
@@ -151,6 +162,22 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 			this._promptsService.onDidChangeSkills,
 			this._promptsService.onDidChangeInstructions,
 		)(() => scheduleUpdate()));
+		// Plugin discovery completes asynchronously and may happen after the
+		// agent registration's initial customization resolution. Observe the
+		// plugin inventory and its mutable contributions so newly discovered,
+		// enabled, or updated plugins are published without restarting.
+		store.add(autorun(reader => {
+			for (const plugin of this._agentPluginService.plugins.read(reader)) {
+				plugin.enablement.read(reader);
+				plugin.hooks.read(reader);
+				plugin.commands.read(reader);
+				plugin.skills.read(reader);
+				plugin.agents.read(reader);
+				plugin.instructions.read(reader);
+				plugin.mcpServerDefinitions.read(reader);
+			}
+			scheduleUpdate();
+		}));
 		// Re-resolve when MCP servers configured in VS Code change (added,
 		// removed, enabled/disabled, or reconfigured) so they stay in sync.
 		store.add(autorun(reader => {
@@ -171,11 +198,27 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 			}
 		}));
 		store.add(this._setCustomizations(sessionType, customizations));
+		store.add(this._setCustomAgents(sessionType, customAgents));
 		return {
 			syncProvider,
 			bundler,
 			dispose: () => store.dispose(),
 		};
+	}
+
+	private _setCustomAgents(sessionType: string, customAgents: IObservable<readonly AgentCustomization[]>): IDisposable {
+		const next = new Map(this._customAgentsByType.get());
+		next.set(sessionType, customAgents);
+		this._customAgentsByType.set(next, undefined);
+		return toDisposable(() => {
+			const current = this._customAgentsByType.get();
+			if (current.get(sessionType) !== customAgents) {
+				return;
+			}
+			const removed = new Map(current);
+			removed.delete(sessionType);
+			this._customAgentsByType.set(removed, undefined);
+		});
 	}
 
 	private _setCustomizations(sessionType: string, customizations: IObservable<readonly ClientPluginCustomization[]>): IDisposable {
@@ -203,6 +246,10 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 
 	getCustomizations(sessionType: string): IObservable<readonly ClientPluginCustomization[]> {
 		return derived(reader => this._customizationsByType.read(reader).get(sessionType)?.read(reader) ?? EMPTY_CUSTOMIZATIONS);
+	}
+
+	getCustomAgents(sessionType: string): IObservable<readonly AgentCustomization[]> {
+		return derived(reader => this._customAgentsByType.read(reader).get(sessionType)?.read(reader) ?? EMPTY_CUSTOM_AGENTS);
 	}
 
 	getClientTools(sessionType: string): IObservable<readonly ToolDefinition[]> {
@@ -235,6 +282,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 }
 
 const EMPTY_CUSTOMIZATIONS: readonly ClientPluginCustomization[] = Object.freeze([]);
+const EMPTY_CUSTOM_AGENTS: readonly AgentCustomization[] = Object.freeze([]);
 
 /** Debounce window (ms) used to coalesce bursts of customization change events into a single re-resolution. */
 const CUSTOMIZATION_UPDATE_DEBOUNCE_DELAY = 50;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
@@ -133,7 +133,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 			try {
 				const [refs, agents] = await Promise.all([
 					resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, this._mcpService, this._configurationResolverService, bundler, sessionType, shouldIncludeWorkspaceDotMcp(), options),
-					resolveLocalCustomAgents(this._fileService, syncProvider, this._agentPluginService),
+					resolveLocalCustomAgents(this._fileService, this._promptsService, syncProvider, this._agentPluginService, sessionType, options),
 				]);
 				if (seq !== updateSeq) {
 					return;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -262,6 +262,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 		const itemProvider = store.add(this._instantiationService.createInstance(AgentCustomizationItemProvider, 'local', undefined,
 			syncedUri => agentRegistration.bundler.getOrigin(syncedUri)));
+		itemProvider.setDraftCustomAgents(this._activeClientService.getCustomAgents(sessionType));
 		// `[Agent Host]` suffix disambiguates from the extension-host Copilot CLI harness, which uses the same displayName.
 		store.add(this._customizationHarnessService.registerExternalHarness({
 			id: sessionType,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -263,6 +263,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		const itemProvider = store.add(this._instantiationService.createInstance(AgentCustomizationItemProvider, 'local', undefined,
 			syncedUri => agentRegistration.bundler.getOrigin(syncedUri)));
 		itemProvider.setDraftCustomAgents(this._activeClientService.getCustomAgents(sessionType));
+		itemProvider.setDraftCustomizations(this._activeClientService.getCustomizations(sessionType));
 		// `[Agent Host]` suffix disambiguates from the extension-host Copilot CLI harness, which uses the same displayName.
 		store.add(this._customizationHarnessService.registerExternalHarness({
 			id: sessionType,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { Iterable } from '../../../../../../base/common/iterator.js';
 import { isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { CustomizationType, type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { type AgentCustomization, CustomizationType, type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { customizationId, type ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IMcpServerConfiguration, McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { AICustomizationSource, AICustomizationSources } from '../../../common/aiCustomizationWorkspaceService.js';
@@ -25,6 +25,7 @@ import type { ISyncableFile, ISyncableMcpServer, SyncedCustomizationBundler } fr
 import { AGENT_HOST_COPILOT_CLI_SESSION_TYPE } from './agentHostToolSetEnablementService.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { isDefined } from '../../../../../../base/common/types.js';
+import { PromptFileParser } from '../../../common/promptSyntax/promptFileParser.js';
 
 /**
  * Prompt types that participate in auto-sync to an agent host harness.
@@ -112,6 +113,62 @@ export async function enumerateLocalCustomizationsForHarness(
 		}
 	}
 
+	return result;
+}
+
+/**
+ * Resolves the selectable custom-agent metadata that the client has already
+ * discovered and will publish to an agent host for `sessionType`.
+ *
+ * Client customization refs intentionally omit parsed children; the host adds
+ * those later in `SessionState.customizations`. New Agents-window drafts need
+ * the picker before that state exists, so this mirrors the same eligibility
+ * rules used by {@link resolveCustomizationRefs} without waiting for the host
+ * to parse the plugin or synthetic bundle.
+ */
+export async function resolveLocalCustomAgents(
+	fileService: IFileService,
+	syncProvider: ICustomizationSyncProvider,
+	agentPluginService: IAgentPluginService,
+): Promise<readonly AgentCustomization[]> {
+	const plugins = agentPluginService.plugins.get();
+	const result: AgentCustomization[] = [];
+	const parser = new PromptFileParser();
+	const pending: Promise<void>[] = [];
+
+	for (const plugin of plugins) {
+		if (syncProvider.isDisabled(plugin.uri) || !isContributionEnabled(plugin.enablement.get())) {
+			continue;
+		}
+		for (const agent of plugin.agents.get()) {
+			pending.push((async () => {
+				let name = agent.name;
+				let description = agent.description;
+				let disableUserInvocation: boolean | undefined;
+				try {
+					const content = await fileService.readFile(agent.uri);
+					const header = parser.parse(agent.uri, content.value.toString()).header;
+					name = header?.name ?? name;
+					description = header?.description ?? description;
+					disableUserInvocation = header?.userInvocable === false || undefined;
+				} catch {
+					// The host will parse the full agent after session creation. Keep the
+					// discovery metadata as a best-effort draft fallback if the file moved.
+				}
+				result.push({
+					type: CustomizationType.Agent,
+					id: agent.uri.toString(),
+					uri: agent.uri.toString(),
+					name,
+					description,
+					disableUserInvocation,
+				});
+			})());
+		}
+	}
+	await Promise.all(pending);
+
+	result.sort((a, b) => a.name.localeCompare(b.name) || a.uri.toString().localeCompare(b.uri.toString()));
 	return result;
 }
 
@@ -346,9 +403,10 @@ export async function resolveCustomizationRefs(
 		}
 	}
 
-	// Plugins that only contribute MCP servers have no prompt files, so they
-	// are never surfaced by enumeration above. Include them explicitly so
-	// their servers are still synced to the harness.
+	// Plugin prompt discovery is not guaranteed to be hydrated before an agent
+	// host registration resolves (notably in the Agents window). Include every
+	// enabled plugin with a concrete contribution directly; `pluginRefs`
+	// de-duplicates those already found through prompt-file enumeration.
 	for (const plugin of plugins) {
 		if (pluginRefs.has(plugin.uri.toString())) {
 			continue;
@@ -359,7 +417,12 @@ export async function resolveCustomizationRefs(
 		if (!isContributionEnabled(plugin.enablement.get())) {
 			continue;
 		}
-		if (plugin.mcpServerDefinitions.get().length === 0) {
+		if (plugin.hooks.get().length === 0
+			&& plugin.commands.get().length === 0
+			&& plugin.skills.get().length === 0
+			&& plugin.agents.get().length === 0
+			&& plugin.instructions.get().length === 0
+			&& plugin.mcpServerDefinitions.get().length === 0) {
 			continue;
 		}
 		addPluginRef(plugin);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Iterable } from '../../../../../../base/common/iterator.js';
-import { isEqualOrParent } from '../../../../../../base/common/resources.js';
+import { basename, isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { type AgentCustomization, CustomizationType, type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { customizationId, type ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -49,6 +49,7 @@ export const SYNCABLE_PROMPT_TYPES: readonly PromptsType[] = [
  * and in the regular VS Code workbench window it returns nothing at all.
  */
 export const SYNCABLE_STORAGE_SOURCES: readonly PromptsStorage[] = [
+	PromptsStorage.local,
 	PromptsStorage.plugin,
 	PromptsStorage.extension,
 	PromptsStorage.builtIn,
@@ -128,46 +129,55 @@ export async function enumerateLocalCustomizationsForHarness(
  */
 export async function resolveLocalCustomAgents(
 	fileService: IFileService,
+	promptsService: IPromptsService,
 	syncProvider: ICustomizationSyncProvider,
 	agentPluginService: IAgentPluginService,
+	sessionType: string,
+	options?: ILocalCustomizationSyncOptions,
 ): Promise<readonly AgentCustomization[]> {
 	const plugins = agentPluginService.plugins.get();
 	const result: AgentCustomization[] = [];
 	const parser = new PromptFileParser();
 	const pending: Promise<void>[] = [];
+	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options);
 
-	for (const plugin of plugins) {
-		if (syncProvider.isDisabled(plugin.uri) || !isContributionEnabled(plugin.enablement.get())) {
+	for (const agent of enumerated) {
+		if (agent.type !== PromptsType.agent || agent.disabled) {
 			continue;
 		}
-		for (const agent of plugin.agents.get()) {
-			pending.push((async () => {
-				let name = agent.name;
-				let description = agent.description;
-				let disableUserInvocation: boolean | undefined;
-				try {
-					const content = await fileService.readFile(agent.uri);
-					const header = parser.parse(agent.uri, content.value.toString()).header;
-					name = header?.name ?? name;
-					description = header?.description ?? description;
-					disableUserInvocation = header?.userInvocable === false || undefined;
-				} catch {
-					// The host will parse the full agent after session creation. Keep the
-					// discovery metadata as a best-effort draft fallback if the file moved.
-				}
-				result.push({
-					type: CustomizationType.Agent,
-					id: agent.uri.toString(),
-					uri: agent.uri.toString(),
-					name,
-					description,
-					disableUserInvocation,
-				});
-			})());
+		const plugin = agent.source === AICustomizationSources.plugin
+			? plugins.find(candidate => isEqualOrParent(agent.uri, candidate.uri))
+			: undefined;
+		if (agent.source === AICustomizationSources.plugin
+			&& (!plugin || syncProvider.isDisabled(plugin.uri) || !isContributionEnabled(plugin.enablement.get()))) {
+			continue;
 		}
+		const pluginAgent = plugin?.agents.get().find(candidate => candidate.uri.toString() === agent.uri.toString());
+		pending.push((async () => {
+			let name = pluginAgent?.name ?? basename(agent.uri, '.agent.md');
+			let description = pluginAgent?.description;
+			let disableUserInvocation: boolean | undefined;
+			try {
+				const content = await fileService.readFile(agent.uri);
+				const header = parser.parse(agent.uri, content.value.toString()).header;
+				name = header?.name ?? name;
+				description = header?.description ?? description;
+				disableUserInvocation = header?.userInvocable === false || undefined;
+			} catch {
+				// The host will parse the full agent after session creation. Keep the
+				// discovery metadata as a best-effort draft fallback if the file moved.
+			}
+			result.push({
+				type: CustomizationType.Agent,
+				id: agent.uri.toString(),
+				uri: agent.uri.toString(),
+				name,
+				description,
+				disableUserInvocation,
+			});
+		})());
 	}
 	await Promise.all(pending);
-
 	result.sort((a, b) => a.name.localeCompare(b.name) || a.uri.toString().localeCompare(b.uri.toString()));
 	return result;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1337,7 +1337,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		);
 		this._activeSessions.set(sessionResource, session);
-		this._ensureActiveClient(resolvedSession);
 
 		if (!isNewSession) {
 			// Only wire up pending-message/draft sync once the chat URI has been

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -781,6 +781,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * already be cleared by then.
 	 */
 	private readonly _inputNeededWatcherBackends = new ResourceMap<URI>();
+	/** Per-session subscription reconciling client data after session state hydration. */
+	private readonly _activeClientRefreshSubscriptions = this._register(new DisposableResourceMap());
 	/** Historical turns with file edits, pending hydration into the editing session. */
 	private readonly _pendingHistoryTurns = new ResourceMap<readonly Turn[]>();
 	/**
@@ -1303,6 +1305,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			historySubagentObservations,
 			() => {
 				this._activeSessions.delete(sessionResource);
+				this._activeClientRefreshSubscriptions.deleteAndDispose(sessionResource);
 				this._pendingMessageSubscriptions.deleteAndDispose(sessionResource);
 				this._draftSyncSubscriptions.deleteAndDispose(sessionResource);
 				this._serverTurnWatchers.deleteAndDispose(sessionResource);
@@ -1337,6 +1340,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		);
 		this._activeSessions.set(sessionResource, session);
+		if (sessionSubscription) {
+			this._ensureActiveClientRefreshSubscription(sessionResource, resolvedSession, sessionSubscription);
+		}
+		this._refreshActiveClientIfPresent(resolvedSession);
 
 		if (!isNewSession) {
 			// Only wire up pending-message/draft sync once the chat URI has been
@@ -1856,6 +1863,35 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			type: ActionType.SessionActiveClientSet,
 			activeClient,
 		});
+	}
+
+	/**
+	 * Refresh this client's tools and customizations when it is already active.
+	 * Unlike {@link _ensureActiveClient}, this never claims a session owned by a
+	 * different client, so opening a session cannot interrupt another window's
+	 * in-progress turn. This closes the initialization race where customization
+	 * discovery finishes before the session is added to `_activeSessions`.
+	 */
+	private _refreshActiveClientIfPresent(backendSession: URI): void {
+		const state = this._getSessionState(backendSession.toString());
+		const activeClient = this._getCurrentActiveClient();
+		const existing = state?.activeClients.find(c => c.clientId === activeClient.clientId);
+		if (!existing || equals(existing, activeClient)) {
+			return;
+		}
+		this._dispatchAction(backendSession, {
+			type: ActionType.SessionActiveClientSet,
+			activeClient,
+		});
+	}
+
+	private _ensureActiveClientRefreshSubscription(sessionResource: URI, backendSession: URI, sessionSubscription: IAgentSubscription<SessionState>): void {
+		if (this._activeClientRefreshSubscriptions.has(sessionResource)) {
+			return;
+		}
+		this._activeClientRefreshSubscriptions.set(sessionResource, sessionSubscription.onDidChange(() => {
+			this._refreshActiveClientIfPresent(backendSession);
+		}));
 	}
 
 	/**
@@ -4658,6 +4694,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// Subscribe to the new session's state
 		onFailureStage?.('subscribeSession');
 		const newSub = this._ensureSessionSubscription(session.toString());
+		this._ensureActiveClientRefreshSubscription(sessionResource, session, newSub);
 		if (!this._getSessionState(session.toString())) {
 			// Wait for the subscription to hydrate. `_whenSubscriptionHydrated`
 			// settles on snapshot, error, or cancellation and attaches its

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1337,6 +1337,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		);
 		this._activeSessions.set(sessionResource, session);
+		this._ensureActiveClient(resolvedSession);
 
 		if (!isNewSession) {
 			// Only wire up pending-message/draft sync once the chat URI has been
@@ -1845,7 +1846,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return this._activeClientService.getActiveClient(this._config.sessionType, this._config.connection.clientId);
 	}
 
-	private _ensureActiveClientForMessage(backendSession: URI): void {
+	private _ensureActiveClient(backendSession: URI): void {
 		const state = this._getSessionState(backendSession.toString());
 		const activeClient = this._getCurrentActiveClient();
 		const existing = state?.activeClients.find(c => c.clientId === activeClient.clientId);
@@ -2431,7 +2432,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// turn goes out. We only do this on turn start (not on session open)
 		// so that opening a session doesn't eagerly register this client while
 		// another client is in the middle of a turn.
-		this._ensureActiveClientForMessage(session);
+		this._ensureActiveClient(session);
 
 		// Model and agent selection now travel on the turn message itself rather
 		// than via the removed `session/modelChanged` / `session/agentChanged`

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -50,9 +50,10 @@
 
 import { SequencerByKey } from '../../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { equals } from '../../../../../../base/common/objects.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
@@ -72,6 +73,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatConfiguration, getChatPermissionLevelFromDefaultConfiguration, type IChatDefaultConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IAgentHostNewSessionFolderService, computeWorkingDirectories } from './agentHostNewSessionFolderService.js';
+import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
 import { type IAgentHostImportConversation, IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
@@ -194,6 +196,7 @@ type ProvisionalOperationResult = URI | void;
 
 interface IEntry {
 	readonly provider: string;
+	readonly activeClientSync: DisposableStore;
 	generation: IProvisionalGeneration | undefined;
 	/**
 	 * Workbench-owned snapshot of session-config values for this provisional.
@@ -251,6 +254,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IAgentHostImportConversationStore private readonly _importConversationStore: IAgentHostImportConversationStore,
+		@IAgentHostActiveClientService private readonly _activeClientService: IAgentHostActiveClientService,
 	) {
 		super();
 
@@ -371,16 +375,37 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		if (this._rebound.has(sessionResource)) {
 			return undefined;
 		}
-		const entry: IEntry = {
-			provider,
-			generation: undefined,
-			config: { ...(this._getInitialConfig() ?? {}) },
-			configVersion: 0,
-			workingDirectory,
-			disposed: false,
-		};
+		const entry = this._createEntry(provider, { ...(this._getInitialConfig() ?? {}) }, 0, workingDirectory);
 		this._entries.set(sessionResource, entry);
 		return entry;
+	}
+
+	private _createEntry(provider: string, config: Record<string, unknown>, configVersion: number, workingDirectory: URI | undefined, resolvedConfig?: ResolveSessionConfigResult): IEntry {
+		const entry: IEntry = {
+			provider,
+			activeClientSync: new DisposableStore(),
+			generation: undefined,
+			config,
+			configVersion,
+			workingDirectory,
+			resolvedConfig,
+			disposed: false,
+		};
+		entry.activeClientSync.add(autorun(reader => {
+			this._activeClientService.getCustomizations(`agent-host-${provider}`).read(reader);
+			this._publishActiveClient(entry);
+		}));
+		return entry;
+	}
+
+	private _publishActiveClient(entry: IEntry): void {
+		if (entry.disposed || !entry.generation) {
+			return;
+		}
+		this._agentHostService.dispatch(entry.generation.backendSession.toString(), {
+			type: ActionType.SessionActiveClientSet,
+			activeClient: this._activeClientService.getActiveClient(`agent-host-${entry.provider}`, this._agentHostService.clientId),
+		});
 	}
 
 	/**
@@ -457,6 +482,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 
 			const previous = entry.generation;
 			entry.generation = { backendSession: created, workingDirectory };
+			this._publishActiveClient(entry);
 			this._onDidChange.fire(sessionResource);
 			if (previous) {
 				await this._disposeBackend(previous.backendSession, 'replaced provisional generation');
@@ -577,17 +603,13 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 
 				const oldGeneration = oldEntry.generation;
 				// Publish the real mapping before retiring the untitled entry so consumers never observe a partial swap.
-				this._entries.set(newSessionResource, {
-					provider,
-					generation: { backendSession: created, workingDirectory: targetWorkingDirectory },
-					config,
-					configVersion,
-					workingDirectory: targetWorkingDirectory,
-					resolvedConfig: oldEntry.resolvedConfig,
-					disposed: false,
-				});
+				const newEntry = this._createEntry(provider, config, configVersion, targetWorkingDirectory, oldEntry.resolvedConfig);
+				newEntry.generation = { backendSession: created, workingDirectory: targetWorkingDirectory };
+				this._entries.set(newSessionResource, newEntry);
+				this._publishActiveClient(newEntry);
 				this._entries.delete(oldSessionResource);
 				oldEntry.disposed = true;
+				oldEntry.activeClientSync.dispose();
 				this._resolvedConfigs.delete(oldSessionResource);
 				this._resolvedConfigRequestSeq.delete(oldSessionResource);
 				this._rebound.add(oldSessionResource);
@@ -665,6 +687,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			return Promise.resolve();
 		}
 		entry.disposed = true;
+		entry.activeClientSync.dispose();
 		this._entries.delete(sessionResource);
 		this._onDidChange.fire(sessionResource);
 		return this._queue(sessionResource, async () => {
@@ -680,6 +703,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		// awaiting in `dispose()` to keep workbench teardown synchronous.
 		for (const [, entry] of this._entries) {
 			entry.disposed = true;
+			entry.activeClientSync.dispose();
 			if (entry.generation) {
 				this._agentHostService.disposeSession(entry.generation.backendSession).catch(() => { /* swallow on shutdown */ });
 			}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -109,6 +109,10 @@ interface IMcpBuiltinItemEntry {
 
 export type AgentHostMcpServer = ReturnType<IAgentHostCustomizationService['getMcpServers']>[number];
 
+export function createBuiltinActiveSessionMcpEntries(servers: readonly AgentHostMcpServer[]): readonly IMcpSessionServerItemEntry[] {
+	return servers.map(server => ({ type: 'session-server-item', server }));
+}
+
 type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry;
 
 type McpStatusKind = McpConnectionState.Kind | McpServerStatus | 'disabled';
@@ -1234,9 +1238,7 @@ export class McpListWidget extends Disposable {
 			}
 		}
 		const activeSessionOnlyServers = activeSessionMatcher.unmatched(query);
-		for (const server of activeSessionOnlyServers) {
-			groups[0].entries.push({ type: 'session-server-item', server });
-		}
+		const activeSessionBuiltinEntries = createBuiltinActiveSessionMcpEntries(activeSessionOnlyServers);
 
 		// Show empty state only when there are no servers at all (not when filtered to empty)
 		if (this.filteredServers.length === 0 && builtinServers.length === 0 && activeSessionOnlyServers.length === 0) {
@@ -1323,7 +1325,7 @@ export class McpListWidget extends Disposable {
 			isFirst = false;
 		}
 
-		if (otherBuiltinServers.length > 0) {
+		if (otherBuiltinServers.length > 0 || activeSessionBuiltinEntries.length > 0) {
 			const collapsed = this.collapsedGroups.has('builtin');
 			entries.push({
 				type: 'group-header',
@@ -1331,7 +1333,7 @@ export class McpListWidget extends Disposable {
 				scope: 'builtin',
 				label: localize('builtInGroup', "Built-in"),
 				icon: builtinIcon,
-				count: otherBuiltinServers.length,
+				count: otherBuiltinServers.length + activeSessionBuiltinEntries.length,
 				isFirst,
 				description: localize('builtInGroupDescription', "MCP servers built into VS Code. These are available automatically."),
 				collapsed,
@@ -1340,6 +1342,7 @@ export class McpListWidget extends Disposable {
 				for (const { server, activeSessionServer } of otherBuiltinServers) {
 					entries.push(createBuiltinEntry(server, activeSessionServer));
 				}
+				entries.push(...activeSessionBuiltinEntries);
 			}
 			isFirst = false;
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentCustomizationItemProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentCustomizationItemProvider.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { CustomizationType, type AgentCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentCustomizationItemProvider } from '../../../browser/agentSessions/agentHost/agentCustomizationItemProvider.js';
+import { NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
+import { AICustomizationSources } from '../../../common/aiCustomizationWorkspaceService.js';
+import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
+
+suite('AgentCustomizationItemProvider', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('surfaces draft agents in management customizations before session state exists', async () => {
+		class TestCustomizationService extends NullAgentHostCustomizationService {
+			override getWorkingDirectories(): readonly string[] {
+				return ['file:///workspace'];
+			}
+		}
+
+		const provider = disposables.add(new AgentCustomizationItemProvider(
+			'local',
+			undefined,
+			undefined,
+			upcastPartial<IFileService>({}),
+			new NullLogService(),
+			new TestCustomizationService(),
+		));
+		const agent: AgentCustomization = {
+			type: CustomizationType.Agent,
+			id: 'file:///workspace/.github/agents/reviewer.agent.md',
+			uri: 'file:///workspace/.github/agents/reviewer.agent.md',
+			name: 'Reviewer',
+			description: 'Reviews changes',
+			disableUserInvocation: true,
+		};
+		provider.setDraftCustomAgents(observableValue<readonly AgentCustomization[]>('draftAgents', [agent]));
+
+		const items = await provider.provideChatSessionCustomizations(URI.parse('agent-host-codex:///draft'), CancellationToken.None);
+
+		assert.deepStrictEqual(items, [{
+			itemKey: agent.id,
+			uri: URI.parse(agent.uri),
+			type: PromptsType.agent,
+			name: agent.name,
+			description: agent.description,
+			source: AICustomizationSources.local,
+			extensionId: undefined,
+			pluginUri: undefined,
+			enabled: true,
+			userInvocable: false,
+		}]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentCustomizationItemProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentCustomizationItemProvider.test.ts
@@ -4,18 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { FileService } from '../../../../../../platform/files/common/fileService.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
-import { CustomizationType, type AgentCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CustomizationType, type AgentCustomization, type ClientPluginCustomization, type Customization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { AgentCustomizationItemProvider } from '../../../browser/agentSessions/agentHost/agentCustomizationItemProvider.js';
 import { NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { AICustomizationSources } from '../../../common/aiCustomizationWorkspaceService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
+import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../../../../workbench/services/agentHost/common/agentHostFileSystemService.js';
 
 suite('AgentCustomizationItemProvider', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -59,5 +63,66 @@ suite('AgentCustomizationItemProvider', () => {
 			enabled: true,
 			userInvocable: false,
 		}]);
+	});
+
+	test('surfaces draft bundle agents skills and instructions before session state exists', async () => {
+		const bundleUri = URI.from({ scheme: SYNCED_CUSTOMIZATION_SCHEME, path: '/bundle' });
+		const workspaceAgentUri = URI.file('/workspace/.github/agents/reviewer.agent.md');
+		const workspaceSkillUri = URI.file('/workspace/.github/skills/review/SKILL.md');
+		const workspaceInstructionsUri = URI.file('/workspace/.github/instructions/review.instructions.md');
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(SYNCED_CUSTOMIZATION_SCHEME, disposables.add(new InMemoryFileSystemProvider())));
+		await fileService.writeFile(URI.joinPath(bundleUri, 'agents', 'reviewer.agent.md'), VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews changes\n---\nReview carefully.'));
+		await fileService.writeFile(URI.joinPath(bundleUri, 'skills', 'review', 'SKILL.md'), VSBuffer.fromString('---\nname: Review Skill\ndescription: Reviews code\n---\nReview code.'));
+		await fileService.writeFile(URI.joinPath(bundleUri, 'rules', 'review.instructions.md'), VSBuffer.fromString('---\nname: Review Instructions\ndescription: Review rules\n---\nFollow review rules.'));
+
+		class TestCustomizationService extends NullAgentHostCustomizationService {
+			override getWorkingDirectories(): readonly string[] {
+				return ['file:///workspace'];
+			}
+			override getCustomizations(): readonly Customization[] {
+				return [];
+			}
+		}
+
+		const origins = new Map([
+			[URI.joinPath(bundleUri, 'agents', 'reviewer.agent.md').toString(), workspaceAgentUri],
+			[URI.joinPath(bundleUri, 'skills', 'review', 'SKILL.md').toString(), workspaceSkillUri],
+			[URI.joinPath(bundleUri, 'rules', 'review.instructions.md').toString(), workspaceInstructionsUri],
+		]);
+		const provider = disposables.add(new AgentCustomizationItemProvider(
+			'local',
+			undefined,
+			syncedUri => {
+				const uri = origins.get(syncedUri.toString());
+				return uri ? { uri, source: AICustomizationSources.local } : undefined;
+			},
+			fileService,
+			new NullLogService(),
+			new TestCustomizationService(),
+		));
+		provider.setDraftCustomAgents(observableValue<readonly AgentCustomization[]>('draftAgents', [{
+			type: CustomizationType.Agent,
+			id: workspaceAgentUri.toString(),
+			uri: workspaceAgentUri.toString(),
+			name: 'Reviewer',
+			description: 'Reviews changes',
+		}]));
+		provider.setDraftCustomizations(observableValue<readonly ClientPluginCustomization[]>('draftCustomizations', [{
+			type: CustomizationType.Plugin,
+			id: bundleUri.toString(),
+			uri: bundleUri.toString(),
+			name: 'VS Code Synced Data',
+			enabled: true,
+			nonce: '1',
+		}]));
+
+		const items = await provider.provideChatSessionCustomizations(URI.parse('agent-host-codex:///draft'), CancellationToken.None);
+
+		assert.deepStrictEqual(items.map(item => ({ type: item.type, name: item.name, uri: item.uri.toString() })), [
+			{ type: PromptsType.agent, name: 'Reviewer', uri: workspaceAgentUri.toString() },
+			{ type: PromptsType.instructions, name: 'Review Instructions', uri: workspaceInstructionsUri.toString() },
+			{ type: PromptsType.skill, name: 'Review Skill', uri: workspaceSkillUri.toString() },
+		]);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -922,6 +922,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 			customizations: [...(customizationsByType.get(sessionType)?.get() ?? [])],
 		}),
 		getCustomizations: (sessionType: string) => derived(reader => customizationsByType.get(sessionType)?.read(reader) ?? []),
+		getCustomAgents: () => constObservable([]),
 		getClientTools: () => constObservable<readonly ToolDefinition[]>([]),
 	};
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -10287,8 +10287,8 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(activeClientActions[0].channel, sessionResource.toString());
 		});
 
-		test('dispatches activeClientSet on first turn when restoring a session where current client customizations are stale', async () => {
-			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables);
+		test('refreshes stale customizations on open when the current client is already active', async () => {
+			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
 			const customizations = observableValue<ClientPluginCustomization[]>('customizations', [
 				{ type: CustomizationType.Plugin, id: 'file:///plugin-new', uri: 'file:///plugin-new', name: 'Plugin New', enabled: true },
 			]);
@@ -10322,24 +10322,72 @@ suite('AgentHostChatContribution', () => {
 				connectionAuthority: 'local',
 			}));
 
-			// Opening the session does NOT re-claim with fresh customizations.
+			// Opening refreshes this client's stale customizations without claiming
+			// a session where only another client is active.
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
 			disposables.add(toDisposable(() => chatSession.dispose()));
-			assert.strictEqual(
-				agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientSet').length,
-				0,
-				'no dispatch expected on session open',
-			);
-
-			// The fresh customization set is published on first turn.
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, { sessionResource });
-			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
-			await turnPromise;
 
 			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientSet');
 			assert.strictEqual(activeClientActions.length, 1);
 			const activeClientAction = activeClientActions[0].action as { type: string; activeClient: { customizations?: ClientPluginCustomization[] } };
 			assert.strictEqual(activeClientAction.type, 'session/activeClientSet');
+			assert.deepStrictEqual(activeClientAction.activeClient.customizations, [
+				{ type: CustomizationType.Plugin, id: 'file:///plugin-new', uri: 'file:///plugin-new', name: 'Plugin New', enabled: true },
+			]);
+		});
+
+		test('refreshes customizations when the current active client hydrates after open', async () => {
+			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<ClientPluginCustomization[]>('customizations', [
+				{ type: CustomizationType.Plugin, id: 'file:///plugin-new', uri: 'file:///plugin-new', name: 'Plugin New', enabled: true },
+			]);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations }));
+			const sessionResource = AgentSession.uri('copilot', 'late-active-client');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClients: [],
+			});
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+			agentHostService.dispatchedActions.length = 0;
+
+			agentHostService.fireAction({
+				channel: sessionResource.toString(),
+				action: {
+					type: ActionType.SessionActiveClientSet,
+					activeClient: {
+						clientId: agentHostService.clientId,
+						tools: [],
+						customizations: [],
+					},
+				},
+				serverSeq: 1,
+				origin: undefined,
+			});
+
+			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === ActionType.SessionActiveClientSet);
+			assert.strictEqual(activeClientActions.length, 1);
+			const activeClientAction = activeClientActions[0].action as { activeClient: { customizations?: ClientPluginCustomization[] } };
 			assert.deepStrictEqual(activeClientAction.activeClient.customizations, [
 				{ type: CustomizationType.Plugin, id: 'file:///plugin-new', uri: 'file:///plugin-new', name: 'Plugin New', enabled: true },
 			]);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -360,10 +360,10 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 
 		// Dispatch should have happened before the promise resolves (re-resolve
 		// is still blocked).
-		assert.strictEqual(agentHost.dispatched.length, 1, 'dispatched before re-resolve await');
-		assert.strictEqual(agentHost.dispatched[0].type, ActionType.SessionConfigChanged);
-		assert.deepStrictEqual(agentHost.dispatched[0].config, { isolation: 'worktree' });
-		assert.strictEqual(agentHost.dispatched[0].channel, agentHost.createCalls[0].session?.toString());
+		const configChanged = agentHost.dispatched.filter(action => action.type === ActionType.SessionConfigChanged);
+		assert.strictEqual(configChanged.length, 1, 'dispatched before re-resolve await');
+		assert.deepStrictEqual(configChanged[0].config, { isolation: 'worktree' });
+		assert.strictEqual(configChanged[0].channel, agentHost.createCalls[0].session?.toString());
 
 		// Unblock so the queued re-resolve completes and the outer promise settles.
 		blocked.complete({ schema: makeSchema(false), values: { isolation: 'worktree' } });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -17,7 +18,7 @@ import { ILogService, NullLogService } from '../../../../../../platform/log/comm
 import { IAgentCreateSessionConfig, IAgentHostService, IAgentResolveSessionConfigParams } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import type { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import type { ConfigSchema } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationType, type ClientPluginCustomization, type ConfigSchema, type SessionActiveClient } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IWorkspaceContextService, IWorkspace, IWorkspaceFolder, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
@@ -27,17 +28,20 @@ import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostUntitledProvisionalSessionService, IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { AgentHostNewSessionFolderService, IAgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 import { AgentHostImportConversationStore, IAgentHostImportConversationStore } from '../../../browser/agentSessions/agentHost/agentHostImportConversationStore.js';
+import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 
 // ---- Mocks -----------------------------------------------------------------
 
 interface IDispatchedAction {
 	readonly channel: string;
 	readonly type: string;
-	readonly config: Record<string, unknown>;
+	readonly config?: Record<string, unknown>;
+	readonly activeClient?: SessionActiveClient;
 }
 
 class MockAgentHostService extends mock<IAgentHostService>() {
 	declare readonly _serviceBrand: undefined;
+	override readonly clientId = 'test-client';
 
 	readonly createCalls: IAgentCreateSessionConfig[] = [];
 	readonly disposed: URI[] = [];
@@ -164,6 +168,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 	let workspaceName: string | undefined;
 	let workbenchState: WorkbenchState;
 	let isSessionsWindow: boolean;
+	let customizations: ReturnType<typeof observableValue<readonly ClientPluginCustomization[]>>;
 
 	setup(async () => {
 		agentHost = ds.add(new MockAgentHostService());
@@ -199,6 +204,11 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		insta.stub(IAgentHostNewSessionFolderService, folderService);
 		importStore = new AgentHostImportConversationStore();
 		insta.stub(IAgentHostImportConversationStore, importStore);
+		customizations = observableValue<readonly ClientPluginCustomization[]>('customizations', []);
+		insta.stub(IAgentHostActiveClientService, {
+			getCustomizations: () => customizations,
+			getActiveClient: (_sessionType: string, clientId: string) => ({ clientId, tools: [], customizations: [...customizations.get()] }),
+		} as Partial<IAgentHostActiveClientService> as IAgentHostActiveClientService);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());
 	});
@@ -223,6 +233,39 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 			createCount: 1,
 			config: { isolation: 'folder' },
 		});
+	});
+
+	test('publishes active-client customizations before the first prompt and keeps them updated', async () => {
+		const first: ClientPluginCustomization = {
+			type: CustomizationType.Plugin,
+			id: 'plugin:first',
+			uri: 'file:///plugins/first',
+			name: 'First',
+			enabled: true,
+		};
+		const second: ClientPluginCustomization = {
+			type: CustomizationType.Plugin,
+			id: 'plugin:second',
+			uri: 'file:///plugins/second',
+			name: 'Second',
+			enabled: true,
+		};
+		customizations.set([first], undefined);
+
+		await provisional.getOrCreate(untitledChatUri('customizations'), 'copilot', undefined);
+		customizations.set([first, second], undefined);
+
+		assert.deepStrictEqual(agentHost.dispatched
+			.filter(action => action.type === ActionType.SessionActiveClientSet)
+			.map(action => action.activeClient), [{
+				clientId: 'test-client',
+				tools: [],
+				customizations: [first],
+			}, {
+				clientId: 'test-client',
+				tools: [],
+				customizations: [first, second],
+			}]);
 	});
 
 	test('getOrCreate includes Editor multi-root workspace metadata', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
@@ -59,18 +59,21 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		}]);
 	});
 
-	test('combines extension storage entries with built-in skills', async () => {
-		const userAgent = URI.file('/user/agents/foo.agent.md');
+	test('combines workspace, extension, and built-in storage entries', async () => {
+		const workspaceAgent = URI.file('/workspace/.github/agents/reviewer.agent.md');
+		const extensionAgent = URI.file('/extension/agents/foo.agent.md');
 		const builtinSkill = URI.file('/builtin/merge/SKILL.md');
 		const promptsService = makePromptsService(new Map([
-			[`${PromptsType.agent}/${PromptsStorage.extension}`, [makePromptPath(userAgent, PromptsType.agent, PromptsStorage.extension)]],
+			[`${PromptsType.agent}/${PromptsStorage.local}`, [makePromptPath(workspaceAgent, PromptsType.agent, PromptsStorage.local)]],
+			[`${PromptsType.agent}/${PromptsStorage.extension}`, [makePromptPath(extensionAgent, PromptsType.agent, PromptsStorage.extension)]],
 			[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [makePromptPath(builtinSkill, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage)]],
 		]));
 
 		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
 
 		assert.deepStrictEqual(result.map((e: { uri: URI; type: PromptsType; source: unknown; disabled: boolean }) => ({ uri: e.uri.toString(), type: e.type, source: e.source, disabled: e.disabled })), [
-			{ uri: userAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.extension, disabled: false },
+			{ uri: workspaceAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.local, disabled: false },
+			{ uri: extensionAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.extension, disabled: false },
 			{ uri: builtinSkill.toString(), type: PromptsType.skill, source: AICustomizationSources.builtin, disabled: false },
 		]);
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -744,8 +744,12 @@ suite('resolveLocalCustomAgents', () => {
 				'---',
 				'Agent instructions',
 			].join('\n')]])),
+			makePromptsService(new Map([
+				[`${PromptsType.agent}/${PromptsStorage.plugin}`, [makePromptPath(agentUri, PromptsType.agent, PromptsStorage.plugin)]],
+			])),
 			new FakeSyncProvider(),
 			makeAgentPluginService([plugin]),
+			SessionType.CopilotCLI,
 		);
 
 		assert.deepStrictEqual(agents, [{
@@ -755,6 +759,35 @@ suite('resolveLocalCustomAgents', () => {
 			name: 'Inbox',
 			description: 'Triage GitHub notifications',
 			disableUserInvocation: true,
+		}]);
+	});
+
+	test('includes loose workspace agents in the pre-session picker', async () => {
+		const agentUri = URI.file('/workspace/.github/agents/reviewer.agent.md');
+		const agents = await resolveLocalCustomAgents(
+			makeFileService(new Map(), new Map([[agentUri.toString(), [
+				'---',
+				'name: Reviewer',
+				'description: Review workspace changes',
+				'user-invocable: true',
+				'---',
+				'Agent instructions',
+			].join('\n')]])),
+			makePromptsService(new Map([
+				[`${PromptsType.agent}/${PromptsStorage.local}`, [makePromptPath(agentUri, PromptsType.agent, PromptsStorage.local)]],
+			])),
+			new FakeSyncProvider(),
+			makeAgentPluginService(),
+			SessionType.CopilotCLI,
+		);
+
+		assert.deepStrictEqual(agents, [{
+			type: 'agent',
+			id: agentUri.toString(),
+			uri: agentUri.toString(),
+			name: 'Reviewer',
+			description: 'Review workspace changes',
+			disableUserInvocation: undefined,
 		}]);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
@@ -13,7 +14,7 @@ import { PluginFormat } from '../../../../../../platform/agentPlugins/common/plu
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
-import { resolveCustomizationRefs, shouldSyncWorkspaceDotMcp } from '../../../browser/agentSessions/agentHost/agentHostLocalCustomizations.js';
+import { resolveCustomizationRefs, resolveLocalCustomAgents, shouldSyncWorkspaceDotMcp } from '../../../browser/agentSessions/agentHost/agentHostLocalCustomizations.js';
 import { type ISyncableFile, type ISyncableMcpServer, type SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { BUILTIN_STORAGE } from '../../../common/aiCustomizationWorkspaceService.js';
 import { type ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
@@ -78,18 +79,23 @@ function makeAgentPluginService(plugins: readonly IAgentPlugin[] = []): IAgentPl
 	} as unknown as IAgentPluginService;
 }
 
-function makePlugin(uri: URI, options: { label?: string; enabled?: boolean; mcpServers?: number } = {}): IAgentPlugin {
-	const { label = 'Plugin', enabled = true, mcpServers = 0 } = options;
+function makePlugin(uri: URI, options: { label?: string; enabled?: boolean; agents?: number; mcpServers?: number } = {}): IAgentPlugin {
+	const { label = 'Plugin', enabled = true, agents = 0, mcpServers = 0 } = options;
 	return {
 		uri,
 		format: PluginFormat.Copilot,
 		label,
 		enablement: observableValue('enablement', enabled ? ContributionEnablementState.EnabledProfile : ContributionEnablementState.DisabledProfile),
+		hooks: observableValue('hooks', []),
+		commands: observableValue('commands', []),
+		skills: observableValue('skills', []),
+		agents: observableValue('agents', Array.from({ length: agents }, (_, index) => ({ uri: URI.joinPath(uri, 'agents', `agent-${index}.agent.md`), name: `agent-${index}` }))),
+		instructions: observableValue('instructions', []),
 		mcpServerDefinitions: observableValue('mcpServers', new Array(mcpServers).fill({})),
 	} as unknown as IAgentPlugin;
 }
 
-function makeFileService(stats: ReadonlyMap<string, { mtime: number }> = new Map()): IFileService {
+function makeFileService(stats: ReadonlyMap<string, { mtime: number }> = new Map(), contents: ReadonlyMap<string, string> = new Map()): IFileService {
 	return {
 		async stat(uri: URI) {
 			const known = stats.get(uri.toString());
@@ -97,6 +103,13 @@ function makeFileService(stats: ReadonlyMap<string, { mtime: number }> = new Map
 				return known;
 			}
 			throw new Error(`no stat for ${uri.toString()}`);
+		},
+		async readFile(uri: URI) {
+			const content = contents.get(uri.toString());
+			if (content !== undefined) {
+				return { resource: uri, value: VSBuffer.fromString(content) };
+			}
+			throw new Error(`no content for ${uri.toString()}`);
 		},
 	} as unknown as IFileService;
 }
@@ -335,6 +348,24 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 		assert.strictEqual(bundler.received.length, 0);
 		assert.deepStrictEqual(refs.map(r => ({ uri: r.uri, name: r.name })), [
 			{ uri: pluginUri.toString(), name: 'MCP Only' },
+		]);
+	});
+
+	test('includes plugins discovered through their agents before prompt-file hydration', async () => {
+		const pluginUri = URI.file('/plugins/agent-only');
+		const refs = await resolveCustomizationRefs(
+			makeFileService(),
+			makePromptsService(new Map()),
+			new FakeSyncProvider(),
+			makeAgentPluginService([makePlugin(pluginUri, { label: 'Agent Only', agents: 1 })]),
+			makeMcpService(),
+			makeConfigurationResolverService(),
+			new FakeBundler() as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+
+		assert.deepStrictEqual(refs.map(ref => ({ uri: ref.uri, name: ref.name })), [
+			{ uri: pluginUri.toString(), name: 'Agent Only' },
 		]);
 	});
 
@@ -689,6 +720,42 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 		assert.strictEqual(bundler.received.length, 1);
 		assert.deepStrictEqual(bundler.receivedMcp[0].map(s => s.name), ['srv']);
 		assert.strictEqual(refs.length, 1);
+	});
+});
+
+suite('resolveLocalCustomAgents', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('parses agent frontmatter for the pre-session picker', async () => {
+		const pluginUri = URI.file('/plugins/github-inbox');
+		const agentUri = URI.joinPath(pluginUri, 'agents', 'inbox.agent.md');
+		const plugin = {
+			...makePlugin(pluginUri),
+			agents: observableValue('agents', [{ uri: agentUri, name: 'inbox.agent' }]),
+		} as IAgentPlugin;
+
+		const agents = await resolveLocalCustomAgents(
+			makeFileService(new Map(), new Map([[agentUri.toString(), [
+				'---',
+				'name: Inbox',
+				'description: Triage GitHub notifications',
+				'user-invocable: false',
+				'---',
+				'Agent instructions',
+			].join('\n')]])),
+			new FakeSyncProvider(),
+			makeAgentPluginService([plugin]),
+		);
+
+		assert.deepStrictEqual(agents, [{
+			type: 'agent',
+			id: agentUri.toString(),
+			uri: agentUri.toString(),
+			name: 'Inbox',
+			description: 'Triage GitHub notifications',
+			disableUserInvocation: true,
+		}]);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/mcpListWidget.test.ts
@@ -18,6 +18,7 @@ import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 import {
 	AgentHostMcpServer,
 	authenticateMcpServer,
+	createBuiltinActiveSessionMcpEntries,
 	getActiveSessionServerOptionsActions,
 	getAgentHostMcpServerEnablementActions,
 	getLocalMcpServerEnablementActions,
@@ -80,6 +81,15 @@ function trackActions(store: Pick<DisposableStore, 'add'>, actions: readonly IAc
 
 suite('mcpListWidget', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('classifies active-session-only MCP servers as built-in entries', () => {
+		const server = createAgentHostServer({ name: 'node_repl' });
+
+		assert.deepStrictEqual(createBuiltinActiveSessionMcpEntries([server]), [{
+			type: 'session-server-item',
+			server,
+		}]);
+	});
 
 	suite('getSessionEnablementAction', () => {
 		test('labels as Disable (Session) when the server is enabled and toggles it off', () => {

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -72,7 +72,6 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		'chat.extensionUnification.enabled',
 		'chat.agentHost.enabled',
 		'chat.agentHost.claudeAgent.enabled',
-		'chat.agentHost.codexAgent.enabled',
 		'chat.agentHost.byokModels.enabled',
 		'chat.agents.claude.preferAgentHost',
 		'chat.editor.claude.preferAgentHost',
@@ -101,7 +100,6 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 	private readonly extensionUnificationEnabled = new ChangeObserver('boolean');
 	private readonly agentHostEnabled = new ChangeObserver('boolean');
 	private readonly agentHostClaudeAgentEnabled = new ChangeObserver('boolean');
-	private readonly agentHostCodexAgentEnabled = new ChangeObserver('boolean');
 	private readonly agentHostByokModelsEnabled = new ChangeObserver('boolean');
 	private readonly agentsClaudePreferAgentHost = new ChangeObserver('boolean');
 	private readonly editorClaudePreferAgentHost = new ChangeObserver('boolean');
@@ -208,9 +206,8 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		processChanged(this.agentHostEnabled.handleChange(config.chat?.agentHost?.enabled));
 		processChanged(this.agentHostByokModelsEnabled.handleChange(config.chat?.agentHost?.byokModels?.enabled));
 
-		// Provider registration and implementation preferences are read at spawn.
+		// Claude provider registration and implementation preferences are read at spawn.
 		processChanged(this.agentHostClaudeAgentEnabled.handleChange(config.chat?.agentHost?.claudeAgent?.enabled));
-		processChanged(this.agentHostCodexAgentEnabled.handleChange(config.chat?.agentHost?.codexAgent?.enabled));
 		processChanged(this.agentsClaudePreferAgentHost.handleChange(config.chat?.agents?.claude?.preferAgentHost));
 		processChanged(this.editorClaudePreferAgentHost.handleChange(config.chat?.editor?.claude?.preferAgentHost));
 		processChanged(this.editorCodexPreferAgentHost.handleChange(config.chat?.editor?.codex?.preferAgentHost));

--- a/src/vs/workbench/contrib/relauncher/test/browser/relauncher.test.ts
+++ b/src/vs/workbench/contrib/relauncher/test/browser/relauncher.test.ts
@@ -81,15 +81,15 @@ suite('SettingsChangeRelauncher', () => {
 		assert.strictEqual(restartCount, 1, 'should restart when confirmed');
 	});
 
-	test('prompts to restart when chat.agentHost.codexAgent.enabled changes', async () => {
+	test('does not prompt to restart when chat.agentHost.codexAgent.enabled changes', async () => {
 		confirmResult = true;
 		await changeSetting(
 			'chat.agentHost.codexAgent.enabled',
 			() => ({ chat: { agentHost: { codexAgent: { enabled: true } } } }),
 			c => c.chat.agentHost.codexAgent.enabled = false);
 
-		assert.strictEqual(confirmCount, 1, 'should prompt to restart');
-		assert.strictEqual(restartCount, 1, 'should restart when confirmed');
+		assert.strictEqual(confirmCount, 0, 'should not prompt to restart');
+		assert.strictEqual(restartCount, 0, 'should not restart');
 	});
 
 	test('prompts to restart when chat.agentHost.byokModels.enabled changes', async () => {


### PR DESCRIPTION
## Summary
- enable the Codex Agent Host provider at runtime without restarting
- expose and apply custom `.agent.md` agents in Agents and Editor windows
- propagate plugin instructions, skills, and MCP servers into Codex sessions
- surface draft bundled agents, skills, and instructions in customization management before backend session state exists
- de-duplicate recovered workspace agents and group Codex-native MCP servers as Built-In
- add real Codex App Server integration coverage backed by the mock LLM server

## Verification
- live verified Codex model registration after enabling the setting in a running process
- live prompted Codex with `Live Reviewer` in both Editor and Agents windows; both returned `LIVE_CODEX_AGENT_INSTRUCTION_MARKER`
- verified the Agents window sends the original workspace `.agent.md` URI and Codex resolves its synced bundle copy
- verified selected-agent instructions and always-on rules in the developer message, plus skills and MCP tools in mocked-LLM App Server requests
- live verified customization management in both Editor and Agents windows against `~/workspace/vscode`: Codex shows workspace skills and instructions, Claude shows exactly three workspace agents, and Codex groups two workspace MCPs separately from GitHub plus its three native Built-In MCPs
- compile, 334 relevant browser tests, mocked Codex integration tests, ESLint, pre-commit hygiene, and layer checks pass
