### PR TITLE
Fix onboarding microphone picker visibility

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
+++ b/src/vs/workbench/contrib/agentsVoice/browser/media/voiceModeOnboarding.css
@@ -135,6 +135,10 @@
 	transition: border-color 100ms ease-out;
 }
 
+.voice-mode-onboarding-microphone-picker[hidden] {
+	display: none;
+}
+
 .voice-mode-onboarding-microphone-picker:hover {
 	border-color: var(--vscode-focusBorder);
 }

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -96,7 +96,9 @@ suite('Voice Mode onboarding', () => {
 		const selectedOnOpen = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 		const voices = [...host.container.querySelectorAll<HTMLElement>('.voice-mode-onboarding-voice-label')].map(element => element.textContent);
 		const voicesLabel = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voices-label')?.textContent;
-		const microphonePickerHidden = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-microphone-picker')?.hidden;
+		const microphonePicker = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-microphone-picker');
+		const microphonePickerHidden = microphonePicker?.hidden;
+		const microphonePickerDisplay = microphonePicker && dom.getWindow(microphonePicker).getComputedStyle(microphonePicker).display;
 		host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!.click();
 		const selectedAfterPick = host.container.querySelectorAll('.voice-mode-onboarding-voice.selected').length;
 
@@ -110,6 +112,7 @@ suite('Voice Mode onboarding', () => {
 			{
 				shown,
 				microphonePickerHidden,
+				microphonePickerDisplay,
 				selectedOnOpen,
 				voices,
 				voicesLabel,
@@ -121,6 +124,7 @@ suite('Voice Mode onboarding', () => {
 			{
 				shown: true,
 				microphonePickerHidden: true,
+				microphonePickerDisplay: 'none',
 				selectedOnOpen: 0,
 				voices: ['Maya (Default)', 'Victoria', 'Kevin', 'Daniel'],
 				voicesLabel: 'Agent Voice:',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -296,8 +296,7 @@ configurationRegistry.registerConfiguration({
 			],
 			markdownDescription: nls.localize('dictation.model', "The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service."),
 			default: DEFAULT_LOCAL_TRANSCRIPTION_MODEL,
-			tags: ['experimental'],
-			experiment: { mode: 'auto' }
+			tags: ['experimental']
 		},
 		[DictationSettingId.ShowTranscript]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -296,7 +296,8 @@ configurationRegistry.registerConfiguration({
 			],
 			markdownDescription: nls.localize('dictation.model', "The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service."),
 			default: DEFAULT_LOCAL_TRANSCRIPTION_MODEL,
-			tags: ['experimental']
+			tags: ['experimental'],
+			experiment: { mode: 'auto' }
 		},
 		[DictationSettingId.ShowTranscript]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/media/dictationOnboarding.css
@@ -130,6 +130,10 @@
 	transition: border-color 100ms ease-out;
 }
 
+.dictation-onboarding-picker[hidden] {
+	display: none;
+}
+
 .dictation-onboarding-picker:hover {
 	border-color: var(--vscode-focusBorder);
 }

--- a/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationOnboarding.test.ts
@@ -166,6 +166,7 @@ suite('Dictation onboarding', () => {
 
 		const analyser = new class extends mock<AnalyserNode>() {
 			override readonly fftSize = 256;
+			override getByteTimeDomainData(): void { }
 		};
 		await banner.refreshMicrophones(analyser, async deviceId => {
 			selectedDeviceIds.push(deviceId);
@@ -266,15 +267,17 @@ suite('Dictation onboarding', () => {
 		service.show();
 		service.show();
 
+		const microphonePicker = host.container.querySelector<HTMLElement>('.dictation-onboarding-picker');
 		assert.deepStrictEqual(
 			{
 				visible: host.container.classList.contains('has-dictation-onboarding'),
 				cards: host.container.querySelectorAll('.dictation-onboarding-banner').length,
 				hasMicrophoneControls: host.container.querySelector('.dictation-onboarding-device') !== null,
 				hasWaveform: host.container.querySelector('.dictation-onboarding-waveform') !== null,
-				microphonePickerHidden: host.container.querySelector<HTMLElement>('.dictation-onboarding-picker')?.hidden,
+				microphonePickerHidden: microphonePicker?.hidden,
+				microphonePickerDisplay: microphonePicker && dom.getWindow(microphonePicker).getComputedStyle(microphonePicker).display,
 			},
-			{ visible: true, cards: 1, hasMicrophoneControls: true, hasWaveform: true, microphonePickerHidden: true });
+			{ visible: true, cards: 1, hasMicrophoneControls: true, hasWaveform: true, microphonePickerHidden: true, microphonePickerDisplay: 'none' });
 	});
 
 	test('reset shows the introduction on the next dictation', () => {


### PR DESCRIPTION
Fixes the remaining microphone-picker issue from #328851.

The Dictation and Voice Mode onboarding picker containers set `hidden` when only one microphone is available, but their `display: flex` author styles override the browser hidden style. This leaves an empty picker shell visible. Explicit `[hidden]` styles now preserve the intended visibility contract.

Regression coverage checks computed picker visibility in both onboarding surfaces.

The stale `dictation.model` experiment treatment should be updated separately from `nemotron-speech-streaming-en-0.6b` to `nemotron-3.5-asr-streaming-0.6b`; this PR keeps model experimentation enabled.