### PR TITLE
dialogs: show Copilot package versions in About

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -44,6 +44,18 @@ const glob = promisify(globCallback);
 const rcedit = promisify(rceditCallback);
 const root = path.dirname(import.meta.dirname);
 const commit = getVersion(root);
+const packageLock = JSON.parse(fs.readFileSync(path.join(root, 'package-lock.json'), 'utf8')) as {
+	readonly packages?: Readonly<Record<string, { readonly version?: string }>>;
+};
+
+function getLockedPackageVersion(packageName: string): string {
+	const version = packageLock.packages?.[`node_modules/${packageName}`]?.version;
+	if (!version) {
+		throw new Error(`Package ${packageName} is missing a version in package-lock.json.`);
+	}
+
+	return version;
+}
 
 // Build
 const vscodeEntryPoints = [
@@ -327,6 +339,10 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 				json.date = readISODate(out);
 				json.checksums = checksums;
 				json.version = version;
+				json.copilotVersions = {
+					runtime: getLockedPackageVersion('@github/copilot'),
+					sdk: getLockedPackageVersion('@github/copilot-sdk'),
+				};
 				// Stamp agentSdks from the per-platform results file produced
 				// by `build/agent-sdk/produce.ts` (an earlier pipeline step).
 				// Local dev: file absent → empty → not stamped.

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -152,6 +152,11 @@ export interface IProductConfiguration {
 
 	readonly agentSdks?: { readonly [packageId: string]: IAgentSdkProductConfig };
 
+	readonly copilotVersions?: {
+		readonly runtime: string;
+		readonly sdk: string;
+	};
+
 	readonly dictationRuntime?: IDictationRuntimeProductConfig;
 
 	readonly mcpGallery?: {

--- a/src/vs/platform/dialogs/electron-browser/dialog.ts
+++ b/src/vs/platform/dialogs/electron-browser/dialog.ts
@@ -19,8 +19,8 @@ export function createNativeAboutDialogDetails(productService: IProductService, 
 	}
 
 	const getDetails = (useAgo: boolean): string => {
-		return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
-			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
+		return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js, V8 and Copilot are product names that need no translation'] },
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\n@github/copilot: {8}\n@github/copilot-sdk: {9}\nOS: {10}",
 			version,
 			productService.commit || 'Unknown',
 			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',
@@ -29,6 +29,8 @@ export function createNativeAboutDialogDetails(productService: IProductService, 
 			process.versions['chrome'],
 			process.versions['node'],
 			process.versions['v8'],
+			productService.copilotVersions?.runtime || 'Unknown',
+			productService.copilotVersions?.sdk || 'Unknown',
 			`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`
 		);
 	};

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -7,6 +7,15 @@ import { env } from '../../../base/common/process.js';
 import { IProductConfiguration } from '../../../base/common/product.js';
 import { ISandboxConfiguration } from '../../../base/parts/sandbox/common/sandboxTypes.js';
 
+interface IPackageConfiguration {
+	readonly version: string;
+	readonly dependencies?: Readonly<Record<string, string>>;
+}
+
+function getDependencyVersion(packageConfiguration: IPackageConfiguration, packageName: string): string | undefined {
+	return packageConfiguration.dependencies?.[packageName]?.replace(/^[~^]/, '');
+}
+
 /**
  * @deprecated It is preferred that you use `IProductService` if you can. This
  * allows web embedders to override our defaults. But for things like `product.quality`,
@@ -28,6 +37,7 @@ if (typeof vscodeGlobal !== 'undefined' && typeof vscodeGlobal.context !== 'unde
 else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 	// Obtain values from product.json and package.json-data
 	product = globalThis._VSCODE_PRODUCT_JSON as unknown as IProductConfiguration;
+	const packageConfiguration = globalThis._VSCODE_PACKAGE_JSON as unknown as IPackageConfiguration;
 
 	// Running out of sources
 	if (env['VSCODE_DEV']) {
@@ -43,11 +53,17 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 	// want to have it running out of sources so we
 	// read it from package.json only when we need it.
 	if (!product.version) {
-		const pkg = globalThis._VSCODE_PACKAGE_JSON as { version: string };
-
 		Object.assign(product, {
-			version: pkg.version
+			version: packageConfiguration.version
 		});
+	}
+
+	if (!product.copilotVersions) {
+		const runtime = getDependencyVersion(packageConfiguration, '@github/copilot');
+		const sdk = getDependencyVersion(packageConfiguration, '@github/copilot-sdk');
+		if (runtime && sdk) {
+			Object.assign(product, { copilotVersions: { runtime, sdk } });
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- show the bundled `@github/copilot` and `@github/copilot-sdk` versions in the native About dialog
- stamp exact versions from the root lockfile into packaged product metadata
- derive development-build versions from the root dependency pins

## Validation

- `npm run typecheck-client`
- `npm --prefix build run typecheck`
- targeted hygiene check for all changed files

(Written by Copilot)