### PR TITLE
fix: guard notebook match selection against unmaterialized tree element (fixes #328427)

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2288,7 +2288,11 @@ export class SearchView extends ViewPane {
 
 						if (isIMatchInNotebook(match)) {
 							elemParent.showMatch(match);
-							if (!this.tree.getFocus().includes(match) || !this.tree.getSelection().includes(match)) {
+							// `updateMatchesForEditorWidget` rebuilds the notebook matches into new objects and
+							// fires a change that only queues an async refresh of the lazy tree, so `match` may not
+							// be materialized in the tree yet. Selecting or focusing it in that state throws
+							// `TreeError [SearchView] Tree element not found`. Guard on `hasNode` before touching the tree.
+							if (this.tree.hasNode(match) && (!this.tree.getFocus().includes(match) || !this.tree.getSelection().includes(match))) {
 								this.tree.setSelection([match], getSelectionKeyboardEvent());
 								this.tree.setFocus([match]);
 							}


### PR DESCRIPTION
-




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/30874254462) · opus48 · 468.6 AIC · ⌖ 16.6 AIC · ⊞ 18.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-id%3A+errors-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30874254462, workflow_id: errors-fix, run: https://github.com/microsoft/vscode-engineering/actions/runs/30874254462 -->

<!-- gh-aw-workflow-id: errors-fix -->
<!-- gh-aw-workflow-call-id: microsoft/vscode-engineering/errors-fix -->

Fixes microsoft/vscode#328427

---

### errors-fix-driver — cycle 1

**Trigger**: cron_review_comments · **Head**: `09e67c5` (pushed this cycle)

| Item | Action |
|------|--------|
| Review on `searchView.ts:2294` (in scope) | Fixed in `09e67c5` — condensed 4-line comment to one line (replied + resolved) |
| Review on `searchView.ts:2295` (await-refresh vs skip) | Replied + resolved — deliberate scope tradeoff; guard eliminates the crash, selection reconciliation deferred to a follow-up |

**Push**: yes — `09e67c5` · **Copilot rerequested**: ok

**Ready gate**: CI checks in progress + Copilot not yet re-run at new head → not marking ready this cycle

> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/30935033616) · opus48 · 159.5 AIC · ⌖ 10.8 AIC · ⊞ 20.5K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30935033616, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/30935033616 -->