### PR TITLE
ci: surface actionable guidance when the engineering system check fails

### DIFF
--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -155,9 +155,35 @@ jobs:
           fi
       - name: Prevent Copilot from modifying engineering systems
         if: ${{ steps.allowed.outputs.blocked == 'true' && github.event.pull_request.user.login == 'Copilot' }}
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          echo "Copilot is not allowed to modify .github/workflows, build folder files, or package.json files."
-          echo "If you need to update engineering systems, please do so manually or through authorized means."
+          OFFENDING=$(jq -r '.[] | select(test("^\\.github\\/workflows\\/|^build\\/|package\\.json$"))' "$HOME/files.json")
+
+          {
+            echo "## ❌ Engineering system changes are not allowed in this PR"
+            echo
+            echo "This PR was opened by \`$PR_AUTHOR\`, which is never permitted to modify engineering"
+            echo "systems — regardless of the permissions of anyone who later pushes to the branch."
+            echo
+            echo "### Files that triggered this check"
+            echo
+            echo '```'
+            echo "$OFFENDING"
+            echo '```'
+            echo
+            echo "### How to resolve this"
+            echo
+            echo "**Revert the files listed above.** They are almost always incidental — a stray"
+            echo "\`package.json\` or a regenerated \`build/\` artifact — and the PR passes once they are"
+            echo "restored to their base-branch state."
+            echo
+            echo "If the engineering system change is genuinely required, it cannot ship from this PR."
+            echo "A team member must open their **own** PR containing the change, so that an accountable"
+            echo "human with write access is the author of record."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::$PR_AUTHOR is not allowed to modify .github/workflows/, build/, or package.json. See the job summary for the files involved and how to resolve it."
           exit 1
       - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: get_permissions
@@ -177,6 +203,52 @@ jobs:
           echo "should_run=${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) && github.event.pull_request.user.login != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
       - name: Check for engineering system changes
         if: ${{ steps.allowed.outputs.blocked == 'true' && steps.control.outputs.should_run == 'true' }}
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ROLE: ${{ fromJson(steps.get_permissions.outputs.data).permission }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          echo "Changes to .github/workflows/, build/ folder files, or package.json files aren't allowed in PRs."
+          OFFENDING=$(jq -r '.[] | select(test("^\\.github\\/workflows\\/|^build\\/|package\\.json$"))' "$HOME/files.json")
+
+          {
+            echo "## ❌ Engineering system changes are not allowed in this PR"
+            echo
+            echo "Changes to \`.github/workflows/\`, \`build/\`, or any \`package.json\` may only be made by"
+            echo "someone with \`write\`, \`maintain\`, or \`admin\` access to this repository."
+            echo
+            echo "\`$PR_AUTHOR\` (the PR author) has \`$PR_AUTHOR_ROLE\` access, so this check fails."
+            echo
+            echo "> This is based on the **author of the PR**, not on who pushed the most recent commit."
+            echo "> Having a team member push to this branch will not clear the check."
+            echo
+            echo "### Files that triggered this check"
+            echo
+            echo '```'
+            echo "$OFFENDING"
+            echo '```'
+            echo
+            echo "### How to resolve this"
+            echo
+            echo "**1. If these changes are incidental — revert them.** A stray \`package.json\` edit or a"
+            echo "regenerated \`build/\` artifact is the usual cause. Restore the files above to their"
+            echo "base-branch state and this check passes."
+            echo
+            echo "**2. If the changes are intentional — a team member must open the PR.** Ask a VS Code"
+            echo "team member to re-open this work as their own PR:"
+            echo
+            echo '```bash'
+            echo "gh pr checkout $PR_NUMBER"
+            echo "git checkout -b <your-branch>"
+            echo "git push -u origin <your-branch>"
+            echo "gh pr create --repo $GH_REPO --base $BASE_REF"
+            echo '```'
+            echo
+            echo "This is intentional rather than a workaround: engineering systems control how VS Code"
+            echo "is built, tested, and released, so the person accountable for such a change should be"
+            echo "its author of record. Credit the original author with a \`Co-authored-by:\` trailer."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::Changes to .github/workflows/, build/, or package.json aren't allowed from a PR authored by $PR_AUTHOR ($PR_AUTHOR_ROLE access). See the job summary for the files involved and how to resolve it."
           exit 1


### PR DESCRIPTION
The `Prevent engineering system changes in PRs` check fails with a single line naming the three restricted paths. It does not say **which** files tripped it, **why** the author was rejected, or **what to do next** — so contributors guess.

They guess badly. #327903 (Copilot-authored, tripped by one incidental `build/lib/stylelint/vscode-known-variables.json` edit) burned three commits — *"Remove copilot change to build files"*, *"Manually add back change to stylelint known variables file"*, *"Remove change to stylelint tool once more"* — before being closed and re-opened by hand as #328492.

## Change

On failure, write a job summary that gives:

- **the exact offending files**, filtered from the PR diff with the same pattern the check uses
- **the author and their permission level** (`OssSecurityBot (the PR author) has read access`)
- **an explicit note that the verdict keys off the PR author, not the last pusher** — the single most common misconception about this check, and the reason people waste time pushing "fix" commits that cannot possibly clear it
- **the two real resolutions**: revert the incidental change, or have a team member open the PR themselves, with the exact `gh` commands

Applied to both failure paths (the `Copilot` hard-block and the general permission block), with wording appropriate to each.

## Not a policy change

No conditions were touched. Every exception (`bot_field_exception`, `cherry_pick_exception`, the dependabot carve-out, the `Copilot` block) behaves identically — the same PRs pass and fail as before. This only changes what a failing run *says*.

`$GITHUB_STEP_SUMMARY` is used rather than a PR comment deliberately: this workflow runs with `permissions: {}` and fork PRs get a read-only token, so it cannot comment. The summary renders on the check run’s details page, which is where the "Details" link on the failed check already points.

## Verification

- `actionlint` clean (includes shellcheck on the `run` blocks).
- Summary generation executed against real PR data:
  - #328868 (17 files) → correctly lists only the 14 `.github/workflows/` files, excluding `.github/dependabot.yml` and `.github/actions/**`, which are not engineering-system paths.
  - #327903 (3 files) → correctly isolates the single `build/lib/stylelint/vscode-known-variables.json`, which is precisely the file that PR struggled with.