### PR TITLE
Restrict terminal auto-approval setting in untrusted workspaces 

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -85,6 +85,7 @@ const terminalChatAgentProfileSchema: IJSONSchema = {
 
 export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalChatAgentToolsSettingId.EnableAutoApprove]: {
+		restricted: true,
 		description: localize('autoApproveMode.description', "Controls whether to allow auto approval in the run in terminal tool."),
 		type: 'boolean',
 		default: true,
@@ -102,6 +103,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		agentsWindow: { default: true },
 	},
 	[TerminalChatAgentToolsSettingId.AutoApprove]: {
+		restricted: true,
 		markdownDescription: [
 			localize('autoApprove.description.intro', "A list of commands or regular expressions that control whether the run in terminal tool commands require explicit approval. These will be matched against the start of a command. A regular expression can be provided by wrapping the string in {0} characters followed by optional flags such as {1} for case-insensitivity.", '`/`', '`i`'),
 			localize('autoApprove.description.values', "Set to {0} to automatically approve commands, {1} to always require explicit approval or {2} to unset the value.", '`true`', '`false`', '`null`'),
@@ -386,6 +388,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		} satisfies Record<string, boolean | { approve: boolean; matchCommandLine?: boolean }>,
 	},
 	[TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules]: {
+		restricted: true,
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],
@@ -401,6 +404,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		markdownDescription: localize('autoApproveWorkspaceNpmScripts.description', "Whether to automatically approve npm, yarn, and pnpm run commands when the script is defined in a workspace package.json file. Since the workspace is trusted, scripts defined in package.json are considered safe to run without explicit approval."),
 	},
 	[TerminalChatAgentToolsSettingId.BlockDetectedFileWrites]: {
+		restricted: true,
 		type: 'string',
 		enum: ['never', 'outsideWorkspace', 'all'],
 		enumDescriptions: [

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -810,6 +810,7 @@ for (const id of [
 	TerminalChatAgentToolsSettingId.DeprecatedAutoApproveCompatible,
 ]) {
 	terminalChatAgentToolsConfiguration[id] = {
+		...(id === TerminalChatAgentToolsSettingId.DeprecatedAutoApproveCompatible ? { restricted: true } : {}),
 		deprecated: true,
 		markdownDeprecationMessage: localize('autoApprove.deprecated', 'Use {0} instead', `\`#${TerminalChatAgentToolsSettingId.AutoApprove}#\``)
 	};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
@@ -25,12 +25,14 @@ suite('Terminal chat agent tools configuration', () => {
 		TerminalChatAgentToolsSettingId.AutoApprove,
 		TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules,
 		TerminalChatAgentToolsSettingId.BlockDetectedFileWrites,
+		TerminalChatAgentToolsSettingId.DeprecatedAutoApproveCompatible,
 	];
 	const workspaceValues: Record<string, unknown> = {
 		[TerminalChatAgentToolsSettingId.EnableAutoApprove]: false,
 		[TerminalChatAgentToolsSettingId.AutoApprove]: { '/.*/': true },
 		[TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules]: true,
 		[TerminalChatAgentToolsSettingId.BlockDetectedFileWrites]: 'never',
+		[TerminalChatAgentToolsSettingId.DeprecatedAutoApproveCompatible]: { '/.*/': true },
 	};
 
 	suiteSetup(() => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
@@ -26,7 +26,7 @@ suite('Terminal chat agent tools configuration', () => {
 		TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules,
 		TerminalChatAgentToolsSettingId.BlockDetectedFileWrites,
 	];
-	const workspaceValues = {
+	const workspaceValues: Record<string, unknown> = {
 		[TerminalChatAgentToolsSettingId.EnableAutoApprove]: false,
 		[TerminalChatAgentToolsSettingId.AutoApprove]: { '/.*/': true },
 		[TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules]: true,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/common/terminalChatAgentToolsConfiguration.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ConfigurationModelParser } from '../../../../../../platform/configuration/common/configurationModels.js';
+import { Extensions, IConfigurationNode, IConfigurationRegistry } from '../../../../../../platform/configuration/common/configurationRegistry.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { Registry } from '../../../../../../platform/registry/common/platform.js';
+import { WorkspaceConfigurationModelParser } from '../../../../../services/configuration/common/configurationModels.js';
+import { terminalChatAgentToolsConfiguration, TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
+
+suite('Terminal chat agent tools configuration', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+	const configurationNode: IConfigurationNode = {
+		id: 'terminalChatAgentToolsConfigurationTest',
+		type: 'object',
+		properties: terminalChatAgentToolsConfiguration,
+	};
+	const restrictedSettingIds = [
+		TerminalChatAgentToolsSettingId.EnableAutoApprove,
+		TerminalChatAgentToolsSettingId.AutoApprove,
+		TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules,
+		TerminalChatAgentToolsSettingId.BlockDetectedFileWrites,
+	];
+	const workspaceValues = {
+		[TerminalChatAgentToolsSettingId.EnableAutoApprove]: false,
+		[TerminalChatAgentToolsSettingId.AutoApprove]: { '/.*/': true },
+		[TerminalChatAgentToolsSettingId.IgnoreDefaultAutoApproveRules]: true,
+		[TerminalChatAgentToolsSettingId.BlockDetectedFileWrites]: 'never',
+	};
+
+	suiteSetup(() => {
+		configurationRegistry.registerConfiguration(configurationNode);
+	});
+
+	suiteTeardown(() => configurationRegistry.deregisterConfigurations([configurationNode]));
+
+	test('registers terminal safety settings as restricted', () => {
+		assert.deepStrictEqual(
+			restrictedSettingIds.map(id => terminalChatAgentToolsConfiguration[id].restricted),
+			restrictedSettingIds.map(() => true),
+		);
+	});
+
+	test('filters terminal safety settings from an untrusted single-folder workspace', () => {
+		const parser = new ConfigurationModelParser('terminalSafetySettings', new NullLogService());
+		parser.parse(JSON.stringify(workspaceValues), { skipRestricted: true });
+
+		assert.deepStrictEqual({
+			values: restrictedSettingIds.map(id => parser.configurationModel.getValue(id)),
+			restricted: parser.restrictedConfigurations.filter(id => restrictedSettingIds.includes(id as TerminalChatAgentToolsSettingId)),
+		}, {
+			values: restrictedSettingIds.map(() => undefined),
+			restricted: restrictedSettingIds,
+		});
+	});
+
+	test('filters terminal safety settings from an untrusted workspace file', () => {
+		const parser = new WorkspaceConfigurationModelParser('terminalSafetySettings', new NullLogService());
+		parser.parse(JSON.stringify({ folders: [], settings: workspaceValues }), { skipRestricted: true });
+
+		assert.deepStrictEqual({
+			values: restrictedSettingIds.map(id => parser.settingsModel.getValue(id)),
+			restricted: parser.getRestrictedWorkspaceSettings().filter(id => restrictedSettingIds.includes(id as TerminalChatAgentToolsSettingId)),
+		}, {
+			values: restrictedSettingIds.map(() => undefined),
+			restricted: restrictedSettingIds,
+		});
+	});
+
+	test('preserves terminal safety settings in a trusted workspace', () => {
+		const parser = new ConfigurationModelParser('terminalSafetySettings', new NullLogService());
+		parser.parse(JSON.stringify(workspaceValues));
+
+		assert.deepStrictEqual(
+			restrictedSettingIds.map(id => parser.configurationModel.getValue(id)),
+			restrictedSettingIds.map(id => workspaceValues[id]),
+		);
+	});
+});


### PR DESCRIPTION
Fixes #329106

- Mark terminal auto-approval enablement, command rules, default-rule overrides, and detected file-write policy as restricted settings.
- Also restrict the deprecated `chat.agent.terminal.autoApprove` compatibility setting.
- Ignore workspace-provided values for these settings while the workspace is untrusted.
- Preserve user, remote, default, and trusted-workspace behavior.
- Keep terminal, Agent Host, warning, sandbox, and permission logic unchanged.
- Add parser-level regressions for untrusted single-folder and `.code-workspace` settings, plus a trusted-workspace negative control.

-----------------------------------------
Inspirations from:

- Restricted-setting filtering follows [`ConfigurationModelParser.shouldInclude`](https://github.com/microsoft/vscode/blob/8e3f97149d1aa801237904995cc3839c1c8220e8/src/vs/platform/configuration/common/configurationModels.ts#L462-L472), which skips properties marked `restricted` when `skipRestricted` is enabled.
- Untrusted workspace loading and trust-change reparsing follow [`WorkspaceService.reload`](https://github.com/microsoft/vscode/blob/8e3f97149d1aa801237904995cc3839c1c8220e8/src/vs/workbench/services/configuration/browser/configuration.ts#L679-L683) and [`WorkspaceService.reparseWorkspaceSettings`](https://github.com/microsoft/vscode/blob/8e3f97149d1aa801237904995cc3839c1c8220e8/src/vs/workbench/services/configuration/browser/configuration.ts#L707-L712).
- The restriction convention matches the neighboring [`chat.tools.terminal.autoApproveWorkspaceNpmScripts`](https://github.com/microsoft/vscode/blob/8e3f97149d1aa801237904995cc3839c1c8220e8/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L394-L401) setting.