### PR TITLE
Include fallback Copilot process log in Agent Host debug exports

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -40,6 +40,7 @@ const AGENT_HOST_LOGGER_CHANNEL_ID = AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
 const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
 /** Output channel ID for the shared process compound log. */
 const SHARED_PROCESS_LOG_CHANNEL_ID = 'shared';
+const MAX_REMOTE_COPILOT_LOG_EXPORT_SIZE = 10 * 1024 * 1024;
 
 /**
  * Description of the agent-host session whose logs should be exported. If
@@ -209,14 +210,18 @@ export async function collectAgentHostDebugLogs(
 
 	// 5. Copilot SDK process logs under <COPILOT_HOME>/logs.
 	const rawSessionId = getCopilotCliSessionRawId(activeSession?.resource);
-	const copilotLogsDir = activeSession?.isLocal === false
-		? remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined
+	const copilotLogsDir = activeSession
+		? rawSessionId
+			? activeSession.isLocal
+				? buildLocalCopilotLogsUri(userHome)
+				: remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined
+			: undefined
 		: buildLocalCopilotLogsUri(userHome);
 	if (copilotLogsDir) {
 		const copilotLogFiles = await findRelevantCopilotLogs(copilotLogsDir, rawSessionId, fileService, logService);
 		for (const file of copilotLogFiles) {
 			try {
-				files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
+				files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size, MAX_REMOTE_COPILOT_LOG_EXPORT_SIZE));
 			} catch (error) {
 				logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${file.path}': ${error instanceof Error ? error.message : String(error)}`);
 			}
@@ -375,7 +380,7 @@ async function exportFilesToLocalFolder(
 	return true;
 }
 
-async function createDebugLogFile(path: string, resource: URI, fileService: IFileService, size?: number): Promise<IAgentHostDebugLogFile> {
+async function createDebugLogFile(path: string, resource: URI, fileService: IFileService, size?: number, maxInlineSize?: number): Promise<IAgentHostDebugLogFile> {
 	if (resource.scheme === Schemas.file) {
 		const observedSize = size ?? (await fileService.resolve(resource, { resolveMetadata: true })).size;
 		return { path, resource, size: observedSize };
@@ -383,7 +388,8 @@ async function createDebugLogFile(path: string, resource: URI, fileService: IFil
 	// Non-local resources (e.g. remote agent-host logs) can't be streamed from
 	// disk, so read them inline, bounded to the captured size when known.
 	if (size !== undefined) {
-		const stream = await fileService.readFileStream(resource, { length: size });
+		const readSize = maxInlineSize === undefined ? size : Math.min(size, maxInlineSize);
+		const stream = await fileService.readFileStream(resource, { position: size - readSize, length: readSize });
 		const content = await streamToBuffer(stream.value);
 		return { path, contents: content.toString() };
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -31,7 +31,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
-import { findCopilotLogsForSession, getRemoteConnectionForSession, readRemoteAgentHostLog, sanitizeFilePart } from '../chatDebug/agentHostLogSources.js';
+import { findRelevantCopilotLogs, getRemoteConnectionForSession, readRemoteAgentHostLog, sanitizeFilePart } from '../chatDebug/agentHostLogSources.js';
 import { buildAgentHostCustomizationsUri, buildAgentHostUsageUri } from '../chatDebug/agentHostUsageSidecar.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
@@ -207,21 +207,18 @@ export async function collectAgentHostDebugLogs(
 		}
 	}
 
-	// 5. Copilot SDK process logs under <COPILOT_HOME>/logs do not include the
-	// session id in the filename, but relevant entries include it in the content.
+	// 5. Copilot SDK process logs under <COPILOT_HOME>/logs.
 	const rawSessionId = getCopilotCliSessionRawId(activeSession?.resource);
-	if (rawSessionId) {
-		const copilotLogsDir = activeSession?.isLocal
-			? buildLocalCopilotLogsUri(userHome)
-			: remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined;
-		if (copilotLogsDir) {
-			const copilotLogFiles = await findCopilotLogsForSession(copilotLogsDir, rawSessionId, fileService, logService);
-			for (const file of copilotLogFiles) {
-				try {
-					files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
-				} catch (error) {
-					logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${file.path}': ${error instanceof Error ? error.message : String(error)}`);
-				}
+	const copilotLogsDir = activeSession?.isLocal === false
+		? remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined
+		: buildLocalCopilotLogsUri(userHome);
+	if (copilotLogsDir) {
+		const copilotLogFiles = await findRelevantCopilotLogs(copilotLogsDir, rawSessionId, fileService, logService);
+		for (const file of copilotLogFiles) {
+			try {
+				files.push(await createDebugLogFile(file.path, file.resource, fileService, file.size));
+			} catch (error) {
+				logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${file.path}': ${error instanceof Error ? error.message : String(error)}`);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -26,13 +26,14 @@ const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
 /** Output channel ID for the shared process compound log. */
 const SHARED_PROCESS_LOG_CHANNEL_ID = 'shared';
 /** Bound the best-effort scan of Copilot SDK process logs. */
-export const MAX_COPILOT_LOG_SCAN_FILES = 20;
-export const MAX_COPILOT_LOG_FILE_SIZE = 10 * 1024 * 1024;
+export const MAX_COPILOT_LOG_SCAN_FILES = 10;
+export const MAX_COPILOT_LOG_SCAN_FILE_SIZE = 1024 * 1024 * 1024;
+const MAX_COPILOT_LOG_VIEW_FILE_SIZE = 10 * 1024 * 1024;
 /** Default cap for the amount of text loaded into the inline raw-log viewer. */
 export const DEFAULT_RAW_LOG_VIEW_CAP_BYTES = 2 * 1024 * 1024;
 
 /**
- * A matching Copilot process log that can be read lazily.
+ * A selected Copilot process log that can be read lazily.
  */
 export interface ICopilotLogFile {
 	readonly path: string;
@@ -71,7 +72,7 @@ export interface IAgentHostLogSource {
 	readonly resource?: URI;
 	/** Output channel id for channel-backed sources. */
 	readonly channelId?: string;
-	/** Copilot logs directory + session id, for the lazy content-filtered CLI log read. */
+	/** Copilot logs directory + session id, for the lazy session-matched CLI log read. */
 	readonly cliLogs?: { readonly dir: URI; readonly rawSessionId: string };
 	/** Remote connection for lazily downloading `agenthost.log`. */
 	readonly remoteConnection?: IRemoteAgentHostConnectionInfo;
@@ -216,7 +217,7 @@ export async function enumerateAgentHostLogSources(
 		});
 	}
 
-	// 5. Copilot SDK process logs (<COPILOT_HOME>/logs), content-filtered lazily by session id.
+	// 5. Copilot SDK process logs (<COPILOT_HOME>/logs), matched lazily by session id with a newest-log fallback.
 	const rawSessionId = getCopilotCliSessionRawId(sessionResource);
 	if (rawSessionId) {
 		const copilotLogsDir = isLocal
@@ -365,9 +366,9 @@ function tailString(value: string, capBytes: number): IAgentHostLogContent {
 }
 
 /**
- * Scans a Copilot logs directory for `.log` files whose content mentions the
- * given session id, returning their contents. Bounded by
- * {@link MAX_COPILOT_LOG_SCAN_FILES} and {@link MAX_COPILOT_LOG_FILE_SIZE}.
+ * Reads Copilot process logs selected for a session, or the newest log when
+ * none mention the session id. Bounded by
+ * {@link MAX_COPILOT_LOG_SCAN_FILES} and {@link MAX_COPILOT_LOG_SCAN_FILE_SIZE}.
  */
 export async function readCopilotLogsForSession(
 	logsDir: URI,
@@ -375,11 +376,13 @@ export async function readCopilotLogsForSession(
 	fileService: IFileService,
 	logService: ILogService,
 ): Promise<{ path: string; contents: string }[]> {
-	const matchingLogs = await findCopilotLogsForSession(logsDir, rawSessionId, fileService, logService);
+	const matchingLogs = await findRelevantCopilotLogs(logsDir, rawSessionId, fileService, logService);
 	const files: { path: string; contents: string }[] = [];
 	for (const log of matchingLogs) {
 		try {
-			const content = await fileService.readFile(log.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
+			const content = log.size > MAX_COPILOT_LOG_VIEW_FILE_SIZE
+				? await fileService.readFile(log.resource, { position: log.size - MAX_COPILOT_LOG_VIEW_FILE_SIZE, length: MAX_COPILOT_LOG_VIEW_FILE_SIZE })
+				: await fileService.readFile(log.resource, { limits: { size: MAX_COPILOT_LOG_VIEW_FILE_SIZE } });
 			files.push({ path: log.path, contents: content.value.toString() });
 		} catch (error) {
 			logService.warn(`[AgentHostLogSources] Failed to read Copilot log '${log.resource.path}': ${error instanceof Error ? error.message : String(error)}`);
@@ -389,11 +392,12 @@ export async function readCopilotLogsForSession(
 }
 
 /**
- * Finds bounded Copilot process logs whose contents mention the session id.
+ * Scans a bounded set of Copilot process logs for the session id, falling back
+ * to the newest process log when no match can be found.
  */
-export async function findCopilotLogsForSession(
+export async function findRelevantCopilotLogs(
 	logsDir: URI,
-	rawSessionId: string,
+	rawSessionId: string | undefined,
 	fileService: IFileService,
 	logService: ILogService,
 ): Promise<ICopilotLogFile[]> {
@@ -404,21 +408,26 @@ export async function findCopilotLogsForSession(
 		return [];
 	}
 
-	const files: ICopilotLogFile[] = [];
-	const candidateLogs = (children ?? [])
-		.filter(child => !child.isDirectory && child.name.endsWith('.log') && child.size <= MAX_COPILOT_LOG_FILE_SIZE)
+	const processLogs = (children ?? [])
+		.filter(child => !child.isDirectory && child.name.endsWith('.log'))
 		.sort((a, b) => b.mtime - a.mtime)
+		.map(child => ({ path: `copilot-logs/${child.name}`, resource: child.resource, size: child.size }));
+	const files: ICopilotLogFile[] = [];
+	const candidateLogs = processLogs
+		.filter(child => child.size <= MAX_COPILOT_LOG_SCAN_FILE_SIZE)
 		.slice(0, MAX_COPILOT_LOG_SCAN_FILES);
-	for (const child of candidateLogs) {
-		try {
-			if (await logStreamContains(child.resource, rawSessionId, fileService)) {
-				files.push({ path: `copilot-logs/${child.name}`, resource: child.resource, size: child.size });
+	if (rawSessionId) {
+		for (const candidate of candidateLogs) {
+			try {
+				if (await logStreamContains(candidate.resource, rawSessionId, fileService)) {
+					files.push(candidate);
+				}
+			} catch (error) {
+				logService.warn(`[AgentHostLogSources] Failed to scan Copilot log '${candidate.path}': ${error instanceof Error ? error.message : String(error)}`);
 			}
-		} catch (error) {
-			logService.warn(`[AgentHostLogSources] Failed to scan Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
 		}
 	}
-	return files;
+	return files.length > 0 ? files : processLogs.slice(0, 1);
 }
 
 async function logStreamContains(
@@ -430,8 +439,8 @@ async function logStreamContains(
 	let stream: VSBufferReadableStream;
 	try {
 		stream = (await fileService.readFileStream(resource, {
-			length: MAX_COPILOT_LOG_FILE_SIZE,
-			limits: { size: MAX_COPILOT_LOG_FILE_SIZE },
+			length: MAX_COPILOT_LOG_SCAN_FILE_SIZE,
+			limits: { size: MAX_COPILOT_LOG_SCAN_FILE_SIZE },
 		}, tokenSource.token)).value;
 	} catch (error) {
 		tokenSource.dispose(true);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -414,8 +414,8 @@ export async function findRelevantCopilotLogs(
 		.map(child => ({ path: `copilot-logs/${child.name}`, resource: child.resource, size: child.size }));
 	const files: ICopilotLogFile[] = [];
 	const candidateLogs = processLogs
-		.filter(child => child.size <= MAX_COPILOT_LOG_SCAN_FILE_SIZE)
-		.slice(0, MAX_COPILOT_LOG_SCAN_FILES);
+		.slice(0, MAX_COPILOT_LOG_SCAN_FILES)
+		.filter(child => child.size <= MAX_COPILOT_LOG_SCAN_FILE_SIZE);
 	if (rawSessionId) {
 		for (const candidate of candidateLogs) {
 			try {

--- a/src/vs/workbench/contrib/chat/test/browser/agentHostLogSources.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHostLogSources.test.ts
@@ -10,18 +10,32 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { IStat } from '../../../../../platform/files/common/files.js';
 import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { findRelevantCopilotLogs } from '../../browser/chatDebug/agentHostLogSources.js';
+import { findRelevantCopilotLogs, MAX_COPILOT_LOG_SCAN_FILE_SIZE } from '../../browser/chatDebug/agentHostLogSources.js';
+
+class TestLogFileSystemProvider extends InMemoryFileSystemProvider {
+	readonly oversizedResources = new Set<string>();
+
+	override async stat(resource: URI): Promise<IStat> {
+		const stat = await super.stat(resource);
+		return this.oversizedResources.has(resource.toString())
+			? { ...stat, size: MAX_COPILOT_LOG_SCAN_FILE_SIZE + 1 }
+			: stat;
+	}
+}
 
 suite('AgentHostLogSources', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	const logsDir = URI.from({ scheme: Schemas.inMemory, path: '/logs' });
 	let fileService: FileService;
+	let fileSystemProvider: TestLogFileSystemProvider;
 
 	setup(async () => {
 		fileService = disposables.add(new FileService(new NullLogService()));
-		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		fileSystemProvider = disposables.add(new TestLogFileSystemProvider());
+		disposables.add(fileService.registerProvider(Schemas.inMemory, fileSystemProvider));
 		await fileService.createFolder(logsDir);
 	});
 
@@ -74,5 +88,18 @@ suite('AgentHostLogSources', () => {
 		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
 
 		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/recent-9.log']);
+	});
+
+	test('applies the scan size limit within the 10 most recent process logs', async () => {
+		await writeLog('oldest.log', 'session-1');
+		for (let index = 0; index < 9; index++) {
+			await writeLog(`recent-${index}.log`, 'another session');
+		}
+		await writeLog('oversized.log', 'another session');
+		fileSystemProvider.oversizedResources.add(URI.joinPath(logsDir, 'oversized.log').toString());
+
+		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/oversized.log']);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentHostLogSources.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHostLogSources.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { findRelevantCopilotLogs } from '../../browser/chatDebug/agentHostLogSources.js';
+
+suite('AgentHostLogSources', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const logsDir = URI.from({ scheme: Schemas.inMemory, path: '/logs' });
+	let fileService: FileService;
+
+	setup(async () => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		await fileService.createFolder(logsDir);
+	});
+
+	async function writeLog(name: string, contents: string): Promise<void> {
+		await fileService.writeFile(URI.joinPath(logsDir, name), VSBuffer.fromString(contents));
+		await timeout(1);
+	}
+
+	test('returns session-matching logs instead of the latest unrelated log', async () => {
+		await writeLog('matching.log', 'session-1');
+		await writeLog('latest.log', 'another session');
+
+		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/matching.log']);
+	});
+
+	test('falls back to the latest process log when no session id matches', async () => {
+		await writeLog('older.log', 'another session');
+		await writeLog('latest.log', 'also another session');
+
+		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/latest.log']);
+	});
+
+	test('falls back to the latest process log without a session id', async () => {
+		await writeLog('older.log', 'older');
+		await writeLog('latest.log', 'latest');
+
+		const logs = await findRelevantCopilotLogs(logsDir, undefined, fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/latest.log']);
+	});
+
+	test('searches process logs larger than 10 MiB', async () => {
+		await writeLog('large.log', `${'x'.repeat(10 * 1024 * 1024)}session-1`);
+
+		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/large.log']);
+	});
+
+	test('searches only the 10 most recent process logs', async () => {
+		await writeLog('oldest.log', 'session-1');
+		for (let index = 0; index < 10; index++) {
+			await writeLog(`recent-${index}.log`, 'another session');
+		}
+
+		const logs = await findRelevantCopilotLogs(logsDir, 'session-1', fileService, new NullLogService());
+
+		assert.deepStrictEqual(logs.map(log => log.path), ['copilot-logs/recent-9.log']);
+	});
+});


### PR DESCRIPTION
## Summary

- include the newest Copilot process log when no recent log contains the Agent Host session ID
- include a local fallback log when the export has no active session context
- scan only the 10 newest logs, with streamed matching up to 1 GiB per file
- add focused coverage for matching and fallback selection

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentHostLogSources.test.ts`
- `npm run typecheck-client`
- `npm run precommit`

(Written by Copilot)