### PR TITLE
sessions: Register user data sync utility channel

### DIFF
--- a/src/vs/sessions/README.md
+++ b/src/vs/sessions/README.md
@@ -38,7 +38,7 @@ When adding features to the Agents Window:
 1. **Core workbench code** (layout, parts, services) goes under `browser/` or `services/`
 2. **Feature contributions** (views, actions, editors) go under `contrib/<featureName>/browser/`
 3. **Session providers** go under `contrib/providers/<providerName>/browser/`
-4. Register contributions, including desktop-only channel contributions, by importing them in `sessions.desktop.main.ts` (or `sessions.common.main.ts` for browser-compatible code)
+4. Register contributions by importing them in `sessions.desktop.main.ts` (or `sessions.common.main.ts` for browser-compatible code)
 5. Non-provider `contrib/*` modules **must not** import from `contrib/providers/*` — see [LAYERS.md](LAYERS.md)
 6. Update the layout spec ([LAYOUT.md](LAYOUT.md)) for any layout changes
 7. Update the sessions spec ([SESSIONS.md](SESSIONS.md)) when changing provider interfaces or data flow

--- a/src/vs/sessions/README.md
+++ b/src/vs/sessions/README.md
@@ -38,7 +38,7 @@ When adding features to the Agents Window:
 1. **Core workbench code** (layout, parts, services) goes under `browser/` or `services/`
 2. **Feature contributions** (views, actions, editors) go under `contrib/<featureName>/browser/`
 3. **Session providers** go under `contrib/providers/<providerName>/browser/`
-4. Register contributions by importing them in `sessions.desktop.main.ts` (or `sessions.common.main.ts` for browser-compatible code)
+4. Register contributions, including desktop-only channel contributions, by importing them in `sessions.desktop.main.ts` (or `sessions.common.main.ts` for browser-compatible code)
 5. Non-provider `contrib/*` modules **must not** import from `contrib/providers/*` — see [LAYERS.md](LAYERS.md)
 6. Update the layout spec ([LAYOUT.md](LAYOUT.md)) for any layout changes
 7. Update the sessions spec ([SESSIONS.md](SESSIONS.md)) when changing provider interfaces or data flow

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -72,6 +72,7 @@ import '../workbench/services/extensionManagement/electron-browser/extensionGall
 import '../workbench/services/extensionManagement/electron-browser/extensionTipsService.js';
 import '../workbench/services/userDataSync/electron-browser/userDataSyncService.js';
 import '../workbench/services/userDataSync/electron-browser/userDataAutoSyncService.js';
+import '../workbench/contrib/userDataSync/electron-browser/userDataSyncUtilChannel.contribution.js';
 import '../workbench/services/timer/electron-browser/timerService.js';
 import '../workbench/services/environment/electron-browser/shellEnvironmentService.js';
 import '../workbench/services/integrity/electron-browser/integrityService.js';

--- a/src/vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution.ts
+++ b/src/vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution.ts
@@ -3,9 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
-import { IUserDataSyncUtilService, SyncStatus } from '../../../../platform/userDataSync/common/userDataSync.js';
-import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
+import { SyncStatus } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { registerAction2, Action2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -15,23 +13,7 @@ import { INativeHostService } from '../../../../platform/native/common/native.js
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { CONTEXT_SYNC_STATE, DOWNLOAD_ACTIVITY_ACTION_DESCRIPTOR, IUserDataSyncWorkbenchService, SYNC_TITLE } from '../../../services/userDataSync/common/userDataSync.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
-
-class UserDataSyncServicesContribution extends Disposable implements IWorkbenchContribution {
-
-	static readonly ID = 'workbench.contrib.userDataSyncServices';
-
-	constructor(
-		@IUserDataSyncUtilService userDataSyncUtilService: IUserDataSyncUtilService,
-		@ISharedProcessService sharedProcessService: ISharedProcessService,
-	) {
-		super();
-		sharedProcessService.registerChannel('userDataSyncUtil', ProxyChannel.fromService(userDataSyncUtilService, this._store));
-	}
-}
-
-registerWorkbenchContribution2(UserDataSyncServicesContribution.ID, UserDataSyncServicesContribution, WorkbenchPhase.BlockStartup);
+import './userDataSyncUtilChannel.contribution.js';
 
 registerAction2(class OpenSyncBackupsFolder extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/userDataSync/electron-browser/userDataSyncUtilChannel.contribution.ts
+++ b/src/vs/workbench/contrib/userDataSync/electron-browser/userDataSyncUtilChannel.contribution.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
+import { IUserDataSyncUtilService } from '../../../../platform/userDataSync/common/userDataSync.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+
+export class UserDataSyncUtilChannelContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.userDataSyncServices';
+
+	constructor(
+		@IUserDataSyncUtilService userDataSyncUtilService: IUserDataSyncUtilService,
+		@ISharedProcessService sharedProcessService: ISharedProcessService,
+	) {
+		super();
+		sharedProcessService.registerChannel('userDataSyncUtil', ProxyChannel.fromService(userDataSyncUtilService, this._store));
+	}
+}
+
+registerWorkbenchContribution2(UserDataSyncUtilChannelContribution.ID, UserDataSyncUtilChannelContribution, WorkbenchPhase.BlockStartup);

--- a/src/vs/workbench/contrib/userDataSync/test/electron-browser/userDataSyncUtilChannel.test.ts
+++ b/src/vs/workbench/contrib/userDataSync/test/electron-browser/userDataSyncUtilChannel.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IStringDictionary } from '../../../../../base/common/collections.js';
+import { FormattingOptions } from '../../../../../base/common/jsonFormatter.js';
+import { IChannel, IServerChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ISharedProcessService } from '../../../../../platform/ipc/electron-browser/services.js';
+import { IUserDataSyncUtilService } from '../../../../../platform/userDataSync/common/userDataSync.js';
+import { UserDataSyncUtilChannelContribution } from '../../electron-browser/userDataSyncUtilChannel.contribution.js';
+
+class TestUserDataSyncUtilService implements IUserDataSyncUtilService {
+
+	declare readonly _serviceBrand: undefined;
+
+	async resolveUserBindings(): Promise<IStringDictionary<string>> {
+		return {};
+	}
+
+	async resolveFormattingOptions(): Promise<FormattingOptions> {
+		return { eol: '\n', insertSpaces: true, tabSize: 4 };
+	}
+
+	async resolveDefaultCoreIgnoredSettings(): Promise<string[]> {
+		return ['editor.fontSize'];
+	}
+}
+
+class RecordingSharedProcessService implements ISharedProcessService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private channelRegistration: { channelName: string; channel: IServerChannel<string> } | undefined;
+
+	get registration(): { channelName: string; channel: IServerChannel<string> } {
+		if (!this.channelRegistration) {
+			throw new Error('No channel was registered');
+		}
+
+		return this.channelRegistration;
+	}
+
+	getChannel(): IChannel {
+		throw new Error('Not implemented');
+	}
+
+	registerChannel(channelName: string, channel: IServerChannel<string>): void {
+		this.channelRegistration = { channelName, channel };
+	}
+
+	createRawConnection(): Promise<MessagePort> {
+		throw new Error('Not implemented');
+	}
+
+	notifyRestored(): void { }
+}
+
+suite('UserDataSyncUtilChannelContribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('registers the user data sync utility channel', async () => {
+		const sharedProcessService = new RecordingSharedProcessService();
+		disposables.add(new UserDataSyncUtilChannelContribution(new TestUserDataSyncUtilService(), sharedProcessService));
+
+		const registration = sharedProcessService.registration;
+		const value = await registration.channel.call<string[]>('window:1', 'resolveDefaultCoreIgnoredSettings');
+
+		assert.deepStrictEqual({ channelName: registration.channelName, value }, {
+			channelName: 'userDataSyncUtil',
+			value: ['editor.fontSize']
+		});
+	});
+});


### PR DESCRIPTION
## Problem

A recent Code - Insiders session logged 44 uncaught shared-process errors with the following message:

`Channel name 'userDataSyncUtil' timed out after 1000ms`

The shared process obtains `IUserDataSyncUtilService` by proxying calls to a renderer client that is not the main process. The normal desktop workbench registers the `userDataSyncUtil` channel during `WorkbenchPhase.BlockStartup`, but the Agents window has a separate desktop entrypoint and did not load that registration.

Because an Agents window still connects to the shared-process IPC server and satisfies the renderer-client filter, the shared process could route a user-data-sync utility call to that window. The request then waited for a channel the window never registered, timed out, and surfaced as an uncaught shared-process error. This was especially visible when several windows were open because routing chooses among eligible renderer clients.

## Fix

- Extract the existing `userDataSyncUtil` channel registration from the broader Settings Sync action contribution into a dedicated user-data-sync channel contribution.
- Load that contribution from both the normal desktop workbench and the Agents window desktop entrypoint, so every eligible renderer client exposes the channel.
- Keep registration at `WorkbenchPhase.BlockStartup` instead of changing IPC timeout behavior or swallowing the error.
- Add a focused test that verifies the contribution registers the expected channel and that a service method can be called through it.

## Testing

- `npm run compile`
- `npm run precommit`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/workbench/contrib/userDataSync/test/electron-browser/userDataSyncUtilChannel.test.ts`

(Written by Copilot)