### PR TITLE
Add Integrated Browser as an HTML editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -420,7 +420,9 @@ export class BreadcrumbsControl {
 		this._breadcrumbsDisposables.clear();
 
 		// honor diff editors and such
-		const uri = EditorResourceAccessor.getCanonicalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		const canonicalUri = EditorResourceAccessor.getCanonicalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		const originalUri = EditorResourceAccessor.getOriginalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		const uri = originalUri ?? canonicalUri;
 		const wasHidden = this.isHidden();
 
 		if (!uri || !this._fileService.hasProvider(uri)) {
@@ -436,15 +438,12 @@ export class BreadcrumbsControl {
 			}
 		}
 
-		// display uri which can be derived from certain inputs
-		const fileInfoUri = EditorResourceAccessor.getOriginalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
-
 		this.show();
 		this._ckBreadcrumbsPossible.set(true);
 		this._updateEditorTypeControl();
 
 		const model = this._instantiationService.createInstance(BreadcrumbsModel,
-			fileInfoUri ?? uri,
+			uri,
 			this._editorGroup.activeEditorPane
 		);
 		this._model.value = model;

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -14,7 +14,7 @@ import { IModelService } from '../../editor/common/services/model.js';
 import { Schemas } from '../../base/common/network.js';
 import { EditorInput } from './editor/editorInput.js';
 import { IEditorResolverService } from '../services/editor/common/editorResolverService.js';
-import { DEFAULT_EDITOR_ASSOCIATION, isDiffEditorInput } from './editor.js';
+import { DEFAULT_EDITOR_ASSOCIATION, EditorResourceAccessor, isDiffEditorInput } from './editor.js';
 
 //#region < --- Workbench --- >
 
@@ -357,8 +357,9 @@ function getAvailableEditorIds(editor: EditorInput, editorResolverService: IEdit
 	}
 
 	// Normal editors.
-	if (editor.resource) {
-		return editorResolverService.getEditors(editor.resource).map(editor => editor.id);
+	const resource = EditorResourceAccessor.getOriginalUri(editor);
+	if (resource) {
+		return editorResolverService.getEditors(resource).map(editor => editor.id);
 	}
 
 	return [];

--- a/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../base/common/codicons.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { truncate } from '../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { BrowserViewUri } from '../../../../platform/browserView/common/browserViewUri.js';
 import { BrowserViewSharingState, INavigateOptions, IBrowserEditorViewState, IBrowserViewWorkbenchService } from './browserView.js';
-import { EditorInputCapabilities, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../common/editor.js';
+import { EditorInputCapabilities, GroupIdentifier, IEditorSerializer, IMoveResult, IUntypedEditorInput, Verbosity } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { TAB_ACTIVE_FOREGROUND } from '../../../common/theme.js';
@@ -43,6 +44,7 @@ const MAX_TITLE_LENGTH = 30;
  */
 export interface IBrowserEditorInputData extends IBrowserEditorViewState {
 	readonly id: string;
+	readonly associatedResource?: URI;
 }
 
 /**
@@ -79,6 +81,7 @@ export class BrowserEditorInput extends EditorInput {
 	static readonly DEFAULT_LABEL = localize('browser.editorLabel', "Browser");
 
 	private readonly _id: string;
+	private _associatedResource: URI | undefined;
 	private _initialData: IBrowserEditorInputData;
 
 	private _model: IBrowserViewModel | undefined;
@@ -101,6 +104,7 @@ export class BrowserEditorInput extends EditorInput {
 	) {
 		super();
 		this._id = options.id;
+		this._associatedResource = options.associatedResource;
 		this._initialData = options;
 	}
 
@@ -148,6 +152,17 @@ export class BrowserEditorInput extends EditorInput {
 
 	get id() {
 		return this._id;
+	}
+
+	setAssociatedResource(resource: URI): void {
+		if (this._associatedResource && !isEqual(this._associatedResource, resource)) {
+			throw new Error(`Browser editor ${this._id} is already associated with another resource.`);
+		}
+		if (this._associatedResource) {
+			return;
+		}
+		this._associatedResource = resource;
+		this._onDidChangeLabel.fire();
 	}
 
 	get url(): string | undefined {
@@ -217,6 +232,10 @@ export class BrowserEditorInput extends EditorInput {
 
 	override get resource(): URI {
 		return BrowserViewUri.forId(this._id);
+	}
+
+	get preferredResource(): URI {
+		return this._associatedResource ?? this.resource;
 	}
 
 	override getIcon(): ThemeIcon | URI | undefined {
@@ -295,6 +314,10 @@ export class BrowserEditorInput extends EditorInput {
 	}
 
 	override matches(otherInput: EditorInput | IUntypedEditorInput): boolean {
+		if (this._associatedResource && !(otherInput instanceof EditorInput) && hasKey(otherInput, { resource: true }) && isEqual(this._associatedResource, otherInput.resource)) {
+			return otherInput.options?.override === BrowserEditorInput.EDITOR_ID;
+		}
+
 		if (super.matches(otherInput)) {
 			return true;
 		}
@@ -327,7 +350,7 @@ export class BrowserEditorInput extends EditorInput {
 				url: this.url,
 				title: this.title,
 				favicon: this.favicon
-			});
+			}, this._associatedResource);
 		});
 	}
 
@@ -338,10 +361,30 @@ export class BrowserEditorInput extends EditorInput {
 			favicon: this.favicon
 		};
 		return {
-			resource: this.resource,
+			resource: this.preferredResource,
 			options: {
 				override: BrowserEditorInput.EDITOR_ID,
 				viewState
+			}
+		};
+	}
+
+	override async rename(_group: GroupIdentifier, target: URI): Promise<IMoveResult | undefined> {
+		if (!this._associatedResource) {
+			return undefined;
+		}
+
+		return {
+			editor: {
+				resource: target,
+				options: {
+					override: BrowserEditorInput.EDITOR_ID,
+					viewState: {
+						url: this.url === this._associatedResource.toString() ? target.toString() : this.url,
+						title: this.title,
+						favicon: this.favicon
+					}
+				}
 			}
 		};
 	}
@@ -372,6 +415,7 @@ export class BrowserEditorInput extends EditorInput {
 	serialize(): IBrowserEditorInputData {
 		return {
 			id: this._id,
+			associatedResource: this._associatedResource,
 			url: this.url,
 			title: this.title,
 			favicon: this.favicon
@@ -397,7 +441,11 @@ export class BrowserEditorSerializer implements IEditorSerializer {
 			const data: IBrowserEditorInputData = JSON.parse(serializedEditor);
 			return instantiationService.invokeFunction((accessor) => {
 				const browserViewWorkbenchService = accessor.get(IBrowserViewWorkbenchService);
-				return browserViewWorkbenchService.getOrCreateLazy(data.id, data);
+				return browserViewWorkbenchService.getOrCreateLazy(data.id, {
+					url: data.url,
+					title: data.title,
+					favicon: data.favicon
+				}, URI.revive(data.associatedResource));
 			});
 		} catch {
 			return undefined;

--- a/src/vs/workbench/contrib/browserView/common/browserView.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserView.ts
@@ -302,7 +302,7 @@ export interface IBrowserViewWorkbenchService {
 	 * Get an existing browser view for the given ID, or create a new one if it doesn't exist.
 	 * The underlying browser view is not created until the editor is opened or the model is resolved.
 	 */
-	getOrCreateLazy(id: string, initialState?: IBrowserEditorViewState): BrowserEditorInput;
+	getOrCreateLazy(id: string, initialState?: IBrowserEditorViewState, associatedResource?: URI): BrowserEditorInput;
 
 	/**
 	 * Clear all storage data for the global browser session

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -15,6 +15,7 @@ import { registerSingleton, InstantiationType } from '../../../../platform/insta
 import { IEditorResolverService, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { IBrowserViewCDPService, IBrowserViewWorkbenchService } from '../common/browserView.js';
 import { BrowserViewWorkbenchService } from './browserViewWorkbenchService.js';
 import { BrowserViewCDPService } from './browserViewCDPService.js';
@@ -37,6 +38,11 @@ import './features/browserEditorFindFeature.js';
 import './features/browserSearchFeatures.js';
 import './features/browserTabManagementFeatures.js';
 import './features/browserRemoteFeatures.js';
+
+function getBrowserViewStateUrl(viewState: object | undefined): string | undefined {
+	const url = Object.entries(viewState ?? {}).find(([key]) => key === 'url')?.[1];
+	return typeof url === 'string' ? url : undefined;
+}
 
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(
@@ -95,6 +101,39 @@ class BrowserEditorResolverContribution implements IWorkbenchContribution {
 				}
 			}
 		);
+
+		for (const extension of ['html', 'htm']) {
+			editorResolverService.registerEditor(
+				`${Schemas.file}:/**/*.${extension}`,
+				{
+					id: BrowserEditorInput.EDITOR_ID,
+					label: localize('browser.htmlEditorLabel', "Integrated Browser"),
+					priority: RegisteredEditorPriority.option
+				},
+				{
+					canSupportResource: resource => resource.scheme === Schemas.file,
+					singlePerResource: true
+				},
+				{
+					createEditorInput: ({ resource, options }) => {
+						const viewState = options?.viewState;
+						const browserInput = browserViewWorkbenchService.getOrCreateLazy(generateUuid(), {
+							...viewState,
+							url: getBrowserViewStateUrl(viewState) ?? resource.toString()
+						}, resource);
+						void browserInput.resolve();
+
+						return {
+							editor: browserInput,
+							options: {
+								pinned: true,
+								...options
+							}
+						};
+					}
+				}
+			);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -324,9 +324,9 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 		});
 	}
 
-	getOrCreateLazy(id: string, initialState?: IBrowserEditorViewState, model?: IBrowserViewModel): BrowserEditorInput {
+	getOrCreateLazy(id: string, initialState?: IBrowserEditorViewState, associatedResource?: URI, model?: IBrowserViewModel): BrowserEditorInput {
 		if (!this._known.has(id)) {
-			const input = this.instantiationService.createInstance(BrowserEditorInput, { id, ...initialState }, async () => {
+			const input = this.instantiationService.createInstance(BrowserEditorInput, { id, ...initialState, associatedResource }, async () => {
 				const state = await this._browserViewService.getOrCreateBrowserView(
 					id,
 					{
@@ -352,6 +352,8 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 			}
 			this._known.set(id, input);
 			this._onDidChangeBrowserViews.fire();
+		} else if (associatedResource) {
+			this._known.get(id)!.setAssociatedResource(associatedResource);
 		}
 
 		return this._known.get(id)!;
@@ -415,7 +417,7 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 		const model = this.instantiationService.createInstance(BrowserViewModel, id, owner, state, this._browserViewService);
 
 		// Sanity: both pass and assign the model to be sure. It will no-op if already set.
-		this.getOrCreateLazy(id, {}, model).model = model;
+		this.getOrCreateLazy(id, {}, undefined, model).model = model;
 
 		this._onDidChangeBrowserViews.fire();
 

--- a/src/vs/workbench/contrib/browserView/test/electron-browser/browserEditorInput.test.ts
+++ b/src/vs/workbench/contrib/browserView/test/electron-browser/browserEditorInput.test.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { hasKey } from '../../../../../base/common/types.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { BrowserViewUri } from '../../../../../platform/browserView/common/browserViewUri.js';
+import { IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ITunnelProxyInfo } from '../../../../../platform/tunnel/common/tunnelProxy.js';
+import { BrowserEditorInput, BrowserEditorSerializer, IBrowserEditorInputData } from '../../common/browserEditorInput.js';
+import { IBrowserEditorViewState, IBrowserViewContextualFilter, IBrowserViewFilterContext, IBrowserViewOpenHandler, IBrowserViewWorkbenchService } from '../../common/browserView.js';
+import { IUntypedEditorInput } from '../../../../common/editor.js';
+import { applyAvailableEditorIds } from '../../../../common/contextkeys.js';
+import { IEditorResolverService, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import type { PreferredGroup } from '../../../../services/editor/common/editorService.js';
+
+class TestBrowserViewWorkbenchService implements IBrowserViewWorkbenchService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly onDidChangeBrowserViews = Event.None;
+	readonly onDidChangeSharingAvailable = Event.None;
+	readonly isSharingAvailable = false;
+	readonly known = new Map<string, BrowserEditorInput>();
+	input: BrowserEditorInput | undefined;
+	lastCreate: { id: string; url: string | undefined; associatedResource: string | undefined } | undefined;
+
+	willUseRemoteProxy(): boolean {
+		return false;
+	}
+
+	setRemoteProxyInfo(_info: ITunnelProxyInfo | undefined): void { }
+
+	getKnownBrowserViews(): Map<string, BrowserEditorInput> {
+		return this.known;
+	}
+
+	registerContextualFilter(_filter: IBrowserViewContextualFilter): IDisposable {
+		return Disposable.None;
+	}
+
+	getContextualBrowserViews(_context?: IBrowserViewFilterContext): Map<string, BrowserEditorInput> {
+		return this.known;
+	}
+
+	async getPreferredGroup(preferredGroup?: PreferredGroup): Promise<PreferredGroup | undefined> {
+		return preferredGroup;
+	}
+
+	registerOpenHandler(_handler: IBrowserViewOpenHandler): IDisposable {
+		return Disposable.None;
+	}
+
+	getOrCreateLazy(id: string, initialState?: IBrowserEditorViewState, associatedResource?: URI): BrowserEditorInput {
+		this.lastCreate = {
+			id,
+			url: initialState?.url,
+			associatedResource: associatedResource?.toString()
+		};
+		if (!this.input) {
+			throw new Error('No browser editor input configured for test.');
+		}
+		return this.input;
+	}
+
+	async clearGlobalStorage(): Promise<void> { }
+
+	async clearWorkspaceStorage(): Promise<void> { }
+}
+
+function getResource(input: IUntypedEditorInput): URI | undefined {
+	return hasKey(input, { resource: true }) ? input.resource : undefined;
+}
+
+suite('BrowserEditorInput', () => {
+	const disposables = new DisposableStore();
+	let browserViewWorkbenchService: TestBrowserViewWorkbenchService;
+	let instantiationService: ReturnType<typeof workbenchInstantiationService>;
+
+	setup(() => {
+		browserViewWorkbenchService = new TestBrowserViewWorkbenchService();
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+		instantiationService.stub(IBrowserViewWorkbenchService, browserViewWorkbenchService);
+	});
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createInput(data: IBrowserEditorInputData): BrowserEditorInput {
+		const input = disposables.add(instantiationService.createInstance(BrowserEditorInput, data, async () => {
+			throw new Error('Unexpected model resolution in BrowserEditorInput test.');
+		}));
+		browserViewWorkbenchService.input = input;
+		return input;
+	}
+
+	test('uses the browser resource for regular inputs', () => {
+		const input = createInput({ id: 'regular-browser' });
+		const untyped = input.toUntyped();
+
+		assert.deepStrictEqual({
+			resourceScheme: input.resource.scheme,
+			untypedResource: getResource(untyped)?.toString(),
+			override: untyped.options?.override
+		}, {
+			resourceScheme: Schemas.vscodeBrowser,
+			untypedResource: input.resource.toString(),
+			override: BrowserEditorInput.EDITOR_ID
+		});
+	});
+
+	test('preserves an associated file resource through reopen and serialization', () => {
+		const associatedResource = URI.file('/workspace/index.html');
+		const input = createInput({
+			id: 'file-browser',
+			url: associatedResource.toString()
+		});
+		input.setAssociatedResource(associatedResource);
+		const untyped = input.toUntyped();
+		const serializer = new BrowserEditorSerializer();
+		const serialized = serializer.serialize(input);
+		assert.ok(serialized);
+		serializer.deserialize(instantiationService, serialized);
+
+		assert.deepStrictEqual({
+			resource: input.resource.toString(),
+			preferredResource: input.preferredResource.toString(),
+			untypedResource: getResource(untyped)?.toString(),
+			matchesBrowserInput: input.matches(untyped),
+			matchesTextInput: input.matches({ resource: associatedResource }),
+			restored: browserViewWorkbenchService.lastCreate
+		}, {
+			resource: BrowserViewUri.forId('file-browser').toString(),
+			preferredResource: associatedResource.toString(),
+			untypedResource: associatedResource.toString(),
+			matchesBrowserInput: true,
+			matchesTextInput: false,
+			restored: {
+				id: 'file-browser',
+				url: associatedResource.toString(),
+				associatedResource: associatedResource.toString()
+			}
+		});
+	});
+
+	test('uses the associated file resource to find available editor types', () => {
+		const associatedResource = URI.file('/workspace/index.html');
+		const input = createInput({
+			id: 'file-browser',
+			associatedResource
+		});
+		const editorResolverService = instantiationService.get(IEditorResolverService);
+		disposables.add(editorResolverService.registerEditor('*.html', {
+			id: 'test.browserEditor',
+			label: 'Test Browser Editor',
+			priority: RegisteredEditorPriority.default
+		}, {}, {}));
+		const contextKey = new RawContextKey<string>('browserEditorAvailableEditorIds', '').bindTo(instantiationService.get(IContextKeyService));
+
+		applyAvailableEditorIds(contextKey, input, editorResolverService);
+
+		assert.strictEqual(contextKey.get()?.split(',').includes('test.browserEditor'), true);
+	});
+
+	test('follows associated file renames', async () => {
+		const associatedResource = URI.file('/workspace/index.html');
+		const target = URI.file('/workspace/renamed.html');
+		const input = createInput({
+			id: 'file-browser',
+			associatedResource,
+			url: associatedResource.toString()
+		});
+
+		const result = await input.rename(1, target);
+
+		assert.deepStrictEqual(result, {
+			editor: {
+				resource: target,
+				options: {
+					override: BrowserEditorInput.EDITOR_ID,
+					viewState: {
+						url: target.toString(),
+						title: undefined,
+						favicon: undefined
+					}
+				}
+			}
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -33,12 +33,13 @@ import { AnythingQuickAccessProviderRunOptions } from '../../../../../platform/q
 import { IQuickInputService, IQuickPickItem, IQuickPickItemWithResource, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { resolveCommandsContext } from '../../../../browser/parts/editor/editorCommandsContext.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
-import { EditorResourceAccessor, isEditorCommandsContext, SideBySideEditor } from '../../../../common/editor.js';
+import { EditorResourceAccessor, isEditorCommandsContext, isEditorInput, SideBySideEditor } from '../../../../common/editor.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { BrowserEditorInput } from '../../../browserView/common/browserEditorInput.js';
 import { ExplorerFolderContext } from '../../../files/common/files.js';
 import { CTX_INLINE_CHAT_V2_ENABLED } from '../../../inlineChat/common/inlineChat.js';
-import { AnythingQuickAccessProvider } from '../../../search/browser/anythingQuickAccess.js';
+import { AnythingQuickAccessProvider, type IAnythingQuickPickItem } from '../../../search/browser/anythingQuickAccess.js';
 import { isSearchTreeFileMatch, isSearchTreeMatch } from '../../../search/browser/searchTreeModel/searchTreeCommon.js';
 import { ISymbolQuickPickItem, SymbolsQuickAccessProvider } from '../../../search/browser/symbolsQuickAccess.js';
 import { SearchContext } from '../../../search/common/constants.js';
@@ -440,7 +441,7 @@ interface IContextPickItemItem extends IQuickPickItem {
 }
 
 /** These are the types we get from "platform QP" */
-type IQuickPickServicePickItem = IGotoSymbolQuickPickItem | ISymbolQuickPickItem | IQuickPickItemWithResource;
+type IQuickPickServicePickItem = IGotoSymbolQuickPickItem | ISymbolQuickPickItem | IAnythingQuickPickItem;
 
 function isIContextPickItemItem(obj: unknown): obj is IContextPickItemItem {
 	return (
@@ -462,6 +463,11 @@ function isIQuickPickItemWithResource(obj: unknown): obj is IQuickPickItemWithRe
 	return (
 		isObject(obj)
 		&& URI.isUri((obj as IQuickPickItemWithResource).resource));
+}
+
+function isAnythingQuickPickItemWithBrowserEditor(obj: unknown): obj is IAnythingQuickPickItem & { readonly editor: NonNullable<IAnythingQuickPickItem['editor']> } {
+	const editor = (obj as IAnythingQuickPickItem | undefined)?.editor;
+	return editor instanceof BrowserEditorInput || (!!editor && !isEditorInput(editor) && editor.options?.override === BrowserEditorInput.EDITOR_ID);
 }
 
 
@@ -614,7 +620,12 @@ export class AttachContextAction extends Action2 {
 
 		const toAttach: IChatRequestVariableEntry[] = [];
 
-		if (isIQuickPickItemWithResource(pick) && pick.resource) {
+		if (isAnythingQuickPickItemWithBrowserEditor(pick)) {
+			const entry = await chatAttachmentResolveService.resolveEditorAttachContext(pick.editor);
+			if (entry) {
+				toAttach.push(entry);
+			}
+		} else if (isIQuickPickItemWithResource(pick) && pick.resource) {
 			if (/\.(png|jpg|jpeg|bmp|gif|tiff)$/i.test(pick.resource.path)) {
 				// checks if the file is an image
 				if (URI.isUri(pick.resource)) {

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService.ts
@@ -30,6 +30,7 @@ import { IBrowserViewVariableEntry, IChatRequestVariableEntry, OmittedState, IDi
 import { imageToHash } from '../widget/input/editor/chatPasteProviders.js';
 import { resizeImage } from '../chatImageUtils.js';
 import { BrowserViewUri } from '../../../../../platform/browserView/common/browserViewUri.js';
+import { BrowserEditorInput } from '../../../browserView/common/browserEditorInput.js';
 import { BrowserViewSharingState, IBrowserViewWorkbenchService } from '../../../browserView/common/browserView.js';
 
 export const IChatAttachmentResolveService = createDecorator<IChatAttachmentResolveService>('IChatAttachmentResolveService');
@@ -65,6 +66,14 @@ export class ChatAttachmentResolveService implements IChatAttachmentResolveServi
 	// --- EDITORS ---
 
 	public async resolveEditorAttachContext(editor: EditorInput | IDraggedResourceEditorInput): Promise<IChatRequestVariableEntry | undefined> {
+		if (!(editor instanceof EditorInput) && editor.options?.override === BrowserEditorInput.EDITOR_ID) {
+			const browserEditor = [...this.browserViewService.getKnownBrowserViews().values()].find(candidate => candidate.matches(editor));
+			if (!browserEditor) {
+				return undefined;
+			}
+			editor = browserEditor;
+		}
+
 		// untitled editor
 		if (isUntitledResourceEditorInput(editor)) {
 			return await this.resolveUntitledEditorAttachContext(editor);

--- a/src/vs/workbench/contrib/chat/test/browser/chatAttachmentResolveService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatAttachmentResolveService.test.ts
@@ -15,6 +15,10 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { BrowserViewSharingState, IBrowserViewWorkbenchService, IBrowserViewModel } from '../../../browserView/common/browserView.js';
 import { BrowserEditorInput } from '../../../browserView/common/browserEditorInput.js';
 import { BrowserViewUri } from '../../../../../platform/browserView/common/browserViewUri.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
 import { ChatAttachmentResolveService } from '../../browser/attachments/chatAttachmentResolveService.js';
 import { createFileStat } from '../../../../test/common/workbenchTestServices.js';
 import { IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
@@ -36,14 +40,22 @@ suite('ChatAttachmentResolveService', () => {
 	 * by the mocked resolveImageEditorAttachContext.
 	 */
 	let imageFileUris: Set<string>;
+	let knownBrowserViews: Map<string, BrowserEditorInput>;
+	let fileStatCalls: number;
 
 	setup(() => {
 		instantiationService = testDisposables.add(new TestInstantiationService());
 		directoryTree = new Map();
 		imageFileUris = new Set();
+		knownBrowserViews = new Map();
+		fileStatCalls = 0;
 
 		// Stub IFileService with resolve() that uses the directoryTree map
 		instantiationService.stub(IFileService, {
+			stat: async (resource: URI): Promise<IFileStatWithMetadata> => {
+				fileStatCalls++;
+				return createFileStat(resource, false, true, false);
+			},
 			resolve: async (resource: URI): Promise<IFileStatWithMetadata> => {
 				const children = directoryTree.get(resource.toString());
 				if (children !== undefined) {
@@ -58,7 +70,9 @@ suite('ChatAttachmentResolveService', () => {
 		instantiationService.stub(ITextModelService, {});
 		instantiationService.stub(IExtensionService, {});
 		instantiationService.stub(IDialogService, {});
-		instantiationService.stub(IBrowserViewWorkbenchService, { getKnownBrowserViews: () => new Map() });
+		instantiationService.stub(IBrowserViewWorkbenchService, { getKnownBrowserViews: () => knownBrowserViews });
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IThemeService, new TestThemeService());
 
 		service = instantiationService.createInstance(ChatAttachmentResolveService);
 
@@ -75,6 +89,51 @@ suite('ChatAttachmentResolveService', () => {
 			}
 			return undefined;
 		};
+	});
+
+	test('resolves associated browser editor inputs through the live browser', async () => {
+		const browserId = 'browser-id';
+		const associatedResource = URI.file('/workspace/index.html');
+		const browserEditor = testDisposables.add(instantiationService.createInstance(BrowserEditorInput, {
+			id: browserId,
+			associatedResource
+		}, async () => {
+			throw new Error('Unexpected browser editor resolution.');
+		}));
+		knownBrowserViews.set(browserId, browserEditor);
+		let resolvedBrowserId: string | undefined;
+		service.resolveBrowserViewAttachContext = async id => {
+			resolvedBrowserId = id;
+			return undefined;
+		};
+
+		await service.resolveEditorAttachContext({
+			resource: associatedResource,
+			options: { override: BrowserEditorInput.EDITOR_ID }
+		});
+
+		assert.deepStrictEqual({
+			resolvedBrowserId,
+			fileStatCalls
+		}, {
+			resolvedBrowserId: browserId,
+			fileStatCalls: 0
+		});
+	});
+
+	test('does not treat an unknown transferred browser editor as a file', async () => {
+		const result = await service.resolveEditorAttachContext({
+			resource: URI.file('/workspace/index.html'),
+			options: { override: BrowserEditorInput.EDITOR_ID }
+		});
+
+		assert.deepStrictEqual({
+			result,
+			fileStatCalls
+		}, {
+			result: undefined,
+			fileStatCalls: 0
+		});
 	});
 
 	test('returns empty array for empty directory', async () => {

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -59,7 +59,9 @@ import { IChatWidgetService, IQuickChatService } from '../../chat/browser/chat.j
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ICustomEditorLabelService } from '../../../services/editor/common/customEditorLabelService.js';
 
-interface IAnythingQuickPickItem extends IPickerQuickAccessItem, IQuickPickItemWithResource { }
+export interface IAnythingQuickPickItem extends IPickerQuickAccessItem, IQuickPickItemWithResource {
+	readonly editor?: EditorInput | IResourceEditorInput;
+}
 
 interface IEditorSymbolAnythingQuickPickItem extends IAnythingQuickPickItem {
 	resource: URI;
@@ -1060,6 +1062,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		return {
 			resource,
+			editor: !URI.isUri(resourceOrEditor) ? resourceOrEditor : undefined,
 			label,
 			ariaLabel: isDirty ? localize('filePickAriaLabelDirty', "{0} unsaved changes", labelAndDescription) : labelAndDescription,
 			description,

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -8,7 +8,7 @@ import { PauseableEmitter } from '../../../../base/common/event.js';
 import * as glob from '../../../../base/common/glob.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { basename, extname, isEqual } from '../../../../base/common/resources.js';
+import { basename, extname } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -19,6 +19,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IKeyMods, IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { DEFAULT_EDITOR_ASSOCIATION, EditorInputWithOptions, EditorResourceAccessor, IResourceSideBySideEditorInput, isEditorInputWithOptions, isEditorInputWithOptionsAndGroup, isResourceDiffEditorInput, isResourceMergeEditorInput, isResourceMultiDiffEditorInput, isResourceSideBySideEditorInput, isUntitledResourceEditorInput, IUntypedEditorInput, SideBySideEditor } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { SideBySideEditorInput } from '../../../common/editor/sideBySideEditorInput.js';
@@ -79,7 +80,8 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		@INotificationService private readonly notificationService: INotificationService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IExtensionService private readonly extensionService: IExtensionService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
 	) {
 		super();
 		// Read in the cache on statup
@@ -712,7 +714,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 		for (const group of orderedGroups) {
 			for (const editor of group.editors) {
-				if (isEqual(editor.resource, resource) && editor.editorId === editorId) {
+				if ((this.uriIdentityService.extUri.isEqual(editor.resource, resource) || this.uriIdentityService.extUri.isEqual(EditorResourceAccessor.getOriginalUri(editor), resource)) && editor.editorId === editorId) {
 					out.push({ editor, group });
 				}
 			}

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -257,7 +257,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 			const replacements: (IUntypedEditorReplacement | IEditorReplacement)[] = [];
 
 			for (const editor of group.editors) {
-				const resource = editor.resource;
+				const resource = EditorResourceAccessor.getOriginalUri(editor) ?? editor.resource;
 				if (!resource || !this.uriIdentityService.extUri.isEqualOrParent(resource, source)) {
 					continue; // not matching our resource
 				}
@@ -334,7 +334,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	private handleDeletedFile(arg1: URI | FileChangesEvent, isExternal: boolean, movedTo?: URI): void {
 		for (const editor of this.getAllNonDirtyEditors({ includeUntitled: false, supportSideBySide: true })) {
 			(async () => {
-				const resource = editor.resource;
+				const resource = EditorResourceAccessor.getOriginalUri(editor) ?? editor.resource;
 				if (!resource) {
 					return;
 				}

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -87,6 +87,43 @@ suite('EditorResolverService', () => {
 		registeredEditor.dispose();
 	});
 
+	test('singlePerResource finds editors by preferred resource', async () => {
+		const [part, service] = await createEditorResolverService();
+		const resource = URI.file('/workspace/index.test');
+		const editorId = 'TEST_EDITOR';
+		const existingEditor = constructDisposableFileEditorInput(URI.from({ scheme: Schemas.vscodeBrowser, path: 'browser-id' }), editorId, disposables);
+		Object.defineProperty(existingEditor, 'preferredResource', { value: resource });
+		await part.activeGroup.openEditor(existingEditor);
+		let createCount = 0;
+		disposables.add(service.registerEditor('*.test',
+			{
+				id: editorId,
+				label: 'Test Editor Label',
+				priority: RegisteredEditorPriority.default
+			},
+			{
+				singlePerResource: true
+			},
+			{
+				createEditorInput: () => {
+					createCount++;
+					return { editor: constructDisposableFileEditorInput(resource, editorId, disposables) };
+				},
+			}
+		));
+
+		const result = await service.resolveEditor({ resource, options: { override: editorId } }, part.activeGroup);
+
+		assert.ok(result && result !== ResolvedStatus.ABORT && result !== ResolvedStatus.NONE);
+		assert.deepStrictEqual({
+			reusedExistingEditor: result.editor === existingEditor,
+			createCount
+		}, {
+			reusedExistingEditor: true,
+			createCount: 0
+		});
+	});
+
 	test('Untitled Resolve', async () => {
 		const UNTITLED_TEST_EDITOR_INPUT_ID = 'UNTITLED_TEST_INPUT';
 		const [part, service] = await createEditorResolverService();

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -2267,6 +2267,20 @@ suite('EditorService', () => {
 		return testFileDeleteEditorClose(true);
 	});
 
+	test('file delete closes editor by preferred resource', async function () {
+		const [part, service, accessor] = await createEditorService();
+		const resource = URI.parse('my://resource');
+		const input = createTestFileEditorInput(URI.parse('test-browser://editor'), TEST_EDITOR_INPUT_ID);
+		Object.defineProperty(input, 'preferredResource', { value: resource });
+		await service.openEditor(input, { pinned: true });
+
+		const activeEditorChangePromise = awaitActiveEditorChange(service);
+		accessor.fileService.fireAfterOperation(new FileOperationEvent(resource, FileOperation.DELETE));
+		await activeEditorChangePromise;
+
+		assert.strictEqual(part.activeGroup.activeEditor, null);
+	});
+
 	async function testFileDeleteEditorClose(dirty: boolean): Promise<void> {
 		const [part, service, accessor] = await createEditorService();
 
@@ -2325,6 +2339,37 @@ suite('EditorService', () => {
 		await activeEditorChangePromise;
 
 		assert.strictEqual(rootGroup.activeEditor, movedInput);
+	});
+
+	test('file move asks input to move by preferred resource', async function () {
+		const [part, service, accessor] = await createEditorService();
+		const resource = URI.parse('my://resource1');
+		const target = URI.parse('my://resource2');
+		const input = createTestFileEditorInput(URI.parse('test-browser://editor'), TEST_EDITOR_INPUT_ID);
+		Object.defineProperty(input, 'preferredResource', { value: resource });
+		const movedInput = createTestFileEditorInput(target, TEST_EDITOR_INPUT_ID);
+		input.movedEditor = { editor: movedInput };
+		await service.openEditor(input, { pinned: true });
+
+		const activeEditorChangePromise = awaitActiveEditorChange(service);
+		accessor.fileService.fireAfterOperation(new FileOperationEvent(resource, FileOperation.MOVE, {
+			resource: target,
+			ctime: 0,
+			etag: '',
+			isDirectory: false,
+			isFile: true,
+			mtime: 0,
+			name: 'resource2',
+			size: 0,
+			isSymbolicLink: false,
+			readonly: false,
+			locked: false,
+			executable: false,
+			children: undefined
+		}));
+		await activeEditorChangePromise;
+
+		assert.strictEqual(part.activeGroup.activeEditor, movedInput);
 	});
 
 	function awaitActiveEditorChange(editorService: IEditorService): Promise<void> {


### PR DESCRIPTION
## Summary
- add the Integrated Browser as an optional editor for local HTML files
- preserve the associated HTML resource across editor switching, restoration, breadcrumbs, editor-type discovery, and file moves while retaining browser-tab identity
- reuse existing file-backed browser tabs and close them when the associated file is deleted
- keep chat picker and tab-drop attachments on the live browser sharing and accessibility-snapshot path, without silently falling back to file attachments

## Testing
- focused browser input, editor resolver, editor service, and chat attachment unit tests (86 passed)
- client typecheck, targeted ESLint, and client transpilation
- pre-commit hygiene