### PR TITLE
Fix prompt cache options for OpenAI custom endpoints

### DIFF
--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -269,6 +269,7 @@ export class OpenAIEndpoint extends ChatEndpoint {
 			// not chain via `previous_response_id` and must not ask it to `store`.
 			options.ignoreStatefulMarker = options.ignoreStatefulMarker || zdr;
 			const body = super.createRequestBody(options);
+			body.prompt_cache_options = undefined;
 			body.store = !zdr;
 			body.n = undefined;
 			body.stream_options = undefined;

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -245,6 +245,24 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 	});
 
 	describe('Responses API mode (useResponsesApi = true)', () => {
+		it('does not include Copilot prompt cache options for custom endpoints', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					id: 'gpt-5.6-luna',
+					capabilities: {
+						...modelMetadata.capabilities,
+						family: 'gpt-5.6-luna',
+					},
+				},
+				'test-api-key',
+				'https://opencode.ai/zen/go/v1/responses');
+
+			const body = endpoint.createRequestBody(createTestOptions([]));
+
+			expect(body.prompt_cache_options).toBeUndefined();
+		});
+
 		it('should preserve reasoning object when thinking is supported', () => {
 			const modelWithReasoningEffort = {
 				...modelMetadata,


### PR DESCRIPTION
Prevent Copilot-specific Responses API prompt cache options from leaking into BYOK requests that may target OpenAI-compatible providers.

Fixes #329182

