### PR TITLE
chat: generalize language model source presentation

### DIFF
--- a/src/vs/platform/agentHost/common/agentModelSource.ts
+++ b/src/vs/platform/agentHost/common/agentModelSource.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IAgentModelInfo } from './agentService.js';
+import type { SessionModelInfo } from './state/protocol/state.js';
+
+/** Well-known source id for models provided by a user's ChatGPT subscription. */
+export const CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID = 'chatgptSubscription';
+
+/** Well-known key carrying a model's source id under its open `_meta` bag. */
+export const AGENT_MODEL_SOURCE_ID_META_KEY = 'modelSourceId';
+
+/**
+ * Builds a `_meta` payload carrying a model source id, or `undefined` when the
+ * producer cannot confidently identify the source.
+ */
+export function createAgentModelSourceMeta(sourceId: string | undefined): Record<string, unknown> | undefined {
+	return sourceId !== undefined ? { [AGENT_MODEL_SOURCE_ID_META_KEY]: sourceId } : undefined;
+}
+
+/** Reads a model source id from the open `_meta` bag, ignoring invalid values. */
+export function readAgentModelSourceId(model: IAgentModelInfo | SessionModelInfo): string | undefined {
+	const meta = model._meta;
+	if (!meta) {
+		return undefined;
+	}
+	const value = meta[AGENT_MODEL_SOURCE_ID_META_KEY];
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -23,6 +23,7 @@ import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { createSchema, platformRootSchema, platformSessionSchema, schemaProperty, AgentHostCodexMultiRootEnabledConfigKey, AgentHostMcpServersConfigKey, type ISchemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
+import { CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID, createAgentModelSourceMeta } from '../../common/agentModelSource.js';
 import { CODEX_ACCOUNT_META_KEY, CODEX_ACCOUNT_SIGN_IN_REQUEST_KEY, CODEX_ACCOUNT_SIGN_OUT_REQUEST_KEY, type ICodexAccountInfo } from '../../common/codexAccount.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, CODEX_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider, type AuthenticateParams } from '../../common/agentService.js';
@@ -1416,6 +1417,7 @@ export class CodexAgent extends Disposable implements IAgent {
 					name: model.displayName,
 					supportsVision: model.inputModalities.includes('image'),
 					configSchema,
+					_meta: createAgentModelSourceMeta(pickerProvider === 'chatgpt' ? CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID : undefined),
 				}));
 			this._codexModels = models;
 		} catch (err) {

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -180,6 +180,7 @@ const MCP_TOOL_APPROVAL_ANSWER_DECLINE = '__codex_mcp_decline__';
  */
 const CODEX_RESPONSES_ENDPOINT = '/responses';
 const CODEX_COPILOT_MODEL_PROVIDER = 'vscode-proxy';
+const CODEX_OPENAI_MODEL_PROVIDER = 'openai';
 const CODEX_MODEL_SELECTION_PREFIX = '@provider=';
 
 export function toCodexModelSelectionId(modelProvider: string, modelId: string): string {
@@ -1399,8 +1400,9 @@ export class CodexAgent extends Disposable implements IAgent {
 				return;
 			}
 			const configResponse = await connection.client.request<'config/read', ConfigReadResponse>('config/read', { includeLayers: false });
-			const modelProvider = configResponse.config.model_provider ?? 'openai';
-			const pickerProvider = account.status === 'signedIn' && account.authType === 'chatgpt' ? 'chatgpt' : modelProvider;
+			const modelProvider = configResponse.config.model_provider ?? CODEX_OPENAI_MODEL_PROVIDER;
+			const usesChatGPTSubscription = modelProvider === CODEX_OPENAI_MODEL_PROVIDER && account.status === 'signedIn' && account.authType === 'chatgpt';
+			const pickerProvider = usesChatGPTSubscription ? 'chatgpt' : modelProvider;
 			const data = [] as ModelListResponse['data'];
 			let cursor: string | null = null;
 			do {
@@ -1417,7 +1419,7 @@ export class CodexAgent extends Disposable implements IAgent {
 					name: model.displayName,
 					supportsVision: model.inputModalities.includes('image'),
 					configSchema,
-					_meta: createAgentModelSourceMeta(pickerProvider === 'chatgpt' ? CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID : undefined),
+					_meta: createAgentModelSourceMeta(usesChatGPTSubscription ? CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID : undefined),
 				}));
 			this._codexModels = models;
 		} catch (err) {

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -11,6 +11,7 @@ import { getCommandArgumentHint, getCompletionAction, readCompletionAttachmentMe
 import { CustomizationType, MessageAttachmentKind, ToolCallStatus, hasReportedUsage, readUsageInfoMeta, type AgentCustomization, type ToolCallState, type UsageInfo } from '../../common/state/sessionState.js';
 import type { SessionModelInfo, SimpleMessageAttachment } from '../../common/state/protocol/state.js';
 import { createAgentModelByokMeta, readAgentModelByokIdentifier } from '../../common/agentModelByokMeta.js';
+import { createAgentModelSourceMeta, readAgentModelSourceId } from '../../common/agentModelSource.js';
 
 /** Wraps a `_meta` bag in a minimal {@link ToolCallState} so the reader sees the right source type. */
 function toolCall(meta: Record<string, unknown> | undefined): ToolCallState {
@@ -184,6 +185,25 @@ suite('Agent host _meta readers', () => {
 
 		test('ignores a wrong-typed identifier value', () => {
 			assert.strictEqual(readAgentModelByokIdentifier(model({ byokModelIdentifier: 42 })), undefined);
+		});
+	});
+
+	suite('agent model source meta', () => {
+		function model(meta: Record<string, unknown> | undefined): SessionModelInfo {
+			return { id: 'm', provider: 'p', name: 'n', _meta: meta };
+		}
+
+		test('round-trips a source id through _meta', () => {
+			const meta = createAgentModelSourceMeta('chatgptSubscription');
+			assert.deepStrictEqual(meta, { modelSourceId: 'chatgptSubscription' });
+			assert.strictEqual(readAgentModelSourceId(model(meta)), 'chatgptSubscription');
+		});
+
+		test('omits unknown sources and ignores invalid values', () => {
+			assert.strictEqual(createAgentModelSourceMeta(undefined), undefined);
+			assert.strictEqual(readAgentModelSourceId(model(undefined)), undefined);
+			assert.strictEqual(readAgentModelSourceId(model({ modelSourceId: 42 })), undefined);
+			assert.strictEqual(readAgentModelSourceId(model({ modelSourceId: '' })), undefined);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -115,10 +115,12 @@ suite('CodexAgent model refresh', () => {
 			provider: model.provider,
 			id: model.id,
 			name: model.name,
+			meta: model._meta,
 		})), [{
 			provider: 'chatgpt',
 			id: toCodexModelSelectionId('openai', 'gpt-5.6-sol'),
 			name: 'GPT-5.6-Sol',
+			meta: { modelSourceId: 'chatgptSubscription' },
 		}]);
 	});
 
@@ -166,9 +168,10 @@ suite('CodexAgent model refresh', () => {
 
 		await agent['_refreshCodexModels']();
 
-		assert.deepStrictEqual(agent['_codexModels'].map(model => ({ provider: model.provider, id: model.id })), [{
+		assert.deepStrictEqual(agent['_codexModels'].map(model => ({ provider: model.provider, id: model.id, meta: model._meta })), [{
 			provider: 'custom-provider',
 			id: toCodexModelSelectionId('custom-provider', 'gpt-5.6-sol'),
+			meta: undefined,
 		}]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -175,6 +175,66 @@ suite('CodexAgent model refresh', () => {
 		}]);
 	});
 
+	test('does not treat a custom provider named chatgpt as a ChatGPT subscription', async () => {
+		const agent = createAgent(disposables, async () => []);
+		agent['_connection'] = {
+			kind: 'ready',
+			client: {
+				request: async (method: string) => {
+					if (method === 'account/read') {
+						return { account: { type: 'apiKey' }, requiresOpenaiAuth: false };
+					}
+					if (method === 'config/read') {
+						return { config: { model_provider: 'chatgpt' } };
+					}
+					if (method === 'model/list') {
+						return modelListResponse;
+					}
+					throw new Error(`Unexpected request: ${method}`);
+				},
+			},
+			proxyHandle: { dispose() { } },
+			child: { kill: () => true },
+		} as never;
+
+		await agent['_refreshCodexModels']();
+
+		assert.deepStrictEqual(agent['_codexModels'].map(model => ({ provider: model.provider, meta: model._meta })), [{
+			provider: 'chatgpt',
+			meta: undefined,
+		}]);
+	});
+
+	test('does not relabel a custom provider when ChatGPT authentication is available', async () => {
+		const agent = createAgent(disposables, async () => []);
+		agent['_connection'] = {
+			kind: 'ready',
+			client: {
+				request: async (method: string) => {
+					if (method === 'account/read') {
+						return { account: { type: 'chatgpt', email: 'person@example.com', planType: 'plus' }, requiresOpenaiAuth: false };
+					}
+					if (method === 'config/read') {
+						return { config: { model_provider: 'custom-provider' } };
+					}
+					if (method === 'model/list') {
+						return modelListResponse;
+					}
+					throw new Error(`Unexpected request: ${method}`);
+				},
+			},
+			proxyHandle: { dispose() { } },
+			child: { kill: () => true },
+		} as never;
+
+		await agent['_refreshCodexModels']();
+
+		assert.deepStrictEqual(agent['_codexModels'].map(model => ({ provider: model.provider, meta: model._meta })), [{
+			provider: 'custom-provider',
+			meta: undefined,
+		}]);
+	});
+
 	test('signs out through app-server and refreshes account state', async () => {
 		const agent = createAgent(disposables, async () => []);
 		const requests: string[] = [];

--- a/src/vs/sessions/contrib/chat/test/browser/sessionModelSelectionModel.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionModelSelectionModel.test.ts
@@ -168,7 +168,7 @@ suite('SessionModelSelectionModel', () => {
 		};
 		const chatGPTModel = {
 			...model('codex:@provider=openai:gpt-test'),
-			metadata: { ...model('codex:@provider=openai:gpt-test').metadata, modelGroup: { id: 'openai', source: 'chatgptSubscription' as const } },
+			metadata: { ...model('codex:@provider=openai:gpt-test').metadata, modelGroup: { id: 'openai', sourceId: 'chatgptSubscription' } },
 		};
 		const storage = disposables.add(new InMemoryStorageService());
 		storeSelectedModel(storage, ChatAgentLocation.Chat, codexModelTarget, chatGPTModel.identifier);

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -42,7 +42,7 @@ import { IChatSendRequestOptions, IChatService, type IChatModelReference } from 
 import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, getChatPermissionLevelFromDefaultConfiguration, isChatPermissionLevel, type IChatDefaultConfiguration } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { isAutoApprovePolicyRestricted, normalizeSessionConfigValue } from '../../../../../workbench/contrib/chat/common/agentHostConfigPolicy.js';
-import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
+import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { getRegisteredLanguageModels, resolveConfiguredModel, resolveModelIdentifier, resolveModelIdentifierFromLanguageModels } from '../../../../../workbench/contrib/chat/common/modelSelection.js';
 import { buildMutableConfigSchema, IAgentHostMcpServer, IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../../common/agentHostSessionsProvider.js';
 import { agentHostSessionWorkspaceKey } from '../../../../common/agentHostSessionWorkspace.js';
@@ -3166,7 +3166,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	// -- Model selection ------------------------------------------------------
 
 	get onDidChangeModels(): Event<void> {
-		return Event.signal(this._languageModelsService.onDidChangeLanguageModels);
+		return Event.signal(Event.any(
+			this._languageModelsService.onDidChangeLanguageModels,
+			this._languageModelsService.onDidChangeModelVisibility,
+		));
 	}
 
 	getModelsSnapshot(sessionId: string, desiredModelId?: string): ISessionModelsSnapshot {
@@ -3182,7 +3185,16 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			};
 		}
 		const allModels = getRegisteredLanguageModels(this._languageModelsService);
-		const models = allModels.filter(model => model.metadata.targetChatSessionType === resourceScheme);
+		const models = allModels.filter(model => {
+			if (model.metadata.targetChatSessionType !== resourceScheme) {
+				return false;
+			}
+			if (this._languageModelsService.isModelHidden(model.identifier)) {
+				return false;
+			}
+			const manageModelsIdentifier = ILanguageModelChatMetadata.getAgentHostByokManageModelsIdentifier(model.metadata);
+			return manageModelsIdentifier === undefined || !this._languageModelsService.isModelHidden(manageModelsIdentifier);
+		});
 		const desiredModel = desiredModelId ? this._languageModelsService.lookupLanguageModel(desiredModelId) : undefined;
 		const resolvedDesiredModelId = desiredModel?.targetChatSessionType && this.resourceSchemeForProvider(desiredModel.targetChatSessionType) === resourceScheme
 			? `${resourceScheme}:${desiredModel.id}`

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -399,7 +399,7 @@ function createSchemaDefaultConfigurationService(): TestConfigurationService {
 
 function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = [
 	{ type: 'agent-host-copilotcli', name: 'copilot', displayName: 'Copilot', description: 'test', icon: undefined },
-], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; activeClientAgents?: IObservable<readonly AgentCustomization[]>; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService; agentHostEnabled?: boolean }): LocalAgentHostSessionsProvider {
+], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; hiddenLanguageModelIds?: ReadonlySet<string>; languageModelVisibilityChanges?: Event<void>; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; activeClientAgents?: IObservable<readonly AgentCustomization[]>; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService; agentHostEnabled?: boolean }): LocalAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -429,6 +429,9 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 		getLanguageModelIds: () => options?.languageModelIds ?? [],
 		lookupLanguageModel: options?.lookupLanguageModel ?? (() => undefined),
 		hasResolvedVendor: () => true,
+		isModelHidden: (modelId: string) => options?.hiddenLanguageModelIds?.has(modelId) ?? false,
+		onDidChangeLanguageModels: Event.None,
+		onDidChangeModelVisibility: options?.languageModelVisibilityChanges ?? Event.None,
 	});
 	instantiationService.stub(ILabelService, {
 		getUriLabel: (uri: URI) => uri.path,
@@ -1624,6 +1627,30 @@ suite('LocalAgentHostSessionsProvider', () => {
 			models: ['matching'],
 			modelTarget: 'agent-host-copilotcli',
 		});
+	});
+
+	test('getModelsSnapshot excludes hidden models and announces visibility changes', () => {
+		const matchingModel = { ...createTestLanguageModel('matching'), targetChatSessionType: 'agent-host-copilotcli' };
+		const hiddenLanguageModelIds = new Set(['matching']);
+		const visibilityChanges = disposables.add(new Emitter<void>());
+		const provider = createProvider(disposables, agentHost, undefined, {
+			languageModelIds: ['matching'],
+			lookupLanguageModel: id => id === 'matching' ? matchingModel : undefined,
+			hiddenLanguageModelIds,
+			languageModelVisibilityChanges: visibilityChanges.event,
+		});
+		fireSessionAdded(agentHost, 'hidden-model-catalog', { title: 'Hidden Model Catalog Session' });
+		const session = provider.getSessions().find(session => session.title.get() === 'Hidden Model Catalog Session');
+		assert.ok(session);
+
+		let changes = 0;
+		disposables.add(provider.onDidChangeModels(() => changes++));
+		assert.deepStrictEqual(provider.getModelsSnapshot(session.sessionId).models, []);
+
+		hiddenLanguageModelIds.delete('matching');
+		visibilityChanges.fire();
+		assert.strictEqual(changes, 1);
+		assert.deepStrictEqual(provider.getModelsSnapshot(session.sessionId).models.map(model => model.identifier), ['matching']);
 	});
 
 	test('getModelsSnapshot canonicalizes a matching logical-session model identifier', () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -16,6 +16,7 @@ import { LOCAL_AGENT_HOST_AUTHORITY } from '../../../../../../platform/agentHost
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { NotificationType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID } from '../../../../../../platform/agentHost/common/agentModelSource.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -28,6 +29,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatSessionsService, isLocalAgentHostTarget } from '../../../common/chatSessionsService.js';
 import { ICustomizationHarnessService } from '../../../common/customizationHarnessService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
+import { languageModelSourcePresentationRegistry } from '../../../common/languageModelSourcePresentation.js';
 import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { AgentCustomizationItemProvider } from './agentCustomizationItemProvider.js';
 import { AgentHostDownloadProgress } from './agentHostDownloadProgress.js';
@@ -40,6 +42,14 @@ import { IAgentHostProtectedResourcesService } from './agentHostProtectedResourc
 import { AICustomizationManagementSection } from '../../../common/aiCustomizationWorkspaceService.js';
 
 const LOCAL_AGENT_HOST_SESSION_TYPE_PREFIX = 'agent-host-';
+
+languageModelSourcePresentationRegistry.register({
+	ownerVendor: 'agent-host-codex',
+	sourceId: CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID,
+	label: localize('agentHostModelSource.chatGPT.label', "ChatGPT"),
+	icon: Codicon.openai,
+	description: localize('agentHostModelSource.chatGPT.description', "Models provided by your ChatGPT subscription"),
+});
 
 Registry.as<IAsyncChatSessionActivationRegistry>(ChatSessionsExtensions.AsyncActivation).register({
 	matchSessionType: sessionType => isLocalAgentHostTarget(sessionType),
@@ -308,13 +318,6 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		// `registerLanguageModelProvider` so the initial `onDidChange` is observed.
 		const vendorDescriptors = [
 			{ vendor, displayName: agent.displayName, configuration: undefined, managementCommand: undefined, when: undefined },
-			...(agent.provider === 'codex' ? [{
-				vendor: 'chatgpt',
-				displayName: localize('agentHostModelProvider.chatGPT', "ChatGPT"),
-				configuration: undefined,
-				managementCommand: undefined,
-				when: undefined,
-			}] : []),
 		];
 		this._languageModelsService.deltaLanguageModelChatProviderDescriptors(vendorDescriptors, []);
 		store.add(toDisposable(() => this._languageModelsService.deltaLanguageModelChatProviderDescriptors([], vendorDescriptors)));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -10,6 +10,7 @@ import { localize } from '../../../../../../nls.js';
 import { ConfigSchema, SessionModelInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { readAgentModelPricingMeta } from '../../../../../../platform/agentHost/common/agentModelPricing.js';
 import { readAgentModelByokIdentifier } from '../../../../../../platform/agentHost/common/agentModelByokMeta.js';
+import { readAgentModelSourceId } from '../../../../../../platform/agentHost/common/agentModelSource.js';
 import { nullExtensionDescription } from '../../../../../services/extensions/common/extensions.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelChatProvider, ILanguageModelConfigurationSchema } from '../../../common/languageModels.js';
 
@@ -169,9 +170,8 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 		if (!groupVendorId) {
 			return undefined;
 		}
-		return this._sessionType === 'agent-host-codex' && model.provider === 'chatgpt'
-			? { id: groupVendorId, source: 'chatgptSubscription' }
-			: { id: groupVendorId };
+		const sourceId = readAgentModelSourceId(model);
+		return { id: groupVendorId, ...(sourceId !== undefined && { sourceId }) };
 	}
 
 	async sendChatRequest(): Promise<never> {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
@@ -532,16 +532,11 @@ export class ChatModelsViewModel extends Disposable {
 	}
 
 	toggleGroupHidden(entry: ILanguageModelProviderEntry): void {
-		const hidden = !entry.hidden;
-		for (const model of this.getModelsForGroup(entry)) {
-			this.languageModelsService.setModelHidden(model.identifier, hidden);
-		}
+		this.languageModelsService.setModelsHidden(this.getModelsForGroup(entry).map(model => model.identifier), !entry.hidden);
 	}
 
 	setModelsHidden(entries: readonly ILanguageModelEntry[], hidden: boolean): void {
-		for (const entry of entries) {
-			this.languageModelsService.setModelHidden(entry.model.identifier, hidden);
-		}
+		this.languageModelsService.setModelsHidden(entries.map(entry => entry.model.identifier), hidden);
 	}
 
 	private refreshVisibility(): void {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel.ts
@@ -10,6 +10,7 @@ import { getLanguageModelProviderDisplayName, ILanguageModelChatMetadata, ILangu
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ILanguageModelsProviderGroup } from '../../common/languageModelsConfiguration.js';
 import Severity from '../../../../../base/common/severity.js';
+import { ILanguageModelSourcePresentation, languageModelSourcePresentationRegistry } from '../../common/languageModelSourcePresentation.js';
 
 export const MODEL_ENTRY_TEMPLATE_ID = 'model.entry.template';
 export const VENDOR_ENTRY_TEMPLATE_ID = 'vendor.entry.template';
@@ -34,7 +35,8 @@ export const SEARCH_SUGGESTIONS = {
 export interface ILanguageModelProvider {
 	vendor: ILanguageModelProviderDescriptor;
 	group: ILanguageModelsProviderGroup;
-	source?: 'chatgptSubscription';
+	sourceId?: string;
+	sourcePresentation?: ILanguageModelSourcePresentation;
 }
 
 export interface ILanguageModel extends ILanguageModelChatMetadataAndIdentifier {
@@ -72,7 +74,7 @@ export interface ILanguageModelProviderEntry {
 	templateId: string;
 	collapsed: boolean;
 	hidden: boolean;
-	chatgptSubscription: boolean;
+	sourcePresentation?: ILanguageModelSourcePresentation;
 	vendorEntry: ILanguageModelProvider;
 }
 
@@ -183,7 +185,7 @@ export class ChatModelsViewModel extends Disposable {
 	private doFilter(): void {
 		const viewModelEntries: IViewModelEntry[] = [];
 		const shouldShowGroupHeaders = this.languageModelGroups.length > 1
-			|| this.languageModelGroups.some(group => isLanguageModelProviderEntry(group.group) && group.group.chatgptSubscription);
+			|| this.languageModelGroups.some(group => isLanguageModelProviderEntry(group.group) && group.group.sourcePresentation !== undefined);
 
 		for (const group of this.languageModelGroups) {
 			if (this.collapsedGroups.has(group.group.id)) {
@@ -383,6 +385,9 @@ export class ChatModelsViewModel extends Disposable {
 			});
 		}
 		for (const group of result) {
+			if (isLanguageModelProviderEntry(group.group)) {
+				group.group.hidden = group.models.length > 0 && group.models.every(model => model.hidden);
+			}
 			group.models.sort((a, b) => {
 				if (a.provider.vendor.isDefault && b.provider.vendor.isDefault) {
 					return a.metadata.name.localeCompare(b.metadata.name);
@@ -407,12 +412,9 @@ export class ChatModelsViewModel extends Disposable {
 			label: provider.group.name,
 			templateId: VENDOR_ENTRY_TEMPLATE_ID,
 			collapsed: this.collapsedGroups.has(id),
-			hidden: this.languageModelsService.isGroupHidden(provider.group.vendor, provider.group.name),
-			chatgptSubscription: provider.source === 'chatgptSubscription',
-			vendorEntry: {
-				group: provider.group,
-				vendor: provider.vendor
-			},
+			hidden: false,
+			sourcePresentation: provider.sourcePresentation,
+			vendorEntry: provider,
 		};
 	}
 
@@ -491,13 +493,17 @@ export class ChatModelsViewModel extends Disposable {
 				if (ILanguageModelChatMetadata.getAgentHostByokManageModelsIdentifier(metadata) !== undefined) {
 					continue;
 				}
+				const sourcePresentation = metadata.modelGroup?.sourceId
+					? languageModelSourcePresentationRegistry.get(metadata.vendor, metadata.modelGroup.sourceId)
+					: undefined;
 				const provider = metadata.modelGroup ? {
 					vendor,
 					group: {
 						vendor: metadata.modelGroup.id,
-						name: getLanguageModelProviderDisplayName(this.languageModelsService, metadata.modelGroup.id),
+						name: sourcePresentation?.label ?? getLanguageModelProviderDisplayName(this.languageModelsService, metadata.modelGroup.id),
 					},
-					source: metadata.modelGroup.source,
+					sourceId: metadata.modelGroup.sourceId,
+					sourcePresentation,
 				} satisfies ILanguageModelProvider : defaultProvider;
 				models.push({
 					identifier,
@@ -526,7 +532,10 @@ export class ChatModelsViewModel extends Disposable {
 	}
 
 	toggleGroupHidden(entry: ILanguageModelProviderEntry): void {
-		this.languageModelsService.setGroupHidden(entry.vendorEntry.group.vendor, entry.vendorEntry.group.name, !entry.hidden);
+		const hidden = !entry.hidden;
+		for (const model of this.getModelsForGroup(entry)) {
+			this.languageModelsService.setModelHidden(model.identifier, hidden);
+		}
 	}
 
 	setModelsHidden(entries: readonly ILanguageModelEntry[], hidden: boolean): void {
@@ -549,7 +558,7 @@ export class ChatModelsViewModel extends Disposable {
 	}
 
 	private getProviderGroupId(provider: ILanguageModelProvider): string {
-		return `${provider.group.vendor}-${provider.group.name}-${provider.source ?? 'configured'}`;
+		return `${provider.group.vendor}-${provider.group.name}-${provider.sourceId ?? 'configured'}`;
 	}
 
 	toggleCollapsed(viewModelEntry: IViewModelEntry): void {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -503,6 +503,7 @@ interface IModelNameColumnTemplateData extends IModelTableColumnTemplateData {
 	readonly statusIcon: HTMLElement;
 	readonly providerIcon: HTMLElement;
 	readonly nameLabel: HighlightedLabel;
+	readonly sourceDescription: HTMLElement;
 	readonly modelStatusIcon: HTMLElement;
 	readonly deprecationLinkContainer: HTMLElement;
 	readonly deprecationLink: Link;
@@ -529,6 +530,8 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 		const providerIcon = DOM.append(nameContainer, $('.model-provider-icon'));
 		providerIcon.setAttribute('aria-hidden', 'true');
 		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(nameContainer, $('.model-name'))));
+		const sourceDescription = DOM.append(nameContainer, $('.model-source-description'));
+		sourceDescription.style.display = 'none';
 		const deprecationLinkContainer = DOM.append(nameContainer, $('.model-deprecation-link'));
 		deprecationLinkContainer.style.display = 'none';
 		const deprecationLink = disposables.add(this.instantiationService.createInstance(Link, deprecationLinkContainer, { label: '', href: '' }, {}));
@@ -538,6 +541,7 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 			statusIcon,
 			providerIcon,
 			nameLabel,
+			sourceDescription,
 			modelStatusIcon,
 			deprecationLinkContainer,
 			deprecationLink,
@@ -550,6 +554,8 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 		DOM.clearNode(templateData.modelStatusIcon);
 		templateData.providerIcon.className = 'model-provider-icon';
 		templateData.providerIcon.style.display = 'none';
+		templateData.sourceDescription.textContent = '';
+		templateData.sourceDescription.style.display = 'none';
 		templateData.nameLabel.element.classList.remove('error-status', 'warning-status', 'info-status');
 		templateData.deprecationLinkContainer.style.display = 'none';
 		super.renderElement(entry, index, templateData);
@@ -560,6 +566,10 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 		if (entry.sourcePresentation?.icon) {
 			templateData.providerIcon.classList.add(...ThemeIcon.asClassNameArray(entry.sourcePresentation.icon));
 			templateData.providerIcon.style.display = '';
+		}
+		if (entry.sourcePresentation?.description) {
+			templateData.sourceDescription.textContent = entry.sourcePresentation.description;
+			templateData.sourceDescription.style.display = '';
 		}
 
 		const deprecationLink = entry.vendorEntry.vendor.deprecation?.link;
@@ -1082,7 +1092,7 @@ class ProviderColumnRenderer extends ModelsTableColumnRenderer<IProviderColumnTe
 	}
 
 	override renderVendorElement(entry: ILanguageModelProviderEntry, index: number, templateData: IProviderColumnTemplateData): void {
-		templateData.providerElement.textContent = entry.sourcePresentation?.description ?? '';
+		templateData.providerElement.textContent = '';
 	}
 
 	override renderGroupElement(entry: ILanguageModelGroupEntry, index: number, templateData: IProviderColumnTemplateData): void {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -527,6 +527,7 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 		const nameContainer = DOM.append(container, $('.model-name-container'));
 		const statusIcon = DOM.append(nameContainer, $('.status-icon'));
 		const providerIcon = DOM.append(nameContainer, $('.model-provider-icon'));
+		providerIcon.setAttribute('aria-hidden', 'true');
 		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(nameContainer, $('.model-name'))));
 		const deprecationLinkContainer = DOM.append(nameContainer, $('.model-deprecation-link'));
 		deprecationLinkContainer.style.display = 'none';
@@ -556,8 +557,8 @@ class ModelNameColumnRenderer extends ModelsTableColumnRenderer<IModelNameColumn
 
 	override renderVendorElement(entry: ILanguageModelProviderEntry, index: number, templateData: IModelNameColumnTemplateData): void {
 		templateData.nameLabel.set(entry.vendorEntry.group.name, undefined);
-		if (entry.chatgptSubscription) {
-			templateData.providerIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.openai));
+		if (entry.sourcePresentation?.icon) {
+			templateData.providerIcon.classList.add(...ThemeIcon.asClassNameArray(entry.sourcePresentation.icon));
 			templateData.providerIcon.style.display = '';
 		}
 
@@ -1081,9 +1082,7 @@ class ProviderColumnRenderer extends ModelsTableColumnRenderer<IProviderColumnTe
 	}
 
 	override renderVendorElement(entry: ILanguageModelProviderEntry, index: number, templateData: IProviderColumnTemplateData): void {
-		templateData.providerElement.textContent = entry.chatgptSubscription
-			? localize('models.chatgptSubscriptionProvider', "Models provided by your ChatGPT subscription")
-			: '';
+		templateData.providerElement.textContent = entry.sourcePresentation?.description ?? '';
 	}
 
 	override renderGroupElement(entry: ILanguageModelGroupEntry, index: number, templateData: IProviderColumnTemplateData): void {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
@@ -129,6 +129,15 @@
 	font-size: 16px;
 }
 
+.models-widget .models-table-container .monaco-table-td .model-name-container .model-source-description {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+}
+
 .models-widget .models-table-container .monaco-table-tr.models-vendor-row .model-provider {
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives.ts
@@ -15,6 +15,7 @@ import { IOpenerService } from '../../../../../../../platform/opener/common/open
 import { StateType } from '../../../../../../../platform/update/common/update.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../../services/chat/common/chatEntitlementService.js';
 import { getLanguageModelProviderDisplayName, IModelControlEntry, ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../common/languageModels.js';
+import { languageModelSourcePresentationRegistry } from '../../../../common/languageModelSourcePresentation.js';
 import { getModelHoverContent } from './modelPickerHover.js';
 import { getPriceCategoryLabel, isMultiplierPricing } from './modelPickerPresentation.js';
 
@@ -71,9 +72,12 @@ export function getProviderGroupForModel(
 ): IProviderGroupInfo {
 	if (model.metadata.modelGroup) {
 		const byokGroup = model.metadata.byokModelIdentifier ? modelToGroup.get(model.metadata.byokModelIdentifier) : undefined;
+		const sourcePresentation = model.metadata.modelGroup.sourceId
+			? languageModelSourcePresentationRegistry.get(model.metadata.vendor, model.metadata.modelGroup.sourceId)
+			: undefined;
 		return byokGroup ?? {
 			vendor: model.metadata.vendor,
-			groupName: getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id),
+			groupName: sourcePresentation?.label ?? getLanguageModelProviderDisplayName(languageModelsService, model.metadata.modelGroup.id),
 		};
 	}
 	return modelToGroup.get(model.identifier) ?? {

--- a/src/vs/workbench/contrib/chat/common/languageModelSourcePresentation.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelSourcePresentation.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+
+/** Presentation for a trusted model source owned by one language-model vendor. */
+export interface ILanguageModelSourcePresentation {
+	readonly ownerVendor: string;
+	readonly sourceId: string;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly description: string;
+}
+
+export interface ILanguageModelSourcePresentationRegistry {
+	register(presentation: ILanguageModelSourcePresentation): IDisposable;
+	get(ownerVendor: string, sourceId: string): ILanguageModelSourcePresentation | undefined;
+}
+
+class LanguageModelSourcePresentationRegistry implements ILanguageModelSourcePresentationRegistry {
+	private readonly _presentations = new Map<string, ILanguageModelSourcePresentation>();
+
+	register(presentation: ILanguageModelSourcePresentation): IDisposable {
+		const key = this._key(presentation.ownerVendor, presentation.sourceId);
+		if (this._presentations.has(key)) {
+			throw new Error(`A language model source presentation is already registered for ${presentation.ownerVendor}/${presentation.sourceId}`);
+		}
+		this._presentations.set(key, presentation);
+		return toDisposable(() => {
+			if (this._presentations.get(key) === presentation) {
+				this._presentations.delete(key);
+			}
+		});
+	}
+
+	get(ownerVendor: string, sourceId: string): ILanguageModelSourcePresentation | undefined {
+		return this._presentations.get(this._key(ownerVendor, sourceId));
+	}
+
+	private _key(ownerVendor: string, sourceId: string): string {
+		return `${ownerVendor}\u0000${sourceId}`;
+	}
+}
+
+export const languageModelSourcePresentationRegistry: ILanguageModelSourcePresentationRegistry = new LanguageModelSourcePresentationRegistry();

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -649,6 +649,11 @@ export interface ILanguageModelsService {
 	setModelHidden(modelIdentifier: string, hidden: boolean): void;
 
 	/**
+	 * Hide or show multiple exact model identifiers in the chat model picker.
+	 */
+	setModelsHidden(modelIdentifiers: readonly string[], hidden: boolean): void;
+
+	/**
 	 * Hide or show every model in a (vendor, groupName) bucket.
 	 */
 	setGroupHidden(vendor: string, groupName: string, hidden: boolean): void;
@@ -2375,9 +2380,16 @@ export class LanguageModelsService implements ILanguageModelsService {
 	}
 
 	setGroupHidden(vendor: string, groupName: string, hidden: boolean): void {
+		this.setModelsHidden(this._getModelIdsInGroup(vendor, groupName), hidden);
+	}
+
+	setModelHidden(modelIdentifier: string, hidden: boolean): void {
+		this.setModelsHidden([modelIdentifier], hidden);
+	}
+
+	setModelsHidden(modelIdentifiers: readonly string[], hidden: boolean): void {
 		let changed = false;
-		const modelIds = this._getModelIdsInGroup(vendor, groupName);
-		for (const id of modelIds) {
+		for (const id of modelIdentifiers) {
 			if (hidden) {
 				if (!this._hiddenModelIds.has(id)) {
 					this._hiddenModelIds.add(id);
@@ -2386,22 +2398,6 @@ export class LanguageModelsService implements ILanguageModelsService {
 			} else if (this._hiddenModelIds.delete(id)) {
 				changed = true;
 			}
-		}
-		if (changed) {
-			this._saveVisibility();
-			this._onDidChangeModelVisibility.fire();
-		}
-	}
-
-	setModelHidden(modelIdentifier: string, hidden: boolean): void {
-		let changed = false;
-		if (hidden) {
-			if (!this._hiddenModelIds.has(modelIdentifier)) {
-				this._hiddenModelIds.add(modelIdentifier);
-				changed = true;
-			}
-		} else if (this._hiddenModelIds.delete(modelIdentifier)) {
-			changed = true;
 		}
 		if (changed) {
 			this._saveVisibility();

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -298,8 +298,12 @@ export interface ILanguageModelChatMetadata {
 	 */
 	readonly modelGroup?: {
 		readonly id: string;
-		/** Identifies a first-party provider group that must remain distinct from user-configured groups with the same name. */
-		readonly source?: 'chatgptSubscription';
+		/**
+		 * Identifies a trusted source presentation owned by this model's vendor.
+		 * Source ids are resolved together with {@link ILanguageModelChatMetadata.vendor},
+		 * so another vendor cannot claim the same presentation by reusing the id.
+		 */
+		readonly sourceId?: string;
 	};
 	/**
 	 * For an agent-host copy of an extension-provided BYOK model, the identifier the

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
@@ -120,7 +120,7 @@ suite('AgentHostLanguageModelProvider', () => {
 		const provider = store.add(new AgentHostLanguageModelProvider('agent-host-codex', 'codex'));
 		provider.updateModels([
 			{ id: '@provider=vscode-proxy:gpt-5.6-sol', provider: 'copilot', name: 'GPT-5.6 Sol' },
-			{ id: '@provider=openai:gpt-5.6-sol', provider: 'chatgpt', name: 'GPT-5.6 Sol' },
+			{ id: '@provider=openai:gpt-5.6-sol', provider: 'chatgpt', name: 'GPT-5.6 Sol', _meta: { modelSourceId: 'chatgptSubscription' } },
 		]);
 
 		const infos = await provider.provideLanguageModelChatInfo(undefined, CancellationToken.None);
@@ -130,8 +130,16 @@ suite('AgentHostLanguageModelProvider', () => {
 			group: info.metadata.modelGroup,
 		})), [
 			{ identifier: 'codex:@provider=vscode-proxy:gpt-5.6-sol', name: 'GPT-5.6 Sol', group: { id: 'copilot' } },
-			{ identifier: 'codex:@provider=openai:gpt-5.6-sol', name: 'GPT-5.6 Sol', group: { id: 'chatgpt', source: 'chatgptSubscription' } },
+			{ identifier: 'codex:@provider=openai:gpt-5.6-sol', name: 'GPT-5.6 Sol', group: { id: 'chatgpt', sourceId: 'chatgptSubscription' } },
 		]);
+	});
+
+	test('does not infer a trusted source from provider names', async () => {
+		const provider = store.add(new AgentHostLanguageModelProvider('agent-host-codex', 'codex'));
+		provider.updateModels([{ id: '@provider=openai:gpt-5.6-sol', provider: 'chatgpt', name: 'GPT-5.6 Sol' }]);
+
+		const info = (await provider.provideLanguageModelChatInfo(undefined, CancellationToken.None))[0];
+		assert.deepStrictEqual(info.metadata.modelGroup, { id: 'chatgpt' });
 	});
 
 	test('carries the BYOK model identifier from _meta so the Manage Models toggle can be honoured', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { IAction } from '../../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
@@ -15,6 +16,7 @@ import { ExtensionIdentifier } from '../../../../../../platform/extensions/commo
 import { IStringDictionary } from '../../../../../../base/common/collections.js';
 import { ILanguageModelsProviderGroup } from '../../../common/languageModelsConfiguration.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
+import { languageModelSourcePresentationRegistry } from '../../../common/languageModelSourcePresentation.js';
 
 class MockLanguageModelsService implements ILanguageModelsService {
 	_serviceBrand: undefined;
@@ -23,6 +25,7 @@ class MockLanguageModelsService implements ILanguageModelsService {
 	private models = new Map<string, ILanguageModelChatMetadata>();
 	private modelsByVendor = new Map<string, string[]>();
 	private modelGroups = new Map<string, ILanguageModelsGroup[]>();
+	private hiddenModelIds = new Set<string>();
 
 	private readonly _onDidChangeLanguageModels = new Emitter<string>();
 	readonly onDidChangeLanguageModels = this._onDidChangeLanguageModels.event;
@@ -172,11 +175,17 @@ class MockLanguageModelsService implements ILanguageModelsService {
 	unpinModel(_modelIdentifier: string): void { }
 	isModelPinned(_modelIdentifier: string): boolean { return false; }
 	onDidChangePinnedModels = Event.None;
-	isModelHidden(_modelIdentifier: string): boolean { return false; }
+	isModelHidden(modelIdentifier: string): boolean { return this.hiddenModelIds.has(modelIdentifier); }
 	isGroupHidden(_vendor: string, _groupName: string): boolean { return false; }
-	setModelHidden(_modelIdentifier: string, _hidden: boolean): void { }
+	setModelHidden(modelIdentifier: string, hidden: boolean): void {
+		if (hidden) {
+			this.hiddenModelIds.add(modelIdentifier);
+		} else {
+			this.hiddenModelIds.delete(modelIdentifier);
+		}
+	}
 	setGroupHidden(_vendor: string, _groupName: string, _hidden: boolean): void { }
-	getHiddenModelIds(): string[] { return []; }
+	getHiddenModelIds(): string[] { return [...this.hiddenModelIds]; }
 	onDidChangeModelVisibility = Event.None;
 	getModelsControlManifest(): IModelsControlManifest { return { free: {}, paid: {} }; }
 	restrictedChatParticipants = observableValue('restrictedChatParticipants', Object.create(null));
@@ -188,6 +197,13 @@ suite('ChatModelsViewModel', () => {
 	let viewModel: ChatModelsViewModel;
 
 	setup(async () => {
+		store.add(languageModelSourcePresentationRegistry.register({
+			ownerVendor: 'codex',
+			sourceId: 'chatgptSubscription',
+			label: 'ChatGPT',
+			icon: Codicon.openai,
+			description: 'Models provided by your ChatGPT subscription',
+		}));
 		languageModelsService = new MockLanguageModelsService();
 
 		// Setup test data
@@ -320,7 +336,7 @@ suite('ChatModelsViewModel', () => {
 			maxInputTokens: 8192,
 			maxOutputTokens: 4096,
 			isDefaultForLocation: {},
-			modelGroup: { id: 'chatgpt', source: 'chatgptSubscription' },
+			modelGroup: { id: 'chatgpt', sourceId: 'chatgptSubscription' },
 		});
 		service.addModel('custom', 'custom:gpt-5.6', {
 			extension: new ExtensionIdentifier('example.custom'),
@@ -340,7 +356,7 @@ suite('ChatModelsViewModel', () => {
 		const groups = entries.filter(isLanguageModelProviderEntry).map(entry => ({
 			id: entry.id,
 			label: entry.label,
-			chatgptSubscription: entry.chatgptSubscription,
+			sourcePresentation: entry.sourcePresentation?.sourceId,
 		}));
 		const models = entries.filter(entry => !isLanguageModelProviderEntry(entry) && !isLanguageModelGroupEntry(entry)) as ILanguageModelEntry[];
 
@@ -349,8 +365,8 @@ suite('ChatModelsViewModel', () => {
 			providerLabels: models.map(entry => getManageModelsProviderLabel(entry.model)),
 		}, {
 			groups: [
-				{ id: 'chatgpt-ChatGPT-chatgptSubscription', label: 'ChatGPT', chatgptSubscription: true },
-				{ id: 'custom-ChatGPT-configured', label: 'ChatGPT', chatgptSubscription: false },
+				{ id: 'chatgpt-ChatGPT-chatgptSubscription', label: 'ChatGPT', sourcePresentation: 'chatgptSubscription' },
+				{ id: 'custom-ChatGPT-configured', label: 'ChatGPT', sourcePresentation: undefined },
 			],
 			providerLabels: ['ChatGPT', 'ChatGPT'],
 		});
@@ -370,7 +386,7 @@ suite('ChatModelsViewModel', () => {
 			maxInputTokens: 8192,
 			maxOutputTokens: 4096,
 			isDefaultForLocation: {},
-			modelGroup: { id: 'chatgpt', source: 'chatgptSubscription' },
+			modelGroup: { id: 'chatgpt', sourceId: 'chatgptSubscription' },
 		});
 
 		const model = store.add(new ChatModelsViewModel(service));
@@ -379,11 +395,60 @@ suite('ChatModelsViewModel', () => {
 		assert.deepStrictEqual(model.filter('').map(entry => ({
 			type: entry.type,
 			label: isLanguageModelProviderEntry(entry) ? entry.label : undefined,
-			chatgptSubscription: isLanguageModelProviderEntry(entry) ? entry.chatgptSubscription : undefined,
+			sourcePresentation: isLanguageModelProviderEntry(entry) ? entry.sourcePresentation?.sourceId : undefined,
 		})), [
-			{ type: 'vendor', label: 'ChatGPT', chatgptSubscription: true },
-			{ type: 'model', label: undefined, chatgptSubscription: undefined },
+			{ type: 'vendor', label: 'ChatGPT', sourcePresentation: 'chatgptSubscription' },
+			{ type: 'model', label: undefined, sourcePresentation: undefined },
 		]);
+	});
+
+	test('trusted source presentations are scoped to their owner vendor', async () => {
+		const service = new MockLanguageModelsService();
+		service.addVendor({ vendor: 'other', displayName: 'Other', managementCommand: undefined, when: undefined, configuration: undefined });
+		service.addModel('other', 'other:gpt-5.6', {
+			extension: new ExtensionIdentifier('example.other'),
+			id: 'gpt-5.6',
+			name: 'GPT-5.6',
+			family: 'gpt-5.6',
+			version: '1.0',
+			vendor: 'other',
+			maxInputTokens: 8192,
+			maxOutputTokens: 4096,
+			isDefaultForLocation: {},
+			modelGroup: { id: 'chatgpt', sourceId: 'chatgptSubscription' },
+		});
+
+		const model = store.add(new ChatModelsViewModel(service));
+		await model.refresh();
+		const entry = model.filter('').find(candidate => !isLanguageModelProviderEntry(candidate) && !isLanguageModelGroupEntry(candidate)) as ILanguageModelEntry;
+		assert.strictEqual(entry.model.provider.group.name, 'Chatgpt');
+		assert.strictEqual(entry.model.provider.sourcePresentation, undefined);
+	});
+
+	test('group visibility toggles only the exact models rendered in that source group', async () => {
+		const service = new MockLanguageModelsService();
+		service.addVendor({ vendor: 'codex', displayName: 'Codex', managementCommand: undefined, when: undefined, configuration: undefined });
+		service.addVendor({ vendor: 'custom', displayName: 'Custom', managementCommand: undefined, when: undefined, configuration: undefined });
+		const metadata = {
+			extension: new ExtensionIdentifier('vscode.codex'),
+			id: 'gpt-5.6',
+			name: 'GPT-5.6',
+			family: 'gpt-5.6',
+			version: '1.0',
+			maxInputTokens: 8192,
+			maxOutputTokens: 4096,
+			isDefaultForLocation: {},
+		};
+		service.addModel('codex', 'codex:gpt-5.6', { ...metadata, vendor: 'codex', modelGroup: { id: 'chatgpt', sourceId: 'chatgptSubscription' } });
+		service.addModel('custom', 'custom:gpt-5.6', { ...metadata, extension: new ExtensionIdentifier('example.custom'), vendor: 'custom' }, 'ChatGPT');
+
+		const model = store.add(new ChatModelsViewModel(service));
+		await model.refresh();
+		const subscriptionGroup = model.filter('').find(entry => isLanguageModelProviderEntry(entry) && entry.sourcePresentation !== undefined);
+		assert.ok(subscriptionGroup && isLanguageModelProviderEntry(subscriptionGroup));
+
+		model.toggleGroupHidden(subscriptionGroup);
+		assert.deepStrictEqual(service.getHiddenModelIds(), ['codex:gpt-5.6']);
 	});
 
 	test('should filter by provider name (vendor ID and display name)', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
@@ -26,6 +26,7 @@ class MockLanguageModelsService implements ILanguageModelsService {
 	private modelsByVendor = new Map<string, string[]>();
 	private modelGroups = new Map<string, ILanguageModelsGroup[]>();
 	private hiddenModelIds = new Set<string>();
+	readonly setModelsHiddenCalls: { readonly modelIdentifiers: readonly string[]; readonly hidden: boolean }[] = [];
 
 	private readonly _onDidChangeLanguageModels = new Emitter<string>();
 	readonly onDidChangeLanguageModels = this._onDidChangeLanguageModels.event;
@@ -178,10 +179,16 @@ class MockLanguageModelsService implements ILanguageModelsService {
 	isModelHidden(modelIdentifier: string): boolean { return this.hiddenModelIds.has(modelIdentifier); }
 	isGroupHidden(_vendor: string, _groupName: string): boolean { return false; }
 	setModelHidden(modelIdentifier: string, hidden: boolean): void {
-		if (hidden) {
-			this.hiddenModelIds.add(modelIdentifier);
-		} else {
-			this.hiddenModelIds.delete(modelIdentifier);
+		this.setModelsHidden([modelIdentifier], hidden);
+	}
+	setModelsHidden(modelIdentifiers: readonly string[], hidden: boolean): void {
+		this.setModelsHiddenCalls.push({ modelIdentifiers: [...modelIdentifiers], hidden });
+		for (const modelIdentifier of modelIdentifiers) {
+			if (hidden) {
+				this.hiddenModelIds.add(modelIdentifier);
+			} else {
+				this.hiddenModelIds.delete(modelIdentifier);
+			}
 		}
 	}
 	setGroupHidden(_vendor: string, _groupName: string, _hidden: boolean): void { }
@@ -448,7 +455,13 @@ suite('ChatModelsViewModel', () => {
 		assert.ok(subscriptionGroup && isLanguageModelProviderEntry(subscriptionGroup));
 
 		model.toggleGroupHidden(subscriptionGroup);
-		assert.deepStrictEqual(service.getHiddenModelIds(), ['codex:gpt-5.6']);
+		assert.deepStrictEqual({
+			hiddenModelIds: service.getHiddenModelIds(),
+			setModelsHiddenCalls: service.setModelsHiddenCalls,
+		}, {
+			hiddenModelIds: ['codex:gpt-5.6'],
+			setModelsHiddenCalls: [{ modelIdentifiers: ['codex:gpt-5.6'], hidden: true }],
+		});
 	});
 
 	test('should filter by provider name (vendor ID and display name)', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -16,6 +16,7 @@ import { filterModelsForSession } from '../../../../../browser/widget/input/chat
 import { ChatAgentLocation, ChatModeKind } from '../../../../../common/constants.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelControlEntry, IModelsControlManifest } from '../../../../../common/languageModels.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../../../services/chat/common/chatEntitlementService.js';
+import { languageModelSourcePresentationRegistry } from '../../../../../common/languageModelSourcePresentation.js';
 
 function createStubEntitlementService(opts?: { entitlement?: ChatEntitlement; isInternal?: boolean; anonymous?: boolean }): IChatEntitlementService {
 	return {
@@ -54,7 +55,7 @@ function createAutoModel(): ILanguageModelChatMetadataAndIdentifier {
  * vendor id via `modelGroup`. The picker buckets by it and resolves the
  * display name from the vendor registry.
  */
-function createAgentHostModel(id: string, name: string, modelGroup: { id: string }): ILanguageModelChatMetadataAndIdentifier {
+function createAgentHostModel(id: string, name: string, modelGroup: { id: string; sourceId?: string }): ILanguageModelChatMetadataAndIdentifier {
 	const vendor = 'agent-host-copilotcli';
 	return {
 		identifier: `${vendor}:${id}`,
@@ -196,7 +197,7 @@ function createControlManifest(): IModelsControlManifest {
 
 suite('buildModelPickerItems', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('accessibility provider uses radio semantics for model items', () => {
 		const provider = getModelPickerAccessibilityProvider();
@@ -942,6 +943,27 @@ suite('buildModelPickerItems', () => {
 		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
 		// Buckets sorted alphabetically by resolved group display name.
 		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'Hugging Face', 'OpenAI']);
+	});
+
+	test('Other Models resolves a trusted source label without a synthetic vendor descriptor', () => {
+		store.add(languageModelSourcePresentationRegistry.register({
+			ownerVendor: 'agent-host-copilotcli',
+			sourceId: 'chatgptSubscription',
+			label: 'ChatGPT',
+			icon: Codicon.openai,
+			description: 'Models provided by your ChatGPT subscription',
+		}));
+		const auto = createAutoModel();
+		const cli = createAgentHostModel('claude-haiku-4.5', 'Claude Haiku 4.5', { id: 'copilotcli' });
+		const chatgpt = createAgentHostModel('gpt-5.6', 'GPT-5.6', { id: 'chatgpt', sourceId: 'chatgptSubscription' });
+		const service = createLanguageModelsServiceStub([
+			{ vendor: 'copilotcli', displayName: 'Copilot CLI', groups: [] },
+		]);
+
+		const items = callBuild([auto, cli, chatgpt], { languageModelsService: service });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['ChatGPT', 'Copilot']);
 	});
 
 	test('Other Models respects the configured BYOK group name for agent-host models', () => {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -379,6 +379,24 @@ suite('LanguageModels', function () {
 		assert.strictEqual(fired, 2);
 	});
 
+	test('model visibility — bulk updates fire once', async function () {
+		await languageModels.selectLanguageModels({});
+
+		let fired = 0;
+		store.add(languageModels.onDidChangeModelVisibility(() => fired++));
+
+		languageModels.setModelsHidden(['test-id-1', 'test-id-12'], true);
+		assert.deepStrictEqual(languageModels.getHiddenModelIds(), ['test-id-1', 'test-id-12']);
+		assert.strictEqual(fired, 1);
+
+		languageModels.setModelsHidden(['test-id-1', 'test-id-12'], true);
+		assert.strictEqual(fired, 1);
+
+		languageModels.setModelsHidden(['test-id-1', 'test-id-12'], false);
+		assert.deepStrictEqual(languageModels.getHiddenModelIds(), []);
+		assert.strictEqual(fired, 2);
+	});
+
 	test('model visibility — hiding every model in a group hides the group', async function () {
 		await languageModels.selectLanguageModels({});
 

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.ts
@@ -131,6 +131,7 @@ export class NullLanguageModelsService implements ILanguageModelsService {
 	isModelHidden(_modelIdentifier: string): boolean { return false; }
 	isGroupHidden(_vendor: string, _groupName: string): boolean { return false; }
 	setModelHidden(_modelIdentifier: string, _hidden: boolean): void { }
+	setModelsHidden(_modelIdentifiers: readonly string[], _hidden: boolean): void { }
 	setGroupHidden(_vendor: string, _groupName: string, _hidden: boolean): void { }
 	getHiddenModelIds(): string[] { return []; }
 


### PR DESCRIPTION
## Summary

- add generic source metadata for agent-host language models
- resolve source labels, icons, and descriptions through an owner-scoped presentation registry
- mark only canonical OpenAI-provider Codex models authenticated through ChatGPT as subscription-backed
- keep custom providers, including providers named `chatgpt`, distinct from trusted subscription groups
- keep trusted subscription groups distinct from identically named custom model groups and toggle exact model identifiers

## Testing

- `npm run compile-client`
- `npm run hygiene`
- focused browser and node suites (`292 passing`, `11 pending`)
- ESLint on changed Codex files
- launch-skill verification with a fresh authenticated Code OSS profile
- manually verified Code OSS starts in the Agents window and the Codex picker continues loading Copilot models
