### PR TITLE
RFC/POC show only exported symbols in outline

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts
@@ -109,8 +109,15 @@ class TypeScriptDocumentSymbolProvider implements vscode.DocumentSymbolProvider 
 
 
 		const kindModifiers = parseKindModifier(item.kindModifiers);
+		const tags = [];
 		if (kindModifiers.has(PConst.KindModifiers.deprecated)) {
-			symbolInfo.tags = [vscode.SymbolTag.Deprecated];
+			tags.push(vscode.SymbolTag.Deprecated);
+		}
+		if (kindModifiers.has(PConst.KindModifiers.exported)) {
+			tags.push(vscode.SymbolTag.Exported);
+		}
+		if (tags.length) {
+			symbolInfo.tags = tags;
 		}
 
 		return symbolInfo;

--- a/extensions/typescript-language-features/src/tsServer/protocol/protocol.const.ts
+++ b/extensions/typescript-language-features/src/tsServer/protocol/protocol.const.ts
@@ -46,6 +46,7 @@ export class DiagnosticCategory {
 export class KindModifiers {
 	public static readonly optional = 'optional';
 	public static readonly deprecated = 'deprecated';
+	public static readonly exported = 'export';
 	public static readonly color = 'color';
 
 	public static readonly dtsFile = '.d.ts';

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1662,6 +1662,7 @@ export function getAriaLabelForSymbol(symbolName: string, kind: SymbolKind): str
 
 export const enum SymbolTag {
 	Deprecated = 1,
+	Exported = 2
 }
 
 /**

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -912,7 +912,8 @@ export enum SymbolKind {
 }
 
 export enum SymbolTag {
-	Deprecated = 1
+	Deprecated = 1,
+	Exported = 2
 }
 
 /**

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -815,12 +815,14 @@ export namespace SymbolTag {
 	export function from(kind: types.SymbolTag): languages.SymbolTag {
 		switch (kind) {
 			case types.SymbolTag.Deprecated: return languages.SymbolTag.Deprecated;
+			case types.SymbolTag.Exported: return languages.SymbolTag.Exported;
 		}
 	}
 
 	export function to(kind: languages.SymbolTag): types.SymbolTag {
 		switch (kind) {
 			case languages.SymbolTag.Deprecated: return types.SymbolTag.Deprecated;
+			case languages.SymbolTag.Exported: return types.SymbolTag.Exported;
 		}
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypes/symbolInformation.ts
+++ b/src/vs/workbench/api/common/extHostTypes/symbolInformation.ts
@@ -38,7 +38,8 @@ export enum SymbolKind {
 }
 
 export enum SymbolTag {
-	Deprecated = 1
+	Deprecated = 1,
+	Exported = 2
 }
 
 @es5ClassCompat

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -227,6 +227,9 @@ export class DocumentSymbolRenderer implements ITreeRenderer<OutlineElement, Fuz
 			extraClasses.push(`deprecated`);
 			options.matches = [];
 		}
+		if (element.symbol.tags.indexOf(SymbolTag.Exported) >= 0) {
+			extraClasses.push(`exported`);
+		}
 		template.iconLabel.setLabel(element.symbol.name, element.symbol.detail, options);
 
 		if (this._renderMarker) {
@@ -328,7 +331,12 @@ export class DocumentSymbolFilter implements ITreeFilter<DocumentSymbolItem> {
 		}
 		const configName = DocumentSymbolFilter.kindToConfigName[element.symbol.kind];
 		const configKey = `${this._prefix}.${configName}`;
-		return this._textResourceConfigService.getValue(outline?.uri, configKey);
+
+		const exportedConfigKey = `${this._prefix}.hideLocalSymbols`;
+		const symbolExported = element.symbol.tags?.includes(SymbolTag.Exported);
+		const hideAsLocal = !symbolExported && this._textResourceConfigService.getValue(outline?.uri, exportedConfigKey);
+
+		return !hideAsLocal && this._textResourceConfigService.getValue(outline?.uri, configKey);
 	}
 }
 

--- a/src/vs/workbench/contrib/outline/browser/outline.contribution.ts
+++ b/src/vs/workbench/contrib/outline/browser/outline.contribution.ts
@@ -234,6 +234,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
 			markdownDescription: localize('filteredTypes.typeParameter', "When enabled, Outline shows `typeParameter`-symbols.")
+		},
+		'outline.hideLocalSymbols': {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			markdownDescription: localize('outline.hideLocal', "When enabled, Outline shows only exported symbols.")
 		}
 	}
 });

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -3518,7 +3518,12 @@ declare module 'vscode' {
 		/**
 		 * Render a symbol as obsolete, usually using a strike-out.
 		 */
-		Deprecated = 1
+		Deprecated = 1,
+
+		/**
+		 * Render a symbol as exported from the given file
+		 */
+		Exported = 2,
 	}
 
 	/**


### PR DESCRIPTION
This is a proof of concept and a request for comments towards addressing issue #322907

This PR introduces a new setting, "Outline: Hide Local Symbols", which, if enabled, makes the Outline view only show symbols with the "export" tag.

I'd like feedback - is this roughly how this feature should be handled? Does it cover the use cases that people want? FWIW, it does exactly what I want. It could be doable with an extension, but it feels like such a natural extension to the built-in Outline view.

## Limitations

This is a proof of concept that works only for typescript, and only for directly exported symbols. I made it to see if the information is already available (it is, partially), and if it's easy to propagate it (it seems to be).

Also, there is no styling for exported symbols in the outline, but that could be added with the new information being available to it.

```typescript
// current limitation: foo will be visible in overview, bar won't be visible if we tick Hide Local Symbols
export const foo = 42;
const bar = 3.14; 
export { bar }
```

## Screenshots:

Default behaviour, showing all symbols:

<img width="1521" height="1034" alt="Screenshot 2026-08-04 at 19 53 00" src="https://github.com/user-attachments/assets/e03233bc-adf4-4d86-a8f1-37aa0237ce1b" />

New behaviour, showing only exported symbols:

<img width="1521" height="1034" alt="Screenshot 2026-08-04 at 19 52 46" src="https://github.com/user-attachments/assets/53e7c63c-e89e-481a-a056-aba604a61f7b" />

Btw, I was surprised by how much the `SymbolTag` type is duplicated.
