### PR TITLE
fix: do not copy tracked files into a new worktree

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2041,11 +2041,18 @@ export class Repository implements Disposable {
 			gitIgnoredFiles.delete(uri.fsPath);
 		}
 
-		// Compute the base directory for each glob pattern (the fixed
-		// prefix before any wildcard characters). This will be used to
-		// optimize the upward traversal when adding parent directories.
-		const filePatternBases = new Set<string>();
+		const gitIgnoredPaths = new Set(gitIgnoredFiles);
+
+		// Only a pattern that ends in ** asks for an entire folder. Collect the folder
+		// of each such pattern (the fixed prefix before any wildcard characters) so that
+		// large ignored folders (ex: node_modules) are copied using a single recursive
+		// copy operation instead of one operation per file.
+		const candidateFolders = new Set<string>();
 		for (const pattern of worktreeIncludeFiles) {
+			if (!/(^|[\/\\])\*\*$/.test(pattern)) {
+				continue;
+			}
+
 			const segments = pattern.split(/[\/\\]/);
 			const fixedSegments: string[] = [];
 			for (const seg of segments) {
@@ -2054,21 +2061,42 @@ export class Repository implements Disposable {
 				}
 				fixedSegments.push(seg);
 			}
-			filePatternBases.add(path.join(this.root, ...fixedSegments));
-		}
 
-		// Add the folder paths for git ignored files, walking
-		// up only to the nearest file pattern base directory.
-		const gitIgnoredPaths = new Set(gitIgnoredFiles);
+			// Only coalesce when the terminal ** is the pattern's first wildcard. Otherwise
+			// the fixed prefix is an ancestor of what the pattern actually matches (ex:
+			// ignored/*/cache/** yields "ignored"), and the recursive copy would pull in
+			// unrelated content from that ancestor.
+			if (fixedSegments.length !== segments.length - 1) {
+				continue;
+			}
 
-		for (const filePath of gitIgnoredFiles) {
-			let dir = path.dirname(filePath);
-			while (dir !== this.root && !gitIgnoredPaths.has(dir)) {
-				gitIgnoredPaths.add(dir);
-				if (filePatternBases.has(dir)) {
+			const folder = path.join(this.root, ...fixedSegments);
+			if (folder === this.root) {
+				// The pattern is not anchored to a folder (ex: **/node_modules/**)
+				continue;
+			}
+
+			// Only coalesce if the pattern actually matched something in the folder
+			for (const filePath of gitIgnoredFiles) {
+				if (filePath.startsWith(folder + path.sep)) {
+					candidateFolders.add(folder);
 					break;
 				}
-				dir = path.dirname(dir);
+			}
+		}
+
+		// The copy operation is recursive, so a folder is only used when the folder
+		// itself is git ignored. Copying a folder that is not git ignored would copy
+		// tracked files from this repository into the worktree, overwriting the files
+		// that were just checked out.
+		if (candidateFolders.size !== 0) {
+			try {
+				for (const folder of await this.checkIgnore(Array.from(candidateFolders))) {
+					gitIgnoredPaths.add(folder);
+				}
+			} catch (err) {
+				// Fall back to copying the individual files
+				this.logger.warn(`[Repository][_getWorktreeIncludePaths] Failed to determine whether folder(s) are git ignored: ${err}`);
 			}
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #329147 

`_getWorktreeIncludePaths()` correctly reduces the `git.worktreeIncludeFiles` matches to git ignored files, but the upward traversal that follows adds ancestor folders to that same set, and those folders are usually not git ignored. The copy is recursive, so every tracked file below such a folder is copied from the parent worktree over the freshly checked out branch content — leaving a brand new worktree whose working tree does not match its `HEAD`.

The traversal stopped at a file pattern base (the fixed prefix before the first wildcard), which is the repository root for any pattern starting with `**/`, so it always reached the match's top level folder. A fully literal pattern such as `src/module/.env` had the same problem, since its base is a file rather than a folder.

## Change

Replaces the traversal with a pass over the patterns themselves:

- Only a pattern ending in `**` asks for an entire folder, so only those are coalesced into their base folder — this keeps the single recursive copy for large ignored folders such as `node_modules`.
- A folder is used only when the folder itself is git ignored (`checkIgnore`), because the copy is recursive. Everything else copies the matched files, as documented.
- Patterns that are not anchored to a folder (ex: `**/node_modules/**`) and folders without matches are skipped.

## Result

With `["**/.env", "**/.env.local", "node_modules/**"]` in a repo whose ignored `.env` files live at `docker/.env` and `src/backend/.env`:

| | paths copied |
|---|---|
| before | `docker`, `node_modules`, `src` — whole folders, tracked files included |
| after | `docker/.env`, `src/backend/.env`, `node_modules` |

Also verified: `src/**` where `src` is not ignored copies only the ignored files below it, `**/node_modules/**` no longer nominates the repository root, and a pattern for a non-existent folder no longer produces a failed copy.

This PR was produced under use of AI (Claude Opus 5).