### PR TITLE
Add deletion actions to automation run history

### DIFF
--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -333,6 +333,22 @@ export class AutomationService extends Disposable implements IAutomationService 
 		});
 	}
 
+	async deleteRun(runId: string): Promise<void> {
+		await this.mutateLedger(ledger => {
+			if (!ledger.runs.some(run => run.id === runId)) {
+				return { kind: 'noChange', result: undefined };
+			}
+			return {
+				kind: 'commit',
+				ledger: {
+					automations: ledger.automations,
+					runs: ledger.runs.filter(run => run.id !== runId),
+				},
+				result: undefined,
+			};
+		});
+	}
+
 	getActiveRunFor(automationId: string): IAutomationRun | undefined {
 		return findActiveRun(this._runs.get(), automationId);
 	}

--- a/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
@@ -235,6 +235,18 @@ suite('AutomationService', () => {
 		assert.strictEqual(updated?.sessionResource, 'vscode-chat-session://copilot/sess-1');
 	});
 
+	test('deleteRun removes only the matching history entry', async () => {
+		const { service } = createService();
+		const automation = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), target: workspaceTarget() });
+		const first = await claimRun(service, automation.id, 'manual');
+		await service.updateRun(first.id, { status: 'completed' });
+		const second = await claimRun(service, automation.id, 'manual');
+
+		await service.deleteRun(first.id);
+
+		assert.deepStrictEqual(service.runs.get().map(run => run.id), [second.id]);
+	});
+
 	test('recordRunStart updates lastRunAt and advances the next scheduled run', async () => {
 		const { service } = createService();
 		service.setClockForTesting(() => new Date('2025-06-01T00:00:00Z'));

--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -337,11 +337,11 @@
 
 .automations-run-card {
 	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	padding: var(--vscode-spacing-size100) var(--vscode-spacing-size160);
+	flex-direction: row;
+	align-items: center;
 	border: 1px solid var(--vscode-widget-border);
 	border-radius: 6px;
+	overflow: hidden;
 }
 
 .automations-run-card.clickable {
@@ -352,7 +352,63 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
-.automations-run-card.clickable:focus-within {
+.automations-run-card-main {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	align-items: stretch;
+	justify-content: center;
+	gap: var(--vscode-spacing-size40);
+	min-width: 0;
+	padding: var(--vscode-spacing-size100) var(--vscode-spacing-size160);
+	border: none;
+	border-radius: 0;
+	outline: none;
+	background: transparent;
+	color: inherit;
+	text-align: left;
+}
+
+.automations-run-card.clickable .automations-run-card-main {
+	cursor: pointer;
+}
+
+.automations-run-card-main:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.automations-run-card-actions {
+	flex: 0 0 auto;
+	padding-right: var(--vscode-spacing-size80);
+	opacity: 0;
+}
+
+.automations-run-card:hover .automations-run-card-actions,
+.automations-run-card:focus-within .automations-run-card-actions {
+	opacity: 1;
+}
+
+.automations-run-card-actions .monaco-button.automations-run-card-delete-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--vscode-spacing-size240);
+	height: var(--vscode-spacing-size240);
+	min-width: var(--vscode-spacing-size240);
+	padding: 0;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small);
+	background: transparent;
+	color: var(--vscode-icon-foreground);
+	font-size: var(--vscode-codiconFontSize);
+}
+
+.automations-run-card-actions .monaco-button.automations-run-card-delete-button:hover:not(.disabled) {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.automations-run-card-actions .monaco-button.automations-run-card-delete-button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -374,7 +374,7 @@
 }
 
 .automations-run-card-main:focus-visible {
-	outline: 1px solid var(--vscode-focusBorder);
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
@@ -409,7 +409,7 @@
 }
 
 .automations-run-card-actions .monaco-button.automations-run-card-delete-button:focus-visible {
-	outline: 1px solid var(--vscode-focusBorder);
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsAccessibility.ts
@@ -28,7 +28,7 @@ class AutomationsCustomViewAccessibilityHelp implements IAccessibleViewImplement
 		const content = [
 			localize('automationsCustomView.help.overview', "You are in the Automations view. It contains automation cards followed by run history."),
 			localize('automationsCustomView.help.cards', "Tab to a card's Edit control and action buttons. Use Left Arrow and Right Arrow to move between Run now and Delete. Press Enter or Space to activate a control. Edit, or clicking anywhere else on the card, opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation."),
-			localize('automationsCustomView.help.history', "Run history is grouped by date. Each run reports its Pending, Running, Completed, or Failed status. Runs with an available session can be opened with Enter or Space."),
+			localize('automationsCustomView.help.history', "Run history is grouped by date. Each run reports its Pending, Running, Completed, or Failed status. Runs with an available session can be opened with Enter or Space. Tab to a run's delete button to permanently delete its session and history item, or to remove a terminal run that has no session from history, after confirmation."),
 			localize('automationsCustomView.help.read', "Completed and failed runs that have not been opened are announced as unread. Use Mark all as read to clear all available unread runs."),
 			localize('automationsCustomView.help.accessibleView', "Use Open Accessible View to read the current automations and run history as text."),
 		].join('\n');

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -81,7 +81,7 @@ export class AutomationsCardsWidget extends Disposable {
 		const scrollContent = DOM.append(this.element, $('.automations-cards-scroll-content'));
 
 		this.cardsSection = this._register(instantiationService.createInstance(AutomationCardsSection, scrollContent));
-		this.historySection = this._register(instantiationService.createInstance(AutomationHistorySection, scrollContent, this.isMarkingAllRead));
+		this.historySection = this._register(instantiationService.createInstance(AutomationHistorySection, scrollContent, this.element, this.isMarkingAllRead));
 
 		this._register(autorun(reader => {
 			const items = this.automationService.automations.read(reader);
@@ -400,9 +400,14 @@ class AutomationHistorySection extends Disposable {
 
 	private readonly container: HTMLElement;
 	private readonly disposables = this._register(new DisposableStore());
+	private readonly runFocusTargets = new Map<string, HTMLElement>();
+	private renderedFocusableRunIds: string[] = [];
+	private pendingFocusRunId: string | undefined;
+	private shouldRestoreFocus = false;
 
 	constructor(
 		parent: HTMLElement,
+		private readonly focusFallback: HTMLElement,
 		private readonly isMarkingAllRead: ISettableObservable<boolean>,
 		@IAutomationService private readonly automationService: IAutomationService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
@@ -417,9 +422,12 @@ class AutomationHistorySection extends Disposable {
 	render(runs: readonly IAutomationRun[], automations: readonly IAutomation[], sessions: ReadonlyMap<string, IAutomationRunSessionState>): void {
 		this.disposables.clear();
 		DOM.clearNode(this.container);
+		this.runFocusTargets.clear();
+		this.renderedFocusableRunIds = [];
 
 		if (runs.length === 0) {
 			this.container.style.display = 'none';
+			this.restoreFocusAfterRender();
 			return;
 		}
 
@@ -457,6 +465,7 @@ class AutomationHistorySection extends Disposable {
 				this.renderRunRow(groupGrid, run, automationMap, group.kind, sessions.get(run.id));
 			}
 		}
+		this.restoreFocusAfterRender();
 	}
 
 	private renderRunRow(parent: HTMLElement, run: IAutomationRun, automationMap: Map<string, IAutomation>, bucketKind: DateBucketKind, sessionState: IAutomationRunSessionState | undefined): void {
@@ -535,14 +544,16 @@ class AutomationHistorySection extends Disposable {
 			}));
 		}
 
-		const canDeleteSession = sessionState?.supportsDelete === true;
-		const canDeleteHistory = !sessionState && (run.status === 'completed' || run.status === 'failed');
+		const isTerminal = run.status === 'completed' || run.status === 'failed';
+		const canDeleteSession = isTerminal && sessionState?.supportsDelete === true;
+		const canDeleteHistory = isTerminal && !sessionState;
+		let deleteButton: Button | undefined;
 		if (canDeleteSession || canDeleteHistory) {
 			const actions = DOM.append(card, $('.automations-run-card-actions'));
 			const deleteLabel = canDeleteSession
 				? localize('deleteAutomationRunSession', "Delete session for {0}", title)
 				: localize('deleteAutomationRunHistory', "Delete run for {0} from history", title);
-			const deleteButton = this.disposables.add(new Button(actions, {
+			deleteButton = this.disposables.add(new Button(actions, {
 				ariaLabel: deleteLabel,
 				supportIcons: true,
 				title: deleteLabel,
@@ -556,6 +567,11 @@ class AutomationHistorySection extends Disposable {
 					void this.confirmDeleteRunHistory(run, title);
 				}
 			}));
+		}
+		const focusTarget = openButton?.element ?? deleteButton?.element;
+		if (focusTarget) {
+			this.renderedFocusableRunIds.push(run.id);
+			this.runFocusTargets.set(run.id, focusTarget);
 		}
 	}
 
@@ -587,9 +603,11 @@ class AutomationHistorySection extends Disposable {
 		if (!confirmed.confirmed) {
 			return;
 		}
+		this.prepareFocusAfterDeletion(run.id);
 		try {
 			await this.sessionsManagementService.deleteSession(session);
 		} catch (error) {
+			this.clearPendingFocus();
 			this.logService.error('[AutomationsCards] Failed to delete automation run session', error);
 			await this.dialogService.error(
 				localize('automationRunSessionDeleteFailed', "Failed to delete the automation run session."),
@@ -597,10 +615,13 @@ class AutomationHistorySection extends Disposable {
 			);
 			return;
 		}
+		this.prepareFocusAfterDeletion(run.id);
 		try {
 			await this.automationService.deleteRun(run.id);
+			this.restoreFocusAfterRender();
 			status(localize('automationRunSessionDeletedStatus', "Deleted the session for {0}", automationName));
 		} catch (error) {
+			this.clearPendingFocus();
 			this.logService.error('[AutomationsCards] Failed to remove deleted automation run from history', error);
 			await this.dialogService.error(
 				localize('automationRunHistoryDeleteFailed', "The session was deleted, but its run history item could not be removed."),
@@ -618,16 +639,41 @@ class AutomationHistorySection extends Disposable {
 		if (!confirmed.confirmed) {
 			return;
 		}
+		this.prepareFocusAfterDeletion(run.id);
 		try {
 			await this.automationService.deleteRun(run.id);
+			this.restoreFocusAfterRender();
 			status(localize('automationRunDeletedStatus', "Removed the run for {0} from history", automationName));
 		} catch (error) {
+			this.clearPendingFocus();
 			this.logService.error('[AutomationsCards] Failed to remove automation run from history', error);
 			await this.dialogService.error(
 				localize('automationRunDeleteFailed', "Failed to remove the automation run from history."),
 				getErrorMessage(error),
 			);
 		}
+	}
+
+	private prepareFocusAfterDeletion(runId: string): void {
+		const index = this.renderedFocusableRunIds.indexOf(runId);
+		this.pendingFocusRunId = index >= 0
+			? this.renderedFocusableRunIds[index + 1] ?? this.renderedFocusableRunIds[index - 1]
+			: undefined;
+		this.shouldRestoreFocus = true;
+	}
+
+	private restoreFocusAfterRender(): void {
+		if (!this.shouldRestoreFocus) {
+			return;
+		}
+		const target = this.pendingFocusRunId ? this.runFocusTargets.get(this.pendingFocusRunId) : undefined;
+		this.clearPendingFocus();
+		(target ?? this.focusFallback).focus();
+	}
+
+	private clearPendingFocus(): void {
+		this.pendingFocusRunId = undefined;
+		this.shouldRestoreFocus = false;
 	}
 
 	private async markAllRunsRead(runs: readonly IAutomationRun[]): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -11,7 +11,7 @@ import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/ho
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { autorun, constObservable, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { autorun, constObservable, IObservable, ISettableObservable, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -88,10 +88,12 @@ export class AutomationsCardsWidget extends Disposable {
 			this.cardsSection.render(items);
 		}));
 
+		const sessionDeleted = observableSignalFromEvent(this, this.sessionsManagementService.onDidDeleteSession);
 		this._register(autorun(reader => {
 			if (this.isMarkingAllRead.read(reader)) {
 				return;
 			}
+			sessionDeleted.read(reader);
 			const items = this.automationService.automations.read(reader);
 			const allRuns = this.automationService.runs.read(reader);
 			const sessions = new Map<string, IAutomationRunSessionState>();
@@ -101,7 +103,11 @@ export class AutomationsCardsWidget extends Disposable {
 				}
 				const session = this.sessionsManagementService.getSession(URI.parse(run.sessionResource));
 				if (session) {
-					sessions.set(run.id, { isRead: session.isRead.read(reader) });
+					sessions.set(run.id, {
+						session,
+						isRead: session.isRead.read(reader),
+						supportsDelete: session.capabilities.read(reader).supportsDelete === true,
+					});
 				}
 			}
 			this.historySection.render(allRuns, items, sessions);
@@ -398,6 +404,7 @@ class AutomationHistorySection extends Disposable {
 	constructor(
 		parent: HTMLElement,
 		private readonly isMarkingAllRead: ISettableObservable<boolean>,
+		@IAutomationService private readonly automationService: IAutomationService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ILogService private readonly logService: ILogService,
@@ -475,9 +482,20 @@ class AutomationHistorySection extends Disposable {
 			ariaLabelParts.push(localize('automationRunUnreadAriaLabel', "Unread"));
 		}
 		card.setAttribute('role', 'group');
-		card.setAttribute('aria-label', ariaLabelParts.join(', '));
+		const ariaLabel = ariaLabelParts.join(', ');
+		let main: HTMLElement;
+		let openButton: Button | undefined;
+		if (sessionState) {
+			openButton = this.disposables.add(new Button(card, { ariaLabel }));
+			main = openButton.element;
+			main.classList.add('automations-run-card-main');
+			card.classList.add('clickable');
+		} else {
+			main = DOM.append(card, $('.automations-run-card-main'));
+			card.setAttribute('aria-label', ariaLabel);
+		}
 
-		const nameEl = DOM.append(card, $('.automations-run-card-name'));
+		const nameEl = DOM.append(main, $('.automations-run-card-name'));
 		if (isUnread) {
 			DOM.append(nameEl, $('span.automations-run-card-unread-dot'));
 		}
@@ -489,7 +507,7 @@ class AutomationHistorySection extends Disposable {
 		}
 
 		// Status icon + timestamp + error (single row)
-		const statusRow = DOM.append(card, $('.automations-run-card-status-row'));
+		const statusRow = DOM.append(main, $('.automations-run-card-status-row'));
 
 		if (run.status === 'running' || run.status === 'pending') {
 			const spinnerContainer = DOM.append(statusRow, $('span.automations-run-card-icon'));
@@ -511,21 +529,31 @@ class AutomationHistorySection extends Disposable {
 			errorEl.textContent = run.errorMessage;
 		}
 
-		if (run.sessionResource && sessionState) {
-			card.classList.add('clickable');
-			card.setAttribute('tabindex', '0');
-			card.setAttribute('role', 'button');
-			this.disposables.add(Gesture.addTarget(card));
-			const activate = () => this.openRunSession(run);
-			for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap]) {
-				this.disposables.add(DOM.addDisposableListener(card, eventType, () => {
-					void activate();
-				}));
-			}
-			this.disposables.add(DOM.addDisposableListener(card, DOM.EventType.KEY_DOWN, event => {
-				if ((event.key === 'Enter' || event.key === ' ') && event.target === card) {
-					event.preventDefault();
-					void activate();
+		if (openButton) {
+			this.disposables.add(openButton.onDidClick(() => {
+				void this.openRunSession(run);
+			}));
+		}
+
+		const canDeleteSession = sessionState?.supportsDelete === true;
+		const canDeleteHistory = !sessionState && (run.status === 'completed' || run.status === 'failed');
+		if (canDeleteSession || canDeleteHistory) {
+			const actions = DOM.append(card, $('.automations-run-card-actions'));
+			const deleteLabel = canDeleteSession
+				? localize('deleteAutomationRunSession', "Delete session for {0}", title)
+				: localize('deleteAutomationRunHistory', "Delete run for {0} from history", title);
+			const deleteButton = this.disposables.add(new Button(actions, {
+				ariaLabel: deleteLabel,
+				supportIcons: true,
+				title: deleteLabel,
+			}));
+			deleteButton.label = `$(${Codicon.trash.id})`;
+			deleteButton.element.classList.add('automations-run-card-delete-button');
+			this.disposables.add(deleteButton.onDidClick(() => {
+				if (sessionState?.supportsDelete) {
+					void this.confirmDeleteRunSession(run, sessionState.session, title);
+				} else {
+					void this.confirmDeleteRunHistory(run, title);
 				}
 			}));
 		}
@@ -545,6 +573,58 @@ class AutomationHistorySection extends Disposable {
 			this.logService.error('[AutomationsCards] Failed to open automation run', error);
 			await this.dialogService.error(
 				localize('automationRunOpenFailed', "Failed to open automation run."),
+				getErrorMessage(error),
+			);
+		}
+	}
+
+	private async confirmDeleteRunSession(run: IAutomationRun, session: ISession, automationName: string): Promise<void> {
+		const confirmed = await this.dialogService.confirm({
+			message: localize('confirmDeleteAutomationRunSession', "Delete the session for \"{0}\"?", automationName),
+			detail: localize('confirmDeleteAutomationRunSessionDetail', "This will permanently delete the session and remove this item from run history. This action cannot be undone."),
+			primaryButton: localize('delete', "Delete"),
+		});
+		if (!confirmed.confirmed) {
+			return;
+		}
+		try {
+			await this.sessionsManagementService.deleteSession(session);
+		} catch (error) {
+			this.logService.error('[AutomationsCards] Failed to delete automation run session', error);
+			await this.dialogService.error(
+				localize('automationRunSessionDeleteFailed', "Failed to delete the automation run session."),
+				getErrorMessage(error),
+			);
+			return;
+		}
+		try {
+			await this.automationService.deleteRun(run.id);
+			status(localize('automationRunSessionDeletedStatus', "Deleted the session for {0}", automationName));
+		} catch (error) {
+			this.logService.error('[AutomationsCards] Failed to remove deleted automation run from history', error);
+			await this.dialogService.error(
+				localize('automationRunHistoryDeleteFailed', "The session was deleted, but its run history item could not be removed."),
+				getErrorMessage(error),
+			);
+		}
+	}
+
+	private async confirmDeleteRunHistory(run: IAutomationRun, automationName: string): Promise<void> {
+		const confirmed = await this.dialogService.confirm({
+			message: localize('confirmDeleteAutomationRunHistory', "Delete this run from history?"),
+			detail: localize('confirmDeleteAutomationRunHistoryDetail', "This will permanently remove the run for \"{0}\" from history. This action cannot be undone.", automationName),
+			primaryButton: localize('delete', "Delete"),
+		});
+		if (!confirmed.confirmed) {
+			return;
+		}
+		try {
+			await this.automationService.deleteRun(run.id);
+			status(localize('automationRunDeletedStatus', "Removed the run for {0} from history", automationName));
+		} catch (error) {
+			this.logService.error('[AutomationsCards] Failed to remove automation run from history', error);
+			await this.dialogService.error(
+				localize('automationRunDeleteFailed', "Failed to remove the automation run from history."),
 				getErrorMessage(error),
 			);
 		}
@@ -582,7 +662,9 @@ class AutomationHistorySection extends Disposable {
 type DateBucketKind = 'today' | 'yesterday' | 'week' | 'month';
 
 interface IAutomationRunSessionState {
+	readonly session: ISession;
 	readonly isRead: boolean;
+	readonly supportsDelete: boolean;
 }
 
 function isUnreadAutomationRun(run: IAutomationRun, sessionState: IAutomationRunSessionState | undefined): boolean {

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.fixture.ts
@@ -71,11 +71,14 @@ class FixtureAutomationService extends mock<IAutomationService>() {
 		this.automations = constObservable(automations);
 		this.runs = constObservable(runs);
 	}
+
+	override async deleteRun(): Promise<void> { }
 }
 
 class FixtureSessionsManagementService extends mock<ISessionsManagementService>() {
 
 	private readonly sessions = new Map<string, ISession>();
+	override readonly onDidDeleteSession = Event.None;
 
 	constructor(runs: readonly IAutomationRun[]) {
 		super();
@@ -88,6 +91,7 @@ class FixtureSessionsManagementService extends mock<ISessionsManagementService>(
 				resource,
 				sessionId: `fixture-session-${index + 1}`,
 				isRead: constObservable(index !== 0),
+				capabilities: constObservable({ supportsMultipleChats: false, supportsDelete: true }),
 			}));
 		}
 	}
@@ -210,7 +214,7 @@ function createPopulatedData(): IAutomationsFixtureData {
 	const runs: readonly IAutomationRun[] = [
 		createRun('daily-review-run', 'daily-review', 'completed', today),
 		createRun('dependency-audit-run', 'dependency-audit', 'running', today),
-		createRun('issue-triage-run', 'issue-triage', 'failed', yesterday, 'The repository could not be reached.'),
+		createRun('issue-triage-run', 'issue-triage', 'failed', yesterday, 'The repository could not be reached.', false),
 	];
 
 	return { automations, runs };
@@ -231,13 +235,13 @@ function createAutomation(overrides: Partial<IAutomation>): IAutomation {
 	};
 }
 
-function createRun(id: string, automationId: string, status: IAutomationRun['status'], startedAt: Date, errorMessage?: string): IAutomationRun {
+function createRun(id: string, automationId: string, status: IAutomationRun['status'], startedAt: Date, errorMessage?: string, hasSession = true): IAutomationRun {
 	return {
 		id,
 		automationId,
 		status,
 		trigger: 'schedule',
-		sessionResource: URI.parse(`vscode-chat-session://fixture/${id}`).toString(),
+		sessionResource: hasSession ? URI.parse(`vscode-chat-session://fixture/${id}`).toString() : undefined,
 		startedAt: startedAt.toISOString(),
 		completedAt: status === 'completed' || status === 'failed' ? startedAt.toISOString() : undefined,
 		errorMessage,

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -7,15 +7,16 @@ import assert from 'assert';
 import { DeferredPromise } from '../../../../../base/common/async.js';
 import { GestureEvent, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../base/common/event.js';
 import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
-import { toDisposable } from '../../../../../base/common/lifecycle.js';
+import { IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
-import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IConfirmation, IConfirmationResult, IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { NullHoverService } from '../../../../../platform/hover/test/browser/nullHoverService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -89,6 +90,7 @@ class FakeAutomationService extends mock<IAutomationService>() {
 	override readonly runs: IObservable<readonly IAutomationRun[]> = this.runValue;
 	updateResult: IGuardedAutomationUpdateResult | undefined;
 	updateCalls = 0;
+	deleteRunCalls = 0;
 
 	setAutomations(value: readonly IAutomation[]): void {
 		this.automationValue.set(value, undefined);
@@ -162,6 +164,11 @@ class FakeAutomationService extends mock<IAutomationService>() {
 	override async updateRun(_runId: string, _patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined> {
 		return undefined;
 	}
+
+	override async deleteRun(runId: string): Promise<void> {
+		this.deleteRunCalls++;
+		this.setRuns(this.runValue.get().filter(run => run.id !== runId));
+	}
 }
 
 class FakeAutomationDialogService extends mock<IAutomationDialogService>() {
@@ -181,8 +188,15 @@ class FakeAutomationDialogService extends mock<IAutomationDialogService>() {
 class FakeDialogService extends mock<IDialogService>() {
 	readonly errors: { message: string; detail: string }[] = [];
 	readonly infos: string[] = [];
+	readonly confirmations: IConfirmation[] = [];
 	readonly errorCalled = new DeferredPromise<void>();
 	readonly infoCalled = new DeferredPromise<void>();
+	confirmResult: IConfirmationResult = { confirmed: false };
+
+	override async confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {
+		this.confirmations.push(confirmation);
+		return this.confirmResult;
+	}
 
 	override async error(message: string, detail?: string): Promise<void> {
 		this.errors.push({ message, detail: detail ?? '' });
@@ -224,23 +238,30 @@ class FakeSessionsService extends mock<ISessionsService>() {
 	}
 }
 
-class FakeSessionsManagementService extends mock<ISessionsManagementService>() {
+class FakeSessionsManagementService extends mock<ISessionsManagementService>() implements IDisposable {
+	private readonly sessionDeletedEmitter = new Emitter<ISession>();
+	override readonly onDidDeleteSession = this.sessionDeletedEmitter.event;
 	sessionExists = true;
 	readonly isRead = observableValue<boolean>(this, false);
 	readonly secondIsRead = observableValue<boolean>(this, false);
+	readonly capabilities = observableValue(this, { supportsMultipleChats: false, supportsDelete: true });
 	readonly session = upcastPartial<ISession>({
 		resource: SESSION_RESOURCE,
 		sessionId: 'test/session-1',
 		isRead: this.isRead,
+		capabilities: this.capabilities,
 	});
 	readonly secondSession = upcastPartial<ISession>({
 		resource: SECOND_SESSION_RESOURCE,
 		sessionId: 'test/session-2',
 		isRead: this.secondIsRead,
+		capabilities: this.capabilities,
 	});
 	markAllReadCalls = 0;
 	markAllReadSessionCount = 0;
 	getSessionCalls = 0;
+	deleteSessionCalls = 0;
+	deleteError: Error | undefined;
 	readonly markAllReadCompleted = new DeferredPromise<void>();
 
 	override getSession(resource: URI): ISession | undefined {
@@ -265,6 +286,15 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() {
 		}
 	}
 
+	override async deleteSession(session: ISession): Promise<void> {
+		this.deleteSessionCalls++;
+		if (this.deleteError) {
+			throw this.deleteError;
+		}
+		this.sessionExists = false;
+		this.sessionDeletedEmitter.fire(session);
+	}
+
 	override async markAllRead(sessions: readonly ISession[]): Promise<void> {
 		this.markAllReadCalls++;
 		this.markAllReadSessionCount = sessions.length;
@@ -277,6 +307,14 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() {
 	setRead(isRead: boolean): void {
 		this.isRead.set(isRead, undefined);
 	}
+
+	setSupportsDelete(supportsDelete: boolean): void {
+		this.capabilities.set({ supportsMultipleChats: false, supportsDelete }, undefined);
+	}
+
+	dispose(): void {
+		this.sessionDeletedEmitter.dispose();
+	}
 }
 
 suite('AutomationsCardsWidget', () => {
@@ -287,7 +325,7 @@ suite('AutomationsCardsWidget', () => {
 		const automationDialogService = new FakeAutomationDialogService();
 		const dialogService = new FakeDialogService();
 		const runner = new FakeRunner();
-		const sessionsManagementService = new FakeSessionsManagementService();
+		const sessionsManagementService = disposables.add(new FakeSessionsManagementService());
 		const sessionsService = new FakeSessionsService(() => sessionsManagementService.markRead(sessionsManagementService.session));
 		const configurationService = new TestConfigurationService({ chat: { automations: { enabled: true } } });
 		const instantiationService = disposables.add(new TestInstantiationService());
@@ -318,7 +356,7 @@ suite('AutomationsCardsWidget', () => {
 
 		assert.deepStrictEqual({
 			schedule: widget.element.querySelector('.automations-card-meta-item')?.textContent,
-			runLabel: widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label'),
+			runLabel: widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label'),
 		}, {
 			schedule: `Daily at ${scheduleTime.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' })}`,
 			runLabel: `Daily review, workspace, Completed, ${runTime}, Unread`,
@@ -443,9 +481,10 @@ suite('AutomationsCardsWidget', () => {
 		const { automationService, sessionsManagementService, sessionsService, widget } = setup();
 		automationService.setAutomations([automation()]);
 		automationService.setRuns([run()]);
-		const card = widget.element.querySelector<HTMLElement>('.automations-run-card');
+		const card = widget.element.querySelector<HTMLElement>('.automations-run-card-main');
 
-		card?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+		assert.ok(card);
+		dispatchKeydown(card, { key: ' ', code: 'Space', keyCode: 32 });
 		assert.deepStrictEqual({
 			openCalls: sessionsService.openCalls,
 			readBeforeOpen: sessionsManagementService.isRead.get(),
@@ -460,7 +499,7 @@ suite('AutomationsCardsWidget', () => {
 
 		assert.deepStrictEqual({
 			isRead: sessionsManagementService.isRead.get(),
-			label: widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label'),
+			label: widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label'),
 		}, {
 			isRead: true,
 			label: card?.getAttribute('aria-label')?.replace(', Unread', ''),
@@ -472,15 +511,15 @@ suite('AutomationsCardsWidget', () => {
 		automationService.setAutomations([automation()]);
 		automationService.setRuns([run()]);
 		sessionsService.error = new Error('open failed');
-		const unreadLabel = widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label');
+		const unreadLabel = widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label');
 
-		widget.element.querySelector<HTMLDivElement>('.automations-run-card')?.click();
+		widget.element.querySelector<HTMLElement>('.automations-run-card-main')?.click();
 		sessionsService.openGate.complete();
 		await dialogService.errorCalled.p;
 
 		assert.deepStrictEqual({
 			isRead: sessionsManagementService.isRead.get(),
-			label: widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label'),
+			label: widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label'),
 			error: dialogService.errors,
 		}, {
 			isRead: false,
@@ -494,9 +533,9 @@ suite('AutomationsCardsWidget', () => {
 		automationService.setAutomations([automation()]);
 		automationService.setRuns([run()]);
 
-		const unreadLabel = widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label');
+		const unreadLabel = widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label');
 		sessionsManagementService.setRead(true);
-		const readLabel = widget.element.querySelector('.automations-run-card')?.getAttribute('aria-label');
+		const readLabel = widget.element.querySelector('.automations-run-card-main')?.getAttribute('aria-label');
 
 		assert.deepStrictEqual({
 			unreadLabel,
@@ -554,7 +593,7 @@ suite('AutomationsCardsWidget', () => {
 		});
 	});
 
-	test('stale run sessions are not exposed as buttons', () => {
+	test('stale run sessions cannot be opened but can be removed from history', () => {
 		const { automationService, sessionsManagementService, widget } = setup();
 		sessionsManagementService.sessionExists = false;
 		const staleRun = run();
@@ -565,13 +604,134 @@ suite('AutomationsCardsWidget', () => {
 
 		assert.deepStrictEqual({
 			role: card?.getAttribute('role'),
-			tabIndex: card?.getAttribute('tabindex'),
+			openButton: !!card?.querySelector('.automations-run-card-main[role="button"]'),
+			deleteButton: !!card?.querySelector('.automations-run-card-delete-button'),
+			deleteLabel: card?.querySelector('.automations-run-card-delete-button')?.getAttribute('aria-label'),
 			label: card?.getAttribute('aria-label'),
 		}, {
 			role: 'group',
-			tabIndex: null,
+			openButton: false,
+			deleteButton: true,
+			deleteLabel: 'Delete run for Daily review from history',
 			label: `Daily review, workspace, Completed, ${runTime}`,
 		});
+	});
+
+	test('deletes a failed run without a session from history', async () => {
+		const { automationService, dialogService, sessionsManagementService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run({ status: 'failed', sessionResource: undefined, errorMessage: 'startup failed' })]);
+		dialogService.confirmResult = { confirmed: true };
+
+		const deleteButton = widget.element.querySelector<HTMLElement>('.automations-run-card-delete-button');
+		assert.ok(deleteButton);
+		deleteButton.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			confirmation: dialogService.confirmations[0],
+			deleteSessionCalls: sessionsManagementService.deleteSessionCalls,
+			deleteRunCalls: automationService.deleteRunCalls,
+			historyItemStillVisible: !!widget.element.querySelector('.automations-run-card'),
+		}, {
+			confirmation: {
+				message: 'Delete this run from history?',
+				detail: 'This will permanently remove the run for "Daily review" from history. This action cannot be undone.',
+				primaryButton: 'Delete',
+			},
+			deleteSessionCalls: 0,
+			deleteRunCalls: 1,
+			historyItemStillVisible: false,
+		});
+	});
+
+	test('does not expose history deletion for an active run without a session', () => {
+		const { automationService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run({ status: 'running', sessionResource: undefined })]);
+
+		assert.strictEqual(widget.element.querySelector('.automations-run-card-delete-button'), null);
+	});
+
+	test('deleting a run session confirms the permanent deletion without opening it', async () => {
+		const { automationService, dialogService, sessionsManagementService, sessionsService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run()]);
+		dialogService.confirmResult = { confirmed: true };
+
+		const deleteButton = widget.element.querySelector<HTMLElement>('.automations-run-card-delete-button');
+		assert.ok(deleteButton);
+		deleteButton.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			confirmation: dialogService.confirmations[0],
+			deleteSessionCalls: sessionsManagementService.deleteSessionCalls,
+			deleteRunCalls: automationService.deleteRunCalls,
+			openCalls: sessionsService.openCalls,
+			historyItemStillVisible: !!widget.element.querySelector('.automations-run-card'),
+		}, {
+			confirmation: {
+				message: 'Delete the session for "Daily review"?',
+				detail: 'This will permanently delete the session and remove this item from run history. This action cannot be undone.',
+				primaryButton: 'Delete',
+			},
+			deleteSessionCalls: 1,
+			deleteRunCalls: 1,
+			openCalls: 0,
+			historyItemStillVisible: false,
+		});
+	});
+
+	test('canceling run session deletion keeps the session', async () => {
+		const { automationService, dialogService, sessionsManagementService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run()]);
+
+		widget.element.querySelector<HTMLElement>('.automations-run-card-delete-button')?.click();
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			confirmations: dialogService.confirmations.length,
+			deleteSessionCalls: sessionsManagementService.deleteSessionCalls,
+			deleteButtonStillVisible: !!widget.element.querySelector('.automations-run-card-delete-button'),
+		}, {
+			confirmations: 1,
+			deleteSessionCalls: 0,
+			deleteButtonStillVisible: true,
+		});
+	});
+
+	test('keeps run history when session deletion fails', async () => {
+		const { automationService, dialogService, sessionsManagementService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run()]);
+		dialogService.confirmResult = { confirmed: true };
+		sessionsManagementService.deleteError = new Error('delete failed');
+
+		widget.element.querySelector<HTMLElement>('.automations-run-card-delete-button')?.click();
+		await dialogService.errorCalled.p;
+
+		assert.deepStrictEqual({
+			deleteRunCalls: automationService.deleteRunCalls,
+			historyItemStillVisible: !!widget.element.querySelector('.automations-run-card'),
+			error: dialogService.errors,
+		}, {
+			deleteRunCalls: 0,
+			historyItemStillVisible: true,
+			error: [{ message: 'Failed to delete the automation run session.', detail: 'delete failed' }],
+		});
+	});
+
+	test('does not expose session deletion when the provider does not support it', () => {
+		const { automationService, sessionsManagementService, widget } = setup();
+		sessionsManagementService.setSupportsDelete(false);
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run()]);
+
+		assert.strictEqual(widget.element.querySelector('.automations-run-card-delete-button'), null);
 	});
 
 	test('edit conflict is reported to the user', async () => {

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -240,6 +240,7 @@ class FakeSessionsService extends mock<ISessionsService>() {
 
 class FakeSessionsManagementService extends mock<ISessionsManagementService>() implements IDisposable {
 	private readonly sessionDeletedEmitter = new Emitter<ISession>();
+	private readonly deletedSessionResources = new Set<string>();
 	override readonly onDidDeleteSession = this.sessionDeletedEmitter.event;
 	sessionExists = true;
 	readonly isRead = observableValue<boolean>(this, false);
@@ -269,6 +270,9 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() i
 		if (!this.sessionExists) {
 			return undefined;
 		}
+		if (this.deletedSessionResources.has(resource.toString())) {
+			return undefined;
+		}
 		if (resource.toString() === SESSION_RESOURCE.toString()) {
 			return this.session;
 		}
@@ -291,7 +295,7 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() i
 		if (this.deleteError) {
 			throw this.deleteError;
 		}
-		this.sessionExists = false;
+		this.deletedSessionResources.add(session.resource.toString());
 		this.sessionDeletedEmitter.fire(session);
 	}
 
@@ -654,6 +658,14 @@ suite('AutomationsCardsWidget', () => {
 		assert.strictEqual(widget.element.querySelector('.automations-run-card-delete-button'), null);
 	});
 
+	test('does not expose session deletion for an active run', () => {
+		const { automationService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run({ status: 'running' })]);
+
+		assert.strictEqual(widget.element.querySelector('.automations-run-card-delete-button'), null);
+	});
+
 	test('deleting a run session confirms the permanent deletion without opening it', async () => {
 		const { automationService, dialogService, sessionsManagementService, sessionsService, widget } = setup();
 		automationService.setAutomations([automation()]);
@@ -682,6 +694,32 @@ suite('AutomationsCardsWidget', () => {
 			deleteRunCalls: 1,
 			openCalls: 0,
 			historyItemStillVisible: false,
+		});
+	});
+
+	test('deleting the focused run moves focus to the next run', async () => {
+		const { automationService, dialogService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([
+			run(),
+			run({ id: 'run-2', sessionResource: SECOND_SESSION_RESOURCE.toString() }),
+		]);
+		dialogService.confirmResult = { confirmed: true };
+
+		const deleteButton = widget.element.querySelector<HTMLElement>('.automations-run-card-delete-button');
+		assert.ok(deleteButton);
+		deleteButton.focus();
+		deleteButton.click();
+		await Promise.resolve();
+		await Promise.resolve();
+		const remainingOpenButton = widget.element.querySelector<HTMLElement>('.automations-run-card-main[role="button"]');
+
+		assert.deepStrictEqual({
+			historyItemCount: widget.element.querySelectorAll('.automations-run-card').length,
+			focusedNextRun: document.activeElement === remainingOpenButton,
+		}, {
+			historyItemCount: 1,
+			focusedNextRun: true,
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/common/automations/automationService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationService.ts
@@ -149,6 +149,8 @@ export interface IAutomationService {
 
 	/** Applies a patch to a run; returns the updated run or `undefined` if not found. */
 	updateRun(runId: string, patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined>;
+	/** Deletes a retained run history entry; missing IDs are ignored. */
+	deleteRun(runId: string): Promise<void>;
 
 	/** Most recent `pending`/`running` run for an automation, or `undefined`. Backs the runner's per-automation claim. */
 	getActiveRunFor(automationId: string): IAutomationRun | undefined;


### PR DESCRIPTION
## Summary

- add a hover/focus trash action to automation run history items
- delete both the generated session and its history entry when a session exists
- allow completed or failed runs without sessions to be removed from history
- add confirmation dialogs, accessibility guidance, and regression coverage

## Testing

- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused automation service and Automations view tests
- `npm run precommit`

Closes microsoft/vscode-internalbacklog#8322