### PR TITLE
sessions: update turn changes editor title

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -318,7 +318,10 @@ below.
 For agent-host sessions, the floating turn-status pills above the chat input read
 the viewed chat's `lastTurnChanges` while the turn streams. They remain visible
 when the chat transitions from `InProgress` to `NeedsInput`, since tool or input
-confirmation does not end the active turn. Each `lastTurnChanges` entry carries
+confirmation does not end the active turn. Opening the changes pill labels its
+multi-diff editor **Current Turn Changes** while the turn is active, including
+`NeedsInput`, and updates the open editor to **Last Turn Changes** as soon as the
+turn completes. Each `lastTurnChanges` entry carries
 `isOutsideWorkspace`, derived from the owning session's workspace folder,
 working directory, and worktree roots. `AgentHostSessionAdapter` caches that
 classification in its generic session-output cache under

--- a/src/vs/sessions/contrib/chat/browser/lastTurnChangesMultiDiffSourceResolver.ts
+++ b/src/vs/sessions/contrib/chat/browser/lastTurnChangesMultiDiffSourceResolver.ts
@@ -4,19 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { constObservable, derivedObservableWithCache, ValueWithChangeEventFromObservable } from '../../../../base/common/observable.js';
+import { constObservable, derived, derivedObservableWithCache, ValueWithChangeEventFromObservable } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService, IResolvedMultiDiffSource, MultiDiffEditorItem } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISessionTurnFileChange } from '../../../services/sessions/common/session.js';
+import { isActiveSessionStatus, ISessionTurnFileChange } from '../../../services/sessions/common/session.js';
 
 const LAST_TURN_CHANGES_MULTI_DIFF_SOURCE_SCHEME = 'chat-last-turn-changes-multi-diff-source';
 
 interface ILastTurnChangesMultiDiffUriFields {
 	readonly chatResource: string;
+}
+
+/** Return the title for a turn-scoped changes editor. */
+export function getTurnChangesEditorLabel(isTurnActive: boolean): string {
+	return isTurnActive
+		? localize('sessions.currentTurnChanges.title', "Current Turn Changes")
+		: localize('sessions.lastTurnChanges.title', "Last Turn Changes");
 }
 
 /**
@@ -96,6 +104,9 @@ export class LastTurnChangesMultiDiffSourceResolver extends Disposable implement
 		// once here rather than re-finding it on every observable read.
 		const chat = this._sessionsManagementService.getSessionForChatResource(chatResource)?.chat;
 		const lastTurnChanges = chat?.lastTurnChanges ?? constObservable<readonly ISessionTurnFileChange[]>([]);
+		const label = chat
+			? derived(this, reader => getTurnChangesEditorLabel(isActiveSessionStatus(chat.status.read(reader))))
+			: constObservable(getTurnChangesEditorLabel(false));
 
 		// Reuse the row for a file we've already seen (keeping its first origin) and
 		// keep the previous array reference when no new file appears, so the diff
@@ -146,7 +157,10 @@ export class LastTurnChangesMultiDiffSourceResolver extends Disposable implement
 			return items;
 		});
 
-		return { resources: new ValueWithChangeEventFromObservable(resourcesObs) };
+		return {
+			resources: new ValueWithChangeEventFromObservable(resourcesObs),
+			label: new ValueWithChangeEventFromObservable(label),
+		};
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -11,7 +11,6 @@ import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { localize } from '../../../../nls.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsEnabled, openChatTurnFile, previewFilesEqual, previewKind } from '../../../../workbench/contrib/chat/browser/widget/chatTurnPills.js';
@@ -19,7 +18,7 @@ import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IChat, isActiveSessionStatus } from '../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
-import { LastTurnChangesMultiDiffSourceResolver } from './lastTurnChangesMultiDiffSourceResolver.js';
+import { getTurnChangesEditorLabel, LastTurnChangesMultiDiffSourceResolver } from './lastTurnChangesMultiDiffSourceResolver.js';
 import { SessionBackgroundActivitiesControl } from './sessionBackgroundActivitiesControl.js';
 import { SessionBrowsersControl } from './sessionBrowsersControl.js';
 import type { ISessionChatPillsDebugData } from './sessionChatInputToolbarDebug.js';
@@ -222,14 +221,11 @@ export class SessionChatInputToolbar extends Disposable {
 		if (!chat) {
 			return;
 		}
-		// Open the multi-diff editor scoped to this chat's last turn. Its resource
-		// list is resolved reactively via the `LastTurnChangesMultiDiffSourceResolver`
-		// registered as a workbench contribution, so it live-updates as further
-		// edits stream in.
+		// The resolver live-updates the resources and title as the turn progresses.
 		const multiDiffSource = LastTurnChangesMultiDiffSourceResolver.getMultiDiffSourceUri(chat.resource);
 		await this._editorService.openEditor({
 			multiDiffSource,
-			label: localize('sessions.lastTurnChanges.title', "Last Turn Changes"),
+			label: getTurnChangesEditorLabel(isActiveSessionStatus(chat.status.get())),
 		});
 	}
 

--- a/src/vs/sessions/contrib/chat/test/browser/lastTurnChangesMultiDiffSourceResolver.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/lastTurnChangesMultiDiffSourceResolver.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService } from '../../../../../workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.js';
+import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { LastTurnChangesMultiDiffSourceResolver } from '../../browser/lastTurnChangesMultiDiffSourceResolver.js';
+
+suite('LastTurnChangesMultiDiffSourceResolver', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('updates the editor label when the turn completes', async () => {
+		const chatResource = URI.parse('chat:test');
+		const status = observableValue<SessionStatus>('status', SessionStatus.InProgress);
+		const chat = new class extends mock<IChat>() {
+			override readonly resource = chatResource;
+			override readonly status = status;
+		}();
+		const session = new class extends mock<ISession>() { }();
+		const sessionsManagementService = new class extends mock<ISessionsManagementService>() {
+			override getSessionForChatResource(resource: URI) {
+				return isEqual(resource, chatResource) ? { session, chat } : undefined;
+			}
+		}();
+		const multiDiffSourceResolverService = new class extends mock<IMultiDiffSourceResolverService>() {
+			override registerResolver(_resolver: IMultiDiffSourceResolver) {
+				return Disposable.None;
+			}
+		}();
+		const resolver = disposables.add(new LastTurnChangesMultiDiffSourceResolver(sessionsManagementService, multiDiffSourceResolverService));
+		const source = await resolver.resolveDiffSource(LastTurnChangesMultiDiffSourceResolver.getMultiDiffSourceUri(chatResource));
+		const label = source.label;
+		assert.ok(label);
+
+		const labels = [label.value];
+		disposables.add(label.onDidChange(() => labels.push(label.value)));
+		status.set(SessionStatus.NeedsInput, undefined);
+		status.set(SessionStatus.Completed, undefined);
+
+		assert.deepStrictEqual(labels, [
+			'Current Turn Changes',
+			'Last Turn Changes',
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -108,6 +108,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 			return {
 				source,
 				resources: source ? observableFromValueWithChangeEvent(this, source.resources) : constObservable([]),
+				label: source?.label ? observableFromValueWithChangeEvent(this, source.label) : undefined,
 			};
 		});
 		this.resources = derived(this, reader => this._resolvedSource.cachedPromiseResult.read(reader)?.data?.resources.read(reader));
@@ -141,7 +142,8 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		this._register(autorun((reader) => {
 			/** @description Updates name */
 			const resources = this.resources.read(reader);
-			const label = this.label ?? localize('name', "Multi Diff Editor");
+			const resolvedSource = this._resolvedSource.cachedPromiseResult.read(reader)?.data;
+			const label = resolvedSource?.label?.read(reader) ?? this.label ?? localize('name', "Multi Diff Editor");
 			if (resources && resources.length === 1) {
 				this._name = localize({ key: 'nameWithOneFile', comment: ['{0} is the name of the editor'] }, "{0} (1 file)", label);
 			} else if (resources) {

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.ts
@@ -28,6 +28,7 @@ export interface IMultiDiffSourceResolver {
 
 export interface IResolvedMultiDiffSource {
 	readonly resources: IValueWithChangeEvent<readonly MultiDiffEditorItem[]>;
+	readonly label?: IValueWithChangeEvent<string>;
 	readonly contextKeys?: Record<string, ContextKeyValue>;
 }
 

--- a/src/vs/workbench/contrib/multiDiffEditor/test/browser/multiDiffEditorInput.test.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/test/browser/multiDiffEditorInput.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event, ValueWithChangeEvent } from '../../../../../base/common/event.js';
+import { observableValue, ValueWithChangeEventFromObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { ITextResourceConfigurationService } from '../../../../../editor/common/services/textResourceConfiguration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ITextFileEditorModelManager, ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { MultiDiffEditorInput } from '../../browser/multiDiffEditorInput.js';
+import { IMultiDiffSourceResolverService } from '../../browser/multiDiffSourceResolverService.js';
+
+suite('MultiDiffEditorInput', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('updates its name from the resolved source label', async () => {
+		const sourceLabel = observableValue('sourceLabel', 'Current Turn Changes');
+		const sourceResolverService = new class extends mock<IMultiDiffSourceResolverService>() {
+			override resolve() {
+				return Promise.resolve({
+					resources: ValueWithChangeEvent.const([]),
+					label: new ValueWithChangeEventFromObservable(sourceLabel),
+				});
+			}
+		}();
+		const textFileService = new class extends mock<ITextFileService>() {
+			override readonly files = new class extends mock<ITextFileEditorModelManager>() {
+				override readonly onDidChangeDirty = Event.None;
+			}();
+		}();
+		const input = disposables.add(new MultiDiffEditorInput(
+			URI.parse('multi-diff-editor:test'),
+			'Fallback',
+			undefined,
+			false,
+			new class extends mock<ITextModelService>() { }(),
+			new class extends mock<ITextResourceConfigurationService>() { }(),
+			new class extends mock<IInstantiationService>() { }(),
+			sourceResolverService,
+			textFileService,
+		));
+		await input.getViewModel();
+
+		const names = [input.getName()];
+		disposables.add(input.onDidChangeLabel(() => names.push(input.getName())));
+		sourceLabel.set('Last Turn Changes', undefined);
+
+		assert.deepStrictEqual(names, [
+			'Current Turn Changes (0 files)',
+			'Last Turn Changes (0 files)',
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- open active turn diffs as Current Turn Changes
- relabel the open multi-diff to Last Turn Changes when the turn completes
- add focused resolver and multi-diff input coverage

## Testing
- Not run (per requested workflow).