### PR TITLE
Remove experimental label from Markdown editor

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -873,7 +873,7 @@
       },
       {
         "viewType": "vscode.markdown.editor",
-        "displayName": "Markdown Editor (Experimental)",
+        "displayName": "Markdown Editor",
         "priority": {
           "diffEditor": "explicit",
           "textEditor": "option"


### PR DESCRIPTION
## Summary

Rename the custom editor display name from **Markdown Editor (Experimental)** to **Markdown Editor** now that the experimental qualifier is no longer needed.

## Validation

- Parsed the staged extension manifest as JSON
- git diff --check