### PR TITLE
Add space between status bar buttons

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -329,7 +329,11 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 		const accessor: IStatusbarEntryAccessor = {
 			update: entry => {
 				lastEntry = entry;
+				const hadBackgroundColor = itemContainer.classList.contains('has-background-color');
 				item.update(this.withEntryOverride(entry, id));
+				if (hadBackgroundColor !== itemContainer.classList.contains('has-background-color')) {
+					this.updateVisibleBackgroundColorNeighbors();
+				}
 			},
 			dispose: () => {
 				const { needsFullRefresh } = this.doAddOrRemoveModelEntry(viewModelEntry, false);
@@ -590,6 +594,38 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 					}));
 				}
 			}
+		}
+
+		this.updateVisibleBackgroundColorNeighbors();
+	}
+
+	private updateVisibleBackgroundColorNeighbors(): void {
+		this.doUpdateVisibleBackgroundColorNeighbors(this.viewModel.getEntries(StatusbarAlignment.LEFT), StatusbarAlignment.LEFT);
+		this.doUpdateVisibleBackgroundColorNeighbors(this.viewModel.getEntries(StatusbarAlignment.RIGHT).reverse(), StatusbarAlignment.RIGHT);
+	}
+
+	private doUpdateVisibleBackgroundColorNeighbors(entries: IStatusbarViewModelEntry[], alignment: StatusbarAlignment): void {
+		let previousVisibleEntry: IStatusbarViewModelEntry | undefined;
+
+		for (const entry of entries) {
+			entry.container.classList.remove('visible-background-color-neighbor');
+
+			if (this.viewModel.isHidden(entry.id)) {
+				continue;
+			}
+
+			const isCompactNeighbor = alignment === StatusbarAlignment.LEFT
+				? previousVisibleEntry?.container.classList.contains('compact-right') && entry.container.classList.contains('compact-left')
+				: previousVisibleEntry?.container.classList.contains('compact-left') && entry.container.classList.contains('compact-right');
+			if (
+				previousVisibleEntry?.container.classList.contains('has-background-color') &&
+				entry.container.classList.contains('has-background-color') &&
+				!isCompactNeighbor
+			) {
+				entry.container.classList.add('visible-background-color-neighbor');
+			}
+
+			previousVisibleEntry = entry;
 		}
 	}
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
@@ -70,20 +70,12 @@
 	border-bottom-right-radius: 0;
 }
 
-.style-override .part.statusbar > .left-items > .statusbar-item.has-background-color + .statusbar-item.has-background-color {
+.style-override .part.statusbar > .left-items > .statusbar-item.visible-background-color-neighbor {
 	margin-left: var(--vscode-spacing-size40);
 }
 
-.style-override .part.statusbar > .right-items > .statusbar-item.has-background-color + .statusbar-item.has-background-color {
+.style-override .part.statusbar > .right-items > .statusbar-item.visible-background-color-neighbor {
 	margin-right: var(--vscode-spacing-size40);
-}
-
-.style-override .part.statusbar > .left-items > .statusbar-item.has-background-color.compact-right + .statusbar-item.has-background-color.compact-left {
-	margin-left: 0;
-}
-
-.style-override .part.statusbar > .right-items > .statusbar-item.has-background-color.compact-left + .statusbar-item.has-background-color.compact-right {
-	margin-right: 0;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
@@ -70,6 +70,22 @@
 	border-bottom-right-radius: 0;
 }
 
+.style-override .part.statusbar > .left-items > .statusbar-item.has-background-color + .statusbar-item.has-background-color {
+	margin-left: var(--vscode-spacing-size40);
+}
+
+.style-override .part.statusbar > .right-items > .statusbar-item.has-background-color + .statusbar-item.has-background-color {
+	margin-right: var(--vscode-spacing-size40);
+}
+
+.style-override .part.statusbar > .left-items > .statusbar-item.has-background-color.compact-right + .statusbar-item.has-background-color.compact-left {
+	margin-left: 0;
+}
+
+.style-override .part.statusbar > .right-items > .statusbar-item.has-background-color.compact-left + .statusbar-item.has-background-color.compact-right {
+	margin-right: 0;
+}
+
 /*
  * Compact combo controls — a left/right pair that merges into one pill — give
  * the whole combo a single hover tint (painted inline on every sub-item's label


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/329031

Adds spacing between adjacent visible status bar buttons with background colors, while preserving compact button groups. This fixes the zoom level and screen reader optimized buttons shown below.

<img width="720" height="372" alt="ui-diff-20260804-162457" src="https://github.com/user-attachments/assets/80c67705-ffb7-437c-b674-cc2c2ce89eb6" />