### PR TITLE
Add GitHub context to Agent Host session titles

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -20,7 +20,8 @@ const MAX_TITLE_LENGTH = 200;
 const MAX_TITLE_TOKENS = 32;
 const GITHUB_CONTEXT_REQUEST_TIMEOUT = 5_000;
 const MAX_CONCURRENT_GITHUB_CONTEXT_REQUESTS = 5;
-const MAX_GITHUB_CONTEXT_BODY_CHARS = 2_000;
+const MAX_GITHUB_CONTEXT_BODY_CHARS = 4_000;
+const MAX_GITHUB_CONTEXT_REFERENCES = 10;
 const MAX_TRAILING_HAN_SUFFIX_CODE_UNITS = 6;
 const MIN_LATIN_LETTERS_BEFORE_HAN_SUFFIX = 4;
 const MIN_LATIN_LETTER_RATIO = 0.8;
@@ -34,7 +35,6 @@ const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?<host>[\w.-]+)\
  * small model's context window while leaving room for the prompt scaffolding.
  */
 const MAX_TITLE_CONTEXT_CHARS = 20000;
-const MAX_GITHUB_CONTEXT_REFERENCES = Math.floor(MAX_TITLE_CONTEXT_CHARS / MAX_GITHUB_CONTEXT_BODY_CHARS);
 
 type GitHubReferenceKind = 'issue' | 'pull request';
 

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -26,7 +26,7 @@ const MIN_LATIN_LETTERS_BEFORE_HAN_SUFFIX = 4;
 const MIN_LATIN_LETTER_RATIO = 0.8;
 const HAN_CHARACTER = /\p{sc=Han}/u;
 const TRAILING_HAN_SUFFIX = /(?<!\p{sc=Han})\p{sc=Han}{2,3}$/u;
-const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?github\.com\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/(?<kind>issues|pull)\/(?<number>\d+)\b/gi;
+const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?<host>[\w.-]+)\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/(?<kind>issues|pull)\/(?<number>\d+)\b/gi;
 
 /**
  * Soft upper bound, in characters, for the first-turn context fed to the
@@ -34,6 +34,7 @@ const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?github\
  * small model's context window while leaving room for the prompt scaffolding.
  */
 const MAX_TITLE_CONTEXT_CHARS = 20000;
+const MAX_GITHUB_CONTEXT_REFERENCES = Math.floor(MAX_TITLE_CONTEXT_CHARS / MAX_GITHUB_CONTEXT_BODY_CHARS);
 
 type GitHubReferenceKind = 'issue' | 'pull request';
 
@@ -53,6 +54,7 @@ export interface IAgentHostSessionTitleControllerOptions {
 	readonly sessionDataService: ISessionDataService;
 	readonly getGitHubCopilotToken?: () => string | undefined;
 	readonly getGitHubToken?: () => string | undefined;
+	readonly getGitHubHost?: () => string | undefined;
 	readonly gitHubContextRequestTimeout?: number;
 	readonly octoKitService?: IAgentHostOctoKitService;
 	readonly copilotApiService?: ICopilotApiService;
@@ -459,12 +461,14 @@ export class AgentHostSessionTitleController extends Disposable {
 	private _parseGitHubReferences(text: string): IGitHubReference[] {
 		const references: IGitHubReference[] = [];
 		const seen = new Set<string>();
+		const configuredHost = this._normalizeGitHubHost(this._options.getGitHubHost?.() ?? 'github.com');
 		for (const match of text.matchAll(GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN)) {
+			const host = match.groups?.host;
 			const owner = match.groups?.owner;
 			const repo = match.groups?.repo;
 			const rawKind = match.groups?.kind;
 			const number = Number(match.groups?.number);
-			if (!owner || !repo || (rawKind !== 'issues' && rawKind !== 'pull') || !Number.isSafeInteger(number) || number <= 0) {
+			if (!host || this._normalizeGitHubHost(host) !== configuredHost || !owner || !repo || (rawKind !== 'issues' && rawKind !== 'pull') || !Number.isSafeInteger(number) || number <= 0) {
 				continue;
 			}
 			const kind: GitHubReferenceKind = rawKind === 'issues' ? 'issue' : 'pull request';
@@ -474,8 +478,16 @@ export class AgentHostSessionTitleController extends Disposable {
 			}
 			seen.add(key);
 			references.push({ owner, repo, number, kind });
+			if (references.length === MAX_GITHUB_CONTEXT_REFERENCES) {
+				break;
+			}
 		}
 		return references;
+	}
+
+	private _normalizeGitHubHost(host: string): string {
+		const normalizedHost = host.toLowerCase();
+		return normalizedHost === 'www.github.com' ? 'github.com' : normalizedHost;
 	}
 
 	private _formatGitHubContexts(contexts: readonly IGitHubReferenceContext[]): string {
@@ -493,7 +505,7 @@ export class AgentHostSessionTitleController extends Disposable {
 			remainingBodyBudget -= body.length;
 			return this._formatGitHubContext(context.reference, context.value, body);
 		});
-		return `${heading}${sections.join('\n\n')}`;
+		return truncateMiddle(`${heading}${sections.join('\n\n')}`, MAX_TITLE_CONTEXT_CHARS);
 	}
 
 	private _formatGitHubContext(reference: IGitHubReference, value: GitHubIssueOrPullRequest, body: string): string {

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -13,7 +13,7 @@ import { ActionType } from '../common/state/sessionActions.js';
 import { isAhpChatChannel, isDefaultChatUri, type Turn, type URI as ProtocolURI } from '../common/state/sessionState.js';
 import { buildConversationContext, renderResponseMarkdown, truncateMiddle } from '../common/agentHostConversationContext.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
-import { IAgentHostOctoKitService, type GitHubIssueOrPullRequest } from './shared/agentHostOctoKitService.js';
+import type { GitHubIssueOrPullRequest, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
 
 const MAX_TITLE_LENGTH = 200;
@@ -53,6 +53,7 @@ export interface IAgentHostSessionTitleControllerOptions {
 	readonly getGitHubCopilotToken?: () => string | undefined;
 	readonly getGitHubToken?: () => string | undefined;
 	readonly gitHubContextRequestTimeout?: number;
+	readonly octoKitService?: IAgentHostOctoKitService;
 	readonly copilotApiService?: ICopilotApiService;
 }
 
@@ -81,7 +82,6 @@ export class AgentHostSessionTitleController extends Disposable {
 		private readonly _stateManager: AgentHostStateManager,
 		private readonly _options: IAgentHostSessionTitleControllerOptions,
 		@ILogService private readonly _logService: ILogService,
-		@IAgentHostOctoKitService private readonly _octoKitService: IAgentHostOctoKitService,
 	) {
 		super();
 	}
@@ -420,7 +420,8 @@ export class AgentHostSessionTitleController extends Disposable {
 	private async _appendGitHubContext(promptContent: string, cancellationSignal: AbortSignal, token: CancellationToken): Promise<string> {
 		const references = this._parseGitHubReferences(promptContent);
 		const githubToken = this._options.getGitHubToken?.();
-		if (references.length === 0 || !githubToken) {
+		const octoKitService = this._options.octoKitService;
+		if (references.length === 0 || !githubToken || !octoKitService) {
 			return promptContent;
 		}
 
@@ -429,7 +430,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		try {
 			const contexts = await Promise.all(references.map(reference => limiter.queue(async () => {
 				try {
-					const value = await this._octoKitService.getIssueOrPullRequest(
+					const value = await octoKitService.getIssueOrPullRequest(
 						reference.owner,
 						reference.repo,
 						reference.number,

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Limiter } from '../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
@@ -12,15 +13,19 @@ import { ActionType } from '../common/state/sessionActions.js';
 import { isAhpChatChannel, isDefaultChatUri, type Turn, type URI as ProtocolURI } from '../common/state/sessionState.js';
 import { buildConversationContext, renderResponseMarkdown, truncateMiddle } from '../common/agentHostConversationContext.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
+import { IAgentHostOctoKitService, type GitHubIssueOrPullRequest } from './shared/agentHostOctoKitService.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_TITLE_TOKENS = 32;
+const GITHUB_CONTEXT_REQUEST_TIMEOUT = 5_000;
+const MAX_CONCURRENT_GITHUB_CONTEXT_REQUESTS = 5;
 const MAX_TRAILING_HAN_SUFFIX_CODE_UNITS = 6;
 const MIN_LATIN_LETTERS_BEFORE_HAN_SUFFIX = 4;
 const MIN_LATIN_LETTER_RATIO = 0.8;
 const HAN_CHARACTER = /\p{sc=Han}/u;
 const TRAILING_HAN_SUFFIX = /(?<!\p{sc=Han})\p{sc=Han}{2,3}$/u;
+const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?github\.com\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/(?<kind>issues|pull)\/(?<number>\d+)\b/gi;
 
 /**
  * Soft upper bound, in characters, for the first-turn context fed to the
@@ -29,9 +34,25 @@ const TRAILING_HAN_SUFFIX = /(?<!\p{sc=Han})\p{sc=Han}{2,3}$/u;
  */
 const MAX_TITLE_CONTEXT_CHARS = 20000;
 
+type GitHubReferenceKind = 'issue' | 'pull request';
+
+interface IGitHubReference {
+	readonly owner: string;
+	readonly repo: string;
+	readonly number: number;
+	readonly kind: GitHubReferenceKind;
+}
+
+interface IGitHubReferenceContext {
+	readonly reference: IGitHubReference;
+	readonly value: GitHubIssueOrPullRequest;
+}
+
 export interface IAgentHostSessionTitleControllerOptions {
 	readonly sessionDataService: ISessionDataService;
 	readonly getGitHubCopilotToken?: () => string | undefined;
+	readonly getGitHubToken?: () => string | undefined;
+	readonly gitHubContextRequestTimeout?: number;
 	readonly copilotApiService?: ICopilotApiService;
 }
 
@@ -60,6 +81,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		private readonly _stateManager: AgentHostStateManager,
 		private readonly _options: IAgentHostSessionTitleControllerOptions,
 		@ILogService private readonly _logService: ILogService,
+		@IAgentHostOctoKitService private readonly _octoKitService: IAgentHostOctoKitService,
 	) {
 		super();
 	}
@@ -371,13 +393,19 @@ export class AgentHostSessionTitleController extends Disposable {
 		const abortController = new AbortController();
 		const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 		try {
+			const titlePromptContent = isConversation
+				? promptContent
+				: await this._appendGitHubContext(promptContent, abortController.signal, token);
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
 			const rawTitle = await copilotApiService.utilityChatCompletion(githubToken, {
-				messages: this._buildTitlePrompt(promptContent, isConversation),
+				messages: this._buildTitlePrompt(titlePromptContent, isConversation),
 				maxTokens: MAX_TITLE_TOKENS,
 			}, {
 				signal: abortController.signal,
 			});
-			return this._cleanTitle(rawTitle, promptContent);
+			return this._cleanTitle(rawTitle, titlePromptContent);
 		} catch (err) {
 			if (token.isCancellationRequested) {
 				return undefined;
@@ -387,6 +415,89 @@ export class AgentHostSessionTitleController extends Disposable {
 		} finally {
 			cancellationListener.dispose();
 		}
+	}
+
+	private async _appendGitHubContext(promptContent: string, cancellationSignal: AbortSignal, token: CancellationToken): Promise<string> {
+		const references = this._parseGitHubReferences(promptContent);
+		const githubToken = this._options.getGitHubToken?.();
+		if (references.length === 0 || !githubToken) {
+			return promptContent;
+		}
+
+		const signal = AbortSignal.any([cancellationSignal, AbortSignal.timeout(this._options.gitHubContextRequestTimeout ?? GITHUB_CONTEXT_REQUEST_TIMEOUT)]);
+		const limiter = new Limiter<IGitHubReferenceContext | undefined>(MAX_CONCURRENT_GITHUB_CONTEXT_REQUESTS);
+		try {
+			const contexts = await Promise.all(references.map(reference => limiter.queue(async () => {
+				try {
+					const value = await this._octoKitService.getIssueOrPullRequest(
+						reference.owner,
+						reference.repo,
+						reference.number,
+						githubToken,
+						signal,
+					);
+					return { reference, value };
+				} catch (error) {
+					if (!token.isCancellationRequested) {
+						this._logService.warn(`[AgentHostSessionTitleController] Failed to fetch GitHub ${reference.kind} ${reference.owner}/${reference.repo}#${reference.number}`, error);
+					}
+					return undefined;
+				}
+			})));
+			const successfulContexts = contexts.filter(context => context !== undefined);
+			if (successfulContexts.length === 0) {
+				return promptContent;
+			}
+			return `${promptContent}\n\n${this._formatGitHubContexts(successfulContexts)}`;
+		} finally {
+			limiter.dispose();
+		}
+	}
+
+	private _parseGitHubReferences(text: string): IGitHubReference[] {
+		const references: IGitHubReference[] = [];
+		const seen = new Set<string>();
+		for (const match of text.matchAll(GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN)) {
+			const owner = match.groups?.owner;
+			const repo = match.groups?.repo;
+			const rawKind = match.groups?.kind;
+			const number = Number(match.groups?.number);
+			if (!owner || !repo || (rawKind !== 'issues' && rawKind !== 'pull') || !Number.isSafeInteger(number) || number <= 0) {
+				continue;
+			}
+			const kind: GitHubReferenceKind = rawKind === 'issues' ? 'issue' : 'pull request';
+			const key = `${owner.toLowerCase()}/${repo.toLowerCase()}/${kind}/${number}`;
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			references.push({ owner, repo, number, kind });
+		}
+		return references;
+	}
+
+	private _formatGitHubContexts(contexts: readonly IGitHubReferenceContext[]): string {
+		const heading = 'GitHub issue and pull request context:\n\n';
+		const fixedLength = heading.length + contexts.reduce((length, context, index) => {
+			return length + this._formatGitHubContext(context.reference, context.value, '').length + (index === 0 ? 0 : 2);
+		}, 0);
+		let remainingBodyBudget = Math.max(0, MAX_TITLE_CONTEXT_CHARS - fixedLength);
+		const sections = contexts.map((context, index) => {
+			const bodyBudget = Math.floor(remainingBodyBudget / (contexts.length - index));
+			const body = truncateMiddle(context.value.body, bodyBudget);
+			remainingBodyBudget -= body.length;
+			return this._formatGitHubContext(context.reference, context.value, body);
+		});
+		return `${heading}${sections.join('\n\n')}`;
+	}
+
+	private _formatGitHubContext(reference: IGitHubReference, value: GitHubIssueOrPullRequest, body: string): string {
+		return [
+			`GitHub ${reference.kind} ${reference.owner}/${reference.repo}#${reference.number}:`,
+			`The title of the ${reference.kind} is: ${value.title}`,
+			`The body of the ${reference.kind} is:`,
+			body,
+		].join('\n');
 	}
 
 	private _buildTitlePrompt(promptContent: string, isConversation: boolean): ICopilotUtilityChatMessage[] {

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -20,6 +20,7 @@ const MAX_TITLE_LENGTH = 200;
 const MAX_TITLE_TOKENS = 32;
 const GITHUB_CONTEXT_REQUEST_TIMEOUT = 5_000;
 const MAX_CONCURRENT_GITHUB_CONTEXT_REQUESTS = 5;
+const MAX_GITHUB_CONTEXT_BODY_CHARS = 2_000;
 const MAX_TRAILING_HAN_SUFFIX_CODE_UNITS = 6;
 const MIN_LATIN_LETTERS_BEFORE_HAN_SUFFIX = 4;
 const MIN_LATIN_LETTER_RATIO = 0.8;
@@ -484,7 +485,10 @@ export class AgentHostSessionTitleController extends Disposable {
 		}, 0);
 		let remainingBodyBudget = Math.max(0, MAX_TITLE_CONTEXT_CHARS - fixedLength);
 		const sections = contexts.map((context, index) => {
-			const bodyBudget = Math.floor(remainingBodyBudget / (contexts.length - index));
+			const bodyBudget = Math.min(
+				MAX_GITHUB_CONTEXT_BODY_CHARS,
+				Math.floor(remainingBodyBudget / (contexts.length - index)),
+			);
 			const body = truncateMiddle(context.value.body, bodyBudget);
 			remainingBodyBudget -= body.length;
 			return this._formatGitHubContext(context.reference, context.value, body);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -536,6 +536,7 @@ export class AgentService extends Disposable implements IAgentService {
 					scopes: this._gitHubEndpointService.getRepoResource().scopes_supported,
 				});
 			},
+			getGitHubHost: () => this._gitHubEndpointService.getEnterpriseHost() ?? 'github.com',
 			octoKitService: agentHostOctoKitService,
 			resolveWorkingDirectoryBeforeSend: params => this._resolveWorkingDirectoryBeforeSend(params),
 			resolveChatAttachmentTurns: resource => this._resolveChatAttachmentTurns(resource),

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -536,6 +536,7 @@ export class AgentService extends Disposable implements IAgentService {
 					scopes: this._gitHubEndpointService.getRepoResource().scopes_supported,
 				});
 			},
+			octoKitService: agentHostOctoKitService,
 			resolveWorkingDirectoryBeforeSend: params => this._resolveWorkingDirectoryBeforeSend(params),
 			resolveChatAttachmentTurns: resource => this._resolveChatAttachmentTurns(resource),
 			onTurnComplete: session => {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -530,6 +530,12 @@ export class AgentService extends Disposable implements IAgentService {
 					scopes: this._gitHubEndpointService.getCopilotResource().scopes_supported,
 				});
 			},
+			getGitHubToken: () => {
+				return this.getAuthToken({
+					resource: this._gitHubEndpointService.getRepoResource().resource,
+					scopes: this._gitHubEndpointService.getRepoResource().scopes_supported,
+				});
+			},
 			resolveWorkingDirectoryBeforeSend: params => this._resolveWorkingDirectoryBeforeSend(params),
 			resolveChatAttachmentTurns: resource => this._resolveChatAttachmentTurns(resource),
 			onTurnComplete: session => {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -96,6 +96,8 @@ export interface IAgentSideEffectsOptions {
 	readonly getGitHubCopilotToken?: () => string | undefined;
 	/** Get the GitHub repository token used to fetch issue and pull request context. */
 	readonly getGitHubToken?: () => string | undefined;
+	/** Get the configured GitHub host used to validate issue and pull request URLs. */
+	readonly getGitHubHost?: () => string | undefined;
 	/** GitHub REST client used to fetch issue and pull request context. */
 	readonly octoKitService?: IAgentHostOctoKitService;
 	/** CAPI service used for Copilot utility title generation. */
@@ -244,6 +246,7 @@ export class AgentSideEffects extends Disposable {
 			sessionDataService: this._options.sessionDataService,
 			getGitHubCopilotToken: this._options.getGitHubCopilotToken,
 			getGitHubToken: this._options.getGitHubToken,
+			getGitHubHost: this._options.getGitHubHost,
 			octoKitService: this._options.octoKitService,
 			copilotApiService: this._options.copilotApiService,
 		}));

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -74,6 +74,7 @@ import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostLocalCommands } from './localCommands/localChatCommand.js';
 import './localCommands/localChatCommands.contribution.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
+import type { IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import type { ICopilotApiService } from './shared/copilotApiService.js';
 import { stripProxyErrorMarker, toChatErrorMeta, tryParseForwardedChatError } from './shared/forwardedChatError.js';
 import { persistSessionMetadata } from './shared/persistSessionMetadata.js';
@@ -95,6 +96,8 @@ export interface IAgentSideEffectsOptions {
 	readonly getGitHubCopilotToken?: () => string | undefined;
 	/** Get the GitHub repository token used to fetch issue and pull request context. */
 	readonly getGitHubToken?: () => string | undefined;
+	/** GitHub REST client used to fetch issue and pull request context. */
+	readonly octoKitService?: IAgentHostOctoKitService;
 	/** CAPI service used for Copilot utility title generation. */
 	readonly copilotApiService?: ICopilotApiService;
 	/**
@@ -241,6 +244,7 @@ export class AgentSideEffects extends Disposable {
 			sessionDataService: this._options.sessionDataService,
 			getGitHubCopilotToken: this._options.getGitHubCopilotToken,
 			getGitHubToken: this._options.getGitHubToken,
+			octoKitService: this._options.octoKitService,
 			copilotApiService: this._options.copilotApiService,
 		}));
 		this._register(this._stateManager.onDidChangeSessionConfig(e => {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -93,6 +93,8 @@ export interface IAgentSideEffectsOptions {
 	readonly localTurns: AgentHostLocalTurns;
 	/** Get the GitHub token used for Copilot utility title generation. */
 	readonly getGitHubCopilotToken?: () => string | undefined;
+	/** Get the GitHub repository token used to fetch issue and pull request context. */
+	readonly getGitHubToken?: () => string | undefined;
 	/** CAPI service used for Copilot utility title generation. */
 	readonly copilotApiService?: ICopilotApiService;
 	/**
@@ -238,6 +240,7 @@ export class AgentSideEffects extends Disposable {
 		this._titleController = this._register(instantiationService.createInstance(AgentHostSessionTitleController, this._stateManager, {
 			sessionDataService: this._options.sessionDataService,
 			getGitHubCopilotToken: this._options.getGitHubCopilotToken,
+			getGitHubToken: this._options.getGitHubToken,
 			copilotApiService: this._options.copilotApiService,
 		}));
 		this._register(this._stateManager.onDidChangeSessionConfig(e => {

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -35,6 +35,16 @@ interface GitHubPullRequestResponseItem {
 	readonly node_id?: unknown;
 }
 
+interface GitHubIssueOrPullRequestResponseItem {
+	readonly title?: unknown;
+	readonly body?: unknown;
+}
+
+export interface GitHubIssueOrPullRequest {
+	readonly title: string;
+	readonly body: string;
+}
+
 export interface IGitHubApiResponse<T> {
 	readonly data: T | undefined;
 	readonly statusCode: number;
@@ -80,6 +90,9 @@ export interface IAgentHostOctoKitService {
 
 	/** Finds the most recently updated pull request for `headOwner:branch`, if any. */
 	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, headOwner?: string): Promise<CreatedPullRequest | undefined>;
+
+	/** Fetches the title and body of an issue or pull request. */
+	getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest>;
 
 	/**
 	 * Enables auto-merge on a pull request so GitHub merges it automatically
@@ -184,6 +197,21 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 					: undefined
 			}
 			: undefined;
+	}
+
+	async getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest> {
+		const response = await this._makeGHAPIRequest<GitHubIssueOrPullRequestResponseItem>(
+			`repos/${owner}/${repo}/issues/${number}`,
+			'GET',
+			token,
+			signal,
+		);
+		const title = response.data?.title;
+		const body = response.data?.body;
+		if (typeof title !== 'string' || (typeof body !== 'string' && body !== null)) {
+			throw new Error(`Failed to fetch issue or pull request ${owner}/${repo}#${number}`);
+		}
+		return { title, body: body ?? '' };
 	}
 
 	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, token: string, signal: AbortSignal): Promise<void> {

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -16,7 +16,7 @@ import type { IAgentHostGitService, IBranch, IDefaultBranch, IPushOptions } from
 import { AgentHostPullRequestOperationHandler } from '../../node/agentHostPullRequestOperationHandler.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import type { AutoMergeMethod, CreatedPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
+import type { AutoMergeMethod, CreatedPullRequest, GitHubIssueOrPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import type { ICopilotApiService, ICopilotApiServiceRequestOptions, ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { CCAModel } from '@vscode/copilot-api';
@@ -143,6 +143,9 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 			return this.existingAfterCreateFailure;
 		}
 		return this.existing;
+	}
+	async getIssueOrPullRequest(): Promise<GitHubIssueOrPullRequest> {
+		throw new Error('not used');
 	}
 	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, _token: string, _signal: AbortSignal): Promise<void> {
 		this.calls.push(`enablePullRequestAutoMerge:${pullRequestId}:${mergeMethod}`);

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -124,6 +124,7 @@ suite('AgentHostSessionTitleController', () => {
 		octoKitService = new TestAgentHostOctoKitService(),
 		getGitHubToken = () => 'github-token',
 		gitHubContextRequestTimeout?: number,
+		getGitHubHost = () => 'github.com',
 	): {
 		controller: AgentHostSessionTitleController;
 		stateManager: AgentHostStateManager;
@@ -147,6 +148,7 @@ suite('AgentHostSessionTitleController', () => {
 			sessionDataService: createSessionDataService(db),
 			getGitHubCopilotToken,
 			getGitHubToken,
+			getGitHubHost,
 			gitHubContextRequestTimeout,
 			octoKitService,
 			copilotApiService,
@@ -214,6 +216,53 @@ suite('AgentHostSessionTitleController', () => {
 				'The body of the pull request is:',
 				'Pull request body',
 			].join('\n'),
+		});
+	});
+
+	test('seedTitleFromFirstMessage only fetches links from the configured GitHub host', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#456', { title: 'Enterprise issue', body: 'Enterprise body' });
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService, () => 'github-token', undefined, () => 'github.enterprise.test');
+		const prompt = 'Compare https://github.com/microsoft/vscode/issues/123 with https://github.enterprise.test/microsoft/vscode/issues/456';
+
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			calls: octoKitService.calls.map(call => call.number),
+			hasGitHubIssue: userMessage.includes('microsoft/vscode#123'),
+			hasEnterpriseIssue: userMessage.includes('The title of the issue is: Enterprise issue'),
+		}, {
+			calls: [456],
+			hasGitHubIssue: false,
+			hasEnterpriseIssue: true,
+		});
+	});
+
+	test('seedTitleFromFirstMessage fetches at most ten GitHub references', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		const links: string[] = [];
+		for (let number = 1; number <= 11; number++) {
+			octoKitService.responses.set(`microsoft/vscode#${number}`, { title: `Issue ${number}`, body: `Body ${number}` });
+			links.push(`https://github.com/microsoft/vscode/issues/${number}`);
+		}
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), links.join(' '));
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			calls: octoKitService.calls.map(call => call.number),
+			hasTenthContext: userMessage.includes('The title of the issue is: Issue 10'),
+			hasEleventhContext: userMessage.includes('The title of the issue is: Issue 11'),
+		}, {
+			calls: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+			hasTenthContext: true,
+			hasEleventhContext: false,
 		});
 	});
 
@@ -292,6 +341,30 @@ suite('AgentHostSessionTitleController', () => {
 			hasEnd: body.includes('end'),
 		}, {
 			bodyLength: 2_000,
+			hasStart: true,
+			hasTruncationMarker: true,
+			hasEnd: true,
+		});
+	});
+
+	test('seedTitleFromFirstMessage caps the fully formatted GitHub context', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: `start${'x'.repeat(30_000)}end`, body: '' });
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix https://github.com/microsoft/vscode/issues/123');
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		const context = userMessage.slice(userMessage.indexOf('GitHub issue and pull request context:'));
+		assert.deepStrictEqual({
+			contextLength: context.length,
+			hasStart: context.includes('start'),
+			hasTruncationMarker: context.includes('\n...\n'),
+			hasEnd: context.includes('end'),
+		}, {
+			contextLength: 20_000,
 			hasStart: true,
 			hasTruncationMarker: true,
 			hasEnd: true,

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -148,8 +148,9 @@ suite('AgentHostSessionTitleController', () => {
 			getGitHubCopilotToken,
 			getGitHubToken,
 			gitHubContextRequestTimeout,
+			octoKitService,
 			copilotApiService,
-		}, new NullLogService(), octoKitService));
+		}, new NullLogService()));
 		return { controller, stateManager, session, db, titleActions, copilotApiService, octoKitService };
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -272,7 +272,7 @@ suite('AgentHostSessionTitleController', () => {
 		});
 	});
 
-	test('seedTitleFromFirstMessage bounds appended GitHub context', async () => {
+	test('seedTitleFromFirstMessage caps each appended GitHub body at 2000 characters', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		const octoKitService = new TestAgentHostOctoKitService();
 		octoKitService.responses.set('microsoft/vscode#123', { title: 'Issue title', body: `start\n${'x'.repeat(30_000)}\nend` });
@@ -283,13 +283,15 @@ suite('AgentHostSessionTitleController', () => {
 
 		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
 		const context = userMessage.slice(userMessage.indexOf('GitHub issue and pull request context:'));
+		const bodyMarker = 'The body of the issue is:\n';
+		const body = context.slice(context.indexOf(bodyMarker) + bodyMarker.length);
 		assert.deepStrictEqual({
-			isBounded: context.length <= 20_000,
-			hasStart: context.includes('start'),
-			hasTruncationMarker: context.includes('\n...\n'),
-			hasEnd: context.includes('end'),
+			bodyLength: body.length,
+			hasStart: body.includes('start'),
+			hasTruncationMarker: body.includes('\n...\n'),
+			hasEnd: body.includes('end'),
 		}, {
-			isBounded: true,
+			bodyLength: 2_000,
 			hasStart: true,
 			hasTruncationMarker: true,
 			hasEnd: true,

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -14,6 +14,7 @@ import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { AgentHostSessionTitleController } from '../../node/agentHostSessionTitleController.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ResponsePart, type SessionSummary, type ToolCallCompletedState, type Turn } from '../../common/state/sessionState.js';
+import { type AutoMergeMethod, type CreatedPullRequest, type GitHubIssueOrPullRequest, type IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import { createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
@@ -47,6 +48,48 @@ class TestCopilotApiService implements ICopilotApiService {
 	}
 }
 
+class TestAgentHostOctoKitService implements IAgentHostOctoKitService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly calls: { owner: string; repo: string; number: number; token: string; signal: AbortSignal }[] = [];
+	readonly responses = new Map<string, GitHubIssueOrPullRequest | Error>();
+	readonly pendingResponses = new Set<string>();
+
+	async createPullRequest(): Promise<CreatedPullRequest> {
+		throw new Error('not used');
+	}
+
+	async findPullRequestByHeadBranch(): Promise<CreatedPullRequest | undefined> {
+		throw new Error('not used');
+	}
+
+	async getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest> {
+		this.calls.push({ owner, repo, number, token, signal });
+		const key = `${owner}/${repo}#${number}`;
+		if (this.pendingResponses.has(key)) {
+			return new Promise((_resolve, reject) => {
+				if (signal.aborted) {
+					reject(signal.reason);
+					return;
+				}
+				signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+			});
+		}
+		const response = this.responses.get(key);
+		if (response instanceof Error) {
+			throw response;
+		}
+		if (!response) {
+			throw new Error('missing test response');
+		}
+		return response;
+	}
+
+	async enablePullRequestAutoMerge(_pullRequestId: string, _mergeMethod: AutoMergeMethod): Promise<void> {
+		throw new Error('not used');
+	}
+}
+
 suite('AgentHostSessionTitleController', () => {
 	const disposables = new DisposableStore();
 
@@ -74,13 +117,21 @@ suite('AgentHostSessionTitleController', () => {
 		assert.ok(await predicate(), message);
 	}
 
-	function setup(copilotApiService = new TestCopilotApiService(), title = '', getGitHubCopilotToken = () => 'gh-token'): {
+	function setup(
+		copilotApiService = new TestCopilotApiService(),
+		title = '',
+		getGitHubCopilotToken = () => 'gh-token',
+		octoKitService = new TestAgentHostOctoKitService(),
+		getGitHubToken = () => 'github-token',
+		gitHubContextRequestTimeout?: number,
+	): {
 		controller: AgentHostSessionTitleController;
 		stateManager: AgentHostStateManager;
 		session: URI;
 		db: TestSessionDatabase;
 		titleActions: string[];
 		copilotApiService: TestCopilotApiService;
+		octoKitService: TestAgentHostOctoKitService;
 	} {
 		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		const db = new TestSessionDatabase();
@@ -95,9 +146,11 @@ suite('AgentHostSessionTitleController', () => {
 		const controller = disposables.add(new AgentHostSessionTitleController(stateManager, {
 			sessionDataService: createSessionDataService(db),
 			getGitHubCopilotToken,
+			getGitHubToken,
+			gitHubContextRequestTimeout,
 			copilotApiService,
-		}, new NullLogService()));
-		return { controller, stateManager, session, db, titleActions, copilotApiService };
+		}, new NullLogService(), octoKitService));
+		return { controller, stateManager, session, db, titleActions, copilotApiService, octoKitService };
 	}
 
 	test('seedTitleFromFirstMessage applies fallback and persists generated title', async () => {
@@ -120,6 +173,125 @@ suite('AgentHostSessionTitleController', () => {
 			maxTokens: 32,
 			promptIncludesUserText: true,
 			persistedTitle: 'Generated title',
+		});
+	});
+
+	test('seedTitleFromFirstMessage appends every unique GitHub issue and pull request', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Issue title', body: 'Issue body' });
+		octoKitService.responses.set('microsoft/vscode#456', { title: 'Pull request title', body: 'Pull request body' });
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const prompt = 'Fix https://github.com/microsoft/vscode/issues/123 and review https://github.com/microsoft/vscode/pull/456. Duplicate: https://www.github.com/microsoft/vscode/issues/123#issuecomment-1';
+
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content;
+		assert.deepStrictEqual({
+			calls: octoKitService.calls.map(call => ({ owner: call.owner, repo: call.repo, number: call.number, token: call.token })),
+			userMessage,
+		}, {
+			calls: [
+				{ owner: 'microsoft', repo: 'vscode', number: 123, token: 'github-token' },
+				{ owner: 'microsoft', repo: 'vscode', number: 456, token: 'github-token' },
+			],
+			userMessage: [
+				'Please write a brief title for the following request:',
+				'',
+				prompt,
+				'',
+				'GitHub issue and pull request context:',
+				'',
+				'GitHub issue microsoft/vscode#123:',
+				'The title of the issue is: Issue title',
+				'The body of the issue is:',
+				'Issue body',
+				'',
+				'GitHub pull request microsoft/vscode#456:',
+				'The title of the pull request is: Pull request title',
+				'The body of the pull request is:',
+				'Pull request body',
+			].join('\n'),
+		});
+	});
+
+	test('seedTitleFromFirstMessage omits GitHub context when the request fails', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', new Error('Not found'));
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const prompt = 'Fix https://github.com/microsoft/vscode/issues/123';
+
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content;
+		assert.strictEqual(userMessage, `Please write a brief title for the following request:\n\n${prompt}`);
+	});
+
+	test('seedTitleFromFirstMessage keeps successful GitHub context when another request fails', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Issue title', body: 'Issue body' });
+		octoKitService.responses.set('microsoft/vscode#456', new Error('Not found'));
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const prompt = 'Fix https://github.com/microsoft/vscode/issues/123 and https://github.com/microsoft/vscode/pull/456';
+
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			hasIssue: userMessage.includes('The title of the issue is: Issue title'),
+			hasPullRequest: userMessage.includes('GitHub pull request microsoft/vscode#456'),
+		}, {
+			hasIssue: true,
+			hasPullRequest: false,
+		});
+	});
+
+	test('seedTitleFromFirstMessage times out GitHub context requests', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.pendingResponses.add('microsoft/vscode#123');
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService, () => 'github-token', 1);
+		const prompt = 'Fix https://github.com/microsoft/vscode/issues/123';
+
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted after the GitHub request times out');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content;
+		assert.deepStrictEqual({
+			requestAborted: octoKitService.calls[0].signal.aborted,
+			userMessage,
+		}, {
+			requestAborted: true,
+			userMessage: `Please write a brief title for the following request:\n\n${prompt}`,
+		});
+	});
+
+	test('seedTitleFromFirstMessage bounds appended GitHub context', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Issue title', body: `start\n${'x'.repeat(30_000)}\nend` });
+		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix https://github.com/microsoft/vscode/issues/123');
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		const context = userMessage.slice(userMessage.indexOf('GitHub issue and pull request context:'));
+		assert.deepStrictEqual({
+			isBounded: context.length <= 20_000,
+			hasStart: context.includes('start'),
+			hasTruncationMarker: context.includes('\n...\n'),
+			hasEnd: context.includes('end'),
+		}, {
+			isBounded: true,
+			hasStart: true,
+			hasTruncationMarker: true,
+			hasEnd: true,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -321,7 +321,7 @@ suite('AgentHostSessionTitleController', () => {
 		});
 	});
 
-	test('seedTitleFromFirstMessage caps each appended GitHub body at 2000 characters', async () => {
+	test('seedTitleFromFirstMessage caps each appended GitHub body at 4000 characters', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		const octoKitService = new TestAgentHostOctoKitService();
 		octoKitService.responses.set('microsoft/vscode#123', { title: 'Issue title', body: `start\n${'x'.repeat(30_000)}\nend` });
@@ -340,7 +340,7 @@ suite('AgentHostSessionTitleController', () => {
 			hasTruncationMarker: body.includes('\n...\n'),
 			hasEnd: body.includes('end'),
 		}, {
-			bodyLength: 2_000,
+			bodyLength: 4_000,
 			hasStart: true,
 			hasTruncationMarker: true,
 			hasEnd: true,

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -116,6 +116,23 @@ suite('AgentHostOctoKitService', () => {
 		assert.strictEqual(captured().url, 'https://api.github.com/repos/o/r/pulls?head=fork-owner%3Afeature%2Ftest&state=all&sort=updated&direction=desc&per_page=1');
 	});
 
+	test('getIssueOrPullRequest fetches the title and body from the issues endpoint', async () => {
+		const { fetch, captured } = capturingFetch(jsonResponse({ title: 'Issue title', body: 'Issue body' }));
+		const service = makeService(fetch);
+
+		const result = await service.getIssueOrPullRequest('o', 'r', 42, 'tok', signal());
+
+		assert.deepStrictEqual({
+			result,
+			url: captured().url,
+			method: captured().init?.method,
+		}, {
+			result: { title: 'Issue title', body: 'Issue body' },
+			url: 'https://api.github.com/repos/o/r/issues/42',
+			method: 'GET',
+		});
+	});
+
 	test('createPullRequest throws on non-OK response', async () => {
 		const service = makeService(capturingFetch(new Response('{"message":"Validation Failed"}', { status: 422, statusText: 'Unprocessable Entity' })).fetch);
 


### PR DESCRIPTION
## Summary
- fetch referenced GitHub issue and pull-request titles/bodies before initial Agent Host title generation
- append successful metadata with a shared five-second timeout, bounded context, deduplication, and limited concurrency
- cover enrichment, deduplication, partial failures, timeout, context bounds, and REST response parsing

## Testing
- Not run per requested workflow