### PR TITLE
Fix automations card keyboard accessibility

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
@@ -27,7 +27,7 @@ class AutomationsCustomViewAccessibilityHelp implements IAccessibleViewImplement
 		const restoreFocus = createFocusRestorer(layoutService);
 		const content = [
 			localize('automationsCustomView.help.overview', "You are in the Automations view. It contains automation cards followed by run history."),
-			localize('automationsCustomView.help.cards', "Tab between each card's Edit, Run now, and Delete controls. Edit, or clicking anywhere else on the card, opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation."),
+			localize('automationsCustomView.help.cards', "Tab to a card's Edit control and action buttons. Use Left Arrow and Right Arrow to move between Run now and Delete. Press Enter or Space to activate a control. Edit, or clicking anywhere else on the card, opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation."),
 			localize('automationsCustomView.help.history', "Run history is grouped by date. Each run reports its Pending, Running, Completed, or Failed status. Runs with an available session can be opened with Enter or Space."),
 			localize('automationsCustomView.help.read', "Completed and failed runs that have not been opened are announced as unread. Use Mark all as read to clear all available unread runs."),
 			localize('automationsCustomView.help.accessibleView', "Use Open Accessible View to read the current automations and run history as text."),

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -6,7 +6,7 @@
 import '../media/automationsCards.css';
 import './automationsAccessibility.js';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { Button, ButtonBar, IButton } from '../../../../../base/browser/ui/button/button.js';
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
@@ -205,12 +205,13 @@ class AutomationCardsSection extends Disposable {
 		const actions = DOM.append(card, $('.automations-card-actions'));
 		actions.setAttribute('role', 'group');
 		actions.setAttribute('aria-label', localize('automationActions', "Actions for {0}", automation.name));
-		const runBtn = this.createIconButton(actions, Codicon.play, localize('runNow', "Run now"), false);
+		const buttonBar = this.disposables.add(new ButtonBar(actions));
+		const runBtn = this.createIconButton(buttonBar, Codicon.play, localize('runNow', "Run now"), false);
 		this.disposables.add(runBtn.onDidClick(() => {
 			void this.runNow(automation);
 		}));
 
-		const deleteBtn = this.createIconButton(actions, Codicon.trash, localize('deleteAutomation', "Delete"), false);
+		const deleteBtn = this.createIconButton(buttonBar, Codicon.trash, localize('deleteAutomation', "Delete"), false);
 		this.disposables.add(deleteBtn.onDidClick(() => {
 			void this.confirmDelete(automation);
 		}));
@@ -226,13 +227,13 @@ class AutomationCardsSection extends Disposable {
 		}
 	}
 
-	private createIconButton(container: HTMLElement, icon: ThemeIcon, tooltip: string, disabled: boolean): Button {
-		const button = this.disposables.add(new Button(container, {
+	private createIconButton(buttonBar: ButtonBar, icon: ThemeIcon, tooltip: string, disabled: boolean): IButton {
+		const button = buttonBar.addButton({
 			ariaLabel: tooltip,
 			disabled,
 			supportIcons: true,
 			title: tooltip,
-		}));
+		});
 		button.label = `$(${icon.id})`;
 		button.element.classList.add('automations-card-action-button');
 		return button;

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -76,6 +76,12 @@ function run(overrides: Partial<IAutomationRun> = {}): IAutomationRun {
 	};
 }
 
+function dispatchKeydown(element: HTMLElement, init: KeyboardEventInit & { keyCode: number }): void {
+	const event = new KeyboardEvent('keydown', { ...init, bubbles: true });
+	Object.defineProperty(event, 'keyCode', { get: () => init.keyCode });
+	element.dispatchEvent(event);
+}
+
 class FakeAutomationService extends mock<IAutomationService>() {
 	private readonly automationValue = observableValue<readonly IAutomation[]>(this, []);
 	private readonly runValue = observableValue<readonly IAutomationRun[]>(this, []);
@@ -372,6 +378,33 @@ suite('AutomationsCardsWidget', () => {
 			showCalls: 1,
 			existing: item,
 			runCalls: 1,
+		});
+	});
+
+	test('automation action buttons support arrow navigation and keyboard activation', async () => {
+		const { automationService, runner, widget } = setup();
+		automationService.setAutomations([automation()]);
+		const buttons = widget.element.querySelectorAll<HTMLElement>('.automations-card-action-button');
+		const runButton = buttons.item(0);
+		const deleteButton = buttons.item(1);
+
+		runButton.focus();
+		dispatchKeydown(runButton, { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 });
+		const movedRight = document.activeElement === deleteButton;
+		dispatchKeydown(deleteButton, { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 });
+		const movedLeft = document.activeElement === runButton;
+		dispatchKeydown(runButton, { key: 'Enter', code: 'Enter', keyCode: 13 });
+		dispatchKeydown(runButton, { key: ' ', code: 'Space', keyCode: 32 });
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			movedRight,
+			movedLeft,
+			runCalls: runner.runCalls,
+		}, {
+			movedRight: true,
+			movedLeft: true,
+			runCalls: 2,
 		});
 	});
 


### PR DESCRIPTION
## Summary

- use the shared button bar for automation card actions so Left Arrow and Right Arrow move focus between actions
- preserve Enter and Space activation through the standard button behavior
- document the keyboard interaction in accessibility help and add regression coverage

## Testing

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `.\scripts\test.bat --run src\vs\sessions\contrib\sessions\test\browser\automationsView.test.ts`
- `npm run precommit`

Closes microsoft/vscode-internalbacklog#8333