### PR TITLE
Require confirmation for CMD delayed-expansion redirects in terminal auto-approval

### DIFF
--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -18,6 +18,7 @@ import { isDefined } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
+import { containsCmdDelayedExpansion } from '../../terminal/common/autoApprove/cmdDelayedExpansion.js';
 import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, platformRootSchema, platformSessionSchema } from '../common/agentHostSchema.js';
 import type { IAgentToolPendingConfirmationSignal } from '../common/agentService.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
@@ -500,8 +501,9 @@ export class SessionPermissionManager extends Disposable {
 	/**
 	 * Matches redirect destinations whose final path is decided by the shell
 	 * rather than by the text: variable expansions (`$HOME/x`, `$env:TEMP/x`,
-	 * `%APPDATA%\x`), command substitutions (`$(pwd)/x`, `` `pwd`/x ``), brace
-	 * expansions, and `~` in a position {@link untildify} does not handle.
+	 * `%APPDATA%\x`, `!APPDATA!\x`), command substitutions (`$(pwd)/x`,
+	 * `` `pwd`/x ``), brace expansions, and `~` in a position {@link untildify}
+	 * does not handle.
 	 * Mirrors the workbench's file-write analyzer guard.
 	 *
 	 * See https://github.com/microsoft/vscode/issues/274166 and
@@ -525,7 +527,7 @@ export class SessionPermissionManager extends Disposable {
 		// A destination the shell expands (e.g. `$HOME/x.txt`) would otherwise be
 		// treated as a literal relative path and resolve *inside* the working
 		// directory, auto-approving a write that actually lands elsewhere.
-		if (SessionPermissionManager._dynamicRedirectDestRegex.test(trimmed)) {
+		if (SessionPermissionManager._dynamicRedirectDestRegex.test(trimmed) || containsCmdDelayedExpansion(trimmed)) {
 			this._logService.trace(`[SessionPermissionManager] Redirect destination expands at runtime, requiring confirmation: ${dest}`);
 			return undefined;
 		}

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -329,6 +329,20 @@ suite('SessionPermissionManager', () => {
 		});
 	});
 
+	test('CMD delayed-expansion redirect destinations require confirmation', async () => {
+		const delayedExpansion = shellEvent('echo hi >!APPDATA!\\outside.txt', 'bash');
+		const literalExclamation = shellEvent('echo hi >important!.txt', 'bash');
+		assert.deepStrictEqual({
+			delayedApproval: await permissions.getAutoApproval(delayedExpansion, sessionUri),
+			delayedRuleResolvable: permissions.isAutoApproveRuleResolvable(delayedExpansion, sessionUri),
+			literalApproval: await permissions.getAutoApproval(literalExclamation, sessionUri),
+		}, {
+			delayedApproval: undefined,
+			delayedRuleResolvable: false,
+			literalApproval: ToolCallConfirmationReason.NotNeeded,
+		});
+	});
+
 	test('missing shell language disables terminal rules and rule suggestions', async () => {
 		const event = shellEvent('Get-ChildItem', undefined);
 		assert.deepStrictEqual({

--- a/src/vs/platform/terminal/common/autoApprove/cmdDelayedExpansion.ts
+++ b/src/vs/platform/terminal/common/autoApprove/cmdDelayedExpansion.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const cmdDelayedExpansionRegex = /![^!\r\n]+!/;
+
+/**
+ * Returns whether the text contains balanced CMD delayed environment-variable
+ * expansion syntax, such as `!APPDATA!` or `!VAR:~0,1!`.
+ */
+// TODO: Consolidate with shared terminal command helpers when `runInTerminalHelpers` moves to platform. https://github.com/microsoft/vscode/issues/329028
+export function containsCmdDelayedExpansion(value: string): boolean {
+	return cmdDelayedExpansionRegex.test(value);
+}

--- a/src/vs/platform/terminal/test/common/autoApprove/cmdDelayedExpansion.test.ts
+++ b/src/vs/platform/terminal/test/common/autoApprove/cmdDelayedExpansion.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { containsCmdDelayedExpansion } from '../../../common/autoApprove/cmdDelayedExpansion.js';
+
+suite('containsCmdDelayedExpansion', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('detects balanced delayed environment-variable expansion', () => {
+		assert.deepStrictEqual([
+			containsCmdDelayedExpansion('!APPDATA!\\file.txt'),
+			containsCmdDelayedExpansion('!TARGET!'),
+			containsCmdDelayedExpansion('!VAR:~0,1!\\file.txt'),
+			containsCmdDelayedExpansion('!ROOT!\\!NAME!'),
+		], [true, true, true, true]);
+	});
+
+	test('ignores literal or unmatched exclamation marks', () => {
+		assert.deepStrictEqual([
+			containsCmdDelayedExpansion('file.txt'),
+			containsCmdDelayedExpansion('important!.txt'),
+			containsCmdDelayedExpansion('!APPDATA'),
+			containsCmdDelayedExpansion('APPDATA!'),
+			containsCmdDelayedExpansion('!!'),
+		], [false, false, false, false, false]);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -10,6 +10,7 @@ import { extUri, normalizePath } from '../../../../../../../base/common/resource
 import { localize } from '../../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IWorkspaceContextService } from '../../../../../../../platform/workspace/common/workspace.js';
+import { containsCmdDelayedExpansion } from '../../../../../../../platform/terminal/common/autoApprove/cmdDelayedExpansion.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
 import { TreeSitterCommandParserLanguage, type TreeSitterCommandParser } from '../../treeSitterCommandParser.js';
 import type { ICommandLineAnalyzer, ICommandLineAnalyzerOptions, ICommandLineAnalyzerResult } from './commandLineAnalyzer.js';
@@ -148,12 +149,13 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							const fileUri = normalizePath(URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite));
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
-							// `~` catches POSIX tilde expansion (e.g. `~/foo`) and `%` catches Windows
-							// environment variable expansions (e.g. `%APPDATA%\foo`). Neither is
-							// recognized as absolute by `posix.isAbsolute` / `win32.isAbsolute`, so
+							// `~` catches POSIX tilde expansion (e.g. `~/foo`), `%` catches Windows
+							// environment variable expansion (e.g. `%APPDATA%\foo`), and the shared
+							// predicate catches CMD delayed expansion (e.g. `!APPDATA!\foo`). These are
+							// not recognized as absolute by `posix.isAbsolute` / `win32.isAbsolute`, so
 							// without this guard they would be joined onto cwd and incorrectly classified
 							// as inside the workspace while expanding at runtime to a location outside it.
-							if (fileUri.fsPath.match(/[$\(\){}`~%]/)) {
+							if (fileUri.fsPath.match(/[$\(\){}`~%]/) || containsCmdDelayedExpansion(fileUri.fsPath)) {
 								isAutoApproveAllowed = false;
 								this._log('File write blocked due to likely containing a variable, sub-command, or tilde/environment-variable expansion', fileUri.toString());
 								break;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -126,11 +126,14 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('brace expansion - block', () => t('echo hello > {a,b}.txt', 'outsideWorkspace', false, 1));
 			test('tilde expansion - block', () => t('echo hello > ~/file.txt', 'outsideWorkspace', false, 1));
 			test('percent-style variable - block', () => t('echo hello > %HOME%/file.txt', 'outsideWorkspace', false, 1));
+			test('cmd delayed-expansion variable - block', () => t('echo hello > !APPDATA!\\file.txt', 'outsideWorkspace', false, 1));
+			test('literal unmatched exclamation mark - allow', () => t('echo hello > important!.txt', 'outsideWorkspace', true, 1));
 		});
 
 		suite('tilde and environment-variable expansion', () => {
 			test('tilde home expansion - block', () => t('echo hello > ~/file.txt', 'outsideWorkspace', false, 1));
 			test('windows-style env-var expansion - block', () => t('echo hello > %HOME%/file.txt', 'outsideWorkspace', false, 1));
+			test('cmd delayed environment-variable expansion - block', () => t('echo hello > !APPDATA!\\file.txt', 'outsideWorkspace', false, 1));
 		});
 
 		suite('blockDetectedFileWrites: all', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -3198,7 +3198,7 @@ suite('RunInTerminalTool', () => {
 		suite('getCopilotProfile', () => {
 			(isWindows ? test : test.skip)('should return custom profile when configured', async () => {
 				runInTerminalTool.setBackendOs(OperatingSystem.Windows);
-				const customProfile = Object.freeze({ path: 'C:\\Windows\\System32\\powershell.exe', args: ['-NoProfile'] });
+				const customProfile = Object.freeze({ path: 'C:\\Windows\\System32\\cmd.exe', args: ['/V:ON'] });
 				setConfig(TerminalChatAgentToolsSettingId.TerminalProfileWindows, customProfile);
 
 				const result = await runInTerminalTool.profileFetcher.getCopilotProfile();


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/329056
Part of: https://github.com/microsoft/vscode/issues/329028

- Add a shared detector for balanced CMD delayed environment-variable expansion such as `!APPDATA!` and `!VAR:~0,1!`.
- Use the shared detector in workbench and Agent Host redirect-destination checks.
- Require confirmation instead of treating unresolved CMD redirect targets as workspace-local paths.
- Keep ordinary or unmatched `!` characters eligible for auto-approval.
- Preserve existing Bash, PowerShell, `%VAR%`, `$VAR`, literal-path, and file-write setting behavior.
- Add regressions for the workbench file-write analyzer, custom `/V:ON` CMD profiles, and Agent Host approval/rule eligibility.

-----------------------------------------
Inspirations from:

- The CMD check extends the existing conservative expansion guard in [`CommandLineFileWriteAnalyzer`](https://github.com/microsoft/vscode/blob/8071803783292ef5cbc023cd87bc7c27c66cfd99/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts#L149-L159).
- Agent Host integration follows its existing mirrored redirect-resolution policy in [`SessionPermissionManager`](https://github.com/microsoft/vscode/blob/8071803783292ef5cbc023cd87bc7c27c66cfd99/src/vs/platform/agentHost/node/sessionPermissions.ts#L500-L530).
- The custom CMD profile scope comes from [`TerminalProfileFetcher.getCopilotProfile`](https://github.com/microsoft/vscode/blob/8071803783292ef5cbc023cd87bc7c27c66cfd99/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L3492-L3511), where configured chat profiles are honored before the default `cmd.exe` profile is replaced with PowerShell.