### PR TITLE
smoke: wait for the window reload to actually happen

### DIFF
--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -334,6 +334,19 @@ export class Code {
 		await this.poll(() => this.driver.whenWorkbenchRestored(), () => true, `when workbench restored`);
 	}
 
+	/**
+	 * Triggers a window reload via `trigger` and waits until the new window is up
+	 * and its workbench restored. Awaiting {@link whenWorkbenchRestored} alone is
+	 * not enough because that call can still be answered by the old, already
+	 * restored document before the reload took effect.
+	 */
+	async reloadWindow(trigger: () => Promise<void>): Promise<void> {
+		const marker = await this.driver.markWindowForReload();
+		await trigger();
+		await this.driver.waitForWindowReload(marker);
+		await this.whenWorkbenchRestored();
+	}
+
 	getLocaleInfo(): Promise<ILocaleInfo> {
 		return this.driver.getLocaleInfo();
 	}

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -48,6 +48,7 @@ export class PlaywrightDriver {
 
 	private static traceCounter = 1;
 	private static screenShotCounter = 1;
+	private static reloadMarkerCounter = 1;
 
 	private static readonly vscodeToPlaywrightKey: { [key: string]: string } = {
 		cmd: 'Meta',
@@ -434,6 +435,25 @@ export class PlaywrightDriver {
 
 	async didFinishLoad(): Promise<void> {
 		await this.whenLoaded;
+	}
+
+	/**
+	 * Stamps the current document so that {@link waitForWindowReload} can tell the
+	 * document apart from the one that a window reload will bring up.
+	 */
+	async markWindowForReload(): Promise<string> {
+		const marker = `vscodeSmokeTestReloadMarker${PlaywrightDriver.reloadMarkerCounter++}`;
+		await this.page.evaluate(m => { (window as unknown as Record<string, boolean>)[m] = true; }, marker);
+
+		return marker;
+	}
+
+	/**
+	 * Waits until the document that was stamped via {@link markWindowForReload} is
+	 * gone, meaning the window reload actually took effect.
+	 */
+	async waitForWindowReload(marker: string, timeout: number = 60_000): Promise<void> {
+		await this.page.waitForFunction(m => !(window as unknown as Record<string, boolean>)[m], marker, { timeout, polling: 100 });
 	}
 
 	private _cdpSession: playwright.CDPSession | undefined;

--- a/test/smoke/src/areas/extensions/extension-host-restart.test.ts
+++ b/test/smoke/src/areas/extensions/extension-host-restart.test.ts
@@ -54,8 +54,7 @@ export function setup(logger: Logger) {
 			logger.log(`Old extension host PID: ${pid}`);
 
 			// Reload window while extension host is blocked
-			await app.workbench.quickaccess.runCommand('Developer: Reload Window', { keepOpen: true });
-			await app.code.whenWorkbenchRestored();
+			await app.code.reloadWindow(() => app.workbench.quickaccess.runCommand('Developer: Reload Window', { keepOpen: true }));
 			logger.log('Window reloaded');
 
 			// Verify old process is gone, allowing for slower teardown on busy machines
@@ -108,8 +107,7 @@ export function setup(logger: Logger) {
 			logger.log(`Extension host PID for graceful deactivation test: ${pid}`);
 
 			// Reload window - this should trigger graceful deactivation
-			await app.workbench.quickaccess.runCommand('Developer: Reload Window', { keepOpen: true });
-			await app.code.whenWorkbenchRestored();
+			await app.code.reloadWindow(() => app.workbench.quickaccess.runCommand('Developer: Reload Window', { keepOpen: true }));
 			logger.log('Window reloaded');
 
 			// Wait for the process to exit and marker file to be written


### PR DESCRIPTION
Fixes a flake in the `Extension Host Restart` smoke suite, seen on Windows x64 in the Flaky Smoke Tests pipeline (definition 700, build 461297, iteration 13/20):

```
1) VSCode Smoke Tests (Electron)
     Extension Host Restart
       kills blocked extension host on restart extension host (issue #296681):
   Error: Timeout: set value '.quick-input-widget .quick-input-box input' after 20 seconds.
```

### Root cause

The failing line is the *first* `runCommand(...)` of the test, so the problem is the state the test starts in.

The two preceding tests end with `Developer: Reload Window` followed by `app.code.whenWorkbenchRestored()`. That call is a `page.evaluate` and can be answered by the **pre-reload document**, which is already restored, so it returns almost immediately. From the runner log of a passing iteration:

```
20:42:05.735  sendKeybinding enter          <- Developer: Reload Window
20:42:05.743  whenWorkbenchRestored
20:42:05.754  [driver] Workbench contributions created.   <- old document answered
20:42:05.759  sendKeybinding ctrl+shift+p   <- next test already running
20:42:05.949  workbench#open()              <- new window only starts here
```

The next test therefore dispatches its command palette keybinding into a window that is still tearing down. `openQuickAccessWithRetry` burns its retries, then falls through to `type()`, which polls `setValue` for 20s against a `.quick-input-widget` that was never created in the new document — producing the misleading "set value ... after 20 seconds" error.

### Fix

- `PlaywrightDriver#markWindowForReload()` stamps the current document, `PlaywrightDriver#waitForWindowReload()` waits (via `page.waitForFunction`) until the stamp is gone, i.e. a new document is loaded.
- `Code#reloadWindow(trigger)` composes stamp → trigger → wait for the new document → `whenWorkbenchRestored()`.
- `extension-host-restart.test.ts` uses `app.code.reloadWindow(...)` at both reload sites.

### Validation

https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461398
