### PR TITLE
Force custom menus in Integrated Browser smoke tests

### DIFF
--- a/test/smoke/src/areas/browserView/browserView.test.ts
+++ b/test/smoke/src/areas/browserView/browserView.test.ts
@@ -48,7 +48,10 @@ export function setup(logger: Logger): void {
 				throw new Error('Integrated Browser smoke server did not expose a TCP address.');
 			}
 			baseUrl = `http://127.0.0.1:${address.port}`;
-			await app.workbench.settingsEditor.addUserSetting('workbench.browser.experimentalUserTools.enabled', 'true');
+			await app.workbench.settingsEditor.addUserSettings([
+				['workbench.browser.experimentalUserTools.enabled', 'true'],
+				['window.menuStyle', '"custom"'],
+			]);
 		});
 
 		afterEach(async () => {


### PR DESCRIPTION
The `Integrated Browser` smoke suite drives the browser toolbar overflow menu (`Site Permissions`) and the `Add to Chat` menu through HTML locators:

```
.monaco-menu-container:visible .action-menu-item
```

On macOS the default for `window.menuStyle` is quality dependent:

```ts
'default': product.quality !== 'stable' ? 'inherit' : (isMacintosh ? 'native' : 'inherit'),
```

So a stable build renders those menus as native OS menus, which never create a `.monaco-menu-container` element, while insiders renders custom HTML menus. Building both qualities from the same `release/1.132` commit reproduces this: the suite passes on insiders and fails on stable with

```
locator.waitFor: Timeout 30000ms exceeded.
  - waiting for locator('.monaco-menu-container:visible .action-menu-item').filter({ hasText: 'Site Permissions' }).last()
```

The follow-on `"after each" hook` timeout is a cascade: the native menu stays open, so closing the browser page in `afterEach` never completes. Retries cannot help because the mismatch is deterministic per quality.

This pins `window.menuStyle` to `custom` for the suite so the menu-driving helpers hit the DOM menus they assert on, regardless of build quality. The suite covers browser actions, not native menu integration.

Validation runs in CI.
