### PR TITLE
Fix duplicated word in notebook.cellToolbarLocation setting description

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},


### PR DESCRIPTION
The setting description renders in the Settings UI when the `notebook.cellToolbarLocation` object is expanded, so the doubled word is user-visible.

Per the [contributing guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute), spelling fixes in translatable strings are welcome.