### PR TITLE
Enable editor type picker by default

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -171,8 +171,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'breadcrumbs.showEditorType': {
 			markdownDescription: localize('showEditorType', "Controls whether the breadcrumbs bar shows a dropdown to switch between the editors that can open the current file (for example the text editor and a custom editor). The dropdown only appears when a more specialized editor is available."),
 			type: 'boolean',
-			default: false,
-			agentsWindow: { default: true },
+			default: true,
 			tags: ['experimental']
 		},
 		'breadcrumbs.symbolPathSeparator': {


### PR DESCRIPTION
## Summary

Enable the breadcrumbs editor type dropdown by default in both editor and Agents windows, replacing the Agents-window-specific default override.

## Validation

- npm run eslint -- src/vs/workbench/browser/parts/editor/breadcrumbs.ts
- git diff --check