### PR TITLE
Chat: make editor send button circular

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1291,12 +1291,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: var(--vscode-spacing-size40);
 }
 
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button {
+.action-item.chat-submit-button {
 	position: relative;
 	border-radius: var(--vscode-cornerRadius-circle);
 }
 
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label {
+.action-item.menu-entry.chat-submit-button > .action-label.codicon[class*='codicon-'] {
 	box-sizing: border-box;
 	width: 22px;
 	height: 22px;
@@ -1309,37 +1309,37 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Nudge icon position to ensure it looks optically aligned within the button */
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label.codicon-arrow-up-compact::before {
+.action-item.chat-submit-button > .action-label.codicon-arrow-up-compact::before {
 	display: inline-block;
 	transform: translateY(0.5px);
 }
 
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label.codicon-plus::before {
+.action-item.chat-submit-button > .action-label.codicon-plus::before {
 	transform: translateX(0.5px);
 }
 
 /* Focus indicator drawn on the action-item wrapper so it sits cleanly around
 	the button surface with a small offset. */
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button:not(.disabled):has(> .action-label:focus-visible) {
+.action-item.chat-submit-button:not(.disabled):has(> .action-label:focus-visible) {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 1px;
 	border-radius: var(--vscode-cornerRadius-circle);
 }
 
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label:focus,
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label:focus-visible {
+.action-item.chat-submit-button > .action-label:focus,
+.action-item.chat-submit-button > .action-label:focus-visible {
 	outline: none;
 }
 
 /* Idle: solid primary button background. */
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button:not(.disabled) > .action-label {
+.action-item.chat-submit-button:not(.disabled) > .action-label {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground) !important;
 	transition: background-color 120ms ease;
 }
 
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button:not(.disabled) > .action-label:hover,
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button:not(.disabled) > .action-label:focus-visible {
+.action-item.chat-submit-button:not(.disabled) > .action-label:hover,
+.action-item.chat-submit-button:not(.disabled) > .action-label:focus-visible {
 	background: var(--vscode-button-hoverBackground);
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1336,11 +1336,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground) !important;
 	transition: background-color 120ms ease;
-}
 
-.monaco-workbench .action-item.menu-entry.chat-submit-button:not(.disabled) > .action-label.codicon[class*='codicon-']:hover,
-.monaco-workbench .action-item.menu-entry.chat-submit-button:not(.disabled) > .action-label.codicon[class*='codicon-']:focus-visible {
-	background: var(--vscode-button-hoverBackground);
+	&:is(:hover, :focus-visible) {
+		background: var(--vscode-button-hoverBackground);
+	}
 }
 
 .interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1332,7 +1332,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Idle: solid primary button background. */
-.action-item.chat-submit-button:not(.disabled) > .action-label {
+.monaco-workbench .action-item.menu-entry.chat-submit-button:not(.disabled) > .action-label.codicon[class*='codicon-'] {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground) !important;
 	transition: background-color 120ms ease;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1338,8 +1338,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	transition: background-color 120ms ease;
 }
 
-.action-item.chat-submit-button:not(.disabled) > .action-label:hover,
-.action-item.chat-submit-button:not(.disabled) > .action-label:focus-visible {
+.monaco-workbench .action-item.menu-entry.chat-submit-button:not(.disabled) > .action-label.codicon[class*='codicon-']:hover,
+.monaco-workbench .action-item.menu-entry.chat-submit-button:not(.disabled) > .action-label.codicon[class*='codicon-']:focus-visible {
 	background: var(--vscode-button-hoverBackground);
 }
 


### PR DESCRIPTION
## Summary

- make the shared Chat send button circular in editor-hosted Chat, matching the Agents window
- preserve the primary button foreground for the enabled send icon across Chat hosts

## Testing

- verified the enabled editor Chat send button is 22×22 with a circular radius
- verified the enabled icon uses the primary button foreground (white) on the primary button background
- `npm run transpile-client`
- hygiene checks