### PR TITLE
Require confirmation for git show --output in terminal auto-approval

### DIFF
--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -11,6 +11,7 @@ import { escapeRegExpCharacters, regExpLeadsToEndlessLoop } from '../../../base/
 import { URI } from '../../../base/common/uri.js';
 import { getAppNodeModulesPath } from './appNodeModules.js';
 import { ILogService } from '../../log/common/log.js';
+import { gitAutoApproveRules } from '../../terminal/common/autoApprove/gitAutoApproveRules.js';
 import { SedFileWriteParser } from '../../terminal/common/autoApprove/sedFileWriteParser.js';
 import type { AgentHostTerminalAutoApproveRuleValue, AgentHostTerminalAutoApproveRules } from '../common/agentHostSchema.js';
 
@@ -599,15 +600,7 @@ const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerm
 	grep: true,
 
 	// Safe git sub-commands
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+status\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b.*\\s--output(=|\\s|$)/': false,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+show\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+diff\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+ls-files\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+grep\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b/': true,
-	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b.*\\s-(d|D|m|M|-delete|-force)\\b/': false,
+	...gitAutoApproveRules,
 
 	// Docker readonly sub-commands
 	'/^docker\\s+(ps|images|info|version|inspect|logs|top|stats|port|diff|search|events)\\b/': true,

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -57,19 +57,52 @@ suite('CommandAutoApprover', () => {
 
 		// Safe git sub-commands
 		test('approves allowed git sub-commands', () => {
-			assert.strictEqual(approver.shouldAutoApprove('git status'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('git log --oneline'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('git diff HEAD'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('git show HEAD'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('git ls-files'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('git branch'), 'approved');
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('git status'),
+				approver.shouldAutoApprove('git log --oneline'),
+				approver.shouldAutoApprove('git diff HEAD'),
+				approver.shouldAutoApprove('git show HEAD'),
+				approver.shouldAutoApprove('git show --format=%B HEAD'),
+				approver.shouldAutoApprove('git --no-pager show HEAD'),
+				approver.shouldAutoApprove('git -C repo show HEAD'),
+				approver.shouldAutoApprove('git show --output-format=text HEAD'),
+				approver.shouldAutoApprove('git ls-files'),
+				approver.shouldAutoApprove('git branch'),
+			], [
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+				'approved',
+			]);
 		});
 
 		// Unsafe git sub-commands
 		test('denies denied git operations', () => {
-			assert.strictEqual(approver.shouldAutoApprove('git branch -D main'), 'denied');
-			assert.strictEqual(approver.shouldAutoApprove('git branch --delete main'), 'denied');
-			assert.strictEqual(approver.shouldAutoApprove('git log --output=/tmp/out'), 'denied');
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('git branch -D main'),
+				approver.shouldAutoApprove('git branch --delete main'),
+				approver.shouldAutoApprove('git log --output=/tmp/out'),
+				approver.shouldAutoApprove('git show --output=message.txt HEAD'),
+				approver.shouldAutoApprove('git show --output message.txt HEAD'),
+				approver.shouldAutoApprove('git show --format=%B --output=message.txt HEAD'),
+				approver.shouldAutoApprove('git --no-pager show --output=message.txt HEAD'),
+				approver.shouldAutoApprove('git -C repo show --output message.txt HEAD'),
+			], [
+				'denied',
+				'denied',
+				'denied',
+				'denied',
+				'denied',
+				'denied',
+				'denied',
+				'denied',
+			]);
 		});
 
 		// Safe commands with dangerous arg blocking

--- a/src/vs/platform/terminal/common/autoApprove/gitAutoApproveRules.ts
+++ b/src/vs/platform/terminal/common/autoApprove/gitAutoApproveRules.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Default auto-approval rules for safe Git subcommands.
+ *
+ * These patterns support `-C <path>` and `--no-pager` immediately after `git`.
+ */
+export const gitAutoApproveRules: Readonly<Record<string, boolean>> = {
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+status\\b/': true,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b/': true,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b.*\\s--output(=|\\s|$)/': false,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+show\\b/': true,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+show\\b.*\\s--output(=|\\s|$)/': false,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+diff\\b/': true,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+ls-files\\b/': true,
+
+	// git grep
+	// - `--open-files-in-pager`: This is the configured pager, so no risk of code execution
+	// - See notes on `grep` in the terminal auto-approval configuration.
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+grep\\b/': true,
+
+	// git branch
+	// - `-d`, `-D`, `--delete`: Prevent branch deletion
+	// - `-m`, `-M`: Prevent branch renaming
+	// - `--force`: Generally dangerous
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b/': true,
+	'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b.*\\s-(d|D|m|M|-delete|-force)\\b/': false,
+};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -8,6 +8,7 @@ import type { IJSONSchema } from '../../../../../base/common/jsonSchema.js';
 import { localize } from '../../../../../nls.js';
 import { type IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../../platform/sandbox/common/settings.js';
+import { gitAutoApproveRules } from '../../../../../platform/terminal/common/autoApprove/gitAutoApproveRules.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 import { terminalProfileBaseProperties } from '../../../../../platform/terminal/common/terminalPlatformConfiguration.js';
 import { PolicyCategory } from '../../../../../base/common/policy.js';
@@ -216,25 +217,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			//
 			// Safe and common sub-commands
 
-			// Note: These patterns support `-C <path>` and `--no-pager` immediately after `git`
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+status\\b/': true,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b/': true,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+log\\b.*\\s--output(=|\\s|$)/': false,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+show\\b/': true,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+diff\\b/': true,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+ls-files\\b/': true,
-
-			// git grep
-			// - `--open-files-in-pager`: This is the configured pager, so no risk of code execution
-			// - See notes on `grep`
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+grep\\b/': true,
-
-			// git branch
-			// - `-d`, `-D`, `--delete`: Prevent branch deletion
-			// - `-m`, `-M`: Prevent branch renaming
-			// - `--force`: Generally dangerous
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b/': true,
-			'/^git(\\s+(-C\\s+\\S+|--no-pager))*\\s+branch\\b.*\\s-(d|D|m|M|-delete|-force)\\b/': false,
+			...gitAutoApproveRules,
 
 			// docker - readonly sub-commands
 			'/^docker\\s+(ps|images|info|version|inspect|logs|top|stats|port|diff|search|events)\\b/': true,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1161,6 +1161,8 @@ suite('RunInTerminalTool', () => {
 			'git status',
 			'git log --oneline',
 			'git show HEAD',
+			'git show --format=%B HEAD',
+			'git show --output-format=text HEAD',
 			'git diff main',
 			'git grep "TODO"',
 
@@ -1252,6 +1254,10 @@ suite('RunInTerminalTool', () => {
 		const confirmationRequiredTestCases = [
 			// git log file output
 			'git log --output=log.txt',
+
+			// git show file output
+			'git show --format=%B --output=message.txt HEAD',
+			'git show --output message.txt HEAD',
 
 			// Dangerous file operations
 			'rm README.md',


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/329029

- Share the default Git terminal auto-approval rules between workbench and Agent Host.
- Require confirmation when `git show` uses `--output=<path>` or `--output <path>`.
- Keep ordinary `git show`, `--format`, and similarly named options auto-approved.
- Preserve support for `git -C <path>` and `git --no-pager` prefixes.
- Keep all other existing Git auto-approval behavior unchanged.
- Add focused workbench and Agent Host regression coverage.

-----------------------------------------
Inspirations from:

- The `git show --output` rule mirrors the existing [`git log --output` confirmation rule](https://github.com/microsoft/vscode/blob/d510219a2158b679b5288e45ece12d3462270390/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L219-L224).
- The shared rule block preserves the existing [`-C` and `--no-pager` Git rule behavior](https://github.com/microsoft/vscode/blob/d510219a2158b679b5288e45ece12d3462270390/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L219-L237).
- Agent Host parity comes from its existing duplicated [`DEFAULT_TERMINAL_AUTO_APPROVE_RULES` Git block](https://github.com/microsoft/vscode/blob/d510219a2158b679b5288e45ece12d3462270390/src/vs/platform/agentHost/node/commandAutoApprover.ts#L601-L610).
- The regression coverage extends the existing [`git log --output` deny test](https://github.com/microsoft/vscode/blob/d510219a2158b679b5288e45ece12d3462270390/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts#L68-L73).