### PR TITLE
Raise Copilot vitest timeouts to absorb CI agent jitter

### DIFF
--- a/extensions/copilot/chat-lib/vitest.config.ts
+++ b/extensions/copilot/chat-lib/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig(({ mode }) => ({
 		],
 		env: loadEnv(mode, process.cwd(), ''),
 		environment: 'node',
-		globals: true
+		globals: true,
+		// Vitest defaults (5s test / 10s hook) are below the scheduling noise floor of loaded CI
+		// agents, where even trivial synchronous tests have been observed taking >5s and failing
+		// with `Test timed out in 5000ms`. Keep these generous enough to absorb that jitter while
+		// still catching genuinely hung tests.
+		testTimeout: 30_000,
+		hookTimeout: 30_000
 	}
 }));

--- a/extensions/copilot/vite.config.ts
+++ b/extensions/copilot/vite.config.ts
@@ -19,6 +19,12 @@ export default defineConfig(({ mode }) => ({
 		include: ['**/*.spec.ts', '**/*.spec.tsx'],
 		exclude,
 		env: loadEnv(mode, process.cwd(), ''),
+		// Vitest defaults (5s test / 10s hook) are below the scheduling noise floor of loaded CI
+		// agents, where even trivial synchronous tests have been observed taking >5s and failing
+		// with `Test timed out in 5000ms`. Keep these generous enough to absorb that jitter while
+		// still catching genuinely hung tests.
+		testTimeout: 30_000,
+		hookTimeout: 30_000,
 		alias: {
 			// similar to aliasing in the esbuild config `.esbuild.mts`
 			// vitest requires aliases to be absolute paths. reference: https://vitejs.dev/config/shared-options#resolve-alias


### PR DESCRIPTION
## Problem

The `Run vitest unit tests` step in the Copilot stage has been intermittently failing on `main` with `Test timed out in 5000ms`, taking down the entire build (the failed Copilot job cascades into all the `Download Copilot VSIX`, Electron/Browser/Remote test, and crash/log publish tasks).

Two consecutive builds failed this way, each on a **different, randomly-selected set of tests**:

| Build | Result | Signature |
|---|---|---|
| [461369](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461369) (`20260804.50`) | `6 failed \| 431 passed \| 4 skipped` | 6 × `Test timed out in 5000ms` + a cascading `Obsolete snapshots found when no snapshot update is expected` |
| [461391](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461391) (`20260804.53`) | `2 failed \| 435 passed \| 4 skipped` | 2 × `Test timed out in 5000ms` |

Because the affected tests differ every run, this is not attributable to any commit in the failing range.

## Root cause

The tests are not slow — the CI agent (`1es-ubuntu-22.04-x64`) is CPU-starved, and vitest's default 5000 ms `testTimeout` sits below its scheduling noise floor.

Per-test durations parsed out of the build logs:

| test | duration | outcome |
|---|---|---|
| `encodes Cyrillic domain` — **pure synchronous**, no awaits | 5803 ms | ❌ failed |
| `returns nothing for an empty array` — trivial | 4548 ms | ✅ passed |
| `is reproducible: two runs with the same seed produce identical output` | 4996 ms | ✅ passed, by 4 ms |

A synchronous one-line assertion taking 5.8 s can only mean the fork was descheduled for seconds — the timeout fires before the test body is even scheduled. The run summary corroborates the load: `Duration 94.10s (transform 300.17s, import 745.13s, tests 260.53s)`, i.e. ~13× aggregate CPU-time over wall time across forks.

The "obsolete snapshots" error in build 461369 was purely a cascade: the timed-out test never consumed its 3 snapshots.

## Fix

Neither vitest config set `testTimeout`, so vitest 4's 5 s test / 10 s hook defaults applied. This raises both to 30 s in:

- `extensions/copilot/vite.config.ts` — used by `npm run test:unit` in the ADO Copilot stage and the PR workflow
- `extensions/copilot/chat-lib/vitest.config.ts` — same suites via the separate `chat-lib tests` workflow

30 s matches the largest per-test override already in the tree (`copilotCLISDKUpgrade.spec.ts` uses `}, 30000)`), so it's consistent with existing precedent. It gives ~5× headroom over the worst observed starvation while still catching genuinely hung tests.

## Validation

- A temporary probe spec sleeping 7 s **passes** with the new config; the same probe run with `--testTimeout=5000` **fails** with `Test timed out in 5000ms`, confirming the setting takes effect. Probe removed.
- Ran the previously-flaking specs locally (`toolUtils`, `copilotCliShims`, `alternativeContent`, `cloudSessionIdStore`): **540/540 passed**.
- Both configs typecheck; eslint clean; hygiene pre-commit hook passed.

## Follow-up (not in this PR)

The underlying starvation remains. `xtabProvider.spec.ts` alone accounts for 81.6 s of the ~94 s wall time (191 tests, many sitting on real ~2103 ms timers), so it single-handedly gates the run while other forks queue behind it. Converting those to fake timers would meaningfully cut the Copilot job duration, but that's a separate change from unblocking the build.
