### PR TITLE
Stop dictation when submitting chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -441,6 +441,13 @@ export async function stopDictation(): Promise<void> {
 	}
 }
 
+/** Stop dictation only when it is targeting `editor`. */
+export async function stopDictationForEditor(editor: ICodeEditor): Promise<void> {
+	if (_active?.editor === editor) {
+		await stopDictation();
+	}
+}
+
 /** Abort the active dictation, discarding whatever was recorded. */
 export function cancelDictation(): void {
 	const active = _active;

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationSession.ts
@@ -295,6 +295,14 @@ interface IActiveDictation {
  */
 let _active: IActiveDictation | undefined;
 
+/**
+ * The in-flight {@link stopDictation} finalization, if any. `stopDictation`
+ * clears {@link _active} before awaiting the final transcript, so this lets a
+ * concurrent stop/submit for the same editor await that same finalization (and
+ * the final transcript it inserts) instead of racing ahead with interim text.
+ */
+let _finalizing: { readonly editor: ICodeEditor; readonly promise: Promise<void> } | undefined;
+
 /** True while a dictation is in progress. */
 export function isDictating(): boolean {
 	return !!_active;
@@ -409,9 +417,25 @@ export async function startDictation(service: IChatSpeechToTextService, editor: 
 export async function stopDictation(): Promise<void> {
 	const active = _active;
 	if (!active) {
+		// A finalization started by an earlier stop may still be running for the
+		// same editor (it cleared `_active` before awaiting the transcript); wait
+		// for it so callers observe the final transcript rather than returning early.
+		await _finalizing?.promise;
 		return;
 	}
 	_active = undefined;
+	const promise = finalizeDictation(active);
+	_finalizing = { editor: active.editor, promise };
+	try {
+		await promise;
+	} finally {
+		if (_finalizing?.promise === promise) {
+			_finalizing = undefined;
+		}
+	}
+}
+
+async function finalizeDictation(active: IActiveDictation): Promise<void> {
 	active.logService.trace(`${LOG_PREFIX} stopDictation begin, state=${active.service.state}`);
 	// Drop the interim styling and lock out interim updates right away so a
 	// trailing interim transcript emitted while transcription finalizes cannot
@@ -445,6 +469,11 @@ export async function stopDictation(): Promise<void> {
 export async function stopDictationForEditor(editor: ICodeEditor): Promise<void> {
 	if (_active?.editor === editor) {
 		await stopDictation();
+	} else if (_finalizing?.editor === editor) {
+		// A stop for this editor is already finalizing (it cleared `_active` before
+		// awaiting the transcript); await that finalization so a second submit does
+		// not send interim text ahead of the final transcript being inserted.
+		await _finalizing.promise;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -93,6 +93,7 @@ import { CHAT_READ_ONLY_BANNER_HEIGHT, ChatReadOnlyBanner } from './chatReadOnly
 import { IChatSubmitRequestHandlerService } from '../chatSubmitRequestHandlerService.js';
 import { ChatPetWidget, isChatPetVisible } from './chatPetWidget.js';
 import { IChatPetService } from '../chatPetService.js';
+import { stopDictationForEditor } from '../speechToText/dictationSession.js';
 
 const $ = dom.$;
 
@@ -2601,6 +2602,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (this._readOnly || this.input.hasPendingProgrammaticModelSelection) {
 			return undefined;
 		}
+
+		await stopDictationForEditor(this.inputEditor);
 
 		if (this.viewModel) {
 			markChat(this.viewModel.sessionResource, ChatPerfMark.RequestStart);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2603,7 +2603,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return undefined;
 		}
 
-		await stopDictationForEditor(this.inputEditor);
+		if (!options?.preserveInput) {
+			// preserveInput submissions (e.g. /compact or programmatic maintenance
+			// requests) leave the input draft untouched, so they must not stop an
+			// unrelated dictation and flush its final transcript into that draft.
+			await stopDictationForEditor(this.inputEditor);
+		}
 
 		if (this.viewModel) {
 			markChat(this.viewModel.sessionResource, ChatPerfMark.RequestStart);

--- a/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../base/browser/window.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Position } from '../../../../../editor/common/core/position.js';
@@ -25,11 +26,12 @@ suite('DictationSession', () => {
 	 * the test drive interim updates through the returned emitter. `setTranscript`
 	 * updates what a subsequent `stopAndTranscribe` resolves with.
 	 */
-	function createService(transcript: string, showTranscriptWhileDictating: boolean): { service: IChatSpeechToTextService; onDidUpdateTranscript: Emitter<IChatDictationTranscript>; setTranscript(text: string): void } {
+	function createService(transcript: string, showTranscriptWhileDictating: boolean): { service: IChatSpeechToTextService; onDidUpdateTranscript: Emitter<IChatDictationTranscript>; setTranscript(text: string): void; blockStop(): () => void } {
 		const onDidUpdateTranscript = store.add(new Emitter<IChatDictationTranscript>());
 		const onDidChangeState = store.add(new Emitter<ChatSpeechToTextState>());
 		let state = ChatSpeechToTextState.Idle;
 		let finalTranscript = transcript;
+		let stopBarrier: Promise<void> | undefined;
 		const service: IChatSpeechToTextService = {
 			_serviceBrand: undefined,
 			onDidUpdateTranscript: onDidUpdateTranscript.event,
@@ -51,6 +53,8 @@ suite('DictationSession', () => {
 				onDidChangeState.fire(state);
 			},
 			async stopAndTranscribe() {
+				// Lets a test hold the finalization open to exercise concurrent stops.
+				await stopBarrier;
 				state = ChatSpeechToTextState.Idle;
 				onDidChangeState.fire(state);
 				return finalTranscript;
@@ -58,7 +62,16 @@ suite('DictationSession', () => {
 			cancel() { },
 			logDictationAccuracy() { },
 		};
-		return { service, onDidUpdateTranscript, setTranscript: text => { finalTranscript = text; } };
+		return {
+			service,
+			onDidUpdateTranscript,
+			setTranscript: text => { finalTranscript = text; },
+			blockStop: () => {
+				const deferred = new DeferredPromise<void>();
+				stopBarrier = deferred.p;
+				return () => deferred.complete();
+			},
+		};
 	}
 
 	/** Ranges rendered as still being processed, as `[startLine,startColumn -> endLine,endColumn]`. */
@@ -113,6 +126,38 @@ suite('DictationSession', () => {
 		}, {
 			afterOtherEditor: true,
 			afterDictationEditor: false,
+			value: 'hello world',
+		});
+	});
+
+	test('a second submit during finalization waits for the final transcript', async () => {
+		const { service, onDidUpdateTranscript, blockStop } = createService('hello world', true);
+		const model = store.add(createTextModel(''));
+		const editor = store.add(createTestCodeEditor(model));
+
+		await startDictation(service, editor, mainWindow, new NullLogService());
+		onDidUpdateTranscript.fire({ text: 'hello world', finalizedText: '' });
+
+		// The first submit begins finalizing but blocks inside stopAndTranscribe.
+		const release = blockStop();
+		const firstStop = stopDictationForEditor(editor);
+		// A second submit for the same editor arrives mid-finalization; it must
+		// await the in-flight finalization rather than returning early.
+		let secondResolved = false;
+		const secondStop = stopDictationForEditor(editor).then(() => { secondResolved = true; });
+		await timeout(0);
+		const secondResolvedWhileBlocked = secondResolved;
+
+		release();
+		await Promise.all([firstStop, secondStop]);
+
+		assert.deepStrictEqual({
+			secondResolvedWhileBlocked,
+			secondResolvedAfterFinal: secondResolved,
+			value: editor.getValue(),
+		}, {
+			secondResolvedWhileBlocked: false,
+			secondResolvedAfterFinal: true,
 			value: 'hello world',
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/dictationSession.test.ts
@@ -14,7 +14,7 @@ import { createTestCodeEditor } from '../../../../../editor/test/browser/testCod
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { ChatSpeechToTextState, IChatDictationTranscript, IChatSpeechToTextService } from '../../browser/speechToText/chatSpeechToTextService.js';
-import { startDictation, stopDictation } from '../../browser/speechToText/dictationSession.js';
+import { isDictating, startDictation, stopDictation, stopDictationForEditor } from '../../browser/speechToText/dictationSession.js';
 
 suite('DictationSession', () => {
 
@@ -94,6 +94,27 @@ suite('DictationSession', () => {
 		await stopDictation();
 
 		assert.deepStrictEqual([interimValue, editor.getValue()], ['', transcript]);
+	});
+
+	test('stops only when the submitted editor owns dictation', async () => {
+		const { service } = createService('hello world', true);
+		const dictationEditor = store.add(createTestCodeEditor(store.add(createTextModel(''))));
+		const otherEditor = store.add(createTestCodeEditor(store.add(createTextModel(''))));
+
+		await startDictation(service, dictationEditor, mainWindow, new NullLogService());
+		await stopDictationForEditor(otherEditor);
+		const afterOtherEditor = isDictating();
+		await stopDictationForEditor(dictationEditor);
+
+		assert.deepStrictEqual({
+			afterOtherEditor,
+			afterDictationEditor: isDictating(),
+			value: dictationEditor.getValue(),
+		}, {
+			afterOtherEditor: true,
+			afterDictationEditor: false,
+			value: 'hello world',
+		});
 	});
 
 	test('renders the whole in-progress transcript as still processing', async () => {


### PR DESCRIPTION
Fixes #328897

When a chat input is submitted while Dictation is active in that input, finalize Dictation before accepting the request. This ensures the final transcript is included in the message and leaves Dictation stopped after send.

The behavior is scoped to the owning editor, so submitting another chat input does not interrupt Dictation elsewhere. Includes regression coverage for ownership scoping and final transcript insertion.