### PR TITLE
Implement `/explain` slash command for code tours

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -109,6 +109,9 @@ const vscodeResourceIncludes = [
 	'out-build/vs/sessions/prompts/*.prompt.md',
 	'out-build/vs/sessions/skills/**/SKILL.md',
 
+	// Chat - built-in skills bundled with the workbench
+	'out-build/vs/workbench/contrib/chat/skills/**/SKILL.md',
+
 	// Extensions
 	'out-build/vs/workbench/contrib/extensions/browser/media/{theme-icon.png,language-icon.svg}',
 	'out-build/vs/workbench/services/extensionManagement/common/media/*.{svg,png}',

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -298,6 +298,9 @@ const desktopResourcePatterns = [
 	// Sessions - built-in prompts and skills
 	'vs/sessions/prompts/*.prompt.md',
 	'vs/sessions/skills/**/SKILL.md',
+
+	// Chat - built-in skills bundled with the workbench
+	'vs/workbench/contrib/chat/skills/**/SKILL.md',
 ];
 
 // Resources for server target (minimal - no UI)

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,9 +251,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -268,9 +265,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -285,9 +279,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -302,9 +293,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1173,9 +1161,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1191,9 +1176,6 @@
       "integrity": "sha512-k33XIr6/PVp+K+5F/zv3No4PPaNImvHz73mcbIw63oxh5iiacXjgr0WqbBIS5s/rkhOWjNPIkbof/TTPZ7mQjA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1211,9 +1193,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1229,9 +1208,6 @@
       "integrity": "sha512-/BpOXSb16wHEu8I1SaKiLszQ4Kvu4+Z4uCn7W0bv4xI4fPZwTEG0u3zgaI2W9Ao3+aBl0XRpPmpWzE9ziYEq+w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -4464,9 +4440,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4479,9 +4452,6 @@
       "integrity": "sha512-CmQPXcjfrfvVQ446dGxeITtsGwd58kO0j207vYBjamUjYMgi1frltKPeOIYHgklJwGVQZNwqVBUIS5d45VE1Bg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4496,9 +4466,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4512,9 +4479,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4527,9 +4491,6 @@
       "integrity": "sha512-FnFEBsLeOSgTkA9mE+ezOksWBVoFaz5hJZbpNegAAMURpEGqdwtDl62InD3LGODhRd55qpVoG5HZ7c8CJZO9cA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -5,10 +5,9 @@
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { FileAccess } from '../../../../base/common/network.js';
-import { basename, joinPath } from '../../../../base/common/resources.js';
-import { SKILL_FILENAME } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { IAgentSkill, IBuiltinPromptPath, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { discoverBuiltinSkills } from '../../../../workbench/contrib/chat/common/promptSyntax/service/builtinSkillDiscovery.js';
+import { IBuiltinPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.js';
 
 /** URI root for built-in skills bundled with the Agents app. */
@@ -16,7 +15,8 @@ export const BUILTIN_SKILLS_URI = FileAccess.asFileUri('vs/sessions/skills');
 
 /**
  * Sessions-specific PromptsService that additionally discovers built-in skills
- * bundled at `vs/sessions/skills/{folder}/SKILL.md`.
+ * bundled at `vs/sessions/skills/{folder}/SKILL.md`, on top of the skills the
+ * base service bundles with the workbench.
  *
  * Built-in skills are contributed via the single {@link getBuiltinPromptFiles}
  * override, so the base service merges them into `findAgentSkills()`,
@@ -27,91 +27,21 @@ export const BUILTIN_SKILLS_URI = FileAccess.asFileUri('vs/sessions/skills');
  */
 export class AgenticPromptsService extends PromptsService {
 
-	private _builtinSkillsCache: Promise<readonly IAgentSkill[]> | undefined;
-
-	private async getBuiltinSkills(): Promise<readonly IAgentSkill[]> {
-		if (!this._builtinSkillsCache) {
-			this._builtinSkillsCache = this.discoverBuiltinSkills();
-		}
-		return this._builtinSkillsCache;
-	}
-
-	private async discoverBuiltinSkills(): Promise<readonly IAgentSkill[]> {
-		try {
-			const stat = await this.fileService.resolve(BUILTIN_SKILLS_URI);
-			if (!stat.children) {
-				return [];
-			}
-
-			const skills: IAgentSkill[] = [];
-			for (const child of stat.children) {
-				if (!child.isDirectory) {
-					continue;
-				}
-				const skillFileUri = joinPath(child.resource, SKILL_FILENAME);
-				try {
-					const parsed = await this.parseNew(skillFileUri, CancellationToken.None);
-					const rawName = parsed.header?.name;
-					const rawDescription = parsed.header?.description;
-					if (!rawName || !rawDescription) {
-						continue;
-					}
-					const name = sanitizeSkillText(rawName, 64);
-					const description = sanitizeSkillText(rawDescription, 1024);
-					const folderName = basename(child.resource);
-					if (name !== folderName) {
-						continue;
-					}
-					skills.push({
-						uri: skillFileUri,
-						storage: PromptsStorage.builtIn,
-						name,
-						description,
-						disableModelInvocation: parsed.header?.disableModelInvocation === true,
-						userInvocable: parsed.header?.userInvocable !== false,
-					});
-				} catch (e) {
-					this.logger.warn(`[AgenticPromptsService] Failed to parse built-in skill: ${skillFileUri}`, e instanceof Error ? e.message : String(e));
-				}
-			}
-			return skills;
-		} catch {
-			return [];
-		}
-	}
-
-	private async getBuiltinSkillPaths(): Promise<readonly IBuiltinPromptPath[]> {
-		const skills = await this.getBuiltinSkills();
-		return skills.map(s => ({
-			uri: s.uri,
-			storage: PromptsStorage.builtIn,
-			type: PromptsType.skill,
-			name: s.name,
-			description: s.description,
-		}));
-	}
+	private _sessionsSkillsCache: Promise<readonly IBuiltinPromptPath[]> | undefined;
 
 	/**
-	 * Contributes the built-in skills bundled with the Agents app. The base
-	 * {@link PromptsService} merges these into skill discovery
-	 * (`findAgentSkills()`), `listPromptFiles(skill)` and
-	 * `listPromptFilesForStorage(skill, PromptsStorage.builtIn)`, applying its
-	 * own parsing, sanitization and duplicate-name precedence (built-ins have
-	 * the lowest priority, so user/workspace skills of the same name win).
+	 * Contributes the built-in skills bundled with the Agents app, in addition to
+	 * the workbench-bundled skills the base service provides.
 	 */
 	protected override async getBuiltinPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IBuiltinPromptPath[]> {
+		const inherited = await super.getBuiltinPromptFiles(type, token);
 		if (type !== PromptsType.skill) {
-			return [];
+			return inherited;
 		}
-		return this.getBuiltinSkillPaths();
-	}
-}
 
-/**
- * Strips XML tags and truncates to the given max length.
- * Matches the sanitization applied by PromptsService for other skill sources.
- */
-function sanitizeSkillText(text: string, maxLength: number): string {
-	const sanitized = text.replace(/<[^>]+>/g, '');
-	return sanitized.length > maxLength ? sanitized.substring(0, maxLength) : sanitized;
+		if (!this._sessionsSkillsCache) {
+			this._sessionsSkillsCache = discoverBuiltinSkills(BUILTIN_SKILLS_URI, this.fileService, (uri, t) => this.parseNew(uri, t), this.logger);
+		}
+		return [...inherited, ...await this._sessionsSkillsCache];
+	}
 }

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
@@ -18,7 +18,7 @@ import { IStorageService, StorageScope } from '../../../../../platform/storage/c
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
+import { IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatCodeTourData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { IToolResultInputOutputDetails, IToolResultOutputDetails, isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../chat.js';
@@ -60,7 +60,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 	}
 }
 
-type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData;
+type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData | IChatCodeTourData;
 type ResultDetails = Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails | IToolResultOutputDetailsSerialized;
 
 export const CHAT_ACCESSIBLE_VIEW_INCLUDE_THINKING_STORAGE_KEY = 'chat.accessibleView.includeThinking';
@@ -117,6 +117,13 @@ export function getToolSpecificDataDescription(toolSpecificData: ToolSpecificDat
 		}
 		case 'pullRequest':
 			return localize('pullRequestInfo', "PR: {0} by {1}", toolSpecificData.title, toolSpecificData.author);
+		case 'codeTour': {
+			const stops = toolSpecificData.stops;
+			if (stops.length === 0) {
+				return toolSpecificData.title;
+			}
+			return localize('codeTourInfo', "Code tour \"{0}\", {1} stops: {2}", toolSpecificData.title, stops.length, stops.map(s => s.title).join('; '));
+		}
 		case 'input':
 			return typeof toolSpecificData.rawInput === 'string'
 				? toolSpecificData.rawInput

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -86,6 +86,8 @@ import { ClientToolSetsContribution } from './tools/clientToolSetsContribution.j
 import './telemetry/chatModelCountTelemetry.js';
 import { BuiltinToolsContribution } from '../common/tools/builtinTools/tools.js';
 import { RenameToolContribution } from './tools/renameTool.js';
+import { CodeTourToolContribution } from './tools/codeTourTool.js';
+import { CodeTourService, ICodeTourService } from './codeTour/codeTourService.js';
 import { UsagesToolContribution } from './tools/usagesTool.js';
 import { IVoiceChatService, VoiceChatService } from '../common/voiceChatService.js';
 import './voiceClient/voiceClientService.js';
@@ -741,6 +743,12 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.ArtifactsEnabled]: {
 			default: false,
 			description: nls.localize('chat.artifacts.enabled', "Controls whether the artifacts view is available in chat."),
+			type: 'boolean',
+			tags: ['experimental']
+		},
+		[ChatConfiguration.CodeTourEnabled]: {
+			default: false,
+			description: nls.localize('chat.codeTour.enabled', "Controls whether the agent can present explanations as a guided code tour that opens and highlights files as it narrates."),
 			type: 'boolean',
 			tags: ['experimental']
 		},
@@ -2827,6 +2835,7 @@ registerWorkbenchContribution2(ChatStatusBarEntry.ID, ChatStatusBarEntry, Workbe
 registerWorkbenchContribution2(BuiltinToolsContribution.ID, BuiltinToolsContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ClientToolSetsContribution.ID, ClientToolSetsContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(UsagesToolContribution.ID, UsagesToolContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(CodeTourToolContribution.ID, CodeTourToolContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(RenameToolContribution.ID, RenameToolContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatAgentSettingContribution.ID, ChatAgentSettingContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatForegroundSessionCountContribution.ID, ChatForegroundSessionCountContribution, WorkbenchPhase.AfterRestored);
@@ -2936,5 +2945,6 @@ registerSingleton(IChatTipService, ChatTipService, InstantiationType.Delayed);
 registerSingleton(IChatDebugService, ChatDebugServiceImpl, InstantiationType.Delayed);
 registerSingleton(IChatImageCarouselService, ChatImageCarouselService, InstantiationType.Delayed);
 registerSingleton(IAgentHostImportConversationStore, AgentHostImportConversationStore, InstantiationType.Delayed);
+registerSingleton(ICodeTourService, CodeTourService, InstantiationType.Delayed);
 
 ChatWidget.CONTRIBS.push(ChatDynamicVariableModel);

--- a/src/vs/workbench/contrib/chat/browser/codeTour/codeTourService.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeTour/codeTourService.ts
@@ -1,0 +1,380 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Disposable, DisposableMap, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { isCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { IRange, Range } from '../../../../../editor/common/core/range.js';
+import { DocumentSymbol } from '../../../../../editor/common/languages.js';
+import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { TextEditorSelectionRevealType } from '../../../../../platform/editor/common/editor.js';
+import { IAgentNetworkFilterService } from '../../../../../platform/networkFilter/common/networkFilterService.js';
+import { createDecorator, IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { RangeHighlightDecorations } from '../../../../browser/codeeditor.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IBrowserViewWorkbenchService } from '../../../browserView/common/browserView.js';
+import { IChatCodeTourData, IChatCodeTourStop, IChatService } from '../../common/chatService/chatService.js';
+
+export const ICodeTourService = createDecorator<ICodeTourService>('codeTourService');
+
+/**
+ * Live state for a tour that is still being presented. Persisted tours (e.g.
+ * after a window reload) have no runtime, but their stops remain replayable.
+ */
+export interface ICodeTourRuntime {
+	/** Index of the stop the tour is currently showing, or `-1` before the first stop. */
+	readonly currentIndex: IObservable<number>;
+	/** Whether the tour is finished, either because the agent reached the last stop or the user ended it. */
+	readonly finished: IObservable<boolean>;
+}
+
+export interface ICodeTourService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Starts a tour for a chat session, replacing any tour that session already
+	 * has. The returned data is the live object the tool hands to the renderer:
+	 * its `stops` array is appended to as the agent contributes stops.
+	 */
+	startTour(sessionResource: URI, title: string): IChatCodeTourData;
+
+	/** The tour currently being presented in a chat session, if any. */
+	getActiveTour(sessionResource: URI): IChatCodeTourData | undefined;
+
+	/** Appends a stop to the session's tour and reveals it. Returns `false` when the tour already ended. */
+	addStop(sessionResource: URI, stop: IChatCodeTourStop, isLast: boolean): Promise<boolean>;
+
+	/**
+	 * Reveals a stop without changing tour membership, used when the user clicks
+	 * a past stop in the tour widget. Works for persisted tours too, in which
+	 * case `tourId` has no runtime and only navigation happens.
+	 */
+	revealStop(tourId: string, index: number, stop: IChatCodeTourStop): Promise<void>;
+
+	/** Observes the live runtime of a tour, or `undefined` when it is not running. */
+	observeRuntime(tourId: string): IObservable<ICodeTourRuntime | undefined>;
+
+	/** Ends the tour early at the user's request. */
+	stopTour(tourId: string): void;
+
+	/** Whether the session's tour was ended by the user. */
+	isStopped(sessionResource: URI): boolean;
+
+	/**
+	 * Resolves a stop's range from an explicit line span, or from a symbol name
+	 * when the agent could not supply line numbers.
+	 */
+	resolveRange(resource: URI, startLine: number | undefined, endLine: number | undefined, symbol: string | undefined): Promise<IRange | undefined>;
+}
+
+/** How a tour ended, reported once per tour in telemetry. */
+type CodeTourEndReason =
+	/** The agent presented its final stop. */
+	| 'completed'
+	/** The user pressed "Stop Tour". */
+	| 'stopped'
+	/** The tour was still running when the session or a new tour replaced it. */
+	| 'abandoned';
+
+type CodeTourEndedEvent = {
+	endReason: CodeTourEndReason;
+	stopCount: number;
+	stopsWithRange: number;
+	stopsWithUrl: number;
+	replayCount: number;
+};
+
+type CodeTourEndedClassification = {
+	endReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the code tour ended: completed, stopped by the user, or abandoned.' };
+	stopCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of stops the agent presented in the tour.' };
+	stopsWithRange: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many stops resolved to a concrete code range, which indicates how precise the agent was able to be.' };
+	stopsWithUrl: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many stops also opened a page in the integrated browser.' };
+	replayCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many times the user clicked a past stop to navigate back to it.' };
+	owner: 'osortega';
+	comment: 'Reports how a guided code tour ended so we can tell whether tours are watched through, cut short, or abandoned.';
+};
+
+class CodeTour extends Disposable {
+
+	readonly currentIndex: ISettableObservable<number> = observableValue(this, -1);
+	readonly finished: ISettableObservable<boolean> = observableValue(this, false);
+
+	/** Set once telemetry has been reported, so each tour is only counted once. */
+	ended = false;
+	replayCount = 0;
+
+	readonly data: IChatCodeTourData;
+
+	constructor(title: string) {
+		super();
+		this.data = { kind: 'codeTour', tourId: generateUuid(), title, stops: [] };
+	}
+
+	add<T extends IDisposable>(disposable: T): T {
+		return this._register(disposable);
+	}
+}
+
+export class CodeTourService extends Disposable implements ICodeTourService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _toursBySession = this._register(new DisposableMap<string, CodeTour>());
+	private readonly _toursById = new Map<string, CodeTour>();
+
+	/**
+	 * Observables handed out by {@link observeRuntime}. Cached so repeated calls
+	 * for the same tour reuse one observable, and so a widget created before its
+	 * tour is registered still lights up once the tour arrives.
+	 */
+	private readonly _runtimeObservables = new Map<string, ISettableObservable<ICodeTourRuntime | undefined>>();
+
+	/**
+	 * Tours the user ended with "Stop Tour". Tracked separately from
+	 * {@link CodeTour.finished} so a tour that simply reached its last stop does
+	 * not make the tool report the tour as user-cancelled.
+	 */
+	private readonly _stoppedTourIds = new Set<string>();
+
+	private readonly _rangeHighlight: RangeHighlightDecorations;
+
+	constructor(
+		@IEditorService private readonly _editorService: IEditorService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
+		@ITextModelService private readonly _textModelService: ITextModelService,
+		@IBrowserViewWorkbenchService private readonly _browserViewService: IBrowserViewWorkbenchService,
+		@IAgentNetworkFilterService private readonly _agentNetworkFilterService: IAgentNetworkFilterService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IChatService private readonly _chatService: IChatService,
+	) {
+		super();
+
+		this._rangeHighlight = this._register(instantiationService.createInstance(RangeHighlightDecorations));
+
+		this._register(this._chatService.onDidDisposeSession(e => {
+			for (const resource of e.sessionResources) {
+				this._disposeTourForSession(resource);
+			}
+		}));
+
+		// A tour belongs to the turn that produced it. Ending it when the next
+		// turn starts keeps "Stop Tour" meaningful for the rest of the current
+		// turn while still letting a later `/explain` start a fresh tour.
+		this._register(this._chatService.onDidSubmitRequest(e => this._disposeTourForSession(e.chatSessionResource)));
+	}
+
+	startTour(sessionResource: URI, title: string): IChatCodeTourData {
+		this._disposeTourForSession(sessionResource);
+
+		const tour = new CodeTour(title);
+		this._toursBySession.set(sessionResource.toString(), tour);
+		this._toursById.set(tour.data.tourId, tour);
+		this._runtimeObservable(tour.data.tourId).set({ currentIndex: tour.currentIndex, finished: tour.finished }, undefined);
+
+		// `onDidSubmitRequest` misses turns that an agent host starts itself when
+		// draining its own queue, so watch the session model too: every turn adds
+		// a request to it, whichever side initiated it.
+		const model = this._chatService.getSession(sessionResource);
+		if (model) {
+			tour.add(model.onDidChange(e => {
+				if (e.kind === 'addRequest') {
+					this._disposeTourForSession(sessionResource);
+				}
+			}));
+		}
+
+		return tour.data;
+	}
+
+	getActiveTour(sessionResource: URI): IChatCodeTourData | undefined {
+		return this._toursBySession.get(sessionResource.toString())?.data;
+	}
+
+	async addStop(sessionResource: URI, stop: IChatCodeTourStop, isLast: boolean): Promise<boolean> {
+		const tour = this._toursBySession.get(sessionResource.toString());
+		if (!tour || tour.finished.get()) {
+			return false;
+		}
+
+		tour.data.stops.push(stop);
+		tour.currentIndex.set(tour.data.stops.length - 1, undefined);
+		await this._navigate(stop);
+
+		if (isLast) {
+			tour.finished.set(true, undefined);
+			this._reportTourEnded(tour, 'completed');
+		}
+		return true;
+	}
+
+	async revealStop(tourId: string, index: number, stop: IChatCodeTourStop): Promise<void> {
+		const tour = this._toursById.get(tourId);
+		if (tour) {
+			tour.replayCount++;
+			tour.currentIndex.set(index, undefined);
+		}
+		await this._navigate(stop);
+	}
+
+	observeRuntime(tourId: string): IObservable<ICodeTourRuntime | undefined> {
+		return this._runtimeObservable(tourId);
+	}
+
+	stopTour(tourId: string): void {
+		const tour = this._toursById.get(tourId);
+		if (!tour || tour.finished.get()) {
+			return;
+		}
+		tour.finished.set(true, undefined);
+		this._stoppedTourIds.add(tourId);
+		this._rangeHighlight.removeHighlightRange();
+		this._reportTourEnded(tour, 'stopped');
+	}
+
+	isStopped(sessionResource: URI): boolean {
+		const tour = this._toursBySession.get(sessionResource.toString());
+		return !!tour && this._stoppedTourIds.has(tour.data.tourId);
+	}
+
+	async resolveRange(resource: URI, startLine: number | undefined, endLine: number | undefined, symbol: string | undefined): Promise<IRange | undefined> {
+		if (typeof startLine === 'number' && startLine > 0) {
+			const start = Math.floor(startLine);
+			const end = typeof endLine === 'number' && endLine >= start ? Math.floor(endLine) : start;
+			return new Range(start, 1, end, Number.MAX_SAFE_INTEGER);
+		}
+
+		if (!symbol) {
+			return undefined;
+		}
+
+		let reference;
+		try {
+			reference = await this._textModelService.createModelReference(resource);
+		} catch {
+			return undefined;
+		}
+
+		try {
+			const model = reference.object.textEditorModel;
+			for (const provider of this._languageFeaturesService.documentSymbolProvider.ordered(model)) {
+				const symbols = await provider.provideDocumentSymbols(model, CancellationToken.None);
+				const match = symbols && findSymbol(symbols, symbol);
+				if (match) {
+					return match.range;
+				}
+			}
+			return undefined;
+		} catch {
+			// The caller opens the file without a selection and tells the model so.
+			return undefined;
+		} finally {
+			reference.dispose();
+		}
+	}
+
+	/**
+	 * Reveals a stop: opens the file without stealing focus from chat, highlights
+	 * the range, and opens the stop's page in the integrated browser when it has one.
+	 */
+	private async _navigate(stop: IChatCodeTourStop): Promise<void> {
+		if (stop.uri) {
+			const resource = URI.revive(stop.uri);
+			const pane = await this._editorService.openEditor({
+				resource,
+				options: {
+					selection: stop.range,
+					selectionRevealType: TextEditorSelectionRevealType.NearTopIfOutsideViewport,
+					// The tour narrates in chat, so keep focus where the user is
+					// reading, and reuse one preview tab instead of piling up
+					// pinned editors over a long tour.
+					preserveFocus: true,
+					pinned: false,
+				},
+			});
+
+			this._rangeHighlight.removeHighlightRange();
+			const control = pane?.getControl();
+			if (stop.range && isCodeEditor(control)) {
+				this._rangeHighlight.highlightRange({ resource, range: stop.range }, control);
+			}
+		}
+
+		if (stop.url) {
+			// The URL comes from the model, so it goes through the same network
+			// filter the integrated browser tools use before anything is loaded.
+			const uri = URI.parse(stop.url);
+			if (this._agentNetworkFilterService.isUriAllowed(uri)) {
+				const browserInput = this._browserViewService.getOrCreateLazy(generateUuid(), { url: stop.url });
+				const group = await this._browserViewService.getPreferredGroup();
+				await this._editorService.openEditor(browserInput, { preserveFocus: true }, group);
+			}
+		}
+	}
+
+	private _runtimeObservable(tourId: string): ISettableObservable<ICodeTourRuntime | undefined> {
+		let obs = this._runtimeObservables.get(tourId);
+		if (!obs) {
+			obs = observableValue<ICodeTourRuntime | undefined>('codeTourRuntime', undefined);
+			this._runtimeObservables.set(tourId, obs);
+		}
+		return obs;
+	}
+
+	private _disposeTourForSession(sessionResource: URI): void {
+		const key = sessionResource.toString();
+		const existing = this._toursBySession.get(key);
+		if (!existing) {
+			return;
+		}
+		this._reportTourEnded(existing, 'abandoned');
+		this._toursById.delete(existing.data.tourId);
+		this._stoppedTourIds.delete(existing.data.tourId);
+		this._runtimeObservables.get(existing.data.tourId)?.set(undefined, undefined);
+		this._runtimeObservables.delete(existing.data.tourId);
+		this._toursBySession.deleteAndDispose(key);
+		this._rangeHighlight.removeHighlightRange();
+	}
+
+	/** Reports a tour exactly once, the first time it reaches a terminal state. */
+	private _reportTourEnded(tour: CodeTour, endReason: CodeTourEndReason): void {
+		if (tour.ended || tour.data.stops.length === 0) {
+			return;
+		}
+		tour.ended = true;
+
+		this._telemetryService.publicLog2<CodeTourEndedEvent, CodeTourEndedClassification>('chat.codeTour.ended', {
+			endReason,
+			stopCount: tour.data.stops.length,
+			stopsWithRange: tour.data.stops.filter(s => !!s.range).length,
+			stopsWithUrl: tour.data.stops.filter(s => !!s.url).length,
+			replayCount: tour.replayCount,
+		});
+	}
+}
+
+/** Depth-first search for a symbol by name, falling back to a case-insensitive match. */
+function findSymbol(symbols: readonly DocumentSymbol[], name: string): DocumentSymbol | undefined {
+	for (const symbol of symbols) {
+		if (symbol.name === name) {
+			return symbol;
+		}
+		const child = symbol.children && findSymbol(symbol.children, name);
+		if (child) {
+			return child;
+		}
+	}
+	for (const symbol of symbols) {
+		if (symbol.name.toLowerCase() === name.toLowerCase()) {
+			return symbol;
+		}
+	}
+	return undefined;
+}

--- a/src/vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution.ts
@@ -89,6 +89,7 @@ export class ClientToolSetsContribution extends Disposable implements IWorkbench
 				'rename',
 				'usages',
 				'toolSearch',
+				'codeTour',
 			],
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/tools/codeTourTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/codeTourTool.ts
@@ -1,0 +1,251 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IAgentNetworkFilterService } from '../../../../../platform/networkFilter/common/networkFilterService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { IChatCodeTourStop } from '../../common/chatService/chatService.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
+import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolInvocationPresentation, ToolProgress } from '../../common/tools/languageModelToolsService.js';
+import { WorkingDirectory } from '../../common/workingDirectory.js';
+import { ICodeTourService } from '../codeTour/codeTourService.js';
+
+export const CodeTourToolId = 'vscode_codeTour';
+export const CodeTourToolReferenceName = 'codeTour';
+
+export const CodeTourToolData: IToolData = {
+	id: CodeTourToolId,
+	toolReferenceName: CodeTourToolReferenceName,
+	displayName: localize('codeTourTool.displayName', 'Code Tour'),
+	userDescription: localize('codeTourTool.userDescription', 'Walk the user through code by opening and highlighting one stop at a time'),
+	modelDescription: `Present ONE stop of a guided code tour: open a file in the editor, reveal and highlight the relevant range, and optionally open a page in the integrated browser. Use this to explain an existing implementation or a design you are proposing, so the user sees exactly the code you are talking about.
+
+Call this tool once per stop, in the order you want the user to follow. The chat renders a tour widget that accumulates the stops, so the user can jump back to any of them.
+
+Guidelines:
+- Pass "tourTitle" on the first call only. It names the whole tour.
+- Keep "narration" to a few sentences that explain what this specific stop shows and why it matters. Do not repeat the narration in your assistant message.
+- Prefer precise ranges. Use "startLine"/"endLine" when you know them; use "symbol" when you only know the name of a function, class, or method.
+- Aim for 3 to 8 stops. Order them so each one builds on the last.
+- Set "isLast" on the final stop, then write a short wrap-up message.
+- If the result says the user stopped the tour, stop calling this tool and respond to the user instead.`,
+	icon: Codicon.mapVertical,
+	source: ToolDataSource.Internal,
+	inputSchema: {
+		type: 'object',
+		properties: {
+			tourTitle: {
+				type: 'string',
+				description: 'Title of the whole tour. Required on the first stop, ignored afterwards.'
+			},
+			stopTitle: {
+				type: 'string',
+				description: 'Short label for this stop, shown in the tour widget (e.g. "Where the request is parsed").'
+			},
+			narration: {
+				type: 'string',
+				description: 'Markdown explanation of this stop. A few sentences describing what this code does and why it matters to the explanation.'
+			},
+			file: {
+				type: 'string',
+				description: 'File to open for this stop, as a workspace-relative path or an absolute path. Omit for a narration-only stop.'
+			},
+			startLine: {
+				type: 'number',
+				description: 'First line of the range to reveal and highlight (1-based).'
+			},
+			endLine: {
+				type: 'number',
+				description: 'Last line of the range to reveal and highlight (1-based, inclusive). Defaults to "startLine".'
+			},
+			symbol: {
+				type: 'string',
+				description: 'Name of the function, class, or method to reveal when you do not know the line numbers. Ignored when "startLine" is provided.'
+			},
+			url: {
+				type: 'string',
+				description: 'Absolute http(s) URL to open in the integrated browser alongside this stop, for example rendered docs or a running app.'
+			},
+			isLast: {
+				type: 'boolean',
+				description: 'Set to true on the final stop of the tour.'
+			}
+		},
+		required: ['stopTitle', 'narration'],
+	},
+};
+
+interface ICodeTourToolParams {
+	tourTitle?: string;
+	stopTitle: string;
+	narration: string;
+	file?: string;
+	startLine?: number;
+	endLine?: number;
+	symbol?: string;
+	url?: string;
+	isLast?: boolean;
+}
+
+/** Normalizes a model-supplied URL, or returns `undefined` when it is not a usable absolute URL. */
+function normalizeUrl(url: string | undefined): string | undefined {
+	return url ? URL.parse(url)?.href : undefined;
+}
+
+export class CodeTourTool implements IToolImpl {
+
+	constructor(
+		@ICodeTourService private readonly _codeTourService: ICodeTourService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IAgentNetworkFilterService private readonly _agentNetworkFilterService: IAgentNetworkFilterService,
+	) { }
+
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+		const params = context.parameters as ICodeTourToolParams;
+		// Only the first stop renders the tour widget. Later stops append to the
+		// same live `stops` array, so hiding them avoids a second widget and a
+		// row of redundant progress messages.
+		const isFirstStop = !context.chatSessionResource || !this._codeTourService.getActiveTour(context.chatSessionResource);
+		const prepared: IPreparedToolInvocation = {
+			invocationMessage: localize('codeTour.invocation', "Showing {0}", params.stopTitle),
+			pastTenseMessage: localize('codeTour.past', "Showed {0}", params.stopTitle),
+			presentation: isFirstStop ? undefined : ToolInvocationPresentation.Hidden,
+		};
+
+		// A stop that opens a page loads model-supplied content in the user's
+		// browser session, so it goes through the same allow-list and
+		// confirmation as the integrated browser tools.
+		const url = normalizeUrl(params.url);
+		if (!url) {
+			return prepared;
+		}
+		if (!this._agentNetworkFilterService.isUriAllowed(URI.parse(url))) {
+			throw new Error(this._agentNetworkFilterService.formatError(URI.parse(url)));
+		}
+		return {
+			...prepared,
+			// Hidden invocations cannot show a confirmation, so a stop with a URL
+			// always renders.
+			presentation: undefined,
+			confirmationMessages: {
+				title: localize('codeTour.confirmTitle', "Open Browser Page?"),
+				message: localize('codeTour.confirmMessage', "The code tour wants to open {0} in the integrated browser.", url),
+				allowAutoConfirm: true,
+			},
+		};
+	}
+
+	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
+		const params = invocation.parameters as ICodeTourToolParams;
+		const sessionResource = invocation.context?.sessionResource;
+		if (!sessionResource) {
+			return createToolSimpleTextResult('The code tour tool can only be used inside a chat session.');
+		}
+
+		if (this._codeTourService.isStopped(sessionResource)) {
+			return createToolSimpleTextResult('The user stopped the tour. Do not present more stops; respond to the user directly instead.');
+		}
+
+		const isFirstStop = !this._codeTourService.getActiveTour(sessionResource);
+		if (isFirstStop) {
+			this._codeTourService.startTour(sessionResource, params.tourTitle?.trim() || localize('codeTour.defaultTitle', "Code tour"));
+		}
+
+		const { uri, range, note } = await this._resolveLocation(params, invocation);
+		const url = normalizeUrl(params.url);
+		const stop: IChatCodeTourStop = {
+			title: params.stopTitle,
+			narration: params.narration,
+			uri,
+			range,
+			url: url && this._agentNetworkFilterService.isUriAllowed(URI.parse(url)) ? url : undefined,
+		};
+
+		const added = await this._codeTourService.addStop(sessionResource, stop, !!params.isLast);
+		if (!added) {
+			return createToolSimpleTextResult('This tour has already ended. Do not present more stops; summarize the explanation for the user instead.');
+		}
+
+		// Only the first stop carries the widget. Later stops mutate the same
+		// live `stops` array, so the widget grows without rendering a second one.
+		const tour = this._codeTourService.getActiveTour(sessionResource);
+		const messages = [`Showed stop ${tour?.stops.length ?? 1}: ${params.stopTitle}.`];
+		if (note) {
+			messages.push(note);
+		}
+		if (params.isLast) {
+			messages.push('This was the final stop. Wrap up the explanation for the user.');
+		}
+
+		return {
+			content: [{ kind: 'text', value: messages.join(' ') }],
+			toolSpecificData: isFirstStop ? tour : undefined,
+		};
+	}
+
+	/**
+	 * Turns the model-supplied file/line/symbol input into a concrete location,
+	 * along with a note explaining any part that could not be resolved so the
+	 * model can correct itself on the next stop.
+	 */
+	private async _resolveLocation(params: ICodeTourToolParams, invocation: IToolInvocation): Promise<{ uri?: URI; range?: IChatCodeTourStop['range']; note?: string }> {
+		if (!params.file) {
+			return {};
+		}
+
+		const workingDir = new WorkingDirectory(this._workspaceContextService, invocation.context?.workingDirectory);
+		const uri = workingDir.resolveRelativePath(params.file);
+		if (!uri) {
+			return { note: `Could not resolve "${params.file}" inside the workspace, so no file was opened for this stop.` };
+		}
+
+		const range = await this._codeTourService.resolveRange(uri, params.startLine, params.endLine, params.symbol);
+		if (!range && (params.symbol || params.startLine !== undefined)) {
+			return { uri, note: 'Could not resolve the requested range, so the file was opened without a highlight. Provide startLine/endLine for the next stop.' };
+		}
+
+		return { uri, range };
+	}
+}
+
+export class CodeTourToolContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.codeTourTool';
+
+	private readonly _registration = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._update();
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.CodeTourEnabled)) {
+				this._update();
+			}
+		}));
+	}
+
+	private _update(): void {
+		if (!this._configurationService.getValue<boolean>(ChatConfiguration.CodeTourEnabled)) {
+			this._registration.clear();
+			return;
+		}
+		if (!this._registration.value) {
+			this._registration.value = this._toolsService.registerTool(CodeTourToolData, this._instantiationService.createInstance(CodeTourTool));
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeTour.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeTour.css
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-code-tour {
+	display: flex;
+	flex-direction: column;
+	gap: var(--vscode-spacing-size80);
+	border: var(--vscode-strokeThickness) solid var(--vscode-chat-requestBorder);
+	border-radius: var(--vscode-cornerRadius-large);
+	padding: var(--vscode-spacing-size100) var(--vscode-spacing-size120);
+}
+
+.chat-code-tour .chat-code-tour-header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--vscode-spacing-size60);
+}
+
+.chat-code-tour .chat-code-tour-title {
+	font-size: var(--vscode-fontSize-heading3);
+	font-weight: var(--vscode-fontWeight-semiBold);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.chat-code-tour .chat-code-tour-stops {
+	display: flex;
+	flex-direction: column;
+	gap: var(--vscode-spacing-size80);
+}
+
+.chat-code-tour .chat-code-tour-stop {
+	display: flex;
+	flex-direction: row;
+	gap: var(--vscode-spacing-size80);
+	align-items: flex-start;
+	opacity: 0.75;
+}
+
+/* The stop currently being narrated is the one the editor is showing, so it is
+   the only one at full strength. */
+.chat-code-tour .chat-code-tour-stop.current {
+	opacity: 1;
+}
+
+.chat-code-tour .chat-code-tour-stop-marker {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	border-radius: var(--vscode-cornerRadius-circle);
+	background-color: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	font-size: var(--vscode-fontSize-label3);
+}
+
+.chat-code-tour .chat-code-tour-stop-body {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.chat-code-tour .chat-code-tour-stop-heading {
+	font-weight: var(--vscode-fontWeight-semiBold);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.chat-code-tour .chat-code-tour-stop-location {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	font-size: var(--vscode-fontSize-label1);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: fit-content;
+	max-width: 100%;
+}
+
+.chat-code-tour .chat-code-tour-stop-location:hover {
+	color: var(--vscode-textLink-activeForeground);
+	text-decoration: underline;
+}
+
+.chat-code-tour .chat-code-tour-stop-location:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: var(--vscode-spacing-size20);
+	border-radius: var(--vscode-cornerRadius-xSmall);
+}
+
+.chat-code-tour .chat-code-tour-stop-narration > *:first-child {
+	margin-top: var(--vscode-spacing-size40);
+}
+
+.chat-code-tour .chat-code-tour-stop-narration > *:last-child {
+	margin-bottom: 0;
+}
+
+.chat-code-tour .chat-code-tour-footer:empty {
+	display: none;
+}
+
+.chat-code-tour .chat-code-tour-footer .monaco-button {
+	width: fit-content;
+	padding: var(--vscode-spacing-size20) var(--vscode-spacing-size100);
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatCodeTourSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatCodeTourSubPart.ts
@@ -1,0 +1,173 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../../base/browser/dom.js';
+import { status } from '../../../../../../../base/browser/ui/aria/aria.js';
+import { Button } from '../../../../../../../base/browser/ui/button/button.js';
+import { renderIcon } from '../../../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { KeyCode } from '../../../../../../../base/common/keyCodes.js';
+import { StandardKeyboardEvent } from '../../../../../../../base/browser/keyboardEvent.js';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../../../base/common/themables.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../../nls.js';
+import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
+import { ILabelService } from '../../../../../../../platform/label/common/label.js';
+import { IMarkdownRenderer } from '../../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { defaultButtonStyles } from '../../../../../../../platform/theme/browser/defaultStyles.js';
+import { IChatCodeTourData, IChatCodeTourStop, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../../common/chatService/chatService.js';
+import { ICodeTourService } from '../../../codeTour/codeTourService.js';
+import { IChatCodeBlockInfo } from '../../../chat.js';
+import { IChatContentPartRenderContext } from '../chatContentParts.js';
+import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
+import '../media/chatCodeTour.css';
+
+/**
+ * Renders a guided code tour: the agent contributes one stop per tool call, and
+ * this widget shows the stops it has narrated so far. The current stop is
+ * highlighted, clicking any stop re-opens its location, and "Stop Tour" ends the
+ * tour so the agent stops taking over the editor.
+ *
+ * The widget reads the same live `stops` array the code tour service appends to,
+ * so it grows in place instead of rendering one widget per stop. That array is
+ * also what gets persisted, so a reloaded session still lists every stop and can
+ * replay them — only the live "current stop" and "Stop Tour" affordances go away.
+ */
+export class ChatCodeTourSubPart extends BaseChatToolInvocationSubPart {
+
+	public readonly domNode: HTMLElement;
+	public readonly codeblocks: IChatCodeBlockInfo[] = [];
+
+	private readonly _stopsContainer: HTMLElement;
+	private readonly _footer: HTMLElement;
+	private readonly _renderStore = this._register(new DisposableStore());
+
+	/** Stop index most recently announced, so a re-render doesn't repeat it. */
+	private _announcedIndex = -1;
+
+	constructor(
+		toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
+		private readonly _data: IChatCodeTourData,
+		_context: IChatContentPartRenderContext,
+		private readonly _renderer: IMarkdownRenderer,
+		@ICodeTourService private readonly _codeTourService: ICodeTourService,
+		@ILabelService private readonly _labelService: ILabelService,
+		@IHoverService private readonly _hoverService: IHoverService,
+	) {
+		super(toolInvocation);
+
+		this.domNode = dom.$('.chat-code-tour');
+
+		const header = dom.append(this.domNode, dom.$('.chat-code-tour-header'));
+		header.appendChild(renderIcon(Codicon.mapVertical));
+		const title = dom.append(header, dom.$('.chat-code-tour-title'));
+		title.textContent = this._data.title;
+
+		this._stopsContainer = dom.append(this.domNode, dom.$('.chat-code-tour-stops'));
+		this._stopsContainer.setAttribute('role', 'list');
+		this._stopsContainer.setAttribute('aria-label', localize('codeTour.stopsLabel', "Code tour stops"));
+
+		this._footer = dom.append(this.domNode, dom.$('.chat-code-tour-footer'));
+
+		this._register(autorun(reader => {
+			const runtime = this._codeTourService.observeRuntime(this._data.tourId).read(reader);
+			const currentIndex = runtime?.currentIndex.read(reader) ?? -1;
+			const finished = runtime?.finished.read(reader) ?? true;
+			this._render(currentIndex, !finished);
+		}));
+	}
+
+	protected override getIcon(): ThemeIcon {
+		return Codicon.mapVertical;
+	}
+
+	private _render(currentIndex: number, isRunning: boolean): void {
+		this._renderStore.clear();
+		dom.clearNode(this._stopsContainer);
+		dom.clearNode(this._footer);
+
+		this._data.stops.forEach((stop, index) => {
+			this._renderStop(stop, index, index === currentIndex);
+		});
+
+		if (isRunning) {
+			const stopButton = this._renderStore.add(new Button(this._footer, {
+				...defaultButtonStyles,
+				secondary: true,
+				supportIcons: true,
+				title: localize('codeTour.stopTourTitle', "End the tour and stop opening files"),
+			}));
+			stopButton.label = `$(${Codicon.stopCircle.id}) ${localize('codeTour.stopTour', "Stop Tour")}`;
+			this._renderStore.add(stopButton.onDidClick(() => this._codeTourService.stopTour(this._data.tourId)));
+		}
+
+		const current = currentIndex >= 0 ? this._data.stops[currentIndex] : undefined;
+		if (current && currentIndex !== this._announcedIndex) {
+			this._announcedIndex = currentIndex;
+			status(localize('codeTour.announceStop', "Code tour stop {0} of {1}: {2}", currentIndex + 1, this._data.stops.length, current.title));
+		}
+	}
+
+	private _renderStop(stop: IChatCodeTourStop, index: number, isCurrent: boolean): void {
+		const row = dom.append(this._stopsContainer, dom.$('.chat-code-tour-stop'));
+		row.setAttribute('role', 'listitem');
+		row.classList.toggle('current', isCurrent);
+
+		const marker = dom.append(row, dom.$('.chat-code-tour-stop-marker'));
+		marker.textContent = String(index + 1);
+
+		const body = dom.append(row, dom.$('.chat-code-tour-stop-body'));
+		const heading = dom.append(body, dom.$('.chat-code-tour-stop-heading'));
+		heading.textContent = stop.title;
+
+		const location = this._locationLabel(stop);
+		if (location) {
+			// The heading names the idea; the location is the "go here" affordance,
+			// so it is the only interactive element in the row.
+			const link = dom.append(body, dom.$('a.chat-code-tour-stop-location'));
+			link.tabIndex = 0;
+			link.setAttribute('role', 'button');
+			link.textContent = location;
+			link.setAttribute('aria-label', localize('codeTour.stopAriaLabel', "Stop {0}: {1}, {2}", index + 1, stop.title, location));
+
+			this._renderStore.add(this._hoverService.setupDelayedHover(link, {
+				content: localize('codeTour.revealHover', "Reveal {0}", location),
+			}));
+
+			const reveal = () => this._codeTourService.revealStop(this._data.tourId, index, stop);
+			this._renderStore.add(dom.addDisposableListener(link, dom.EventType.CLICK, e => {
+				dom.EventHelper.stop(e, true);
+				reveal();
+			}));
+			this._renderStore.add(dom.addDisposableListener(link, dom.EventType.KEY_DOWN, e => {
+				const event = new StandardKeyboardEvent(e);
+				if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
+					dom.EventHelper.stop(e, true);
+					reveal();
+				}
+			}));
+		}
+
+		const narration = this._renderStore.add(this._renderer.render({ value: stop.narration, isTrusted: false }));
+		narration.element.classList.add('chat-code-tour-stop-narration');
+		body.appendChild(narration.element);
+	}
+
+	/** A short, human-readable "where am I" label: `file.ts:12-40` or the URL host. */
+	private _locationLabel(stop: IChatCodeTourStop): string | undefined {
+		if (stop.uri) {
+			const label = this._labelService.getUriLabel(URI.revive(stop.uri), { relative: true });
+			if (!stop.range) {
+				return label;
+			}
+			return stop.range.startLineNumber === stop.range.endLineNumber
+				? `${label}:${stop.range.startLineNumber}`
+				: `${label}:${stop.range.startLineNumber}-${stop.range.endLineNumber}`;
+		}
+		return stop.url;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -22,6 +22,7 @@ import { ChatInputOutputMarkdownProgressPart } from './chatInputOutputMarkdownPr
 import { ChatMcpAppSubPart, IMcpAppRenderData } from './chatMcpAppSubPart.js';
 import { ChatResultListSubPart } from './chatResultListSubPart.js';
 import { ChatAutomationConfiguredResultSubPart } from './chatAutomationConfiguredResultSubPart.js';
+import { ChatCodeTourSubPart } from './chatCodeTourSubPart.js';
 import { ChatSessionCreatedResultSubPart } from './chatSessionCreatedResultSubPart.js';
 import { ChatSimpleToolProgressPart } from './chatSimpleToolProgressPart.js';
 import { ChatSandboxPrerequisiteConfirmationSubPart } from './chatSandboxPrerequisiteConfirmationSubPart.js';
@@ -276,6 +277,10 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 
 		if (this.toolInvocation.toolSpecificData?.kind === 'automationConfigured') {
 			return this.instantiationService.createInstance(ChatAutomationConfiguredResultSubPart, this.toolInvocation, this.toolInvocation.toolSpecificData, this.context, this.renderer);
+		}
+
+		if (this.toolInvocation.toolSpecificData?.kind === 'codeTour') {
+			return this.instantiationService.createInstance(ChatCodeTourSubPart, this.toolInvocation, this.toolInvocation.toolSpecificData, this.context, this.renderer);
 		}
 
 		if (this.toolInvocation.toolSpecificData?.kind === 'terminal') {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -756,7 +756,7 @@ export interface IChatToolInvocationOtherClientData {
 
 export interface IChatToolInvocation {
 	readonly presentation: IPreparedToolInvocation['presentation'];
-	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData;
+	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData | IChatCodeTourData;
 	/** Active-only metadata that is omitted when the invocation is serialized. */
 	readonly otherClientToolCall?: IChatToolInvocationOtherClientData;
 	/**
@@ -1044,7 +1044,7 @@ export interface IToolResultOutputDetailsSerialized {
  */
 export interface IChatToolInvocationSerialized {
 	presentation: IPreparedToolInvocation['presentation'];
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfiguredData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfiguredData | IChatCodeTourData;
 	invocationMessage: string | IMarkdownString;
 	originMessage: string | IMarkdownString | undefined;
 	pastTenseMessage: string | IMarkdownString | undefined;
@@ -1181,6 +1181,35 @@ export interface IChatAutomationConfigurationData {
 	readonly kind: 'automationConfiguration';
 	readonly expectedAutomationId: string;
 	readonly expectedEditableState: string;
+}
+
+/**
+ * A single stop in a code tour: a piece of narration anchored to a location in
+ * the workspace and/or a page in the integrated browser.
+ */
+export interface IChatCodeTourStop {
+	/** Short label shown in the tour widget. */
+	readonly title: string;
+	/** Markdown narration explaining this stop. */
+	readonly narration: string;
+	/** File revealed for this stop, when the stop is anchored to code. */
+	readonly uri?: UriComponents;
+	/** Range revealed and highlighted within {@link uri}. */
+	readonly range?: IRange;
+	/** Page opened in the integrated browser for this stop. */
+	readonly url?: string;
+}
+
+/**
+ * Tool-specific data for a code tour. The agent contributes one stop per tool
+ * call, so {@link stops} is appended to in place while the tour runs and the
+ * widget re-renders from the code tour service.
+ */
+export interface IChatCodeTourData {
+	readonly kind: 'codeTour';
+	readonly tourId: string;
+	readonly title: string;
+	readonly stops: IChatCodeTourStop[];
 }
 
 export interface IChatModifiedFilesConfirmationData {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -96,6 +96,7 @@ export enum ChatConfiguration {
 	DefaultModel = 'chat.defaultModel',
 	ImageCarouselEnabled = 'imageCarousel.chat.enabled',
 	ArtifactsEnabled = 'chat.artifacts.enabled',
+	CodeTourEnabled = 'chat.codeTour.enabled',
 	ArtifactsRulesByMimeType = 'chat.artifacts.rules.byMimeType',
 	ArtifactsRulesByFilePath = 'chat.artifacts.rules.byFilePath',
 	ArtifactsRulesByMemoryFilePath = 'chat.artifacts.rules.byMemoryFilePath',

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -8,7 +8,7 @@ import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationOtherClientData, IChatToolInvocationSerialized, ToolConfirmKind, type IChatMcpAuthenticationRequiredServer, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
+import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatCodeTourData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationOtherClientData, IChatToolInvocationSerialized, ToolConfirmKind, type IChatMcpAuthenticationRequiredServer, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../../tools/languageModelToolsService.js';
 
 export interface IStreamingToolCallOptions {
@@ -37,7 +37,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public isAttachedToThinking: boolean = false;
 	public otherClientToolCall?: IChatToolInvocationOtherClientData;
 
-	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData;
+	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData | IChatCodeTourData;
 	private readonly _toolSpecificDataKind = observableValue<string | undefined>(this, undefined);
 	public readonly toolSpecificDataKind: IObservable<string | undefined> = this._toolSpecificDataKind;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/builtinSkillDiscovery.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/builtinSkillDiscovery.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { basename, joinPath } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { ChatConfiguration } from '../../constants.js';
+import { SKILL_FILENAME } from '../config/promptFileLocations.js';
+import { ParsedPromptFile } from '../promptFileParser.js';
+import { PromptsType } from '../promptTypes.js';
+import { IBuiltinPromptPath, PromptsStorage } from './promptsService.js';
+
+/**
+ * Session types a built-in skill is offered in, when it should not be available
+ * everywhere. Keyed by skill folder name.
+ *
+ * Entries use the prefix-wildcard form understood by `matchesSessionType`, since
+ * remote agent host session types embed a connection authority
+ * (`remote-{authority}-{provider}`) and cannot be listed exhaustively.
+ */
+const BUILTIN_SKILL_SESSION_TYPES = new Map<string, readonly string[]>([
+	// The code tour the `explain` skill drives is only wired up for agent host
+	// sessions, so don't offer it where it cannot work.
+	['explain', ['agent-host-*', 'remote-*']],
+]);
+
+/**
+ * Setting that must be enabled for a built-in skill to be offered at all, keyed
+ * by skill folder name. Skills without an entry are always offered.
+ */
+const BUILTIN_SKILL_ENABLEMENT_SETTINGS = new Map<string, string>([
+	// `/explain` is useless without the code tour tool it drives.
+	['explain', ChatConfiguration.CodeTourEnabled],
+]);
+
+/** Settings that change which built-in skills are offered, for cache invalidation. */
+export const BUILTIN_SKILL_ENABLEMENT_SETTING_IDS: readonly string[] = [...new Set(BUILTIN_SKILL_ENABLEMENT_SETTINGS.values())];
+
+/** Whether a discovered built-in skill is currently enabled by configuration. */
+export function isBuiltinSkillEnabled(name: string | undefined, configurationService: IConfigurationService): boolean {
+	const setting = name && BUILTIN_SKILL_ENABLEMENT_SETTINGS.get(name);
+	return !setting || configurationService.getValue<boolean>(setting) === true;
+}
+
+/**
+ * Discovers skills bundled with the application at `{root}/{folder}/SKILL.md`.
+ *
+ * Only the folder layout and header sanity checks live here; the calling
+ * {@link PromptsService} applies its own parsing, sanitization and duplicate-name
+ * precedence on top of the returned paths, and filters them with
+ * {@link isBuiltinSkillEnabled}.
+ */
+export async function discoverBuiltinSkills(
+	root: URI,
+	fileService: IFileService,
+	parse: (uri: URI, token: CancellationToken) => Promise<ParsedPromptFile>,
+	logService: ILogService,
+): Promise<readonly IBuiltinPromptPath[]> {
+	let stat;
+	try {
+		stat = await fileService.resolve(root);
+	} catch {
+		return [];
+	}
+
+	if (!stat.children) {
+		return [];
+	}
+
+	const skills: IBuiltinPromptPath[] = [];
+	for (const child of stat.children) {
+		if (!child.isDirectory) {
+			continue;
+		}
+
+		const skillFileUri = joinPath(child.resource, SKILL_FILENAME);
+		try {
+			// Parsed with `CancellationToken.None` deliberately: the folder is
+			// static and the result is memoized by the caller, so a caller that
+			// cancels must not poison the cache with a partial scan.
+			const parsed = await parse(skillFileUri, CancellationToken.None);
+			const rawName = parsed.header?.name;
+			const rawDescription = parsed.header?.description;
+			if (!rawName || !rawDescription) {
+				continue;
+			}
+
+			const name = sanitizeSkillText(rawName, 64);
+			const folderName = basename(child.resource);
+			if (name !== folderName) {
+				continue;
+			}
+
+			skills.push({
+				uri: skillFileUri,
+				storage: PromptsStorage.builtIn,
+				type: PromptsType.skill,
+				name,
+				description: sanitizeSkillText(rawDescription, 1024),
+				sessionTypes: BUILTIN_SKILL_SESSION_TYPES.get(folderName),
+			});
+		} catch (e) {
+			logService.warn(`[builtinSkills] Failed to parse built-in skill: ${skillFileUri}`, e instanceof Error ? e.message : String(e));
+		}
+	}
+
+	return skills;
+}
+
+/**
+ * Strips XML tags and truncates to the given max length.
+ * Matches the sanitization applied by PromptsService for other skill sources.
+ */
+function sanitizeSkillText(text: string, maxLength: number): string {
+	const sanitized = text.replace(/<[^>]+>/g, '');
+	return sanitized.length > maxLength ? sanitized.substring(0, maxLength) : sanitized;
+}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -99,9 +99,18 @@ export interface IPromptFileResource {
 
 /**
  * Returns whether a customization can be used in the provided chat session type.
+ *
+ * An entry ending in `*` matches by prefix, so a customization can target a
+ * whole family of session types (e.g. `agent-host-*` for every local agent host,
+ * or `remote-*` for remote ones, whose ids embed a connection authority).
  */
 export function matchesSessionType(sessionTypes: readonly string[] | undefined, currentSessionType: string | undefined): boolean {
-	return sessionTypes === undefined || currentSessionType === undefined || sessionTypes.includes(currentSessionType);
+	if (sessionTypes === undefined || currentSessionType === undefined) {
+		return true;
+	}
+	return sessionTypes.some(sessionType => sessionType.endsWith('*')
+		? currentSessionType.startsWith(sessionType.slice(0, -1))
+		: sessionType === currentSessionType);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -35,7 +35,7 @@ import { IWorkspaceInstructionFile, PromptFilesLocator } from '../utils/promptFi
 import { evaluateApplyToPattern, PromptFileParser, ParsedPromptFile, PromptHeaderAttributes } from '../promptFileParser.js';
 import { IAgentInstructions, IAgentSource, IChatPromptSlashCommand, IConfiguredHooksInfo, ICustomAgent, IExtensionPromptPath, ILocalPromptPath, IPluginPromptPath, IBuiltinPromptPath, IPromptPath, IPromptsService, IAgentSkill, IInstructionDiscoveryInfo, IInstructionDiscoveryResult, IInstructionFile, IUserPromptPath, PromptsStorage, IPromptFileContext, IPromptFileResource, IPromptDiscoveryInfo, IPromptFileDiscoveryResult, IPromptSourceFolderResult, ICustomAgentVisibility, IAgentInstructionFile, AgentInstructionFileType, Logger, ISlashCommandDiscoveryInfo, ISlashCommandDiscoveryResult, IAgentDiscoveryInfo, IAgentDiscoveryResult, IHookDiscoveryInfo, IResolvedChatPromptSlashCommand, matchesSessionType } from './promptsService.js';
 import { Delayer, raceCancellationError } from '../../../../../../base/common/async.js';
-import { Schemas } from '../../../../../../base/common/network.js';
+import { FileAccess, Schemas } from '../../../../../../base/common/network.js';
 import { ChatRequestHooks, parseSubagentHooksFromYaml } from '../hookSchema.js';
 import { type IParsedHookCommand } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { HookType } from '../hookTypes.js';
@@ -48,6 +48,10 @@ import { getCanonicalPluginCommandId, IAgentPlugin, IAgentPluginService } from '
 import { isContributionEnabled } from '../../enablement.js';
 import { assertNever } from '../../../../../../base/common/assert.js';
 import { ExtensionPromptFileService } from './extensionPromptFileService.js';
+import { BUILTIN_SKILL_ENABLEMENT_SETTING_IDS, discoverBuiltinSkills, isBuiltinSkillEnabled } from './builtinSkillDiscovery.js';
+
+/** URI root for skills bundled with the workbench. */
+export const WORKBENCH_BUILTIN_SKILLS_URI = FileAccess.asFileUri('vs/workbench/contrib/chat/skills');
 
 /**
  * Provides prompt services.
@@ -79,6 +83,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 	 * Cached skill discovery info.
 	 */
 	private readonly cachedSkills: CachedPromise<IPromptDiscoveryInfo>;
+
+	/**
+	 * Built-in skills bundled with the workbench. They never change at runtime,
+	 * so the folder is scanned once per service instance.
+	 */
+	private _builtinSkillsCache: Promise<readonly IBuiltinPromptPath[]> | undefined;
 
 	/**
 	 * Cached instructions.
@@ -167,6 +177,16 @@ export class PromptsService extends Disposable implements IPromptsService {
 		}));
 
 		const modelChangeEvent = this._register(new ModelChangeTracker(this.modelService)).onDidPromptChange;
+		const builtinSkillEnablementChangeEvent = Event.filter(
+			this.configurationService.onDidChangeConfiguration,
+			e => BUILTIN_SKILL_ENABLEMENT_SETTING_IDS.some(setting => e.affectsConfiguration(setting)));
+
+		// Which built-in skills are offered depends on configuration, so the
+		// memoized file list has to be dropped alongside the discovery caches.
+		this._register(builtinSkillEnablementChangeEvent(() => {
+			this.cachedFileLocations[PromptsType.skill] = undefined;
+		}));
+
 		this.cachedCustomAgents = this._register(new CachedPromise(
 			(token) => this.computeAgentDiscoveryInfo(token),
 			() => Event.any(
@@ -187,6 +207,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.prompt),
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.skill),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.prompt || e.type === PromptsType.skill),
+				builtinSkillEnablementChangeEvent,
 				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.prompt || t === PromptsType.skill)),
 		));
 
@@ -196,6 +217,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				this.getFileLocatorEvent(PromptsType.skill),
 				Event.filter(modelChangeEvent, e => e.promptType === PromptsType.skill),
 				Event.filter(onDidChangeExtensionPromptFiles, e => e.type === PromptsType.skill),
+				builtinSkillEnablementChangeEvent,
 				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.skill))
 		));
 
@@ -398,12 +420,19 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	/**
-	 * Returns the built-in prompt files of the given type. The base service ships
-	 * no built-in prompts; subclasses (e.g. the Agents app) override this to
-	 * contribute bundled prompts such as built-in skills.
+	 * Returns the built-in prompt files of the given type. The base service
+	 * contributes the skills bundled with the workbench (e.g. `/explain`);
+	 * subclasses (e.g. the Agents app) override this to add their own bundled
+	 * prompts on top.
 	 */
 	protected async getBuiltinPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IBuiltinPromptPath[]> {
-		return [];
+		if (type !== PromptsType.skill) {
+			return [];
+		}
+		if (!this._builtinSkillsCache) {
+			this._builtinSkillsCache = discoverBuiltinSkills(WORKBENCH_BUILTIN_SKILLS_URI, this.fileService, (uri, t) => this.parseNew(uri, t), this.logger);
+		}
+		return (await this._builtinSkillsCache).filter(skill => isBuiltinSkillEnabled(skill.name, this.configurationService));
 	}
 
 	public async getSourceFolders(type: PromptsType): Promise<readonly IPromptPath[]> {

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -25,7 +25,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../attachments/chatVariableEntries.js';
 import { IVariableReference } from '../chatModes.js';
-import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
+import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatAutomationConfigurationData, IChatAutomationConfiguredData, IChatCodeTourData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSessionCreatedData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
 import { ILanguageModelChatMetadata, LanguageModelPartAudience } from '../languageModels.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { PromptElementJSON, stringifyPromptElementJSON } from './promptTsxTypes.js';
@@ -190,7 +190,7 @@ export interface IToolInvocation {
 	 * Lets us add some nicer UI to toolcalls that came from a sub-agent, but in the long run, this should probably just be rendered in a similar way to thinking text + tool call groups
 	 */
 	subAgentInvocationId?: string;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData | IChatCodeTourData;
 	modelId?: string;
 	userSelectedTools?: UserSelectedTools;
 	/** The label of the custom button selected by the user during confirmation, if custom buttons were used. */
@@ -295,7 +295,7 @@ export function isToolResultOutputDetails(obj: any): obj is IToolResultOutputDet
 
 export interface IToolResult {
 	content: (IToolResultPromptTsxPart | IToolResultTextPart | IToolResultDataPart)[];
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfiguredData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfiguredData | IChatCodeTourData;
 	toolResultMessage?: string | IMarkdownString;
 	toolResultDetails?: Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails;
 	toolResultError?: string | boolean;
@@ -417,7 +417,7 @@ export interface IPreparedToolInvocation {
 	confirmationMessages?: IToolConfirmationMessages;
 	presentation?: ToolInvocationPresentation;
 	icon?: ThemeIcon;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | IChatSessionCreatedData | IChatAutomationConfigurationData | IChatAutomationConfiguredData | IChatCodeTourData;
 }
 
 export interface IToolImpl {

--- a/src/vs/workbench/contrib/chat/skills/explain/SKILL.md
+++ b/src/vs/workbench/contrib/chat/skills/explain/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: explain
+description: Explain an existing implementation or a design you are proposing as a guided code tour that opens and highlights the relevant code as you narrate. Use when the user asks how something works, how a feature is wired up, where something lives, or to walk them through an approach before implementing it.
+---
+
+# Explain as a code tour
+
+Explain the subject as a **guided tour** rather than a wall of prose. You drive the
+editor with the `codeTour` tool while you narrate, so the user is always looking at
+the code you are talking about.
+
+## Workflow
+
+### 1. Understand the subject first
+
+Before presenting anything, read enough of the codebase to be sure of the story you
+are going to tell. Do not start the tour and discover the code as you go — a tour
+that backtracks is worse than no tour.
+
+Decide on:
+
+- The **spine** of the explanation: the path a request, event, or piece of data
+  actually takes, or the sequence of decisions in the design.
+- The **3 to 8 stops** that spine passes through. Fewer than 3 is a paragraph, not a
+  tour; more than 8 and the user loses the thread.
+
+### 2. Present the tour
+
+Call `codeTour` once per stop, in order.
+
+- Pass `tourTitle` on the **first** call only.
+- Give each stop a `stopTitle` that names the *idea*, not the file — "Where the
+  request is parsed" beats "chatRequestParser.ts".
+- Keep `narration` to two or three sentences: what this code does, and why it
+  matters to the question that was asked. Do not repeat the narration in your
+  assistant message; the tour widget already shows it.
+- Point at the **narrowest range that makes the point**. A tight `startLine`/
+  `endLine` around the relevant function beats highlighting a whole file. Use
+  `symbol` when you know the name but not the lines.
+- Use `url` when a stop is genuinely better shown in a browser — rendered docs, a
+  running dev server, a spec. Do not attach a URL to every stop.
+- Set `isLast: true` on the final stop.
+
+### 3. Wrap up
+
+After the final stop, write a short summary: the through-line of what you showed,
+and anything that surprised you or looks fragile. If the user asked you to explain a
+design you are proposing, end by asking whether they want you to implement it.
+
+## Guidelines
+
+- **A stop must earn its place.** If a stop does not change the user's understanding,
+  cut it.
+- **Explain the code that exists.** When you are touring an implementation, do not
+  describe how you would have written it. Save that for the wrap-up.
+- **Stop when asked.** If a `codeTour` result says the user stopped the tour, do not
+  present more stops — respond to the user directly.
+- **Narration-only stops are allowed** but rare. Omit `file` when a stop is a piece
+  of framing that has no single home in the code.
+- When you are proposing a design, anchor stops to the **existing** code the design
+  would touch, so the user can judge the fit.

--- a/src/vs/workbench/contrib/chat/test/browser/codeTour/codeTourService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/codeTour/codeTourService.test.ts
@@ -1,0 +1,287 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import { DocumentSymbolProvider, SymbolKind } from '../../../../../../editor/common/languages.js';
+import { ILanguageFeaturesService } from '../../../../../../editor/common/services/languageFeatures.js';
+import { LanguageFeaturesService } from '../../../../../../editor/common/services/languageFeaturesService.js';
+import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
+import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { IAgentNetworkFilterService } from '../../../../../../platform/networkFilter/common/networkFilterService.js';
+import { IBrowserViewWorkbenchService } from '../../../../browserView/common/browserView.js';
+import { CodeTourService } from '../../../browser/codeTour/codeTourService.js';
+import { IChatService } from '../../../common/chatService/chatService.js';
+import { IChatChangeEvent } from '../../../common/model/chatModel.js';
+
+suite('CodeTourService', () => {
+
+	const disposables = new DisposableStore();
+
+	const sessionResource = URI.parse('vscode-chat-session://test/1');
+	const fileUri = URI.parse('file:///test/file.ts');
+	const testContent = [
+		'export function first() {',
+		'\treturn 1;',
+		'}',
+		'',
+		'export function second() {',
+		'\treturn 2;',
+		'}',
+	].join('\n');
+
+	/** Records what the service asked the workbench to open. */
+	interface IOpenedEditor {
+		readonly resource?: URI;
+		readonly selection?: unknown;
+		readonly preserveFocus?: boolean;
+		readonly pinned?: boolean;
+		readonly browserUrl?: string;
+	}
+
+	let opened: IOpenedEditor[];
+	let langFeatures: LanguageFeaturesService;
+	/** Stands in for the session model's `addRequest` notification. */
+	let modelChange: Emitter<IChatChangeEvent>;
+
+	function createService(sessionDisposeEvent = Event.None, submitRequestEvent = Event.None): CodeTourService {
+		opened = [];
+		langFeatures = new LanguageFeaturesService();
+		modelChange = disposables.add(new Emitter<IChatChangeEvent>());
+
+		const model = disposables.add(createTextModel(testContent, 'typescript', undefined, fileUri));
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IEditorService, {
+			openEditor: async (editor: { resource?: URI; url?: string; options?: { selection?: unknown; preserveFocus?: boolean; pinned?: boolean } }) => {
+				opened.push(editor.resource
+					? { resource: editor.resource, selection: editor.options?.selection, preserveFocus: editor.options?.preserveFocus, pinned: editor.options?.pinned }
+					: { browserUrl: editor.url });
+				return undefined;
+			},
+		} as unknown as IEditorService);
+		instantiationService.stub(ILanguageFeaturesService, langFeatures);
+		instantiationService.stub(ITextModelService, {
+			createModelReference: async () => ({ object: { textEditorModel: model }, dispose: () => { } }),
+		} as unknown as ITextModelService);
+		instantiationService.stub(IBrowserViewWorkbenchService, {
+			getOrCreateLazy: (_id: string, state?: { url?: string }) => ({ url: state?.url }),
+			getPreferredGroup: async () => undefined,
+		} as unknown as IBrowserViewWorkbenchService);
+		instantiationService.stub(IAgentNetworkFilterService, {
+			isUriAllowed: (uri: URI) => uri.authority !== 'blocked.example.com',
+			formatError: () => 'blocked',
+		} as unknown as IAgentNetworkFilterService);
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IChatService, {
+			onDidDisposeSession: sessionDisposeEvent,
+			onDidSubmitRequest: submitRequestEvent,
+			getSession: () => ({ onDidChange: modelChange.event }),
+		} as unknown as IChatService);
+
+		return disposables.add(instantiationService.createInstance(CodeTourService));
+	}
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('startTour creates an empty tour that addStop appends to and reveals', async () => {
+		const service = createService();
+		const tour = service.startTour(sessionResource, 'How chat works');
+
+		await service.addStop(sessionResource, { title: 'Entry point', narration: 'Where it starts.', uri: fileUri, range: new Range(1, 1, 3, 1) }, false);
+		await service.addStop(sessionResource, { title: 'The docs', narration: 'Background.', url: 'https://example.com' }, false);
+
+		assert.deepStrictEqual(
+			{
+				title: tour.title,
+				stopTitles: tour.stops.map(s => s.title),
+				isActive: service.getActiveTour(sessionResource) === tour,
+				opened,
+			},
+			{
+				title: 'How chat works',
+				stopTitles: ['Entry point', 'The docs'],
+				isActive: true,
+				opened: [
+					{ resource: fileUri, selection: new Range(1, 1, 3, 1), preserveFocus: true, pinned: false },
+					{ browserUrl: 'https://example.com' },
+				],
+			});
+	});
+
+	test('stopTour ends the tour and blocks further stops', async () => {
+		const service = createService();
+		const tour = service.startTour(sessionResource, 'Tour');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.', uri: fileUri }, false);
+
+		service.stopTour(tour.tourId);
+		await service.addStop(sessionResource, { title: 'Two', narration: 'Second.', uri: fileUri }, false);
+
+		assert.deepStrictEqual(
+			{
+				isStopped: service.isStopped(sessionResource),
+				stopTitles: tour.stops.map(s => s.title),
+				finished: service.observeRuntime(tour.tourId).get()?.finished.get(),
+			},
+			{ isStopped: true, stopTitles: ['One'], finished: true });
+	});
+
+	test('a completed tour finishes without being reported as stopped by the user', async () => {
+		const service = createService();
+		const tour = service.startTour(sessionResource, 'Tour');
+		const added = await service.addStop(sessionResource, { title: 'Only', narration: 'Done.', uri: fileUri }, true);
+		const afterEnd = await service.addStop(sessionResource, { title: 'Encore', narration: 'Too late.', uri: fileUri }, false);
+
+		assert.deepStrictEqual(
+			{
+				added,
+				afterEnd,
+				stopTitles: tour.stops.map(s => s.title),
+				finished: service.observeRuntime(tour.tourId).get()?.finished.get(),
+				isStopped: service.isStopped(sessionResource),
+			},
+			{ added: true, afterEnd: false, stopTitles: ['Only'], finished: true, isStopped: false });
+	});
+
+	test('revealStop navigates to a past stop and updates the current index', async () => {
+		const service = createService();
+		const tour = service.startTour(sessionResource, 'Tour');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.', uri: fileUri, range: new Range(1, 1, 1, 1) }, false);
+		await service.addStop(sessionResource, { title: 'Two', narration: 'Second.', uri: fileUri, range: new Range(5, 1, 5, 1) }, false);
+
+		await service.revealStop(tour.tourId, 0, tour.stops[0]);
+
+		assert.deepStrictEqual(
+			{
+				currentIndex: service.observeRuntime(tour.tourId).get()?.currentIndex.get(),
+				lastOpenedSelection: opened.at(-1)?.selection,
+			},
+			{ currentIndex: 0, lastOpenedSelection: new Range(1, 1, 1, 1) });
+	});
+
+	test('starting a second tour in the same session replaces the first', async () => {
+		const service = createService();
+		const first = service.startTour(sessionResource, 'First');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.', uri: fileUri }, false);
+
+		const second = service.startTour(sessionResource, 'Second');
+
+		assert.deepStrictEqual(
+			{
+				active: service.getActiveTour(sessionResource)?.title,
+				firstRuntime: service.observeRuntime(first.tourId).get(),
+				secondHasRuntime: !!service.observeRuntime(second.tourId).get(),
+			},
+			{ active: 'Second', firstRuntime: undefined, secondHasRuntime: true });
+	});
+
+	test('resolveRange handles line spans, symbols, and unresolvable input', async () => {
+		const service = createService();
+		disposables.add(langFeatures.documentSymbolProvider.register({ scheme: 'file' }, {
+			provideDocumentSymbols: async () => ([{
+				name: 'second',
+				detail: '',
+				kind: SymbolKind.Function,
+				tags: [],
+				range: new Range(5, 1, 7, 2),
+				selectionRange: new Range(5, 17, 5, 23),
+			}]),
+		} satisfies DocumentSymbolProvider));
+
+		assert.deepStrictEqual(
+			{
+				fromLines: await service.resolveRange(fileUri, 2, 4, undefined),
+				fromSingleLine: await service.resolveRange(fileUri, 2, undefined, undefined),
+				fromSymbol: await service.resolveRange(fileUri, undefined, undefined, 'second'),
+				unknownSymbol: await service.resolveRange(fileUri, undefined, undefined, 'nope'),
+				nothing: await service.resolveRange(fileUri, undefined, undefined, undefined),
+			},
+			{
+				fromLines: new Range(2, 1, 4, Number.MAX_SAFE_INTEGER),
+				fromSingleLine: new Range(2, 1, 2, Number.MAX_SAFE_INTEGER),
+				fromSymbol: new Range(5, 1, 7, 2),
+				unknownSymbol: undefined,
+				nothing: undefined,
+			});
+	});
+
+	test('a disposed session ends its tour', async () => {
+		const onDidDisposeSession = disposables.add(new Emitter<{ sessionResources: URI[] }>());
+		const service = createService(onDidDisposeSession.event as Event<never>);
+
+		const tour = service.startTour(sessionResource, 'Tour');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.' }, false);
+
+		onDidDisposeSession.fire({ sessionResources: [sessionResource] });
+
+		assert.deepStrictEqual(
+			{
+				active: service.getActiveTour(sessionResource),
+				runtime: service.observeRuntime(tour.tourId).get(),
+			},
+			{ active: undefined, runtime: undefined });
+	});
+
+	test('the next user request clears a stopped tour so a later turn can start a fresh one', async () => {
+		const onDidSubmitRequest = disposables.add(new Emitter<{ chatSessionResource: URI }>());
+		const service = createService(Event.None, onDidSubmitRequest.event as Event<never>);
+
+		const first = service.startTour(sessionResource, 'First');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.' }, false);
+		service.stopTour(first.tourId);
+
+		const stoppedDuringTurn = service.isStopped(sessionResource);
+		onDidSubmitRequest.fire({ chatSessionResource: sessionResource });
+
+		const second = service.startTour(sessionResource, 'Second');
+		const added = await service.addStop(sessionResource, { title: 'Fresh', narration: 'New tour.' }, false);
+
+		assert.deepStrictEqual(
+			{
+				stoppedDuringTurn,
+				stoppedAfterNextRequest: service.isStopped(sessionResource),
+				added,
+				secondStops: second.stops.map(s => s.title),
+			},
+			{ stoppedDuringTurn: true, stoppedAfterNextRequest: false, added: true, secondStops: ['Fresh'] });
+	});
+
+	test('a stop URL that the network filter blocks is not opened', async () => {
+		const service = createService();
+		service.startTour(sessionResource, 'Tour');
+
+		await service.addStop(sessionResource, { title: 'Blocked', narration: 'Nope.', url: 'https://blocked.example.com/x' }, false);
+		await service.addStop(sessionResource, { title: 'Allowed', narration: 'Fine.', url: 'https://ok.example.com/y' }, false);
+
+		assert.deepStrictEqual(opened, [{ browserUrl: 'https://ok.example.com/y' }]);
+	});
+
+	test('a server-initiated turn also ends the previous tour', async () => {
+		const service = createService();
+		const first = service.startTour(sessionResource, 'First');
+		await service.addStop(sessionResource, { title: 'One', narration: 'First.' }, true);
+
+		// Agent hosts drain their own queue, so the next turn only shows up as a
+		// request added to the session model.
+		modelChange.fire({ kind: 'addRequest' } as IChatChangeEvent);
+
+		assert.deepStrictEqual(
+			{
+				active: service.getActiveTour(sessionResource),
+				runtime: service.observeRuntime(first.tourId).get(),
+				isStopped: service.isStopped(sessionResource),
+			},
+			{ active: undefined, runtime: undefined, isStopped: false });
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/tools/codeTourTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/codeTourTool.test.ts
@@ -1,0 +1,241 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IRange, Range } from '../../../../../../editor/common/core/range.js';
+import { IAgentNetworkFilterService } from '../../../../../../platform/networkFilter/common/networkFilterService.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
+import { ICodeTourRuntime, ICodeTourService } from '../../../browser/codeTour/codeTourService.js';
+import { CodeTourTool } from '../../../browser/tools/codeTourTool.js';
+import { IChatCodeTourData, IChatCodeTourStop } from '../../../common/chatService/chatService.js';
+import { IToolInvocation, IToolResult, IToolResultTextPart, ToolInvocationPresentation, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
+import { IObservable, constObservable } from '../../../../../../base/common/observable.js';
+
+function getTextContent(result: IToolResult): string {
+	return result.content.find((p): p is IToolResultTextPart => p.kind === 'text')?.value ?? '';
+}
+
+suite('CodeTourTool', () => {
+
+	const disposables = new DisposableStore();
+
+	const sessionResource = URI.parse('vscode-chat-session://test/1');
+	const workspaceFolder = URI.parse('file:///workspace');
+
+	/** In-memory stand-in that records what the tool asked the tour service to do. */
+	class TestCodeTourService implements ICodeTourService {
+		declare readonly _serviceBrand: undefined;
+
+		tour: IChatCodeTourData | undefined;
+		stopped = false;
+		finished = false;
+		/** Range `resolveRange` should hand back, or `undefined` to simulate a failed resolve. */
+		resolvedRange: IRange | undefined = new Range(3, 1, 5, 1);
+
+		startTour(_sessionResource: URI, title: string): IChatCodeTourData {
+			this.tour = { kind: 'codeTour', tourId: 'tour-1', title, stops: [] };
+			return this.tour;
+		}
+		getActiveTour(): IChatCodeTourData | undefined {
+			return this.tour;
+		}
+		async addStop(_sessionResource: URI, stop: IChatCodeTourStop): Promise<boolean> {
+			if (this.finished) {
+				return false;
+			}
+			this.tour?.stops.push(stop);
+			return true;
+		}
+		async revealStop(): Promise<void> { }
+		observeRuntime(): IObservable<ICodeTourRuntime | undefined> {
+			return constObservable(undefined);
+		}
+		stopTour(): void {
+			this.stopped = true;
+		}
+		isStopped(): boolean {
+			return this.stopped;
+		}
+		async resolveRange(): Promise<IRange | undefined> {
+			return this.resolvedRange;
+		}
+	}
+
+	function createWorkspaceService(): IWorkspaceContextService {
+		return {
+			_serviceBrand: undefined,
+			getWorkspace: () => ({ folders: [{ uri: workspaceFolder } as IWorkspaceFolder] }),
+			getWorkspaceFolder: () => ({ uri: workspaceFolder } as IWorkspaceFolder),
+		} as unknown as IWorkspaceContextService;
+	}
+
+	/** Allows everything except a single blocked host, mirroring the agent network filter. */
+	function createNetworkFilter(): IAgentNetworkFilterService {
+		return {
+			isUriAllowed: (uri: URI) => uri.authority !== 'blocked.example.com',
+			formatError: (uri: URI) => `Blocked ${uri.authority}`,
+		} as unknown as IAgentNetworkFilterService;
+	}
+
+	function createTool(tourService: TestCodeTourService): CodeTourTool {
+		return new CodeTourTool(tourService, createWorkspaceService(), createNetworkFilter());
+	}
+
+	function createInvocation(parameters: Record<string, unknown>): IToolInvocation {
+		return {
+			callId: '1',
+			toolId: 'vscode_codeTour',
+			parameters,
+			context: { sessionResource },
+		} as IToolInvocation;
+	}
+
+	const noopProgress: ToolProgress = { report() { } };
+
+	function invoke(tool: CodeTourTool, parameters: Record<string, unknown>): Promise<IToolResult> {
+		return tool.invoke(createInvocation(parameters), async () => 0, noopProgress, CancellationToken.None);
+	}
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('the first stop starts the tour and carries the widget data', async () => {
+		const tourService = new TestCodeTourService();
+		const tool = createTool(tourService);
+
+		const result = await invoke(tool, { tourTitle: 'How chat works', stopTitle: 'Entry point', narration: 'Where it starts.', file: 'src/main.ts', startLine: 3, endLine: 5 });
+
+		assert.deepStrictEqual(
+			{
+				toolSpecificData: result.toolSpecificData,
+				text: getTextContent(result),
+			},
+			{
+				toolSpecificData: {
+					kind: 'codeTour',
+					tourId: 'tour-1',
+					title: 'How chat works',
+					stops: [{
+						title: 'Entry point',
+						narration: 'Where it starts.',
+						uri: URI.parse('file:///workspace/src/main.ts'),
+						range: new Range(3, 1, 5, 1),
+						url: undefined,
+					}],
+				},
+				text: 'Showed stop 1: Entry point.',
+			});
+	});
+
+	test('later stops append to the same tour without a second widget', async () => {
+		const tourService = new TestCodeTourService();
+		const tool = createTool(tourService);
+
+		await invoke(tool, { tourTitle: 'Tour', stopTitle: 'One', narration: 'First.', file: 'a.ts', startLine: 1 });
+		const second = await invoke(tool, { stopTitle: 'Two', narration: 'Second.', file: 'b.ts', startLine: 1, isLast: true });
+
+		const prepared = await tool.prepareToolInvocation({ parameters: { stopTitle: 'Three', narration: 'Third.' }, toolCallId: '3', chatSessionResource: sessionResource }, CancellationToken.None);
+
+		assert.deepStrictEqual(
+			{
+				secondToolSpecificData: second.toolSpecificData,
+				secondText: getTextContent(second),
+				stopTitles: tourService.tour?.stops.map(s => s.title),
+				laterPresentation: prepared?.presentation,
+			},
+			{
+				secondToolSpecificData: undefined,
+				secondText: 'Showed stop 2: Two. This was the final stop. Wrap up the explanation for the user.',
+				stopTitles: ['One', 'Two'],
+				laterPresentation: ToolInvocationPresentation.Hidden,
+			});
+	});
+
+	test('a stopped tour tells the model to stop presenting', async () => {
+		const tourService = new TestCodeTourService();
+		tourService.stopped = true;
+		const tool = createTool(tourService);
+
+		const result = await invoke(tool, { stopTitle: 'One', narration: 'First.', file: 'a.ts', startLine: 1 });
+
+		assert.deepStrictEqual(
+			{ text: getTextContent(result), startedTour: !!tourService.tour },
+			{ text: 'The user stopped the tour. Do not present more stops; respond to the user directly instead.', startedTour: false });
+	});
+
+	test('a stop after the final one tells the model the tour already ended', async () => {
+		const tourService = new TestCodeTourService();
+		const tool = createTool(tourService);
+
+		await invoke(tool, { tourTitle: 'Tour', stopTitle: 'One', narration: 'First.', file: 'a.ts', startLine: 1, isLast: true });
+		tourService.finished = true;
+		const extra = await invoke(tool, { stopTitle: 'Two', narration: 'Encore.', file: 'b.ts', startLine: 1 });
+
+		assert.deepStrictEqual(
+			{ text: getTextContent(extra), stopTitles: tourService.tour?.stops.map(s => s.title) },
+			{ text: 'This tour has already ended. Do not present more stops; summarize the explanation for the user instead.', stopTitles: ['One'] });
+	});
+
+	test('unresolvable locations still produce a stop, with a note for the model', async () => {
+		const tourService = new TestCodeTourService();
+		tourService.resolvedRange = undefined;
+		const tool = createTool(tourService);
+
+		const outsideWorkspace = await invoke(tool, { tourTitle: 'Tour', stopTitle: 'Escape', narration: 'Nope.', file: '../outside.ts' });
+		const unresolvedRange = await invoke(tool, { stopTitle: 'Symbol', narration: 'Hmm.', file: 'a.ts', symbol: 'missing' });
+
+		assert.deepStrictEqual(
+			{
+				outsideWorkspaceText: getTextContent(outsideWorkspace),
+				unresolvedRangeText: getTextContent(unresolvedRange),
+				stopUris: tourService.tour?.stops.map(s => s.uri?.toString()),
+			},
+			{
+				outsideWorkspaceText: 'Showed stop 1: Escape. Could not resolve "../outside.ts" inside the workspace, so no file was opened for this stop.',
+				unresolvedRangeText: 'Showed stop 2: Symbol. Could not resolve the requested range, so the file was opened without a highlight. Provide startLine/endLine for the next stop.',
+				stopUris: [undefined, 'file:///workspace/a.ts'],
+			});
+	});
+
+	test('the tool refuses to run outside a chat session', async () => {
+		const tool = createTool(new TestCodeTourService());
+
+		const result = await tool.invoke(
+			{ callId: '1', toolId: 'vscode_codeTour', parameters: { stopTitle: 'One', narration: 'First.' }, context: undefined } as IToolInvocation,
+			async () => 0, noopProgress, CancellationToken.None);
+
+		assert.strictEqual(getTextContent(result), 'The code tour tool can only be used inside a chat session.');
+	});
+
+	test('a stop URL is confirmed when allowed and rejected when the network filter blocks it', async () => {
+		const tourService = new TestCodeTourService();
+		const tool = createTool(tourService);
+
+		const prepared = await tool.prepareToolInvocation(
+			{ parameters: { stopTitle: 'Docs', narration: 'Read this.', url: 'https://ok.example.com/docs' }, toolCallId: '1', chatSessionResource: sessionResource },
+			CancellationToken.None);
+
+		await assert.rejects(
+			() => tool.prepareToolInvocation(
+				{ parameters: { stopTitle: 'Bad', narration: 'Nope.', url: 'https://blocked.example.com/x' }, toolCallId: '2', chatSessionResource: sessionResource },
+				CancellationToken.None),
+			/Blocked blocked.example.com/);
+
+		await invoke(tool, { tourTitle: 'Tour', stopTitle: 'Junk', narration: 'Not a URL.', url: 'not a url' });
+
+		assert.deepStrictEqual(
+			{
+				confirmationTitle: prepared?.confirmationMessages?.title,
+				// A confirmation cannot render on a hidden invocation.
+				presentation: prepared?.presentation,
+				storedUrl: tourService.tour?.stops[0].url,
+			},
+			{ confirmationTitle: 'Open Browser Page?', presentation: undefined, storedUrl: undefined });
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/matchesSessionType.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/matchesSessionType.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { matchesSessionType } from '../../../common/promptSyntax/service/promptsService.js';
+
+suite('matchesSessionType', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('matches everything when either side is unconstrained', () => {
+		assert.deepStrictEqual(
+			[
+				matchesSessionType(undefined, 'local'),
+				matchesSessionType(['local'], undefined),
+				matchesSessionType([], 'local'),
+			],
+			[true, true, false]);
+	});
+
+	test('matches exact session types', () => {
+		assert.deepStrictEqual(
+			[
+				matchesSessionType(['local'], 'local'),
+				matchesSessionType(['local', 'agent-host-claude'], 'agent-host-claude'),
+				matchesSessionType(['local'], 'agent-host-claude'),
+			],
+			[true, true, false]);
+	});
+
+	test('a trailing wildcard matches a whole family of session types', () => {
+		const agentHostOnly = ['agent-host-*', 'remote-*'];
+		assert.deepStrictEqual(
+			[
+				matchesSessionType(agentHostOnly, 'agent-host-claude'),
+				matchesSessionType(agentHostOnly, 'agent-host-copilotcli'),
+				matchesSessionType(agentHostOnly, 'remote-ssh-my-box-codex'),
+				matchesSessionType(agentHostOnly, 'local'),
+				matchesSessionType(agentHostOnly, 'agent-host'),
+			],
+			[true, true, true, false, false]);
+	});
+});


### PR DESCRIPTION
This pull request implements the `/explain` slash command feature, allowing the agent to provide real-time explanations of implementations or design proposals through a code tour. Key changes include:

- **New Code Tour Service**: Introduced `codeTourService.ts` to manage the state and navigation of the code tour.
- **Tool Implementation**: Created `codeTourTool.ts` to handle the agent's interactions during the tour.
- **Chat Widget**: Developed a chat widget in `chatCodeTourSubPart.ts` that accumulates tour stops and allows users to navigate through them.
- **Skill Documentation**: Added `SKILL.md` to document the `/explain` skill and its usage.
- **Testing**: Comprehensive tests added for the new functionality, ensuring all features work as intended.

The feature is gated behind the `chat.codeTour.enabled` setting, which is off by default to prevent unintended usage. This implementation enhances the agent's capabilities by integrating with VS Code's tools for a more interactive experience.