### PR TITLE
Require approval incomplete PowerShell parses and restrict terminal auto-approval to known cmdlets

### DIFF
--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -643,7 +643,7 @@ const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerm
 	'/^sed\\b.*\\s(-[a-zA-Z]*(e|f)[a-zA-Z]*|--expression|--file)\\b/': false,
 	'/^sed\\b.*s\\/.*\\/.*\\/[ew]/': false,
 	'/^sed\\b.*;W/': false,
-	'/^sort(?=\\s|$)/': true,
+	'/^sort\\b(?!-)/': true,
 	'/^sort\\b.*\\s-(o|S)\\b/': false,
 	tree: true,
 	'/^tree\\b.*\\s-o\\b/': false,

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -11,6 +11,7 @@ import { escapeRegExpCharacters, regExpLeadsToEndlessLoop } from '../../../base/
 import { URI } from '../../../base/common/uri.js';
 import { getAppNodeModulesPath } from './appNodeModules.js';
 import { ILogService } from '../../log/common/log.js';
+import { shouldRequireConfirmationForAutoApproveParse } from '../../terminal/common/autoApprove/autoApproveParseSafety.js';
 import { gitAutoApproveRules } from '../../terminal/common/autoApprove/gitAutoApproveRules.js';
 import { SedFileWriteParser } from '../../terminal/common/autoApprove/sedFileWriteParser.js';
 import type { AgentHostTerminalAutoApproveRuleValue, AgentHostTerminalAutoApproveRules } from '../common/agentHostSchema.js';
@@ -336,10 +337,7 @@ export class CommandAutoApprover extends Disposable {
 			}
 
 			try {
-				if (isPowerShell && tree.rootNode.hasError) {
-					// An erroring parse can produce truncated captures that hide
-					// part of the command line from rule matching, so require
-					// confirmation instead of judging the partial parse.
+				if (shouldRequireConfirmationForAutoApproveParse(isPowerShell ? 'powershell' : 'bash', tree.rootNode.hasError)) {
 					this._logService.trace('[CommandAutoApprover] PowerShell parse contains errors, requiring confirmation');
 					return undefined;
 				}

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -13,6 +13,7 @@ import { getAppNodeModulesPath } from './appNodeModules.js';
 import { ILogService } from '../../log/common/log.js';
 import { shouldRequireConfirmationForAutoApproveParse } from '../../terminal/common/autoApprove/autoApproveParseSafety.js';
 import { gitAutoApproveRules } from '../../terminal/common/autoApprove/gitAutoApproveRules.js';
+import { powershellAutoApproveRules } from '../../terminal/common/autoApprove/powershellAutoApproveRules.js';
 import { SedFileWriteParser } from '../../terminal/common/autoApprove/sedFileWriteParser.js';
 import type { AgentHostTerminalAutoApproveRuleValue, AgentHostTerminalAutoApproveRules } from '../common/agentHostSchema.js';
 
@@ -606,24 +607,7 @@ const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerm
 	'/^docker\\s+compose\\s+(ps|ls|top|logs|images|config|version|port|events)\\b/': true,
 
 	// PowerShell
-	'Get-ChildItem': true,
-	'Get-Content': true,
-	'Get-Date': true,
-	'Get-Random': true,
-	'Get-Location': true,
-	'Set-Location': true,
-	'Write-Host': true,
-	'Write-Output': true,
-	'Out-String': true,
-	'Split-Path': true,
-	'Join-Path': true,
-	'Start-Sleep': true,
-	'Where-Object': true,
-	'/^Select-[a-z0-9]/i': true,
-	'/^Measure-[a-z0-9]/i': true,
-	'/^Compare-[a-z0-9]/i': true,
-	'/^Format-[a-z0-9]/i': true,
-	'/^Sort-[a-z0-9]/i': true,
+	...powershellAutoApproveRules,
 
 	// Package manager read-only commands
 	'/^npm\\s+(ls|list|outdated|view|info|show|explain|why|root|prefix|bin|search|doctor|fund|repo|bugs|docs|home|help(-search)?)\\b/': true,
@@ -659,7 +643,7 @@ const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerm
 	'/^sed\\b.*\\s(-[a-zA-Z]*(e|f)[a-zA-Z]*|--expression|--file)\\b/': false,
 	'/^sed\\b.*s\\/.*\\/.*\\/[ew]/': false,
 	'/^sed\\b.*;W/': false,
-	sort: true,
+	'/^sort(?=\\s|$)/': true,
 	'/^sort\\b.*\\s-(o|S)\\b/': false,
 	tree: true,
 	'/^tree\\b.*\\s-o\\b/': false,

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -434,6 +434,13 @@ suite('CommandAutoApprover', () => {
 			], ['approved', 'denied']);
 		});
 
+		test('requires confirmation for incomplete PowerShell parses', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Write-Output before; "unterminated', pwsh),
+				approver.shouldAutoApprove('Get-ChildItem -Recurse', pwsh),
+			], ['noMatch', 'approved']);
+		});
+
 		test('PowerShell matchCommandLine allow rules stay case-sensitive', () => {
 			const autoApproveRules = { '/^Get-ChildItem$/': { approve: true, matchCommandLine: true } };
 			assert.deepStrictEqual([

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -209,18 +209,37 @@ suite('CommandAutoApprover', () => {
 
 		// PowerShell
 		test('approves allowed PowerShell commands', () => {
-			assert.strictEqual(approver.shouldAutoApprove('Get-ChildItem'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('Get-Content file.txt'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('Write-Host "hello"'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('Select-Object Name'), 'approved');
+			const pwsh = { language: 'powershell' } as const;
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Get-ChildItem', pwsh),
+				approver.shouldAutoApprove('Get-Content file.txt', pwsh),
+				approver.shouldAutoApprove('Write-Host "hello"', pwsh),
+				approver.shouldAutoApprove('Select-Object Name', pwsh),
+				approver.shouldAutoApprove('Measure-Object Length', pwsh),
+				approver.shouldAutoApprove('Compare-Object $a $b', pwsh),
+				approver.shouldAutoApprove('Format-Table', pwsh),
+				approver.shouldAutoApprove('Sort-Object Name', pwsh),
+			], ['approved', 'approved', 'approved', 'approved', 'approved', 'approved', 'approved', 'approved']);
 		});
 
 		test('PowerShell case-insensitive rules work', () => {
-			// Rules with /i flag (like Select-*, Measure-*, etc.) are case-insensitive
-			assert.strictEqual(approver.shouldAutoApprove('select-object Name'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('SELECT-OBJECT Name'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('Measure-Command'), 'approved');
-			assert.strictEqual(approver.shouldAutoApprove('measure-command'), 'approved');
+			const pwsh = { language: 'powershell' } as const;
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('select-object Name', pwsh),
+				approver.shouldAutoApprove('SELECT-OBJECT Name', pwsh),
+				approver.shouldAutoApprove('measure-object Length', pwsh),
+			], ['approved', 'approved', 'approved']);
+		});
+
+		test('does not auto-approve arbitrary PowerShell cmdlets by verb', () => {
+			const pwsh = { language: 'powershell' } as const;
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Select-Custom', pwsh),
+				approver.shouldAutoApprove('Measure-Command', pwsh),
+				approver.shouldAutoApprove('Compare-Custom', pwsh),
+				approver.shouldAutoApprove('Format-Hex', pwsh),
+				approver.shouldAutoApprove('Sort-Custom', pwsh),
+			], ['noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch']);
 		});
 
 		test('denies denied PowerShell commands', () => {
@@ -437,8 +456,9 @@ suite('CommandAutoApprover', () => {
 		test('requires confirmation for incomplete PowerShell parses', () => {
 			assert.deepStrictEqual([
 				approver.shouldAutoApprove('Write-Output before; "unterminated', pwsh),
+				approver.shouldAutoApprove('Write-Output before; `Write-Output after', pwsh),
 				approver.shouldAutoApprove('Get-ChildItem -Recurse', pwsh),
-			], ['noMatch', 'approved']);
+			], ['noMatch', 'noMatch', 'approved']);
 		});
 
 		test('PowerShell matchCommandLine allow rules stay case-sensitive', () => {
@@ -485,13 +505,15 @@ suite('CommandAutoApprover', () => {
 				approver.shouldAutoApprove('Get-ChildItem; [System.IO.File]::Delete("x")', pwsh),
 				approver.shouldAutoApprove('Get-ChildItem | Where-Object { [System.IO.File]::Delete($_.FullName) }', pwsh),
 				approver.shouldAutoApprove('Get-ChildItem; $obj.Delete()', pwsh),
+				approver.shouldAutoApprove('[Math]::Max(1, 2) | Out-String', pwsh),
+				approver.shouldAutoApprove(`Out-String -InputObject ([scriptblock]::Create('Write-Output ok').Invoke())`, pwsh),
 				// Deliberate over-block: an invocation in an argument is usually
 				// harmless, but the rules cannot tell `[math]::Round` from
 				// `[System.IO.File]::Delete`, so both require confirmation.
 				approver.shouldAutoApprove('Write-Output ([math]::Round(1.5))', pwsh),
 				// Property access executes no method, so it stays approved.
 				approver.shouldAutoApprove('(Get-Content README.md).Length', pwsh),
-			], ['noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'approved']);
+			], ['noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'noMatch', 'approved']);
 		});
 
 		test('exact allow rules require a safely analyzable command line', () => {

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -279,7 +279,10 @@ suite('CommandAutoApprover', () => {
 		// to the filesystem, so they remain eligible for auto-approval when
 		// the command name is on the allowlist.
 		test('input redirections do not block auto-approval', () => {
-			assert.strictEqual(approver.shouldAutoApprove('cat < file.txt'), 'approved');
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('cat < file.txt'),
+				approver.shouldAutoApprove('sort<input.txt'),
+			], ['approved', 'approved']);
 		});
 
 		// Redirections to /dev/null and other known-safe sinks do not write

--- a/src/vs/platform/terminal/common/autoApprove/autoApproveParseSafety.ts
+++ b/src/vs/platform/terminal/common/autoApprove/autoApproveParseSafety.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Returns whether a tree-sitter parse error should prevent auto-approval.
+ * The command can still run after the user confirms it.
+ */
+// TODO: Consolidate fragmented terminal auto-approval parsing and policy helpers. https://github.com/microsoft/vscode/issues/329028
+export function shouldRequireConfirmationForAutoApproveParse(language: 'bash' | 'powershell', hasError: boolean): boolean {
+	return language === 'powershell' && hasError;
+}

--- a/src/vs/platform/terminal/common/autoApprove/powershellAutoApproveRules.ts
+++ b/src/vs/platform/terminal/common/autoApprove/powershellAutoApproveRules.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Default auto-approval rules for known PowerShell cmdlets.
+ *
+ * Keep this list explicit. PowerShell modules can define arbitrary cmdlets with
+ * standard verbs, so verb-prefix rules such as `Select-*` or `Format-*` are not
+ * safe enough for auto-approval.
+ */
+export const powershellAutoApproveRules: Readonly<Record<string, boolean>> = {
+	'Get-ChildItem': true,
+	'Get-Content': true,
+	'Get-Date': true,
+	'Get-Random': true,
+	'Get-Location': true,
+	'Set-Location': true,
+	'Write-Host': true,
+	'Write-Output': true,
+	'Out-String': true,
+	'Split-Path': true,
+	'Join-Path': true,
+	'Start-Sleep': true,
+	'Where-Object': true,
+	'Select-Object': true,
+	'Select-String': true,
+	'Measure-Object': true,
+	'Compare-Object': true,
+	'Format-List': true,
+	'Format-Table': true,
+	'Sort-Object': true,
+};

--- a/src/vs/platform/terminal/test/common/autoApprove/autoApproveParseSafety.test.ts
+++ b/src/vs/platform/terminal/test/common/autoApprove/autoApproveParseSafety.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { shouldRequireConfirmationForAutoApproveParse } from '../../../common/autoApprove/autoApproveParseSafety.js';
+
+suite('shouldRequireConfirmationForAutoApproveParse', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('requires confirmation for PowerShell parse errors', () => {
+		assert.deepStrictEqual([
+			shouldRequireConfirmationForAutoApproveParse('powershell', false),
+			shouldRequireConfirmationForAutoApproveParse('powershell', true),
+			shouldRequireConfirmationForAutoApproveParse('bash', false),
+			shouldRequireConfirmationForAutoApproveParse('bash', true),
+		], [
+			false,
+			true,
+			false,
+			false,
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -11,6 +11,7 @@ import { Disposable, MutableDisposable, toDisposable } from '../../../../../base
 import { posix, win32 } from '../../../../../base/common/path.js';
 import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
 import type { ITerminalSandboxCommand } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
+import { shouldRequireConfirmationForAutoApproveParse } from '../../../../../platform/terminal/common/autoApprove/autoApproveParseSafety.js';
 import { SedFileWriteParser } from '../../../../../platform/terminal/common/autoApprove/sedFileWriteParser.js';
 import { ICommandFileWriteParser } from './commandParsers/commandFileWriteParser.js';
 
@@ -73,10 +74,10 @@ export class TreeSitterCommandParser extends Disposable {
 
 	async extractAutoApprovalSubCommands(languageId: TreeSitterCommandParserLanguage, commandLine: string): Promise<IAutoApprovalCommandParseResult> {
 		const masked = languageId === TreeSitterCommandParserLanguage.PowerShell ? maskPwshFlagEquals(commandLine) : commandLine;
-		const query = languageId === TreeSitterCommandParserLanguage.PowerShell
+		const querySource = languageId === TreeSitterCommandParserLanguage.PowerShell
 			? '(command) @command (assignment_expression) @unanalyzable (invokation_expression) @unanalyzable'
 			: '(command) @command (variable_assignment) @unanalyzable (declaration_command) @unanalyzable';
-		const captures = await this._queryTree(languageId, masked, query);
+		const { captures, hasError } = await this._queryTreeWithParseStatus(languageId, masked, querySource);
 		const subCommands: string[] = [];
 		let hasUnanalyzableSyntax = false;
 		for (const capture of captures) {
@@ -91,6 +92,10 @@ export class TreeSitterCommandParser extends Disposable {
 				}
 			}
 		}
+		hasUnanalyzableSyntax ||= shouldRequireConfirmationForAutoApproveParse(
+			languageId === TreeSitterCommandParserLanguage.PowerShell ? 'powershell' : 'bash',
+			hasError,
+		);
 		return { subCommands, hasUnanalyzableSyntax };
 	}
 
@@ -175,7 +180,23 @@ export class TreeSitterCommandParser extends Disposable {
 
 	private async _queryTree(languageId: TreeSitterCommandParserLanguage, commandLine: string, querySource: string): Promise<QueryCapture[]> {
 		const { tree, query } = await this._doQuery(languageId, commandLine, querySource);
-		return query.captures(tree.rootNode);
+		try {
+			return query.captures(tree.rootNode);
+		} finally {
+			query.delete();
+		}
+	}
+
+	private async _queryTreeWithParseStatus(languageId: TreeSitterCommandParserLanguage, commandLine: string, querySource: string): Promise<{ captures: QueryCapture[]; hasError: boolean }> {
+		const { tree, query } = await this._doQuery(languageId, commandLine, querySource);
+		try {
+			return {
+				captures: query.captures(tree.rootNode),
+				hasError: tree.rootNode.hasError,
+			};
+		} finally {
+			query.delete();
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -316,7 +316,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			//   blocked currently
 			// - `-S`: Memory exhaustion is possible (`sort -S 100G file`), we allow possible denial
 			//   of service.
-			'/^sort(?=\\s|$)/': true,
+			'/^sort\\b(?!-)/': true,
 			'/^sort\\b.*\\s-(o|S)\\b/': false,
 
 			// tree

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -9,6 +9,7 @@ import { localize } from '../../../../../nls.js';
 import { type IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../../platform/sandbox/common/settings.js';
 import { gitAutoApproveRules } from '../../../../../platform/terminal/common/autoApprove/gitAutoApproveRules.js';
+import { powershellAutoApproveRules } from '../../../../../platform/terminal/common/autoApprove/powershellAutoApproveRules.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 import { terminalProfileBaseProperties } from '../../../../../platform/terminal/common/terminalPlatformConfiguration.js';
 import { PolicyCategory } from '../../../../../base/common/policy.js';
@@ -228,26 +229,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 
 			// #region PowerShell
 
-			'Get-ChildItem': true,
-			'Get-Content': true,
-			'Get-Date': true,
-			'Get-Random': true,
-			'Get-Location': true,
-			'Set-Location': true,
-			'Write-Host': true,
-			'Write-Output': true,
-			'Out-String': true,
-			'Split-Path': true,
-			'Join-Path': true,
-			'Start-Sleep': true,
-			'Where-Object': true,
-
-			// Blanket approval of safe verbs
-			'/^Select-[a-z0-9]/i': true,
-			'/^Measure-[a-z0-9]/i': true,
-			'/^Compare-[a-z0-9]/i': true,
-			'/^Format-[a-z0-9]/i': true,
-			'/^Sort-[a-z0-9]/i': true,
+			...powershellAutoApproveRules,
 
 			// #endregion
 
@@ -334,7 +316,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			//   blocked currently
 			// - `-S`: Memory exhaustion is possible (`sort -S 100G file`), we allow possible denial
 			//   of service.
-			sort: true,
+			'/^sort(?=\\s|$)/': true,
 			'/^sort\\b.*\\s-(o|S)\\b/': false,
 
 			// tree

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
@@ -8,9 +8,9 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import type { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
-import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
+import { terminalChatAgentToolsConfiguration, TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
-import { ok, strictEqual } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { CommandLineAutoApprover } from '../../browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.js';
 import { isAutoApproveRule } from '../../browser/tools/commandLineAnalyzer/commandLineAnalyzer.js';
 
@@ -60,6 +60,39 @@ suite('CommandLineAutoApprover', () => {
 	function isCommandLineAutoApproved(commandLine: string): boolean {
 		return commandLineAutoApprover.isCommandLineAutoApproved(commandLine).result === 'approved';
 	}
+
+	suite('default PowerShell rules', () => {
+		setup(() => {
+			shell = 'pwsh';
+			os = OperatingSystem.Windows;
+			setAutoApproveWithCommandLine(
+				terminalChatAgentToolsConfiguration[TerminalChatAgentToolsSettingId.AutoApprove].default as Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>
+			);
+		});
+
+		test('auto-approves explicit safe cmdlets case-insensitively', async () => {
+			const commands = [
+				'Select-Object Name',
+				'select-object Name',
+				'Measure-Object Length',
+				'Compare-Object $a $b',
+				'Format-Table',
+				'Sort-Object Name',
+			];
+			strictEqual((await Promise.all(commands.map(isAutoApproved))).every(Boolean), true);
+		});
+
+		test('does not auto-approve arbitrary cmdlets by verb', async () => {
+			const commands = [
+				'Select-Custom',
+				'Measure-Command',
+				'Compare-Custom',
+				'Format-Hex',
+				'Sort-Custom',
+			];
+			deepStrictEqual(await Promise.all(commands.map(isAutoApproved)), [false, false, false, false, false]);
+		});
+	});
 
 	suite('autoApprove with allow patterns only', () => {
 		test('should auto-approve exact command match', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
@@ -94,6 +94,13 @@ suite('CommandLineAutoApprover', () => {
 		});
 	});
 
+	test('default sort rule preserves no-space Bash input redirection', async () => {
+		setAutoApproveWithCommandLine(
+			terminalChatAgentToolsConfiguration[TerminalChatAgentToolsSettingId.AutoApprove].default as Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>
+		);
+		strictEqual(await isAutoApproved('sort<input.txt'), true);
+	});
+
 	suite('autoApprove with allow patterns only', () => {
 		test('should auto-approve exact command match', async () => {
 			setAutoApprove({

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1179,7 +1179,7 @@ suite('RunInTerminalTool', () => {
 			'Join-Path C:\\Users test',
 			'Start-Sleep 2',
 
-			// PowerShell safe verbs (regex patterns)
+			// Explicit PowerShell cmdlets
 			'Select-Object Name',
 			'Measure-Object Length',
 			'Compare-Object $a $b',
@@ -1299,6 +1299,13 @@ suite('RunInTerminalTool', () => {
 			'eval "echo hello"',
 			'Invoke-Expression "Get-Date"',
 			'iex "Write-Host test"',
+
+			// Arbitrary PowerShell cmdlets must not be approved by verb alone
+			'Select-Custom',
+			'Measure-Command',
+			'Compare-Custom',
+			'Format-Hex',
+			'Sort-Custom',
 
 			// Commands with dangerous arguments
 			'column -c 10000 file.txt',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
@@ -255,6 +255,34 @@ suite('TreeSitterCommandParser', () => {
 				{ subCommands: ['git log --format="%h|%s" -5'], hasUnanalyzableSyntax: false },
 			]);
 		});
+
+		test('marks incomplete PowerShell parses as unanalyzable for auto-approve', async () => {
+			const result = await parser.extractAutoApprovalSubCommands(
+				TreeSitterCommandParserLanguage.PowerShell,
+				'Write-Output before; "unterminated',
+			);
+			deepStrictEqual(result.hasUnanalyzableSyntax, true);
+			ok(result.subCommands.some(command => /Write-Output/i.test(command)));
+		});
+
+		test('marks PowerShell method invocations as unanalyzable for auto-approve', async () => {
+			const result = await parser.extractAutoApprovalSubCommands(
+				TreeSitterCommandParserLanguage.PowerShell,
+				'Write-Output ([Math]::Max(1, 2))',
+			);
+			deepStrictEqual(result.hasUnanalyzableSyntax, true);
+		});
+
+		test('keeps clean PowerShell commands analyzable', async () => {
+			const result = await parser.extractAutoApprovalSubCommands(
+				TreeSitterCommandParserLanguage.PowerShell,
+				'Get-ChildItem -Recurse',
+			);
+			deepStrictEqual(result, {
+				subCommands: ['Get-ChildItem -Recurse'],
+				hasUnanalyzableSyntax: false,
+			});
+		});
 	});
 
 	suite('extractCommands', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
@@ -257,20 +257,36 @@ suite('TreeSitterCommandParser', () => {
 		});
 
 		test('marks incomplete PowerShell parses as unanalyzable for auto-approve', async () => {
-			const result = await parser.extractAutoApprovalSubCommands(
-				TreeSitterCommandParserLanguage.PowerShell,
-				'Write-Output before; "unterminated',
-			);
-			deepStrictEqual(result.hasUnanalyzableSyntax, true);
-			ok(result.subCommands.some(command => /Write-Output/i.test(command)));
+			const results = await Promise.all([
+				parser.extractAutoApprovalSubCommands(
+					TreeSitterCommandParserLanguage.PowerShell,
+					'Write-Output before; "unterminated',
+				),
+				parser.extractAutoApprovalSubCommands(
+					TreeSitterCommandParserLanguage.PowerShell,
+					'Write-Output before; `Write-Output after',
+				),
+			]);
+			deepStrictEqual(results.map(result => result.hasUnanalyzableSyntax), [true, true]);
+			ok(results.every(result => result.subCommands.some(command => /Write-Output/i.test(command))));
 		});
 
 		test('marks PowerShell method invocations as unanalyzable for auto-approve', async () => {
-			const result = await parser.extractAutoApprovalSubCommands(
-				TreeSitterCommandParserLanguage.PowerShell,
-				'Write-Output ([Math]::Max(1, 2))',
-			);
-			deepStrictEqual(result.hasUnanalyzableSyntax, true);
+			const results = await Promise.all([
+				parser.extractAutoApprovalSubCommands(
+					TreeSitterCommandParserLanguage.PowerShell,
+					'Write-Output ([Math]::Max(1, 2))',
+				),
+				parser.extractAutoApprovalSubCommands(
+					TreeSitterCommandParserLanguage.PowerShell,
+					'[Math]::Max(1, 2) | Out-String',
+				),
+				parser.extractAutoApprovalSubCommands(
+					TreeSitterCommandParserLanguage.PowerShell,
+					`Out-String -InputObject ([scriptblock]::Create('Write-Output ok').Invoke())`,
+				),
+			]);
+			deepStrictEqual(results.map(result => result.hasUnanalyzableSyntax), [true, true, true]);
 		});
 
 		test('keeps clean PowerShell commands analyzable', async () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/329042
Part of: https://github.com/microsoft/vscode/issues/329028

- Add a shared PowerShell parse-safety policy for workbench and Agent Host terminal auto-approval.
- Require confirmation when tree-sitter reports an incomplete PowerShell parse, even when the surviving command captures match allow rules.
- Replace broad PowerShell verb-prefix defaults with an explicit shared list of known cmdlets.
- Tighten the POSIX `sort` rule so case-insensitive PowerShell matching cannot approve arbitrary `Sort-*` cmdlets.
- Keep clean PowerShell parses, Bash behavior, and user-configured auto-approval rules unchanged.
- Add regressions for incomplete and escaped syntax, method and scriptblock invocations, expression pipelines, and arbitrary cmdlet names.

-----------------------------------------
Inspirations from:

- The PowerShell parse-error policy comes from Agent Host's existing confirmation behavior in [`CommandAutoApprover`](https://github.com/microsoft/vscode/blob/063821f3f5fb0e29b1fb52b5e399abc41fc420ea/src/vs/platform/agentHost/node/commandAutoApprover.ts#L339-L345).
- Requiring confirmation and suppressing persistent allow-rule suggestions follows the existing workbench handling for unanalyzable syntax in [`CommandLineAutoApproveAnalyzer`](https://github.com/microsoft/vscode/blob/063821f3f5fb0e29b1fb52b5e399abc41fc420ea/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts#L150-L154) and [`CommandLineAutoApproveAnalyzer`](https://github.com/microsoft/vscode/blob/063821f3f5fb0e29b1fb52b5e399abc41fc420ea/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts#L210-L218).
- The shared PowerShell rule module follows the existing [`gitAutoApproveRules`](https://github.com/microsoft/vscode/blob/063821f3f5fb0e29b1fb52b5e399abc41fc420ea/src/vs/platform/terminal/common/autoApprove/gitAutoApproveRules.ts#L6-L31) pattern.
- The explicit cmdlet list preserves the existing named PowerShell defaults while replacing the blanket verb-prefix rules in [`terminalChatAgentToolsConfiguration`](https://github.com/microsoft/vscode/blob/063821f3f5fb0e29b1fb52b5e399abc41fc420ea/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L229-L250).
