### PR TITLE
fix: guard against stale line numbers in test decorations (fixes #328988)

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -593,10 +593,17 @@ export class TestingDecorations extends Disposable implements IEditorContributio
 						continue;
 					}
 
+					const model = this.editor.getModel();
+					if (model && (line < 1 || line > model.getLineCount())) {
+						// The message location was recorded against a previous document
+						// state; the referenced line no longer exists after edits.
+						continue;
+					}
+
 					seenLines.add(line);
 					let deco = this.errorContentWidgets.get(m);
 					if (!deco) {
-						const lineLength = this.editor.getModel()?.getLineLength(line) ?? 100;
+						const lineLength = model?.getLineLength(line) ?? 100;
 						deco = this.instantiationService.createInstance(
 							TestErrorContentWidget,
 							this.editor,


### PR DESCRIPTION
### Summary

`TestingDecorations.applyContentWidgetsFromResult` computes a target `line` from a recorded test message's `location`/`stackTrace` position and passes it directly to `ITextModel.getLineLength(line)`. When the editor document has been edited since the test result was recorded, that line number can exceed the model's current line count (or be `< 1` for extension-provided stack positions), and `getLineLength` throws `BugIndicatingError: Illegal value for lineNumber`. This fires when a test run completes (`markComplete` → `onComplete`) and decorations are re-applied against a now-shorter document, affecting ~786 users across all platforms in 1.131.0.

Fixes microsoft/vscode#328988
Recommended reviewer: `@connor4312`

### Culprit Commit

| Field | Value |
|-------|-------|
| Commit | [`cdd03ef9`](https://github.com/microsoft/vscode/commit/cdd03ef96920) |
| Author | `@connor4312` |
| PR | #233137 |
| Message | testing: try out new 'badges' UI for test failures |
| Why | This commit introduced the content-widget code path that reads a line number from a recorded test message and calls `this.editor.getModel()?.getLineLength(line)` (crash line 599) with no bounds check against the live model, so a stale/out-of-range line throws. |

> Note: the crash-site code predates the 1.131.0 anomaly window; the bucket surfaced as `new` because the offending decoration path only throws when a recorded line exceeds the current document, which depends on user editing after a run. The root cause is the missing bounds guard introduced in the commit above.

### Code Flow

```mermaid
sequenceDiagram
    participant Run as TestService.runResolvedTests
    participant Result as TestResult.markComplete
    participant Deco as TestingDecorations.applyResults
    participant Model as TextModel.getLineLength

    Run->>Result: complete run
    Result->>Deco: onComplete fires
    Note over Deco: reads recorded line from<br/>message.location / stackTrace
    Deco->>Model: getLineLength(line)
    Note over Model: line > getLineCount()<br/>after document edits
    Note over Model: Illegal value for lineNumber
```

### Affected Files

| File | Role | Evidence |
|------|------|----------|
| `src/vs/editor/common/model/textModel.ts` | crash site | L862-863 (from stack): `if (lineNumber < 1 || lineNumber > this.getLineCount()) { throw new BugIndicatingError('Illegal value for lineNumber'); }` |
| `src/vs/workbench/contrib/testing/browser/testingDecorations.ts` | root cause | L589-599: `line` derived from recorded `m.location.range.startLineNumber` / stackTrace position, then passed to `getModel()?.getLineLength(line)` with no bounds check against the live model |

### Repro Steps

1. Run a test that produces an error message with a location near the end of a file (e.g. an assertion failure on the last line).
2. After the run completes, delete lines from the file so it becomes shorter than the recorded error line.
3. Re-run the test (or trigger a result update) so `applyResults` re-applies decorations against the shortened document.
4. The recorded line now exceeds the current line count and `getLineLength` throws `Illegal value for lineNumber`.

Because it depends on the document being edited after a result was recorded, the error is timing/edit dependent; keeping a test file open and editing it between runs increases the likelihood.

### How the Fix Works

**Chosen approach** (`testingDecorations.ts`): before calling `getLineLength(line)`, resolve the current model once and skip the message when `line` falls outside the live document range (`line < 1 || line > model.getLineCount()`). This fixes the problem at the point where recorded (potentially stale) result data crosses into the live editor model — an untrusted-boundary guard placed on the consumer side because the producer is the recorded test result, which is legitimately valid data for the document state at record time and cannot be corrected retroactively. The guard prevents the out-of-range line from ever reaching `getLineLength`, so the `BugIndicatingError` telemetry path is never entered, without swallowing any error or touching `logService`/`getLineLength` itself. The existing model lookup is reused for the length call to avoid a redundant `getModel()`.

**Alternatives considered**: wrapping the `getLineLength` call in try/catch — rejected because it would silence the `BugIndicatingError` after the fact and mask any genuinely illegal line, rather than skipping the known stale-position case up front.

### Recommended Owner

`@connor4312` — author of the culprit commit (#233137) and owner of the testing area (`src/vs/workbench/contrib/testing/`).




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/30926880159) · opus48 · 242.2 AIC · ⌖ 11.3 AIC · ⊞ 18.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-id%3A+errors-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30926880159, workflow_id: errors-fix, run: https://github.com/microsoft/vscode-engineering/actions/runs/30926880159 -->

<!-- gh-aw-workflow-id: errors-fix -->
<!-- gh-aw-workflow-call-id: microsoft/vscode-engineering/errors-fix -->