### PR TITLE
Conditional agent-window auth for signed-out users

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -30,6 +30,15 @@ export const enum AgentHostConfigKey {
 	 * the user's own credentials (BYO Anthropic — Phase 19).
 	 */
 	ClaudeUseCopilotProxy = 'claudeUseCopilotProxy',
+	/**
+	 * Experimentation flag for conditional agent-window auth. When true, a
+	 * session type that is usable without GitHub (e.g. Claude in native mode with
+	 * an existing local setup) lets the agent window open for a signed-out user
+	 * instead of forcing GitHub sign-in. The workbench forwards it here from the
+	 * `chat.agentHost.allowSignedOutWhenUsable` VS Code setting; when unset the
+	 * feature is dark (today's always-proxy behavior).
+	 */
+	AllowSignedOutWhenUsable = 'allowSignedOutWhenUsable',
 	CodexUsageSource = 'codexUsageSource',
 	/** Controls whether session-scoped file customizations come from local scan or SDK discovery. */
 	SessionCustomizationDiscoveryMode = 'sessionCustomizationDiscoveryMode',
@@ -98,6 +107,12 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		title: localize('agentHost.config.claudeUseCopilotProxy.title', "Route Claude Through Copilot"),
 		description: localize('agentHost.config.claudeUseCopilotProxy.description', "When enabled (the default), the Claude agent routes all requests through GitHub Copilot. When disabled, Claude talks to Anthropic directly using your own credentials (API key or Claude subscription)."),
 		default: true,
+	}),
+	[AgentHostConfigKey.AllowSignedOutWhenUsable]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.allowSignedOutWhenUsable.title', "Allow Signed-Out Agent Window"),
+		description: localize('agentHost.config.allowSignedOutWhenUsable.description', "Experimental. When enabled, the agent window opens without forcing GitHub sign-in as long as at least one agent is usable without GitHub (for example Claude in native mode with your own Anthropic API key). When disabled (the default), GitHub sign-in is required."),
+		default: false,
 	}),
 	[AgentHostConfigKey.CodexUsageSource]: schemaProperty<CodexUsageSource>({
 		type: 'string',

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -83,6 +83,21 @@ export const AgentHostClaudeMultiRootEnabledSettingId = 'chat.agentHost.claudeAg
  */
 export const AgentHostCodexMultiRootEnabledSettingId = 'chat.agentHost.codexAgent.multiRootEnabled';
 
+/**
+ * Experimentation setting id gating the conditional agent-window auth feature.
+ * When `true`, a session type that is usable without GitHub (e.g. Claude in
+ * native mode with an existing local setup) lets the agent window open for a
+ * signed-out user instead of forcing GitHub sign-in.
+ *
+ * This is the **workbench** VS Code setting id. The workbench registers the
+ * configuration schema and forwards the value into the agent-host root config
+ * under the short key `AgentHostConfigKey.AllowSignedOutWhenUsable`, which the
+ * Claude provider reads node-side via `getRootValue`. Until it is wired and
+ * enabled the root key is absent, so it reads `false` and behavior is identical
+ * to today.
+ */
+export const AgentHostAllowSignedOutWhenUsableSettingId = 'chat.agentHost.allowSignedOutWhenUsable';
+
 // The Copilot-CLI-specific setting IDs (`customTerminalTool`, `opus48Prompt`,
 // `reasoningEffortOverride`, `modelCapabilityOverrides`) live with their
 // root-config keys in `copilotCliConfig.ts`.
@@ -943,6 +958,24 @@ export const GITHUB_REPO_PROTECTED_RESOURCE: ProtectedResourceMetadata = {
 	scopes_supported: ['repo'],
 	required: false,
 };
+
+/**
+ * Pure decision: does this set of advertised protected resources require the
+ * user to be signed in to GitHub Copilot right now?
+ *
+ * Returns `true` iff the agent advertises the canonical GitHub Copilot
+ * protected resource ({@link GITHUB_COPILOT_PROTECTED_RESOURCE}) with
+ * `required !== false`. Provider-agnostic by design: an agent that drops the
+ * resource entirely (e.g. Claude in native mode) or advertises it with
+ * `required: false` (e.g. Codex on OpenAI) does not require a GitHub sign-in.
+ *
+ * An absent `required` field is treated the same as `true` (see
+ * {@link ProtectedResourceMetadata.required}).
+ */
+export function protectedResourcesRequireGitHubCopilotSignIn(resources: readonly ProtectedResourceMetadata[]): boolean {
+	return resources.some(resource =>
+		resource.resource === GITHUB_COPILOT_PROTECTED_RESOURCE.resource && resource.required !== false);
+}
 
 export interface IAgentCreateSessionConfig {
 	readonly provider?: AgentProvider;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -41,6 +41,7 @@ import { projectFromCopilotContext } from '../copilot/copilotGitProject.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildModelEnumerationOptions } from './claudeSdkOptions.js';
+import { detectExistingClaudeSetup, resolveClaudeTransportMode, type ClaudeTransportMode } from './claudeTransportMode.js';
 import { mapSessionMessagesToTurns, resolveForkAnchorUuid } from './claudeReplayMapper.js';
 import { getSubagentTranscript } from './claudeSubagentResolver.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
@@ -243,11 +244,13 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	/**
 	 * Resolved host transport mode (Phase 19). `proxy` (default) routes through
 	 * the Copilot-CAPI proxy; `native` talks to Anthropic directly on the user's
-	 * own credentials. Resolved once from the `ClaudeUseCopilotProxy` root
-	 * config value and kept current by an `onDidRootConfigChange` subscription.
-	 * Config changes affect FUTURE sessions only — never an in-flight subprocess.
+	 * own credentials. Resolved from the precedence in {@link resolveClaudeTransportMode}
+	 * (explicit `claudeUseCopilotProxy` override; else the experimentation flag,
+	 * GitHub sign-in state, and any existing local Claude setup) and kept current
+	 * by config-change and sign-in triggers. Config/auth changes affect FUTURE
+	 * sessions only — never an in-flight subprocess.
 	 */
-	private _transportMode: 'proxy' | 'native' = 'proxy';
+	private _transportMode: ClaudeTransportMode = 'proxy';
 
 	/**
 	 * Memoized teardown promise. Set on the first call to {@link shutdown},
@@ -479,29 +482,14 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// subprocesses keep their original transport. When native, kick off an
 		// initial model refresh since no GitHub auth (which would otherwise
 		// trigger it) is required.
+		//
+		// Resolution now depends on the `claudeUseCopilotProxy` setting, the
+		// experimentation flag, and GitHub sign-in state. The setting and flag
+		// both live in the root config, so `onDidRootConfigChange` covers them;
+		// the sign-in trigger is wired in {@link authenticate}.
 		this._transportMode = this._resolveTransportMode();
 		this._register(this._configurationService.onDidRootConfigChange(() => {
-			const next = this._resolveTransportMode();
-			if (next !== this._transportMode) {
-				this._transportMode = next;
-				// Proxy and native enumerate different catalogs. Do not retain
-				// models from the previous transport if the replacement cannot
-				// enumerate its own list.
-				this._models.set([], undefined);
-				void this._startModelRefresh();
-				// Flipping into proxy makes GitHub Copilot auth newly required.
-				// If no proxy handle was ever established, proactively ask the
-				// client to authenticate rather than waiting for the next command
-				// to fail with `AHP_AUTH_REQUIRED`. A handle persists across a
-				// proxy→native→proxy round-trip (cleared only on dispose), so this
-				// fires only when a credential is genuinely missing.
-				if (next === 'proxy' && !this._proxyHandle) {
-					this._onDidRequireAuth.fire({
-						resource: this._gitHubEndpointService.getCopilotResource().resource,
-						reason: AuthRequiredReason.Required,
-					});
-				}
-			}
+			this._applyTransportModeChange(this._resolveTransportMode());
 		}));
 		if (this._transportMode === 'native') {
 			// Only native bootstraps its model list here. Proxy mode fetches
@@ -516,10 +504,45 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		}
 	}
 
-	private _resolveTransportMode(): 'proxy' | 'native' {
-		// Defaults to proxied when the `claudeUseCopilotProxy` root value is unset.
-		const useProxy = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.ClaudeUseCopilotProxy) ?? true;
-		return useProxy ? 'proxy' : 'native';
+	/**
+	 * Gather the four precedence inputs and delegate the decision to the pure
+	 * {@link resolveClaudeTransportMode}. {@link authenticate} passes
+	 * `hasGitHubToken: true` while a token is arriving, so resolution reflects the
+	 * imminent sign-in before the token is committed to {@link _githubToken}.
+	 */
+	private _resolveTransportMode(hasGitHubToken: boolean = this._githubToken !== undefined): ClaudeTransportMode {
+		// An absent `claudeUseCopilotProxy` stays `undefined` so the pure function
+		// can tell an explicit override from "fall through to the flag/sign-in rules".
+		const explicitProxy = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.ClaudeUseCopilotProxy);
+		const allowSignedOutWhenUsable = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.AllowSignedOutWhenUsable) === true;
+		const hasExistingSetup = allowSignedOutWhenUsable && detectExistingClaudeSetup(this._environmentService.userHome.fsPath);
+		return resolveClaudeTransportMode({ explicitProxy, allowSignedOutWhenUsable, hasGitHubToken, hasExistingSetup });
+	}
+
+	/**
+	 * Apply a freshly-resolved transport mode. No-op when it matches the current
+	 * mode. On a real flip it drops the stale model catalog — which also
+	 * republishes the newly-resolved protected resources downstream, since the
+	 * side-effects layer reads `models` and `getProtectedResources()` together —
+	 * kicks off a fresh enumeration, and, when flipping into proxy with no proxy
+	 * handle, proactively asks the client to authenticate rather than waiting for
+	 * the next command to fail with `AHP_AUTH_REQUIRED`. A handle persists across
+	 * a proxy→native→proxy round-trip (cleared only on dispose), so the auth
+	 * prompt fires only when a credential is genuinely missing.
+	 */
+	private _applyTransportModeChange(next: ClaudeTransportMode): void {
+		if (next === this._transportMode) {
+			return;
+		}
+		this._transportMode = next;
+		this._models.set([], undefined);
+		void this._startModelRefresh();
+		if (next === 'proxy' && !this._proxyHandle) {
+			this._onDidRequireAuth.fire({
+				resource: this._gitHubEndpointService.getCopilotResource().resource,
+				reason: AuthRequiredReason.Required,
+			});
+		}
 	}
 
 	// #region Descriptor + auth
@@ -541,14 +564,24 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
-		// Native (BYO-Anthropic) mode needs no GitHub Copilot auth — the SDK owns
-		// the Anthropic credential — so the required Copilot resource is dropped.
+		// Native (BYO-Anthropic) mode does not *require* GitHub Copilot auth — the
+		// SDK owns the Anthropic credential. Rather than DROP the Copilot resource,
+		// native keeps advertising it with `required: false` (mirroring Codex on
+		// OpenAI — see `codexProtectedResourcesForUsageSource`). Two effects, both
+		// wanted:
+		//   1. The host silently forwards a GitHub token IFF the user is already
+		//      signed in (no prompt when signed out) — the sign-in probe that lets
+		//      `authenticate()` flip a signed-in user from native to proxy at
+		//      startup (precedence rule 3). Without advertising it, a signed-in
+		//      user with a local Claude setup would be stuck in native forever.
+		//   2. `required: false` still tells the window gate the type is usable
+		//      without GitHub when signed out (see
+		//      `protectedResourcesRequireGitHubCopilotSignIn`, which checks
+		//      `required !== false`), so no sign-in is forced.
 		// The optional repo resource is kept for git operations either way.
-		if (this._transportMode !== 'proxy') {
-			return [this._gitHubEndpointService.getRepoResource()];
-		}
+		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		return [
-			this._gitHubEndpointService.getCopilotResource(),
+			this._transportMode === 'proxy' ? copilotResource : { ...copilotResource, required: false },
 			this._gitHubEndpointService.getRepoResource(),
 		];
 	}
@@ -580,15 +613,27 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		if (resource !== this._gitHubEndpointService.getCopilotResource().resource) {
 			return false;
 		}
+		// A GitHub Copilot token is arriving (sign-in). Re-resolve the transport
+		// with the token now available: absent an explicit `claudeUseCopilotProxy`,
+		// signing in prefers proxy even over an existing native setup, so this can
+		// flip a signed-out native session into proxy.
+		const nextMode = this._resolveTransportMode(true);
+
 		// Native (BYO-Anthropic) mode needs no proxy and no GitHub token. Record
 		// the token (harmless; lets a later flip back to proxy reuse it) but do
 		// NOT start the proxy or treat the absence of a token as unauthenticated.
-		if (this._transportMode !== 'proxy') {
+		// The only way to resolve to native with a token present is an explicit
+		// `claudeUseCopilotProxy=false`, so `_applyTransportModeChange` here is a
+		// no-op unless a stale proxy mode still needs reconciling to native.
+		if (nextMode === 'native') {
 			this._githubToken = token;
+			this._applyTransportModeChange('native');
 			return true;
 		}
+
 		const tokenChanged = this._githubToken !== token;
-		if (!tokenChanged && this._proxyHandle) {
+		const modeChanged = this._transportMode !== nextMode;
+		if (!tokenChanged && !modeChanged && this._proxyHandle) {
 			this._logService.info('[Claude] Auth token unchanged');
 			return true;
 		}
@@ -608,12 +653,17 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		const oldHandle = this._proxyHandle;
 		this._proxyHandle = newHandle;
 		this._githubToken = token;
+		// Commit the (possibly flipped native→proxy) mode now that a handle is in
+		// hand — do NOT route through `_applyTransportModeChange`, which would
+		// fire a redundant `auth/required` even though we just authenticated.
+		this._transportMode = nextMode;
 		this._logService.info('[Claude] Auth token updated');
 		oldHandle?.dispose();
-		if (tokenChanged) {
-			// A different account can have different model entitlements. Do
-			// not retain the previous token's catalog if enumeration for the
-			// replacement token fails.
+		if (tokenChanged || modeChanged) {
+			// A different account can have different model entitlements, and a
+			// transport flip enumerates a different catalog. Do not retain the
+			// previous list if enumeration for the new input fails. The `models`
+			// write also republishes the (now proxy) protected resources downstream.
 			this._models.set([], undefined);
 		}
 		void this._startModelRefresh();
@@ -622,8 +672,8 @@ export class ClaudeAgent extends Disposable implements IAgent {
 
 	/**
 	 * Whether the Claude provider routes through the Copilot-CAPI proxy.
-	 * Reads the resolved {@link _transportMode} (Phase 19), which the
-	 * constructor seeds from the `ClaudeUseCopilotProxy` root config value.
+	 * Reads the resolved {@link _transportMode} (Phase 19), kept current by
+	 * {@link _resolveTransportMode} on construction, config change, and sign-in.
 	 */
 	private _isProxyEnabled(): boolean {
 		return this._transportMode === 'proxy';
@@ -661,6 +711,18 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		const proxyAtStart = this._isProxyEnabled();
 		const tokenAtStart = this._githubToken;
 		if (proxyAtStart && !tokenAtStart) {
+			this._models.set([], undefined);
+			return;
+		}
+		// Native without a credential cannot run a turn. The SDK's
+		// `supportedModels()` is a static catalog and answers regardless, so
+		// publishing it would advertise models that fail on first use — and would
+		// make the agent look usable-without-GitHub to the window gate. Report an
+		// empty catalog instead, which surfaces as "no models" (see the `Unusable`
+		// entry in `src/vs/sessions/CONTEXT.md`). Only reachable via an explicit
+		// `claudeUseCopilotProxy: false`; the flag-driven path only picks native
+		// when a setup was detected.
+		if (!proxyAtStart && !detectExistingClaudeSetup(this._environmentService.userHome.fsPath)) {
 			this._models.set([], undefined);
 			return;
 		}

--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { readFileSync } from 'fs';
+import { join } from '../../../../base/common/path.js';
+import { vObj, vOptionalProp, vString, type ValidatorType } from '../../../../base/common/validation.js';
+
+/**
+ * Resolved Claude host transport. `proxy` routes Anthropic traffic through the
+ * local Copilot-CAPI proxy (requires GitHub auth); `native` talks to Anthropic
+ * directly on the user's own credentials (no GitHub).
+ */
+export type ClaudeTransportMode = 'proxy' | 'native';
+
+/**
+ * The four precedence inputs {@link resolveClaudeTransportMode} decides over.
+ */
+export interface IClaudeTransportModeInputs {
+	/**
+	 * User/workspace-set value of `claudeUseCopilotProxy`, or `undefined` when
+	 * unset — the distinction between an explicit choice and the default is what
+	 * makes an explicit setting a hard override.
+	 */
+	readonly explicitProxy: boolean | undefined;
+	/** Whether the experimentation flag enabling signed-out-when-usable is on. */
+	readonly allowSignedOutWhenUsable: boolean;
+	/** Whether a GitHub Copilot token has been captured (i.e. signed in). */
+	readonly hasGitHubToken: boolean;
+	/** Whether an existing local Claude setup was detected (see {@link detectExistingClaudeSetup}). */
+	readonly hasExistingSetup: boolean;
+}
+
+/**
+ * Pure decision (ADR 0001, "D4"): which transport should the Claude provider
+ * use right now? Precedence, highest first:
+ *
+ *  1. An explicit `claudeUseCopilotProxy` setting is a HARD override.
+ *  2. Feature flag off means today's default behavior (always proxy).
+ *  3. Signed in to GitHub prefers Copilot (proxy).
+ *  4. Signed out but with the user's own Claude credentials uses native (no GitHub).
+ *  5. Nothing usable falls back to proxy, which surfaces as requires-GitHub and drives the
+ *     window sign-in gate.
+ *
+ * Native mode drops the GitHub Copilot protected resource, so getting this
+ * decision right is what lets a signed-out user with their own credentials run
+ * without being forced to sign in.
+ */
+export function resolveClaudeTransportMode(inputs: IClaudeTransportModeInputs): ClaudeTransportMode {
+	const { explicitProxy, allowSignedOutWhenUsable, hasGitHubToken, hasExistingSetup } = inputs;
+	if (explicitProxy !== undefined) {
+		return explicitProxy ? 'proxy' : 'native';
+	}
+	if (!allowSignedOutWhenUsable) {
+		return 'proxy';
+	}
+	if (hasGitHubToken) {
+		return 'proxy';
+	}
+	if (hasExistingSetup) {
+		return 'native';
+	}
+	return 'proxy';
+}
+
+/**
+ * Validator for the slice of `~/.claude/settings.json` we care about: an
+ * optional `env` block that may carry either recognized Anthropic credential.
+ * Reuses the shared combinators in `base/common/validation.ts` so parsing the
+ * untrusted file is type-safe without hand-rolled shape checks. This validator
+ * is the single source of truth for the credential-key set — {@link
+ * ClaudeCredentialEnv} is derived from it rather than hand-authored.
+ */
+const claudeSettingsValidator = vObj({
+	env: vOptionalProp(vObj({
+		ANTHROPIC_API_KEY: vOptionalProp(vString()),
+		CLAUDE_CODE_OAUTH_TOKEN: vOptionalProp(vString()),
+	})),
+});
+
+/**
+ * The `env` block shape both `process.env` and `~/.claude/settings.json` are
+ * probed for, derived from {@link claudeSettingsValidator} so the two never
+ * drift. A non-empty value under either key is a usable native credential.
+ */
+type ClaudeCredentialEnv = NonNullable<ValidatorType<typeof claudeSettingsValidator>['env']>;
+
+/**
+ * Detects whether a local Claude configuration exists that lets Claude run
+ * natively (without GitHub). Returns `true` when either:
+ *
+ *  - an `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` is set in the
+ *    environment, or
+ *  - either of those keys appears in the `env` block of
+ *    `<homeDir>/.claude/settings.json`.
+ *
+ * These are the same credential sources the SDK subprocess env is built from
+ * (see `buildSubprocessEnv`), so detecting them here means "asking for what we
+ * actually need": when a native credential is present the provider never
+ * advertises the GitHub Copilot resource, so the server never asks the client
+ * for a GitHub token and no sign-in is triggered.
+ *
+ * Detection is deliberately conservative — an empty-string value does not count
+ * — so it neither misses a real login nor misfires on a leftover blank entry.
+ *
+ * `env` and the settings-file path are the only external inputs, so both are
+ * injectable: `env` defaults to `process.env` and the file is located under
+ * `homeDir`, letting tests exercise real detection without stubbing globals.
+ */
+export function detectExistingClaudeSetup(homeDir: string, env: NodeJS.ProcessEnv = process.env): boolean {
+	return hasClaudeCredential(env)
+		|| hasClaudeCredential(readClaudeSettingsEnv(join(homeDir, '.claude', 'settings.json')));
+}
+
+/** True when either recognized Anthropic credential is present and non-empty. */
+function hasClaudeCredential(env: ClaudeCredentialEnv | undefined): boolean {
+	return !!(env?.ANTHROPIC_API_KEY || env?.CLAUDE_CODE_OAUTH_TOKEN);
+}
+
+/**
+ * Reads and validates the `env` block of `~/.claude/settings.json`. Returns
+ * `undefined` when the file is missing, unreadable, not valid JSON, or does not
+ * match the expected shape.
+ */
+function readClaudeSettingsEnv(path: string): ClaudeCredentialEnv | undefined {
+	let text: string;
+	try {
+		text = readFileSync(path, 'utf8');
+	} catch {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+	return claudeSettingsValidator.validate(parsed).content?.env;
+}

--- a/src/vs/platform/agentHost/test/common/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentService.test.ts
@@ -7,7 +7,8 @@ import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
-import { AgentHostByokModelsEnabledEnvVar, AgentHostCodexAgentEnabledSettingId, AgentSession, AgentHostOTelEnvVars, buildAgentHostOTelEnv, buildAgentSdkEnv, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId, isAgentEnabled, readAgentHostOTelPolicySettings, sanitizeAgentHostOTelPolicySettings, shouldSurfaceLocalAgentHostProvider } from '../../common/agentService.js';
+import { AgentHostByokModelsEnabledEnvVar, AgentHostCodexAgentEnabledSettingId, AgentSession, AgentHostOTelEnvVars, buildAgentHostOTelEnv, buildAgentSdkEnv, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, isAgentEnabled, protectedResourcesRequireGitHubCopilotSignIn, readAgentHostOTelPolicySettings, sanitizeAgentHostOTelPolicySettings, shouldSurfaceLocalAgentHostProvider } from '../../common/agentService.js';
+import type { ProtectedResourceMetadata } from '../../common/state/protocol/state.js';
 import { buildChatUri, buildDefaultChatUri, resolveChatUri } from '../../common/state/sessionState.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 
@@ -325,5 +326,48 @@ suite('buildAgentSdkEnv (BYOK gate forwarding)', () => {
 	test('lets an inherited env var win over the setting (developer override)', () => {
 		const env = buildAgentSdkEnv({ byokModelsEnabled: true }, { [AgentHostByokModelsEnabledEnvVar]: 'false' });
 		assert.strictEqual(env[AgentHostByokModelsEnabledEnvVar], undefined);
+	});
+});
+
+suite('protectedResourcesRequireGitHubCopilotSignIn', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const githubCopilotWithoutRequired: ProtectedResourceMetadata = { resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource };
+	const githubCopilotRequiredFalse: ProtectedResourceMetadata = { ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false };
+	const otherRequiredResource: ProtectedResourceMetadata = { resource: 'https://api.openai.com', required: true };
+
+	test('derives the requirement from advertised protected resources', () => {
+		const scenarios: Record<string, ProtectedResourceMetadata[]> = {
+			// Proxy-mode Copilot / Claude: advertises the resource as required.
+			copilotRequired: [GITHUB_COPILOT_PROTECTED_RESOURCE],
+			// Absent `required` is treated the same as `true`.
+			copilotRequiredAbsent: [githubCopilotWithoutRequired],
+			// An agent that advertises no protected resources at all.
+			noResourcesAdvertised: [],
+			// Codex on OpenAI: advertises the resource but marks it optional.
+			copilotRequiredFalse: [githubCopilotRequiredFalse],
+			// Only unrelated resources are advertised.
+			onlyOtherResource: [otherRequiredResource],
+			// Mixed: an optional GitHub Copilot resource alongside a required other one.
+			optionalCopilotWithOtherRequired: [githubCopilotRequiredFalse, otherRequiredResource],
+		};
+
+		const result = Object.fromEntries(
+			Object.entries(scenarios).map(([name, resources]) => [name, protectedResourcesRequireGitHubCopilotSignIn(resources)]),
+		);
+
+		assert.deepStrictEqual(result, {
+			copilotRequired: true,
+			copilotRequiredAbsent: true,
+			noResourcesAdvertised: false,
+			copilotRequiredFalse: false,
+			onlyOtherResource: false,
+			optionalCopilotWithOtherRequired: false,
+		});
+	});
+
+	test('the GitHub repo resource alone does not require Copilot sign-in', () => {
+		assert.strictEqual(protectedResourcesRequireGitHubCopilotSignIn([GITHUB_REPO_PROTECTED_RESOURCE]), false);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1143,48 +1143,85 @@ suite('ClaudeAgent', () => {
 	});
 
 	test('native transport: models populate from supportedModels() with no proxy start and no CAPI models() call', async () => {
-		const { agent, proxy, api, sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
-		let capiModelsCalls = 0;
-		api.models = async () => { capiModelsCalls++; return []; };
+		// Native enumeration only runs when a credential is actually present, so
+		// give this a real `~/.claude/settings.json` under a temp home.
+		const userHome = URI.file(await fs.mkdtemp(`${os.tmpdir()}/claude-native-models-`));
+		await fs.mkdir(join(userHome.fsPath, '.claude'), { recursive: true });
+		await fs.writeFile(join(userHome.fsPath, '.claude', 'settings.json'), JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-test-key' } }), 'utf8');
+		try {
+			const { agent, proxy, api, sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false }, userHome });
+			let capiModelsCalls = 0;
+			api.models = async () => { capiModelsCalls++; return []; };
+			sdk.supportedModelsResult = [
+				{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '', supportedEffortLevels: ['high'] },
+			];
+			// The constructor kicks off an initial native refresh; `_fetchNativeModels`
+			// awaits a real `mkdtemp` before enumerating, so poll until it lands.
+			for (let i = 0; i < 100 && sdk.supportedModelsCallCount === 0; i++) {
+				await tick();
+			}
+			await tick();
+			assert.deepStrictEqual({
+				models: agent.models.get().map(m => ({ id: m.id, name: m.name })),
+				proxyStarts: proxy.startCalls.length,
+				supportedModelsCalls: sdk.supportedModelsCallCount,
+				capiModelsCalls,
+			}, {
+				models: [{ id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5' }],
+				proxyStarts: 0,
+				supportedModelsCalls: 1,
+				capiModelsCalls: 0,
+			});
+		} finally {
+			await fs.rm(userHome.fsPath, { recursive: true, force: true });
+		}
+	});
+
+	test('native without a credential publishes an empty catalog instead of the SDK static list', async () => {
+		// `supportedModels()` answers even with no credentials (it is a static
+		// catalog), so publishing it would advertise models that fail on first
+		// use — and would make the type look usable-without-GitHub to the window
+		// gate. `/mock-home` has no `.claude` credential.
+		const { agent, sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
 		sdk.supportedModelsResult = [
-			{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '', supportedEffortLevels: ['high'] },
+			{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '' },
 		];
-		// The constructor kicks off an initial native refresh; `_fetchNativeModels`
-		// awaits a real `mkdtemp` before enumerating, so poll until it lands.
-		for (let i = 0; i < 100 && sdk.supportedModelsCallCount === 0; i++) {
+		for (let i = 0; i < 20; i++) {
 			await tick();
 		}
-		await tick();
 		assert.deepStrictEqual({
-			models: agent.models.get().map(m => ({ id: m.id, name: m.name })),
-			proxyStarts: proxy.startCalls.length,
+			models: agent.models.get(),
 			supportedModelsCalls: sdk.supportedModelsCallCount,
-			capiModelsCalls,
 		}, {
-			models: [{ id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5' }],
-			proxyStarts: 0,
-			supportedModelsCalls: 1,
-			capiModelsCalls: 0,
+			models: [],
+			supportedModelsCalls: 0,
 		});
 	});
 
 	test('native model enumeration closes the throwaway query (no leaked subprocess)', async () => {
-		const { sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
-		sdk.supportedModelsResult = [
-			{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '' },
-		];
-		// The constructor kicks off the initial native enumeration; wait for it.
-		for (let i = 0; i < 100 && sdk.supportedModelsCallCount === 0; i++) {
+		const userHome = URI.file(await fs.mkdtemp(`${os.tmpdir()}/claude-native-close-`));
+		await fs.mkdir(join(userHome.fsPath, '.claude'), { recursive: true });
+		await fs.writeFile(join(userHome.fsPath, '.claude', 'settings.json'), JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-test-key' } }), 'utf8');
+		try {
+			const { sdk } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false }, userHome });
+			sdk.supportedModelsResult = [
+				{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '' },
+			];
+			// The constructor kicks off the initial native enumeration; wait for it.
+			for (let i = 0; i < 100 && sdk.supportedModelsCallCount === 0; i++) {
+				await tick();
+			}
 			await tick();
+			assert.deepStrictEqual({
+				queries: sdk.enumerationQueries.length,
+				closed: sdk.enumerationQueries[0]?.closeCount,
+			}, {
+				queries: 1,
+				closed: 1,
+			});
+		} finally {
+			await fs.rm(userHome.fsPath, { recursive: true, force: true });
 		}
-		await tick();
-		assert.deepStrictEqual({
-			queries: sdk.enumerationQueries.length,
-			closed: sdk.enumerationQueries[0]?.closeCount,
-		}, {
-			queries: 1,
-			closed: 1,
-		});
 	});
 
 	test('native transport: authenticate never starts the proxy', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -31,6 +31,7 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { join } from '../../../../base/common/path.js';
 import { isUUID } from '../../../../base/common/uuid.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -46,6 +47,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { IAgentChatDataChange, IAgentMaterializeSessionEvent, IAgentSpawnChatEvent, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../common/agentService.js';
 import { AgentHostClaudeMultiRootEnabledConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
 import { AgentFeedbackAttachmentDisplayKind } from '../../common/meta/agentFeedbackAttachments.js';
 import { ActionType, type AuthRequiredParams } from '../../common/state/sessionActions.js';
 import { CustomizationLoadStatus, CustomizationType, MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputResponseKind, SessionStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, parseChatUri, parseDefaultChatUri, type ClientPluginCustomization, type Customization, type PluginCustomization, type Turn } from '../../common/state/sessionState.js';
@@ -1017,12 +1019,72 @@ suite('ClaudeAgent', () => {
 		});
 	});
 
-	test('native transport: getProtectedResources omits the Copilot resource', () => {
+	test('native transport: getProtectedResources keeps the Copilot resource but marks it not required', () => {
+		// Native keeps advertising the Copilot resource with `required: false`
+		// (rather than dropping it) so the host can silently probe for a GitHub
+		// token when the user is already signed in, while the window gate still
+		// treats the type as usable without GitHub. See `getProtectedResources`.
 		const { agent } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
 		assert.deepStrictEqual(
-			agent.getProtectedResources().map(r => r.resource),
-			['https://api.github.com/repos'],
+			agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+			[
+				{ resource: 'https://api.github.com', required: false },
+				{ resource: 'https://api.github.com/repos', required: false },
+			],
 		);
+	});
+
+	test('signed-in probe flips inferred-native to proxy (allowSignedOutWhenUsable)', async () => {
+		// The fix for the startup catch-22: with the exp flag on and a local Claude
+		// setup present, a signed-OUT user resolves to native — which still
+		// advertises the Copilot resource as not-required so the host can probe. If
+		// the host then silently forwards a GitHub token (the user was signed in all
+		// along), `authenticate` re-resolves (rule 3: signed in ⇒ proxy) and flips
+		// the transport to proxy, starting the proxy. Real detection is used against
+		// a real `~/.claude/settings.json` credential under a temp home.
+		const userHome = URI.file(await fs.mkdtemp(`${os.tmpdir()}/claude-probe-home-`));
+		await fs.mkdir(join(userHome.fsPath, '.claude'), { recursive: true });
+		await fs.writeFile(join(userHome.fsPath, '.claude', 'settings.json'), JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-test-key' } }), 'utf8');
+		try {
+			const { agent, proxy } = createTestContext(disposables, {
+				rootConfig: { [AgentHostConfigKey.AllowSignedOutWhenUsable]: true },
+				userHome,
+			});
+			// Signed out at startup ⇒ native, Copilot advertised as not-required.
+			const before = {
+				resources: agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+				proxyStarts: proxy.startCalls.length,
+			};
+
+			// Host probe forwards a GitHub token (user was signed in) ⇒ flip to proxy.
+			await agent.authenticate('https://api.github.com', 'gh-token');
+			await tick();
+
+			assert.deepStrictEqual({
+				before,
+				after: {
+					resources: agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+					proxyStarts: proxy.startCalls.length,
+				},
+			}, {
+				before: {
+					resources: [
+						{ resource: 'https://api.github.com', required: false },
+						{ resource: 'https://api.github.com/repos', required: false },
+					],
+					proxyStarts: 0,
+				},
+				after: {
+					resources: [
+						{ resource: 'https://api.github.com', required: true },
+						{ resource: 'https://api.github.com/repos', required: false },
+					],
+					proxyStarts: 1,
+				},
+			});
+		} finally {
+			await fs.rm(userHome.fsPath, { recursive: true, force: true });
+		}
 	});
 
 	test('coalesces concurrent refreshModels calls onto one CAPI models request', async () => {
@@ -1130,6 +1192,24 @@ suite('ClaudeAgent', () => {
 		const accepted = await agent.authenticate('https://api.github.com', 'tok');
 		await tick();
 		assert.deepStrictEqual({ accepted, proxyStarts: proxy.startCalls.length }, { accepted: true, proxyStarts: 0 });
+	});
+
+	test('unusable native (explicit proxy off, no setup) does not demand GitHub sign-in', async () => {
+		// The "unusable" case: explicit `claudeUseCopilotProxy=false` is a hard
+		// override to native even with no usable credentials. It must degrade to
+		// "no models" (NoModels), NOT a GitHub sign-in prompt — so the Copilot
+		// resource is advertised `required: false` and `createSession` resolves
+		// (native needs no proxy) instead of throwing `AHP_AUTH_REQUIRED` the way
+		// proxy mode does before authentication (cf. the AHP_AUTH_REQUIRED test).
+		const { agent } = createTestContext(disposables, { rootConfig: { claudeUseCopilotProxy: false } });
+		const created = await agent.createSession({ workingDirectories: [URI.file('/workspace')] });
+		assert.deepStrictEqual({
+			copilotRequired: agent.getProtectedResources().find(r => r.resource === 'https://api.github.com')?.required,
+			createdWithoutAuthPrompt: created.provisional === true,
+		}, {
+			copilotRequired: false,
+			createdWithoutAuthPrompt: true,
+		});
 	});
 
 	test('transport flip native→proxy with no proxy handle emits auth/required once', () => {

--- a/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from '../../../../base/common/path.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { detectExistingClaudeSetup, resolveClaudeTransportMode } from '../../node/claude/claudeTransportMode.js';
+
+suite('claudeTransportMode', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('resolveClaudeTransportMode precedence over the full input matrix', () => {
+		const explicitValues: readonly (boolean | undefined)[] = [undefined, true, false];
+		const bools: readonly boolean[] = [false, true];
+
+		const actual: Record<string, string> = {};
+		for (const explicitProxy of explicitValues) {
+			for (const allowSignedOutWhenUsable of bools) {
+				for (const hasGitHubToken of bools) {
+					for (const hasExistingSetup of bools) {
+						const key = `explicit=${explicitProxy},flag=${allowSignedOutWhenUsable},token=${hasGitHubToken},setup=${hasExistingSetup}`;
+						actual[key] = resolveClaudeTransportMode({ explicitProxy, allowSignedOutWhenUsable, hasGitHubToken, hasExistingSetup });
+					}
+				}
+			}
+		}
+
+		assert.deepStrictEqual(actual, {
+			// Explicit unset: the flag/sign-in/setup rules decide.
+			'explicit=undefined,flag=false,token=false,setup=false': 'proxy', // flag off ⇒ today's default
+			'explicit=undefined,flag=false,token=false,setup=true': 'proxy',  // flag off ignores setup
+			'explicit=undefined,flag=false,token=true,setup=false': 'proxy',
+			'explicit=undefined,flag=false,token=true,setup=true': 'proxy',
+			'explicit=undefined,flag=true,token=false,setup=false': 'proxy',  // nothing usable ⇒ requires-GitHub
+			'explicit=undefined,flag=true,token=false,setup=true': 'native',  // signed out + own creds ⇒ native
+			'explicit=undefined,flag=true,token=true,setup=false': 'proxy',   // signed in ⇒ prefer Copilot
+			'explicit=undefined,flag=true,token=true,setup=true': 'proxy',    // signed in wins over setup
+			// Explicit proxy=true: hard override, always proxy.
+			'explicit=true,flag=false,token=false,setup=false': 'proxy',
+			'explicit=true,flag=false,token=false,setup=true': 'proxy',
+			'explicit=true,flag=false,token=true,setup=false': 'proxy',
+			'explicit=true,flag=false,token=true,setup=true': 'proxy',
+			'explicit=true,flag=true,token=false,setup=false': 'proxy',
+			'explicit=true,flag=true,token=false,setup=true': 'proxy',
+			'explicit=true,flag=true,token=true,setup=false': 'proxy',
+			'explicit=true,flag=true,token=true,setup=true': 'proxy',
+			// Explicit proxy=false: hard override, always native.
+			'explicit=false,flag=false,token=false,setup=false': 'native',
+			'explicit=false,flag=false,token=false,setup=true': 'native',
+			'explicit=false,flag=false,token=true,setup=false': 'native',
+			'explicit=false,flag=false,token=true,setup=true': 'native',
+			'explicit=false,flag=true,token=false,setup=false': 'native',
+			'explicit=false,flag=true,token=false,setup=true': 'native',
+			'explicit=false,flag=true,token=true,setup=false': 'native',
+			'explicit=false,flag=true,token=true,setup=true': 'native',
+		});
+	});
+
+	suite('detectExistingClaudeSetup', () => {
+		// The credential env is injected explicitly (never `process.env`), so the
+		// ambient machine's real credentials can't leak into the assertions and no
+		// global is mutated. The file source is exercised through a real temp home.
+		let homeDir: string;
+
+		setup(async () => {
+			homeDir = await fs.promises.mkdtemp(join(os.tmpdir(), 'claude-setup-detect-'));
+		});
+
+		teardown(async () => {
+			await fs.promises.rm(homeDir, { recursive: true, force: true });
+		});
+
+		function writeSettings(contents: string): void {
+			const dir = join(homeDir, '.claude');
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(join(dir, 'settings.json'), contents, 'utf8');
+		}
+
+		test('detects each env-var credential (and ignores an empty value)', () => {
+			assert.deepStrictEqual({
+				none: detectExistingClaudeSetup(homeDir, {}),
+				apiKey: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: 'sk-ant-api-x' }),
+				oauthToken: detectExistingClaudeSetup(homeDir, { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-x' }),
+				emptyValue: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: '' }),
+			}, { none: false, apiKey: true, oauthToken: true, emptyValue: false });
+		});
+
+		test('detects a credential in the settings.json env block (empty env injected)', () => {
+			const results: Record<string, boolean> = {};
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-api-x' } }));
+			results.apiKey = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-x' } }));
+			results.oauthToken = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: '' } }));
+			results.emptyValue = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ model: 'claude-sonnet-4-5' }));
+			results.noEnvBlock = detectExistingClaudeSetup(homeDir, {});
+			writeSettings('not json');
+			results.malformed = detectExistingClaudeSetup(homeDir, {});
+
+			assert.deepStrictEqual(results, { apiKey: true, oauthToken: true, emptyValue: false, noEnvBlock: false, malformed: false });
+		});
+	});
+});

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -64,6 +64,14 @@ export interface IAccountTitleBarStateContext {
 		readonly chat?: IQuotaSnapshot;
 		readonly completions?: IQuotaSnapshot;
 	};
+	/**
+	 * Whether at least one registered session type is usable without GitHub
+	 * right now (the conditional-auth opt-in is on and a usable type exists).
+	 * When true, a signed-out account shows a calm opt-in sign-in instead of the
+	 * alarming "Agents Signed Out". Defaults to `false`, so the opt-in being off
+	 * keeps today's behavior.
+	 */
+	readonly usableWithoutGitHub: boolean;
 }
 
 export interface IAccountTitleBarState {
@@ -105,7 +113,7 @@ export function getAccountTitleBarState(context: IAccountTitleBarStateContext): 
 		};
 	}
 
-	const copilotState = getCopilotPresentation(context.entitlement, context.sentiment, context.quotas);
+	const copilotState = getCopilotPresentation(context.entitlement, context.sentiment, context.quotas, context.usableWithoutGitHub);
 	if (copilotState) {
 		return copilotState;
 	}
@@ -135,13 +143,25 @@ export function getAccountTitleBarState(context: IAccountTitleBarStateContext): 
 function getCopilotPresentation(
 	entitlement: ChatEntitlement,
 	sentiment: IChatSentiment,
-	quotas: { readonly chat?: IQuotaSnapshot; readonly completions?: IQuotaSnapshot }
+	quotas: { readonly chat?: IQuotaSnapshot; readonly completions?: IQuotaSnapshot },
+	usableWithoutGitHub: boolean
 ): IAccountTitleBarState | undefined {
 	if (sentiment.hidden) {
 		return undefined;
 	}
 
 	if (entitlement === ChatEntitlement.Unknown) {
+		if (usableWithoutGitHub) {
+			// A session type is usable without GitHub, so signing in is optional:
+			// present a calm opt-in affordance rather than alarming the user.
+			return {
+				source: 'copilot',
+				kind: 'default',
+				icon: Codicon.account,
+				label: localize('agentsSignInOptional', "Sign In"),
+				ariaLabel: localize('agentsSignInOptionalAria', "Sign in to GitHub to use more agents"),
+			};
+		}
 		return {
 			source: 'copilot',
 			kind: 'prominent',

--- a/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
@@ -343,6 +343,9 @@ export class MobileTitlebarPart extends Disposable {
 			entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
+			// The conditional-auth opt-in is desktop-only (the native agent host
+			// that makes a type usable without GitHub does not run on mobile/web).
+			usableWithoutGitHub: false,
 		});
 
 		// Avatar
@@ -429,6 +432,7 @@ export class MobileTitlebarPart extends Disposable {
 			entitlement: this.chatEntitlementService.entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
+			usableWithoutGitHub: false,
 		}));
 		if (badgeKey) {
 			this.dismissedBadgeKey = badgeKey;

--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../base/common/event.js';
+import { IObservable, observableFromEvent } from '../../base/common/observable.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../platform/agentHost/common/agentService.js';
+import type { IConfigurationService } from '../../platform/configuration/common/configuration.js';
+import { SessionTypeAuthRequirement } from '../services/sessions/common/session.js';
+import type { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
+
+/**
+ * Whether the `chat.agentHost.allowSignedOutWhenUsable` experimentation opt-in
+ * is enabled. When off (the default), the conditional-auth feature is dark and
+ * every caller behaves as it did before.
+ */
+export function isAllowSignedOutWhenUsableEnabled(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true;
+}
+
+/**
+ * Whether a signed-out user can work without GitHub right now: the opt-in is on
+ * and some registered session type reports that it runs without a GitHub
+ * account (e.g. an agent-host agent that discovered an existing native
+ * configuration).
+ *
+ * The per-type fact is resolved by each provider into
+ * {@link ISessionType.authRequirement}, so this stays provider-agnostic. A type
+ * that cannot run at all ({@link SessionTypeAuthRequirement.Unusable}) does not
+ * count, so a broken agent never holds the window open.
+ * The opt-in is re-checked here as well as on the agent host so the setting
+ * remains an authoritative kill switch even if a host is still running in a
+ * mode it resolved before the setting changed.
+ *
+ * TODO: this deliberately does NOT reuse `getSessionTypeAvailability`, which the
+ * per-type pickers use to answer a related question. Two reasons: that helper
+ * lives in `vs/workbench/contrib` and is unreachable from this layer, and its
+ * model check cannot detect a credential-less native agent (the Claude SDK's
+ * `supportedModels()` is a static catalog). The cost is two predicates that can
+ * drift — they already differ over `chatEntitlementService.anonymous`, which the
+ * pickers honour and this gate ignores. That divergence is pre-existing (with
+ * the opt-in off this collapses to today's always-force-sign-in) but should be
+ * converged: have providers resolve availability the same way the pickers do, so
+ * both read one derivation.
+ */
+export function observeUsableWithoutGitHub(
+	sessionsManagementService: ISessionsManagementService,
+	configurationService: IConfigurationService,
+): IObservable<boolean> {
+	return observableFromEvent(
+		Event.any(
+			Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(AgentHostAllowSignedOutWhenUsableSettingId)),
+			sessionsManagementService.onDidChangeSessionTypes,
+		),
+		() => isAllowSignedOutWhenUsableEnabled(configurationService)
+			&& sessionsManagementService.getAllSessionTypes().some(type => type.authRequirement === SessionTypeAuthRequirement.None));
+}
+
+/**
+ * Inputs to the "discovered your existing <agent> configuration" nudge for a
+ * single agent-host session type.
+ */
+export interface IDiscoveredConfigNudgeContext {
+	/** Whether a GitHub account is currently signed in. */
+	readonly signedIn: boolean;
+	/** The `chat.agentHost.allowSignedOutWhenUsable` experimentation opt-in. */
+	readonly allowSignedOutWhenUsable: boolean;
+	/**
+	 * Whether the agent's session type is usable without GitHub right now — i.e.
+	 * its agent discovered an existing native configuration and is running in
+	 * native mode rather than the Copilot proxy.
+	 */
+	readonly usableWithoutGitHub: boolean;
+	/**
+	 * Whether the user has permanently silenced this nudge via its "Don't Show
+	 * Again" affordance. Once muted, the nudge never shows again regardless of
+	 * the other inputs.
+	 */
+	readonly muted: boolean;
+}
+
+/**
+ * Decides whether to surface the discovered-config nudge for one agent-host
+ * session type: shown only to a signed-out user who has opted in, when that
+ * type is usable without GitHub right now — the agent found an existing native
+ * config, so we let them in and explain how to switch to a Copilot subscription
+ * instead. Signed-in users never see it; with the opt-in off, or once the user
+ * has muted it, it is always false.
+ */
+export function shouldShowDiscoveredConfigNudge(context: IDiscoveredConfigNudgeContext): boolean {
+	return !context.signedIn && context.allowSignedOutWhenUsable && context.usableWithoutGitHub && !context.muted;
+}

--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -54,7 +54,7 @@ export function observeUsableWithoutGitHub(
 			sessionsManagementService.onDidChangeSessionTypes,
 		),
 		() => isAllowSignedOutWhenUsableEnabled(configurationService)
-			&& sessionsManagementService.getAllSessionTypes().some(type => type.authRequirement === SessionTypeAuthRequirement.None));
+			&& sessionsManagementService.getAllProviderSessionTypes().some(type => type.sessionType.authRequirement === SessionTypeAuthRequirement.None));
 }
 
 /**

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -5,6 +5,7 @@
 
 import './media/sessionsSetUp.css';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../base/common/lifecycle.js';
+import { IObservable, runOnChange } from '../../base/common/observable.js';
 import { DeferredPromise, disposableTimeout } from '../../base/common/async.js';
 import { createDecorator, IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../platform/log/common/log.js';
@@ -26,6 +27,8 @@ import { IHostService } from '../../workbench/services/host/browser/host.js';
 import { IMarkdownRendererService } from '../../platform/markdown/browser/markdownRenderer.js';
 import { WELCOME_COMPLETE_KEY } from '../common/welcome.js';
 import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
+import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
+import { observeUsableWithoutGitHub } from './sessionsAuthGate.js';
 
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { Codicon } from '../../base/common/codicons.js';
@@ -71,6 +74,10 @@ class SessionsSetUpWidget extends Disposable {
 	private readonly dialogRef = this._register(new MutableDisposable<DisposableStore>());
 	private readonly watcherRef = this._register(new MutableDisposable());
 	private _initialSetupFlow = true;
+	/** True while the window is open for a signed-out user via the conditional-auth opt-in. */
+	private _proceedingSignedOut = false;
+	/** Whether a signed-out user can work without GitHub right now. */
+	private readonly _usableWithoutGitHub: IObservable<boolean>;
 
 	// Non-service params must come before @-decorated service params
 	constructor(
@@ -91,8 +98,10 @@ class SessionsSetUpWidget extends Disposable {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHostService private readonly hostService: IHostService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 	) {
 		super();
+		this._usableWithoutGitHub = observeUsableWithoutGitHub(this.sessionsManagementService, this.configurationService);
 		this._start();
 	}
 
@@ -176,10 +185,23 @@ class SessionsSetUpWidget extends Disposable {
 		disposables.add(this.defaultAccountService.onDidChangeDefaultAccount(account => {
 			const nowSignedIn = account !== null;
 			if (signedIn && !nowSignedIn) {
+				// Signed out: drop the completion marker and re-consult the gate.
 				this.storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
-				this._showWelcome(false);
+				this._reevaluateSignedOut();
+			} else if (!signedIn && nowSignedIn) {
+				// Signed in while running signed-out: the window is already open.
+				this._proceedingSignedOut = false;
 			}
 			signedIn = nowSignedIn;
+		}));
+
+		// While signed out, a change to the set of session types usable without
+		// GitHub (or to the opt-in itself) can flip the last-resort gate, so
+		// re-drive the decision.
+		disposables.add(runOnChange(this._usableWithoutGitHub, () => {
+			if (!signedIn) {
+				this._reevaluateSignedOut();
+			}
 		}));
 
 		disposables.add(this.configurationService.onDidChangeConfiguration(e => {
@@ -194,6 +216,53 @@ class SessionsSetUpWidget extends Disposable {
 		}));
 
 		return disposables;
+	}
+
+	/**
+	 * Whether the Agents window must fall back to forcing GitHub sign-in. Every
+	 * caller is on a signed-out path, so this is simply the inverse of "can work
+	 * without GitHub" — always true while the opt-in is off, which is today's
+	 * mandatory-sign-in behavior.
+	 */
+	private _mustForceGitHubSignIn(): boolean {
+		return !this._usableWithoutGitHub.get();
+	}
+
+	/**
+	 * Re-run the signed-out decision after an input change: force GitHub sign-in
+	 * when the gate demands it, otherwise open the window without GitHub. A no-op
+	 * while a dialog is up — that dialog owns the next transition.
+	 */
+	private _reevaluateSignedOut(): void {
+		if (this.dialogRef.value) {
+			return;
+		}
+		if (this._mustForceGitHubSignIn()) {
+			this._proceedingSignedOut = false;
+			void this._showWelcome(false);
+		} else {
+			void this._proceedWithoutGitHub();
+		}
+	}
+
+	/**
+	 * Open the Agents window for a signed-out user because at least one session
+	 * type is usable without GitHub. Mirrors the signed-in completion path, but
+	 * keeps watching so a later change (a usable type disappears, or the user
+	 * signs in) re-drives the decision. Idempotent while already proceeding.
+	 */
+	private async _proceedWithoutGitHub(): Promise<void> {
+		if (this._proceedingSignedOut) {
+			return;
+		}
+		this._proceedingSignedOut = true;
+		this.logService.info('[sessions welcome] Proceeding without GitHub sign-in; a session type is usable while signed out');
+		await this._ensureAIFeaturesEnabled();
+		if (this._store.isDisposed) {
+			return;
+		}
+		this.onCompleted();
+		this.watcherRef.value = this._watchActiveState(false);
 	}
 
 	private async _ensureAIFeaturesEnabled(): Promise<void> {
@@ -248,6 +317,14 @@ class SessionsSetUpWidget extends Disposable {
 			return;
 		}
 
+		// A non-first-launch _showWelcome means the user is signed out. Consult the
+		// last-resort GitHub gate before forcing sign-in: when a session type is
+		// usable without GitHub (and the opt-in is on), open the window instead.
+		if (!isFirstLaunch && !this._mustForceGitHubSignIn()) {
+			await this._proceedWithoutGitHub();
+			return;
+		}
+
 		this.watcherRef.clear();
 		this.dialogRef.value = new DisposableStore();
 
@@ -281,8 +358,13 @@ class SessionsSetUpWidget extends Disposable {
 				}
 
 				await this._showWelcomeDialog();
-			} else {
+			} else if (this._mustForceGitHubSignIn()) {
 				await this._showSignInDialog();
+			} else {
+				// Signed-out first launch, but a session type is usable without GitHub.
+				this.dialogRef.clear();
+				await this._proceedWithoutGitHub();
+				return;
 			}
 		} else {
 			await this._showSignInDialog();

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -102,7 +102,32 @@ class SessionsSetUpWidget extends Disposable {
 	) {
 		super();
 		this._usableWithoutGitHub = observeUsableWithoutGitHub(this.sessionsManagementService, this.configurationService);
+		// The gate's inputs resolve asynchronously: the local agent host advertises
+		// Claude at `AfterRestored`, i.e. after this widget has already decided. So
+		// this subscription is lifetime-scoped rather than installed once setup
+		// completes — otherwise a signed-out startup shows the non-dismissible
+		// modal before Claude resolves and never reconsiders.
+		this._register(runOnChange(this._usableWithoutGitHub, usable => this._onUsableWithoutGitHubChanged(usable)));
 		this._start();
+	}
+
+	/**
+	 * The last-resort gate's answer changed while the window is open. Signed-in
+	 * users are unaffected. Becoming usable retires an already-open sign-in
+	 * modal (it was raised before the answer resolved); becoming unusable falls
+	 * back to demanding sign-in.
+	 */
+	private _onUsableWithoutGitHubChanged(usable: boolean): void {
+		if (this.defaultAccountService.currentDefaultAccount !== null) {
+			return;
+		}
+		if (!usable) {
+			this._proceedingSignedOut = false;
+			void this._showWelcome(false);
+			return;
+		}
+		this.dialogRef.clear();
+		void this._proceedWithoutGitHub();
 	}
 
 	private _start(): void {
@@ -193,15 +218,6 @@ class SessionsSetUpWidget extends Disposable {
 				this._proceedingSignedOut = false;
 			}
 			signedIn = nowSignedIn;
-		}));
-
-		// While signed out, a change to the set of session types usable without
-		// GitHub (or to the opt-in itself) can flip the last-resort gate, so
-		// re-drive the decision.
-		disposables.add(runOnChange(this._usableWithoutGitHub, () => {
-			if (!signedIn) {
-				this._reevaluateSignedOut();
-			}
 		}));
 
 		disposables.add(this.configurationService.onDidChangeConfiguration(e => {

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -9,9 +9,11 @@ import './media/accountTitleBarWidget.css';
 import '../../../../workbench/contrib/chat/browser/chatStatus/media/chatStatus.css';
 import Severity from '../../../../base/common/severity.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, runOnChange } from '../../../../base/common/observable.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2, IMenuService } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
@@ -33,6 +35,8 @@ import { ChatStatusDashboard, IChatStatusDashboardOptions } from '../../../../wo
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, resolveAccountInfo } from '../../../browser/accountTitleBarState.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { observeUsableWithoutGitHub } from '../../../browser/sessionsAuthGate.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IAuthenticationAccessService } from '../../../../workbench/services/authentication/browser/authenticationAccessService.js';
@@ -168,6 +172,8 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 	private readonly copilotDashboardStore = this._register(new MutableDisposable<DisposableStore>());
 	private readonly clickPanelDisposable = this._register(new MutableDisposable<DisposableStore>());
 	private readonly avatarLoadDisposable = this._register(new MutableDisposable());
+	/** Whether a signed-out user can work without GitHub right now. */
+	private readonly usableWithoutGitHub: IObservable<boolean>;
 
 	constructor(
 		action: IAction,
@@ -179,13 +185,17 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		@IHoverService private readonly hoverService: IHoverService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super(undefined, action, options);
+		this.usableWithoutGitHub = observeUsableWithoutGitHub(sessionsManagementService, configurationService);
 		this.lastState = getAccountTitleBarState({
 			isAccountLoading: true,
 			entitlement: this.chatEntitlementService.entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
+			usableWithoutGitHub: false,
 		});
 
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.refreshAccount()));
@@ -194,6 +204,9 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this._register(this.chatEntitlementService.onDidChangeSentiment(() => this.renderState()));
 		this._register(this.chatEntitlementService.onDidChangeQuotaExceeded(() => this.renderState()));
 		this._register(this.chatEntitlementService.onDidChangeQuotaRemaining(() => this.renderState()));
+		// A type becoming usable/unusable without GitHub, or toggling the opt-in,
+		// can flip the signed-out affordance between the calm and alarming states.
+		this._register(runOnChange(this.usableWithoutGitHub, () => this.renderState()));
 		this.refreshAccount();
 	}
 
@@ -264,6 +277,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
+			usableWithoutGitHub: this.usableWithoutGitHub.get(),
 		});
 		this.lastState = state;
 

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
@@ -20,6 +20,7 @@ suite('Sessions - Account Title Bar State', () => {
 			entitlement: ChatEntitlement.Pro,
 			sentiment: {},
 			quotas: {},
+			usableWithoutGitHub: false,
 			...overrides,
 		};
 	}
@@ -141,6 +142,25 @@ suite('Sessions - Account Title Bar State', () => {
 			source: 'copilot',
 			label: 'Agents Signed Out',
 			kind: 'prominent',
+		});
+	});
+
+	test('offers a calm opt-in sign-in instead of "Agents Signed Out" when a type is usable without GitHub', () => {
+		const state = getAccountTitleBarState(createState({
+			accountName: undefined,
+			accountProviderLabel: undefined,
+			entitlement: ChatEntitlement.Unknown,
+			usableWithoutGitHub: true,
+		}));
+
+		assert.deepStrictEqual({
+			source: state.source,
+			label: state.label,
+			kind: state.kind,
+		}, {
+			source: 'copilot',
+			label: 'Sign In',
+			kind: 'default',
 		});
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/automationDialog.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationDialog.test.ts
@@ -23,7 +23,7 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { IWorkspaceTrustRequestService, ResourceTrustRequestOptions } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { GitRefType, IGitRepository, IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
-import { ISessionWorkspace } from '../../../../services/sessions/common/session.js';
+import { ISessionWorkspace, SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { AutomationIsolationGroupActionViewItem, canSelectAutomationWorkspace, IFormState, IValidationState, isAutomationDialogPopupTarget, registerAutomationDialogKeyboardNavigation, resolveAutomationModelIdentifier, updateSaveButtonState } from '../../browser/automationDialog.js';
 import { AutomationIsolationModel } from '../../common/isolationGroupModel.js';
@@ -276,6 +276,7 @@ suite('Automation branch picker', () => {
 					label: 'Copilot',
 					icon: Codicon.copilot,
 					supportsWorktreeConfiguration: state.sessionTypeId === 'copilotcli',
+					authRequirement: SessionTypeAuthRequirement.GitHub,
 				},
 			}] : [],
 		}));

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -19,10 +19,12 @@ import { IContextKey, IContextKeyService } from '../../../../platform/contextkey
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { localize } from '../../../../nls.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, SessionTypeAuthRequirement } from '../../../services/sessions/common/session.js';
 import { IOpenNewSessionResult, ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { isAllowSignedOutWhenUsableEnabled } from '../../../browser/sessionsAuthGate.js';
 import { IAquariumService, IMountedToggleHandle } from '../../aquarium/browser/aquariumOverlay.js';
 import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
@@ -118,6 +120,7 @@ export class NewChatWidget extends Disposable {
 		@IChatPetService private readonly chatPetService: IChatPetService,
 		@IChatTipService private readonly chatTipService: IChatTipService,
 		@IOpenerService private readonly openerService: IOpenerService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 		this._workspacePickerVisibleKey = SessionWorkspacePickerVisibleContext.bindTo(contextKeyService);
@@ -591,9 +594,16 @@ export class NewChatWidget extends Disposable {
 	private async _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined, token: CancellationToken): Promise<IOpenNewSessionResult> {
 		// Prefer the user's explicit pick when its provider can serve the
 		// folder; otherwise fall back to the preferred (first) session type.
-		const effectivePick = userPick && this._isPreferredServable(folderUri, userPick)
+		const preferredPick = userPick && this._isPreferredServable(folderUri, userPick)
 			? userPick
 			: this._newChatInput.sessionTypePicker.getPreferredSessionType(folderUri);
+		// A signed-out user (under the conditional-auth opt-in) can't run a type
+		// that requires GitHub, so default to the first offered type usable
+		// without it. No-op when signed in or the opt-in is off — today's behavior.
+		// TODO: reconsider silently switching away from the remembered selection;
+		// instead keep it and surface an inline "sign in for this type" affordance
+		// for GitHub-only types.
+		const effectivePick = this._preferUsableSessionTypeWhenSignedOut(folderUri, preferredPick);
 		const fallbackProviderId = this._workspacePicker.selectedResolved?.providerId;
 		try {
 			return await this.sessionsService.openNewSession({
@@ -608,6 +618,25 @@ export class NewChatWidget extends Disposable {
 			this.logService.error('Failed to create new session:', e);
 			return { session: undefined, trustDeclined: false };
 		}
+	}
+
+	/**
+	 * While the user is signed out and the conditional-auth opt-in is on, replace
+	 * a pick that requires GitHub with the first offered session type usable
+	 * without it. A no-op when signed in, when the opt-in is off (today's
+	 * behavior), or when no offered type is usable — in which case the caller's
+	 * existing fallbacks still apply.
+	 */
+	private _preferUsableSessionTypeWhenSignedOut(folderUri: URI, pick: IPreferredSessionType | undefined): IPreferredSessionType | undefined {
+		if (this.defaultAccountService.currentDefaultAccount !== null || !isAllowSignedOutWhenUsableEnabled(this.configurationService)) {
+			return pick;
+		}
+		const usable = this.sessionsManagementService.getSessionTypesForFolder(folderUri)
+			.filter(type => type.sessionType.authRequirement === SessionTypeAuthRequirement.None);
+		if (usable.length === 0 || usable.some(type => type.sessionType.id === pick?.sessionTypeId)) {
+			return pick;
+		}
+		return { providerId: usable[0].providerId, sessionTypeId: usable[0].sessionType.id };
 	}
 
 	private _scheduleRecreateOnProviderChange(folderUri: URI, userPick: IPreferredSessionType | undefined, created: ISession | undefined, replayMissedChange: boolean): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -633,7 +633,11 @@ export class NewChatWidget extends Disposable {
 		}
 		const usable = this.sessionsManagementService.getSessionTypesForFolder(folderUri)
 			.filter(type => type.sessionType.authRequirement === SessionTypeAuthRequirement.None);
-		if (usable.length === 0 || usable.some(type => type.sessionType.id === pick?.sessionTypeId)) {
+		// Match on provider too when the pick names one: two providers can offer
+		// the same session type id, and only one of them may be usable.
+		const pickIsUsable = usable.some(type => type.sessionType.id === pick?.sessionTypeId
+			&& (pick?.providerId === undefined || type.providerId === pick.providerId));
+		if (usable.length === 0 || pickIsUsable) {
 			return pick;
 		}
 		return { providerId: usable[0].providerId, sessionTypeId: usable[0].sessionType.id };

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -23,7 +23,7 @@ import { ChatEntitlement, IChatEntitlementService } from '../../../../../workben
 import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IProviderSessionType, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { SessionTypeAuthRequirement, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IPickedSessionType, IPreferredSessionType, ISessionTypePickerOptions, SessionTypePicker } from '../../browser/sessionTypePicker.js';
 
 // ---- Mocks ------------------------------------------------------------------
@@ -73,7 +73,7 @@ function createFakeQuickChatSession(providerId: string, sessionTypeId: string): 
 }
 
 function sessionType(providerId: string, id: string, label: string, chatSessionType?: string): IProviderSessionType {
-	return { providerId, sessionType: { id, label, icon: Codicon.terminal, chatSessionType } };
+	return { providerId, sessionType: { id, label, icon: Codicon.terminal, chatSessionType, authRequirement: SessionTypeAuthRequirement.GitHub } };
 }
 
 function createFakeSession(providerId: string, sessionTypeId: string, folderUri: URI, status = SessionStatus.Untitled): ISession {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
@@ -27,9 +27,11 @@ const SIGN_IN_COMMAND_ID = 'workbench.action.chat.triggerSetup';
 const MUTE_COMMAND_ID = 'workbench.action.agentHost.discoveredConfig.mute';
 
 /**
- * Application-scoped flag persisting the user's "Don't Show Again" choice. The
- * discovered config lives on this machine, so the preference is machine-wide
- * ({@link StorageScope.APPLICATION}) rather than per-workspace or per-profile.
+ * Persists the user's "Don't Show Again" choice. The discovered config lives on
+ * this machine, so the preference is scoped to the machine — {@link
+ * StorageScope.APPLICATION} to span profiles and workspaces, and {@link
+ * StorageTarget.MACHINE} so settings sync does not carry it to a machine where
+ * no such config exists.
  */
 const MUTED_STORAGE_KEY = 'agentHost.discoveredConfig.claude.muted';
 
@@ -65,13 +67,13 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 		// The bell-slash button runs this command, which persists the mute; the
 		// storage listener below then re-drives `_update` to tear the banner down.
 		this._register(CommandsRegistry.registerCommand(MUTE_COMMAND_ID, () => {
-			this._storageService.store(MUTED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+			this._storageService.store(MUTED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}));
 
 		// Signing in/out flips the nudge; a session-type change is how the agent
 		// host signals that Claude switched between native and proxy (i.e. whether
 		// it is usable without GitHub); the opt-in and the mute can both toggle at
-		// runtime (the latter possibly via settings sync from another machine).
+		// runtime (the mute from another window on this machine).
 		this._register(Event.any(
 			this._defaultAccountService.onDidChangeDefaultAccount,
 			this._sessionsManagementService.onDidChangeSessionTypes,
@@ -84,8 +86,12 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 
 	private _update(): void {
 		// The Claude agent-host session type, once the host has advertised it.
-		const claude = this._sessionsManagementService.getAllSessionTypes()
-			.find(type => (type.chatSessionType ?? type.id) === SessionType.AgentHostClaude);
+		// Two providers (local / remote agent host) can offer the same id, so
+		// prefer a usable instance and fall back to any for the display label.
+		const claudeTypes = this._sessionsManagementService.getAllProviderSessionTypes()
+			.filter(type => (type.sessionType.chatSessionType ?? type.sessionType.id) === SessionType.AgentHostClaude)
+			.map(type => type.sessionType);
+		const claude = claudeTypes.find(type => type.authRequirement === SessionTypeAuthRequirement.None) ?? claudeTypes[0];
 
 		const show = shouldShowDiscoveredConfigNudge({
 			signedIn: this._defaultAccountService.currentDefaultAccount !== null,

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../../../../platform/agentHost/common/agentService.js';
+import { IWorkbenchContribution } from '../../../../../workbench/common/contributions.js';
+import { SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ChatInputNotificationActionKind, ChatInputNotificationSeverity, IChatInputNotificationService } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputNotificationService.js';
+import { isAllowSignedOutWhenUsableEnabled, shouldShowDiscoveredConfigNudge } from '../../../../browser/sessionsAuthGate.js';
+
+const DISCOVERED_CONFIG_NOTIFICATION_ID = 'agentHost.discoveredConfig.claude';
+
+/** Single entry point for starting GitHub Copilot sign-in from a nudge. */
+const SIGN_IN_COMMAND_ID = 'workbench.action.chat.triggerSetup';
+
+/** Command bound to the nudge's bell-slash "Don't Show Again" button. */
+const MUTE_COMMAND_ID = 'workbench.action.agentHost.discoveredConfig.mute';
+
+/**
+ * Application-scoped flag persisting the user's "Don't Show Again" choice. The
+ * discovered config lives on this machine, so the preference is machine-wide
+ * ({@link StorageScope.APPLICATION}) rather than per-workspace or per-profile.
+ */
+const MUTED_STORAGE_KEY = 'agentHost.discoveredConfig.claude.muted';
+
+/**
+ * Surfaces a calm chat-input notification in the Agents window when a signed-out
+ * user — who has opted into `chat.agentHost.allowSignedOutWhenUsable` — lands
+ * with the Claude agent running in native mode because it discovered an existing
+ * configuration on disk. Instead of forcing GitHub sign-in, the Agents window
+ * lets them in; this banner explains what happened and offers a single "Sign in
+ * to GitHub" action for anyone who actually meant to use a Copilot subscription.
+ *
+ * The banner is scoped to the Claude session type (so it only renders when that
+ * harness is selected) and clears itself the moment the user signs in or the
+ * agent stops advertising native mode. Its bell-slash button persists a
+ * machine-wide "Don't Show Again" choice; the X button dismisses it only for the
+ * current window.
+ */
+export class AgentHostDiscoveredConfigNotificationContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.agentHostDiscoveredConfigNotification';
+
+	private _shown = false;
+
+	constructor(
+		@IChatInputNotificationService private readonly _chatInputNotificationService: IChatInputNotificationService,
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		super();
+
+		// The bell-slash button runs this command, which persists the mute; the
+		// storage listener below then re-drives `_update` to tear the banner down.
+		this._register(CommandsRegistry.registerCommand(MUTE_COMMAND_ID, () => {
+			this._storageService.store(MUTED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+		}));
+
+		// Signing in/out flips the nudge; a session-type change is how the agent
+		// host signals that Claude switched between native and proxy (i.e. whether
+		// it is usable without GitHub); the opt-in and the mute can both toggle at
+		// runtime (the latter possibly via settings sync from another machine).
+		this._register(Event.any(
+			this._defaultAccountService.onDidChangeDefaultAccount,
+			this._sessionsManagementService.onDidChangeSessionTypes,
+			Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(AgentHostAllowSignedOutWhenUsableSettingId), this._store),
+			this._storageService.onDidChangeValue(StorageScope.APPLICATION, MUTED_STORAGE_KEY, this._store),
+		)(() => this._update()));
+
+		this._update();
+	}
+
+	private _update(): void {
+		// The Claude agent-host session type, once the host has advertised it.
+		const claude = this._sessionsManagementService.getAllSessionTypes()
+			.find(type => (type.chatSessionType ?? type.id) === SessionType.AgentHostClaude);
+
+		const show = shouldShowDiscoveredConfigNudge({
+			signedIn: this._defaultAccountService.currentDefaultAccount !== null,
+			allowSignedOutWhenUsable: isAllowSignedOutWhenUsableEnabled(this._configurationService),
+			usableWithoutGitHub: claude?.authRequirement === SessionTypeAuthRequirement.None,
+			muted: this._storageService.getBoolean(MUTED_STORAGE_KEY, StorageScope.APPLICATION, false),
+		});
+
+		if (!show) {
+			if (this._shown) {
+				this._chatInputNotificationService.deleteNotification(DISCOVERED_CONFIG_NOTIFICATION_ID);
+				this._shown = false;
+			}
+			return;
+		}
+
+		// Already up: don't re-push, which would clear a pending user dismissal.
+		if (this._shown || !claude) {
+			return;
+		}
+		this._shown = true;
+
+		this._chatInputNotificationService.setNotification({
+			id: DISCOVERED_CONFIG_NOTIFICATION_ID,
+			severity: ChatInputNotificationSeverity.Info,
+			message: localize('agentHost.discoveredConfig.message', "We've discovered your existing {0} configuration.", claude.label),
+			description: localize('agentHost.discoveredConfig.description', "If you intended to use a Copilot subscription, sign in to GitHub."),
+			actions: [{
+				kind: ChatInputNotificationActionKind.Command,
+				label: localize('agentHost.discoveredConfig.signIn', "Sign in to GitHub"),
+				commandId: SIGN_IN_COMMAND_ID,
+			}],
+			dismissible: true,
+			autoDismissOnMessage: true,
+			mute: {
+				commandId: MUTE_COMMAND_ID,
+				tooltip: localize('agentHost.discoveredConfig.mute', "Don't Show Again"),
+			},
+			sessionTypes: [SessionType.AgentHostClaude],
+		});
+	}
+}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -17,7 +17,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize } from '../../../../../nls.js';
-import { AgentSession, AuthenticateParams, AuthenticateResult, IAgentConnection, IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
+import { AgentSession, AuthenticateParams, AuthenticateResult, IAgentConnection, IAgentSessionMetadata, protectedResourcesRequireGitHubCopilotSignIn } from '../../../../../platform/agentHost/common/agentService.js';
 import { buildAnnotationsUri } from '../../../../../platform/agentHost/common/annotationsUri.js';
 import { parseGitHubIssueUrl } from '../../../../../platform/agentHost/common/githubIssueReferences.js';
 import { getEffectiveAgents } from '../../../../../platform/agentHost/common/customAgents.js';
@@ -47,7 +47,7 @@ import { getRegisteredLanguageModels, resolveConfiguredModel, resolveModelIdenti
 import { buildMutableConfigSchema, IAgentHostMcpServer, IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../../common/agentHostSessionsProvider.js';
 import { agentHostSessionWorkspaceKey } from '../../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../../common/sessionConfig.js';
-import { ChatInteractivity, ChatOriginKind, DEFAULT_CHAT_CAPABILITIES, effectiveChatInteractivity, IChat, IChatCapabilities, IGitHubInfo, IGitHubIssueRef, ISession, ISessionAgentRef, ISessionCapabilities, ISessionChangeset, ISessionChangesSummary, ISessionFile, ISessionFileChange, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, ISideChatSelection, sessionFileChangesEqual, SessionStatus, toSessionId } from '../../../../services/sessions/common/session.js';
+import { ChatInteractivity, ChatOriginKind, DEFAULT_CHAT_CAPABILITIES, effectiveChatInteractivity, IChat, IChatCapabilities, IGitHubInfo, IGitHubIssueRef, ISession, ISessionAgentRef, ISessionCapabilities, ISessionChangeset, ISessionChangesSummary, ISessionFile, ISessionFileChange, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, ISideChatSelection, sessionFileChangesEqual, SessionStatus, SessionTypeAuthRequirement, toSessionId } from '../../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { IDeleteChatOptions, ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions, ISessionModelsSnapshot } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
@@ -226,7 +226,24 @@ export const CopilotCLISessionType: ISessionType = {
 	label: localize('copilotCLI', "Copilot"),
 	icon: Codicon.copilot,
 	supportsWorktreeConfiguration: true,
+	authRequirement: SessionTypeAuthRequirement.GitHub,
 };
+
+/**
+ * Resolve what an agent needs before it can serve a request, from what it
+ * advertises. An agent that still requires the GitHub Copilot protected
+ * resource needs sign-in; one that has dropped the requirement is running on
+ * its own credentials — but only counts as usable if it actually has models,
+ * since an agent with an empty catalog cannot produce a request no matter who
+ * is signed in. Absent resources mean the host has not resolved the agent yet,
+ * so assume GitHub until it does.
+ */
+export function resolveAgentAuthRequirement(agent: AgentInfo): SessionTypeAuthRequirement {
+	if (!agent.protectedResources || protectedResourcesRequireGitHubCopilotSignIn(agent.protectedResources)) {
+		return SessionTypeAuthRequirement.GitHub;
+	}
+	return agent.models.length > 0 ? SessionTypeAuthRequirement.None : SessionTypeAuthRequirement.Unusable;
+}
 
 /**
  * Strategy that captures the quick-chat vs. workspace differences of an
@@ -2325,6 +2342,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			.map((agent): ISessionType => ({
 				id: agent.provider,
 				supportsWorktreeConfiguration: agent.provider === CopilotCLISessionType.id,
+				authRequirement: resolveAgentAuthRequirement(agent),
 				// The chat session contribution and language models for an agent-host
 				// agent are registered under its resource scheme (`agent-host-<provider>`),
 				// not the bare provider id, so carry it for availability lookups.
@@ -2334,7 +2352,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}));
 
 		const prev = this._sessionTypes;
-		if (prev.length === next.length && prev.every((t, i) => t.id === next[i].id && t.label === next[i].label)) {
+		if (prev.length === next.length && prev.every((t, i) => t.id === next[i].id && t.label === next[i].label && t.authRequirement === next[i].authRequirement)) {
 			return;
 		}
 		this._sessionTypes = next;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
@@ -10,6 +10,8 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { AgentHostContribution } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { AgentHostTerminalContribution } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.js';
+import { AgentHostAllowSignedOutWhenUsableContribution } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.js';
+import { AgentHostDiscoveredConfigNotificationContribution } from './agentHostDiscoveredConfigNotification.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { SessionStatus } from '../../../../services/sessions/common/session.js';
 import { LocalAgentHostDefaultProviderSettingId } from '../../../../common/agentHostSessionsProvider.js';
@@ -94,4 +96,6 @@ class LocalAgentHostContribution extends Disposable implements IWorkbenchContrib
 
 registerWorkbenchContribution2(AgentHostContribution.ID, AgentHostContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostAllowSignedOutWhenUsableContribution.ID, AgentHostAllowSignedOutWhenUsableContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostDiscoveredConfigNotificationContribution.ID, AgentHostDiscoveredConfigNotificationContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(LocalAgentHostContribution.ID, LocalAgentHostContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/sessionTypeAuthRequirement.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/sessionTypeAuthRequirement.test.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../../../../../platform/agentHost/common/agentService.js';
+import type { AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import type { ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { resolveAgentAuthRequirement } from '../../browser/baseAgentHostSessionsProvider.js';
+import { SessionTypeAuthRequirement } from '../../../../../services/sessions/common/session.js';
+
+function agent(protectedResources: ProtectedResourceMetadata[] | undefined, modelCount: number): AgentInfo {
+	return {
+		provider: 'claude',
+		displayName: 'Claude',
+		description: '',
+		models: Array.from({ length: modelCount }, (_, i) => ({ id: `m${i}` })),
+		protectedResources,
+	} as AgentInfo;
+}
+
+const copilotRequired = GITHUB_COPILOT_PROTECTED_RESOURCE;
+const copilotOptional: ProtectedResourceMetadata = { ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false };
+
+suite('Agent Host - session type auth requirement', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('an agent is only usable without GitHub when it drops the requirement AND has models', () => {
+		// Independent source of truth. The `unusable` row is the one that matters:
+		// Claude pinned to native by an explicit `claudeUseCopilotProxy: false`
+		// with no credentials still advertises the Copilot resource as
+		// `required: false`, so the requirement alone would wrongly read as
+		// "usable without GitHub". Its empty model catalog is what distinguishes
+		// it. See the amendment in docs/adr/0001-conditional-agent-window-auth.md.
+		const cases = [
+			{ name: 'unresolved (no resources yet)', agent: agent(undefined, 4) },
+			{ name: 'proxy: Copilot required', agent: agent([copilotRequired], 4) },
+			{ name: 'proxy: required, no models', agent: agent([copilotRequired], 0) },
+			{ name: 'native with credentials', agent: agent([copilotOptional], 4) },
+			{ name: 'native WITHOUT credentials', agent: agent([copilotOptional], 0) },
+		];
+
+		assert.deepStrictEqual(
+			cases.map(c => `${c.name}: ${resolveAgentAuthRequirement(c.agent)}`),
+			[
+				'unresolved (no resources yet): github',
+				'proxy: Copilot required: github',
+				'proxy: required, no models: github',
+				'native with credentials: none',
+				'native WITHOUT credentials: unusable',
+			],
+		);
+	});
+
+	test('only `none` counts as usable without GitHub', () => {
+		// The window gate counts `none` only, so `unusable` never holds the
+		// window open and never triggers the discovered-config nudge.
+		const usable = [
+			SessionTypeAuthRequirement.None,
+			SessionTypeAuthRequirement.GitHub,
+			SessionTypeAuthRequirement.Unusable,
+		].map(r => r === SessionTypeAuthRequirement.None);
+
+		assert.deepStrictEqual(usable, [true, false, false]);
+	});
+});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -23,7 +23,7 @@ import { AgentSessionProviders, AgentSessionTarget } from '../../../../../workbe
 import { IChatService, IChatSendRequestOptions } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatResponseModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, gitHubInfoEqual, sessionWorkspaceEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset, IChatCheckpoints, ChatInteractivity } from '../../../../services/sessions/common/session.js';
+import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, gitHubInfoEqual, sessionWorkspaceEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset, IChatCheckpoints, ChatInteractivity, SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
 import { IDeleteChatOptions, ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions, ISessionModelsSnapshot, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
@@ -60,6 +60,8 @@ export const ClaudeCodeSessionType: ISessionType = {
 	id: 'claude-code',
 	label: localize('claudeCode', "Claude"),
 	icon: Codicon.claude,
+	// Extension-contributed (legacy) generation: no native mode, always Copilot-backed.
+	authRequirement: SessionTypeAuthRequirement.GitHub,
 };
 
 /** Copilot Cloud session type - cloud-hosted agent. */
@@ -67,6 +69,7 @@ export const CopilotCloudSessionType: ISessionType = {
 	id: 'copilot-cloud-agent',
 	label: localize('copilotCloud', "Cloud"),
 	icon: Codicon.cloud,
+	authRequirement: SessionTypeAuthRequirement.GitHub,
 };
 
 const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -13,7 +13,7 @@ import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatService, IChatSendRequestOptions, IChatDetail, convertLegacyChatSessionTiming } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionFileChange2, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, ISessionType, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, IChatCheckpoints, ChatInteractivity } from '../../../../services/sessions/common/session.js';
+import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, ISessionType, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, IChatCheckpoints, ChatInteractivity, SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
 import { IDeleteChatOptions, ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions, ISessionModelsSnapshot, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
@@ -39,6 +39,8 @@ export const LocalSessionType: ISessionType = {
 	id: 'local',
 	label: localize('localSession', "Local"),
 	icon: Codicon.vm,
+	// In-process VS Code chat, which is Copilot-backed.
+	authRequirement: SessionTypeAuthRequirement.GitHub,
 };
 
 /** Setting key controlling whether Local VS Code chat sessions are available in the Agents app. */

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -218,6 +218,16 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return [...this._sessionTypes];
 	}
 
+	getAllProviderSessionTypes(): IProviderSessionType[] {
+		const result: IProviderSessionType[] = [];
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			for (const sessionType of provider.sessionTypes) {
+				result.push({ providerId: provider.id, sessionType });
+			}
+		}
+		return result;
+	}
+
 	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[] {
 		const result: IProviderSessionType[] = [];
 		for (const provider of this.sessionsProvidersService.getProviders()) {

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -30,6 +30,33 @@ export interface ISessionType {
 	 * to {@link id} when omitted.
 	 */
 	readonly chatSessionType?: string;
+	/**
+	 * Whether this session type can run right now, and if it needs GitHub to do
+	 * so. Providers resolve this from what their agent advertises; it is not a
+	 * fixed trait (Claude and Codex both move between values as their own
+	 * credentials come and go).
+	 */
+	readonly authRequirement: SessionTypeAuthRequirement;
+}
+
+/**
+ * What a session type needs before it can serve a request. The three values are
+ * mutually exclusive: {@link Unusable} is deliberately distinct from
+ * {@link GitHub}, because a type that cannot run at all must not be presented as
+ * a reason to demand GitHub sign-in (see `src/vs/sessions/CONTEXT.md`).
+ */
+export const enum SessionTypeAuthRequirement {
+	/** Runs on the user's own credentials — usable while signed out of GitHub. */
+	None = 'none',
+	/** Needs a GitHub Copilot account. Also the assumption until an agent resolves. */
+	GitHub = 'github',
+	/**
+	 * Cannot run at all right now, and signing in to GitHub would not help — e.g.
+	 * Claude pinned to native mode by an explicit `claudeUseCopilotProxy: false`
+	 * with no local Claude credentials. Surfaces as "no models", not a sign-in
+	 * prompt.
+	 */
+	Unusable = 'unusable',
 }
 
 export const GITHUB_REMOTE_FILE_SCHEME = 'github-remote-file';

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -223,9 +223,19 @@ export interface ISessionsManagementService {
 	getSessionForChatResource(resource: URI): { session: ISession; chat: IChat } | undefined;
 
 	/**
-	 * Get all session types from all registered providers.
+	 * Get all session types from all registered providers, deduplicated by
+	 * {@link ISessionType.id} (first provider wins). Use
+	 * {@link getAllProviderSessionTypes} when provider identity matters.
 	 */
 	getAllSessionTypes(): ISessionType[];
+
+	/**
+	 * Get every (provider × session type) pair from all registered providers,
+	 * without collapsing types that share an id. Two providers can offer the
+	 * same id while differing in properties that matter — e.g. only one of them
+	 * being usable without GitHub.
+	 */
+	getAllProviderSessionTypes(): IProviderSessionType[];
 
 	/**
 	 * Get all session types that can serve the given workspace URI, across all

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -170,6 +170,7 @@ class MockSessionStore implements ISessionsManagementService {
 	}
 
 	getAllSessionTypes(): ISessionType[] { return []; }
+	getAllProviderSessionTypes(): IProviderSessionType[] { return []; }
 	getSessionTypesForFolder(_folderUri: URI): IProviderSessionType[] { return []; }
 	getQuickChatSessionTypes(): IProviderSessionType[] { return []; }
 	isNewSessionTargetAvailable(_folderUri: URI, _options?: ICreateNewSessionOptions): boolean { return false; }

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -27,7 +27,7 @@ import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browse
 import { IChatWidgetHistoryService } from '../../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
 import { nullExtensionDescription } from '../../../../../workbench/services/extensions/common/extensions.js';
-import { ChatInteractivity, ChatOriginKind, IChat, ISession, ISessionType, ISessionWorkspace, ISideChatSelection, SessionStatus } from '../../common/session.js';
+import { SessionTypeAuthRequirement, ChatInteractivity, ChatOriginKind, IChat, ISession, ISessionType, ISessionWorkspace, ISideChatSelection, SessionStatus } from '../../common/session.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionModelsSnapshot, ISessionModelPickerOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
@@ -157,7 +157,7 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override readonly label = 'Test';
 	override readonly icon = Codicon.vm;
 	override readonly order: number = 0;
-	override readonly sessionTypes: readonly ISessionType[] = [{ id: 'test', label: 'Test', icon: Codicon.vm, supportsWorktreeConfiguration: true }];
+	override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'test', label: 'Test', icon: Codicon.vm, supportsWorktreeConfiguration: true }];
 	override readonly onDidChangeSessionTypes = Event.None;
 	override readonly onDidChangeSessions = Event.None;
 	override readonly browseActions = [];
@@ -1061,8 +1061,8 @@ suite('SessionsManagementService', () => {
 		const provider = new class extends TestSessionsProvider {
 			override readonly supportsQuickChats = true;
 			override readonly sessionTypes: readonly ISessionType[] = [
-				{ id: 'workspace-agent', label: 'Workspace Agent', icon: Codicon.vm },
-				{ id: 'quick-agent', label: 'Quick Agent', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'workspace-agent', label: 'Workspace Agent', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick-agent', label: 'Quick Agent', icon: Codicon.vm },
 			];
 			override resolveWorkspace(folderUri: URI): ISessionWorkspace | undefined {
 				return extUriBiasedIgnorePathCase.isEqual(folderUri, availableFolder) ? { folderUri } as unknown as ISessionWorkspace : undefined;
@@ -1117,7 +1117,7 @@ suite('SessionsManagementService', () => {
 				return { folderUri: _folderUri } as unknown as ISessionWorkspace;
 			}
 			override getSessionTypes(): ISessionType[] {
-				return [{ id: 'test', label: 'Test', icon: Codicon.vm }];
+				return [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'test', label: 'Test', icon: Codicon.vm }];
 			}
 		}(hiddenHarnessSession);
 		const { service } = createSessionsManagementService(hiddenHarnessSession, disposables, provider);
@@ -1162,9 +1162,9 @@ suite('SessionsManagementService', () => {
 		const agentHost = new class extends TestSessionsProvider {
 			override readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
 			override readonly order = -1;
-			override readonly sessionTypes: readonly ISessionType[] = [{ id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }];
+			override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }];
 			override resolveWorkspace(_folderUri: URI): ISessionWorkspace { return { folderUri: _folderUri } as unknown as ISessionWorkspace; }
-			override getSessionTypes(): ISessionType[] { return [{ id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }]; }
+			override getSessionTypes(): ISessionType[] { return [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'copilotcli', label: 'Copilot', icon: Codicon.vm }]; }
 			override getSessions(): ISession[] { return []; }
 			override createNewSession(_folderUri: URI, sessionTypeId: string): ISession {
 				created.push({ providerId: this.id, sessionTypeId });
@@ -1648,7 +1648,7 @@ suite('SessionsManagementService', () => {
 		});
 		let sent = false;
 		const provider = new class extends TestSessionsProvider {
-			override readonly sessionTypes: readonly ISessionType[] = [{ id: 'test', label: 'Test', icon: Codicon.vm }];
+			override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'test', label: 'Test', icon: Codicon.vm }];
 			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
 			override setIsolationMode(): never { throw new Error('isolation should not be configured'); }
 			override setBranch(): never { throw new Error('branch should not be configured'); }
@@ -2408,7 +2408,7 @@ suite('SessionsManagementService', () => {
 				seed: ISession,
 				override readonly id: string = 'quick-provider',
 				override readonly order: number = 0,
-				override readonly sessionTypes: readonly ISessionType[] = [{ id: 'quick', label: 'Quick', icon: Codicon.vm }],
+				override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick', label: 'Quick', icon: Codicon.vm }],
 			) {
 				super(seed);
 			}
@@ -2484,8 +2484,8 @@ suite('SessionsManagementService', () => {
 
 		test('honours options.providerId and the requested session type', () => {
 			const quick = new QuickChatProvider(stubSession({ sessionId: 'seed', providerId: 'quick-provider' }), 'quick-provider', 0, [
-				{ id: 'quick', label: 'Quick', icon: Codicon.vm },
-				{ id: 'other', label: 'Other', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick', label: 'Quick', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'other', label: 'Other', icon: Codicon.vm },
 			]);
 
 			const service = setupQuickChat([quick]);
@@ -2496,8 +2496,8 @@ suite('SessionsManagementService', () => {
 
 		test('honours an explicit sessionTypeId without a providerId', () => {
 			const quick = new QuickChatProvider(stubSession({ sessionId: 'seed', providerId: 'quick-provider' }), 'quick-provider', 0, [
-				{ id: 'quick', label: 'Quick', icon: Codicon.vm },
-				{ id: 'other', label: 'Other', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick', label: 'Quick', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'other', label: 'Other', icon: Codicon.vm },
 			]);
 
 			const service = setupQuickChat([quick]);
@@ -2508,8 +2508,8 @@ suite('SessionsManagementService', () => {
 
 		test('defaults to the last-used session type on the next call', () => {
 			const quick = new QuickChatProvider(stubSession({ sessionId: 'seed', providerId: 'quick-provider' }), 'quick-provider', 0, [
-				{ id: 'quick', label: 'Quick', icon: Codicon.vm },
-				{ id: 'other', label: 'Other', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick', label: 'Quick', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'other', label: 'Other', icon: Codicon.vm },
 			]);
 
 			const service = setupQuickChat([quick]);
@@ -2539,8 +2539,8 @@ suite('SessionsManagementService', () => {
 				override readonly order = 0;
 			}(stubSession({ sessionId: 'p1', providerId: 'plain' }));
 			const quick = new QuickChatProvider(stubSession({ sessionId: 'seed', providerId: 'quick-provider' }), 'quick-provider', 1, [
-				{ id: 'quick', label: 'Quick', icon: Codicon.vm },
-				{ id: 'other', label: 'Other', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'quick', label: 'Quick', icon: Codicon.vm },
+				{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'other', label: 'Other', icon: Codicon.vm },
 			]);
 
 			const service = setupQuickChat([plain, quick]);
@@ -2566,12 +2566,12 @@ function createOrderedTypesService(disposables: ReturnType<typeof ensureNoDispos
 	const copilotProvider = new class extends TestSessionsProvider {
 		override readonly id = 'default-copilot';
 		override readonly order = copilotOrder;
-		override readonly sessionTypes: readonly ISessionType[] = [{ id: 'copilot', label: 'Copilot', icon: Codicon.vm }];
+		override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'copilot', label: 'Copilot', icon: Codicon.vm }];
 	}(stubSession({ sessionId: 'c1', providerId: 'default-copilot' }));
 	const agentHostProvider = new class extends TestSessionsProvider {
 		override readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
 		override readonly order = agentHostOrder;
-		override readonly sessionTypes: readonly ISessionType[] = [{ id: 'agent-host', label: 'Agent Host', icon: Codicon.vm }];
+		override readonly sessionTypes: readonly ISessionType[] = [{ authRequirement: SessionTypeAuthRequirement.GitHub, id: 'agent-host', label: 'Agent Host', icon: Codicon.vm }];
 	}(stubSession({ sessionId: 'a1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID }));
 
 	const instantiationService = disposables.add(new TestInstantiationService());

--- a/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
+++ b/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
+
+suite('Sessions - Auth Gate', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shows the discovered-config nudge only when signed out, opted in, the type is usable without GitHub, and not muted', () => {
+		// Independent source of truth: the nudge is the calm inverse of the gate —
+		// it appears iff the user is signed out AND the opt-in is on AND that type
+		// is usable without GitHub AND the user has not muted it. Of all 16 input
+		// combinations only one satisfies every condition.
+		const cases = [
+			{ signedIn: true, allowSignedOutWhenUsable: false, usableWithoutGitHub: false, muted: false },
+			{ signedIn: true, allowSignedOutWhenUsable: false, usableWithoutGitHub: false, muted: true },
+			{ signedIn: true, allowSignedOutWhenUsable: false, usableWithoutGitHub: true, muted: false },
+			{ signedIn: true, allowSignedOutWhenUsable: false, usableWithoutGitHub: true, muted: true },
+			{ signedIn: true, allowSignedOutWhenUsable: true, usableWithoutGitHub: false, muted: false },
+			{ signedIn: true, allowSignedOutWhenUsable: true, usableWithoutGitHub: false, muted: true },
+			{ signedIn: true, allowSignedOutWhenUsable: true, usableWithoutGitHub: true, muted: false },
+			{ signedIn: true, allowSignedOutWhenUsable: true, usableWithoutGitHub: true, muted: true },
+			{ signedIn: false, allowSignedOutWhenUsable: false, usableWithoutGitHub: false, muted: false },
+			{ signedIn: false, allowSignedOutWhenUsable: false, usableWithoutGitHub: false, muted: true },
+			{ signedIn: false, allowSignedOutWhenUsable: false, usableWithoutGitHub: true, muted: false },
+			{ signedIn: false, allowSignedOutWhenUsable: false, usableWithoutGitHub: true, muted: true },
+			{ signedIn: false, allowSignedOutWhenUsable: true, usableWithoutGitHub: false, muted: false },
+			{ signedIn: false, allowSignedOutWhenUsable: true, usableWithoutGitHub: false, muted: true },
+			{ signedIn: false, allowSignedOutWhenUsable: true, usableWithoutGitHub: true, muted: false },
+			{ signedIn: false, allowSignedOutWhenUsable: true, usableWithoutGitHub: true, muted: true },
+		];
+
+		assert.deepStrictEqual(cases.map(shouldShowDiscoveredConfigNudge), [
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			true,
+			false,
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../../base/common/event.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution } from '../../../../../../workbench/common/contributions.js';
+import { AgentHostRootConfigForwarder, type IForwardedRootConfigKey } from './agentHostRootConfigForwarder.js';
+
+/**
+ * Forwards the `chat.agentHost.allowSignedOutWhenUsable` experimentation opt-in
+ * into the **local** agent host's root config under the short key
+ * {@link AgentHostConfigKey.AllowSignedOutWhenUsable}. This closes the two-reader
+ * contract: the workbench reads the VS Code setting directly, while the node-side
+ * Layer 1 gate reads the root-config bag (keyed only by short keys), so the flag
+ * must be mirrored here or the node side would never see it. Gated on
+ * `chat.agentHost.enabled`. The schema-gate / hydration-retry / loop-guard
+ * machinery lives in the shared {@link AgentHostRootConfigForwarder}; this
+ * contribution only declares the key.
+ */
+export class AgentHostAllowSignedOutWhenUsableContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.agentHostAllowSignedOutWhenUsable';
+
+	private readonly _forwarder: AgentHostRootConfigForwarder;
+
+	constructor(
+		@IAgentHostService agentHostService: IAgentHostService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IAgentHostEnablementService private readonly _agentHostEnablementService: IAgentHostEnablementService,
+	) {
+		super();
+
+		const keys: readonly IForwardedRootConfigKey[] = [
+			{
+				key: AgentHostConfigKey.AllowSignedOutWhenUsable,
+				computeValue: () => this._configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true,
+				registerTriggers: (store, push) => {
+					const optInChanged = Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(AgentHostAllowSignedOutWhenUsableSettingId), store);
+					store.add(optInChanged(() => push()));
+				},
+			},
+		];
+		this._forwarder = this._register(new AgentHostRootConfigForwarder(keys, agentHostService));
+
+		this._register(autorun(reader => {
+			if (this._agentHostEnablementService.enabled.read(reader)) {
+				this._forwarder.start();
+			}
+		}));
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -10,7 +10,7 @@ import { autorun } from '../../../../../../base/common/observable.js';
 import { mark } from '../../../../../../base/common/performance.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { affectsAgentHostProviderPreference, IAgentHostService, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
+import { affectsAgentHostProviderPreference, IAgentHostService, protectedResourcesRequireGitHubCopilotSignIn, shouldSurfaceLocalAgentHostProvider, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { LOCAL_AGENT_HOST_AUTHORITY } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -36,6 +36,7 @@ import { AgentHostLanguageModelProvider, agentHostProviderSupportsAutoModel } fr
 import { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 import { AgentHostPromptCacheNotification } from './agentHostPromptCacheNotification.js';
 import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
+import { IAgentHostProtectedResourcesService } from './agentHostProtectedResourcesService.js';
 import { AICustomizationManagementSection } from '../../../common/aiCustomizationWorkspaceService.js';
 
 const LOCAL_AGENT_HOST_SESSION_TYPE_PREFIX = 'agent-host-';
@@ -124,6 +125,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		@ICustomizationHarnessService private readonly _customizationHarnessService: ICustomizationHarnessService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IAgentHostActiveClientService private readonly _activeClientService: IAgentHostActiveClientService,
+		@IAgentHostProtectedResourcesService private readonly _protectedResourcesService: IAgentHostProtectedResourcesService,
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
 	) {
 		super();
@@ -244,7 +246,17 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			canDelegate: true,
 			requiresCustomModels: true,
 			supportsAutoModel: agentHostProviderSupportsAutoModel(agent.provider),
-			requiresCopilotSignIn: true,
+			// Derived live from the agent's currently-advertised protected resources
+			// (via the protected-resources service): an agent that marks the GitHub
+			// Copilot resource `required: false` (Claude in native mode, Codex on
+			// OpenAI) is usable without signing in. Falls back to "required" until the
+			// agent host resolves. The paired `onDidChangeRequiresCopilotSignIn` lets
+			// the sessions service re-evaluate this when the set changes.
+			requiresCopilotSignIn: () => {
+				const resources = this._protectedResourcesService.getProtectedResources(agent.provider);
+				return resources !== undefined ? protectedResourcesRequireGitHubCopilotSignIn(resources) : true;
+			},
+			onDidChangeRequiresCopilotSignIn: Event.signal(Event.filter(this._protectedResourcesService.onDidChange, provider => provider === agent.provider, store)),
 			agentHostProviderId: agent.provider,
 			supportsDelegation: true,
 			capabilities: {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostProtectedResourcesService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostProtectedResourcesService.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IAgentHostService, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
+import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+
+export const IAgentHostProtectedResourcesService = createDecorator<IAgentHostProtectedResourcesService>('agentHostProtectedResourcesService');
+
+/**
+ * Tracks the protected resources each live agent-host provider currently
+ * advertises, and signals — with the provider in the payload — when that set
+ * changes. Consumers derive higher-level facts from the raw resources (e.g.
+ * whether a session type requires GitHub Copilot sign-in right now: Claude in
+ * native mode / Codex on OpenAI advertise the Copilot resource with
+ * `required: false`, so they are usable without signing in) and filter
+ * {@link onDidChange} to the provider they care about.
+ *
+ * This is the single source for that "resources + change signal" so consumers
+ * don't each re-watch root state.
+ */
+export interface IAgentHostProtectedResourcesService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Fires the {@link AgentProvider provider id} whose advertised
+	 * protected-resource set just changed. The payload lets a consumer filter to
+	 * the single provider it cares about (`Event.filter(onDidChange, p => p === id)`)
+	 * rather than depending on the service to scope it.
+	 */
+	readonly onDidChange: Event<AgentProvider>;
+
+	/**
+	 * The protected resources the agent for `providerId` currently advertises, or
+	 * `undefined` when no such agent is resolved yet (callers treat this as
+	 * "not known" and fall back to a conservative default).
+	 */
+	getProtectedResources(providerId: AgentProvider): readonly ProtectedResourceMetadata[] | undefined;
+}
+
+export class AgentHostProtectedResourcesService extends Disposable implements IAgentHostProtectedResourcesService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<AgentProvider>());
+	readonly onDidChange = this._onDidChange.event;
+
+	/**
+	 * Signature of the protected resources last seen per provider, so a change is
+	 * emitted only when the advertised set actually changes (e.g. Claude switching
+	 * between native and proxy) rather than on every root state update.
+	 */
+	private readonly _lastSignature = new Map<AgentProvider, string>();
+
+	constructor(
+		@IAgentHostService private readonly _agentHostService: IAgentHostService,
+	) {
+		super();
+		this._register(this._agentHostService.rootState.onDidChange(rootState => this._sync(rootState)));
+		const initial = this._agentHostService.rootState.value;
+		if (initial && !(initial instanceof Error)) {
+			this._sync(initial);
+		}
+	}
+
+	getProtectedResources(providerId: AgentProvider): readonly ProtectedResourceMetadata[] | undefined {
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error) {
+			return undefined;
+		}
+		const agent = rootState.agents.find(a => a.provider === providerId);
+		return agent ? agent.protectedResources ?? [] : undefined;
+	}
+
+	private _sync(rootState: RootState): void {
+		const incoming = new Set(rootState.agents.map(a => a.provider));
+		const changed: AgentProvider[] = [];
+
+		for (const provider of [...this._lastSignature.keys()]) {
+			if (!incoming.has(provider)) {
+				this._lastSignature.delete(provider);
+				changed.push(provider);
+			}
+		}
+
+		for (const agent of rootState.agents) {
+			const signature = JSON.stringify(
+				(agent.protectedResources ?? []).map(resource => [resource.resource, resource.required !== false]),
+			);
+			if (this._lastSignature.get(agent.provider) !== signature) {
+				this._lastSignature.set(agent.provider, signature);
+				changed.push(agent.provider);
+			}
+		}
+
+		for (const provider of changed) {
+			this._onDidChange.fire(provider);
+		}
+	}
+}
+
+registerSingleton(IAgentHostProtectedResourcesService, AgentHostProtectedResourcesService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -12,7 +12,7 @@ import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHostEnablementService.js';
 import '../../../../platform/agentHost/browser/agentHostEnablementService.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostAllowSignedOutWhenUsableSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchDeferThresholdSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
 import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../platform/localTranscription/common/localTranscription.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
@@ -1545,6 +1545,13 @@ configurationRegistry.registerConfiguration({
 				},
 			},
 			default: {},
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostAllowSignedOutWhenUsableSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.allowSignedOutWhenUsable', "When enabled, the Agents window opens without forcing GitHub sign-in as long as at least one agent is usable without GitHub (for example Claude in native mode with your own Anthropic credentials). When disabled (the default), GitHub sign-in is required."),
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostSdkSandboxEnabledSettingId]: {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -930,7 +930,15 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		// registers the in-place "New {0} Session" action for them. Without
 		// this, types like `agent-host-copilotcli` (registered by the local
 		// agent host) have no `openNewChatSessionInPlace.<type>` command.
-		this._contributionDisposables.set(contribution.type, new DisposableStore());
+		const disposables = new DisposableStore();
+		this._contributionDisposables.set(contribution.type, disposables);
+		// A programmatic contribution can derive its availability (e.g. a functional
+		// `requiresCopilotSignIn`) and signal when it changes; re-fire the aggregate
+		// availability event so consumers re-evaluate. Generic — no per-provider
+		// knowledge lives here.
+		if (contribution.onDidChangeRequiresCopilotSignIn) {
+			disposables.add(contribution.onDidChangeRequiresCopilotSignIn(() => this._onDidChangeAvailability.fire()));
+		}
 		this._updateHasCanDelegateProvidersContextKey();
 		this._onDidChangeAvailability.fire();
 
@@ -1450,7 +1458,17 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 	public requiresCopilotSignInForSessionType(chatSessionType: string): boolean {
 		const contribution = this._contributions.get(chatSessionType)?.contribution;
-		return !!contribution?.requiresCopilotSignIn;
+		if (!contribution) {
+			return false;
+		}
+		// The requirement may be a static boolean or, for programmatically-registered
+		// types (e.g. agent host), a function the contribution owns that derives it
+		// dynamically — for instance from the agent's currently-advertised protected
+		// resources, so a session type usable without GitHub (Claude native, Codex on
+		// OpenAI) reports `false` while it is. Re-evaluated whenever the contribution's
+		// availability notifier fires.
+		const requires = contribution.requiresCopilotSignIn;
+		return typeof requires === 'function' ? requires() : !!requires;
 	}
 
 	public sessionSupportsFork(sessionResource: URI): boolean {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -195,8 +195,21 @@ export interface IChatSessionsExtensionPoint {
 	 * Whether this type needs a GitHub Copilot account and so is unusable until the user signs in. Set by
 	 * Copilot-backed types (Copilot CLI / agent host, cloud agent) where BYOK isn't supported. Defaults to false, so
 	 * third-party types that don't depend on Copilot stay usable while signed out.
+	 *
+	 * May be a function for programmatically-registered types (e.g. agent host) that derive the requirement
+	 * dynamically — for instance from the agent's currently-advertised protected resources, re-evaluated whenever
+	 * {@link IChatSessionAvailabilityNotifier.notifyChanged} fires. Declaratively-contributed extensions can only
+	 * supply a static boolean (parsed from JSON).
 	 */
-	readonly requiresCopilotSignIn?: boolean;
+	readonly requiresCopilotSignIn?: boolean | (() => boolean);
+	/**
+	 * Fires when a functional {@link requiresCopilotSignIn} would return a
+	 * different value (e.g. an agent-host agent flipped between proxy and native).
+	 * The sessions service re-fires {@link IChatSessionsService.onDidChangeAvailability}
+	 * in response. Only meaningful for programmatically-registered contributions —
+	 * declaratively-contributed extensions supply a static boolean and omit this.
+	 */
+	readonly onDidChangeRequiresCopilotSignIn?: Event<void>;
 	/**
 	 * When false, the delegation picker is hidden for this session type.
 	 * Defaults to true.
@@ -882,7 +895,9 @@ export interface IChatSessionsService {
 
 	/**
 	 * Whether the session type needs a Copilot account and so is unusable until the user signs in (BYOK isn't
-	 * supported). Defaults to false, so third-party types stay usable while signed out.
+	 * supported). A type's {@link IChatSessionsExtensionPoint.requiresCopilotSignIn} may be a static boolean or a
+	 * function evaluated on demand (e.g. agent-host types derive it from the agent's currently-advertised protected
+	 * resources); defaults to false so third-party types stay usable while signed out.
 	 */
 	requiresCopilotSignInForSessionType(chatSessionType: string): boolean;
 

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -37,6 +37,7 @@ import { AgentHostSessionListContribution } from '../browser/agentSessions/agent
 import { AgentHostOpenSessionLinkOpenerContribution } from '../browser/agentSessions/agentHost/openSessionLinkOpener.contribution.js';
 import { AgentHostTerminalContribution } from '../browser/agentSessions/agentHost/agentHostTerminalContribution.js';
 import { AgentHostCopilotCliSettingsContribution } from '../browser/agentSessions/agentHost/agentHostCopilotCliSettingsContribution.js';
+import { AgentHostAllowSignedOutWhenUsableContribution } from '../browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.js';
 import './codexCustomizationSettings.contribution.js';
 import { CopilotConfigSlashSubmitHandlerContribution } from '../browser/agentSessions/agentHost/copilotConfigSlashSubmitHandler.js';
 import '../browser/agentSessions/agentHost/agentHostSettings.contribution.js';
@@ -278,6 +279,7 @@ registerWorkbenchContribution2(AgentHostSessionListContribution.ID, AgentHostSes
 registerWorkbenchContribution2(AgentHostOpenSessionLinkOpenerContribution.ID, AgentHostOpenSessionLinkOpenerContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostCopilotCliSettingsContribution.ID, AgentHostCopilotCliSettingsContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostAllowSignedOutWhenUsableContribution.ID, AgentHostAllowSignedOutWhenUsableContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(OpenWorkspaceInAgentsContribution.ID, OpenWorkspaceInAgentsContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(AgentsHandoffInputTipContribution.ID, AgentsHandoffInputTipContribution, WorkbenchPhase.Eventually);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAllowSignedOutWhenUsableContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAllowSignedOutWhenUsableContribution.test.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../../base/common/observable.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
+import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
+import type { ClientAnnotationsAction, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import type { ConfigPropertySchema, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentHostAllowSignedOutWhenUsableContribution } from '../../../browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.js';
+
+class MockAgentHostService extends mock<IAgentHostService>() {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onAgentHostStart = new Emitter<void>();
+	override readonly onAgentHostStart = this._onAgentHostStart.event;
+	override readonly onAgentHostExit = Event.None;
+	override readonly onDidAction = Event.None;
+	override readonly onDidNotification: Event<INotification> = Event.None;
+
+	public dispatchedActions: { channel: string; action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction }[] = [];
+
+	override dispatch(channel: string, action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): void {
+		this.dispatchedActions.push({ channel, action });
+	}
+
+	private _rootStateValue: RootState | undefined = undefined;
+	private readonly _rootStateOnDidChange = new Emitter<RootState>();
+	override readonly rootState: IAgentSubscription<RootState> = (() => {
+		const self = this;
+		return {
+			get value() { return self._rootStateValue; },
+			get verifiedValue() { return self._rootStateValue; },
+			onDidChange: this._rootStateOnDidChange.event,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+	})();
+
+	setRootState(state: RootState): void {
+		this._rootStateValue = state;
+		this._rootStateOnDidChange.fire(state);
+	}
+
+	dispose(): void {
+		this._onAgentHostStart.dispose();
+		this._rootStateOnDidChange.dispose();
+	}
+}
+
+function makeRootStateWithSchema(properties: Record<string, ConfigPropertySchema>, values: Record<string, unknown> = {}): RootState {
+	return {
+		agents: [],
+		config: {
+			schema: { type: 'object', properties },
+			values,
+		},
+	};
+}
+
+/** The schema an up-to-date host advertises for the forwarded key. */
+const fullSchema: Record<string, ConfigPropertySchema> = {
+	[AgentHostConfigKey.AllowSignedOutWhenUsable]: { type: 'boolean', title: 'Allow Signed-Out Agent Window' },
+};
+
+/** Two microtask hops: one for the await on computeValue, one for the dispatch. */
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function fireConfigurationChange(configurationService: TestConfigurationService, settingId: string): void {
+	configurationService.onDidChangeConfigurationEmitter.fire({
+		source: ConfigurationTarget.USER,
+		affectedKeys: new Set([settingId]),
+		change: { keys: [settingId], overrides: [] },
+		affectsConfiguration: configuration => configuration === settingId,
+	});
+}
+
+function setup(disposables: DisposableStore, settings: Record<string, unknown>) {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	const agentHostService = new MockAgentHostService();
+	disposables.add({ dispose: () => agentHostService.dispose() });
+	const configurationService = new TestConfigurationService(settings);
+	instantiationService.stub(IAgentHostService, agentHostService);
+	instantiationService.stub(IConfigurationService, configurationService);
+	instantiationService.stub(IAgentHostEnablementService, { _serviceBrand: undefined, enabled: constObservable(true) });
+	disposables.add(instantiationService.createInstance(AgentHostAllowSignedOutWhenUsableContribution));
+	return { agentHostService, configurationService };
+}
+
+suite('AgentHostAllowSignedOutWhenUsableContribution', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('forwards the opt-in into root config under the short key once the schema advertises it', async () => {
+		const { agentHostService } = setup(disposables, {
+			[AgentHostAllowSignedOutWhenUsableSettingId]: true,
+		});
+		agentHostService.setRootState(makeRootStateWithSchema(fullSchema));
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.AllowSignedOutWhenUsable]: true,
+		});
+	});
+
+	test('re-pushes the short key when the setting is toggled on', async () => {
+		const { agentHostService, configurationService } = setup(disposables, {
+			[AgentHostAllowSignedOutWhenUsableSettingId]: false,
+		});
+		agentHostService.setRootState(makeRootStateWithSchema(fullSchema));
+		await flush();
+
+		await configurationService.setUserConfiguration(AgentHostAllowSignedOutWhenUsableSettingId, true);
+		fireConfigurationChange(configurationService, AgentHostAllowSignedOutWhenUsableSettingId);
+		await flush();
+
+		assert.deepStrictEqual(
+			agentHostService.dispatchedActions.map(a => (a.action as IRootConfigChangedAction).config),
+			[
+				{ [AgentHostConfigKey.AllowSignedOutWhenUsable]: false },
+				{ [AgentHostConfigKey.AllowSignedOutWhenUsable]: true },
+			],
+		);
+	});
+
+	test('does not dispatch to a host whose schema does not advertise the key', async () => {
+		const { agentHostService } = setup(disposables, {
+			[AgentHostAllowSignedOutWhenUsableSettingId]: true,
+		});
+		agentHostService.setRootState(makeRootStateWithSchema({}));
+		await flush();
+
+		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -93,6 +93,7 @@ import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { CHAT_SETUP_ACTION_ID } from '../../../browser/actions/chatActions.js';
 import { type ContextKeyValue } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
+import { IAgentHostProtectedResourcesService } from '../../../browser/agentSessions/agentHost/agentHostProtectedResourcesService.js';
 import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
@@ -925,6 +926,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		getClientTools: () => constObservable<readonly ToolDefinition[]>([]),
 	};
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);
+	instantiationService.stub(IAgentHostProtectedResourcesService, { onDidChange: Event.None, getProtectedResources: () => undefined });
 	instantiationService.stub(IOpenerService, openerService as IOpenerService);
 
 	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, chatSessionItemControllers, newSessionFolderService, trustController, modelService, workingCopyService, commandService };

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostProtectedResourcesService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostProtectedResourcesService.test.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { GITHUB_COPILOT_PROTECTED_RESOURCE, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
+import { createRootState, type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentHostProtectedResourcesService } from '../../../browser/agentSessions/agentHost/agentHostProtectedResourcesService.js';
+
+suite('AgentHostProtectedResourcesService', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function agent(provider: string, protectedResources: ProtectedResourceMetadata[]): AgentInfo {
+		return { provider, displayName: provider, description: '', models: [], protectedResources };
+	}
+
+	function createService() {
+		const onDidChange = store.add(new Emitter<RootState>());
+		let value: RootState | undefined;
+		const rootState: IAgentSubscription<RootState> = {
+			get value() { return value; },
+			get verifiedValue() { return value; },
+			onDidChange: onDidChange.event,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+		const agentHostService = new class extends mock<IAgentHostService>() {
+			override readonly rootState = rootState;
+		};
+		const service = store.add(new AgentHostProtectedResourcesService(agentHostService));
+		const setAgents = (agents: AgentInfo[]) => {
+			value = { ...createRootState(), agents };
+			onDidChange.fire(value);
+		};
+		return { service, setAgents };
+	}
+
+	test('onDidChange emits the changed provider, and only on a real change', () => {
+		const { service, setAgents } = createService();
+		const changed: string[] = [];
+		store.add(service.onDidChange(provider => changed.push(provider)));
+
+		// Both providers first advertise a resource set → each is emitted once.
+		setAgents([agent('a', [GITHUB_COPILOT_PROTECTED_RESOURCE]), agent('b', [GITHUB_COPILOT_PROTECTED_RESOURCE])]);
+
+		// Only provider 'a' flips (Copilot required → not-required) → only 'a' is emitted.
+		setAgents([agent('a', [{ ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false }]), agent('b', [GITHUB_COPILOT_PROTECTED_RESOURCE])]);
+
+		// Re-emit an identical root state → the signature is unchanged, so nothing is emitted.
+		setAgents([agent('a', [{ ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false }]), agent('b', [GITHUB_COPILOT_PROTECTED_RESOURCE])]);
+
+		assert.deepStrictEqual(changed, ['a', 'b', 'a']);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -15,7 +15,8 @@ import { applyCodexAgentHostPreference, ChatSessionsService } from '../../../bro
 import { ChatSessionOptionsMap, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsExtensionPoint, ReadonlyChatSessionOptionsMap, SessionType } from '../../../common/chatSessionsService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { AGENT_HOST_ENABLED_CONTEXT_KEY } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
-import { AgentHostCodexAgentEnabledSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostCodexAgentEnabledSettingId, CodexPreferAgentHostEditorSettingId, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, protectedResourcesRequireGitHubCopilotSignIn } from '../../../../../../platform/agentHost/common/agentService.js';
+import { ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 
 suite('Codex Agent Host preference', () => {
@@ -246,6 +247,96 @@ suite('ChatSessionsService - getChatSessionItems availability', () => {
 
 		gatedEnabled.set(false);
 		assert.deepStrictEqual(await resolvedTypes(), [UNGATED_TYPE]);
+	});
+});
+
+suite('ChatSessionsService - requiresCopilotSignInForSessionType', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: ChatSessionsService;
+
+	setup(() => {
+		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
+		service = store.add(instantiationService.createInstance(ChatSessionsService));
+	});
+
+	function register(type: string, extra: Partial<IChatSessionsExtensionPoint>): void {
+		store.add(service.registerChatSessionContribution({ type, name: type, displayName: type, description: '', ...extra }));
+	}
+
+	test('evaluates a functional requiresCopilotSignIn, and reads a static flag otherwise', () => {
+		// Declarative (extension) types supply a static boolean, read directly.
+		register('static-required', { requiresCopilotSignIn: true });
+		register('static-not-required', { requiresCopilotSignIn: false });
+
+		// Programmatic types (e.g. agent host) own a function deriving the
+		// requirement from their agent's advertised protected resources — an agent
+		// that marks the Copilot resource `required: false` (Claude native, Codex on
+		// OpenAI) is usable without signing in; an unresolved agent falls back to
+		// "required".
+		const resourcesByProvider: Record<string, readonly ProtectedResourceMetadata[] | undefined> = {
+			proxy: [GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE],
+			native: [{ ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false }, GITHUB_REPO_PROTECTED_RESOURCE],
+			'codex-openai': [{ ...GITHUB_COPILOT_PROTECTED_RESOURCE, required: false }],
+			unresolved: undefined,
+		};
+		const derive = (provider: string) => () => {
+			const resources = resourcesByProvider[provider];
+			return resources !== undefined ? protectedResourcesRequireGitHubCopilotSignIn(resources) : true;
+		};
+		register('ah-proxy', { agentHostProviderId: 'proxy', requiresCopilotSignIn: derive('proxy') });
+		register('ah-native', { agentHostProviderId: 'native', requiresCopilotSignIn: derive('native') });
+		register('ah-codex-openai', { agentHostProviderId: 'codex-openai', requiresCopilotSignIn: derive('codex-openai') });
+		register('ah-unresolved', { agentHostProviderId: 'unresolved', requiresCopilotSignIn: derive('unresolved') });
+
+		assert.deepStrictEqual({
+			staticRequired: service.requiresCopilotSignInForSessionType('static-required'),
+			staticNotRequired: service.requiresCopilotSignInForSessionType('static-not-required'),
+			ahProxy: service.requiresCopilotSignInForSessionType('ah-proxy'),
+			ahNative: service.requiresCopilotSignInForSessionType('ah-native'),
+			ahCodexOpenai: service.requiresCopilotSignInForSessionType('ah-codex-openai'),
+			ahUnresolved: service.requiresCopilotSignInForSessionType('ah-unresolved'),
+			unknownType: service.requiresCopilotSignInForSessionType('never-registered'),
+		}, {
+			staticRequired: true,
+			staticNotRequired: false,
+			ahProxy: true,
+			ahNative: false,
+			ahCodexOpenai: false,
+			ahUnresolved: true,
+			unknownType: false,
+		});
+	});
+
+	test('a contribution change event re-fires onDidChangeAvailability until it is unregistered', () => {
+		const changed = store.add(new Emitter<void>());
+		let availabilityFires = 0;
+		store.add(service.onDidChangeAvailability(() => availabilityFires++));
+
+		// Registering the contribution fires availability once (a type appeared);
+		// its onDidChangeRequiresCopilotSignIn is wired generically.
+		const registration = store.add(service.registerChatSessionContribution({
+			type: 'dyn', name: 'dyn', displayName: 'dyn', description: '',
+			requiresCopilotSignIn: () => true,
+			onDidChangeRequiresCopilotSignIn: changed.event,
+		}));
+		const afterRegister = availabilityFires;
+
+		changed.fire();
+		const afterChange = availabilityFires;
+
+		// Unregistering disposes the subscription (and fires once for the removal),
+		// so a later change no longer drives availability.
+		registration.dispose();
+		const afterDispose = availabilityFires;
+		changed.fire();
+		const afterChangePostDispose = availabilityFires;
+
+		assert.deepStrictEqual(
+			{ afterRegister, afterChange, afterDispose, afterChangePostDispose },
+			{ afterRegister: 1, afterChange: 2, afterDispose: 3, afterChangePostDispose: 3 },
+		);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -276,7 +276,8 @@ export class MockChatSessionsService implements IChatSessionsService {
 	}
 
 	requiresCopilotSignInForSessionType(chatSessionType: string): boolean {
-		return !!this.contributions.find(c => c.type === chatSessionType)?.requiresCopilotSignIn;
+		const requires = this.contributions.find(c => c.type === chatSessionType)?.requiresCopilotSignIn;
+		return typeof requires === 'function' ? requires() : !!requires;
 	}
 
 	supportsDelegationForSessionType(chatSessionType: string): boolean {


### PR DESCRIPTION
> [!NOTE]
> Draft. Behind an experimentation setting that is **off by default** — with `chat.agentHost.allowSignedOutWhenUsable` unset, behaviour is unchanged.

## What

The Agents window currently forces GitHub sign-in with a non-dismissible modal whenever the user is signed out. With this opt-in enabled, it no longer does so when some registered session type can run on the user's own credentials — today that means Claude in native mode with an existing local setup.

Instead of the modal, the window opens and a chat-input notification explains what happened, with a **Sign in to GitHub** action for anyone who meant to use a Copilot subscription, an X (dismiss for this window), and a bell-slash **Don't Show Again** (machine-wide, `APPLICATION` scope).

## How

Whether a type requires GitHub is **derived from the agent's advertised protected resources**, not a static flag — that signal already crosses the agent-host IPC boundary and updates reactively. It surfaces on the provider-agnostic `ISessionType.authRequirement`:

```ts
'none' | 'github' | 'unusable'
```

The third state is load-bearing rather than decorative. Claude pinned to native by an explicit `claudeUseCopilotProxy: false` **with no credentials** still advertises the Copilot resource as `required: false`, so a boolean would report it usable-without-GitHub — opening the window onto an agent that fails on its first turn, and claiming a configuration was discovered that does not exist.

What distinguishes that case is the model catalog, so Claude now publishes an **empty** catalog when native without a credential. The SDK's `supportedModels()` is a static list that answers even with no credentials (verified: resolves with 4 models under a scrubbed env and empty `HOME`), so publishing it would advertise models that fail on use. This also corrects behaviour that predates this feature, since the explicit override reaches native regardless of the flag.

Layering: the sessions core cannot import `vs/workbench/contrib`, so providers resolve the per-type fact into `ISessionType` and core sessions code reads only the provider-agnostic model.

## Known gap

`observeUsableWithoutGitHub` does not reuse `getSessionTypeAvailability`, which the per-type pickers use for a related question. That helper is unreachable from this layer, and its model check cannot detect a credential-less native agent. The cost is two predicates that can drift — they already differ over `chatEntitlementService.anonymous`, which the pickers honour and this gate ignores. Pre-existing (with the opt-in off the gate collapses to today's behaviour) but worth converging; there is a `TODO` at the call site.

## Testing

- Truth tables for the notification predicate and the `authRequirement` resolution, including the `native WITHOUT credentials → unusable` row
- `claudeTransportMode` precedence matrix + credential detection
- 105 tests passing across the affected suites; `typecheck-client`, `valid-layers-check`, full compile clean
- Verified end-to-end in the Agents window signed out (`--use-mock-keychain`): notification renders, **X** dismisses for the window only and returns on reload, **Don't Show Again** persists across reload, and the notification tears down reactively when the opt-in is toggled off

## Not included

A `CONTEXT.md` glossary and an ADR were written alongside this and are intentionally left out of this PR.
