### PR TITLE
Respect display language for automatic voice locale

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -677,7 +677,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('agents.voice.language.ko', "Korean"),
 				nls.localize('agents.voice.language.zh', "Chinese"),
 			],
-			markdownDescription: nls.localize('agents.voice.language', "The language used for speech recognition, dictation, and spoken responses. The selectable languages support native voice output. Automatic follows the system or browser locale for speech recognition and dictation, and uses English voice output when the detected language does not support native voice output. Changing this while voice mode is connected takes effect immediately."),
+			markdownDescription: nls.localize('agents.voice.language', "The language used for speech recognition, dictation, and spoken responses. The selectable languages support native voice output. Automatic uses the configured display language for speech recognition and dictation when available; otherwise, it follows the system or browser locale. English voice output is used when the detected language does not support native voice output. Changing this while voice mode is connected takes effect immediately."),
 			default: 'auto',
 			scope: ConfigurationScope.APPLICATION,
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -291,7 +291,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('dictation.model.mai.label', "MAI — Cloud"),
 			],
 			markdownEnumDescriptions: [
-				nls.localize('dictation.model.nemotronMultilingual', "NVIDIA Nemotron 3.5 multilingual streaming RNN-T, run on-device through Microsoft Foundry Local. Works offline; no audio leaves the device. Automatic language selection follows the Voice Mode language setting and system or browser locale, with model detection as a fallback. Downloaded on first use and cached on disk."),
+				nls.localize('dictation.model.nemotronMultilingual', "NVIDIA Nemotron 3.5 multilingual streaming RNN-T, run on-device through Microsoft Foundry Local. Works offline; no audio leaves the device. Automatic language selection follows the Voice Mode language setting; when that setting is Automatic, dictation uses the configured display language when available, then the system or browser locale, with model detection as a fallback. Downloaded on first use and cached on disk."),
 				nls.localize('dictation.model.mai', "Cloud transcription through the same Microsoft AI voice service used by Voice Mode. Requires a network connection and GitHub sign-in; audio is streamed to the service."),
 			],
 			markdownDescription: nls.localize('dictation.model', "The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service."),

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -9,6 +9,7 @@ import { VSBuffer, encodeBase64 } from '../../../../../base/common/buffer.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { computeLevenshteinDistance } from '../../../../../base/common/diff/diff.js';
 import { joinPath } from '../../../../../base/common/resources.js';
+import { Language } from '../../../../../base/common/platform.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IAction, toAction } from '../../../../../base/common/actions.js';
@@ -925,7 +926,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		const model = this._getModelId();
 		const language = resolveDictationLanguage(
 			this._configurationService.getValue('agents.voice.language'),
-			window.navigator.language,
+			Language.value(),
 		);
 		await local.start({ cacheDir, model, language });
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationLanguage.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationLanguage.ts
@@ -52,12 +52,12 @@ const NEMOTRON_DEFAULT_LOCALE_BY_LANGUAGE: Readonly<Record<string, string>> = {
 
 /**
  * Resolve the on-device dictation language using the same setting semantics as
- * Voice Mode. Automatic follows the browser locale when Nemotron supports it,
- * then falls back to the model's language detection.
+ * Voice Mode. Automatic follows the VS Code display language when Nemotron
+ * supports it, then falls back to the model's language detection.
  */
-export function resolveDictationLanguage(configuredLanguage: unknown, browserLanguage: string | undefined): string {
+export function resolveDictationLanguage(configuredLanguage: unknown, displayLanguage: string | undefined): string {
 	const configured = typeof configuredLanguage === 'string' ? configuredLanguage.trim() : '';
-	const candidate = configured && configured.toLowerCase() !== 'auto' ? configured : browserLanguage;
+	const candidate = configured && configured.toLowerCase() !== 'auto' ? configured : displayLanguage;
 	if (!candidate || typeof Intl.getCanonicalLocales !== 'function') {
 		return 'auto';
 	}

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationLanguage.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationLanguage.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Language } from '../../../../../base/common/platform.js';
+
 const NEMOTRON_LOCALES = new Set([
 	'ar-AR', 'bg-BG', 'cs-CZ', 'da-DK', 'de-DE', 'en-GB', 'en-US', 'es-ES',
 	'es-US', 'et-EE', 'fi-FI', 'fr-CA', 'fr-FR', 'el-GR', 'he-IL', 'hi-IN',
@@ -50,16 +52,29 @@ const NEMOTRON_DEFAULT_LOCALE_BY_LANGUAGE: Readonly<Record<string, string>> = {
 	zh: 'zh-CN',
 };
 
+function getConfiguredDisplayLanguage(): string | undefined {
+	return Language.isDefaultVariant() ? undefined : Language.value();
+}
+
 /**
  * Resolve the on-device dictation language using the same setting semantics as
- * Voice Mode. Automatic follows the browser locale when Nemotron supports it,
- * then falls back to the model's language detection.
+ * Voice Mode. Automatic follows the configured display language when available,
+ * then the system or browser locale, then the model's language detection.
  */
-export function resolveDictationLanguage(configuredLanguage: unknown, browserLanguage: string | undefined): string {
+export function resolveDictationLanguage(configuredLanguage: unknown, browserLanguage: string | undefined, displayLanguage = getConfiguredDisplayLanguage()): string {
 	const configured = typeof configuredLanguage === 'string' ? configuredLanguage.trim() : '';
-	const candidate = configured && configured.toLowerCase() !== 'auto' ? configured : browserLanguage;
+	if (configured && configured.toLowerCase() !== 'auto') {
+		return resolveSupportedDictationLanguage(configured) ?? 'auto';
+	}
+
+	return resolveSupportedDictationLanguage(displayLanguage)
+		?? resolveSupportedDictationLanguage(browserLanguage)
+		?? 'auto';
+}
+
+function resolveSupportedDictationLanguage(candidate: string | undefined): string | undefined {
 	if (!candidate || typeof Intl.getCanonicalLocales !== 'function') {
-		return 'auto';
+		return undefined;
 	}
 
 	try {
@@ -67,8 +82,8 @@ export function resolveDictationLanguage(configuredLanguage: unknown, browserLan
 		if (NEMOTRON_LOCALES.has(canonical)) {
 			return canonical;
 		}
-		return NEMOTRON_DEFAULT_LOCALE_BY_LANGUAGE[canonical.split('-')[0]] ?? 'auto';
+		return NEMOTRON_DEFAULT_LOCALE_BY_LANGUAGE[canonical.split('-')[0]];
 	} catch {
-		return 'auto';
+		return undefined;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -7,6 +7,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { mainWindow } from '../../../../../base/browser/window.js';
+import { Language } from '../../../../../base/common/platform.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -57,6 +58,26 @@ function asOptionalString(value: unknown): string | undefined {
 function asOptionalNonEmptyString(value: unknown): string | undefined {
 	const result = asOptionalString(value);
 	return result && result.length > 0 ? result : undefined;
+}
+
+function canonicalizeSupportedLanguage(value: string | undefined, supportedBases: ReadonlySet<string>): string | undefined {
+	const candidate = value?.trim();
+	if (!candidate || typeof Intl.getCanonicalLocales !== 'function') {
+		return undefined;
+	}
+
+	try {
+		const canonical = Intl.getCanonicalLocales(candidate)[0];
+		return supportedBases.has(canonical.split('-')[0]) ? canonical : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function resolveAutomaticVoiceLanguage(browserLanguage: string | undefined, displayLanguage: string | undefined): string {
+	return canonicalizeSupportedLanguage(displayLanguage, ASR_SUPPORTED_LANGUAGE_BASES)
+		?? canonicalizeSupportedLanguage(browserLanguage, ASR_SUPPORTED_LANGUAGE_BASES)
+		?? DEFAULT_LANGUAGE;
 }
 
 function asTranscriptionStatus(value: unknown): IVoiceTranscription['status'] | undefined {
@@ -201,7 +222,7 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	private _getLanguage(): string {
 		const configured = this._configurationService.getValue<string>('agents.voice.language');
 		if (typeof configured === 'string' && configured.trim().toLowerCase() !== 'auto') {
-			const language = this._canonicalizeSupportedLanguage(configured, TTS_SUPPORTED_LANGUAGE_BASES);
+			const language = canonicalizeSupportedLanguage(configured, TTS_SUPPORTED_LANGUAGE_BASES);
 			if (language) {
 				return language;
 			}
@@ -209,22 +230,8 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 			return DEFAULT_LANGUAGE;
 		}
 
-		return this._canonicalizeSupportedLanguage(this._window?.navigator.language, ASR_SUPPORTED_LANGUAGE_BASES)
-			?? DEFAULT_LANGUAGE;
-	}
-
-	private _canonicalizeSupportedLanguage(value: string | undefined, supportedBases: ReadonlySet<string>): string | undefined {
-		const candidate = value?.trim();
-		if (!candidate || typeof Intl.getCanonicalLocales !== 'function') {
-			return undefined;
-		}
-
-		try {
-			const canonical = Intl.getCanonicalLocales(candidate)[0];
-			return supportedBases.has(canonical.split('-')[0]) ? canonical : undefined;
-		} catch {
-			return undefined;
-		}
+		const displayLanguage = Language.isDefaultVariant() ? undefined : Language.value();
+		return resolveAutomaticVoiceLanguage(this._window?.navigator.language, displayLanguage);
 	}
 
 	private _sendSetLanguage(): void {

--- a/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
@@ -12,10 +12,10 @@ suite('ChatSpeechToTextService', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('resolves the dictation language from Voice Mode configuration and browser locale', () => {
+	test('resolves the dictation language from Voice Mode configuration and VS Code display language', () => {
 		assert.deepStrictEqual({
-			explicit: resolveDictationLanguage('fr-FR', 'de-DE'),
-			automatic: resolveDictationLanguage('auto', 'uk-UA'),
+			explicitOverridesDisplayLanguage: resolveDictationLanguage('fr-FR', 'de-DE'),
+			automaticUsesDisplayLanguage: resolveDictationLanguage('auto', 'de-DE'),
 			regionalAutomatic: resolveDictationLanguage('auto', 'pt-BR'),
 			additionalSupportedAutomatic: resolveDictationLanguage('auto', 'he-IL'),
 			unsupportedRegion: resolveDictationLanguage('auto', 'en-AU'),
@@ -25,8 +25,8 @@ suite('ChatSpeechToTextService', () => {
 			invalidExplicit: resolveDictationLanguage('not a locale', 'de-DE'),
 			missing: resolveDictationLanguage(undefined, undefined),
 		}, {
-			explicit: 'fr-FR',
-			automatic: 'uk-UA',
+			explicitOverridesDisplayLanguage: 'fr-FR',
+			automaticUsesDisplayLanguage: 'de-DE',
 			regionalAutomatic: 'pt-BR',
 			additionalSupportedAutomatic: 'he-IL',
 			unsupportedRegion: 'en-US',

--- a/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
@@ -12,9 +12,12 @@ suite('ChatSpeechToTextService', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('resolves the dictation language from Voice Mode configuration and browser locale', () => {
+	test('resolves the dictation language from Voice Mode configuration, display language, and browser locale', () => {
 		assert.deepStrictEqual({
 			explicit: resolveDictationLanguage('fr-FR', 'de-DE'),
+			explicitWithDisplayLanguage: resolveDictationLanguage('fr-FR', 'de-DE', 'ja'),
+			displayLanguage: resolveDictationLanguage('auto', 'en-US', 'de'),
+			unsupportedDisplayLanguage: resolveDictationLanguage('auto', 'pt-BR', 'id-ID'),
 			automatic: resolveDictationLanguage('auto', 'uk-UA'),
 			regionalAutomatic: resolveDictationLanguage('auto', 'pt-BR'),
 			additionalSupportedAutomatic: resolveDictationLanguage('auto', 'he-IL'),
@@ -26,6 +29,9 @@ suite('ChatSpeechToTextService', () => {
 			missing: resolveDictationLanguage(undefined, undefined),
 		}, {
 			explicit: 'fr-FR',
+			explicitWithDisplayLanguage: 'fr-FR',
+			displayLanguage: 'de-DE',
+			unsupportedDisplayLanguage: 'pt-BR',
 			automatic: 'uk-UA',
 			regionalAutomatic: 'pt-BR',
 			additionalSupportedAutomatic: 'he-IL',

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
@@ -11,7 +11,7 @@ import { TestConfigurationService } from '../../../../../../platform/configurati
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import product from '../../../../../../platform/product/common/product.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
-import { VoiceClientService } from '../../../browser/voiceClient/voiceClientService.js';
+import { resolveAutomaticVoiceLanguage, VoiceClientService } from '../../../browser/voiceClient/voiceClientService.js';
 import { IVoiceAudioResponse, IVoiceBargeIn, IVoiceNarrationAck, IVoiceNarrationSignal, IVoiceSpeechStarted, IVoiceTranscription } from '../../../common/voiceClient/voiceClientService.js';
 
 class TestWebSocket {
@@ -574,6 +574,20 @@ suite('VoiceClientService', () => {
 		assert.deepStrictEqual({ browserLocale, fallbackLocale }, {
 			browserLocale: { sessions: [], display_locale: 'pt-BR' },
 			fallbackLocale: { sessions: [], display_locale: 'en-US' },
+		});
+	});
+
+	test('resolves automatic language from display language before browser locale', () => {
+		assert.deepStrictEqual({
+			displayLanguage: resolveAutomaticVoiceLanguage('en-US', 'de'),
+			browserLocale: resolveAutomaticVoiceLanguage('pt-BR', undefined),
+			unsupportedDisplayLanguage: resolveAutomaticVoiceLanguage('pt-BR', 'he-IL'),
+			missing: resolveAutomaticVoiceLanguage(undefined, undefined),
+		}, {
+			displayLanguage: 'de',
+			browserLocale: 'pt-BR',
+			unsupportedDisplayLanguage: 'pt-BR',
+			missing: 'en-US',
 		});
 	});
 


### PR DESCRIPTION
Fixes #328854

Automatic voice and dictation language selection now follows VS Code's configured display language instead of relying only on the browser or system locale.

- Prefer the configured display language for automatic Dictation language resolution, including English, with browser/system locale and model detection fallback for unsupported languages.
- Apply the same display-language-first behavior to Voice Mode automatic language selection.
- Preserve explicit `agents.voice.language` precedence.
- Update the Voice Mode and Nemotron Dictation setting descriptions to document the precedence.
- Add focused coverage for display-language, browser-locale fallback, explicit English, and explicit setting selection.

Includes the changes from #329018.
