### PR TITLE
Make Integrated Browser smoke tests deterministic across build qualities

### DIFF
--- a/test/smoke/src/areas/browserView/browserView.test.ts
+++ b/test/smoke/src/areas/browserView/browserView.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import type { Page } from '@playwright/test';
@@ -18,7 +19,10 @@ export function setup(logger: Logger): void {
 		installAllHandlers(
 			logger,
 			options => withFakeMediaDevice(options),
-			app => preseedChatExtensionEnablement(app.userDataPath)
+			async app => {
+				await preseedChatExtensionEnablement(app.userDataPath);
+				preseedSettings(app.userDataPath);
+			}
 		);
 
 		const comment = 'Smoke-test-comment';
@@ -28,7 +32,6 @@ export function setup(logger: Logger): void {
 		let baseUrl: string;
 
 		before(async function () {
-			const app = this.app as Application;
 			server = http.createServer((request, response) => {
 				const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
 				const count = (requestCounts.get(requestUrl.pathname) ?? 0) + 1;
@@ -48,7 +51,6 @@ export function setup(logger: Logger): void {
 				throw new Error('Integrated Browser smoke server did not expose a TCP address.');
 			}
 			baseUrl = `http://127.0.0.1:${address.port}`;
-			await app.workbench.settingsEditor.addUserSetting('workbench.browser.experimentalUserTools.enabled', 'true');
 		});
 
 		afterEach(async () => {
@@ -226,6 +228,33 @@ export function setup(logger: Logger): void {
 			await waitForWorkbenchUrl(app.code.driver.currentPage, lifecycleUrl);
 		});
 	});
+}
+
+/**
+ * Pre-seed the settings this suite depends on before the application starts.
+ *
+ * `window.menuStyle` must be written to disk rather than through the settings
+ * editor: `SettingsChangeRelauncher` watches it on Windows/Linux and would pop a
+ * modal "restart to take effect" dialog the moment the value changes at runtime,
+ * blocking the workbench. Seeding it up front means it is already in effect when
+ * the window opens, so nothing changes and no prompt appears.
+ *
+ * The suite drives the browser toolbar overflow and "Add to Chat" menus through
+ * DOM locators (`.monaco-menu-container`), which only exist for custom menus. The
+ * default is quality dependent on macOS (`native` for stable, `inherit` for
+ * insiders), so pinning `custom` keeps the suite deterministic across qualities.
+ */
+function preseedSettings(userDataDir: string | undefined): void {
+	if (!userDataDir) {
+		throw new Error('Cannot pre-seed Integrated Browser settings without a user data directory');
+	}
+
+	const settingsPath = path.join(userDataDir, 'User', 'settings.json');
+	fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+	fs.writeFileSync(settingsPath, JSON.stringify({
+		'window.menuStyle': 'custom',
+		'workbench.browser.experimentalUserTools.enabled': true,
+	}, null, 2));
 }
 
 function withFakeMediaDevice(options: ApplicationOptions): ApplicationOptions {


### PR DESCRIPTION
Ports #328969 and #328972 from `release/1.132` to `main`, squashed into a single change since the second PR was a fix-up of the first.

### Problem

The `Integrated Browser` suite drives the browser toolbar overflow menu (`Site Permissions`) and the `Add to Chat` menu through DOM locators:

```
.monaco-menu-container:visible .action-menu-item
```

On macOS the default for `window.menuStyle` is quality dependent:

```ts
'default': product.quality !== 'stable' ? 'inherit' : (isMacintosh ? 'native' : 'inherit'),
```

Stable therefore renders those as native OS menus, which never create a `.monaco-menu-container` element, so the suite passed on insiders and failed on stable built from the *same* commit:

```
locator.waitFor: Timeout 30000ms exceeded.
  - waiting for locator('.monaco-menu-container:visible .action-menu-item').filter({ hasText: 'Site Permissions' }).last()
```

The follow-on `"after each" hook` timeout was a cascade: the native menu stayed open, so closing the browser page never completed.

### Fix

Pin `window.menuStyle` to `custom` for the suite, so the menu-driving helpers hit the DOM menus they assert on regardless of build quality. The suite covers browser actions, not native menu integration.

The setting is seeded into `settings.json` **before** the application starts rather than written through the settings editor. That distinction matters: `window.menuStyle` is watched by [`SettingsChangeRelauncher`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts#L60), which on Windows/Linux treats a change to it as requiring a restart. Writing it at runtime popped a modal "A setting has changed that requires a restart to take effect." over the workbench and broke the first test on Linux CI:

```
locator.fill: Timeout 30000ms exceeded.
  - waiting for locator('.quick-input-widget:visible input[placeholder*="enter URL"]')
    - element is not visible
```

Seeding up front means the value is already in effect when the window opens, so nothing changes and no prompt appears. `workbench.browser.experimentalUserTools.enabled` moves with it — it is declared `experiment: { mode: 'startup' }`, so it is better applied at startup anyway — and the suite no longer touches the settings editor at all, matching the pattern already used by the Chat Sessions and Agents Window suites.

The underlying question of what the `window.menuStyle` default should be, and whether stable and insiders should diverge at all, is tracked separately in #328970.
