### PR TITLE
Add Agents window performance regression scenarios

### DIFF
--- a/.github/skills/chat-perf/SKILL.md
+++ b/.github/skills/chat-perf/SKILL.md
@@ -60,8 +60,8 @@ Launches VS Code via Playwright Electron, opens the chat panel, sends a message 
 | `--production-build` | — | Build a local bundled package via `gulp vscode` for comparison against a release baseline. |
 | `--no-cache` | — | Ignore cached baseline data, always run fresh. |
 | `--force` | — | Skip build mode mismatch confirmation prompt. |
-| `--ci` | — | CI mode: write Markdown summary to `ci-summary.md` (implies `--no-cache`, `--heap-snapshots`, `--cleanup-diagnostics`). |
-| `--heap-snapshots` | — | Take heap snapshots after each run (slow; auto-enabled in `--ci` mode). |
+| `--ci` | — | CI mode: write Markdown summary to `ci-summary.md` (implies `--no-cache` and `--cleanup-diagnostics`). |
+| `--heap-snapshots` | — | Take heap snapshots after each run. This is intentionally opt-in because snapshots are slow and distort routine benchmark cost. |
 | `--gc-object-stats` | — | **GC deep-dives only.** Enables V8 `gc_stats` tracing (per-type heap object dump on every GC). ⚠️ Corrupts all timing metrics — a major GC landing mid-request adds ~550ms — so never use it for benchmarking. Off by default; prefer heap snapshots for memory analysis. |
 | `--cleanup-diagnostics` | — | Delete heap snapshots, CPU profiles, and traces to save disk. During runs, only the latest run's files are kept; after comparison, files for non-regressed scenarios are deleted. Auto-enabled in `--ci` mode. |
 | `--setting <k=v>` | — | Set a VS Code setting override for all builds (repeatable). |
@@ -170,11 +170,14 @@ Confidence levels reported: `high` (p < 0.01), `medium` (p < 0.05), `low` (p < 0
 
 ### Scenarios
 
-Scenarios are defined in `scripts/chat-simulation/common/perf-scenarios.js` and registered via `registerPerfScenarios()`. There are three categories:
+Scenarios are defined in `scripts/chat-simulation/common/perf-scenarios.js` and registered via `registerPerfScenarios()`. There are four categories:
 
 - **Content-only** — plain streaming responses (e.g. `text-only`, `large-codeblock`, `rapid-stream`)
 - **Tool-call** — multi-turn scenarios with tool invocations (e.g. `tool-read-file`, `tool-edit-file`)
 - **Multi-turn user** — multi-turn conversations with user follow-ups, thinking blocks (e.g. `thinking-response`, `multi-turn-user`, `long-conversation`)
+- **Agents-window interaction** — deterministic restored and live multi-session workloads:
+  - `agents-restored-history`: large restored transcript, active subagent tool history, session switching, transcript recycling, and sessions-list scrolling.
+  - `agents-concurrent-sessions`: three visible running sessions with concurrent subagent/tool progress, followed by settle and quiescent-tail measurements for responsive-toolbar and ResizeObserver regressions.
 
 Run `npm run perf:chat -- --help` to see the full list of registered scenario IDs.
 
@@ -235,7 +238,7 @@ Launches one VS Code session, sends N messages sequentially, forces GC between e
 
 ## CI runs & pinpointing regressions
 
-The perf + leak checks run in CI via the **`.github/workflows/chat-perf.yml`** workflow (a scheduled daily `workflow_dispatch`, plus manual dispatch). Each run benchmarks the current `main` as the **test** build against a fixed release **baseline** (from `config.jsonc`, e.g. `1.122.0`). Because the baseline is fixed, the **test** median for a metric across successive daily runs traces `main`'s trajectory over time — that's what lets you bisect *when* something regressed or went flaky.
+The perf + leak checks run in CI via the **`.github/workflows/chat-perf.yml`** workflow. The checked-in workflow exposes `workflow_dispatch`; VS Code's external engineering automation dispatches it daily, and it can also be dispatched manually. Each run benchmarks the current `main` as the **test** build against a fixed release **baseline** (from `config.jsonc`, e.g. `1.127.0`). Because the baseline is fixed, the **test** median for a metric across successive daily runs traces `main`'s trajectory over time — that's what lets you bisect *when* something regressed or went flaky.
 
 ### Finding and reading historic runs
 
@@ -259,9 +262,9 @@ gh workflow run chat-perf.yml -R microsoft/vscode --ref main \
 | Artifact | Contents | Retention |
 |---|---|---|
 | `chat-perf-summary` | Unified `ci-summary.md`: verdicts, per-metric medians ±stddev, **per-run raw tables** | 30 days |
-| `perf-results-<group>` | Everything below **plus traces, CPU profiles, heap snapshots** (large) | 30 days |
+| `perf-results-<group>` | Everything below plus retained traces/CPU profiles for regressed scenarios; heap snapshots only when explicitly requested | 30 days |
 | `leak-results` | Leak log + `chat-simulation-leak-results.json` | 30 days |
-| `perf-summary-<group>` | `results.json` (full per-run metrics incl. `rawRuns`) + `baseline-*.json` | **1 day** |
+| `perf-summary-<group>` | `results.json` (full per-run metrics incl. `rawRuns`) + `baseline-*.json` | 30 days |
 
 ```bash
 # List a run's artifacts + whether they've expired
@@ -279,7 +282,7 @@ gh run download <run-id> -R microsoft/vscode -n chat-perf-summary
 3. **Deep-dive the cause.** Download `perf-results-<group>` (has the `trace.json` per run) for a slow run and inspect what dominates the slow window. Trick that found the `gc_stats` artifact: sum main-thread `RunTask` durations between two `code/chat/*` marks (e.g. `willCollectInstructions` → `didCollectInstructions`) — if the window is ~0% busy, it's an async wait or a GC pause, not real work; then look at the largest `X`-phase events in that window (`MajorGC`, `Layout`, etc.).
 4. **Reproduce a suspect commit locally** to bisect precisely: `npm run perf:chat -- --build <sha> --baseline-build <ver> --runs 7` (or two commits directly via `--build <shaA> --baseline-build <shaB>`).
 
-> Tip: `perf-summary-*` (the machine-readable `results.json` with `rawRuns`) is deleted after **1 day**, so for older runs rely on `chat-perf-summary` (raw tables, 30 days) or extract `results.json` from `perf-results-*` (also 30 days).
+> Tip: `perf-summary-*` contains the machine-readable `results.json` with `rawRuns`; use `chat-perf-summary` for a compact human-readable overview.
 
 ## Architecture
 

--- a/.github/workflows/chat-perf.yml
+++ b/.github/workflows/chat-perf.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      heap_snapshots:
+        description: "Capture renderer and extension-host heap snapshots for diagnostic runs"
+        required: false
+        type: boolean
+        default: false
       test_settings:
         description: 'JSON object of VS Code settings for the test build (e.g. {"chat.experimental.smoothStreaming.enabled": true})'
         required: false
@@ -55,6 +60,7 @@ env:
   PERF_RUNS: ${{ inputs.runs || '' }}
   PERF_THRESHOLD: ${{ inputs.threshold || '' }}
   SCENARIOS_INPUT: ${{ inputs.scenarios || '' }}
+  HEAP_SNAPSHOTS_INPUT: ${{ inputs.heap_snapshots || false }}
   TEST_SETTINGS_INPUT: ${{ inputs.test_settings || '' }}
   BASELINE_SETTINGS_INPUT: ${{ inputs.baseline_settings || '' }}
   # Skip binary downloads during `npm ci` (they hang intermittently on hosted
@@ -144,6 +150,9 @@ jobs:
             fi
             echo "npm ci attempt $i failed or timed out, retrying..."
           done
+
+      - name: Test chat performance corpus
+        run: node --test scripts/chat-simulation/common/agents-window-perf-corpus.test.ts
 
       - name: Transpile source
         run: npm run transpile-client
@@ -320,6 +329,9 @@ jobs:
           if [[ -n "$PERF_THRESHOLD" ]]; then
             PERF_ARGS+=("--threshold" "$PERF_THRESHOLD")
           fi
+          if [[ "$HEAP_SNAPSHOTS_INPUT" == "true" ]]; then
+            PERF_ARGS+=("--heap-snapshots")
+          fi
           PERF_ARGS+=("--production-build")
 
           # Convert JSON settings objects to --test-setting / --baseline-setting flags
@@ -376,7 +388,7 @@ jobs:
             .chat-simulation-data/**/results.json
             .chat-simulation-data/**/baseline-*.json
             .chat-simulation-data/ci-summary.md
-          retention-days: 1
+          retention-days: 30
 
       - name: Check for regressions
         if: always() && steps.perf.outputs.exit_code != '' &&

--- a/scripts/chat-simulation/common/agents-window-perf-corpus.test.ts
+++ b/scripts/chat-simulation/common/agents-window-perf-corpus.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const assert = require('assert');
+const test = require('node:test');
+const { AGENTS_PERF_CONCURRENT_BURST_TICKS, createAgentsWindowConcurrentPerfCorpus, createAgentsWindowPerfCorpus } = require('./agents-window-perf-corpus.ts');
+
+test('creates deterministic rich Agents window history', () => {
+	const first = createAgentsWindowPerfCorpus({
+		sessionCount: 4,
+		primaryTurnCount: 20,
+		secondaryTurnCount: 3,
+		peerChatCount: 2,
+		subagentToolCount: 16,
+	});
+
+	const second = createAgentsWindowPerfCorpus({
+		sessionCount: 4,
+		primaryTurnCount: 20,
+		secondaryTurnCount: 3,
+		peerChatCount: 2,
+		subagentToolCount: 16,
+	});
+	const primary = first.chatFiles[first.expected.primarySessionId];
+	const responseParts = primary.requests.flatMap(request => request.response);
+	const parentSubagent = responseParts.find(part => part.toolSpecificData?.kind === 'subagent');
+	const childTools = responseParts.filter(part => part.subAgentInvocationId === parentSubagent?.toolCallId);
+
+	assert.deepStrictEqual({
+		deterministic: first,
+		sessionCount: first.storedSessions.filter(session => !session.parentUri).length,
+		chatCount: first.storedSessions.length,
+		primaryTurns: primary.requests.length,
+		primaryHasSentinel: JSON.stringify(primary).includes(first.expected.primarySentinel),
+		subagentChildren: childTools.length,
+	}, {
+		deterministic: second,
+		sessionCount: 4,
+		chatCount: 6,
+		primaryTurns: 20,
+		primaryHasSentinel: true,
+		subagentChildren: 16,
+	});
+});
+
+test('creates a deterministic concurrent-session corpus', () => {
+	const first = createAgentsWindowConcurrentPerfCorpus();
+	const second = createAgentsWindowConcurrentPerfCorpus();
+
+	assert.deepStrictEqual({
+		deterministic: first,
+		sessionCount: first.expected.sessionCount,
+		chatCount: first.expected.chatCount,
+		turnCounts: Object.values(first.chatFiles).map(chat => chat.requests.length),
+		subagentToolCount: first.expected.subagentToolCount,
+		burstTicks: AGENTS_PERF_CONCURRENT_BURST_TICKS,
+	}, {
+		deterministic: second,
+		sessionCount: 3,
+		chatCount: 3,
+		turnCounts: [40, 40, 40],
+		subagentToolCount: 0,
+		burstTicks: 48,
+	});
+});

--- a/scripts/chat-simulation/common/agents-window-perf-corpus.ts
+++ b/scripts/chat-simulation/common/agents-window-perf-corpus.ts
@@ -1,0 +1,400 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const DEFAULT_CREATED_AT = Date.UTC(2026, 0, 1, 12, 0, 0);
+const DEFAULT_WORKSPACE = '/tmp/vscode-agents-perf-workspace';
+const INTERNAL_TOOL_SOURCE = { type: 'internal', label: 'Built-In' };
+
+const AGENTS_WINDOW_PERF_SCENARIO_ID = 'agents-restored-history';
+const AGENTS_WINDOW_CONCURRENT_SCENARIO_ID = 'agents-concurrent-sessions';
+const INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID = '_workbench.sessions.perf.injectLiveSubagentTools';
+const SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID = '_workbench.sessions.perf.scrollActiveChatStart';
+const SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID = '_workbench.sessions.perf.scrollActiveChatEnd';
+const SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID = '_workbench.sessions.perf.showConcurrentSessions';
+const RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID = '_workbench.sessions.perf.runConcurrentBurst';
+const STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID = '_workbench.sessions.perf.stopConcurrentSessions';
+const AGENTS_PERF_CONCURRENT_BURST_TICKS = 48;
+const AGENTS_PERF_CONCURRENT_FINAL_MARKER = `AGENTS_PERF_CONCURRENT_${String(AGENTS_PERF_CONCURRENT_BURST_TICKS - 1).padStart(3, '0')}`;
+const AGENTS_PERF_CONCURRENT_DONE_MARKER = 'AGENTS_PERF_CONCURRENT_DONE';
+
+interface IUriData {
+	readonly scheme: string;
+	readonly authority: string;
+	readonly path: string;
+	readonly query: string;
+	readonly fragment: string;
+}
+
+interface IAgentsWindowPerfCorpusOptions {
+	readonly sessionCount?: number;
+	readonly primaryTurnCount?: number;
+	readonly secondaryTurnCount?: number;
+	readonly peerChatCount?: number;
+	readonly subagentToolCount?: number;
+}
+
+interface IStoredSession {
+	readonly uri: IUriData;
+	readonly parentUri?: IUriData;
+	readonly title: string;
+	readonly createdAt: number;
+	readonly lastMessageDate: number;
+	readonly workingDirectory: IUriData;
+	readonly isRead: boolean;
+}
+
+interface IChatIndexEntry {
+	readonly sessionId: string;
+	readonly title: string;
+	readonly lastMessageDate: number;
+	readonly timing: {
+		readonly created: number;
+		readonly lastRequestStarted: number;
+		readonly lastRequestEnded: number;
+	};
+	readonly initialLocation: 'panel';
+	readonly lastResponseState: number;
+	readonly workingDirectory: string;
+}
+
+interface IMarkdownPart {
+	readonly value: string;
+	readonly isTrusted: false;
+	readonly supportThemeIcons: false;
+	readonly supportHtml: false;
+}
+
+interface ISerializedToolOptions {
+	readonly toolCallId: string;
+	readonly toolId: string;
+	readonly invocationMessage: string;
+	readonly pastTenseMessage: string;
+	readonly isComplete?: boolean;
+	readonly subAgentInvocationId?: string;
+	readonly toolSpecificData?: {
+		readonly kind: 'subagent';
+		readonly agentName: string;
+		readonly description: string;
+		readonly prompt: string;
+		readonly isActive: boolean;
+		readonly startedAt?: number;
+	};
+}
+
+interface ISerializedTool extends ISerializedToolOptions {
+	readonly kind: 'toolInvocationSerialized';
+	readonly originMessage: undefined;
+	readonly isConfirmed: { readonly type: 0 };
+	readonly isComplete: boolean;
+	readonly source: typeof INTERNAL_TOOL_SOURCE;
+	readonly presentation: undefined;
+	readonly resultDetails: undefined;
+}
+
+type SerializedResponsePart = IMarkdownPart | ISerializedTool;
+
+interface ISerializedRequest {
+	readonly requestId: string;
+	readonly message: string;
+	readonly variableData: { readonly variables: readonly [] };
+	readonly response: SerializedResponsePart[];
+	readonly responseId: string;
+	readonly timestamp: number;
+	readonly responseTimestamp: number;
+	readonly modelState: { readonly value: 1; readonly completedAt: number };
+	readonly elapsedMs: number;
+}
+
+interface ISerializedChat {
+	readonly version: 3;
+	readonly sessionId: string;
+	readonly creationDate: number;
+	readonly customTitle: string;
+	readonly initialLocation: 'panel';
+	readonly responderUsername: 'Copilot';
+	readonly requests: ISerializedRequest[];
+	readonly workingDirectory: string;
+}
+
+interface IAgentsWindowPerfCorpus {
+	readonly storedSessions: IStoredSession[];
+	readonly chatSessionIndex: { readonly version: 1; readonly entries: Record<string, IChatIndexEntry> };
+	readonly chatFiles: Record<string, ISerializedChat>;
+	readonly expected: {
+		readonly sessionCount: number;
+		readonly chatCount: number;
+		readonly primarySessionId: string;
+		readonly primaryTitle: string;
+		readonly primarySentinel: string;
+		readonly secondarySessionId: string;
+		readonly secondaryTitle: string;
+		readonly secondarySentinel: string;
+		readonly primaryTurnCount: number;
+		readonly subagentToolCount: number;
+		readonly workspaceFsPath: string;
+	};
+}
+
+function createAgentsWindowPerfCorpus(options: IAgentsWindowPerfCorpusOptions = {}): IAgentsWindowPerfCorpus {
+	const sessionCount = options.sessionCount ?? 24;
+	const primaryTurnCount = options.primaryTurnCount ?? 220;
+	const secondaryTurnCount = options.secondaryTurnCount ?? 18;
+	const peerChatCount = options.peerChatCount ?? 3;
+	const subagentToolCount = options.subagentToolCount ?? 128;
+
+	if (sessionCount < 2) {
+		throw new Error('Agents window perf corpus requires at least two sessions');
+	}
+
+	const storedSessions: IStoredSession[] = [];
+	const entries: Record<string, IChatIndexEntry> = {};
+	const chatFiles: Record<string, ISerializedChat> = {};
+	const workspaceUri = fileUri(DEFAULT_WORKSPACE);
+	const workspaceUriString = `file://${DEFAULT_WORKSPACE}`;
+
+	for (let index = 0; index < sessionCount; index++) {
+		const sessionId = `agents-perf-session-${String(index).padStart(3, '0')}`;
+		const title = index === 0 ? 'Agents Perf Primary Large History' : `Agents Perf Session ${String(index).padStart(3, '0')}`;
+		const turnCount = index === 0 ? primaryTurnCount : secondaryTurnCount;
+		const updatedAt = DEFAULT_CREATED_AT - index * 60_000;
+		const sentinel = index === 0 ? 'AGENTS_PERF_PRIMARY_SENTINEL' : `AGENTS_PERF_SESSION_${String(index).padStart(3, '0')}_SENTINEL`;
+		const uri = localChatSessionUri(sessionId);
+
+		storedSessions.push({
+			uri,
+			title,
+			createdAt: updatedAt - turnCount * 1_000,
+			lastMessageDate: updatedAt,
+			workingDirectory: workspaceUri,
+			isRead: true,
+		});
+		entries[sessionId] = createIndexEntry(sessionId, title, updatedAt, workspaceUriString);
+		chatFiles[sessionId] = createSerializedChat({
+			sessionId,
+			title,
+			turnCount,
+			createdAt: updatedAt - turnCount * 1_000,
+			updatedAt,
+			workspaceUriString,
+			sentinel,
+			subagentToolCount: index === 0 ? subagentToolCount : 0,
+		});
+	}
+
+	const primarySessionId = 'agents-perf-session-000';
+	const primaryUri = localChatSessionUri(primarySessionId);
+	for (let index = 0; index < peerChatCount; index++) {
+		const sessionId = `agents-perf-peer-${String(index).padStart(3, '0')}`;
+		const title = `Agents Perf Peer Chat ${String(index).padStart(3, '0')}`;
+		const updatedAt = DEFAULT_CREATED_AT - (sessionCount + index) * 60_000;
+		storedSessions.push({
+			uri: localChatSessionUri(sessionId),
+			parentUri: primaryUri,
+			title,
+			createdAt: updatedAt - secondaryTurnCount * 1_000,
+			lastMessageDate: updatedAt,
+			workingDirectory: workspaceUri,
+			isRead: true,
+		});
+		entries[sessionId] = createIndexEntry(sessionId, title, updatedAt, workspaceUriString);
+		chatFiles[sessionId] = createSerializedChat({
+			sessionId,
+			title,
+			turnCount: secondaryTurnCount,
+			createdAt: updatedAt - secondaryTurnCount * 1_000,
+			updatedAt,
+			workspaceUriString,
+			sentinel: `AGENTS_PERF_PEER_${String(index).padStart(3, '0')}_SENTINEL`,
+			subagentToolCount: 0,
+		});
+	}
+
+	return {
+		storedSessions,
+		chatSessionIndex: { version: 1, entries },
+		chatFiles,
+		expected: {
+			sessionCount,
+			chatCount: sessionCount + peerChatCount,
+			primarySessionId,
+			primaryTitle: 'Agents Perf Primary Large History',
+			primarySentinel: 'AGENTS_PERF_PRIMARY_SENTINEL',
+			secondarySessionId: 'agents-perf-session-001',
+			secondaryTitle: 'Agents Perf Session 001',
+			secondarySentinel: 'AGENTS_PERF_SESSION_001_SENTINEL',
+			primaryTurnCount,
+			subagentToolCount,
+			workspaceFsPath: DEFAULT_WORKSPACE,
+		},
+	};
+}
+
+function createAgentsWindowConcurrentPerfCorpus(): IAgentsWindowPerfCorpus {
+	return createAgentsWindowPerfCorpus({
+		sessionCount: 3,
+		primaryTurnCount: 40,
+		secondaryTurnCount: 40,
+		peerChatCount: 0,
+		subagentToolCount: 0,
+	});
+}
+
+interface ICreateSerializedChatOptions {
+	readonly sessionId: string;
+	readonly title: string;
+	readonly turnCount: number;
+	readonly createdAt: number;
+	readonly updatedAt: number;
+	readonly workspaceUriString: string;
+	readonly sentinel: string;
+	readonly subagentToolCount: number;
+}
+
+function createSerializedChat(options: ICreateSerializedChatOptions): ISerializedChat {
+	const requests: ISerializedRequest[] = [];
+	const subagentTurn = Math.floor(options.turnCount / 2);
+
+	for (let index = 0; index < options.turnCount; index++) {
+		const timestamp = options.createdAt + index * 1_000;
+		const response: SerializedResponsePart[] = [
+			markdownPart([
+				index === 0 || index === options.turnCount - 1 ? `${options.sentinel}\n\n` : '',
+				`## Restored turn ${index + 1}\n\n`,
+				`Deterministic restored response ${index + 1} for ${options.title}. `,
+				'This content exercises virtualized chat row rendering, recycling, dynamic height measurement, and scrolling.\n\n',
+				index % 7 === 0 ? '```typescript\nconst restoredTurn = true;\n```\n' : '',
+			].join('')),
+		];
+
+		if (index % 4 === 0) {
+			response.push(serializedTool({
+				toolCallId: `${options.sessionId}-tool-${index}`,
+				toolId: 'read_file',
+				invocationMessage: `Reading restored file ${index}`,
+				pastTenseMessage: `Read restored file ${index}`,
+			}));
+		}
+
+		if (options.subagentToolCount > 0 && index === subagentTurn) {
+			const parentToolCallId = `${options.sessionId}-subagent`;
+			response.push(serializedTool({
+				toolCallId: parentToolCallId,
+				toolId: 'runSubagent',
+				invocationMessage: 'Running restored performance subagent',
+				pastTenseMessage: 'Ran restored performance subagent',
+				isComplete: false,
+				toolSpecificData: {
+					kind: 'subagent',
+					agentName: 'PerfAgent',
+					description: 'Inspecting a large restored history',
+					prompt: 'Inspect the deterministic performance corpus.',
+					isActive: true,
+					startedAt: timestamp,
+				},
+			}));
+			for (let childIndex = 0; childIndex < options.subagentToolCount; childIndex++) {
+				response.push(serializedTool({
+					toolCallId: `${parentToolCallId}-child-${childIndex}`,
+					toolId: childIndex % 2 === 0 ? 'search_files' : 'read_file',
+					invocationMessage: `Restored subagent tool ${childIndex}`,
+					pastTenseMessage: `Completed restored subagent tool ${childIndex}`,
+					subAgentInvocationId: parentToolCallId,
+				}));
+			}
+		}
+
+		requests.push({
+			requestId: `${options.sessionId}-request-${index}`,
+			message: `Restore performance turn ${index + 1}`,
+			variableData: { variables: [] },
+			response,
+			responseId: `${options.sessionId}-response-${index}`,
+			timestamp,
+			responseTimestamp: timestamp + 500,
+			modelState: { value: 1, completedAt: timestamp + 750 },
+			elapsedMs: 750,
+		});
+	}
+
+	return {
+		version: 3,
+		sessionId: options.sessionId,
+		creationDate: options.createdAt,
+		customTitle: options.title,
+		initialLocation: 'panel',
+		responderUsername: 'Copilot',
+		requests,
+		workingDirectory: options.workspaceUriString,
+	};
+}
+
+function serializedTool(options: ISerializedToolOptions): ISerializedTool {
+	return {
+		kind: 'toolInvocationSerialized',
+		toolCallId: options.toolCallId,
+		toolId: options.toolId,
+		invocationMessage: options.invocationMessage,
+		originMessage: undefined,
+		pastTenseMessage: options.pastTenseMessage,
+		isConfirmed: { type: 0 },
+		isComplete: options.isComplete ?? true,
+		source: INTERNAL_TOOL_SOURCE,
+		presentation: undefined,
+		resultDetails: undefined,
+		subAgentInvocationId: options.subAgentInvocationId,
+		toolSpecificData: options.toolSpecificData,
+	};
+}
+
+function markdownPart(value: string): IMarkdownPart {
+	return { value, isTrusted: false, supportThemeIcons: false, supportHtml: false };
+}
+
+function localChatSessionUri(sessionId: string): IUriData {
+	const encodedId = Buffer.from(sessionId, 'utf8').toString('base64url');
+	return {
+		scheme: 'vscode-chat-session',
+		authority: 'local',
+		path: `/${encodedId}`,
+		query: '',
+		fragment: '',
+	};
+}
+
+function fileUri(fsPath: string): IUriData {
+	return { scheme: 'file', authority: '', path: fsPath, query: '', fragment: '' };
+}
+
+function createIndexEntry(sessionId: string, title: string, updatedAt: number, workingDirectory: string): IChatIndexEntry {
+	return {
+		sessionId,
+		title,
+		lastMessageDate: updatedAt,
+		timing: {
+			created: updatedAt - 60_000,
+			lastRequestStarted: updatedAt - 1_000,
+			lastRequestEnded: updatedAt,
+		},
+		initialLocation: 'panel',
+		lastResponseState: 1,
+		workingDirectory,
+	};
+}
+
+module.exports = {
+	AGENTS_WINDOW_PERF_SCENARIO_ID,
+	AGENTS_WINDOW_CONCURRENT_SCENARIO_ID,
+	AGENTS_PERF_CONCURRENT_BURST_TICKS,
+	AGENTS_PERF_CONCURRENT_FINAL_MARKER,
+	AGENTS_PERF_CONCURRENT_DONE_MARKER,
+	INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID,
+	SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID,
+	SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID,
+	SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID,
+	RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID,
+	STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID,
+	createAgentsWindowPerfCorpus,
+	createAgentsWindowConcurrentPerfCorpus,
+};

--- a/scripts/chat-simulation/common/perf-scenarios.js
+++ b/scripts/chat-simulation/common/perf-scenarios.js
@@ -14,6 +14,7 @@
 
 const path = require('path');
 const { ScenarioBuilder, registerScenario } = require('./mock-llm-server.ts');
+const { AGENTS_WINDOW_CONCURRENT_SCENARIO_ID, AGENTS_WINDOW_PERF_SCENARIO_ID } = require('./agents-window-perf-corpus.ts');
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
@@ -764,6 +765,19 @@ const MULTI_TURN_SCENARIOS = {
 	},
 };
 
+// -- Restored-history interaction scenarios ----------------------------------
+
+const INTERACTION_SCENARIOS = {
+	[AGENTS_WINDOW_PERF_SCENARIO_ID]: {
+		description: 'Agents window restored history: switch sessions and scroll transcript/list',
+		kind: 'agents-window-history',
+	},
+	[AGENTS_WINDOW_CONCURRENT_SCENARIO_ID]: {
+		description: 'Agents window: three visible running sessions with concurrent progress and idle-tail measurement',
+		kind: 'agents-window-concurrent',
+	},
+};
+
 // -- Registration helper ------------------------------------------------------
 
 /**
@@ -778,7 +792,17 @@ function getScenarioDescription(id) {
 	if (tool) { return tool.description; }
 	const multi = MULTI_TURN_SCENARIOS[id];
 	if (multi) { return multi.description; }
+	const interaction = INTERACTION_SCENARIOS[id];
+	if (interaction) { return interaction.description; }
 	return '';
+}
+
+/**
+ * @param {string} id
+ * @returns {'streaming' | 'agents-window-history' | 'agents-window-concurrent'}
+ */
+function getPerfScenarioKind(id) {
+	return INTERACTION_SCENARIOS[id]?.kind ?? 'streaming';
 }
 
 /**
@@ -795,6 +819,9 @@ function registerPerfScenarios() {
 	for (const [id, def] of Object.entries(MULTI_TURN_SCENARIOS)) {
 		registerScenario(id, def.scenario);
 	}
+	for (const id of Object.keys(INTERACTION_SCENARIOS)) {
+		registerScenario(id, new ScenarioBuilder().emit('Agents window restored history interaction').build());
+	}
 }
 
-module.exports = { registerPerfScenarios, getScenarioDescription, CONTENT_SCENARIOS, TOOL_CALL_SCENARIOS, MULTI_TURN_SCENARIOS };
+module.exports = { registerPerfScenarios, getScenarioDescription, getPerfScenarioKind, CONTENT_SCENARIOS, TOOL_CALL_SCENARIOS, MULTI_TURN_SCENARIOS, INTERACTION_SCENARIOS };

--- a/scripts/chat-simulation/common/utils.js
+++ b/scripts/chat-simulation/common/utils.js
@@ -17,6 +17,8 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
+const crypto = require('crypto');
+const { pathToFileURL } = require('url');
 const { execSync, execFileSync, spawn } = require('child_process');
 
 const ROOT = path.join(__dirname, '..', '..', '..');
@@ -159,17 +161,83 @@ async function resolveBuild(buildArg) {
  *
  * Requires `sqlite3` on PATH (pre-installed on macOS and Ubuntu).
  * @param {string} userDataDir
+ * @param {import('./agents-window-perf-corpus').AgentsWindowPerfCorpus} [agentsWindowCorpus]
  */
-function preseedStorage(userDataDir) {
+function preseedStorage(userDataDir, agentsWindowCorpus) {
 	const globalStorageDir = path.join(userDataDir, 'User', 'globalStorage');
 	fs.mkdirSync(globalStorageDir, { recursive: true });
-	const dbPath = path.join(globalStorageDir, 'state.vscdb');
-	const sql = [
-		'CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);',
-		'INSERT INTO ItemTable (key, value) VALUES (\'builtinChatExtensionEnablementMigration\', \'true\');',
-		'INSERT INTO ItemTable (key, value) VALUES (\'chat.tools.global.autoApprove.optIn\', \'true\');',
-	].join(' ');
-	execFileSync('sqlite3', [dbPath, sql]);
+	const defaultEntries = {
+		builtinChatExtensionEnablementMigration: 'true',
+		'chat.tools.global.autoApprove.optIn': 'true',
+	};
+	if (agentsWindowCorpus) {
+		defaultEntries['chat.ChatSessionStore.index'] = JSON.stringify(agentsWindowCorpus.chatSessionIndex);
+	}
+	writeStorageDatabase(path.join(globalStorageDir, 'state.vscdb'), defaultEntries);
+
+	if (!agentsWindowCorpus) {
+		return;
+	}
+
+	writeChatSessionFiles(path.join(globalStorageDir, 'emptyWindowChatSessions'), agentsWindowCorpus);
+
+	const agentsGlobalStorageDir = path.join(userDataDir, 'User', 'profiles', 'builtin', 'agents', 'globalStorage');
+	fs.mkdirSync(agentsGlobalStorageDir, { recursive: true });
+	writeStorageDatabase(path.join(agentsGlobalStorageDir, 'state.vscdb'), {
+		'sessions.localChat.sessions': JSON.stringify(agentsWindowCorpus.storedSessions),
+		'sessions.localChat.migrated': 'true',
+		'chat.ChatSessionStore.index': JSON.stringify(agentsWindowCorpus.chatSessionIndex),
+	});
+
+	const agentsWorkspacePath = path.join(userDataDir, 'User', 'agent-sessions.code-workspace');
+	fs.writeFileSync(agentsWorkspacePath, JSON.stringify({ folders: [] }, null, '\t'));
+	const agentsWorkspaceUri = pathToFileURL(agentsWorkspacePath).toString();
+	const agentsWorkspaceId = vscodeStringHash(agentsWorkspaceUri).toString(16);
+	const agentsWorkspaceStorageDir = path.join(userDataDir, 'User', 'workspaceStorage', agentsWorkspaceId);
+	fs.mkdirSync(agentsWorkspaceStorageDir, { recursive: true });
+	fs.writeFileSync(path.join(agentsWorkspaceStorageDir, 'workspace.json'), JSON.stringify({ workspace: agentsWorkspaceUri }, null, '\t'));
+	writeStorageDatabase(path.join(agentsWorkspaceStorageDir, 'state.vscdb'), {
+		'chat.ChatSessionStore.index': JSON.stringify(agentsWindowCorpus.chatSessionIndex),
+	});
+	writeChatSessionFiles(path.join(agentsWorkspaceStorageDir, 'chatSessions'), agentsWindowCorpus);
+	fs.mkdirSync(agentsWindowCorpus.expected.workspaceFsPath, { recursive: true });
+}
+
+/**
+ * @param {string} chatSessionDir
+ * @param {import('./agents-window-perf-corpus').AgentsWindowPerfCorpus} corpus
+ */
+function writeChatSessionFiles(chatSessionDir, corpus) {
+	fs.mkdirSync(chatSessionDir, { recursive: true });
+	for (const [sessionId, chatData] of Object.entries(corpus.chatFiles)) {
+		fs.writeFileSync(path.join(chatSessionDir, `${sessionId}.json`), JSON.stringify(chatData));
+	}
+}
+
+/** @param {string} value */
+function vscodeStringHash(value) {
+	let hashValue = ((0 * 31) + 149417) | 0;
+	for (let index = 0; index < value.length; index++) {
+		hashValue = ((hashValue * 31) + value.charCodeAt(index)) | 0;
+	}
+	return hashValue;
+}
+
+/**
+ * @param {string} dbPath
+ * @param {Record<string, string>} entries
+ */
+function writeStorageDatabase(dbPath, entries) {
+	const statements = ['CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);'];
+	for (const [key, value] of Object.entries(entries)) {
+		statements.push(`INSERT INTO ItemTable (key, value) VALUES (${sqliteString(key)}, ${sqliteString(value)});`);
+	}
+	execFileSync('sqlite3', [dbPath, statements.join(' ')]);
+}
+
+/** @param {string} value */
+function sqliteString(value) {
+	return `'${value.replace(/'/g, '\'\'')}'`;
 }
 
 // -- Launch helpers ----------------------------------------------------------
@@ -217,7 +285,7 @@ function buildEnv(mockServer, { isDevBuild = true } = {}) {
  * @param {string} logsDir
  * @returns {string[]}
  */
-function buildArgs(userDataDir, extDir, logsDir, { isDevBuild = true, extHostInspectPort = 0, traceFile = '', appRoot = ROOT, gcObjectStats = false } = {}) {
+function buildArgs(userDataDir, extDir, logsDir, { isDevBuild = true, extHostInspectPort = 0, traceFile = '', appRoot = ROOT, gcObjectStats = false, agentsWindow = false } = {}) {
 	// Chromium switches must come BEFORE the app path (ROOT) — Chromium
 	// only processes switches that precede the first non-switch argument.
 	const chromiumFlags = [];
@@ -261,6 +329,9 @@ function buildArgs(userDataDir, extDir, logsDir, { isDevBuild = true, extHostIns
 	if (process.env.CI && process.platform === 'linux') {
 		args.push('--no-sandbox');
 	}
+	if (agentsWindow) {
+		args.push('--agents');
+	}
 	// Enable extension host inspector for profiling/heap snapshots
 	if (extHostInspectPort > 0) {
 		args.push(`--inspect-extensions=${extHostInspectPort}`);
@@ -273,11 +344,12 @@ function buildArgs(userDataDir, extDir, logsDir, { isDevBuild = true, extHostIns
  * @param {string} userDataDir
  * @param {{ url: string }} mockServer
  * @param {Record<string, any>} [overrides]
+ * @param {{ agentsWindow?: boolean }} [options]
  */
-function writeSettings(userDataDir, mockServer, overrides) {
+function writeSettings(userDataDir, mockServer, overrides, options) {
 	const settingsDir = path.join(userDataDir, 'User');
 	fs.mkdirSync(settingsDir, { recursive: true });
-	fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify({
+	const settings = JSON.stringify({
 		'github.copilot.advanced.debug.overrideProxyUrl': mockServer.url,
 		'github.copilot.advanced.debug.overrideCapiUrl': mockServer.url,
 		'chat.allowAnonymousAccess': true,
@@ -291,7 +363,13 @@ function writeSettings(userDataDir, mockServer, overrides) {
 		// scenarios don't block on confirmation dialogs.
 		'chat.tools.global.autoApprove': true,
 		...overrides,
-	}, null, '\t'));
+	}, null, '\t');
+	fs.writeFileSync(path.join(settingsDir, 'settings.json'), settings);
+	if (options?.agentsWindow) {
+		const agentsSettingsDir = path.join(settingsDir, 'profiles', 'builtin', 'agents');
+		fs.mkdirSync(agentsSettingsDir, { recursive: true });
+		fs.writeFileSync(path.join(agentsSettingsDir, 'settings.json'), settings);
+	}
 }
 
 /**
@@ -299,11 +377,14 @@ function writeSettings(userDataDir, mockServer, overrides) {
  * @param {string} runId
  * @param {{ url: string }} mockServer
  * @param {Record<string, any>} [settingsOverrides]
+ * @param {{ agentsWindowCorpus?: import('./agents-window-perf-corpus').AgentsWindowPerfCorpus }} [options]
  * @returns {{ userDataDir: string, extDir: string, logsDir: string }}
  */
-function prepareRunDir(runId, mockServer, settingsOverrides) {
+function prepareRunDir(runId, mockServer, settingsOverrides, options) {
 	const tmpBase = path.join(os.tmpdir(), 'vscode-chat-simulation');
-	const userDataDir = path.join(tmpBase, `run-${runId}`);
+	// Keep the user-data path short enough for Chromium's macOS Unix-domain sockets.
+	const shortRunId = crypto.createHash('sha256').update(runId).digest('hex').slice(0, 12);
+	const userDataDir = path.join(tmpBase, `run-${shortRunId}`);
 	const extDir = path.join(DATA_DIR, 'extensions');
 	const logsDir = path.join(tmpBase, 'logs', `run-${runId}`);
 	// Retry rmSync to handle ENOTEMPTY race conditions from Electron cache locks
@@ -323,8 +404,8 @@ function prepareRunDir(runId, mockServer, settingsOverrides) {
 	fs.mkdirSync(userDataDir, { recursive: true });
 	fs.mkdirSync(extDir, { recursive: true });
 	fs.mkdirSync(logsDir, { recursive: true });
-	preseedStorage(userDataDir);
-	writeSettings(userDataDir, mockServer, settingsOverrides);
+	preseedStorage(userDataDir, options?.agentsWindowCorpus);
+	writeSettings(userDataDir, mockServer, settingsOverrides, { agentsWindow: !!options?.agentsWindowCorpus });
 	return { userDataDir, extDir, logsDir };
 }
 
@@ -478,25 +559,23 @@ async function waitForCDP(port, timeoutMs = 60_000) {
  * For dev builds this checks for `globalThis.driver` (smoke-test driver).
  * For stable builds it checks for `.monaco-workbench` in the DOM.
  * @param {import('playwright').Browser} browser
+ * @param {string} selector
  * @param {number} timeoutMs
  * @returns {Promise<import('playwright').Page>}
  */
-async function findWorkbenchPage(browser, timeoutMs = 60_000) {
+async function findWorkbenchPage(browser, selector = '.monaco-workbench', timeoutMs = 60_000) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		const pages = browser.contexts().flatMap(ctx => ctx.pages());
 		for (const page of pages) {
-			const hasWorkbench = await page.evaluate(() =>
-				// @ts-ignore
-				!!globalThis.driver?.whenWorkbenchRestored || !!document.querySelector('.monaco-workbench')
-			).catch(() => false);
+			const hasWorkbench = await page.evaluate(targetSelector => !!document.querySelector(targetSelector), selector).catch(() => false);
 			if (hasWorkbench) {
 				return page;
 			}
 		}
 		await new Promise(r => setTimeout(r, 500));
 	}
-	throw new Error('Timed out waiting for the workbench page');
+	throw new Error(`Timed out waiting for workbench page matching ${selector}`);
 }
 
 /** @type {number} */
@@ -509,7 +588,7 @@ let nextPort = 19222;
  * @param {string} executable - Path to the VS Code executable (Electron binary or CLI)
  * @param {string[]} launchArgs - Arguments to pass to the executable
  * @param {Record<string, string>} env - Environment variables
- * @param {{ verbose?: boolean }} [opts]
+ * @param {{ verbose?: boolean, pageSelector?: string }} [opts]
  * @returns {Promise<{ page: import('playwright').Page, browser: import('playwright').Browser, close: () => Promise<void> }>}
  */
 async function launchVSCode(executable, launchArgs, env, opts = {}) {
@@ -547,7 +626,7 @@ async function launchVSCode(executable, launchArgs, env, opts = {}) {
 	}
 
 	const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
-	const page = await findWorkbenchPage(browser);
+	const page = await findWorkbenchPage(browser, opts.pageSelector);
 
 	return {
 		page,
@@ -800,11 +879,38 @@ const METRIC_DEFS = [
 	['timeToUIUpdated', 'timing', 'ms'],
 	['instructionCollectionTime', 'timing', 'ms'],
 	['agentInvokeTime', 'timing', 'ms'],
+	['interactionDurationMs', 'interaction', 'ms'],
+	['scrollReturnDurationMs', 'interaction', 'ms'],
+	['rendererTaskDurationMs', 'interaction', 'ms'],
+	['rendererScriptDurationMs', 'interaction', 'ms'],
+	['longTaskTotalMs', 'interaction', 'ms'],
+	['longTaskMaxMs', 'interaction', 'ms'],
+	['concurrentBurstDurationMs', 'concurrent', 'ms'],
+	['burstThreadTimeMs', 'concurrent', 'ms'],
+	['burstTaskDurationMs', 'concurrent', 'ms'],
+	['burstScriptDurationMs', 'concurrent', 'ms'],
+	['burstRecalcStyleDurationMs', 'concurrent', 'ms'],
+	['burstLayoutDurationMs', 'concurrent', 'ms'],
+	['burstRecalcStyleCount', 'concurrent', ''],
+	['burstLayoutCount', 'concurrent', ''],
+	['settleThreadTimeMs', 'concurrent', 'ms'],
+	['settleRecalcStyleDurationMs', 'concurrent', 'ms'],
+	['settleLayoutDurationMs', 'concurrent', 'ms'],
+	['tailThreadTimeMs', 'concurrent', 'ms'],
+	['tailRecalcStyleDurationMs', 'concurrent', 'ms'],
+	['tailLayoutDurationMs', 'concurrent', 'ms'],
+	['tailRecalcStyleCount', 'concurrent', ''],
+	['tailLayoutCount', 'concurrent', ''],
+	['tailLongTaskCount', 'concurrent', ''],
+	['resizeObserverLoopCount', 'concurrent', ''],
+	['pageErrorCount', 'concurrent', ''],
+	['responsiveToolbarCount', 'concurrent', ''],
 	['heapDelta', 'memory', 'MB'],
 	['heapDeltaPostGC', 'memory', 'MB'],
 	['gcDurationMs', 'memory', 'ms'],
 	['layoutCount', 'rendering', ''],
 	['layoutDurationMs', 'rendering', 'ms'],
+	['recalcStyleDurationMs', 'rendering', 'ms'],
 	['recalcStyleCount', 'rendering', ''],
 	['forcedReflowCount', 'rendering', ''],
 	['longTaskCount', 'rendering', ''],

--- a/scripts/chat-simulation/common/utils.js
+++ b/scripts/chat-simulation/common/utils.js
@@ -925,10 +925,20 @@ const METRIC_DEFS = [
 	['extHostHeapDeltaPostGC', 'extHost', 'MB'],
 ];
 
+const REGRESSION_METRIC_NAMES = new Set([
+	'timeToFirstToken',
+	'timeToComplete',
+	'scrollReturnDurationMs',
+	'rendererTaskDurationMs',
+	'layoutDurationMs',
+	'longTaskCount',
+]);
+
 module.exports = {
 	ROOT,
 	DATA_DIR,
 	METRIC_DEFS,
+	REGRESSION_METRIC_NAMES,
 	loadConfig,
 	getElectronPath,
 	getRepoRoot,

--- a/scripts/chat-simulation/config.jsonc
+++ b/scripts/chat-simulation/config.jsonc
@@ -17,8 +17,9 @@
 		"metricThresholds": {
 			"timeToFirstToken": "100ms",
 			"timeToComplete": 0.2,
+			"scrollReturnDurationMs": 0.2,
+			"rendererTaskDurationMs": 0.2,
 			"layoutDurationMs": 0.2,
-			"forcedReflowCount": 0.2,
 			"longTaskCount": 0.2
 		}
 	},

--- a/scripts/chat-simulation/merge-ci-summary.js
+++ b/scripts/chat-simulation/merge-ci-summary.js
@@ -232,6 +232,51 @@ function getMetricThreshold(opts, metric) {
 /** @param {number} v */
 function round2(v) { return Math.round(v * 100) / 100; }
 
+function appendRawRunTable(lines, scenario, runs) {
+	const columns = scenario === 'agents-restored-history'
+		? [
+			['Interaction (ms)', 'interactionDurationMs'],
+			['Scroll Return (ms)', 'scrollReturnDurationMs'],
+			['Renderer CPU (ms)', 'rendererTaskDurationMs'],
+			['Style (ms)', 'recalcStyleDurationMs'],
+			['Layout (ms)', 'layoutDurationMs'],
+			['Long Tasks', 'longTaskCount'],
+		]
+		: scenario === 'agents-concurrent-sessions'
+			? [
+				['Burst Wall (ms)', 'concurrentBurstDurationMs'],
+				['Burst CPU (ms)', 'burstThreadTimeMs'],
+				['Burst Style (ms)', 'burstRecalcStyleDurationMs'],
+				['Burst Layout (ms)', 'burstLayoutDurationMs'],
+				['Tail CPU (ms)', 'tailThreadTimeMs'],
+				['Tail Style (ms)', 'tailRecalcStyleDurationMs'],
+				['Tail Layout (ms)', 'tailLayoutDurationMs'],
+				['RO Errors', 'resizeObserverLoopCount'],
+				['Page Errors', 'pageErrorCount'],
+				['Toolbars', 'responsiveToolbarCount'],
+			]
+			: [
+				['TTFT (ms)', 'timeToFirstToken'],
+				['Complete (ms)', 'timeToComplete'],
+				['Layouts', 'layoutCount'],
+				['Style Recalcs', 'recalcStyleCount'],
+				['LoAF Count', 'longAnimationFrameCount'],
+				['LoAF (ms)', 'longAnimationFrameTotalMs'],
+				['Frames', 'frameCount'],
+				['Heap Delta (MB)', 'heapDelta'],
+			];
+	lines.push(`| Run | ${columns.map(([label]) => label).join(' | ')} |`);
+	lines.push(`|----:|${columns.map(() => '----:').join('|')}|`);
+	for (let index = 0; index < runs.length; index++) {
+		const run = runs[index];
+		const values = columns.map(([, metric]) => {
+			const value = run[metric];
+			return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? String(round2(value)) : '-';
+		});
+		lines.push(`| ${index + 1} | ${values.join(' | ')} |`);
+	}
+}
+
 /**
  * Generate a unified Markdown summary for all scenarios.
  *
@@ -252,8 +297,35 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 	const allMetrics = [
 		['timeToFirstToken', 'timing', 'ms'],
 		['timeToComplete', 'timing', 'ms'],
+		['interactionDurationMs', 'interaction', 'ms'],
+		['scrollReturnDurationMs', 'interaction', 'ms'],
+		['rendererTaskDurationMs', 'interaction', 'ms'],
+		['rendererScriptDurationMs', 'interaction', 'ms'],
+		['longTaskTotalMs', 'interaction', 'ms'],
+		['longTaskMaxMs', 'interaction', 'ms'],
+		['concurrentBurstDurationMs', 'concurrent', 'ms'],
+		['burstThreadTimeMs', 'concurrent', 'ms'],
+		['burstTaskDurationMs', 'concurrent', 'ms'],
+		['burstScriptDurationMs', 'concurrent', 'ms'],
+		['burstRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['burstLayoutDurationMs', 'concurrent', 'ms'],
+		['burstRecalcStyleCount', 'concurrent', ''],
+		['burstLayoutCount', 'concurrent', ''],
+		['settleThreadTimeMs', 'concurrent', 'ms'],
+		['settleRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['settleLayoutDurationMs', 'concurrent', 'ms'],
+		['tailThreadTimeMs', 'concurrent', 'ms'],
+		['tailRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['tailLayoutDurationMs', 'concurrent', 'ms'],
+		['tailRecalcStyleCount', 'concurrent', ''],
+		['tailLayoutCount', 'concurrent', ''],
+		['tailLongTaskCount', 'concurrent', ''],
+		['resizeObserverLoopCount', 'concurrent', ''],
+		['pageErrorCount', 'concurrent', ''],
+		['responsiveToolbarCount', 'concurrent', ''],
 		['layoutCount', 'rendering', ''],
 		['layoutDurationMs', 'rendering', 'ms'],
+		['recalcStyleDurationMs', 'rendering', 'ms'],
 		['recalcStyleCount', 'rendering', ''],
 		['forcedReflowCount', 'rendering', ''],
 		['longTaskCount', 'rendering', ''],
@@ -273,12 +345,13 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 	// gated via layoutDurationMs below / timeToComplete. longAnimationFrameCount
 	// is likewise informational only (noisy, compositor-driven). See SKILL.md.
 	const regressionMetricNames = new Set([
-		'timeToFirstToken', 'timeToComplete', 'layoutDurationMs',
-		'forcedReflowCount', 'longTaskCount',
+		'timeToFirstToken', 'timeToComplete', 'scrollReturnDurationMs', 'rendererTaskDurationMs', 'layoutDurationMs',
+		'longTaskCount',
 	]);
 
 	const lines = [];
 	const scenarios = Object.keys(jsonReport.scenarios);
+	const scenariosWithoutBaseline = scenarios.filter(scenario => !baseline?.scenarios?.[scenario]);
 
 	// -- Collect verdicts ------------------------------------------------
 	/** @type {Map<string, { metric: string, verdict: string, change: number, pValue: string, basStr: string, curStr: string }[]>} */
@@ -339,7 +412,7 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 	const hasRegressions = totalRegressions > 0;
 	const hasLeakFailure = !!opts.hasLeakFailure;
 	const hasFailed = hasRegressions || hasLeakFailure;
-	const verdictIcon = hasFailed ? '\u274C' : '\u2705';
+	const verdictIcon = hasFailed ? '\u274C' : scenariosWithoutBaseline.length > 0 ? '\u26A0\uFE0F' : '\u2705';
 	const verdictParts = [];
 	if (hasRegressions && totalImprovements > 0) {
 		verdictParts.push(`${totalRegressions} regression(s), ${totalImprovements} improvement(s)`);
@@ -347,6 +420,8 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 		verdictParts.push(`${totalRegressions} regression(s) detected`);
 	} else if (totalImprovements > 0) {
 		verdictParts.push(`No regressions \u2014 ${totalImprovements} improvement(s)`);
+	} else if (scenariosWithoutBaseline.length > 0) {
+		verdictParts.push(`${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`);
 	} else {
 		verdictParts.push('No significant changes');
 	}
@@ -408,7 +483,11 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 		const keyVerdicts = [ttft, complete, layouts, styles, loaf].filter(Boolean);
 		const hasRegression = keyVerdicts.some(v => v?.verdict === 'REGRESSION');
 		const hasImproved = keyVerdicts.some(v => v?.verdict === 'improved');
-		const rowVerdict = hasRegression ? '\u274C' : hasImproved ? '\u2B06\uFE0F' : '\u2705';
+		const rowVerdict = !baseline?.scenarios?.[scenario]
+			? '\u26A0\uFE0F no baseline'
+			: keyVerdicts.length === 0
+				? '\u2139\uFE0F informational'
+				: hasRegression ? '\u274C' : hasImproved ? '\u2B06\uFE0F' : '\u2705';
 
 		lines.push(`| ${scenario} | ${fmtCell(ttft)} | ${fmtCell(complete)} | ${fmtCell(layouts)} | ${fmtCell(styles)} | ${fmtCell(loaf)} | ${rowVerdict} |`);
 	}
@@ -489,13 +568,7 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 		const current = jsonReport.scenarios[scenario];
 		lines.push(`### ${scenario}`);
 		lines.push('');
-		lines.push('| Run | TTFT (ms) | Complete (ms) | Layouts | Style Recalcs | LoAF Count | LoAF (ms) | Frames | Heap Delta (MB) |');
-		lines.push('|----:|----------:|--------------:|--------:|--------------:|-----------:|----------:|-------:|----------------:|');
-		const runs = current.rawRuns || [];
-		for (let i = 0; i < runs.length; i++) {
-			const r = runs[i];
-			lines.push(`| ${i + 1} | ${round2(r.timeToFirstToken)} | ${r.timeToComplete} | ${r.layoutCount} | ${r.recalcStyleCount} | ${r.longAnimationFrameCount ?? '-'} | ${round2(r.longAnimationFrameTotalMs ?? 0) || '-'} | ${r.frameCount ?? '-'} | ${r.heapDelta} |`);
-		}
+		appendRawRunTable(lines, scenario, current.rawRuns || []);
 		lines.push('');
 	}
 	if (baseline) {
@@ -504,13 +577,7 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 			if (!base) { continue; }
 			lines.push(`### ${scenario} (baseline)`);
 			lines.push('');
-			lines.push('| Run | TTFT (ms) | Complete (ms) | Layouts | Style Recalcs | LoAF Count | LoAF (ms) | Frames | Heap Delta (MB) |');
-			lines.push('|----:|----------:|--------------:|--------:|--------------:|-----------:|----------:|-------:|----------------:|');
-			const runs = base.rawRuns || [];
-			for (let i = 0; i < runs.length; i++) {
-				const r = runs[i];
-				lines.push(`| ${i + 1} | ${round2(r.timeToFirstToken)} | ${r.timeToComplete} | ${r.layoutCount} | ${r.recalcStyleCount} | ${r.longAnimationFrameCount ?? '-'} | ${round2(r.longAnimationFrameTotalMs ?? 0) || '-'} | ${r.frameCount ?? '-'} | ${r.heapDelta} |`);
-			}
+			appendRawRunTable(lines, scenario, base.rawRuns || []);
 			lines.push('');
 		}
 	}

--- a/scripts/chat-simulation/merge-ci-summary.js
+++ b/scripts/chat-simulation/merge-ci-summary.js
@@ -23,7 +23,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { welchTTest, loadConfig } = require('./common/utils');
+const { REGRESSION_METRIC_NAMES, welchTTest, loadConfig } = require('./common/utils');
 
 // -- CLI args ----------------------------------------------------------------
 
@@ -344,11 +344,6 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 	// animations, compositor-driven, cheap) and do NOT gate — real layout cost is
 	// gated via layoutDurationMs below / timeToComplete. longAnimationFrameCount
 	// is likewise informational only (noisy, compositor-driven). See SKILL.md.
-	const regressionMetricNames = new Set([
-		'timeToFirstToken', 'timeToComplete', 'scrollReturnDurationMs', 'rendererTaskDurationMs', 'layoutDurationMs',
-		'longTaskCount',
-	]);
-
 	const lines = [];
 	const scenarios = Object.keys(jsonReport.scenarios);
 	const scenariosWithoutBaseline = scenarios.filter(scenario => !baseline?.scenarios?.[scenario]);
@@ -372,7 +367,7 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 				if (!cur || !bas || bas.median === null || bas.median === undefined) { continue; }
 
 				const change = bas.median !== 0 ? (cur.median - bas.median) / bas.median : 0;
-				const isRegressionMetric = regressionMetricNames.has(metric);
+				const isRegressionMetric = REGRESSION_METRIC_NAMES.has(metric);
 
 				const curRaw = (current.rawRuns || []).map((/** @type {any} */ r) => r[metric]).filter((/** @type {any} */ v) => v >= 0);
 				const basRaw = (base.rawRuns || []).map((/** @type {any} */ r) => r[metric]).filter((/** @type {any} */ v) => v >= 0);
@@ -420,10 +415,11 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 		verdictParts.push(`${totalRegressions} regression(s) detected`);
 	} else if (totalImprovements > 0) {
 		verdictParts.push(`No regressions \u2014 ${totalImprovements} improvement(s)`);
-	} else if (scenariosWithoutBaseline.length > 0) {
-		verdictParts.push(`${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`);
-	} else {
+	} else if (scenariosWithoutBaseline.length < scenarios.length) {
 		verdictParts.push('No significant changes');
+	}
+	if (scenariosWithoutBaseline.length > 0) {
+		verdictParts.push(`${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`);
 	}
 	if (hasLeakFailure) {
 		verdictParts.push('memory leak detected');
@@ -480,12 +476,12 @@ function generateUnifiedSummary(jsonReport, baseline, opts) {
 			return `${v.change > 0 ? '+' : ''}${(v.change * 100).toFixed(0)}%`;
 		};
 
-		const keyVerdicts = [ttft, complete, layouts, styles, loaf].filter(Boolean);
-		const hasRegression = keyVerdicts.some(v => v?.verdict === 'REGRESSION');
-		const hasImproved = keyVerdicts.some(v => v?.verdict === 'improved');
+		const gatedVerdicts = verdicts.filter(verdict => REGRESSION_METRIC_NAMES.has(verdict.metric));
+		const hasRegression = gatedVerdicts.some(verdict => verdict.verdict === 'REGRESSION');
+		const hasImproved = gatedVerdicts.some(verdict => verdict.verdict === 'improved');
 		const rowVerdict = !baseline?.scenarios?.[scenario]
 			? '\u26A0\uFE0F no baseline'
-			: keyVerdicts.length === 0
+			: gatedVerdicts.length === 0
 				? '\u2139\uFE0F informational'
 				: hasRegression ? '\u274C' : hasImproved ? '\u2B06\uFE0F' : '\u2705';
 

--- a/scripts/chat-simulation/test-chat-perf-regression.js
+++ b/scripts/chat-simulation/test-chat-perf-regression.js
@@ -30,11 +30,24 @@ const {
 	getNextExtHostInspectPort, connectToExtHostInspector, getRepoRoot,
 } = require('./common/utils');
 const { getUserTurns, getScenarioIds } = require('./common/mock-llm-server.ts');
-const { registerPerfScenarios, getScenarioDescription } = require('./common/perf-scenarios');
+const { registerPerfScenarios, getScenarioDescription, getPerfScenarioKind } = require('./common/perf-scenarios');
+const {
+	AGENTS_PERF_CONCURRENT_DONE_MARKER,
+	AGENTS_PERF_CONCURRENT_FINAL_MARKER,
+	RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID,
+	SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID,
+	STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID,
+	createAgentsWindowConcurrentPerfCorpus,
+	createAgentsWindowPerfCorpus,
+	INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID,
+	SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID,
+	SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID,
+} = require('./common/agents-window-perf-corpus.ts');
 
 // -- Config (edit config.jsonc to change defaults) ---------------------------
 
 const CONFIG = loadConfig('perfRegression');
+const HISTORY_REQUIRED_METRICS = ['TaskDuration', 'ScriptDuration', 'LayoutDuration', 'LayoutCount', 'RecalcStyleDuration', 'RecalcStyleCount'];
 
 // -- CLI args ----------------------------------------------------------------
 
@@ -102,7 +115,7 @@ function parseArgs() {
 			case '--force': opts.force = true; break;
 			case '--heap-snapshots': opts.heapSnapshots = true; break;
 			case '--gc-object-stats': opts.gcObjectStats = true; break;
-			case '--ci': opts.ci = true; opts.noCache = true; opts.heapSnapshots = true; opts.cleanupDiagnostics = true; break;
+			case '--ci': opts.ci = true; opts.noCache = true; opts.cleanupDiagnostics = true; break;
 			case '--cleanup-diagnostics': opts.cleanupDiagnostics = true; break;
 			case '--help': case '-h':
 				console.log([
@@ -129,9 +142,9 @@ function parseArgs() {
 					'                       e.g. --setting chat.experimental.incrementalRendering.enabled=true',
 					'  --no-cache          Ignore cached baseline data, always run fresh',
 					'  --force             Skip build mode mismatch confirmation',
-					'  --heap-snapshots    Take heap snapshots (slow; auto-enabled in --ci mode)',
+					'  --heap-snapshots    Take heap snapshots (slow; opt-in for diagnostic runs)',
 					'  --gc-object-stats   Enable V8 gc_stats tracing for GC deep-dives only. WARNING: corrupts timings (adds ~550ms to any request hit by a major GC) — never use for benchmarking',
-					'  --ci                CI mode: write Markdown summary to ci-summary.md (implies --no-cache, --heap-snapshots, --cleanup-diagnostics)',
+					'  --ci                CI mode: write Markdown summary to ci-summary.md (implies --no-cache and --cleanup-diagnostics)',
 					'  --cleanup-diagnostics  Remove heap snapshots, CPU profiles, and traces after each run to save disk space',
 					'  --verbose           Print per-run details',
 					'',
@@ -321,6 +334,32 @@ function exceedsThreshold(threshold, change, absoluteDelta) {
  *   timeToRenderComplete: number,
  *   instructionCollectionTime: number,
  *   agentInvokeTime: number,
+ *   interactionDurationMs: number,
+ *   scrollReturnDurationMs: number,
+ *   rendererTaskDurationMs: number,
+ *   rendererScriptDurationMs: number,
+ *   longTaskTotalMs: number,
+ *   longTaskMaxMs: number,
+ *   concurrentBurstDurationMs?: number,
+ *   burstThreadTimeMs?: number,
+ *   burstTaskDurationMs?: number,
+ *   burstScriptDurationMs?: number,
+ *   burstRecalcStyleDurationMs?: number,
+ *   burstLayoutDurationMs?: number,
+ *   burstRecalcStyleCount?: number,
+ *   burstLayoutCount?: number,
+ *   settleThreadTimeMs?: number,
+ *   settleRecalcStyleDurationMs?: number,
+ *   settleLayoutDurationMs?: number,
+ *   tailThreadTimeMs?: number,
+ *   tailRecalcStyleDurationMs?: number,
+ *   tailLayoutDurationMs?: number,
+ *   tailRecalcStyleCount?: number,
+ *   tailLayoutCount?: number,
+ *   tailLongTaskCount?: number,
+ *   resizeObserverLoopCount?: number,
+ *   pageErrorCount?: number,
+ *   responsiveToolbarCount?: number,
  *   heapUsedBefore: number,
  *   heapUsedAfter: number,
  *   heapDelta: number,
@@ -330,6 +369,7 @@ function exceedsThreshold(threshold, change, absoluteDelta) {
  *   gcDurationMs: number,
  *   layoutCount: number,
  *   layoutDurationMs: number,
+ *   recalcStyleDurationMs?: number,
  *   recalcStyleCount: number,
  *   forcedReflowCount: number,
  *   longTaskCount: number,
@@ -368,33 +408,16 @@ function exceedsThreshold(threshold, change, absoluteDelta) {
  * @returns {Promise<RunMetrics>}
  */
 async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts) {
-	const takeHeapSnapshots = runOpts?.heapSnapshots ?? false;
-	const { userDataDir, extDir, logsDir } = prepareRunDir(runIndex, mockServer, settingsOverrides);
-	const isDevBuild = !electronPath.includes('.vscode-test') && !electronPath.includes('VSCode-');
-	// Extract a clean build label from the path.
-	// Dev:          .build/electron/Code - OSS.app/.../Code - OSS  → "dev"
-	// Stable:       .vscode-test/vscode-darwin-arm64-1.115.0/Visual Studio Code.app/.../Electron → "1.115.0"
-	// Production:   ../VSCode-darwin-arm64/Code - OSS.app/.../Code - OSS → "production"
-	let buildLabel = 'dev';
-	if (!isDevBuild) {
-		const vscodeTestMatch = electronPath.match(/vscode-test\/vscode-[^/]*?-(\d+\.\d+\.\d+)/);
-		if (vscodeTestMatch) {
-			buildLabel = vscodeTestMatch[1];
-		} else if (electronPath.includes('VSCode-')) {
-			buildLabel = 'production';
-		} else {
-			buildLabel = path.basename(electronPath);
-		}
+	if (getPerfScenarioKind(scenario) === 'agents-window-history') {
+		return runAgentsWindowInteractionOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts);
+	}
+	if (getPerfScenarioKind(scenario) === 'agents-window-concurrent') {
+		return runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts);
 	}
 
-	// For dev builds from a different repo, derive the repo root from the
-	// electron path so that the build loads its own out/ source code.
-	const appRoot = isDevBuild ? (getRepoRoot(electronPath) || ROOT) : ROOT;
-	if (isDevBuild && appRoot !== ROOT) {
-		if (verbose) {
-			console.log(`  [debug] Using appRoot from electron path: ${appRoot}`);
-		}
-	}
+	const takeHeapSnapshots = runOpts?.heapSnapshots ?? false;
+	const { userDataDir, extDir, logsDir } = prepareRunDir(runIndex, mockServer, settingsOverrides);
+	const { isDevBuild, buildLabel, appRoot } = getBuildRunInfo(electronPath, verbose);
 
 	// Create a per-run diagnostics directory: <runDir>/<role>-<build>/<scenario>-<i>/
 	const runDiagDir = path.join(runDir, `${role}-${buildLabel}`, runIndex.replace(/^baseline-/, ''));
@@ -416,7 +439,7 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 	let extHostInspector = null;
 	/** @type {{ usedSize: number, totalSize: number } | null} */
 	let extHostHeapBefore = null;
-	/** @type {Omit<RunMetrics, 'majorGCs' | 'minorGCs' | 'gcDurationMs' | 'longTaskCount' | 'longAnimationFrameCount' | 'longAnimationFrameTotalMs' | 'timeToUIUpdated' | 'timeToFirstToken' | 'timeToComplete' | 'timeToRenderComplete' | 'layoutDurationMs' | 'instructionCollectionTime' | 'agentInvokeTime' | 'hasInternalMarks' | 'internalFirstToken'> | null} */
+	/** @type {Omit<RunMetrics, 'majorGCs' | 'minorGCs' | 'gcDurationMs' | 'longTaskCount' | 'longAnimationFrameCount' | 'longAnimationFrameTotalMs' | 'timeToUIUpdated' | 'timeToFirstToken' | 'timeToComplete' | 'timeToRenderComplete' | 'layoutDurationMs' | 'instructionCollectionTime' | 'agentInvokeTime' | 'interactionDurationMs' | 'scrollReturnDurationMs' | 'rendererTaskDurationMs' | 'rendererScriptDurationMs' | 'longTaskTotalMs' | 'longTaskMaxMs' | 'hasInternalMarks' | 'internalFirstToken'> | null} */
 	let partialMetrics = null;
 	// Timing vars hoisted for access in post-close trace parsing
 	let submitTime = 0;
@@ -432,6 +455,7 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 		const heapBefore = /** @type {any} */ (await cdp.send('Runtime.getHeapUsage'));
 
 		const metricsBefore = await cdp.send('Performance.getMetrics');
+		assertRequiredPerformanceMetrics(metricsBefore, HISTORY_REQUIRED_METRICS);
 
 		// Open chat
 		const chatShortcut = process.platform === 'darwin' ? 'Control+Meta+KeyI' : 'Control+Alt+KeyI';
@@ -699,6 +723,7 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 
 		const heapAfter = /** @type {any} */ (await cdp.send('Runtime.getHeapUsage'));
 		const metricsAfter = await cdp.send('Performance.getMetrics');
+		assertRequiredPerformanceMetrics(metricsAfter, HISTORY_REQUIRED_METRICS);
 
 		// -- Extension host metrics (non-snapshot) ---------------------------
 		let extHostHeapUsedBefore = -1;
@@ -936,6 +961,12 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 	return {
 		...partialMetrics,
 		timeToUIUpdated, timeToFirstToken, timeToComplete, timeToRenderComplete, instructionCollectionTime, agentInvokeTime,
+		interactionDurationMs: -1,
+		scrollReturnDurationMs: -1,
+		rendererTaskDurationMs: -1,
+		rendererScriptDurationMs: -1,
+		longTaskTotalMs: -1,
+		longTaskMaxMs: -1,
 		hasInternalMarks: chatMarks.length > 0,
 		internalFirstToken,
 		majorGCs, minorGCs,
@@ -945,6 +976,641 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 		longAnimationFrameCount,
 		longAnimationFrameTotalMs: Math.round(longAnimationFrameTotalMs * 100) / 100,
 	};
+}
+
+/**
+ * @param {string} electronPath
+ * @param {boolean} verbose
+ */
+function getBuildRunInfo(electronPath, verbose) {
+	const isDevBuild = !electronPath.includes('.vscode-test') && !electronPath.includes('VSCode-');
+	let buildLabel = 'dev';
+	if (!isDevBuild) {
+		const vscodeTestMatch = electronPath.match(/vscode-test\/vscode-[^/]*?-(\d+\.\d+\.\d+)/);
+		if (vscodeTestMatch) {
+			buildLabel = vscodeTestMatch[1];
+		} else if (electronPath.includes('VSCode-')) {
+			buildLabel = 'production';
+		} else {
+			buildLabel = path.basename(electronPath);
+		}
+	}
+
+	const appRoot = isDevBuild ? (getRepoRoot(electronPath) || ROOT) : ROOT;
+	if (isDevBuild && appRoot !== ROOT && verbose) {
+		console.log(`  [debug] Using appRoot from electron path: ${appRoot}`);
+	}
+	return { isDevBuild, buildLabel, appRoot };
+}
+
+/**
+ * @param {string} electronPath
+ * @param {{ url: string }} mockServer
+ * @param {boolean} verbose
+ * @param {string} runIndex
+ * @param {string} runDir
+ * @param {'baseline' | 'test'} role
+ * @param {Record<string, any>} [settingsOverrides]
+ * @param {{ heapSnapshots?: boolean, gcObjectStats?: boolean }} [runOpts]
+ * @returns {Promise<RunMetrics>}
+ */
+async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts) {
+	const corpus = process.env.AGENTS_PERF_SMALL_CORPUS === '1'
+		? createAgentsWindowPerfCorpus({ sessionCount: 4, primaryTurnCount: 20, secondaryTurnCount: 3, peerChatCount: 1, subagentToolCount: 16 })
+		: createAgentsWindowPerfCorpus();
+	const agentsSettings = {
+		'sessions.chat.localAgent.enabled': true,
+		'chat.useLogSessionStorage': false,
+		'chat.agentHost.enabled': false,
+		'chat.progressBorder.enabled': false,
+		...settingsOverrides,
+	};
+	const { userDataDir, extDir, logsDir } = prepareRunDir(runIndex, mockServer, agentsSettings, { agentsWindowCorpus: corpus });
+	const { isDevBuild, buildLabel, appRoot } = getBuildRunInfo(electronPath, verbose);
+	const runDiagDir = path.join(runDir, `${role}-${buildLabel}`, runIndex.replace(/^baseline-/, ''));
+	fs.mkdirSync(runDiagDir, { recursive: true });
+	const tracePath = path.join(runDiagDir, 'trace.json');
+	const profilePath = path.join(runDiagDir, 'profile.cpuprofile');
+	const snapshotPath = '';
+	const extHostProfilePath = '';
+	const extHostSnapshotPath = '';
+	const vscode = await launchVSCode(
+		electronPath,
+		buildArgs(userDataDir, extDir, logsDir, {
+			isDevBuild,
+			traceFile: tracePath,
+			appRoot,
+			gcObjectStats: runOpts?.gcObjectStats,
+			agentsWindow: true,
+		}),
+		buildEnv(mockServer, { isDevBuild }),
+		{ verbose, pageSelector: '.agent-sessions-workbench' },
+	);
+	activeVSCode = vscode;
+	const window = vscode.page;
+	const pageErrors = [];
+	const pageErrorListener = error => pageErrors.push(normalizePageErrorMessage(error));
+	window.on('pageerror', pageErrorListener);
+	const sessionRowSelector = '.sessions-list-control .monaco-list-row';
+	const activeSessionSelector = '.agent-sessions-workbench .session-view.is-active';
+	const transcriptScrollSelector = `${activeSessionSelector} .interactive-list > .monaco-list > .monaco-scrollable-element`;
+	const sessionsScrollSelector = '.sessions-list-control .monaco-list > .monaco-scrollable-element';
+	const markId = runIndex.replace(/[^a-zA-Z0-9_-]/g, '_');
+	const startMark = `code/agentsPerf/${markId}/start`;
+	const endMark = `code/agentsPerf/${markId}/end`;
+	let partialMetrics;
+
+	try {
+		await window.waitForSelector('.agent-sessions-workbench', { timeout: 60_000 });
+		await window.waitForFunction(
+			({ selector, expected }) => document.querySelectorAll(selector).length >= expected,
+			{ selector: sessionRowSelector, expected: 2 },
+			{ timeout: 30_000 },
+		);
+		await activateAgentsSession(window, corpus.expected.primaryTitle, corpus.expected.primarySentinel);
+		await window.waitForSelector(transcriptScrollSelector, { state: 'visible', timeout: 30_000 });
+		await window.waitForSelector(sessionsScrollSelector, { state: 'visible', timeout: 30_000 });
+		await window.evaluate(async commandId => {
+			// @ts-ignore
+			await globalThis.driver.executeCommand(commandId);
+		}, INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID);
+		await window.waitForFunction(
+			selector => document.querySelector(selector)?.textContent?.includes('Live subagent tool 127') === true,
+			activeSessionSelector,
+			{ timeout: 30_000 },
+		);
+		await waitForAnimationFrames(window, 3);
+
+		await window.screenshot({ path: path.join(runDiagDir, 'before-interaction.png') });
+		const cdp = await window.context().newCDPSession(window);
+		await cdp.send('Performance.enable');
+		await cdp.send('Profiler.enable');
+		await cdp.send('HeapProfiler.enable');
+		const heapBefore = await cdp.send('Runtime.getHeapUsage');
+		const metricsBefore = await cdp.send('Performance.getMetrics');
+		assertRequiredPerformanceMetrics(metricsBefore, HISTORY_REQUIRED_METRICS);
+		await window.evaluate(() => {
+			// @ts-ignore
+			globalThis.__agentsPerfLongTasks = [];
+			const observer = new PerformanceObserver(list => {
+				// @ts-ignore
+				globalThis.__agentsPerfLongTasks.push(...list.getEntries().map(entry => entry.duration));
+			});
+			observer.observe({ entryTypes: ['longtask'] });
+			// @ts-ignore
+			globalThis.__agentsPerfLongTaskObserver = observer;
+		});
+		await cdp.send('Profiler.start');
+		await window.evaluate(mark => performance.mark(mark), startMark);
+		const interactionStart = performance.now();
+
+		await activateAgentsSession(window, corpus.expected.secondaryTitle, corpus.expected.secondarySentinel);
+		await activateAgentsSession(window, corpus.expected.primaryTitle, corpus.expected.primarySentinel);
+		await window.evaluate(async commandId => {
+			// @ts-ignore
+			await globalThis.driver.executeCommand(commandId);
+		}, SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID);
+		await window.waitForFunction(
+			selector => document.querySelector(selector)?.textContent?.includes('Live subagent tool 127') !== true,
+			activeSessionSelector,
+			{ timeout: 30_000 },
+		);
+		const scrollReturnStart = performance.now();
+		await window.evaluate(async commandId => {
+			// @ts-ignore
+			await globalThis.driver.executeCommand(commandId);
+		}, SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID);
+		await window.waitForFunction(
+			selector => document.querySelector(selector)?.textContent?.includes('Live subagent tool 127') === true,
+			activeSessionSelector,
+			{ timeout: 30_000 },
+		);
+		const scrollReturnDurationMs = performance.now() - scrollReturnStart;
+		await waitForAnimationFrames(window, 3);
+		await scrollAgentsSurface(window, transcriptScrollSelector, 12, -600);
+		await scrollAgentsSurface(window, transcriptScrollSelector, 12, 600);
+		await scrollAgentsSurface(window, sessionsScrollSelector, 10, 500);
+		await scrollAgentsSurface(window, sessionsScrollSelector, 10, -500);
+
+		await waitForAnimationFrames(window, 3);
+		const interactionDurationMs = performance.now() - interactionStart;
+		await window.evaluate(mark => performance.mark(mark), endMark);
+		const { profile } = await cdp.send('Profiler.stop');
+		fs.writeFileSync(profilePath, JSON.stringify(profile));
+		const metricsAfter = await cdp.send('Performance.getMetrics');
+		assertRequiredPerformanceMetrics(metricsAfter, HISTORY_REQUIRED_METRICS);
+		const heapAfter = await cdp.send('Runtime.getHeapUsage');
+		const longTasks = await window.evaluate(() => {
+			// @ts-ignore
+			globalThis.__agentsPerfLongTaskObserver?.disconnect();
+			// @ts-ignore
+			return globalThis.__agentsPerfLongTasks ?? [];
+		});
+		await window.screenshot({ path: path.join(runDiagDir, 'after-interaction.png') });
+		if (pageErrors.length > 0) {
+			fs.writeFileSync(path.join(runDiagDir, 'page-errors.json'), JSON.stringify([...new Set(pageErrors)], null, 2));
+		}
+
+		const getMetric = (result, name) => result.metrics?.find(metric => metric.name === name)?.value ?? 0;
+		const durationDeltaMs = (name) => Math.round((getMetric(metricsAfter, name) - getMetric(metricsBefore, name)) * 100_000) / 100;
+		partialMetrics = {
+			timeToUIUpdated: -1,
+			timeToFirstToken: -1,
+			timeToComplete: -1,
+			timeToRenderComplete: -1,
+			instructionCollectionTime: -1,
+			agentInvokeTime: -1,
+			interactionDurationMs: Math.round(interactionDurationMs * 100) / 100,
+			scrollReturnDurationMs: Math.round(scrollReturnDurationMs * 100) / 100,
+			rendererTaskDurationMs: durationDeltaMs('TaskDuration'),
+			rendererScriptDurationMs: durationDeltaMs('ScriptDuration'),
+			heapUsedBefore: Math.round(heapBefore.usedSize / 1024 / 1024),
+			heapUsedAfter: Math.round(heapAfter.usedSize / 1024 / 1024),
+			heapDelta: Math.round((heapAfter.usedSize - heapBefore.usedSize) / 1024 / 1024),
+			heapDeltaPostGC: -1,
+			majorGCs: 0,
+			minorGCs: 0,
+			gcDurationMs: 0,
+			layoutCount: Math.round(getMetric(metricsAfter, 'LayoutCount') - getMetric(metricsBefore, 'LayoutCount')),
+			layoutDurationMs: durationDeltaMs('LayoutDuration'),
+			recalcStyleDurationMs: durationDeltaMs('RecalcStyleDuration'),
+			recalcStyleCount: Math.round(getMetric(metricsAfter, 'RecalcStyleCount') - getMetric(metricsBefore, 'RecalcStyleCount')),
+			forcedReflowCount: Math.round(getMetric(metricsAfter, 'ForcedStyleRecalcs') - getMetric(metricsBefore, 'ForcedStyleRecalcs')),
+			longTaskCount: longTasks.length,
+			longTaskTotalMs: Math.round(longTasks.reduce((sum, duration) => sum + duration, 0) * 100) / 100,
+			longTaskMaxMs: Math.round((longTasks.length ? Math.max(...longTasks) : 0) * 100) / 100,
+			longAnimationFrameCount: 0,
+			longAnimationFrameTotalMs: 0,
+			frameCount: Math.round(getMetric(metricsAfter, 'FrameCount') - getMetric(metricsBefore, 'FrameCount')),
+			compositeLayers: Math.round(getMetric(metricsAfter, 'CompositeLayers') - getMetric(metricsBefore, 'CompositeLayers')),
+			paintCount: Math.round(getMetric(metricsAfter, 'PaintCount') - getMetric(metricsBefore, 'PaintCount')),
+			hasInternalMarks: true,
+			responseHasContent: true,
+			internalFirstToken: -1,
+			profilePath,
+			tracePath,
+			snapshotPath,
+			extHostHeapUsedBefore: -1,
+			extHostHeapUsedAfter: -1,
+			extHostHeapDelta: -1,
+			extHostHeapDeltaPostGC: -1,
+			extHostProfilePath,
+			extHostSnapshotPath,
+		};
+	} catch (error) {
+		await window.screenshot({ path: path.join(runDiagDir, 'interaction-error.png') }).catch(() => undefined);
+		throw error;
+	} finally {
+		window.off('pageerror', pageErrorListener);
+		activeVSCode = null;
+		await vscode.close();
+	}
+
+	return partialMetrics;
+}
+
+const CONCURRENT_REQUIRED_METRICS = [
+	'ThreadTime',
+	'TaskDuration',
+	'ScriptDuration',
+	'RecalcStyleDuration',
+	'LayoutDuration',
+	'RecalcStyleCount',
+	'LayoutCount',
+];
+
+/**
+ * @param {string} electronPath
+ * @param {{ url: string }} mockServer
+ * @param {boolean} verbose
+ * @param {string} runIndex
+ * @param {string} runDir
+ * @param {'baseline' | 'test'} role
+ * @param {Record<string, any>} [settingsOverrides]
+ * @param {{ heapSnapshots?: boolean, gcObjectStats?: boolean }} [runOpts]
+ * @returns {Promise<RunMetrics>}
+ */
+async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts) {
+	const corpus = createAgentsWindowConcurrentPerfCorpus();
+	const agentsSettings = {
+		'sessions.chat.localAgent.enabled': true,
+		'chat.useLogSessionStorage': false,
+		'chat.agentHost.enabled': false,
+		// Animated progress borders would intentionally keep the quiescent tail busy.
+		'chat.progressBorder.enabled': false,
+		...settingsOverrides,
+	};
+	const { userDataDir, extDir, logsDir } = prepareRunDir(runIndex, mockServer, agentsSettings, { agentsWindowCorpus: corpus });
+	const { isDevBuild, buildLabel, appRoot } = getBuildRunInfo(electronPath, verbose);
+	const runDiagDir = path.join(runDir, `${role}-${buildLabel}`, runIndex.replace(/^baseline-/, ''));
+	fs.mkdirSync(runDiagDir, { recursive: true });
+	const tracePath = path.join(runDiagDir, 'trace.json');
+	const profilePath = path.join(runDiagDir, 'profile.cpuprofile');
+	const vscode = await launchVSCode(
+		electronPath,
+		buildArgs(userDataDir, extDir, logsDir, {
+			isDevBuild,
+			traceFile: tracePath,
+			appRoot,
+			gcObjectStats: runOpts?.gcObjectStats,
+			agentsWindow: true,
+		}),
+		buildEnv(mockServer, { isDevBuild }),
+		{ verbose, pageSelector: '.agent-sessions-workbench' },
+	);
+	activeVSCode = vscode;
+	const window = vscode.page;
+	const pageErrors = [];
+	const pageErrorListener = error => pageErrors.push(normalizePageErrorMessage(error));
+	window.on('pageerror', pageErrorListener);
+	let partialMetrics;
+
+	try {
+		await window.waitForSelector('.agent-sessions-workbench', { timeout: 60_000 });
+		await window.waitForFunction(
+			expected => document.querySelectorAll('.sessions-list-control .monaco-list-row').length >= expected,
+			3,
+			{ timeout: 30_000 },
+		);
+		await executeAgentsPerfCommand(window, SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID);
+		await window.waitForFunction(() => {
+			const views = [...document.querySelectorAll('.agent-sessions-workbench .session-view')];
+			return views.length === 3 && views.every(view =>
+				view.querySelector('.interactive-input-part') &&
+				view.textContent?.includes('Run concurrent Agents performance session')
+			);
+		}, undefined, { timeout: 30_000 });
+		const toolbarState = await window.evaluate(() => {
+			const views = [...document.querySelectorAll('.agent-sessions-workbench .session-view')];
+			const toolbarCounts = views.map(view => view.querySelectorAll('.interactive-input-part .monaco-toolbar.responsive').length);
+			return { viewCount: views.length, toolbarCounts, totalToolbarCount: toolbarCounts.reduce((sum, count) => sum + count, 0) };
+		});
+		if (toolbarState.viewCount !== 3 || toolbarState.toolbarCounts.some(count => count < 1)) {
+			throw new Error(`Concurrent toolbar precondition failed: ${JSON.stringify(toolbarState)}`);
+		}
+		await waitForAnimationFrames(window, 3);
+		await window.screenshot({ path: path.join(runDiagDir, 'concurrent-before.png') });
+
+		const cdp = await window.context().newCDPSession(window);
+		await cdp.send('Performance.enable');
+		await cdp.send('Profiler.enable');
+		await cdp.send('HeapProfiler.enable');
+		const heapBefore = await cdp.send('Runtime.getHeapUsage');
+		await installConcurrentPageObservers(window);
+		await cdp.send('Profiler.start');
+		const metricsBefore = await readRequiredPerformanceMetrics(cdp, CONCURRENT_REQUIRED_METRICS);
+		await window.evaluate(mark => performance.mark(mark), `code/agentsPerf/${runIndex}/concurrent-start`);
+
+		const burstStart = performance.now();
+		await executeAgentsPerfCommand(window, RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID);
+		await window.waitForFunction(marker => {
+			const views = [...document.querySelectorAll('.agent-sessions-workbench .session-view')];
+			return views.length === 3 && views.every(view => view.textContent?.includes(marker));
+		}, AGENTS_PERF_CONCURRENT_FINAL_MARKER, { timeout: 30_000 });
+		await waitForAnimationFrames(window, 3);
+		const concurrentBurstDurationMs = performance.now() - burstStart;
+		const metricsAfterBurst = await readRequiredPerformanceMetrics(cdp, CONCURRENT_REQUIRED_METRICS);
+
+		await window.evaluate(() => {
+			// @ts-ignore
+			globalThis.__agentsConcurrentPerf.phase = 'settle';
+		});
+		await executeAgentsPerfCommand(window, STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID);
+		await window.waitForFunction(marker => {
+			const views = [...document.querySelectorAll('.agent-sessions-workbench .session-view')];
+			return views.length === 3 &&
+				views.every(view => view.textContent?.includes(marker)) &&
+				views.every(view => !view.querySelector('.chat-response-loading'));
+		}, AGENTS_PERF_CONCURRENT_DONE_MARKER, { timeout: 30_000 });
+		await new Promise(resolve => setTimeout(resolve, 500));
+		const metricsAfterSettle = await readRequiredPerformanceMetrics(cdp, CONCURRENT_REQUIRED_METRICS);
+
+		await window.evaluate(() => {
+			// @ts-ignore
+			globalThis.__agentsConcurrentPerf.phase = 'tail';
+		});
+		await new Promise(resolve => setTimeout(resolve, 1_500));
+		const metricsAfterTail = await readRequiredPerformanceMetrics(cdp, CONCURRENT_REQUIRED_METRICS);
+		await window.evaluate(mark => performance.mark(mark), `code/agentsPerf/${runIndex}/concurrent-end`);
+		const { profile } = await cdp.send('Profiler.stop');
+		fs.writeFileSync(profilePath, JSON.stringify(profile));
+		const heapAfter = await cdp.send('Runtime.getHeapUsage');
+		const observerData = await readConcurrentPageObservers(window);
+		await window.screenshot({ path: path.join(runDiagDir, 'concurrent-after.png') });
+		const errorMessages = [...new Set([...pageErrors, ...observerData.pageErrors].map(normalizePageErrorMessage))];
+		if (errorMessages.length > 0) {
+			fs.writeFileSync(path.join(runDiagDir, 'page-errors.json'), JSON.stringify(errorMessages, null, 2));
+		}
+
+		partialMetrics = {
+			...emptyInteractionMetrics(),
+			concurrentBurstDurationMs: round2(concurrentBurstDurationMs),
+			burstThreadTimeMs: metricDeltaMs(metricsBefore, metricsAfterBurst, 'ThreadTime'),
+			burstTaskDurationMs: metricDeltaMs(metricsBefore, metricsAfterBurst, 'TaskDuration'),
+			burstScriptDurationMs: metricDeltaMs(metricsBefore, metricsAfterBurst, 'ScriptDuration'),
+			burstRecalcStyleDurationMs: metricDeltaMs(metricsBefore, metricsAfterBurst, 'RecalcStyleDuration'),
+			burstLayoutDurationMs: metricDeltaMs(metricsBefore, metricsAfterBurst, 'LayoutDuration'),
+			burstRecalcStyleCount: metricDelta(metricsBefore, metricsAfterBurst, 'RecalcStyleCount'),
+			burstLayoutCount: metricDelta(metricsBefore, metricsAfterBurst, 'LayoutCount'),
+			settleThreadTimeMs: metricDeltaMs(metricsAfterBurst, metricsAfterSettle, 'ThreadTime'),
+			settleRecalcStyleDurationMs: metricDeltaMs(metricsAfterBurst, metricsAfterSettle, 'RecalcStyleDuration'),
+			settleLayoutDurationMs: metricDeltaMs(metricsAfterBurst, metricsAfterSettle, 'LayoutDuration'),
+			tailThreadTimeMs: metricDeltaMs(metricsAfterSettle, metricsAfterTail, 'ThreadTime'),
+			tailRecalcStyleDurationMs: metricDeltaMs(metricsAfterSettle, metricsAfterTail, 'RecalcStyleDuration'),
+			tailLayoutDurationMs: metricDeltaMs(metricsAfterSettle, metricsAfterTail, 'LayoutDuration'),
+			tailRecalcStyleCount: metricDelta(metricsAfterSettle, metricsAfterTail, 'RecalcStyleCount'),
+			tailLayoutCount: metricDelta(metricsAfterSettle, metricsAfterTail, 'LayoutCount'),
+			tailLongTaskCount: observerData.longTasks.tail.length,
+			resizeObserverLoopCount: observerData.resizeObserverLoopCount,
+			pageErrorCount: errorMessages.filter(message => !message.includes('ResizeObserver loop')).length,
+			responsiveToolbarCount: toolbarState.totalToolbarCount,
+			heapUsedBefore: Math.round(heapBefore.usedSize / 1024 / 1024),
+			heapUsedAfter: Math.round(heapAfter.usedSize / 1024 / 1024),
+			heapDelta: Math.round((heapAfter.usedSize - heapBefore.usedSize) / 1024 / 1024),
+			profilePath,
+			tracePath,
+			snapshotPath: '',
+			extHostProfilePath: '',
+			extHostSnapshotPath: '',
+		};
+	} catch (error) {
+		await window.screenshot({ path: path.join(runDiagDir, 'concurrent-error.png') }).catch(() => undefined);
+		throw error;
+	} finally {
+		window.off('pageerror', pageErrorListener);
+		activeVSCode = null;
+		await vscode.close();
+	}
+
+	return partialMetrics;
+}
+
+function emptyInteractionMetrics() {
+	return {
+		timeToUIUpdated: -1,
+		timeToFirstToken: -1,
+		timeToComplete: -1,
+		timeToRenderComplete: -1,
+		instructionCollectionTime: -1,
+		agentInvokeTime: -1,
+		interactionDurationMs: -1,
+		scrollReturnDurationMs: -1,
+		rendererTaskDurationMs: -1,
+		rendererScriptDurationMs: -1,
+		longTaskTotalMs: -1,
+		longTaskMaxMs: -1,
+		heapDeltaPostGC: -1,
+		majorGCs: -1,
+		minorGCs: -1,
+		gcDurationMs: -1,
+		layoutCount: -1,
+		layoutDurationMs: -1,
+		recalcStyleDurationMs: -1,
+		recalcStyleCount: -1,
+		forcedReflowCount: -1,
+		longTaskCount: -1,
+		longAnimationFrameCount: -1,
+		longAnimationFrameTotalMs: -1,
+		frameCount: -1,
+		compositeLayers: -1,
+		paintCount: -1,
+		hasInternalMarks: true,
+		responseHasContent: true,
+		internalFirstToken: -1,
+		extHostHeapUsedBefore: -1,
+		extHostHeapUsedAfter: -1,
+		extHostHeapDelta: -1,
+		extHostHeapDeltaPostGC: -1,
+	};
+}
+
+async function executeAgentsPerfCommand(window, commandId) {
+	await withTimeout(window.evaluate(async id => {
+		// @ts-ignore
+		await globalThis.driver.executeCommand(id);
+	}, commandId), 30_000, `Agents performance command ${commandId}`);
+}
+
+async function installConcurrentPageObservers(window) {
+	await window.evaluate(() => {
+		// @ts-ignore
+		globalThis.__agentsConcurrentPerf = {
+			phase: 'burst',
+			longTasks: { burst: [], settle: [], tail: [] },
+			resizeObserverLoopCount: 0,
+			pageErrors: [],
+		};
+		// @ts-ignore
+		globalThis.__agentsConcurrentPerfObserver = new PerformanceObserver(list => {
+			// @ts-ignore
+			const state = globalThis.__agentsConcurrentPerf;
+			state.longTasks[state.phase].push(...list.getEntries().map(entry => entry.duration));
+		});
+		// @ts-ignore
+		globalThis.__agentsConcurrentPerfObserver.observe({ entryTypes: ['longtask'] });
+		// @ts-ignore
+		globalThis.__agentsConcurrentPerfErrorListener = event => {
+			// @ts-ignore
+			const state = globalThis.__agentsConcurrentPerf;
+			const message = event instanceof ErrorEvent ? event.message : String(event);
+			state.pageErrors.push(message);
+			if (message.includes('ResizeObserver loop')) {
+				state.resizeObserverLoopCount++;
+			}
+		};
+		// @ts-ignore
+		addEventListener('error', globalThis.__agentsConcurrentPerfErrorListener);
+	});
+}
+
+async function readConcurrentPageObservers(window) {
+	return window.evaluate(() => {
+		// @ts-ignore
+		globalThis.__agentsConcurrentPerfObserver?.disconnect();
+		// @ts-ignore
+		removeEventListener('error', globalThis.__agentsConcurrentPerfErrorListener);
+		// @ts-ignore
+		return globalThis.__agentsConcurrentPerf;
+	});
+}
+
+async function readRequiredPerformanceMetrics(cdp, requiredNames) {
+	const result = await cdp.send('Performance.getMetrics');
+	const metrics = new Map(result.metrics.map(metric => [metric.name, metric.value]));
+	const missing = requiredNames.filter(name => !metrics.has(name));
+	if (missing.length > 0) {
+		throw new Error(`Required CDP performance metrics are missing: ${missing.join(', ')}`);
+	}
+	return metrics;
+}
+
+function metricDelta(before, after, name) {
+	return round2((after.get(name) ?? 0) - (before.get(name) ?? 0));
+}
+
+function metricDeltaMs(before, after, name) {
+	return round2(((after.get(name) ?? 0) - (before.get(name) ?? 0)) * 1_000);
+}
+
+function normalizePageErrorMessage(error) {
+	return String(error).replace(/^(?:Uncaught\s+)?Error:\s*/, '').trim();
+}
+
+function round2(value) {
+	return Math.round(value * 100) / 100;
+}
+
+function assertRequiredPerformanceMetrics(result, requiredNames) {
+	const names = new Set(result.metrics?.map(metric => metric.name));
+	const missing = requiredNames.filter(name => !names.has(name));
+	if (missing.length > 0) {
+		throw new Error(`Required CDP performance metrics are missing: ${missing.join(', ')}`);
+	}
+}
+
+/**
+ * @param {import('playwright').Page} window
+ * @param {string} title
+ * @param {string} sentinel
+ */
+async function activateAgentsSession(window, title, sentinel) {
+	const row = window.locator('.sessions-list-control .monaco-list-row').filter({ hasText: title }).first();
+	await row.waitFor({ state: 'visible', timeout: 30_000 });
+	await row.locator('.session-main').click();
+	await window.waitForFunction(
+		({ selector, text }) => document.querySelector(selector)?.textContent?.includes(text) === true,
+		{ selector: '.agent-sessions-workbench .session-view.is-active', text: sentinel },
+		{ timeout: 30_000 },
+	);
+}
+
+/**
+ * @param {import('playwright').Page} window
+ * @param {string} selector
+ * @param {number} steps
+ * @param {number} deltaY
+ */
+async function scrollAgentsSurface(window, selector, steps, deltaY) {
+	const surface = window.locator(selector).first();
+	await surface.waitFor({ state: 'visible', timeout: 30_000 });
+	const box = await surface.boundingBox();
+	if (!box) {
+		throw new Error(`Cannot measure scroll surface ${selector}`);
+	}
+	await window.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	for (let index = 0; index < steps; index++) {
+		await window.mouse.wheel(0, deltaY);
+		await waitForAnimationFrames(window, 1);
+	}
+}
+
+/**
+ * @param {import('playwright').Page} window
+ * @param {number} count
+ */
+async function waitForAnimationFrames(window, count) {
+	await withTimeout(window.evaluate(frameCount => new Promise(resolve => {
+		const next = () => frameCount-- <= 0 ? resolve(undefined) : requestAnimationFrame(next);
+		next();
+	}), count), 30_000, `waiting for ${count} animation frame(s)`);
+}
+
+async function withTimeout(promise, timeoutMs, operation) {
+	let handle;
+	const timeout = new Promise((_, reject) => {
+		handle = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms while ${operation}`)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		clearTimeout(handle);
+	}
+}
+
+function appendRawRunTable(lines, scenario, runs) {
+	const kind = getPerfScenarioKind(scenario);
+	const columns = kind === 'agents-window-history'
+		? [
+			['Interaction (ms)', 'interactionDurationMs'],
+			['Scroll Return (ms)', 'scrollReturnDurationMs'],
+			['Renderer CPU (ms)', 'rendererTaskDurationMs'],
+			['Style (ms)', 'recalcStyleDurationMs'],
+			['Layout (ms)', 'layoutDurationMs'],
+			['Long Tasks', 'longTaskCount'],
+		]
+		: kind === 'agents-window-concurrent'
+			? [
+				['Burst Wall (ms)', 'concurrentBurstDurationMs'],
+				['Burst CPU (ms)', 'burstThreadTimeMs'],
+				['Burst Style (ms)', 'burstRecalcStyleDurationMs'],
+				['Burst Layout (ms)', 'burstLayoutDurationMs'],
+				['Tail CPU (ms)', 'tailThreadTimeMs'],
+				['Tail Style (ms)', 'tailRecalcStyleDurationMs'],
+				['Tail Layout (ms)', 'tailLayoutDurationMs'],
+				['RO Errors', 'resizeObserverLoopCount'],
+				['Page Errors', 'pageErrorCount'],
+				['Toolbars', 'responsiveToolbarCount'],
+			]
+			: [
+				['TTFT (ms)', 'timeToFirstToken'],
+				['Complete (ms)', 'timeToComplete'],
+				['Layouts', 'layoutCount'],
+				['Style Recalcs', 'recalcStyleCount'],
+				['LoAF Count', 'longAnimationFrameCount'],
+				['LoAF (ms)', 'longAnimationFrameTotalMs'],
+				['Frames', 'frameCount'],
+				['Heap Delta (MB)', 'heapDelta'],
+			];
+	lines.push(`| Run | ${columns.map(([label]) => label).join(' | ')} |`);
+	lines.push(`|----:|${columns.map(() => '----:').join('|')}|`);
+	for (let index = 0; index < runs.length; index++) {
+		const run = runs[index];
+		const values = columns.map(([, metric]) => {
+			const value = run[metric];
+			return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? String(round2(value)) : '-';
+		});
+		lines.push(`| ${index + 1} | ${values.join(' | ')} |`);
+	}
 }
 
 // -- CI summary generation ---------------------------------------------------
@@ -1005,8 +1671,35 @@ function generateCISummary(jsonReport, baseline, opts) {
 	const allMetrics = [
 		['timeToFirstToken', 'timing', 'ms'],
 		['timeToComplete', 'timing', 'ms'],
+		['interactionDurationMs', 'interaction', 'ms'],
+		['scrollReturnDurationMs', 'interaction', 'ms'],
+		['rendererTaskDurationMs', 'interaction', 'ms'],
+		['rendererScriptDurationMs', 'interaction', 'ms'],
+		['longTaskTotalMs', 'interaction', 'ms'],
+		['longTaskMaxMs', 'interaction', 'ms'],
+		['concurrentBurstDurationMs', 'concurrent', 'ms'],
+		['burstThreadTimeMs', 'concurrent', 'ms'],
+		['burstTaskDurationMs', 'concurrent', 'ms'],
+		['burstScriptDurationMs', 'concurrent', 'ms'],
+		['burstRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['burstLayoutDurationMs', 'concurrent', 'ms'],
+		['burstRecalcStyleCount', 'concurrent', ''],
+		['burstLayoutCount', 'concurrent', ''],
+		['settleThreadTimeMs', 'concurrent', 'ms'],
+		['settleRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['settleLayoutDurationMs', 'concurrent', 'ms'],
+		['tailThreadTimeMs', 'concurrent', 'ms'],
+		['tailRecalcStyleDurationMs', 'concurrent', 'ms'],
+		['tailLayoutDurationMs', 'concurrent', 'ms'],
+		['tailRecalcStyleCount', 'concurrent', ''],
+		['tailLayoutCount', 'concurrent', ''],
+		['tailLongTaskCount', 'concurrent', ''],
+		['resizeObserverLoopCount', 'concurrent', ''],
+		['pageErrorCount', 'concurrent', ''],
+		['responsiveToolbarCount', 'concurrent', ''],
 		['layoutCount', 'rendering', ''],
 		['layoutDurationMs', 'rendering', 'ms'],
+		['recalcStyleDurationMs', 'rendering', 'ms'],
 		['recalcStyleCount', 'rendering', ''],
 		['forcedReflowCount', 'rendering', ''],
 		['longTaskCount', 'rendering', ''],
@@ -1021,10 +1714,11 @@ function generateCISummary(jsonReport, baseline, opts) {
 		['extHostHeapDelta', 'extHost', 'MB'],
 		['extHostHeapDeltaPostGC', 'extHost', 'MB'],
 	];
-	const regressionMetricNames = new Set(['timeToFirstToken', 'timeToComplete', 'layoutDurationMs', 'forcedReflowCount', 'longTaskCount']);
+	const regressionMetricNames = new Set(['timeToFirstToken', 'timeToComplete', 'scrollReturnDurationMs', 'rendererTaskDurationMs', 'layoutDurationMs', 'longTaskCount']);
 
 	const lines = [];
 	const scenarios = Object.keys(jsonReport.scenarios);
+	const scenariosWithoutBaseline = scenarios.filter(scenario => !baseline?.scenarios?.[scenario]);
 
 	// -- Collect verdicts per scenario/metric --------------------------------
 	/** @type {Map<string, { metric: string, verdict: string, change: number, pValue: string, basStr: string, curStr: string }[]>} */
@@ -1083,9 +1777,11 @@ function generateCISummary(jsonReport, baseline, opts) {
 
 	// -- Header with verdict up front ----------------------------------------
 	const hasRegressions = totalRegressions > 0;
-	const verdictIcon = hasRegressions ? '\u274C' : '\u2705';
+	const verdictIcon = hasRegressions ? '\u274C' : scenariosWithoutBaseline.length > 0 ? '\u26A0\uFE0F' : '\u2705';
 	const verdictText = hasRegressions
 		? `${totalRegressions} regression(s) detected`
+		: scenariosWithoutBaseline.length > 0
+			? `${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`
 		: totalImprovements > 0
 			? `No regressions \u2014 ${totalImprovements} improvement(s)`
 			: 'No significant changes';
@@ -1158,7 +1854,11 @@ function generateCISummary(jsonReport, baseline, opts) {
 		};
 
 		const keyVerdicts = [ttft, complete, layouts, styles, loaf].filter(Boolean);
-		const rowVerdict = fmtVerdict(/** @type {any[]} */(keyVerdicts));
+		const rowVerdict = !baseline?.scenarios?.[scenario]
+			? '\u26A0\uFE0F No baseline'
+			: keyVerdicts.length === 0
+				? '\u2139\uFE0F Informational'
+				: fmtVerdict(/** @type {any[]} */(keyVerdicts));
 
 		lines.push(`| ${scenario} | ${getScenarioDescription(scenario)} | ${fmtCell(ttft)} | ${fmtCell(complete)} | ${fmtCell(layouts)} | ${fmtCell(styles)} | ${fmtCell(loaf)} | ${rowVerdict} |`);
 	}
@@ -1242,14 +1942,7 @@ function generateCISummary(jsonReport, baseline, opts) {
 		const current = jsonReport.scenarios[scenario];
 		lines.push(`### ${scenario}`);
 		lines.push('');
-		lines.push('| Run | TTFT (ms) | Complete (ms) | Layouts | Style Recalcs | LoAF Count | LoAF (ms) | Frames | Heap Delta (MB) | Internal Marks |');
-		lines.push('|----:|----------:|--------------:|--------:|--------------:|-----------:|----------:|-------:|----------------:|:--------------:|');
-		const runs = current.rawRuns || [];
-		for (let i = 0; i < runs.length; i++) {
-			const r = runs[i];
-			const round2 = (/** @type {number} */ v) => Math.round(v * 100) / 100;
-			lines.push(`| ${i + 1} | ${round2(r.timeToFirstToken)} | ${r.timeToComplete} | ${r.layoutCount} | ${r.recalcStyleCount} | ${r.longAnimationFrameCount ?? '-'} | ${r.longAnimationFrameTotalMs !== null && r.longAnimationFrameTotalMs !== undefined ? round2(r.longAnimationFrameTotalMs) : '-'} | ${r.frameCount ?? '-'} | ${r.heapDelta} | ${r.hasInternalMarks ? 'yes' : 'no'} |`);
-		}
+		appendRawRunTable(lines, scenario, current.rawRuns || []);
 		lines.push('');
 	}
 	if (baseline) {
@@ -1258,14 +1951,7 @@ function generateCISummary(jsonReport, baseline, opts) {
 			if (!base) { continue; }
 			lines.push(`### ${scenario} (baseline)`);
 			lines.push('');
-			lines.push('| Run | TTFT (ms) | Complete (ms) | Layouts | Style Recalcs | LoAF Count | LoAF (ms) | Frames | Heap Delta (MB) | Internal Marks |');
-			lines.push('|----:|----------:|--------------:|--------:|--------------:|-----------:|----------:|-------:|----------------:|:--------------:|');
-			const runs = base.rawRuns || [];
-			for (let i = 0; i < runs.length; i++) {
-				const r = runs[i];
-				const round2 = (/** @type {number} */ v) => Math.round(v * 100) / 100;
-				lines.push(`| ${i + 1} | ${round2(r.timeToFirstToken)} | ${r.timeToComplete} | ${r.layoutCount} | ${r.recalcStyleCount} | ${r.longAnimationFrameCount ?? '-'} | ${r.longAnimationFrameTotalMs !== null && r.longAnimationFrameTotalMs !== undefined ? round2(r.longAnimationFrameTotalMs) : '-'} | ${r.frameCount ?? '-'} | ${r.heapDelta} | ${r.hasInternalMarks ? 'yes' : 'no'} |`);
-			}
+			appendRawRunTable(lines, scenario, base.rawRuns || []);
 			lines.push('');
 		}
 	}
@@ -1424,12 +2110,12 @@ async function main() {
 			}
 
 			// Recompute stats with merged data
-			const sd = /** @type {any} */ ({ runs: prevTestRuns.length, timing: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: prevTestRuns });
+			const sd = /** @type {any} */ ({ runs: prevTestRuns.length, timing: {}, interaction: {}, concurrent: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: prevTestRuns });
 			for (const [metric, group] of METRIC_DEFS) { sd[group][metric] = robustStats(prevTestRuns.map((/** @type {any} */ r) => r[metric])); }
 			prevResults.scenarios[scenario] = sd;
 
 			if (prevBaseline?.scenarios?.[scenario]) {
-				const bsd = /** @type {any} */ ({ runs: prevBaseRuns.length, timing: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: prevBaseRuns });
+				const bsd = /** @type {any} */ ({ runs: prevBaseRuns.length, timing: {}, interaction: {}, concurrent: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: prevBaseRuns });
 				for (const [metric, group] of METRIC_DEFS) { bsd[group][metric] = robustStats(prevBaseRuns.map((/** @type {any} */ r) => r[metric])); }
 				prevBaseline.scenarios[scenario] = bsd;
 			}
@@ -1513,6 +2199,13 @@ async function main() {
 	// Compute effective settings per role
 	const testSettings = { ...opts.settingsOverrides, ...opts.testSettingsOverrides };
 	const baselineSettings = { ...opts.settingsOverrides, ...opts.baselineSettingsOverrides };
+	const baselineScenarios = opts.scenarios.filter(scenario => {
+		if (!isBaselineVersionString || getPerfScenarioKind(scenario) === 'streaming') {
+			return true;
+		}
+		console.log(`[chat-simulation] Skipping release baseline for ${scenario}; the release does not contain the smoke-driver commands required by this scenario.`);
+		return false;
+	});
 
 	// -- Baseline build --------------------------------------------------
 	if (opts.baselineBuild) {
@@ -1532,10 +2225,10 @@ async function main() {
 		if (cachedBaseline?.baselineBuildVersion === opts.baselineBuild) {
 			// Check if the cache covers all requested scenarios
 			const cachedScenarios = new Set(Object.keys(cachedBaseline.scenarios || {}));
-			const missingScenarios = opts.scenarios.filter((/** @type {string} */ s) => !cachedScenarios.has(s));
+			const missingScenarios = baselineScenarios.filter((/** @type {string} */ s) => !cachedScenarios.has(s));
 
 			// Also check if cached scenarios have fewer runs than requested
-			const shortScenarios = opts.scenarios.filter((/** @type {string} */ s) => {
+			const shortScenarios = baselineScenarios.filter((/** @type {string} */ s) => {
 				const cached = cachedBaseline.scenarios?.[s];
 				return cached && (cached.rawRuns?.length || 0) < opts.runs;
 			});
@@ -1570,7 +2263,7 @@ async function main() {
 					}
 					const allRuns = [...existingRuns, ...newResults];
 					if (allRuns.length > 0) {
-						const sd = /** @type {any} */ ({ runs: allRuns.length, timing: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: allRuns });
+						const sd = /** @type {any} */ ({ runs: allRuns.length, timing: {}, interaction: {}, concurrent: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: allRuns });
 						for (const [metric, group] of METRIC_DEFS) { sd[group][metric] = robustStats(allRuns.map((/** @type {any} */ r) => r[metric])); }
 						cachedBaseline.scenarios[scenario] = sd;
 					}
@@ -1583,23 +2276,25 @@ async function main() {
 				opts.baseline = baselineJsonPath;
 			}
 		} else {
-			const baselineExePath = baselineElectronPath || await resolveBuild(opts.baselineBuild);
 			console.log(`[chat-simulation] Benchmarking baseline build (${baselineLabel})...`);
 			/** @type {Record<string, RunMetrics[]>} */
 			const baselineResults = {};
-			for (const scenario of opts.scenarios) {
-				/** @type {RunMetrics[]} */
-				const results = [];
-				for (let i = 0; i < opts.runs; i++) {
-					try {
-						const m = await runOnce(baselineExePath, scenario, mockServer, opts.verbose, `baseline-${scenario}-${i}`, runDir, 'baseline', baselineSettings, { heapSnapshots: opts.heapSnapshots, gcObjectStats: opts.gcObjectStats });
-						// Clean up previous run's diagnostics to bound disk usage; keep the latest
-						if (opts.cleanupDiagnostics && results.length > 0) { cleanupRunDiagnostics(results[results.length - 1]); }
-						results.push(m);
-					}
-					catch (err) { console.error(`[chat-simulation]   Baseline run ${i + 1} failed: ${err}`); }
+			if (baselineScenarios.length > 0) {
+				const baselineExePath = baselineElectronPath || await resolveBuild(opts.baselineBuild);
+				for (const scenario of baselineScenarios) {
+						/** @type {RunMetrics[]} */
+						const results = [];
+						for (let i = 0; i < opts.runs; i++) {
+							try {
+								const m = await runOnce(baselineExePath, scenario, mockServer, opts.verbose, `baseline-${scenario}-${i}`, runDir, 'baseline', baselineSettings, { heapSnapshots: opts.heapSnapshots, gcObjectStats: opts.gcObjectStats });
+								// Clean up previous run's diagnostics to bound disk usage; keep the latest
+								if (opts.cleanupDiagnostics && results.length > 0) { cleanupRunDiagnostics(results[results.length - 1]); }
+								results.push(m);
+							}
+							catch (err) { console.error(`[chat-simulation]   Baseline run ${i + 1} failed: ${err}`); }
+						}
+						if (results.length > 0) { baselineResults[scenario] = results; }
 				}
-				if (results.length > 0) { baselineResults[scenario] = results; }
 			}
 			const baselineReport = {
 				timestamp: new Date().toISOString(),
@@ -1609,7 +2304,7 @@ async function main() {
 				scenarios: /** @type {Record<string, any>} */ ({}),
 			};
 			for (const [scenario, results] of Object.entries(baselineResults)) {
-				const sd = /** @type {any} */ ({ runs: results.length, timing: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: results });
+				const sd = /** @type {any} */ ({ runs: results.length, timing: {}, interaction: {}, concurrent: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: results });
 				for (const [metric, group] of METRIC_DEFS) { sd[group][metric] = robustStats(results.map(r => /** @type {any} */(r)[metric])); }
 				baselineReport.scenarios[scenario] = sd;
 			}
@@ -1680,8 +2375,12 @@ async function main() {
 				if (opts.cleanupDiagnostics && results.length > 0) { cleanupRunDiagnostics(results[results.length - 1]); }
 				results.push(metrics);
 				if (opts.verbose) {
-					const src = metrics.hasInternalMarks ? 'internal' : 'client-side';
-					console.log(`    [${src}] firstToken=${metrics.timeToFirstToken}ms, complete=${metrics.timeToComplete}ms, heap=delta${metrics.heapDelta}MB, longTasks=${metrics.longTaskCount}${metrics.hasInternalMarks ? `, internalTTFT=${metrics.internalFirstToken}ms` : ''}`);
+					if (metrics.interactionDurationMs >= 0) {
+						console.log(`    [interaction] duration=${metrics.interactionDurationMs}ms, rendererTask=${metrics.rendererTaskDurationMs}ms, layout=${metrics.layoutDurationMs}ms, longTasks=${metrics.longTaskCount}`);
+					} else {
+						const src = metrics.hasInternalMarks ? 'internal' : 'client-side';
+						console.log(`    [${src}] firstToken=${metrics.timeToFirstToken}ms, complete=${metrics.timeToComplete}ms, heap=delta${metrics.heapDelta}MB, longTasks=${metrics.longTaskCount}${metrics.hasInternalMarks ? `, internalTTFT=${metrics.internalFirstToken}ms` : ''}`);
+					}
 				}
 			} catch (err) { console.error(`    Run ${i + 1} failed: ${err}`); }
 		}
@@ -1700,6 +2399,34 @@ async function main() {
 		console.log(summarize(results.map(r => r.timeToFirstToken), '  Request → First token ', 'ms'));
 		console.log(summarize(results.map(r => r.timeToComplete), '  Request → Complete    ', 'ms'));
 		console.log(summarize(results.map(r => r.timeToRenderComplete), '  Request → Rendered    ', 'ms'));
+		if (results.some(r => r.interactionDurationMs >= 0)) {
+			console.log('');
+			console.log('  Interaction:');
+			console.log(summarize(results.map(r => r.interactionDurationMs), '  Wall duration         ', 'ms'));
+			console.log(summarize(results.map(r => r.scrollReturnDurationMs), '  Scroll return         ', 'ms'));
+			console.log(summarize(results.map(r => r.rendererTaskDurationMs), '  Renderer task CPU     ', 'ms'));
+			console.log(summarize(results.map(r => r.rendererScriptDurationMs), '  Renderer script CPU   ', 'ms'));
+			console.log(summarize(results.map(r => r.recalcStyleDurationMs ?? -1), '  Style recalculation   ', 'ms'));
+			console.log(summarize(results.map(r => r.longTaskTotalMs), '  Long task total       ', 'ms'));
+			console.log(summarize(results.map(r => r.longTaskMaxMs), '  Long task maximum     ', 'ms'));
+		}
+		if (results.some(r => r.concurrentBurstDurationMs !== undefined)) {
+			console.log('');
+			console.log('  Concurrent sessions:');
+			console.log(summarize(results.map(r => r.concurrentBurstDurationMs ?? -1), '  Burst wall duration   ', 'ms'));
+			console.log(summarize(results.map(r => r.burstThreadTimeMs ?? -1), '  Burst renderer CPU    ', 'ms'));
+			console.log(summarize(results.map(r => r.burstRecalcStyleDurationMs ?? -1), '  Burst style duration  ', 'ms'));
+			console.log(summarize(results.map(r => r.burstLayoutDurationMs ?? -1), '  Burst layout duration ', 'ms'));
+			console.log(summarize(results.map(r => r.settleThreadTimeMs ?? -1), '  Settle renderer CPU   ', 'ms'));
+			console.log(summarize(results.map(r => r.tailThreadTimeMs ?? -1), '  Tail renderer CPU     ', 'ms'));
+			console.log(summarize(results.map(r => r.tailRecalcStyleDurationMs ?? -1), '  Tail style duration   ', 'ms'));
+			console.log(summarize(results.map(r => r.tailLayoutDurationMs ?? -1), '  Tail layout duration  ', 'ms'));
+			console.log(summarize(results.map(r => r.tailRecalcStyleCount ?? -1), '  Tail style recalcs    ', ''));
+			console.log(summarize(results.map(r => r.tailLayoutCount ?? -1), '  Tail layouts          ', ''));
+			console.log(summarize(results.map(r => r.tailLongTaskCount ?? -1), '  Tail long tasks       ', ''));
+			console.log(summarize(results.map(r => r.responsiveToolbarCount ?? -1), '  Responsive toolbars   ', ''));
+			console.log(summarize(results.map(r => r.resizeObserverLoopCount ?? -1), '  RO loop errors        ', ''));
+		}
 		console.log('');
 		console.log('  Rendering:');
 		console.log(summarize(results.map(r => r.layoutCount), '  Layouts               ', ''));
@@ -1738,7 +2465,7 @@ async function main() {
 		scenarios: /** @type {Record<string, any>} */ ({}),
 	});
 	for (const [scenario, results] of Object.entries(allResults)) {
-		const sd = /** @type {any} */ ({ runs: results.length, timing: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: results });
+		const sd = /** @type {any} */ ({ runs: results.length, timing: {}, interaction: {}, concurrent: {}, memory: {}, rendering: {}, extHost: {}, rawRuns: results });
 		for (const [metric, group] of METRIC_DEFS) { sd[group][metric] = robustStats(results.map(r => /** @type {any} */(r)[metric])); }
 		jsonReport.scenarios[scenario] = sd;
 	}
@@ -1794,8 +2521,9 @@ async function printComparison(jsonReport, opts) {
 			// [metric, group, unit]
 			['timeToFirstToken', 'timing', 'ms'],
 			['timeToComplete', 'timing', 'ms'],
+			['scrollReturnDurationMs', 'interaction', 'ms'],
+			['rendererTaskDurationMs', 'interaction', 'ms'],
 			['layoutDurationMs', 'rendering', 'ms'],
-			['forcedReflowCount', 'rendering', ''],
 			['longTaskCount', 'rendering', ''],
 		];
 		// Informational metrics — shown in comparison but don't trigger failure.
@@ -1805,8 +2533,14 @@ async function printComparison(jsonReport, opts) {
 		// build can do more, cheaper layouts yet spend less layout time and finish
 		// faster (e.g. giant-codeblock: +28% layoutCount but -7% layoutDurationMs).
 		const infoMetrics = [
+			['interactionDurationMs', 'interaction', 'ms'],
+			['rendererScriptDurationMs', 'interaction', 'ms'],
+			['longTaskTotalMs', 'interaction', 'ms'],
+			['longTaskMaxMs', 'interaction', 'ms'],
 			['layoutCount', 'rendering', ''],
 			['recalcStyleCount', 'rendering', ''],
+			['recalcStyleDurationMs', 'rendering', 'ms'],
+			['forcedReflowCount', 'rendering', ''],
 			['heapDelta', 'memory', 'MB'],
 			['gcDurationMs', 'memory', 'ms'],
 			['extHostHeapDelta', 'extHost', 'MB'],

--- a/scripts/chat-simulation/test-chat-perf-regression.js
+++ b/scripts/chat-simulation/test-chat-perf-regression.js
@@ -24,7 +24,7 @@
 const path = require('path');
 const fs = require('fs');
 const {
-	ROOT, DATA_DIR, METRIC_DEFS, loadConfig,
+	ROOT, DATA_DIR, METRIC_DEFS, REGRESSION_METRIC_NAMES, loadConfig,
 	resolveBuild, isVersionString, buildEnv, buildArgs, prepareRunDir,
 	robustStats, welchTTest, summarize, markDuration, launchVSCode,
 	getNextExtHostInspectPort, connectToExtHostInspector, getRepoRoot,
@@ -772,47 +772,7 @@ async function runOnce(electronPath, scenario, mockServer, verbose, runIndex, ru
 		// -- Heap snapshots (opt-in, parallelized) ---------------------------
 		let snapshotPath = '';
 		if (takeHeapSnapshots) {
-			const snapshotPromises = [];
-
-			// Renderer snapshot
-			snapshotPromises.push((async () => {
-				const p = path.join(runDiagDir, 'heap.heapsnapshot');
-				await cdp.send('HeapProfiler.enable');
-				const chunks = /** @type {string[]} */ ([]);
-				cdp.on('HeapProfiler.addHeapSnapshotChunk', (/** @type {any} */ params) => {
-					chunks.push(params.chunk);
-				});
-				await cdp.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false });
-				fs.writeFileSync(p, chunks.join(''));
-				return p;
-			})());
-
-			// Extension host snapshot (parallel with renderer)
-			if (extHostInspector && extHostHeapBefore) {
-				snapshotPromises.push((async () => {
-					const p = path.join(runDiagDir, 'exthost-heap.heapsnapshot');
-					const chunks = /** @type {string[]} */ ([]);
-					extHostInspector.on('HeapProfiler.addHeapSnapshotChunk', (/** @type {any} */ params) => {
-						chunks.push(params.chunk);
-					});
-					await extHostInspector.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false });
-					fs.writeFileSync(p, chunks.join(''));
-					return p;
-				})());
-			}
-
-			const snapshotResults = await Promise.all(snapshotPromises);
-			snapshotPath = snapshotResults[0];
-			if (snapshotResults.length > 1) {
-				extHostSnapshotPath = snapshotResults[1];
-			}
-
-			if (verbose) {
-				console.log(`  [debug] Renderer snapshot saved to ${snapshotPath}`);
-				if (extHostSnapshotPath) {
-					console.log(`  [ext-host] Snapshot saved to ${extHostSnapshotPath}`);
-				}
-			}
+			({ snapshotPath, extHostSnapshotPath } = await captureHeapSnapshots(cdp, extHostInspector, runDiagDir, verbose));
 		}
 
 		// Close ext host inspector now that snapshots (if any) are done
@@ -1004,6 +964,47 @@ function getBuildRunInfo(electronPath, verbose) {
 }
 
 /**
+ * @param {{ send: (method: string, params?: any) => Promise<any>, on: (event: string, listener: (params: any) => void) => void }} cdp
+ * @param {{ send: (method: string, params?: any) => Promise<any>, on: (event: string, listener: (params: any) => void) => void } | null} extHostInspector
+ * @param {string} runDiagDir
+ * @param {boolean} verbose
+ */
+async function captureHeapSnapshots(cdp, extHostInspector, runDiagDir, verbose) {
+	const rendererSnapshotPath = path.join(runDiagDir, 'heap.heapsnapshot');
+	const rendererSnapshot = (async () => {
+		await cdp.send('HeapProfiler.enable');
+		const chunks = /** @type {string[]} */ ([]);
+		cdp.on('HeapProfiler.addHeapSnapshotChunk', (/** @type {any} */ params) => {
+			chunks.push(params.chunk);
+		});
+		await cdp.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false });
+		fs.writeFileSync(rendererSnapshotPath, chunks.join(''));
+		return rendererSnapshotPath;
+	})();
+
+	const extHostSnapshot = extHostInspector ? (async () => {
+		const extHostSnapshotPath = path.join(runDiagDir, 'exthost-heap.heapsnapshot');
+		await extHostInspector.send('HeapProfiler.enable');
+		const chunks = /** @type {string[]} */ ([]);
+		extHostInspector.on('HeapProfiler.addHeapSnapshotChunk', (/** @type {any} */ params) => {
+			chunks.push(params.chunk);
+		});
+		await extHostInspector.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false });
+		fs.writeFileSync(extHostSnapshotPath, chunks.join(''));
+		return extHostSnapshotPath;
+	})() : Promise.resolve('');
+
+	const [snapshotPath, extHostSnapshotPath] = await Promise.all([rendererSnapshot, extHostSnapshot]);
+	if (verbose) {
+		console.log(`  [debug] Renderer snapshot saved to ${snapshotPath}`);
+		if (extHostSnapshotPath) {
+			console.log(`  [ext-host] Snapshot saved to ${extHostSnapshotPath}`);
+		}
+	}
+	return { snapshotPath, extHostSnapshotPath };
+}
+
+/**
  * @param {string} electronPath
  * @param {{ url: string }} mockServer
  * @param {boolean} verbose
@@ -1015,6 +1016,7 @@ function getBuildRunInfo(electronPath, verbose) {
  * @returns {Promise<RunMetrics>}
  */
 async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts) {
+	const takeHeapSnapshots = runOpts?.heapSnapshots ?? false;
 	const corpus = process.env.AGENTS_PERF_SMALL_CORPUS === '1'
 		? createAgentsWindowPerfCorpus({ sessionCount: 4, primaryTurnCount: 20, secondaryTurnCount: 3, peerChatCount: 1, subagentToolCount: 16 })
 		: createAgentsWindowPerfCorpus();
@@ -1031,15 +1033,17 @@ async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose,
 	fs.mkdirSync(runDiagDir, { recursive: true });
 	const tracePath = path.join(runDiagDir, 'trace.json');
 	const profilePath = path.join(runDiagDir, 'profile.cpuprofile');
-	const snapshotPath = '';
+	let snapshotPath = '';
 	const extHostProfilePath = '';
-	const extHostSnapshotPath = '';
+	let extHostSnapshotPath = '';
+	const extHostInspectPort = takeHeapSnapshots ? getNextExtHostInspectPort() : undefined;
 	const vscode = await launchVSCode(
 		electronPath,
 		buildArgs(userDataDir, extDir, logsDir, {
 			isDevBuild,
 			traceFile: tracePath,
 			appRoot,
+			extHostInspectPort,
 			gcObjectStats: runOpts?.gcObjectStats,
 			agentsWindow: true,
 		}),
@@ -1059,6 +1063,8 @@ async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose,
 	const startMark = `code/agentsPerf/${markId}/start`;
 	const endMark = `code/agentsPerf/${markId}/end`;
 	let partialMetrics;
+	/** @type {{ send: (method: string, params?: any) => Promise<any>, on: (event: string, listener: (params: any) => void) => void, close: () => void } | null} */
+	let extHostInspector = null;
 
 	try {
 		await window.waitForSelector('.agent-sessions-workbench', { timeout: 60_000 });
@@ -1150,6 +1156,14 @@ async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose,
 		if (pageErrors.length > 0) {
 			fs.writeFileSync(path.join(runDiagDir, 'page-errors.json'), JSON.stringify([...new Set(pageErrors)], null, 2));
 		}
+		if (extHostInspectPort !== undefined) {
+			try {
+				extHostInspector = await connectToExtHostInspector(extHostInspectPort, { verbose, timeoutMs: 15_000 });
+			} catch (error) {
+				console.warn(`  [ext-host] Could not capture heap snapshot: ${error}`);
+			}
+			({ snapshotPath, extHostSnapshotPath } = await captureHeapSnapshots(cdp, extHostInspector, runDiagDir, verbose));
+		}
 
 		const getMetric = (result, name) => result.metrics?.find(metric => metric.name === name)?.value ?? 0;
 		const durationDeltaMs = (name) => Math.round((getMetric(metricsAfter, name) - getMetric(metricsBefore, name)) * 100_000) / 100;
@@ -1202,6 +1216,7 @@ async function runAgentsWindowInteractionOnce(electronPath, mockServer, verbose,
 		throw error;
 	} finally {
 		window.off('pageerror', pageErrorListener);
+		extHostInspector?.close();
 		activeVSCode = null;
 		await vscode.close();
 	}
@@ -1231,6 +1246,7 @@ const CONCURRENT_REQUIRED_METRICS = [
  * @returns {Promise<RunMetrics>}
  */
 async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, verbose, runIndex, runDir, role, settingsOverrides, runOpts) {
+	const takeHeapSnapshots = runOpts?.heapSnapshots ?? false;
 	const corpus = createAgentsWindowConcurrentPerfCorpus();
 	const agentsSettings = {
 		'sessions.chat.localAgent.enabled': true,
@@ -1246,12 +1262,14 @@ async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, v
 	fs.mkdirSync(runDiagDir, { recursive: true });
 	const tracePath = path.join(runDiagDir, 'trace.json');
 	const profilePath = path.join(runDiagDir, 'profile.cpuprofile');
+	const extHostInspectPort = takeHeapSnapshots ? getNextExtHostInspectPort() : undefined;
 	const vscode = await launchVSCode(
 		electronPath,
 		buildArgs(userDataDir, extDir, logsDir, {
 			isDevBuild,
 			traceFile: tracePath,
 			appRoot,
+			extHostInspectPort,
 			gcObjectStats: runOpts?.gcObjectStats,
 			agentsWindow: true,
 		}),
@@ -1264,6 +1282,8 @@ async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, v
 	const pageErrorListener = error => pageErrors.push(normalizePageErrorMessage(error));
 	window.on('pageerror', pageErrorListener);
 	let partialMetrics;
+	/** @type {{ send: (method: string, params?: any) => Promise<any>, on: (event: string, listener: (params: any) => void) => void, close: () => void } | null} */
+	let extHostInspector = null;
 
 	try {
 		await window.waitForSelector('.agent-sessions-workbench', { timeout: 60_000 });
@@ -1341,6 +1361,16 @@ async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, v
 		if (errorMessages.length > 0) {
 			fs.writeFileSync(path.join(runDiagDir, 'page-errors.json'), JSON.stringify(errorMessages, null, 2));
 		}
+		let snapshotPath = '';
+		let extHostSnapshotPath = '';
+		if (extHostInspectPort !== undefined) {
+			try {
+				extHostInspector = await connectToExtHostInspector(extHostInspectPort, { verbose, timeoutMs: 15_000 });
+			} catch (error) {
+				console.warn(`  [ext-host] Could not capture heap snapshot: ${error}`);
+			}
+			({ snapshotPath, extHostSnapshotPath } = await captureHeapSnapshots(cdp, extHostInspector, runDiagDir, verbose));
+		}
 
 		partialMetrics = {
 			...emptyInteractionMetrics(),
@@ -1369,15 +1399,16 @@ async function runAgentsWindowConcurrentSessionsOnce(electronPath, mockServer, v
 			heapDelta: Math.round((heapAfter.usedSize - heapBefore.usedSize) / 1024 / 1024),
 			profilePath,
 			tracePath,
-			snapshotPath: '',
+			snapshotPath,
 			extHostProfilePath: '',
-			extHostSnapshotPath: '',
+			extHostSnapshotPath,
 		};
 	} catch (error) {
 		await window.screenshot({ path: path.join(runDiagDir, 'concurrent-error.png') }).catch(() => undefined);
 		throw error;
 	} finally {
 		window.off('pageerror', pageErrorListener);
+		extHostInspector?.close();
 		activeVSCode = null;
 		await vscode.close();
 	}
@@ -1714,8 +1745,6 @@ function generateCISummary(jsonReport, baseline, opts) {
 		['extHostHeapDelta', 'extHost', 'MB'],
 		['extHostHeapDeltaPostGC', 'extHost', 'MB'],
 	];
-	const regressionMetricNames = new Set(['timeToFirstToken', 'timeToComplete', 'scrollReturnDurationMs', 'rendererTaskDurationMs', 'layoutDurationMs', 'longTaskCount']);
-
 	const lines = [];
 	const scenarios = Object.keys(jsonReport.scenarios);
 	const scenariosWithoutBaseline = scenarios.filter(scenario => !baseline?.scenarios?.[scenario]);
@@ -1739,7 +1768,7 @@ function generateCISummary(jsonReport, baseline, opts) {
 				if (!cur || !bas || bas.median === null || bas.median === undefined) { continue; }
 
 				const change = bas.median !== 0 ? (cur.median - bas.median) / bas.median : 0;
-				const isRegressionMetric = regressionMetricNames.has(metric);
+				const isRegressionMetric = REGRESSION_METRIC_NAMES.has(metric);
 
 				const curRaw = (current.rawRuns || []).map((/** @type {any} */ r) => r[metric]).filter((/** @type {any} */ v) => v >= 0);
 				const basRaw = (base.rawRuns || []).map((/** @type {any} */ r) => r[metric]).filter((/** @type {any} */ v) => v >= 0);
@@ -1778,13 +1807,18 @@ function generateCISummary(jsonReport, baseline, opts) {
 	// -- Header with verdict up front ----------------------------------------
 	const hasRegressions = totalRegressions > 0;
 	const verdictIcon = hasRegressions ? '\u274C' : scenariosWithoutBaseline.length > 0 ? '\u26A0\uFE0F' : '\u2705';
-	const verdictText = hasRegressions
-		? `${totalRegressions} regression(s) detected`
-		: scenariosWithoutBaseline.length > 0
-			? `${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`
-		: totalImprovements > 0
-			? `No regressions \u2014 ${totalImprovements} improvement(s)`
-			: 'No significant changes';
+	const verdictParts = [];
+	if (hasRegressions) {
+		verdictParts.push(`${totalRegressions} regression(s) detected`);
+	} else if (totalImprovements > 0) {
+		verdictParts.push(`No regressions \u2014 ${totalImprovements} improvement(s)`);
+	} else if (scenariosWithoutBaseline.length < scenarios.length) {
+		verdictParts.push('No significant changes');
+	}
+	if (scenariosWithoutBaseline.length > 0) {
+		verdictParts.push(`${scenariosWithoutBaseline.length} scenario(s) have no compatible baseline`);
+	}
+	const verdictText = verdictParts.join('; ');
 
 	lines.push(`# ${verdictIcon} Chat Performance: ${verdictText}`);
 	lines.push('');
@@ -1853,12 +1887,12 @@ function generateCISummary(jsonReport, baseline, opts) {
 			return '\u2705 OK';
 		};
 
-		const keyVerdicts = [ttft, complete, layouts, styles, loaf].filter(Boolean);
+		const gatedVerdicts = verdicts.filter(verdict => REGRESSION_METRIC_NAMES.has(verdict.metric));
 		const rowVerdict = !baseline?.scenarios?.[scenario]
 			? '\u26A0\uFE0F No baseline'
-			: keyVerdicts.length === 0
+			: gatedVerdicts.length === 0
 				? '\u2139\uFE0F Informational'
-				: fmtVerdict(/** @type {any[]} */(keyVerdicts));
+				: fmtVerdict(gatedVerdicts);
 
 		lines.push(`| ${scenario} | ${getScenarioDescription(scenario)} | ${fmtCell(ttft)} | ${fmtCell(complete)} | ${fmtCell(layouts)} | ${fmtCell(styles)} | ${fmtCell(loaf)} | ${rowVerdict} |`);
 	}
@@ -1985,14 +2019,14 @@ function installSignalHandlers() {
  * Remove large diagnostic files (heap snapshots, CPU profiles, traces) from
  * a run's metrics to free disk space.  Keeps the JSON results data intact.
  * @param {RunMetrics} metrics
+ * @param {{ preserveHeapSnapshots?: boolean }} [options]
  */
-function cleanupRunDiagnostics(metrics) {
+function cleanupRunDiagnostics(metrics, options) {
 	const filesToDelete = [
 		metrics.profilePath,
 		metrics.tracePath,
-		metrics.snapshotPath,
 		metrics.extHostProfilePath,
-		metrics.extHostSnapshotPath,
+		...(options?.preserveHeapSnapshots ? [] : [metrics.snapshotPath, metrics.extHostSnapshotPath]),
 	];
 	for (const filePath of filesToDelete) {
 		if (filePath && fs.existsSync(filePath)) {
@@ -2010,14 +2044,15 @@ function cleanupRunDiagnostics(metrics) {
  * Keeps diagnostics for regressed scenarios so they can be investigated.
  * @param {Record<string, RunMetrics[]>} allResults - test results by scenario
  * @param {Set<string>} regressedScenarios - scenarios that regressed
+ * @param {{ preserveHeapSnapshots?: boolean }} [options]
  */
-function cleanupNonRegressedDiagnostics(allResults, regressedScenarios) {
+function cleanupNonRegressedDiagnostics(allResults, regressedScenarios, options) {
 	for (const [scenario, runs] of Object.entries(allResults)) {
 		if (regressedScenarios.has(scenario)) {
 			continue;
 		}
 		for (const metrics of runs) {
-			cleanupRunDiagnostics(metrics);
+			cleanupRunDiagnostics(metrics, options);
 		}
 	}
 }
@@ -2486,7 +2521,7 @@ async function main() {
 
 	// Clean up diagnostics for scenarios that did not regress
 	if (opts.cleanupDiagnostics) {
-		cleanupNonRegressedDiagnostics(allResults, regressedScenarios);
+		cleanupNonRegressedDiagnostics(allResults, regressedScenarios, { preserveHeapSnapshots: opts.heapSnapshots });
 	}
 
 	if (anyFailed) { process.exit(1); }
@@ -2517,15 +2552,7 @@ async function printComparison(jsonReport, opts) {
 		console.log('');
 
 		// Metrics that trigger regression failure when they exceed the threshold
-		const regressionMetrics = [
-			// [metric, group, unit]
-			['timeToFirstToken', 'timing', 'ms'],
-			['timeToComplete', 'timing', 'ms'],
-			['scrollReturnDurationMs', 'interaction', 'ms'],
-			['rendererTaskDurationMs', 'interaction', 'ms'],
-			['layoutDurationMs', 'rendering', 'ms'],
-			['longTaskCount', 'rendering', ''],
-		];
+		const regressionMetrics = METRIC_DEFS.filter(([metric]) => REGRESSION_METRIC_NAMES.has(metric));
 		// Informational metrics — shown in comparison but don't trigger failure.
 		// layoutCount / recalcStyleCount are informational on purpose: they are
 		// inflated by CSS animations (compositor-driven, cheap) and don't reflect

--- a/src/vs/sessions/contrib/chat/browser/sessionsPerfTest.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsPerfTest.contribution.ts
@@ -1,0 +1,273 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
+import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
+import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
+import { ChatModel, ChatRequestModel } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { ChatRequestTextPart } from '../../../../workbench/contrib/chat/common/requestParser/chatParserTypes.js';
+import { OffsetRange } from '../../../../editor/common/core/ranges/offsetRange.js';
+import { Range } from '../../../../editor/common/core/range.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+export const INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID = '_workbench.sessions.perf.injectLiveSubagentTools';
+export const SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID = '_workbench.sessions.perf.scrollActiveChatStart';
+export const SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID = '_workbench.sessions.perf.scrollActiveChatEnd';
+export const SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID = '_workbench.sessions.perf.showConcurrentSessions';
+export const RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID = '_workbench.sessions.perf.runConcurrentBurst';
+export const STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID = '_workbench.sessions.perf.stopConcurrentSessions';
+
+const CONCURRENT_BURST_TICKS = 48;
+
+interface IConcurrentSessionContext {
+	readonly model: ChatModel;
+	readonly request: ChatRequestModel;
+	readonly parentToolCallId: string;
+	readonly sessionIndex: number;
+}
+
+class SessionsPerfTestContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessionsPerfTest';
+	private readonly _concurrentModelRefs = this._register(new MutableDisposable<DisposableStore>());
+	private _concurrentSessions: IConcurrentSessionContext[] = [];
+
+	constructor(
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@ISessionsService sessionsService: ISessionsService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@IChatService chatService: IChatService,
+		@IChatWidgetService chatWidgetService: IChatWidgetService,
+	) {
+		super();
+
+		if (!environmentService.enableSmokeTestDriver) {
+			return;
+		}
+
+		this._register(CommandsRegistry.registerCommand(INJECT_AGENTS_PERF_LIVE_SUBAGENT_COMMAND_ID, () => {
+			const model = getActiveChatModel(sessionsService, chatService);
+			const messageText = 'Run the live Agents performance subagent';
+			const request = model.addRequest({
+				text: messageText,
+				parts: [new ChatRequestTextPart(
+					new OffsetRange(0, messageText.length),
+					new Range(1, 1, 1, messageText.length + 1),
+					messageText,
+				)],
+			}, { variables: [] }, 0);
+
+			const parentToolCallId = 'agents-perf-live-subagent';
+			chatService.appendProgress(request, {
+				kind: 'externalToolInvocationUpdate',
+				toolCallId: parentToolCallId,
+				toolName: 'runSubagent',
+				isComplete: false,
+				invocationMessage: 'Running live performance subagent',
+				toolSpecificData: {
+					kind: 'subagent',
+					agentName: 'PerfAgent',
+					description: 'Inspecting live performance history',
+					prompt: 'Inspect the restored performance corpus.',
+					isActive: true,
+					startedAt: Date.now(),
+				},
+			});
+
+			for (let index = 0; index < 128; index++) {
+				const toolCallId = `${parentToolCallId}-child-${index}`;
+				chatService.appendProgress(request, {
+					kind: 'externalToolInvocationUpdate',
+					toolCallId,
+					toolName: index % 2 === 0 ? 'search_files' : 'read_file',
+					isComplete: false,
+					invocationMessage: `Live subagent tool ${index}`,
+					subagentInvocationId: parentToolCallId,
+				});
+				chatService.appendProgress(request, {
+					kind: 'externalToolInvocationUpdate',
+					toolCallId,
+					toolName: index % 2 === 0 ? 'search_files' : 'read_file',
+					isComplete: true,
+					invocationMessage: `Live subagent tool ${index}`,
+					pastTenseMessage: `Completed live subagent tool ${index}`,
+					subagentInvocationId: parentToolCallId,
+				});
+			}
+		}));
+
+		this._register(CommandsRegistry.registerCommand(
+			SCROLL_START_AGENTS_PERF_CHAT_COMMAND_ID,
+			() => getActiveChatWidget(sessionsService, chatService, chatWidgetService).scrollTop = 0,
+		));
+		this._register(CommandsRegistry.registerCommand(
+			SCROLL_END_AGENTS_PERF_CHAT_COMMAND_ID,
+			() => {
+				const widget = getActiveChatWidget(sessionsService, chatService, chatWidgetService);
+				widget.scrollTop = widget.scrollHeight;
+			},
+		));
+
+		this._register(CommandsRegistry.registerCommand(SHOW_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID, async () => {
+			this._concurrentModelRefs.clear();
+			this._concurrentSessions = [];
+			const expectedTitles = ['Agents Perf Primary Large History', 'Agents Perf Session 001', 'Agents Perf Session 002'];
+			const localSessions = sessionsManagementService.getSessions().filter(session => session.sessionType === 'local');
+			const sessions = expectedTitles.map(title => localSessions.find(session => session.title.get() === title));
+			if (sessions.some(session => !session)) {
+				throw new Error(`Expected concurrent performance sessions ${expectedTitles.join(', ')}, found ${localSessions.map(session => session.title.get()).join(', ')}`);
+			}
+			const concurrentSessions = sessions.map(session => session!);
+
+			await sessionsService.openSession(concurrentSessions[0].resource, { preserveFocus: true });
+			for (let index = 1; index < concurrentSessions.length; index++) {
+				sessionsService.insertAt(concurrentSessions[index], concurrentSessions[index - 1].sessionId, 'right', false);
+				await sessionsService.openSession(concurrentSessions[index].resource, { preserveFocus: true });
+			}
+
+			const visibleSessions = sessionsService.visibleSessions.get().filter(session => !!session);
+			if (visibleSessions.length !== 3) {
+				throw new Error(`Expected three visible sessions for concurrent performance scenario, found ${visibleSessions.length}`);
+			}
+
+			const refs = new DisposableStore();
+			this._concurrentModelRefs.value = refs;
+			for (let sessionIndex = 0; sessionIndex < visibleSessions.length; sessionIndex++) {
+				const session = visibleSessions[sessionIndex]!;
+				const chat = session.activeChat.get();
+				const ref = await chatService.acquireOrLoadSession(chat.resource, ChatAgentLocation.Chat, CancellationToken.None, 'SessionsPerfTest');
+				if (!ref || !(ref.object instanceof ChatModel)) {
+					throw new Error(`Unable to load chat model for concurrent session ${session.sessionId}`);
+				}
+				refs.add(ref);
+				const messageText = `Run concurrent Agents performance session ${sessionIndex}`;
+				const request = ref.object.addRequest({
+					text: messageText,
+					parts: [new ChatRequestTextPart(
+						new OffsetRange(0, messageText.length),
+						new Range(1, 1, 1, messageText.length + 1),
+						messageText,
+					)],
+				}, { variables: [] }, 0);
+				const parentToolCallId = `agents-perf-concurrent-subagent-${sessionIndex}`;
+				chatService.appendProgress(request, {
+					kind: 'externalToolInvocationUpdate',
+					toolCallId: parentToolCallId,
+					toolName: 'runSubagent',
+					isComplete: false,
+					invocationMessage: `Running concurrent performance subagent ${sessionIndex}`,
+					toolSpecificData: {
+						kind: 'subagent',
+						agentName: `PerfAgent${sessionIndex}`,
+						description: `Concurrent session ${sessionIndex}`,
+						prompt: 'Exercise concurrent toolbar and chat rendering.',
+						isActive: true,
+						startedAt: Date.now(),
+					},
+				});
+				this._concurrentSessions.push({ model: ref.object, request, parentToolCallId, sessionIndex });
+			}
+		}));
+
+		this._register(CommandsRegistry.registerCommand(RUN_AGENTS_PERF_CONCURRENT_BURST_COMMAND_ID, async () => {
+			if (this._concurrentSessions.length !== 3) {
+				throw new Error('Concurrent performance sessions have not been initialized');
+			}
+			for (let tick = 0; tick < CONCURRENT_BURST_TICKS; tick++) {
+				await nextAnimationFrame();
+				for (const context of this._concurrentSessions) {
+					if (tick > 0) {
+						appendConcurrentChild(chatService, context, tick - 1, true);
+					}
+					appendConcurrentChild(chatService, context, tick, false);
+					if (tick % 8 === 0) {
+						chatService.appendProgress(context.request, {
+							kind: 'markdownContent',
+							content: { value: `Concurrent progress ${context.sessionIndex}:${tick}` },
+						});
+					}
+				}
+			}
+			for (const context of this._concurrentSessions) {
+				chatService.appendProgress(context.request, {
+					kind: 'markdownContent',
+					content: { value: `AGENTS_PERF_CONCURRENT_${String(CONCURRENT_BURST_TICKS - 1).padStart(3, '0')}` },
+				});
+			}
+		}));
+
+		this._register(CommandsRegistry.registerCommand(STOP_AGENTS_PERF_CONCURRENT_SESSIONS_COMMAND_ID, () => {
+			for (const context of this._concurrentSessions) {
+				appendConcurrentChild(chatService, context, CONCURRENT_BURST_TICKS - 1, true);
+				chatService.appendProgress(context.request, {
+					kind: 'externalToolInvocationUpdate',
+					toolCallId: context.parentToolCallId,
+					toolName: 'runSubagent',
+					isComplete: true,
+					pastTenseMessage: `Completed concurrent performance subagent ${context.sessionIndex}`,
+					toolSpecificData: {
+						kind: 'subagent',
+						agentName: `PerfAgent${context.sessionIndex}`,
+						description: `Concurrent session ${context.sessionIndex}`,
+						prompt: 'Exercise concurrent toolbar and chat rendering.',
+						isActive: false,
+					},
+				});
+				chatService.appendProgress(context.request, {
+					kind: 'markdownContent',
+					content: { value: 'AGENTS_PERF_CONCURRENT_DONE' },
+				});
+				context.request.response?.complete();
+			}
+		}));
+	}
+}
+
+function appendConcurrentChild(chatService: IChatService, context: IConcurrentSessionContext, tick: number, isComplete: boolean): void {
+	const toolCallId = `${context.parentToolCallId}-child-${tick}`;
+	const variableLabel = `${'x'.repeat(tick % 32)}`;
+	chatService.appendProgress(context.request, {
+		kind: 'externalToolInvocationUpdate',
+		toolCallId,
+		toolName: tick % 2 === 0 ? 'search_files' : 'read_file',
+		isComplete,
+		invocationMessage: `Concurrent tool ${context.sessionIndex}:${tick} ${variableLabel}`,
+		pastTenseMessage: isComplete ? `Completed concurrent tool ${context.sessionIndex}:${tick}` : undefined,
+		subagentInvocationId: context.parentToolCallId,
+	});
+}
+
+function nextAnimationFrame(): Promise<void> {
+	return new Promise(resolve => mainWindow.requestAnimationFrame(() => resolve()));
+}
+
+function getActiveChatModel(sessionsService: ISessionsService, chatService: IChatService): ChatModel {
+	const activeSession = sessionsService.activeSession.get();
+	const chat = activeSession?.activeChat.get();
+	const model = chat && chatService.getSession(chat.resource);
+	if (!(model instanceof ChatModel)) {
+		throw new Error('No active restored chat model is available for Agents performance injection');
+	}
+	return model;
+}
+
+function getActiveChatWidget(sessionsService: ISessionsService, chatService: IChatService, chatWidgetService: IChatWidgetService): ChatWidget {
+	const model = getActiveChatModel(sessionsService, chatService);
+	const widget = chatWidgetService.getWidgetBySessionResource(model.sessionResource);
+	if (!(widget instanceof ChatWidget)) {
+		throw new Error('No active Agents chat widget is available for performance scrolling');
+	}
+	return widget;
+}
+
+registerWorkbenchContribution2(SessionsPerfTestContribution.ID, SessionsPerfTestContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -24,6 +24,7 @@ import '../workbench/electron-browser/desktop.contribution.js';
 
 // Per-session layout controller (desktop / web desktop layout).
 import './contrib/layout/browser/sessions.layout.contribution.js';
+import './contrib/chat/browser/sessionsPerfTest.contribution.js';
 
 //#endregion
 

--- a/src/vs/workbench/services/driver/browser/driver.ts
+++ b/src/vs/workbench/services/driver/browser/driver.ts
@@ -13,6 +13,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import localizedStrings from '../../../../platform/languagePacks/common/localizedStrings.js';
 import { ILogFile, getLogs } from '../../../../platform/log/browser/log.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
 import { IWindowDriver, IElement, ILocaleInfo, ILocalizedStrings } from '../common/driver.js';
@@ -25,7 +26,8 @@ export class BrowserWindowDriver implements IWindowDriver {
 		@IFileService private readonly fileService: IFileService,
 		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 	}
 
@@ -39,6 +41,10 @@ export class BrowserWindowDriver implements IWindowDriver {
 		this.logService.info('[driver] Restored lifecycle phase reached. Waiting for contributions...');
 		await Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).whenRestored;
 		this.logService.info('[driver] Workbench contributions created.');
+	}
+
+	async executeCommand(commandId: string): Promise<void> {
+		await this.commandService.executeCommand(commandId);
 	}
 
 	async setValue(selector: string, text: string): Promise<void> {

--- a/src/vs/workbench/services/driver/common/driver.ts
+++ b/src/vs/workbench/services/driver/common/driver.ts
@@ -45,5 +45,6 @@ export interface IWindowDriver {
 	getLocalizedStrings(): Promise<ILocalizedStrings>;
 	getLogs(): Promise<ILogFile[]>;
 	whenWorkbenchRestored(): Promise<void>;
+	executeCommand(commandId: string): Promise<void>;
 }
 //*END


### PR DESCRIPTION
## Summary

Adds recurring full-app performance coverage for the Agents window so scrolling, virtualization, active-subagent, and concurrent-session rendering regressions are observable before they accumulate.

- adds a deterministic restored-history corpus with 24 sessions, peer chats, 220 restored turns, ordinary tools, and a 128-child subagent
- adds `agents-restored-history`, which exercises real session switching, transcript recycling, chat scrolling, and sessions-list scrolling
- adds `agents-concurrent-sessions`, which keeps three real Sessions views active while deterministic subagent/tool progress updates drive burst, settle, and quiescent-tail phases
- captures renderer CPU, script, style, layout, long-task, heap, responsive-toolbar, ResizeObserver, and page-error signals with required-metric validation
- integrates the scenarios with the recurring chat-perf workflow, compact 30-day summaries, scenario-aware raw tables, and opt-in heap snapshots
- reports incompatible release baselines explicitly as unavailable rather than as successful comparisons

The concurrent-session metrics intentionally remain informational until a corresponding product fix and A/A calibration establish stable gating thresholds. Scenario and harness execution failures remain CI failures.

## Validation

- `npm run transpile-client`
- targeted hygiene checks
- `node --test scripts/chat-simulation/common/agents-window-perf-corpus.test.ts`
- JavaScript syntax checks
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `git diff --check`
- full-app `agents-restored-history` scenario
- full-app `agents-concurrent-sessions` scenario

The concurrent scenario reproduces the reported pathology with six responsive toolbars, substantial burst and quiescent-tail style/layout work, and ResizeObserver loop errors while preserving normalized error diagnostics.
