### PR TITLE
sessions: move changes action to title bar

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -111,10 +111,10 @@ The titlebar is a standalone implementation (`TitlebarPart`) — not extending `
 | Section | Menu ID | Content |
 |---------|---------|---------|
 | Left | `Menus.TitleBarLeftLayout` | Toggle sidebar, new session (when sidebar hidden, A/B experiment), agent host filter |
-| Center | `Menus.CommandCenter` | Session picker widget (plus `Menus.TitleBarSessionMenu` for active-session actions) |
-| Right | `Menus.TitleBarRightLayout` | Remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget |
+| Center | `Menus.CommandCenter` | Session picker widget |
+| Right | `Menus.TitleBarSessionMenu`, `Menus.TitleBarRightLayout` | Active-session actions (including Create Pull Request), remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget |
 
-No menubar, no editor actions, no `WindowTitle` dependency.
+No menubar or `WindowTitle` dependency. Editor-specific actions remain in the editor header, while session-level actions are placed on the right of the title bar.
 
 The account widget shows overlapping provider identities only for accounts that are currently verified as signed in. Its panel keeps provider and status groups in a stable order: Copilot, ChatGPT (or its sign-in action), then contributed account status such as Codebase Semantic Index, with dividers between groups. Subscription usage uses a two-row metric layout with the plan and percentage first, followed by reset timing and the usage label.
 

--- a/src/vs/sessions/browser/parts/media/editorPart.css
+++ b/src/vs/sessions/browser/parts/media/editorPart.css
@@ -32,18 +32,6 @@
 	min-width: 0;
 }
 
-.agent-sessions-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.tabs-border-bottom > .editor-actions:has(.changes-actions-bar > .monaco-button-dropdown) {
-	flex: 0 999 auto;
-	min-width: 70px;
-	overflow: hidden;
-}
-
-.agent-sessions-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.tabs-border-bottom > .editor-actions:has(.changes-actions-bar > .monaco-button) {
-	flex: 0 999 auto;
-	min-width: 32px;
-	overflow: hidden;
-}
-
 .agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-actions-separator {
 	display: block;
 	align-self: center;

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -459,7 +459,7 @@ export class ChangesActionsBar extends Disposable {
 
 export const CHANGES_HEADER_ACTIONS_ID = 'workbench.changesView.headerActions';
 
-/** Renders the {@link ChangesActionsBar} widget as the Create Pull Request editor tabs title action item. */
+/** Renders the {@link ChangesActionsBar} widget as the Create Pull Request title-bar action item. */
 export class ChangesActionsBarActionViewItem extends BaseActionViewItem {
 	constructor(
 		action: IAction,
@@ -475,8 +475,8 @@ export class ChangesActionsBarActionViewItem extends BaseActionViewItem {
 	}
 }
 
-/** Registers the Changes editor-header action view items keyed by the editor-header menu ids. */
-class ChangesEditorHeaderContribution extends Disposable implements IWorkbenchContribution {
+/** Registers custom Changes action view items. */
+class ChangesActionViewItemsContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.changesEditorHeader';
 
@@ -504,10 +504,17 @@ class ChangesEditorHeaderContribution extends Disposable implements IWorkbenchCo
 			return instantiationService.createInstance(SinglePaneChangesDiffStatsActionItem, action, options);
 		}, onDidRegister.event));
 
+		this._register(actionViewItemService.register(Menus.TitleBarSessionMenu, CHANGES_HEADER_ACTIONS_ID, (action, options, instantiationService) => {
+			if (!(action instanceof MenuItemAction)) {
+				return undefined;
+			}
+			return instantiationService.createInstance(ChangesActionsBarActionViewItem, action, options);
+		}, onDidRegister.event));
+
 		onDidRegister.fire();
 	}
 }
-registerWorkbenchContribution2(ChangesEditorHeaderContribution.ID, ChangesEditorHeaderContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ChangesActionViewItemsContribution.ID, ChangesActionViewItemsContribution, WorkbenchPhase.BlockRestore);
 
 // --- View Pane
 

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -24,11 +24,10 @@ import { IChangesViewService } from '../common/changesViewService.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionChangesEditor } from './sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from './changesView.js';
-import { SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
+import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { TOGGLE_DIFF_SIDE_BY_SIDE } from '../../../../workbench/browser/parts/editor/diffEditorCommands.js';
 import { logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
-import { ChangesetHasOperationsContext } from './changesViewService.js';
 
 const openChangesViewActionOptions: IAction2Options = {
 	id: 'workbench.action.agentSessions.openChangesView',
@@ -141,14 +140,7 @@ const singlePaneChangesEditorTitleVisible = ContextKeyExpr.and(
 	MainEditorAreaVisibleContext
 );
 
-/**
- * Anchor action hosting the Create Pull Request button bar ({@link ChangesActionsBar})
- * in the single-pane editor tabs title (the editor-actions area of the docked tab bar).
- * The custom action view item is provided by the Changes editor pane
- * ({@link SessionChangesEditor.getActionViewItem}) when the Changes editor is active,
- * so the anchor is gated on the same. The bar hides itself when its underlying menu has
- * no actions.
- */
+/** Anchor action hosting the Create Pull Request button bar in the title bar. */
 class ChangesHeaderActionsAction extends Action2 {
 	constructor() {
 		super({
@@ -156,12 +148,14 @@ class ChangesHeaderActionsAction extends Action2 {
 			title: localize2('changesView.headerActions', "Changes Actions"),
 			f1: false,
 			menu: {
-				id: Menus.SessionsEditorTitle,
+				id: Menus.TitleBarSessionMenu,
 				group: 'navigation',
 				order: 5,
 				when: ContextKeyExpr.and(
-					singlePaneChangesEditorTitle,
-					ChangesetHasOperationsContext
+					IsSessionsWindowContext,
+					IsAuxiliaryWindowContext.toNegated(),
+					SinglePaneLayoutEnabledContext,
+					SessionHasChangesContext
 				)
 			},
 		});

--- a/src/vs/sessions/contrib/changes/browser/media/sessionChangesEditor.css
+++ b/src/vs/sessions/contrib/changes/browser/media/sessionChangesEditor.css
@@ -233,42 +233,30 @@
 	font-size: var(--vscode-codiconFontSize) !important;
 }
 
-/* Compact the ChangesActionsBar buttons to 24px (2px shorter than the classic
- * 26px header buttons) so the changes-editor header stays compact without extra
- * header padding. Keyed off the bar's marker class. In the editor tabs title the
- * 20px override below (scoped to the toolbar action-item context) wins on
- * specificity, so this 24px baseline effectively applies to the classic internal
- * changes-editor header. */
+/* Compact the ChangesActionsBar buttons so the changes-editor header stays compact
+ * without extra padding. The toolbar action-item override below applies in the title bar. */
 .changes-actions-bar .monaco-button,
 .changes-actions-bar .monaco-button-dropdown {
 	height: 24px;
 	box-sizing: border-box;
 }
 
-/* The Create Pull Request bar is rendered as a toolbar action item
- * (`.action-item.changes-actions-bar` inside a `.monaco-action-bar`) in the editor
- * tabs title (the editor-actions area of the docked tab bar), where the classic
- * `.session-changes-editor-header-right` normalization does not reach. Scope these to
- * the action-item context so the classic internal changes-editor header and the aux-bar
- * Changes view are left untouched. */
+/* Scope title-bar normalization to the toolbar action item so the classic internal
+ * changes-editor header and the auxiliary-bar Changes view are left untouched. */
 .monaco-action-bar .action-item.changes-actions-bar {
 	display: flex;
 	align-items: center;
 	gap: var(--vscode-spacing-size40);
 	min-width: 0;
-	/* Small breathing room so the button isn't flush against neighbouring toolbar icons. */
 	margin-left: var(--vscode-spacing-size20);
 	margin-right: var(--vscode-spacing-size20);
 }
 
-/* Normalize the button bar height so it sits comfortably in the editor tabs title. Overrides the
- * default ChangesActionsBar button height without affecting the classic internal
- * changes-editor header (which renders the bar on a plain div, not inside a
- * `.monaco-action-bar .action-item`). */
+/* Normalize the button bar height for the title bar without affecting the classic header. */
 .monaco-action-bar .action-item.changes-actions-bar .monaco-button,
 .monaco-action-bar .action-item.changes-actions-bar .monaco-button-dropdown {
-	height: 26px;
-	min-height: 26px;
+	height: 24px;
+	min-height: 24px;
 	padding-top: 0;
 }
 
@@ -304,7 +292,7 @@
  * specificity than the base rule) so the buttons size to their own content. */
 .monaco-action-bar .action-item.changes-actions-bar .codicon {
 	width: auto;
-	height: 24px;
+	height: 22px;
 	flex-shrink: 0;
 	color: var(--vscode-button-foreground) !important;
 }

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -38,13 +38,13 @@ import { Menus } from '../../../browser/menus.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { ActiveSessionContextKeys } from '../common/changes.js';
 import { IChangesViewService } from '../common/changesViewService.js';
-import { ChangesActionsBar, ChangesActionsBarActionViewItem, CHANGES_HEADER_ACTIONS_ID } from './changesView.js';
+import { ChangesActionsBar } from './changesView.js';
 import { SessionChangesEditorInput } from './sessionChangesEditorInput.js';
 import { ISessionChangesService } from './sessionChangesService.js';
 import { ISessionFileChange } from '../../../services/sessions/common/session.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IAction } from '../../../../base/common/actions.js';
-import { IActionViewItemOptions, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { CheckboxActionViewItem } from '../../../../base/browser/ui/toggle/toggle.js';
@@ -276,17 +276,6 @@ export class SessionChangesEditor extends AbstractEditorWithViewState<IMultiDiff
 
 	get scopedInstantiationService(): IInstantiationService | undefined {
 		return this._singlePane ? this._scopedInstantiationService : undefined;
-	}
-
-	/**
-	 * In single-pane, render the Create Pull Request button bar ({@link ChangesActionsBar})
-	 * as the editor tabs title anchor action ({@link CHANGES_HEADER_ACTIONS_ID}).
-	 */
-	override getActionViewItem(action: IAction, options: IBaseActionViewItemOptions): IActionViewItem | undefined {
-		if (this._singlePane && action.id === CHANGES_HEADER_ACTIONS_ID) {
-			return this.instantiationService.createInstance(ChangesActionsBarActionViewItem, action, options);
-		}
-		return super.getActionViewItem(action, options);
 	}
 
 	override async setInput(input: SessionChangesEditorInput, options: IMultiDiffEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -10,14 +10,13 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
 import { isICommandActionToggleInfo } from '../../../../../platform/action/common/action.js';
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
-import { ActiveEditorContext, AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext, MainEditorAreaVisibleContext } from '../../../../../workbench/common/contextkeys.js';
+import { ActiveEditorContext, AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, MainEditorAreaVisibleContext } from '../../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../../browser/menus.js';
 import { ChangesContextKeys } from '../../common/changes.js';
-import { SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
+import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
 import { SessionChangesEditor } from '../../browser/sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from '../../browser/changesView.js';
 import '../../browser/changesViewActions.js';
-import { ChangesetHasOperationsContext } from '../../browser/changesViewService.js';
 
 suite('Changes View Actions', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -211,30 +210,31 @@ suite('Changes View Actions', () => {
 		}]);
 	});
 
-	test('Create Pull Request anchor is contributed to the editor tabs title menu', () => {
-		const item = MenuRegistry.getMenuItems(Menus.SessionsEditorTitle)
+	test('Create Pull Request anchor is contributed to the right-side title bar menu', () => {
+		const item = MenuRegistry.getMenuItems(Menus.TitleBarSessionMenu)
+			.filter(isIMenuItem)
+			.find(item => item.command.id === CHANGES_HEADER_ACTIONS_ID);
+		const editorTitleItem = MenuRegistry.getMenuItems(Menus.SessionsEditorTitle)
 			.filter(isIMenuItem)
 			.find(item => item.command.id === CHANGES_HEADER_ACTIONS_ID);
 
-		assert.ok(item, 'expected the changes header actions anchor on the editor tabs title menu');
+		assert.ok(item, 'expected the changes header actions anchor on the title bar session menu');
 		const when = item.when?.serialize() ?? '';
 		assert.deepStrictEqual({
+			editorTitleItem,
 			group: item.group,
 			order: item.order,
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
-			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
-			hasSinglePaneConfigGate: when.includes(SinglePaneLayoutEnabledContext.key),
 			hasAuxiliaryWindowGate: when.includes(IsAuxiliaryWindowContext.key),
-			hasTopRightEditorGroupGate: when.includes(IsTopRightEditorGroupContext.key),
-			hasChangesGate: when.includes(ChangesetHasOperationsContext.key),
+			hasSinglePaneLayoutGate: when.includes(SinglePaneLayoutEnabledContext.key),
+			hasChangesGate: when.includes(SessionHasChangesContext.key),
 		}, {
+			editorTitleItem: undefined,
 			group: 'navigation',
 			order: 5,
 			hasSessionsWindowGate: true,
-			hasActiveEditorGate: true,
-			hasSinglePaneConfigGate: true,
 			hasAuxiliaryWindowGate: true,
-			hasTopRightEditorGroupGate: true,
+			hasSinglePaneLayoutGate: true,
 			hasChangesGate: true,
 		});
 	});


### PR DESCRIPTION
## Summary

Moves the Create Pull Request split-button and dropdown from the Changes editor title to the right side of the Agents window title bar. This keeps the session-level action available when the editor content is closed and removes the editor-owned action host.

Also tightens the title-bar button and codicon line-box heights and updates the layout documentation and menu-registration coverage.

## Validation

- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts`