### PR TITLE
fix: guard against disposed model in notebook diff source editor (fixes #328985)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
@@ -2001,6 +2001,14 @@ export class ModifiedElement extends AbstractElementRenderer {
 		// Else when the model is set, the height of the editor will be x, after diff is computed, then height will be y.
 		// & that results in flicker.
 		await vm.waitForDiff();
+
+		if (this._isDisposed) {
+			// The component was disposed while awaiting the diff computation.
+			// The registered model references have already been disposed, so
+			// attaching them to the editor would throw "Model is disposed!".
+			return;
+		}
+
 		this._editor!.setModel(vm);
 
 		const handleViewStateChange = () => {


### PR DESCRIPTION
### Summary
The notebook diff view throws an unhandled `Model is disposed!` error when a diff cell component is disposed while its source diff editor is still being initialized. `_initializeSourceDiffEditor()` awaits `vm.waitForDiff()`, and if the containing component is disposed during that await, the registered model references are disposed. The subsequent `this._editor!.setModel(vm)` then attaches an already-disposed text model, which throws from `TextModel._assertNotDisposed` via `isDominatedByLongLines` during `_attachModel`.

This is a use-after-dispose async race: an existing `_isDisposed` guard runs *before* the `await vm.waitForDiff()`, but no guard runs *after* it, leaving the disposal-during-await window unhandled.

Fixes microsoft/vscode#328985
Recommended reviewer: `@DonJayamanne`

### Culprit Commit
`d0079eb32b7b` by `@DonJayamanne` — "Collapse unchanged lines in input/metadata editors of NB Diff view (#228051)" (2024-09-10). This commit introduced the `await vm.waitForDiff()` / `this._editor!.setModel(vm)` sequence in `_initializeSourceDiffEditor`, adding an await point after which disposal is not re-checked.

### Code Flow
```mermaid
sequenceDiagram
  participant C as DiffElementViewModel component
  participant I as _initializeSourceDiffEditor
  participant VM as DiffEditorViewModel
  participant DE as DiffEditorWidget.setModel
  participant TM as TextModel
  I->>VM: createViewModel(originalRef, modifiedRef) [_register]
  I->>VM: await vm.waitForDiff()
  Note over C: component disposed during await<br/>_register'd model refs disposed, _isDisposed = true
  I->>DE: this._editor.setModel(vm)
  DE->>DE: _attachModel
  DE->>TM: isDominatedByLongLines()
  TM->>TM: _assertNotDisposed() -> throws "Model is disposed!"
```

### Affected Files
- `src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts` — `_initializeSourceDiffEditor()` (~line 2003).

### Repro Steps
1. Open a notebook diff (e.g. a git diff / SCM comparison of a `.ipynb`).
2. Rapidly close/scroll the diff (or switch away) so a diff cell is disposed while its source diff editor is still computing its diff asynchronously.
3. The disposal races the `await vm.waitForDiff()`; when it wins, `setModel` on the now-disposed model throws `Model is disposed!` to telemetry.

### How the Fix Works
**Chosen approach** — in `_initializeSourceDiffEditor`, after `await vm.waitForDiff()` completes, re-check `this._isDisposed` and return early before calling `this._editor!.setModel(vm)`. This is a use-after-dispose lifecycle fix: the producer of the invalid state is the disposal path that tears down the registered model references while an async initialization is in flight. The guard is placed at the point where control resumes after the async suspension — the correct place to detect that the object's lifetime ended during the await — mirroring the codebase's own existing pattern, which already guards `_isDisposed` immediately after the earlier `await Promise.all([...createModelReference...])` in the same method. The `vm` and its model refs are registered via `_register`, so they are disposed by the time control returns; skipping `setModel` avoids touching disposed models without suppressing any real error or removing telemetry.

**Alternatives considered**
- Wrapping `setModel` in try/catch: rejected — it would hide the disposal race from telemetry instead of preventing the invalid attach, violating the fix-the-producer principle.
- Guarding inside `DiffEditorWidget.setModel`/`_attachModel`: rejected — that is the crash site, shared by all editors; the disposed-model condition here is specific to the notebook diff component's own lifecycle and belongs at that component's async resume point.

### Recommended Owner
`@DonJayamanne` — author of the culprit commit and owner of the notebook diff view input/metadata editor initialization code.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/30926873865) · opus48 · 185.9 AIC · ⌖ 11.1 AIC · ⊞ 18.1K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+errors-fix%22&type=pullrequests)




### errors-fix-driver — cycle 2

**Trigger**: cron_review_comments · **Head**: `25309b1050e8c2abd68b1c6bd35f7511d8c7e963` (`25309b1`)

| Item | Action |
|------|--------|
| Copilot review on `diffComponents.ts:2005` — 3-line disposal-guard comment exceeds the one-line limit (in scope) | Fixed in `25309b1` — collapsed to a single-line comment (replied). Prior `7f8e74f`/`6d302c2` never landed on HEAD, so the comment was still present and Copilot kept re-flagging it. |

**Push**: yes — `25309b1` · **Copilot rerequested**: ok

**Ready gate**: CI in progress (VS Code PR Check, Community PR Approvals) → not marking ready this cycle

> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/30938030424) · opus48 · 177.7 AIC · ⌖ 11.5 AIC · ⊞ 20.5K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30938030424, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/30938030424 -->