### PR TITLE
Fix Color Theme picker closing immediately after opening (#329110)

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -93,6 +93,9 @@ export class QuickInputController extends Disposable {
 
 	private previousFocusElement?: HTMLElement;
 
+	// Swallows one leftover blur from the interaction that opened this widget (#329110)
+	private ignoreNextBlur = false;
+
 	private viewState: QuickInputViewState | undefined;
 	private dndController: QuickInputDragAndDropController | undefined;
 	private readonly closeAnimation = this._register(new MutableDisposable<IDisposable>());
@@ -346,7 +349,9 @@ export class QuickInputController extends Disposable {
 			this.previousFocusElement = dom.isHTMLElement(e.relatedTarget) ? e.relatedTarget : undefined;
 		}, true));
 		this._register(focusTracker.onDidBlur(() => {
-			if (!this.getUI().ignoreFocusOut && !this.options.ignoreFocusOut()) {
+			if (this.ignoreNextBlur) {
+				this.ignoreNextBlur = false;
+			} else if (!this.getUI().ignoreFocusOut && !this.options.ignoreFocusOut()) {
 				this.hide(QuickInputHideReason.Blur);
 			}
 			this.inQuickInputContext.set(false);
@@ -766,6 +771,10 @@ export class QuickInputController extends Disposable {
 		this.onShowEmitter.fire();
 		ui.inputBox.setFocus();
 		this.quickInputTypeContext.set(controller.type);
+
+		// Reset one tick after FocusTracker's own blur delay (dom.ts#FocusTracker) so a same-wave blur is caught, not raced
+		this.ignoreNextBlur = true;
+		disposableTimeout(() => disposableTimeout(() => this.ignoreNextBlur = false, 0, this._store), 0, this._store);
 	}
 
 	isVisible(): boolean {

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -384,6 +384,98 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		assert.strictEqual(quickpick.activeItems.length, 0);
 	});
 
+	test('blur landing in the same tick the picker opens is ignored once (issue #329110)', () => {
+		const clock = sinon.useFakeTimers();
+		try {
+			const instantiationService = new TestInstantiationService();
+			instantiationService.stub(IThemeService, new TestThemeService());
+			instantiationService.stub(IConfigurationService, new TestConfigurationService());
+			instantiationService.stub(IAccessibilityService, new TestAccessibilityService());
+			instantiationService.stub(IListService, store.add(new ListService()));
+			instantiationService.stub(ILayoutService, {
+				_serviceBrand: undefined,
+				activeContainer: fixture,
+				onDidLayoutContainer: Event.None,
+				getContainer: () => fixture,
+			});
+			instantiationService.stub(IContextViewService, store.add(instantiationService.createInstance(ContextViewService)));
+			instantiationService.stub(IContextKeyService, store.add(instantiationService.createInstance(ContextKeyService)));
+			instantiationService.stub(IKeybindingService, {
+				mightProducePrintableCharacter() { return false; },
+				softDispatch() { return NoMatchingKb; },
+			});
+
+			// A controller with `ignoreFocusOut` off, so blur-to-close is actually
+			// exercised (the shared `controller` in `setup()` has it hardcoded on).
+			const blurringController: QuickInputController = store.add(instantiationService.createInstance(
+				QuickInputController,
+				{
+					container: fixture,
+					idPrefix: 'blurTestQuickInput',
+					ignoreFocusOut() { return false; },
+					returnFocus() { },
+					backKeybindingLabel() { return undefined; },
+					setContextKey() { return undefined; },
+					linkOpenerDelegate(content: unknown) { },
+					hoverDelegate: {
+						showHover(options: unknown, focus: unknown) {
+							return undefined;
+						},
+						delay: 200
+					},
+					styles: {
+						button: unthemedButtonStyles,
+						countBadge: unthemedCountStyles,
+						inputBox: unthemedInboxStyles,
+						toggle: unthemedToggleStyles,
+						keybindingLabel: unthemedKeybindingLabelOptions,
+						list: unthemedListStyles,
+						progressBar: unthemedProgressBarOptions,
+						widget: {
+							quickInputBackground: undefined,
+							quickInputForeground: undefined,
+							quickInputTitleBackground: undefined,
+							widgetBorder: undefined,
+							widgetShadow: undefined,
+						},
+						pickerGroup: {
+							pickerGroupBorder: undefined,
+							pickerGroupForeground: undefined,
+						}
+					}
+				}
+			));
+			blurringController.layout({ height: 20, width: 40 }, 0);
+
+			// Stand-in for the gear icon that regains focus while the menu that
+			// triggered this picker is tearing down.
+			const trigger = document.createElement('button');
+			fixture.appendChild(trigger);
+			store.add(toDisposable(() => trigger.remove()));
+			trigger.focus();
+
+			const quickpick = store.add(blurringController.createQuickPick());
+			quickpick.show();
+
+			// Same-tick leftover focus churn from the interaction that opened
+			// the picker (see `ignoreNextBlur` in QuickInputController).
+			trigger.focus();
+			clock.tick(0);
+
+			assert.strictEqual(blurringController.isVisible(), true, 'picker must survive a blur landing in the same tick it opened');
+
+			// A later, genuine blur must still dismiss it as normal.
+			const input = fixture.querySelector<HTMLInputElement>('.quick-input-widget .monaco-inputbox input')!;
+			input.focus();
+			trigger.focus();
+			clock.tick(0);
+
+			assert.strictEqual(blurringController.isVisible(), false, 'a later, unrelated blur must still close the picker');
+		} finally {
+			clock.restore();
+		}
+	});
+
 	test('isKeyModified - returns false when no modifiers are pressed', () => {
 		assert.strictEqual(isKeyModified(NO_KEY_MODS), false);
 		assert.strictEqual(isKeyModified({ ctrlCmd: false, alt: false, shift: false }), false);


### PR DESCRIPTION
Fixes #329110.

## Root cause

Clicking the bottom-left **Manage** icon → **Color Theme** (also **File Icon Theme** / **Product Icon Theme**) opens the picker and closes it again immediately, before the user can interact with it.

Tracing the event flow:

1. `ActionRunner.run()` fires `onWillRun` **synchronously, before the clicked command executes**.
2. `ContextMenuHandler` listens for that event and calls `hideContextView(false)`, which forcibly returns focus to the element that opened the menu.
3. *After* that, the actual command (`workbench.action.selectTheme`) runs and opens the `QuickPick`, giving it focus.
4. `QuickInputController`'s blur handling treats any loss of focus as "the user wants to dismiss this" — and the leftover focus churn from step 2 can race the picker opening in step 3, dismissing it before the user ever sees it.

## Fix

In `QuickInputController` (`src/vs/platform/quickinput/browser/quickInputController.ts`):

- Add a one-shot `ignoreNextBlur` guard.
- Arm it in `show()`, right after the picker takes focus.
- The blur handler consumes it exactly once (swallowing that one blur), then resumes normal blur-to-close behavior for everything after.
- The reset is deliberately deferred by one extra tick beyond `FocusTracker`'s own internal one-tick blur delay (see `dom.ts#FocusTracker`) — an earlier version of this fix reset on the same tick it was armed, which raced ahead of and disarmed itself before a same-wave blur that was already queued, silently failing to fix the bug. Deferring one tick further lets that blur be consumed first.

This is scoped to `QuickInputController` only — the shared `ContextMenuHandler`/`contextMenuHandler.ts` code (used by every context menu in the app) was intentionally left untouched, since a broader fix there risked breaking normal focus-return behavior for menu actions like Copy/Cut that don't open a follow-up picker.

## How to test

1. Check out this branch and run `npm run compile`.
2. Launch with `scripts/code.bat` (or `scripts/code.sh`).
3. Click the gear icon at the bottom-left of the Activity Bar → **Color Theme**. The picker should stay open and respond to arrow keys, `Enter`, and `Escape` as normal.
4. Repeat for **File Icon Theme** and **Product Icon Theme**.

## Test plan

- [x] Added a regression test in `quickinput.test.ts`: `blur landing in the same tick the picker opens is ignored once (issue #329110)`. It fires a blur in the same tick the picker opens (asserting the picker survives), then fires a later blur (asserting the picker still closes normally) — guarding against a fix that's too aggressive and breaks normal dismiss-on-click-away for every quick pick in the app.
- [x] `npm run compile` — 0 errors.
- [x] Full `quickinput.test.ts` suite: 14/14 passing (Chromium, headless via Playwright).
- [x] Adjacent `contextview.test.ts` suite: 3/3 passing (sanity check on neighboring code that wasn't modified).
