### PR TITLE
agentHost: harden integration test timeouts

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
@@ -167,7 +167,7 @@ suite('Protocol WebSocket - Session Config persistence across restarts', functio
 	});
 
 	test('persisted config values are restored on subscribe after server restart', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(30_000, 120_000));
+		this.timeout(getAgentHostE2ETestTimeout(30_000, 180_000));
 
 		const initialConfig = { isolation: 'worktree', branch: 'main' };
 		const updatedBranch = 'release';

--- a/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
@@ -77,7 +77,7 @@ const hasGit = (() => {
 	});
 
 	test('terminal-driven file edit (no ToolResultFileEditContent) lands in the session changeset', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 90_000));
 
 		// Create a session whose working directory is the tmp git repo.
 		await client.call('initialize', { protocolVersions: [PROTOCOL_VERSION], clientId: 'test-git-diffs' });

--- a/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
@@ -45,7 +45,7 @@ const hasGit = (() => {
 	});
 
 	setup(async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 		// Initialize a tmp git repo as the session's working directory.
 		tmpRoot = mkdtempSync(join(tmpdir(), 'agent-host-proto-diff-'));
 		const env = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
@@ -77,7 +77,7 @@ const hasGit = (() => {
 	});
 
 	test('terminal-driven file edit (no ToolResultFileEditContent) lands in the session changeset', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		// Create a session whose working directory is the tmp git repo.
 		await client.call('initialize', { protocolVersions: [PROTOCOL_VERSION], clientId: 'test-git-diffs' });
@@ -120,7 +120,7 @@ const hasGit = (() => {
 				return false;
 			}
 			return matchesEditedFile(getActionEnvelope(n).action as ChangesetContentChangedAction);
-		}, 10_000);
+		}, getAgentHostE2ETestTimeout(10_000, 30_000));
 		const action = getActionEnvelope(contentChangedNotif).action as ChangesetContentChangedAction;
 		const file = action.files.find(f => {
 			const u = fileUri(f.edit);

--- a/src/vs/platform/agentHost/test/node/protocol/sessionLifecycle.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionLifecycle.integrationTest.ts
@@ -53,7 +53,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	setup(async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 		client = new TestProtocolClient(server.port);
 		await client.connect();
 	});
@@ -66,7 +66,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('create session triggers sessionAdded notification', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'test-create-session' });
 
@@ -81,7 +81,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('listSessions returns sessions', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'test-list-sessions' });
 
@@ -96,7 +96,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('dispose session sends sessionRemoved notification', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-dispose');
 		await client.call('disposeSession', { channel: sessionUri });
@@ -150,7 +150,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('idle session is released after its last subscriber drops and restores losslessly on re-subscribe', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'test-release' });
 
@@ -180,7 +180,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('isRead and isArchived flags survive in listSessions after dispatch', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-read-archived-flags');
 
@@ -236,7 +236,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('dispatching isRead=false explicitly persists as false', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-isread-false');
 

--- a/src/vs/platform/agentHost/test/node/protocol/sessionLifecycle.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionLifecycle.integrationTest.ts
@@ -81,7 +81,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('listSessions returns sessions', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 90_000));
 
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'test-list-sessions' });
 
@@ -90,7 +90,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 			n.method === 'root/sessionAdded'
 		);
 
-		const result = await client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		const result = await client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI }, getAgentHostE2ETestTimeout(5_000, 30_000));
 		assert.ok(Array.isArray(result.items));
 		assert.ok(result.items.length >= 1, 'should have at least one session');
 	});
@@ -180,7 +180,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('isRead and isArchived flags survive in listSessions after dispatch', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 120_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-read-archived-flags');
 
@@ -222,7 +222,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 
 		let session: ListSessionsResult['items'][0] | undefined;
 		for (let i = 0; i < 20; i++) {
-			const result = await client2.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+			const result = await client2.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI }, getAgentHostE2ETestTimeout(5_000, 30_000));
 			session = result.items.find(s => s.resource === sessionUri);
 			if (session && (session.status & SessionStatus.IsArchived) && (session.status & SessionStatus.IsRead)) {
 				break;
@@ -236,7 +236,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 	});
 
 	test('dispatching isRead=false explicitly persists as false', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 120_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-isread-false');
 
@@ -261,7 +261,7 @@ suite('Protocol WebSocket — Session Lifecycle', function () {
 
 		let session: ListSessionsResult['items'][0] | undefined;
 		for (let i = 0; i < 20; i++) {
-			const result = await client2.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+			const result = await client2.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI }, getAgentHostE2ETestTimeout(5_000, 30_000));
 			session = result.items.find(s => s.resource === sessionUri);
 			if (session && !(session.status & SessionStatus.IsRead)) {
 				break;

--- a/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
@@ -155,11 +155,15 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('fetchTurns rejects an unknown chat', async function () {
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 60_000));
+
 		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId: 'test-fetchTurns-missing' });
 		await assert.rejects(() => client.call('fetchTurns', { channel: 'ahp-chat:/missing-session/missing-chat' }), /session not found/i);
 	});
 
 	test('fetchTurns rejects an unrecognized cursor', async function () {
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 60_000));
+
 		const sessionUri = await createAndSubscribeSession(client, 'test-fetchTurns-cursor');
 		await assert.rejects(() => client.call('fetchTurns', {
 			channel: defaultChatChannel(sessionUri),
@@ -239,7 +243,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('subagent: child sessions never appear in listSessions', async function () {
-		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 90_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-subagent-list');
 		dispatchTurnStarted(client, sessionUri, 'turn-sa-list', 'subagent', 1);
@@ -253,7 +257,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 		const childSnapshot = await client.call<SubscribeResult>('subscribe', { channel: childUri });
 		assert.ok(childSnapshot.snapshot, 'subagent child session should be live');
 
-		const result = await client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		const result = await client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI }, getAgentHostE2ETestTimeout(5_000, 30_000));
 		assert.deepStrictEqual(
 			{
 				subagentSessions: result.items.filter(s => isSubagentSession(s.resource)).map(s => s.resource),

--- a/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
@@ -45,7 +45,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	setup(async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 		client = new TestProtocolClient(server.port);
 		await client.connect();
 	});
@@ -55,7 +55,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('send message and receive responsePart + turnComplete', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-send-message');
 		dispatchTurnStarted(client, sessionUri, 'turn-1', 'hello', 1);
@@ -69,7 +69,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('tool invocation: toolCallStart → toolCallComplete → responsePart → turnComplete', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-tool-invocation');
 		dispatchTurnStarted(client, sessionUri, 'turn-tool', 'use-tool', 1);
@@ -86,7 +86,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('error prompt triggers chat/error', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-error');
 		dispatchTurnStarted(client, sessionUri, 'turn-err', 'error', 1);
@@ -99,7 +99,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('cancel turn stops in-progress processing', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-cancel');
 		dispatchTurnStarted(client, sessionUri, 'turn-cancel', 'slow', 1);
@@ -118,7 +118,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('multiple sequential turns accumulate in history', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-multi-turns');
 
@@ -135,7 +135,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('fetchTurns acknowledges completed turn history loading', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-fetchTurns');
 
@@ -168,7 +168,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('usage info is captured on completed turn', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-usage');
 		dispatchTurnStarted(client, sessionUri, 'turn-usage', 'with-usage', 1);
@@ -191,7 +191,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('modifiedAt updates on turn completion', async function () {
-		this.timeout(10_000);
+		this.timeout(getAgentHostE2ETestTimeout(10_000, 30_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-modifiedAt');
 
@@ -209,7 +209,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('subagent: inner tool calls land in child session, not parent', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-subagent');
 		dispatchTurnStarted(client, sessionUri, 'turn-sa', 'subagent', 1);
@@ -239,7 +239,7 @@ suite('Protocol WebSocket — Turn Execution', function () {
 	});
 
 	test('subagent: child sessions never appear in listSessions', async function () {
-		this.timeout(15_000);
+		this.timeout(getAgentHostE2ETestTimeout(15_000, 45_000));
 
 		const sessionUri = await createAndSubscribeSession(client, 'test-subagent-list');
 		dispatchTurnStarted(client, sessionUri, 'turn-sa-list', 'subagent', 1);

--- a/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/copilotCustomizations.integrationTest.ts
@@ -19,7 +19,7 @@ import { ActionType, SessionCustomizationsChangedAction } from '../../../common/
 import { customizationId, CustomizationType, ISessionWithDefaultChat, ROOT_STATE_URI, type ClientPluginCustomization, type DirectoryCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
 import { type AhpNotification } from '../../../common/state/sessionProtocol.js';
 import { createProviderSession, dispatchTurn, type IAgentHostProviderTestConfig } from '../providerIntegrationTestHelpers.js';
-import { fetchSessionWithChat, getActionEnvelope, isActionNotification, IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
+import { fetchSessionWithChat, getActionEnvelope, getAgentHostE2ETestTimeout, isActionNotification, IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 
 /**
  * Whether `notification` is a *settled* `session/customizationsChanged` for
@@ -49,10 +49,10 @@ const COPILOT_CONFIG: IAgentHostProviderTestConfig = {
 	githubToken: 'not-a-real-token', // The tests will use a mocked LLM, so the token doesn't need to be valid.
 };
 
-const SETUP_TIMEOUT_MS = 45_000;
-const TEST_TIMEOUT_MS = 90_000;
-const NOTIFICATION_TIMEOUT_MS = 10_000;
-const WATCH_ASSERT_TIMEOUT_MS = 30_000;
+const SETUP_TIMEOUT_MS = getAgentHostE2ETestTimeout(45_000, 120_000);
+const TEST_TIMEOUT_MS = getAgentHostE2ETestTimeout(90_000, 180_000);
+const NOTIFICATION_TIMEOUT_MS = getAgentHostE2ETestTimeout(10_000, 30_000);
+const WATCH_ASSERT_TIMEOUT_MS = getAgentHostE2ETestTimeout(30_000, 90_000);
 const WATCH_ASSERT_POLL_INTERVAL_MS = 100;
 /**
  * Cadence at which {@link applyAndWaitForAssert} re-applies its mutation.

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -73,7 +73,7 @@ interface IPendingCall {
 }
 
 function getProtocolOperationTimeout(): number {
-	if (isCI || AGENT_HOST_E2E_COVERAGE) {
+	if (AGENT_HOST_E2E_COVERAGE) {
 		return 30_000;
 	}
 	return isWindows ? 8_000 : 5_000;

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -61,7 +61,9 @@ import {
 } from '../../common/state/sessionProtocol.js';
 import { AhpSnapshotRecorder, type IAhpSnapshotNormalization, type IAhpSnapshotOptions } from './e2e/harness/ahpSnapshot.js';
 import { recordAhpSurface } from './ahpSurfaceCoverage.js';
-import { isWindows } from '../../../../base/common/platform.js';
+import { isCI, isWindows } from '../../../../base/common/platform.js';
+
+const AGENT_HOST_E2E_COVERAGE = process.env['AGENT_HOST_E2E_COVERAGE'] === '1';
 
 // ---- JSON-RPC test client ---------------------------------------------------
 
@@ -71,7 +73,7 @@ interface IPendingCall {
 }
 
 function getProtocolOperationTimeout(): number {
-	if (process.env['AGENT_HOST_E2E_COVERAGE'] === '1') {
+	if (isCI || AGENT_HOST_E2E_COVERAGE) {
 		return 30_000;
 	}
 	return isWindows ? 8_000 : 5_000;
@@ -625,7 +627,7 @@ export interface IServerHandle {
 	capiReplay?: CapiReplayProxy;
 }
 
-const SERVER_SHUTDOWN_TIMEOUT_MS = isWindows || process.env['AGENT_HOST_E2E_COVERAGE'] === '1' ? 30_000 : 5_000;
+const SERVER_SHUTDOWN_TIMEOUT_MS = isCI || isWindows || AGENT_HOST_E2E_COVERAGE ? 30_000 : 5_000;
 
 /** Gracefully stop an Agent Host test server, killing it if shutdown stalls. */
 export async function stopServer(server: IServerHandle | undefined): Promise<void> {
@@ -682,10 +684,8 @@ export interface IMockScenario {
 	readonly definition: unknown;
 }
 
-const AGENT_HOST_E2E_COVERAGE = process.env['AGENT_HOST_E2E_COVERAGE'] === '1';
-
 export function getAgentHostE2ETestTimeout(normalTimeoutMs: number, extendedTimeoutMs: number): number {
-	return AGENT_HOST_E2E_COVERAGE || isWindows ? extendedTimeoutMs : normalTimeoutMs;
+	return AGENT_HOST_E2E_COVERAGE || isCI || isWindows ? extendedTimeoutMs : normalTimeoutMs;
 }
 
 function withAgentHostCoverage(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {


### PR DESCRIPTION
## Summary

- use extended protocol-operation and graceful-shutdown budgets on CI workers
- preserve fast timeout feedback for local macOS and Linux runs
- apply CI-aware waits to the protocol and Copilot customization suites affected by [Azure build 461453](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461453)

## Why

The failed Linux worker was abnormally slow: its filesystem diagnostics took 4m14s, compared with 35s on a successful comparison worker. Fixed 5–10 second waits caused otherwise responsive tests to time out, and the 5-second shutdown budget could force-kill the Agent Host before persistence completed, cascading into later failures.

This change uses the existing normal/extended timeout policy for CI, as was already done for Windows and coverage runs, while retaining the shorter local budgets.

## Validation

- `npm run compile`
- `npm run hygiene`
- affected Agent Host integration cluster: 6 consecutive CI-mode passes (`42 passing`, `2 pending`)
- affected cluster with local timeout selection: `42 passing`, `2 pending`

The broader Agent Host integration run passed the affected tests but later encountered a separate Copilot idle-release assertion on current `main`.

(Written by Copilot)