### PR TITLE
Remove extra top padding in primary sidebar

### DIFF
--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -217,9 +217,9 @@ class PartLayout {
 
 	private static readonly HEADER_HEIGHT = 35;
 	private static readonly TITLE_HEIGHT = 35;
-	// KEEP IN SYNC WITH: styleOverrides/browser/media/padding.css `.style-override .part > .title { height: 32px }`
-	private static readonly TITLE_HEIGHT_STYLE_OVERRIDE = 32;
-	private static readonly Footer_HEIGHT = 35;
+	private static readonly FOOTER_HEIGHT = 35;
+	// KEEP IN SYNC WITH: styleOverrides/browser/media/padding.css
+	private static readonly AREA_HEIGHT_STYLE_OVERRIDE = 32;
 
 	private headerVisible: boolean = false;
 	private footerVisible: boolean = false;
@@ -227,16 +227,12 @@ class PartLayout {
 	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
+		const isStyleOverride = !!this.contentArea?.closest('.style-override');
 
 		// Title Size: Width (Fill), Height (Variable).
-		// When the Modern UI style-override is active the title bar is 32 px
-		// (set in padding.css). Mirror that value here so the content area
-		// calculation stays in sync. Uses the same `.closest('.style-override')`
-		// check as EditorTabsControl.tabHeight.
 		let titleSize: Dimension;
 		if (this.options.hasTitle) {
-			const isStyleOverride = !!this.contentArea?.closest('.style-override');
-			const titleHeight = isStyleOverride ? PartLayout.TITLE_HEIGHT_STYLE_OVERRIDE : PartLayout.TITLE_HEIGHT;
+			const titleHeight = isStyleOverride ? PartLayout.AREA_HEIGHT_STYLE_OVERRIDE : PartLayout.TITLE_HEIGHT;
 			titleSize = new Dimension(width, Math.min(height, titleHeight));
 		} else {
 			titleSize = Dimension.None;
@@ -245,7 +241,8 @@ class PartLayout {
 		// Header Size: Width (Fill), Height (Variable)
 		let headerSize: Dimension;
 		if (this.headerVisible) {
-			headerSize = new Dimension(width, Math.min(height, PartLayout.HEADER_HEIGHT));
+			const headerHeight = isStyleOverride ? PartLayout.AREA_HEIGHT_STYLE_OVERRIDE : PartLayout.HEADER_HEIGHT;
+			headerSize = new Dimension(width, Math.min(height, headerHeight));
 		} else {
 			headerSize = Dimension.None;
 		}
@@ -253,7 +250,8 @@ class PartLayout {
 		// Footer Size: Width (Fill), Height (Variable)
 		let footerSize: Dimension;
 		if (this.footerVisible) {
-			footerSize = new Dimension(width, Math.min(height, PartLayout.Footer_HEIGHT));
+			const footerHeight = isStyleOverride ? PartLayout.AREA_HEIGHT_STYLE_OVERRIDE : PartLayout.FOOTER_HEIGHT;
+			footerSize = new Dimension(width, Math.min(height, footerHeight));
 		} else {
 			footerSize = Dimension.None;
 		}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -276,11 +276,11 @@
 	border-top: none;
 }
 
-/*
- * Re-center the icon within its item. With the rounded box in place the item is
- * given a touch more horizontal padding and the codicon glyph is nudged so it
- * sits centered inside the box, matching the default position.
- */
+/* Center the icon and its rounded box within the compact header/footer chrome. */
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
+	height: 32px;
+}
+
 .style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon,
 .style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
 	padding: 0 4px;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -45,10 +45,14 @@
 	width: auto;
 }
 
-/* Tighten the part title bar gutters: flush-left, small right inset. Reduce height from 35px to 32px.
- * KEEP IN SYNC WITH: part.ts PartLayout.TITLE_HEIGHT_STYLE_OVERRIDE */
-.style-override.monaco-workbench .part > .title {
+/* Tighten part chrome from 35px to 32px.
+ * KEEP IN SYNC WITH: part.ts PartLayout.AREA_HEIGHT_STYLE_OVERRIDE */
+.style-override.monaco-workbench .part > .title,
+.style-override.monaco-workbench .part > .header-or-footer {
 	height: 32px;
+}
+
+.style-override.monaco-workbench .part > .title {
 	padding-left: var(--vscode-spacing-size40, 4px);
 	padding-right: var(--vscode-spacing-size40, 4px);
 }

--- a/src/vs/workbench/test/browser/part.test.ts
+++ b/src/vs/workbench/test/browser/part.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { Part } from '../../browser/part.js';
 import { isEmptyObject } from '../../../base/common/types.js';
 import { TestThemeService } from '../../../platform/theme/test/common/testThemeService.js';
-import { append, $, hide } from '../../../base/browser/dom.js';
+import { append, $, Dimension, hide } from '../../../base/browser/dom.js';
 import { TestLayoutService } from './workbenchTestServices.js';
 import { StorageScope, StorageTarget } from '../../../platform/storage/common/storage.js';
 import { TestStorageService } from '../common/workbenchTestServices.js';
@@ -82,6 +82,18 @@ suite('Workbench parts', () => {
 			contentSpan.innerText = 'Content';
 
 			return contentContainer;
+		}
+
+		testSetHeaderArea(headerContainer: HTMLElement): void {
+			this.setHeaderArea(headerContainer);
+		}
+
+		testSetFooterArea(footerContainer: HTMLElement): void {
+			this.setFooterArea(footerContainer);
+		}
+
+		testLayoutContents(width: number, height: number) {
+			return this.layoutContents(width, height);
 		}
 	}
 
@@ -167,6 +179,32 @@ suite('Workbench parts', () => {
 
 		assert(mainWindow.document.getElementById('myPart.title'));
 		assert(mainWindow.document.getElementById('myPart.content'));
+	});
+
+	test('Part Layout uses compact chrome with style overrides', () => {
+		const part = disposables.add(new MyPart2());
+		part.create(fixture);
+		part.testSetHeaderArea(document.createElement('div'));
+		part.testSetFooterArea(document.createElement('div'));
+
+		const classicLayout = part.testLayoutContents(100, 200);
+		fixture.classList.add('style-override');
+		const styleOverrideLayout = part.testLayoutContents(100, 200);
+
+		assert.deepStrictEqual({ classicLayout, styleOverrideLayout }, {
+			classicLayout: {
+				headerSize: new Dimension(100, 35),
+				titleSize: new Dimension(100, 35),
+				contentSize: new Dimension(100, 95),
+				footerSize: new Dimension(100, 35),
+			},
+			styleOverrideLayout: {
+				headerSize: new Dimension(100, 32),
+				titleSize: new Dimension(100, 32),
+				contentSize: new Dimension(100, 104),
+				footerSize: new Dimension(100, 32),
+			},
+		});
 	});
 
 	test('Part Layout with Content only', function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/329023

Removes extra top padding from primary sidebar.

<img width="380" height="364" alt="ui-diff-20260804-154810" src="https://github.com/user-attachments/assets/540b6f9c-9a0a-4d9b-9c2d-16eff56e09d0" />
