### PR TITLE
fix: guard notebook cursor-selection reveal during cell disposal (fixes #328986)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
@@ -376,6 +376,15 @@ export class CodeCell extends Disposable {
 		}
 
 		this._register(this.templateData.editor.onDidChangeCursorSelection((e) => {
+			// Do not react to selection changes once the cell is being disposed. Disposal
+			// synchronously detaches the text editor (see `dispose` -> `detachTextEditor`),
+			// which fires cursor/decoration events while a list render transaction may still
+			// be active. Revealing the cell here would re-enter `ListView.render` and throw
+			// "Already in transaction".
+			if (this._isDisposed) {
+				return;
+			}
+
 			if (
 				// do not reveal the cell into view if this selection change was caused by restoring editors
 				e.source === 'restoreState' || e.oldModelVersionId === 0


### PR DESCRIPTION
### Summary

`RowCache.transact` throws **"Already in transaction"** (`rowCache.ts:63`) because `ListView.render` is re-entered while an outer render transaction is still active. The re-entry originates in a notebook code cell being **disposed**: `CodeCell.dispose()` sets `_isDisposed = true` and then synchronously detaches the text editor, which fires an `onDidChangeCursorSelection` event whose listener is still registered. That listener calls `revealRangeInViewAsync`, which updates element height and re-enters `ListView.render` → `RowCache.transact` a second time, throwing. New anomaly in 1.131.0 (absent in 1.130.0), ~1182 affected users, component "notebook cell list".

Fixes microsoft/vscode#328986
Recommended reviewer: `@DonJayamanne`

### Culprit Commit

The re-entrancy surfaced through the notebook cell layout/reveal reworks landing in the 1.131.0 window, authored by `@DonJayamanne` on `codeCell.ts` (e.g. `a45fa66` "Fix notebook cell height on opening notebooks", `d87d06f` "Fix Notebook Cell Editor height calc when pasting and scrolling"). These changes tightened the layout/reveal path that runs from the cursor-selection listener but did not add a disposal guard before the reveal call, allowing the listener to fire during disposal-driven `detachTextEditor()`. The underlying `transact` re-entrancy assertion itself dates to `4133f2d` (rowCache transactions), but that is the detector, not the regression.

### Code Flow

```mermaid
flowchart TD
  A[ListView.render outer] --> B[cache.transact begins]
  B --> C[removeItemFromDOM to disposeElement]
  C --> D[CodeCell.dispose sets _isDisposed true]
  D --> E[viewCell.detachTextEditor synchronously]
  E --> F[editor fires onDidChangeCursorSelection]
  F --> G[listener calls revealRangeInViewAsync line 410]
  G --> H[notebookCellList _revealRangeCommon to updateElementHeight]
  H --> I[ListView.updateElementHeight to render again]
  I --> J[cache.transact AGAIN]
  J --> K[throw Error Already in transaction rowCache.ts:63]
```

### Affected Files

- `src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts` — the `onDidChangeCursorSelection` listener (producer of the re-entrant reveal). **Modified.**
- `src/vs/base/browser/ui/list/rowCache.ts` — crash site (`transact`); NOT modified.
- `src/vs/base/browser/ui/list/listView.ts` — `render`/`updateElementHeight` re-entry path; NOT modified.
- `src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts` — `_revealRangeCommon`; NOT modified.

### Repro Steps

1. Open a notebook, focus a code cell and paste/edit text so a cursor-selection change is pending.
2. Trigger a cell recycle/dispose (rapid scroll, cell deletion, or re-layout) while that selection change is in flight.
3. During disposal, `detachTextEditor()` fires `onDidChangeCursorSelection`; the reveal re-enters `ListView.render` and throws "Already in transaction".

### How the Fix Works

**Chosen approach** (`codeCell.ts`): add an early `if (this._isDisposed) { return; }` at the very top of the `onDidChangeCursorSelection` listener, before it can reach `revealRangeInViewAsync`. This is a fix at the data producer — the disposing cell is what emits the re-entrant reveal. `dispose()` sets `_isDisposed = true` *before* calling `detachTextEditor()`, so the flag is already true when the synchronous cursor event fires; the guard therefore reliably prevents the disposing cell from initiating a reveal/relayout while the outer render transaction is active. The pre-existing `_isDisposed` check at line 405 only covered the height-change branch and fell through to the unconditional reveal at line 410; this hoists the check to cover the whole handler. After this change, `codeCell.ts` cannot produce a re-entrant `revealRangeInViewAsync` call during disposal because the listener returns immediately once `_isDisposed` is set, so `ListView.render` is never re-entered.

This is a lifecycle guard clause, not a try/catch, and it does not touch the crash site (`rowCache.ts`), the `logService.error` telemetry path, or any typed utility body.

**Alternatives considered**:
- Guard `_revealRangeCommon`/`revealRangeInCell` in `notebookCellList.ts` against `inRenderingTransaction` — rejected: that guards a consumer downstream of the real producer (the disposing cell's listener) and would silently suppress legitimate reveals requested during a render, masking rather than fixing the disposal race.
- Catch/ignore the re-entry at `rowCache.ts` — rejected: that is the crash site and would swallow the assertion that legitimately detects re-entrant transactions.

### Recommended Owner

`@DonJayamanne` — primary author of `codeCell.ts` and the notebook cell layout/reveal logic whose 1.131.0 changes exercise this path.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/30926875834) · opus48 · 417.1 AIC · ⌖ 11.4 AIC · ⊞ 18.1K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+errors-fix%22&type=pullrequests)




### errors-fix-driver — cycle 1

**Trigger**: cron_review_comments · **Head**: `6f47d1f44b621d40baff73a6d4a472532bcec923` (`6f47d1f`)

| Item | Action |
|------|--------|
| Review on `codeCell.ts:383` (in scope) | Fixed in `6f47d1f` (replied + resolved) |
| CI: `VS Code PR Check`, `Community PR Approvals` | pending (not yet failing) |

**Push**: yes — `6f47d1f` · **Copilot rerequested**: ok

**Ready gate**: ci pending after push → not marking ready this cycle

> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/30931899199) · opus48 · 177.5 AIC · ⌖ 11.8 AIC · ⊞ 20.5K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, version: 1.0.75, model: claude-opus-4.8, id: 30931899199, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/30931899199 -->