### PR TITLE
feat(scm): show added/removed line counts in Source Control

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -642,6 +642,8 @@
 		"--vscode-radio-inactiveForeground",
 		"--vscode-radio-inactiveHoverBackground",
 		"--vscode-sash-hoverBorder",
+		"--vscode-scm-diffStatisticsDeletionsForeground",
+		"--vscode-scm-diffStatisticsInsertionsForeground",
 		"--vscode-scmGraph-foreground1",
 		"--vscode-scmGraph-foreground2",
 		"--vscode-scmGraph-foreground3",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -32,6 +32,7 @@
     "quickPickSortByLabel",
     "scmActionButton",
     "scmArtifactProvider",
+    "scmDiffStatistics",
     "scmHistoryProvider",
     "scmMultiDiffEditor",
     "scmProviderOptions",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1762,6 +1762,10 @@ export class Repository {
 		return this.diffFilesShortStat(undefined, { cached: false, path });
 	}
 
+	async diffWithHEADWithStats(options?: { similarityThreshold?: number }): Promise<DiffChange[]> {
+		return this.diffFilesWithStats(undefined, { cached: false, similarityThreshold: options?.similarityThreshold });
+	}
+
 	diffWith(ref: string): Promise<Change[]>;
 	diffWith(ref: string, path: string): Promise<string>;
 	diffWith(ref: string, path?: string | undefined): Promise<string | Change[]>;
@@ -1790,6 +1794,10 @@ export class Repository {
 
 	async diffIndexWithHEADShortStats(path?: string): Promise<CommitShortStat> {
 		return this.diffFilesShortStat(undefined, { cached: true, path });
+	}
+
+	async diffIndexWithHEADWithStats(options?: { similarityThreshold?: number }): Promise<DiffChange[]> {
+		return this.diffFilesWithStats(undefined, { cached: true, similarityThreshold: options?.similarityThreshold });
 	}
 
 	diffIndexWith(ref: string): Promise<Change[]>;
@@ -1880,6 +1888,31 @@ export class Repository {
 		}
 
 		return parseGitChanges(this.repositoryRoot, gitResult.stdout);
+	}
+
+	private async diffFilesWithStats(ref: string | undefined, options: { cached: boolean; similarityThreshold?: number }): Promise<DiffChange[]> {
+		const args = ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z'];
+
+		if (options.cached) {
+			args.push('--cached');
+		}
+
+		if (options.similarityThreshold) {
+			args.push(`--find-renames=${options.similarityThreshold}%`);
+		}
+
+		if (ref) {
+			args.push(ref);
+		}
+
+		args.push('--');
+
+		const gitResult = await this.exec(args);
+		if (gitResult.exitCode) {
+			return [];
+		}
+
+		return parseGitChangesRaw(this.repositoryRoot, gitResult.stdout);
 	}
 
 	private async diffFilesShortStat(ref: string | undefined, options: { cached: boolean; path?: string }): Promise<CommitShortStat> {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -53,6 +53,110 @@ export const enum ResourceGroupType {
 	Untracked
 }
 
+type DiffStatistics = { readonly insertions: number; readonly deletions: number };
+
+/**
+ * Untracked files are not reported by `git diff`, so their line count is read from
+ * disk. Files larger than this are skipped to bound the amount of I/O per status
+ * update.
+ */
+const DIFF_STATISTICS_MAX_FILE_SIZE = 1024 * 1024;
+
+/**
+ * Maximum number of untracked files that are read from disk concurrently while
+ * computing diff statistics.
+ */
+const DIFF_STATISTICS_CONCURRENCY = 5;
+
+function toDiffStatisticsMap(changes: DiffChange[]): Map<string, DiffStatistics> {
+	const result = new Map<string, DiffStatistics>();
+
+	for (const change of changes) {
+		result.set(change.uri.fsPath, { insertions: change.insertions, deletions: change.deletions });
+	}
+
+	// For renames `change.uri` is the new path while `Resource.resourceUri` is the
+	// original path. Register the original path as a fallback, without overwriting
+	// an entry that another change already claimed.
+	for (const change of changes) {
+		if (!result.has(change.originalUri.fsPath)) {
+			result.set(change.originalUri.fsPath, { insertions: change.insertions, deletions: change.deletions });
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Counts the lines of a file on disk so that they can be reported as insertions.
+ * Returns `undefined` when git itself would not report line statistics for the
+ * file (binary, too large, or unreadable).
+ */
+export async function countFileLines(uri: Uri): Promise<DiffStatistics | undefined> {
+	let handle: fsPromises.FileHandle | undefined;
+
+	try {
+		const fileStat = await fsPromises.stat(uri.fsPath);
+		if (!fileStat.isFile() || fileStat.size > DIFF_STATISTICS_MAX_FILE_SIZE) {
+			return undefined;
+		}
+
+		if (fileStat.size === 0) {
+			return { insertions: 0, deletions: 0 };
+		}
+
+		handle = await fsPromises.open(uri.fsPath, 'r');
+		const buffer = Buffer.alloc(64 * 1024);
+
+		let insertions = 0;
+		let lastByte = 0;
+
+		while (true) {
+			const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+			if (bytesRead === 0) {
+				break;
+			}
+
+			for (let i = 0; i < bytesRead; i++) {
+				// A NUL byte makes git treat the file as binary, in which case it
+				// reports no line statistics at all.
+				if (buffer[i] === 0) {
+					return undefined;
+				}
+
+				if (buffer[i] === 0x0a /* \n */) {
+					insertions++;
+				}
+			}
+
+			lastByte = buffer[bytesRead - 1];
+		}
+
+		// Git counts a trailing incomplete line as a line
+		return { insertions: lastByte === 0x0a ? insertions : insertions + 1, deletions: 0 };
+	} catch {
+		return undefined;
+	} finally {
+		await handle?.close();
+	}
+}
+
+async function resolveDiffStatistics(resource: Resource, statistics: DiffStatistics | undefined): Promise<DiffStatistics | undefined> {
+	if (statistics) {
+		return statistics;
+	}
+
+	// Untracked and intent-to-add files have no content in the index for git to
+	// diff against, so their line count is read from the working tree instead.
+	switch (resource.type) {
+		case Status.UNTRACKED:
+		case Status.INTENT_TO_ADD:
+			return countFileLines(resource.resourceUri);
+		default:
+			return undefined;
+	}
+}
+
 export class Resource implements SourceControlResourceState {
 
 	static getStatusLetter(type: Status): string {
@@ -190,6 +294,7 @@ export class Resource implements SourceControlResourceState {
 	get original(): Uri { return this._resourceUri; }
 	get renameResourceUri(): Uri | undefined { return this._renameResourceUri; }
 	get contextValue(): string | undefined { return this._repositoryKind; }
+	get diffStatistics(): DiffStatistics | undefined { return this._diffStatistics; }
 
 	private static Icons = {
 		light: {
@@ -319,6 +424,7 @@ export class Resource implements SourceControlResourceState {
 		private _useIcons: boolean,
 		private _renameResourceUri?: Uri,
 		private _repositoryKind?: 'repository' | 'submodule' | 'worktree',
+		private _diffStatistics?: DiffStatistics,
 	) { }
 
 	async open(): Promise<void> {
@@ -342,7 +448,11 @@ export class Resource implements SourceControlResourceState {
 	}
 
 	clone(resourceGroupType?: ResourceGroupType) {
-		return new Resource(this._commandResolver, resourceGroupType ?? this._resourceGroupType, this._resourceUri, this._type, this._useIcons, this._renameResourceUri, this._repositoryKind);
+		return new Resource(this._commandResolver, resourceGroupType ?? this._resourceGroupType, this._resourceUri, this._type, this._useIcons, this._renameResourceUri, this._repositoryKind, this._diffStatistics);
+	}
+
+	withDiffStatistics(diffStatistics: DiffStatistics | undefined): Resource {
+		return new Resource(this._commandResolver, this._resourceGroupType, this._resourceUri, this._type, this._useIcons, this._renameResourceUri, this._repositoryKind, diffStatistics);
 	}
 }
 
@@ -1186,6 +1296,10 @@ export class Repository implements Disposable {
 		return this.run(Operation.Diff, () => this.repository.diffWithHEADShortStats(path));
 	}
 
+	diffWithHEADWithStats(options?: { similarityThreshold?: number }): Promise<DiffChange[]> {
+		return this.run(Operation.Diff, () => this.repository.diffWithHEADWithStats(options));
+	}
+
 	diffWith(ref: string): Promise<Change[]>;
 	diffWith(ref: string, path: string): Promise<string>;
 	diffWith(ref: string, path?: string | undefined): Promise<string | Change[]>;
@@ -1202,6 +1316,10 @@ export class Repository implements Disposable {
 
 	diffIndexWithHEADShortStats(path?: string): Promise<CommitShortStat> {
 		return this.run(Operation.Diff, () => this.repository.diffIndexWithHEADShortStats(path));
+	}
+
+	diffIndexWithHEADWithStats(options?: { similarityThreshold?: number }): Promise<DiffChange[]> {
+		return this.run(Operation.Diff, () => this.repository.diffIndexWithHEADWithStats(options));
 	}
 
 	diffIndexWith(ref: string): Promise<Change[]>;
@@ -3092,7 +3210,67 @@ export class Repository implements Disposable {
 			return undefined;
 		});
 
+		await this.applyDiffStatistics(indexGroup, workingTreeGroup, untrackedGroup, similarityThreshold, cancellationToken);
+
 		return { indexGroup, mergeGroup, untrackedGroup, workingTreeGroup };
+	}
+
+	/**
+	 * Computes the number of inserted/deleted lines for the resources of the index and
+	 * working tree groups, and replaces them in-place with resources that carry the
+	 * statistics. Resources of the merge group are skipped as git does not report line
+	 * statistics for unmerged paths.
+	 */
+	private async applyDiffStatistics(
+		indexGroup: Resource[],
+		workingTreeGroup: Resource[],
+		untrackedGroup: Resource[],
+		similarityThreshold: number,
+		cancellationToken?: CancellationToken
+	): Promise<void> {
+		// Diff statistics require additional git commands as well as reading untracked
+		// files from disk, so they are skipped for repositories that hit the status limit.
+		if (this.isRepositoryHuge) {
+			return;
+		}
+
+		try {
+			const [indexChanges, workingTreeChanges] = await Promise.all([
+				indexGroup.length > 0 ? this.diffIndexWithHEADWithStats({ similarityThreshold }) : Promise.resolve<DiffChange[]>([]),
+				workingTreeGroup.length > 0 ? this.diffWithHEADWithStats({ similarityThreshold }) : Promise.resolve<DiffChange[]>([])
+			]);
+
+			if (cancellationToken?.isCancellationRequested) {
+				throw new CancellationError();
+			}
+
+			const limiter = new Limiter<void>(DIFF_STATISTICS_CONCURRENCY);
+			const applyToGroup = (group: Resource[], statistics: Map<string, DiffStatistics>) =>
+				group.map((resource, index) => limiter.queue(async () => {
+					if (cancellationToken?.isCancellationRequested) {
+						return;
+					}
+
+					group[index] = resource.withDiffStatistics(
+						await resolveDiffStatistics(resource, statistics.get(resource.resourceUri.fsPath)));
+				}));
+
+			await Promise.all([
+				...applyToGroup(indexGroup, toDiffStatisticsMap(indexChanges)),
+				...applyToGroup(workingTreeGroup, toDiffStatisticsMap(workingTreeChanges)),
+				...applyToGroup(untrackedGroup, new Map())
+			]);
+
+			if (cancellationToken?.isCancellationRequested) {
+				throw new CancellationError();
+			}
+		} catch (err) {
+			if (err instanceof CancellationError) {
+				throw err;
+			}
+
+			this.logger.warn(`[Repository][applyDiffStatistics] Failed to compute diff statistics: ${err}`);
+		}
 	}
 
 	private setCountBadge(): void {

--- a/extensions/git/src/test/diffStatistics.test.ts
+++ b/extensions/git/src/test/diffStatistics.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { countFileLines } from '../repository';
+
+suite('diffStatistics', () => {
+	let tempDir: string;
+
+	setup(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-git-diff-statistics-'));
+	});
+
+	teardown(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('countFileLines', async () => {
+		const write = async (name: string, contents: Buffer | string): Promise<Uri> => {
+			const filePath = path.join(tempDir, name);
+			await fs.writeFile(filePath, contents);
+			return Uri.file(filePath);
+		};
+
+		const actual = {
+			empty: await countFileLines(await write('empty.txt', '')),
+			trailingNewLine: await countFileLines(await write('lf.txt', 'a\nb\nc\n')),
+			// Git counts a trailing incomplete line as a line
+			noTrailingNewLine: await countFileLines(await write('no-eol.txt', 'a\nb\nc')),
+			// The carriage return is part of the line content, not a line terminator
+			crlf: await countFileLines(await write('crlf.txt', 'a\r\nb\r\n')),
+			// Git reports no line statistics for binary files
+			binary: await countFileLines(await write('binary.png', Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x0a, 0x1a, 0x0a]))),
+			tooLarge: await countFileLines(await write('large.txt', Buffer.alloc(1024 * 1024 + 1, 0x61))),
+			missing: await countFileLines(Uri.file(path.join(tempDir, 'does-not-exist.txt'))),
+			directory: await countFileLines(Uri.file(tempDir))
+		};
+
+		assert.deepStrictEqual(actual, {
+			empty: { insertions: 0, deletions: 0 },
+			trailingNewLine: { insertions: 3, deletions: 0 },
+			noTrailingNewLine: { insertions: 3, deletions: 0 },
+			crlf: { insertions: 2, deletions: 0 },
+			binary: undefined,
+			tooLarge: undefined,
+			missing: undefined,
+			directory: undefined
+		});
+	});
+});

--- a/extensions/git/tsconfig.json
+++ b/extensions/git/tsconfig.json
@@ -20,6 +20,7 @@
 		"../../src/vscode-dts/vscode.proposed.quickPickSortByLabel.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmActionButton.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmArtifactProvider.d.ts",
+		"../../src/vscode-dts/vscode.proposed.scmDiffStatistics.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmSelectedProvider.d.ts",

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -402,6 +402,9 @@ const _allApiProposals = {
 	scmArtifactProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmArtifactProvider.d.ts',
 	},
+	scmDiffStatistics: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmDiffStatistics.d.ts',
+	},
 	scmHistoryProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts',
 	},

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -8,7 +8,7 @@ import { isUriComponents, URI, UriComponents } from '../../../base/common/uri.js
 import { Event, Emitter } from '../../../base/common/event.js';
 import { IObservable, observableValue, observableValueOpts, transaction } from '../../../base/common/observable.js';
 import { IDisposable, DisposableStore, combinedDisposable, dispose, Disposable } from '../../../base/common/lifecycle.js';
-import { ISCMService, ISCMRepository, ISCMProvider, ISCMResource, ISCMResourceGroup, ISCMResourceDecorations, IInputValidation, ISCMViewService, InputValidationType, ISCMActionButtonDescriptor } from '../../contrib/scm/common/scm.js';
+import { ISCMService, ISCMRepository, ISCMProvider, ISCMResource, ISCMResourceGroup, ISCMResourceDecorations, ISCMResourceDiffStatistics, IInputValidation, ISCMViewService, InputValidationType, ISCMActionButtonDescriptor } from '../../contrib/scm/common/scm.js';
 import { ExtHostContext, MainThreadSCMShape, ExtHostSCMShape, SCMProviderFeatures, SCMRawResourceSplices, SCMGroupFeatures, MainContext, SCMHistoryItemDto, SCMHistoryItemRefsChangeEventDto, SCMHistoryItemRefDto } from '../common/extHost.protocol.js';
 import { Command } from '../../../editor/common/languages.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
@@ -156,6 +156,7 @@ class MainThreadSCMResource implements ISCMResource {
 		readonly command: Command | undefined,
 		readonly multiDiffEditorOriginalUri: URI | undefined,
 		readonly multiDiffEditorModifiedUri: URI | undefined,
+		readonly diffStatistics: ISCMResourceDiffStatistics | undefined,
 	) { }
 
 	open(preserveFocus: boolean): Promise<void> {
@@ -504,7 +505,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 
 			for (const [start, deleteCount, rawResources] of groupSlices) {
 				const resources = rawResources.map(rawResource => {
-					const [handle, sourceUri, icons, tooltip, strikeThrough, faded, contextValue, command, multiDiffEditorOriginalUri, multiDiffEditorModifiedUri] = rawResource;
+					const [handle, sourceUri, icons, tooltip, strikeThrough, faded, contextValue, command, multiDiffEditorOriginalUri, multiDiffEditorModifiedUri, diffStatistics] = rawResource;
 
 					const [light, dark] = icons;
 					const icon = ThemeIcon.isThemeIcon(light) ? light : URI.revive(light);
@@ -530,6 +531,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 						command,
 						URI.revive(multiDiffEditorOriginalUri),
 						URI.revive(multiDiffEditorModifiedUri),
+						diffStatistics,
 					);
 				});
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2099,6 +2099,7 @@ export type SCMRawResource = [
 	ICommandDto | undefined /*command*/,
 	UriComponents | undefined /* multiFileDiffEditorOriginalUri */,
 	UriComponents | undefined /* multiFileDiffEditorModifiedUri */,
+	{ insertions: number; deletions: number } | undefined /* diffStatistics */,
 ];
 
 export type SCMRawResourceSplice = [

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -244,6 +244,25 @@ function compareResourceStates(a: vscode.SourceControlResourceState, b: vscode.S
 		return -1;
 	}
 
+	if (result !== 0) {
+		return result;
+	}
+
+	const aStats = a.diffStatistics;
+	const bStats = b.diffStatistics;
+	if (aStats && bStats) {
+		if (aStats.insertions !== bStats.insertions) {
+			return aStats.insertions - bStats.insertions;
+		}
+		if (aStats.deletions !== bStats.deletions) {
+			return aStats.deletions - bStats.deletions;
+		}
+	} else if (aStats) {
+		return 1;
+	} else if (bStats) {
+		return -1;
+	}
+
 	return result;
 }
 
@@ -504,8 +523,11 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
 				const strikeThrough = r.decorations && !!r.decorations.strikeThrough;
 				const faded = r.decorations && !!r.decorations.faded;
 				const contextValue = r.contextValue || '';
+				const diffStatistics = isProposedApiEnabled(this._extension, 'scmDiffStatistics') && r.diffStatistics
+					? { insertions: r.diffStatistics.insertions, deletions: r.diffStatistics.deletions }
+					: undefined;
 
-				const rawResource = [handle, sourceUri, icons, tooltip, strikeThrough, faded, contextValue, command, multiFileDiffEditorOriginalUri, multiFileDiffEditorModifiedUri] as SCMRawResource;
+				const rawResource = [handle, sourceUri, icons, tooltip, strikeThrough, faded, contextValue, command, multiFileDiffEditorOriginalUri, multiFileDiffEditorModifiedUri, diffStatistics] as SCMRawResource;
 
 				return { rawResource, handle };
 			});

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -295,6 +295,28 @@
 	margin-right: 3px;
 }
 
+.scm-view .monaco-list-row .diff-statistics {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 6px;
+	font-size: 0.9em;
+	font-variant-numeric: tabular-nums;
+	flex-shrink: 0;
+}
+
+.scm-view .monaco-list-row .diff-statistics.empty {
+	display: none;
+}
+
+.scm-view .monaco-list-row .diff-statistics .insertions {
+	color: var(--vscode-scm-diffStatisticsInsertionsForeground);
+}
+
+.scm-view .monaco-list-row .diff-statistics .deletions {
+	color: var(--vscode-scm-diffStatisticsDeletionsForeground);
+}
+
 .scm-view .monaco-list-row .resource > .decoration-icon {
 	width: 16px;
 	height: 100%;

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -243,6 +243,18 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('alwaysShowActions', "Controls whether inline actions are always visible in the Source Control view."),
 			default: false
 		},
+		'scm.diffStatistics': {
+			type: 'string',
+			enum: ['all', 'files', 'groups', 'off'],
+			enumDescriptions: [
+				localize('scm.diffStatistics.all', "Show added and removed line counts on resource group headers and individual resources."),
+				localize('scm.diffStatistics.files', "Show added and removed line counts only on individual resources."),
+				localize('scm.diffStatistics.groups', "Show added and removed line counts only on resource group headers."),
+				localize('scm.diffStatistics.off', "Do not show added and removed line counts.")
+			],
+			description: localize('scm.diffStatistics', "Controls whether Source Control shows added and removed line counts for resources and resource groups."),
+			default: 'all'
+		},
 		'scm.countBadge': {
 			type: 'string',
 			enum: ['all', 'focused', 'off'],

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -11,7 +11,7 @@ import { ViewPane, IViewPaneOptions, ViewAction } from '../../../browser/parts/v
 import { append, $, clearNode, isPointerEvent, isActiveElement } from '../../../../base/browser/dom.js';
 import { asCSSUrl } from '../../../../base/browser/cssValue.js';
 import { IListVirtualDelegate, IIdentityProvider } from '../../../../base/browser/ui/list/list.js';
-import { ISCMResourceGroup, ISCMResource, ISCMRepository, ISCMInput, ISCMViewService, ISCMViewVisibleRepositoryChangeEvent, ISCMService, VIEW_PANE_ID, ISCMActionButton, ISCMActionButtonDescriptor, ISCMRepositorySortKey, ViewMode, ISCMRepositorySelectionMode } from '../common/scm.js';
+import { ISCMResourceGroup, ISCMResource, ISCMRepository, ISCMInput, ISCMViewService, ISCMViewVisibleRepositoryChangeEvent, ISCMService, VIEW_PANE_ID, ISCMActionButton, ISCMActionButtonDescriptor, ISCMRepositorySortKey, ViewMode, ISCMRepositorySelectionMode, ISCMResourceDiffStatistics } from '../common/scm.js';
 import { ResourceLabels, IResourceLabel, IFileLabelOptions } from '../../../browser/labels.js';
 import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -50,6 +50,8 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { RepositoryActionRunner, RepositoryRenderer } from './scmRepositoryRenderer.js';
 import { isDark } from '../../../../platform/theme/common/theme.js';
+import { registerColor } from '../../../../platform/theme/common/colorUtils.js';
+import { historyItemHoverAdditionsForeground, historyItemHoverDeletionsForeground } from './scmHistory.js';
 import { LabelFuzzyScore } from '../../../../base/browser/ui/tree/abstractTree.js';
 import { Selection } from '../../../../editor/common/core/selection.js';
 import { API_OPEN_DIFF_EDITOR_COMMAND_ID, API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
@@ -77,6 +79,82 @@ import { AccessibilityCommandId } from '../../accessibility/common/accessibility
 import { SCMInputWidget } from './scmInput.js';
 
 type TreeElement = ISCMRepository | ISCMInput | ISCMActionButton | ISCMResourceGroup | ISCMResource | IResourceNode<ISCMResource, ISCMResourceGroup>;
+
+type DiffStatisticsVisibility = 'all' | 'files' | 'groups' | 'off';
+
+registerColor('scm.diffStatisticsInsertionsForeground', historyItemHoverAdditionsForeground, localize('scmDiffStatisticsInsertionsForeground', "Foreground color of the number of inserted lines in the Source Control view."));
+registerColor('scm.diffStatisticsDeletionsForeground', historyItemHoverDeletionsForeground, localize('scmDiffStatisticsDeletionsForeground', "Foreground color of the number of deleted lines in the Source Control view."));
+
+/**
+ * Aggregating the statistics of a resource group is linear in the number of its
+ * resources, while the group header is re-rendered on every scroll. Cache the result
+ * keyed on the resources array, which is replaced whenever the group changes.
+ */
+const resourceGroupDiffStatistics = new WeakMap<readonly ISCMResource[], ISCMResourceDiffStatistics | null>();
+
+function showDiffStatistics(configurationService: IConfigurationService, target: 'files' | 'groups'): boolean {
+	const visibility = configurationService.getValue<DiffStatisticsVisibility>('scm.diffStatistics');
+	return visibility === 'all' || visibility === target;
+}
+
+function getResourceGroupDiffStatistics(group: ISCMResourceGroup): ISCMResourceDiffStatistics | undefined {
+	const resources = group.resources;
+	const cached = resourceGroupDiffStatistics.get(resources);
+
+	if (cached !== undefined) {
+		return cached ?? undefined;
+	}
+
+	let insertions = 0;
+	let deletions = 0;
+	let hasStatistics = false;
+
+	for (const resource of resources) {
+		if (!resource.diffStatistics) {
+			continue;
+		}
+
+		hasStatistics = true;
+		insertions += resource.diffStatistics.insertions;
+		deletions += resource.diffStatistics.deletions;
+	}
+
+	const result = hasStatistics ? { insertions, deletions } : null;
+	resourceGroupDiffStatistics.set(resources, result);
+
+	return result ?? undefined;
+}
+
+function renderDiffStatistics(container: HTMLElement, statistics: ISCMResourceDiffStatistics | undefined): void {
+	clearNode(container);
+
+	// The statistics are announced as part of the aria label of the row, so the
+	// element itself is always hidden from screen readers.
+	container.setAttribute('aria-hidden', 'true');
+
+	if (!statistics || (statistics.insertions === 0 && statistics.deletions === 0)) {
+		container.classList.add('empty');
+		return;
+	}
+
+	container.classList.remove('empty');
+
+	if (statistics.insertions > 0) {
+		append(container, $('span.insertions')).textContent = `+${statistics.insertions}`;
+	}
+
+	if (statistics.deletions > 0) {
+		append(container, $('span.deletions')).textContent = `-${statistics.deletions}`;
+	}
+}
+
+function formatDiffStatisticsLabel(statistics: ISCMResourceDiffStatistics | undefined): string | undefined {
+	if (!statistics || (statistics.insertions === 0 && statistics.deletions === 0)) {
+		return undefined;
+	}
+
+	return localize('scmDiffStatisticsLabel', "{0} insertions, {1} deletions", statistics.insertions, statistics.deletions);
+}
 
 function processResourceFilterData(uri: URI, filterData: FuzzyScore | LabelFuzzyScore | undefined): [IMatch[] | undefined, IMatch[] | undefined] {
 	if (!filterData) {
@@ -381,6 +459,7 @@ class InputRenderer implements ICompressibleTreeRenderer<ISCMInput, FuzzyScore, 
 
 interface ResourceGroupTemplate {
 	readonly name: HTMLElement;
+	readonly diffStatistics: HTMLElement;
 	readonly count: CountBadge;
 	readonly actionBar: WorkbenchToolBar;
 	readonly elementDisposables: DisposableStore;
@@ -396,6 +475,7 @@ class ResourceGroupRenderer implements ICompressibleTreeRenderer<ISCMResourceGro
 		private actionViewItemProvider: IActionViewItemProvider,
 		private actionRunner: ActionRunner,
 		@ICommandService private commandService: ICommandService,
+		@IConfigurationService private configurationService: IConfigurationService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IKeybindingService private keybindingService: IKeybindingService,
@@ -412,17 +492,20 @@ class ResourceGroupRenderer implements ICompressibleTreeRenderer<ISCMResourceGro
 			actionViewItemProvider: this.actionViewItemProvider,
 			actionRunner: this.actionRunner
 		}, this.menuService, this.contextKeyService, this.contextMenuService, this.keybindingService, this.commandService, this.telemetryService);
+		const diffStatistics = append(element, $('.diff-statistics.empty'));
 		const countContainer = append(element, $('.count'));
 		const count = new CountBadge(countContainer, {}, defaultCountBadgeStyles);
 		const disposables = combinedDisposable(actionBar, count);
 
-		return { name, count, actionBar, elementDisposables: new DisposableStore(), disposables };
+		return { name, diffStatistics, count, actionBar, elementDisposables: new DisposableStore(), disposables };
 	}
 
 	renderElement(node: ITreeNode<ISCMResourceGroup, FuzzyScore>, index: number, template: ResourceGroupTemplate): void {
 		const group = node.element;
 		template.name.textContent = group.label;
 		template.count.setCount(group.resources.length);
+
+		renderDiffStatistics(template.diffStatistics, showDiffStatistics(this.configurationService, 'groups') ? getResourceGroupDiffStatistics(group) : undefined);
 
 		const menus = this.scmViewService.menus.getRepositoryMenus(group.provider);
 		template.elementDisposables.add(connectPrimaryMenu(menus.getResourceGroupMenu(group), primary => {
@@ -449,6 +532,7 @@ interface ResourceTemplate {
 	element: HTMLElement;
 	name: HTMLElement;
 	fileLabel: IResourceLabel;
+	diffStatistics: HTMLElement;
 	decorationIcon: HTMLElement;
 	actionBar: WorkbenchToolBar;
 	actionBarMenu: IMenu | undefined;
@@ -499,6 +583,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 		private actionViewItemProvider: IActionViewItemProvider,
 		private actionRunner: ActionRunner,
 		@ICommandService private commandService: ICommandService,
+		@IConfigurationService private configurationService: IConfigurationService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IKeybindingService private keybindingService: IKeybindingService,
@@ -521,11 +606,12 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 			actionRunner: this.actionRunner
 		}, this.menuService, this.contextKeyService, this.contextMenuService, this.keybindingService, this.commandService, this.telemetryService);
 
+		const diffStatistics = append(element, $('.diff-statistics.empty'));
 		const decorationIcon = append(element, $('.decoration-icon'));
 		const actionBarMenuListener = new MutableDisposable<IDisposable>();
 		const disposables = combinedDisposable(actionBar, fileLabel, actionBarMenuListener);
 
-		return { element, name, fileLabel, decorationIcon, actionBar, actionBarMenu: undefined, actionBarMenuListener, elementDisposables: new DisposableStore(), disposables };
+		return { element, name, fileLabel, diffStatistics, decorationIcon, actionBar, actionBarMenu: undefined, actionBarMenuListener, elementDisposables: new DisposableStore(), disposables };
 	}
 
 	renderElement(node: ITreeNode<ISCMResource, FuzzyScore | LabelFuzzyScore> | ITreeNode<ISCMResource | IResourceNode<ISCMResource, ISCMResourceGroup>, FuzzyScore | LabelFuzzyScore>, index: number, template: ResourceTemplate): void {
@@ -539,6 +625,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 		let matches: IMatch[] | undefined;
 		let descriptionMatches: IMatch[] | undefined;
 		let strikethrough: boolean | undefined;
+		let diffStatistics: ISCMResourceDiffStatistics | undefined;
 
 		if (ResourceTree.isResourceNode(resourceOrFolder)) {
 			if (resourceOrFolder.element) {
@@ -547,6 +634,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 
 				template.element.classList.toggle('faded', resourceOrFolder.element.decorations.faded);
 				strikethrough = resourceOrFolder.element.decorations.strikeThrough;
+				diffStatistics = resourceOrFolder.element.diffStatistics;
 			} else {
 				const menus = this.scmViewService.menus.getRepositoryMenus(resourceOrFolder.context.provider);
 				this._renderActionBar(template, resourceOrFolder, menus.getResourceFolderMenu(resourceOrFolder.context));
@@ -561,6 +649,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 			[matches, descriptionMatches] = processResourceFilterData(uri, node.filterData);
 			template.element.classList.toggle('faded', resourceOrFolder.decorations.faded);
 			strikethrough = resourceOrFolder.decorations.strikeThrough;
+			diffStatistics = resourceOrFolder.diffStatistics;
 		}
 
 		const renderedData: RenderedResourceData = {
@@ -568,6 +657,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 		};
 
 		this.renderIcon(template, renderedData);
+		renderDiffStatistics(template.diffStatistics, showDiffStatistics(this.configurationService, 'files') ? diffStatistics : undefined);
 
 		this.renderedResources.set(template, renderedData);
 		template.elementDisposables.add(toDisposable(() => this.renderedResources.delete(template)));
@@ -599,6 +689,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 
 		template.name.classList.remove('strike-through');
 		template.element.classList.remove('faded');
+		renderDiffStatistics(template.diffStatistics, undefined);
 		template.decorationIcon.style.display = 'none';
 		template.decorationIcon.style.backgroundImage = '';
 
@@ -897,7 +988,9 @@ export class SCMAccessibilityProvider implements IListAccessibilityProvider<Tree
 		} else if (isSCMActionButton(element)) {
 			return element.button?.command.title ?? '';
 		} else if (isSCMResourceGroup(element)) {
-			return element.label;
+			const statisticsLabel = showDiffStatistics(this.configurationService, 'groups')
+				? formatDiffStatisticsLabel(getResourceGroupDiffStatistics(element)) : undefined;
+			return statisticsLabel ? `${element.label}, ${statisticsLabel}` : element.label;
 		} else {
 			const result: string[] = [];
 
@@ -905,6 +998,13 @@ export class SCMAccessibilityProvider implements IListAccessibilityProvider<Tree
 
 			if (element.decorations.tooltip) {
 				result.push(element.decorations.tooltip);
+			}
+
+			const statisticsLabel = showDiffStatistics(this.configurationService, 'files')
+				? formatDiffStatisticsLabel(element.diffStatistics) : undefined;
+
+			if (statisticsLabel) {
+				result.push(statisticsLabel);
 			}
 
 			const path = this.labelService.getUriLabel(dirname(element.sourceUri), { relative: true, noPrefix: true });
@@ -1557,6 +1657,12 @@ export class SCMViewPane extends ViewPane {
 							e.affectsConfiguration('scm.showActionButton'),
 						this.visibilityDisposables)
 						(() => this.updateChildren(), this, this.visibilityDisposables);
+
+					// Only affects how rows are rendered, so the tree does not have to be refreshed
+					Event.filter(this.configurationService.onDidChangeConfiguration,
+						e => e.affectsConfiguration('scm.diffStatistics'),
+						this.visibilityDisposables)
+						(() => this.tree.rerender(), this, this.visibilityDisposables);
 
 					// Add visible repositories
 					this.editorService.onDidActiveEditorChange(this.onDidActiveEditorChange, this, this.visibilityDisposables);

--- a/src/vs/workbench/contrib/scm/common/scm.ts
+++ b/src/vs/workbench/contrib/scm/common/scm.ts
@@ -42,6 +42,11 @@ export interface ISCMResourceDecorations {
 	faded?: boolean;
 }
 
+export interface ISCMResourceDiffStatistics {
+	readonly insertions: number;
+	readonly deletions: number;
+}
+
 export interface ISCMResource {
 	readonly resourceGroup: ISCMResourceGroup;
 	readonly sourceUri: URI;
@@ -50,6 +55,7 @@ export interface ISCMResource {
 	readonly command: Command | undefined;
 	readonly multiDiffEditorOriginalUri: URI | undefined;
 	readonly multiDiffEditorModifiedUri: URI | undefined;
+	readonly diffStatistics?: ISCMResourceDiffStatistics;
 	open(preserveFocus: boolean): Promise<void>;
 }
 

--- a/src/vscode-dts/vscode.proposed.scmDiffStatistics.d.ts
+++ b/src/vscode-dts/vscode.proposed.scmDiffStatistics.d.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/306507
+
+	/**
+	 * Line-level statistics that describe the size of a change.
+	 */
+	export interface SourceControlResourceDiffStatistics {
+		/**
+		 * The number of lines added.
+		 */
+		readonly insertions: number;
+
+		/**
+		 * The number of lines removed.
+		 */
+		readonly deletions: number;
+	}
+
+	export interface SourceControlResourceState {
+		/**
+		 * Optional line-level diff statistics for this resource state.
+		 *
+		 * When provided, the Source Control view may show the number of inserted and
+		 * deleted lines next to the resource, and aggregate the values of all the
+		 * resources of a {@link SourceControlResourceGroup resource group} on the
+		 * group header.
+		 */
+		readonly diffStatistics?: SourceControlResourceDiffStatistics;
+	}
+}


### PR DESCRIPTION
Fixes #306507

## Summary
Shows `+/- ` line statistics in the Source Control view:
- **Per file**: `+N` / `-M` next to each changed resource
- **Per group**: aggregated `+X` / `-Y` on resource group headers (alongside the existing file-count badge)

## Screenshots
### Source Control view with per-file `+/- ` counts
![SCM focus](https://raw.githubusercontent.com/thexin7/vscode/fe98cd228f5c108d57074469bc3081ddb5788817/.github/pr-screenshots/scm-diff-statistics-focus.png)

### Full window
![SCM full](https://raw.githubusercontent.com/thexin7/vscode/fe98cd228f5c108d57074469bc3081ddb5788817/.github/pr-screenshots/scm-diff-statistics.png)

## Details
- New public API: `SourceControlResourceState.diffStatistics`
- New setting: `scm.diffStatistics` (`all` | `files` | `groups` | `off`, default `all`)
- Git extension fills stats via `git diff --raw --numstat` (working tree + index); untracked/new files fall back to counting file lines as insertions
- Skipped for huge repositories (`git.statusLimit` hit)
- Colors reuse `scmGraph.historyItemHoverAdditionsForeground` / `…DeletionsForeground`

## How to verify
1. Run Code - OSS from this branch
2. Open Source Control with some modified files
3. Confirm group headers and file rows show green `+N` / red `-M`
4. Toggle `scm.diffStatistics` through `all` / `files` / `groups` / `off`

## Notes
Happy to adjust the default setting or UI placement based on maintainer feedback.