### PR TITLE
Adopt forceRemoteSettingsRefresh managed setting

### DIFF
--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -78,6 +78,7 @@ the VS Code bag is **flattened** to dot-paths — e.g. the schema's nested
 | Schema property (path) | Type in schema | Composition (`x-composition.strategy`) |
 |------------------------|----------------|----------------------------------------|
 | `permissions.disableBypassPermissionsMode` | string enum `"disable"` | most-restrictive-wins (sticky once set) |
+| `forceRemoteSettingsRefresh` | boolean | MDM wins; controls the server cache rather than a configuration setting |
 | `enabledPlugins` | `{ "PLUGIN@MARKETPLACE": boolean }` | deny-wins (false beats true; enterprise denials immutable) |
 | `extraKnownMarketplaces` | `{ name: { source, autoUpdate? } }`, source `github` \| `git` \| `directory` | most-restrictive-wins (higher layer is the complete allowlist); explicit `autoUpdate` overrides the client's global plugin auto-update setting for that marketplace |
 | `strictKnownMarketplaces` | array of source descriptors | most-restrictive-wins (empty array = lockdown) |
@@ -199,8 +200,9 @@ delivery slot for the managed value.
 |----------|------|
 | `flattenManagedSettings(obj)` | Flattens a nested response into dot-path scalars (used by `normalizeManagedSettings`). |
 | `normalizeManagedSettings(parsed, onWarn?)` | The **single** normalizer shared by every channel: turns a parsed managed-settings object (server response, file on disk, …) into the canonical bag. Scalar leaves flatten; structured keys (declared in the `STRUCTURED_MANAGED_SETTINGS` table) are JSON-encoded under a single key each. The server adapter `adaptManagedSettings` and the file channel both call it. |
-| `collectManagedSettingsDefinitions(policyDefinitions)` | Aggregates every policy's `managedSettings` into one `key → { type }` map. **Single source of truth** for which keys (and types) are honored; drives both the MDM watcher and the server projection. |
-| `hasManagedSettingsDefinitions(policyDefinitions)` | Cheap short-circuiting existence check (does *any* policy declare a managed key?) — used to decide whether the native MDM watcher is needed at all, without building the full aggregate. |
+| `collectManagedSettingsDefinitions(policyDefinitions)` | Aggregates every policy's `managedSettings` into one `key → { type }` map. **Single source of truth** for policy-backed keys and types; drives server projection and the declaration-driven portion of the MDM watcher. |
+| `MANAGED_SETTINGS_CONTROL_DEFINITIONS` | Fixed schema for transport controls consumed by the managed-settings pipeline itself. These keys are always added to the native MDM watcher but are not projected as configuration policies. |
+| `hasManagedSettingsDefinitions(policyDefinitions)` | Cheap short-circuiting existence check (does *any* policy declare a managed key?) — used to decide whether the declaration-driven watcher schema needs updating, without building the full aggregate. |
 | `projectManagedSettings(values, definitions, onWarn?)` | Keeps only declared keys whose runtime value **matches the declared type**. Undeclared keys and type mismatches are **dropped (validated, never coerced)**, with an optional warning. |
 | `pickManagedSettings(nativeMdm, server, file)` | Merges the channels **per key** by precedence (native MDM → server → file): the highest-precedence channel that sets a key wins, lower channels fill in keys the higher ones leave unset, and every contribution is recorded for provenance. **The extension point when adding a new channel** — extend the `ManagedSettingsChannel` union, the `MANAGED_SETTINGS_CHANNELS` order, and this function together. |
 | `managedSettingValue(key)` | Builds the standard pass-through `value` callback `policyData => policyData.managedSettings?.[key]`. Use for the common "lock to the managed value, else fall through" case (see [Declaring a managed setting](#declaring-a-managed-setting-on-a-policy)). |
@@ -230,6 +232,7 @@ Constants (also in `copilotManagedSettings.ts`):
 | `COPILOT_ENABLED_PLUGINS_KEY` | `enabledPlugins` |
 | `COPILOT_EXTRA_MARKETPLACES_KEY` | `extraKnownMarketplaces` |
 | `COPILOT_STRICT_MARKETPLACES_KEY` | `strictKnownMarketplaces` |
+| `COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY` | `forceRemoteSettingsRefresh` |
 
 ## Wiring (where the MDM service is constructed)
 
@@ -258,9 +261,9 @@ It is exposed to the renderer over IPC via `NativeManagedSettingsChannel` /
 the `nativeManagedSettings` channel in `app.ts`. `AccountPolicyService` subscribes to
 `onDidChangeManagedSettings` and re-evaluates policy values when managed settings change.
 
-The service only watches keys that some policy declares: `updatePolicyDefinitions`
-calls `collectManagedSettingsDefinitions`, then `@vscode/policy-watcher` watches exactly
-those dot-paths. No declared keys ⇒ no watcher.
+The service watches keys that policies declare plus the fixed transport controls in
+`MANAGED_SETTINGS_CONTROL_DEFINITIONS`. `updatePolicyDefinitions` combines those schemas,
+then `@vscode/policy-watcher` watches exactly those keys.
 
 The **file-based** channel is wired the same way (`src/vs/code/electron-main/main.ts`):
 `FileManagedSettingsService` reads `managed-settings.json` from the per-OS well-known path
@@ -298,7 +301,9 @@ the runtime owns its schema and authority resolution independently.
    the `managed-settings-schema.json` key exactly.
 2. **Attach it to a policy** on the governing setting: add `managedSettings: { [KEY]: { type } }`
    and a `value` callback. For a plain pass-through use `value: managedSettingValue(KEY)`;
-   only hand-write the callback when combining with another condition.
+   only hand-write the callback when combining with another condition. A transport control
+   with no governing configuration setting is the exception: add its schema to
+   `MANAGED_SETTINGS_CONTROL_DEFINITIONS` and consume it in the delivery pipeline instead.
 3. **If the value is structured** (object/array), declare the managed key as `'string'` and
    let `PolicyConfiguration` parse the JSON back on read. Then teach the **shared normalizer** by
    adding one row to `STRUCTURED_MANAGED_SETTINGS` in `copilotManagedSettings.ts` (the `key` and an
@@ -311,7 +316,17 @@ the runtime owns its schema and authority resolution independently.
    declaration-driven projection (`projectManagedSettings`) silently drops anything that
    doesn't match the declared type, so a type drift = a silently ignored setting.
 5. **Export & test** as in SKILL.md Step 3–4 (`npm run typecheck-client`,
-   `npm run export-policy-data`). Verify the policy appears in `policyData.jsonc`.
+   `npm run export-policy-data`). Verify the policy appears in `policyData.jsonc`. A transport-only
+   control has no policy catalog entry, so it does not require a policy-data export.
+
+### Transport-only control: `forceRemoteSettingsRefresh`
+
+`forceRemoteSettingsRefresh` is not a user configuration setting. It controls whether the
+server-managed-settings cache may satisfy startup, so VS Code preserves it in the cached raw server
+bag and always includes it in the native MDM watch schema. `DefaultAccountProvider` resolves an
+explicit native MDM boolean ahead of the cached server value; when the result is `true`, it bypasses
+an otherwise-fresh server cache for the first fetch for that account in the current process. The
+cache remains available as the normal fetch-failure fallback.
 
 Reference tests:
 - `src/vs/platform/policy/test/common/copilotManagedSettings.test.ts`

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -52,6 +52,17 @@ export const COPILOT_ALLOW_MANAGED_MCP_SERVERS_ONLY_KEY = 'allowManagedMcpServer
 /** Managed-settings key that allows hooks only from managed sources. */
 export const COPILOT_ALLOW_MANAGED_HOOKS_ONLY_KEY = 'allowManagedHooksOnly';
 
+/** Managed-settings transport control that requires a fresh server fetch on startup. */
+export const COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY = 'forceRemoteSettingsRefresh';
+
+/**
+ * Managed-settings controls consumed by the delivery pipeline itself rather than by a
+ * configuration policy. Native MDM must watch these even though no setting declares them.
+ */
+export const MANAGED_SETTINGS_CONTROL_DEFINITIONS: IManagedSettingsPolicyDefinitions = {
+	[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: { type: 'boolean' },
+};
+
 /** Policy-only configuration delivery slot for {@link COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_KEY}. */
 export const COPILOT_STRICT_PLUGIN_ONLY_CUSTOMIZATION_CONFIG = 'chat.customizations.strictPluginOnlyCustomization';
 
@@ -124,6 +135,18 @@ export function managedSettingValue(key: string): (policyData: IPolicyData) => M
 	return callback;
 }
 
+/**
+ * Resolves the startup refresh control with native MDM taking precedence over the cached server
+ * response. A malformed native value is treated as absent, matching the managed-settings schema.
+ */
+export function shouldForceRemoteSettingsRefresh(nativeMdm: ManagedSettingsData | undefined, server: ManagedSettingsData | undefined): boolean {
+	const nativeValue = nativeMdm?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY];
+	if (typeof nativeValue === 'boolean') {
+		return nativeValue;
+	}
+	return server?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY] === true;
+}
+
 let managedModelValueCallback: ((policyData: IPolicyData) => ManagedSettingValue | undefined) | undefined;
 
 /**
@@ -155,6 +178,7 @@ export interface INativeManagedSettingsService {
 	readonly _serviceBrand: undefined;
 	readonly managedSettings: ManagedSettingsData;
 	readonly onDidChangeManagedSettings: Event<ManagedSettingsData>;
+	initialize(): Promise<ManagedSettingsData>;
 	updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData>;
 }
 
@@ -163,6 +187,7 @@ export class NullNativeManagedSettingsService implements INativeManagedSettingsS
 	readonly managedSettings: ManagedSettingsData = {};
 	readonly onDidChangeManagedSettings = Event.None;
 
+	async initialize(): Promise<ManagedSettingsData> { return this.managedSettings; }
 	async updatePolicyDefinitions(): Promise<ManagedSettingsData> { return this.managedSettings; }
 }
 
@@ -195,9 +220,9 @@ function isManagedSettingsObject(value: unknown): value is Record<string, unknow
 
 /**
  * Aggregate the `managedSettings` declarations of every policy definition into a single
- * key -> definition map. This is the single source of truth for which Copilot managed-settings
- * keys (and their value types) are honored, and it drives both delivery channels: the native
- * MDM watcher and the server `managed_settings` endpoint projection.
+ * key -> definition map. This is the single source of truth for policy-backed Copilot
+ * managed-settings keys and drives both server projection and the declaration-driven portion of
+ * the native MDM watcher. Transport controls are declared separately.
  */
 export function collectManagedSettingsDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): IManagedSettingsPolicyDefinitions {
 	const definitions: Record<string, IManagedSettingPolicyDefinition> = {};
@@ -214,8 +239,9 @@ export function collectManagedSettingsDefinitions(policyDefinitions: IStringDict
 
 /**
  * Whether any policy in `policyDefinitions` declares at least one managed-settings key. Cheap
- * existence check (short-circuits) used to decide whether the native MDM watcher is needed at all,
- * without aggregating the full {@link collectManagedSettingsDefinitions} map.
+ * existence check (short-circuits) used to decide whether the declaration-driven portion of the
+ * native MDM watcher needs updating, without aggregating the full
+ * {@link collectManagedSettingsDefinitions} map.
  */
 export function hasManagedSettingsDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
 	for (const policyName in policyDefinitions) {

--- a/src/vs/platform/policy/common/nativeManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/nativeManagedSettingsIpc.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter, Event } from '../../../base/common/event.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
+import { getErrorMessage } from '../../../base/common/errors.js';
+import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { ILogService } from '../../log/common/log.js';
 import { INativeManagedSettingsService, ManagedSettingsData } from './copilotManagedSettings.js';
 import { PolicyDefinition } from './policy.js';
 
@@ -27,7 +29,7 @@ export class NativeManagedSettingsChannel implements IServerChannel {
 
 	call<T>(_: unknown, command: string, arg?: unknown): Promise<T> {
 		switch (command) {
-			case 'getManagedSettings': return Promise.resolve(this.service.managedSettings as T);
+			case 'getManagedSettings': return this.service.initialize() as Promise<T>;
 			case 'updatePolicyDefinitions': return this.service.updatePolicyDefinitions(arg as IStringDictionary<PolicyDefinition>) as Promise<T>;
 		}
 
@@ -49,15 +51,44 @@ export class NativeManagedSettingsChannelClient extends Disposable implements IN
 
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
+	private initializationPromise: Promise<void> | undefined;
 
-	constructor(private readonly channel: IChannel) {
+	constructor(
+		private readonly channel: IChannel,
+		private readonly logService: ILogService,
+	) {
 		super();
 		this._register(this.channel.listen<ManagedSettingsData>('onDidChangeManagedSettings')(managedSettings => this.updateManagedSettings(managedSettings, true)));
-		this.channel.call<ManagedSettingsData>('getManagedSettings').then(managedSettings => {
-			if (!this.hasReceivedManagedSettings) {
-				this.updateManagedSettings(managedSettings, true);
+		void this.initializeInBackground();
+	}
+
+	private async initializeInBackground(): Promise<void> {
+		try {
+			await this.initialize();
+		} catch (error) {
+			this.logService.warn('NativeManagedSettingsChannelClient#initialize - Failed to initialize native managed settings', getErrorMessage(error));
+		}
+	}
+
+	async initialize(): Promise<ManagedSettingsData> {
+		const initializationPromise = this.initializationPromise ?? this.initializeFromChannel();
+		this.initializationPromise = initializationPromise;
+		try {
+			await initializationPromise;
+		} catch (error) {
+			if (this.initializationPromise === initializationPromise) {
+				this.initializationPromise = undefined;
 			}
-		});
+			throw error;
+		}
+		return this._managedSettings;
+	}
+
+	private async initializeFromChannel(): Promise<void> {
+		const managedSettings = await this.channel.call<ManagedSettingsData>('getManagedSettings');
+		if (!this.hasReceivedManagedSettings) {
+			this.updateManagedSettings(managedSettings, true);
+		}
 	}
 
 	async updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData> {

--- a/src/vs/platform/policy/node/nativeManagedSettingsService.ts
+++ b/src/vs/platform/policy/node/nativeManagedSettingsService.ts
@@ -10,7 +10,7 @@ import { Disposable, MutableDisposable } from '../../../base/common/lifecycle.js
 import { equals } from '../../../base/common/objects.js';
 import { IManagedSettingsPolicyDefinitions, ManagedSettingsData } from '../../../base/common/policy.js';
 import { ILogService } from '../../log/common/log.js';
-import { collectManagedSettingsDefinitions, INativeManagedSettingsService } from '../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, INativeManagedSettingsService, MANAGED_SETTINGS_CONTROL_DEFINITIONS } from '../common/copilotManagedSettings.js';
 import { PolicyDefinition, PolicyValue } from '../common/policy.js';
 import type { Watcher } from '@vscode/policy-watcher';
 
@@ -32,7 +32,9 @@ export class NativeManagedSettingsService extends Disposable implements INativeM
 	private readonly throttler = this._register(new Throttler());
 	private readonly watcher = this._register(new MutableDisposable<Watcher>());
 	private readonly managedSettingsValues = new Map<string, PolicyValue>();
-	private watchedSettings: IManagedSettingsPolicyDefinitions = {};
+	private watchedSettings: IManagedSettingsPolicyDefinitions = MANAGED_SETTINGS_CONTROL_DEFINITIONS;
+	private initializationPromise: Promise<void> | undefined;
+	private initializationVersion = 0;
 
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
@@ -50,20 +52,48 @@ export class NativeManagedSettingsService extends Disposable implements INativeM
 		super();
 	}
 
+	async initialize(): Promise<ManagedSettingsData> {
+		await this.ensureWatcher();
+		return this.managedSettings;
+	}
+
 	async updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData> {
-		const managedSettings = collectManagedSettingsDefinitions(policyDefinitions);
+		const managedSettings = {
+			...collectManagedSettingsDefinitions(policyDefinitions),
+			...MANAGED_SETTINGS_CONTROL_DEFINITIONS,
+		};
 
 		if (equals(this.watchedSettings, managedSettings)) {
-			return this.managedSettings;
+			return this.initialize();
 		}
 
 		this.watchedSettings = managedSettings;
 		const changed = this.pruneManagedSettingsValues();
-		await this.updateWatcher();
+		await this.ensureWatcher(true);
 		if (changed) {
 			this._onDidChangeManagedSettings.fire(this.managedSettings);
 		}
 		return this.managedSettings;
+	}
+
+	private ensureWatcher(force = false): Promise<void> {
+		if (!force && this.initializationPromise) {
+			return this.initializationPromise;
+		}
+		const update = this.updateWatcherAndTrack(++this.initializationVersion);
+		this.initializationPromise = update;
+		return update;
+	}
+
+	private async updateWatcherAndTrack(version: number): Promise<void> {
+		try {
+			await this.updateWatcher();
+		} catch (error) {
+			if (this.initializationVersion === version) {
+				this.initializationPromise = undefined;
+			}
+			throw error;
+		}
 	}
 
 	private pruneManagedSettingsValues(): boolean {

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, managedSettingValue, projectManagedSettings, pickManagedSettings } from '../../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY, hasManagedSettingsDefinitions, managedSettingValue, projectManagedSettings, pickManagedSettings, shouldForceRemoteSettingsRefresh } from '../../common/copilotManagedSettings.js';
 import { PolicyDefinition } from '../../common/policy.js';
 
 suite('Copilot managed settings projection', () => {
@@ -72,6 +72,22 @@ suite('Copilot managed settings projection', () => {
 			managedSettingValue('permissions.disableBypassPermissionsMode'),
 			managedSettingValue('some.other.key'),
 		);
+	});
+
+	test('forceRemoteSettingsRefresh uses native MDM over the cached server value', () => {
+		assert.deepStrictEqual({
+			serverTrue: shouldForceRemoteSettingsRefresh(undefined, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
+			nativeTrue: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }),
+			nativeFalse: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
+			malformedNative: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: 'true' }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
+			unset: shouldForceRemoteSettingsRefresh(undefined, undefined),
+		}, {
+			serverTrue: true,
+			nativeTrue: true,
+			nativeFalse: false,
+			malformedNative: true,
+			unset: false,
+		});
 	});
 
 	test('projectManagedSettings keeps declared+typed keys, drops undeclared and type-mismatched', () => {

--- a/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
@@ -133,6 +133,29 @@ suite('NativeManagedSettingsService', () => {
 		assert.deepStrictEqual({ managedSettings: service.managedSettings, watcherCreateCount }, { managedSettings: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }, watcherCreateCount: 1 });
 	});
 
+	test('retries watcher creation after initialization fails', async () => {
+		let watcherCreateCount = 0;
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, _policies, callback) => {
+			watcherCreateCount++;
+			if (watcherCreateCount === 1) {
+				throw new Error('initial watcher creation failed');
+			}
+			callback({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true });
+			return Disposable.None;
+		};
+
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		await assert.rejects(service.initialize());
+
+		assert.deepStrictEqual({
+			managedSettings: await service.initialize(),
+			watcherCreateCount,
+		}, {
+			managedSettings: { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true },
+			watcherCreateCount: 2,
+		});
+	});
+
 	test('removes raw managed settings whose definitions are no longer watched', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
 		const otherManagedSettingKey = 'permissions.otherManagedSetting';

--- a/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
@@ -10,7 +10,7 @@ import { ManagedSettingsData } from '../../../../base/common/policy.js';
 import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY } from '../../common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY } from '../../common/copilotManagedSettings.js';
 import { NativeManagedSettingsChannelClient } from '../../common/nativeManagedSettingsIpc.js';
 import { PolicyValue } from '../../common/policy.js';
 import { NativeManagedSettingsService, NativePolicyWatcherFactory } from '../../node/nativeManagedSettingsService.js';
@@ -23,7 +23,10 @@ suite('NativeManagedSettingsService', () => {
 	test('watches managed-settings keys from policy definitions and exposes raw managed settings', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
 		const watcherFactory: NativePolicyWatcherFactory = (_productName, policies, callback) => {
-			assert.deepStrictEqual(policies, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' } });
+			assert.deepStrictEqual(policies, {
+				[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
+				[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: { type: 'boolean' },
+			});
 			onDidChange = callback;
 			callback({});
 			return Disposable.None;
@@ -46,17 +49,24 @@ suite('NativeManagedSettingsService', () => {
 		assert.deepStrictEqual(service.managedSettings, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' });
 	});
 
-	test('does not create the watcher until a managed-settings policy definition is registered', async () => {
-		let watcherCreated = false;
-		const watcherFactory: NativePolicyWatcherFactory = () => {
-			watcherCreated = true;
+	test('watches transport controls without a managed-settings policy definition', async () => {
+		let watchedSettings: Record<string, { type: 'string' | 'number' | 'boolean' }> = {};
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, policies, callback) => {
+			watchedSettings = policies;
+			callback({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true });
 			return Disposable.None;
 		};
 
 		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({ OtherPolicy: { type: 'boolean' } });
 
-		assert.strictEqual(watcherCreated, false);
+		assert.deepStrictEqual({
+			watchedSettings,
+			managedSettings: service.managedSettings,
+		}, {
+			watchedSettings: { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: { type: 'boolean' } },
+			managedSettings: { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true },
+		});
 	});
 
 	test('clears stale watcher values when managed-settings definitions are removed', async () => {
@@ -158,18 +168,18 @@ suite('NativeManagedSettingsService', () => {
 
 	test('channel client keeps newer event state when initial snapshot resolves later', async () => {
 		const channel = disposables.add(new DeferredManagedSettingsChannel());
-		const client = disposables.add(new NativeManagedSettingsChannelClient(channel));
+		const client = disposables.add(new NativeManagedSettingsChannelClient(channel, new NullLogService()));
 
 		channel.fire({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
 		channel.resolveInitialSnapshot({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' });
-		await channel.initialSnapshot;
+		await client.initialize();
 
 		assert.deepStrictEqual(client.managedSettings, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
 	});
 
 	test('channel client updatePolicyDefinitions updates cache without firing change event', async () => {
 		const channel = disposables.add(new DeferredManagedSettingsChannel());
-		const client = disposables.add(new NativeManagedSettingsChannelClient(channel));
+		const client = disposables.add(new NativeManagedSettingsChannelClient(channel, new NullLogService()));
 		channel.resolveInitialSnapshot({});
 		await channel.initialSnapshot;
 
@@ -184,6 +194,18 @@ suite('NativeManagedSettingsService', () => {
 			managedSettings: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' },
 			eventCount: 0,
 		});
+	});
+
+	test('channel client retries a failed initial snapshot', async () => {
+		const channel = new RetryManagedSettingsChannel();
+		const client = disposables.add(new NativeManagedSettingsChannelClient(channel, new NullLogService()));
+		const initial = client.initialize();
+
+		channel.rejectInitialSnapshot();
+		await assert.rejects(initial);
+
+		assert.deepStrictEqual(await client.initialize(), { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true });
+		assert.strictEqual(channel.getManagedSettingsCallCount, 2);
 	});
 });
 
@@ -213,5 +235,28 @@ class DeferredManagedSettingsChannel extends Disposable implements IChannel {
 
 	resolveInitialSnapshot(managedSettings: ManagedSettingsData): void {
 		this.resolveInitialSnapshotPromise(managedSettings);
+	}
+}
+
+class RetryManagedSettingsChannel implements IChannel {
+	private rejectInitialSnapshotPromise!: (error: Error) => void;
+	private readonly initialSnapshot = new Promise<ManagedSettingsData>((_resolve, reject) => this.rejectInitialSnapshotPromise = reject);
+	getManagedSettingsCallCount = 0;
+
+	call<T>(command: string): Promise<T> {
+		assert.strictEqual(command, 'getManagedSettings');
+		this.getManagedSettingsCallCount++;
+		if (this.getManagedSettingsCallCount === 1) {
+			return this.initialSnapshot as Promise<T>;
+		}
+		return Promise.resolve({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true } as T);
+	}
+
+	listen<T>(): Event<T> {
+		return Event.None;
+	}
+
+	rejectInitialSnapshot(): void {
+		this.rejectInitialSnapshotPromise(new Error('initial native managed-settings read failed'));
 	}
 }

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -222,7 +222,7 @@ export class SessionsMain extends Disposable {
 		// Policies
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
-		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings')));
+		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings'), logService));
 		serviceCollection.set(INativeManagedSettingsService, nativeManagedSettings);
 		const fileManagedSettings = this._register(new FileManagedSettingsChannelClient(mainProcessService.getChannel('fileManagedSettings')));
 		serviceCollection.set(IFileManagedSettingsService, fileManagedSettings);

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -69,6 +69,7 @@ import { DelayedLogChannel } from '../services/output/common/delayedLogChannel.j
 import { dirname, joinPath } from '../../base/common/resources.js';
 import { IUserDataProfile, IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
+import { INativeManagedSettingsService, NullNativeManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
 import { IRemoteExplorerService } from '../services/remote/common/remoteExplorerService.js';
 import { DisposableTunnel, TunnelProtocol } from '../../platform/tunnel/common/tunnel.js';
 import { ILabelService } from '../../platform/label/common/label.js';
@@ -367,6 +368,7 @@ export class BrowserMain extends Disposable {
 		serviceCollection.set(IDefaultAccountService, defaultAccountService);
 
 		// Policies
+		serviceCollection.set(INativeManagedSettingsService, new NullNativeManagedSettingsService());
 		const policyService = new AccountPolicyService(logService, defaultAccountService);
 		serviceCollection.set(IPolicyService, policyService);
 		serviceCollection.set(IAccountPolicyGateService, policyService);

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -219,7 +219,7 @@ export class DesktopMain extends Disposable {
 		// Policies
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
-		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings')));
+		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings'), logService));
 		serviceCollection.set(INativeManagedSettingsService, nativeManagedSettings);
 		const fileManagedSettings = this._register(new FileManagedSettingsChannelClient(mainProcessService.getChannel('fileManagedSettings')));
 		serviceCollection.set(IFileManagedSettingsService, fileManagedSettings);

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -262,7 +262,7 @@ type ManagedSettingsFetchTelemetryClassification = {
 	rateLimitBackoffActive: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'True when the request was short-circuited because a prior rate-limit Retry-After window was still active.' };
 };
 
-class DefaultAccountProvider extends Disposable implements IDefaultAccountProvider {
+export class DefaultAccountProvider extends Disposable implements IDefaultAccountProvider {
 
 	private _defaultAccount: IDefaultAccountData | null = null;
 	get defaultAccount(): IDefaultAccount | null { return this._defaultAccount?.defaultAccount ?? null; }
@@ -908,7 +908,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		}
 		this.managedSettingsFetchAttemptedAccounts.add(accountId);
 		const data = await this.requestManagedSettings(sessions);
-		return { data, fetchedAt: Date.now() };
+		return { data: data ?? cachedManagedSettings?.data, fetchedAt: Date.now() };
 	}
 
 	private async requestManagedSettings(sessions: AuthenticationSession[]): Promise<Partial<IPolicyData> | undefined> {

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -25,6 +25,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../platform/in
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { asJson, IRequestService, isClientError, isSuccess, readHeader, retryAfterFromHeaders } from '../../../../platform/request/common/request.js';
+import { INativeManagedSettingsService, shouldForceRemoteSettingsRefresh } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
@@ -293,6 +294,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 	private readonly initPromise: Promise<void>;
 	private readonly updateThrottler = this._register(new ThrottledDelayer(100));
 	private readonly accountDataPollScheduler = this._register(new RunOnceScheduler(() => this.refetchDefaultAccount(), ACCOUNT_DATA_POLL_INTERVAL_MS));
+	private readonly managedSettingsFetchAttemptedAccounts = new Set<string>();
 
 	constructor(
 		private readonly defaultAccountConfig: IDefaultAccountConfig,
@@ -308,6 +310,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		@IStorageService private readonly storageService: IStorageService,
 		@IHostService private readonly hostService: IHostService,
 		@ICommandService private readonly commandService: ICommandService,
+		@INativeManagedSettingsService private readonly nativeManagedSettingsService: INativeManagedSettingsService,
 	) {
 		super();
 		this.accountStatusContext = CONTEXT_DEFAULT_ACCOUNT_STATE.bindTo(contextKeyService);
@@ -871,19 +874,38 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 	}
 
 	private async getManagedSettings(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined, options?: { forceRefresh?: boolean }): Promise<{ data: Partial<IPolicyData> | undefined; fetchedAt: number }> {
-		if (!options?.forceRefresh && accountPolicyData?.managedSettingsFetchedAt && !this.isDataStale(accountPolicyData.managedSettingsFetchedAt)) {
+		const accountId = sessions[0].account.id;
+		const cachedManagedSettings = accountPolicyData?.managedSettingsFetchedAt !== undefined && !this.isDataStale(accountPolicyData.managedSettingsFetchedAt)
+			? {
+				data: {
+					managedSettings: accountPolicyData.policyData.managedSettings,
+				},
+				fetchedAt: accountPolicyData.managedSettingsFetchedAt,
+			}
+			: undefined;
+		let forceRemoteSettingsRefresh = false;
+		if (!options?.forceRefresh && cachedManagedSettings && !this.managedSettingsFetchAttemptedAccounts.has(accountId)) {
+			let nativeManagedSettings = this.nativeManagedSettingsService.managedSettings;
+			try {
+				nativeManagedSettings = await this.nativeManagedSettingsService.initialize();
+			} catch (error) {
+				this.logService.warn('[DefaultAccount] Failed to initialize native managed settings before resolving forceRemoteSettingsRefresh; using available values', getErrorMessage(error));
+			}
+			forceRemoteSettingsRefresh = shouldForceRemoteSettingsRefresh(nativeManagedSettings, accountPolicyData?.policyData.managedSettings);
+		}
+
+		if (!options?.forceRefresh && cachedManagedSettings && !forceRemoteSettingsRefresh) {
 			this.logService.debug('[DefaultAccount] Using last fetched managed settings data');
 			// Seed status so Policy Diagnostics reflects "applied" rather than
 			// "not yet fetched" after a process restart that warm-starts from
 			// the cached policy payload.
 			this._managedSettingsFetchStatus = 'ok';
-			return {
-				data: {
-					managedSettings: accountPolicyData.policyData.managedSettings,
-				},
-				fetchedAt: accountPolicyData.managedSettingsFetchedAt,
-			};
+			return cachedManagedSettings;
 		}
+		if (forceRemoteSettingsRefresh) {
+			this.logService.info('[DefaultAccount] forceRemoteSettingsRefresh is set; fetching fresh managed settings instead of using the cached response');
+		}
+		this.managedSettingsFetchAttemptedAccounts.add(accountId);
 		const data = await this.requestManagedSettings(sessions);
 		return { data, fetchedAt: Date.now() };
 	}

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -890,6 +890,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 				nativeManagedSettings = await this.nativeManagedSettingsService.initialize();
 			} catch (error) {
 				this.logService.warn('[DefaultAccount] Failed to initialize native managed settings before resolving forceRemoteSettingsRefresh; using available values', getErrorMessage(error));
+				nativeManagedSettings = this.nativeManagedSettingsService.managedSettings;
 			}
 			forceRemoteSettingsRefresh = shouldForceRemoteSettingsRefresh(nativeManagedSettings, accountPolicyData?.policyData.managedSettings);
 		}

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -43,6 +43,7 @@ export interface IManagedSettingsResponse {
 	readonly strictPluginOnlyCustomization?: boolean;
 	readonly allowManagedMcpServersOnly?: boolean;
 	readonly allowManagedHooksOnly?: boolean;
+	readonly forceRemoteSettingsRefresh?: boolean;
 	readonly telemetry?: {
 		readonly enabled?: boolean;
 		readonly endpoint?: string;

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IRequestContext } from '../../../../../base/parts/request/common/request.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY, INativeManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { IRequestService } from '../../../../../platform/request/common/request.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AuthenticationSession, IAuthenticationExtensionsService, IAuthenticationService } from '../../../authentication/common/authentication.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+import { IExtensionService } from '../../../extensions/common/extensions.js';
+import { IHostService } from '../../../host/browser/host.js';
+import { DefaultAccountProvider } from '../../browser/defaultAccount.js';
+import { IManagedSettingsResponse } from '../../browser/managedSettings.js';
+
+suite('DefaultAccountProvider managed settings', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const accountId = 'account';
+	const sessions: AuthenticationSession[] = [{
+		id: 'session',
+		accessToken: 'token',
+		account: { id: accountId, label: 'octocat' },
+		scopes: ['user:email'],
+	}];
+
+	test('cached server control forces only the first fetch', async () => {
+		const requestService = new TestRequestService(async () => jsonResponse({
+			forceRemoteSettingsRefresh: true,
+			permissions: { disableBypassPermissionsMode: 'disable' },
+		}));
+		const provider = await createProvider({}, requestService);
+		const cachedPolicy = createCachedPolicy(true);
+
+		const first = await provider['getManagedSettings'](sessions, cachedPolicy);
+		const second = await provider['getManagedSettings'](sessions, cachedPolicy);
+
+		assert.deepStrictEqual({
+			requestCount: requestService.requestCount,
+			first: first.data,
+			second: second.data,
+		}, {
+			requestCount: 1,
+			first: cachedPolicy.policyData,
+			second: cachedPolicy.policyData,
+		});
+	});
+
+	test('native false suppresses cached server true', async () => {
+		const requestService = new TestRequestService(async () => {
+			throw new Error('unexpected request');
+		});
+		const provider = await createProvider({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }, requestService);
+		const cachedPolicy = createCachedPolicy(true);
+
+		const result = await provider['getManagedSettings'](sessions, cachedPolicy);
+
+		assert.deepStrictEqual({
+			requestCount: requestService.requestCount,
+			data: result.data,
+		}, {
+			requestCount: 0,
+			data: cachedPolicy.policyData,
+		});
+	});
+
+	test('failed forced fetch retains cached managed settings', async () => {
+		const requestService = new TestRequestService(async () => {
+			throw new Error('managed settings unavailable');
+		});
+		const provider = await createProvider({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }, requestService);
+		const cachedPolicy = createCachedPolicy(false);
+
+		const result = await provider['getManagedSettings'](sessions, cachedPolicy);
+
+		assert.deepStrictEqual({
+			requestCount: requestService.requestCount,
+			status: provider.managedSettingsFetchStatus,
+			data: result.data,
+		}, {
+			requestCount: 1,
+			status: 'no-response',
+			data: cachedPolicy.policyData,
+		});
+	});
+
+	async function createProvider(nativeManagedSettings: Record<string, boolean>, requestService: TestRequestService): Promise<DefaultAccountProvider> {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IAuthenticationService, {
+			declaredProviders: [],
+			isAuthenticationProviderRegistered: () => true,
+			getAccounts: async () => [],
+			getSessions: async () => [],
+			onDidChangeDeclaredProviders: Event.None,
+			onDidChangeSessions: Event.None,
+			onDidRegisterAuthenticationProvider: Event.None,
+			onDidUnregisterAuthenticationProvider: Event.None,
+		});
+		instantiationService.stub(IAuthenticationExtensionsService, {
+			getAccountPreference: () => undefined,
+			onDidChangeAccountPreference: Event.None,
+		});
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IExtensionService, {});
+		instantiationService.stub(IRequestService, requestService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IWorkbenchEnvironmentService, {
+			remoteAuthority: undefined,
+			isSessionsWindow: false,
+		});
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+		instantiationService.stub(IHostService, {
+			hasFocus: true,
+			onDidChangeFocus: Event.None,
+		});
+		instantiationService.stub(ICommandService, {});
+		instantiationService.stub(INativeManagedSettingsService, {
+			managedSettings: nativeManagedSettings,
+			initialize: async () => nativeManagedSettings,
+			onDidChangeManagedSettings: Event.None,
+		});
+
+		const provider = disposables.add(instantiationService.createInstance(DefaultAccountProvider, {
+			preferredExtensions: [],
+			authenticationProvider: {
+				default: { id: 'github', name: 'GitHub' },
+				enterprise: { id: 'github-enterprise', name: 'GitHub Enterprise' },
+				enterpriseProviderConfig: 'github.copilot.advanced.authProvider',
+				enterpriseProviderUriSetting: 'github-enterprise.uri',
+				scopes: [['user:email']],
+			},
+			tokenEntitlementUrl: '',
+			entitlementUrl: '',
+			mcpRegistryDataUrl: '',
+			managedSettingsUrl: 'https://api.github.com/copilot_internal/managed_settings',
+		}));
+		await provider.refresh();
+		return provider;
+	}
+
+	function createCachedPolicy(forceRemoteSettingsRefresh: boolean) {
+		return {
+			accountId,
+			policyData: {
+				managedSettings: {
+					[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: forceRemoteSettingsRefresh,
+					'permissions.disableBypassPermissionsMode': 'disable',
+				},
+			},
+			managedSettingsFetchedAt: Date.now(),
+		};
+	}
+});
+
+class TestRequestService implements IRequestService {
+	readonly _serviceBrand: undefined;
+	readonly onDidCompleteRequest = Event.None;
+	requestCount = 0;
+
+	constructor(private readonly requestHandler: () => Promise<IRequestContext>) { }
+
+	request(): Promise<IRequestContext> {
+		this.requestCount++;
+		return this.requestHandler();
+	}
+
+	async resolveProxy(): Promise<string | undefined> {
+		return undefined;
+	}
+
+	async lookupAuthorization(): Promise<undefined> {
+		return undefined;
+	}
+
+	async lookupKerberosAuthorization(): Promise<undefined> {
+		return undefined;
+	}
+
+	async loadCertificates(): Promise<string[]> {
+		return [];
+	}
+}
+
+function jsonResponse(data: IManagedSettingsResponse): IRequestContext {
+	return {
+		res: { statusCode: 200, headers: {} },
+		stream: bufferToStream(VSBuffer.fromString(JSON.stringify(data))),
+	};
+}

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -95,11 +95,13 @@ suite('adaptManagedSettings', () => {
 			strictPluginOnlyCustomization: true,
 			allowManagedMcpServersOnly: true,
 			allowManagedHooksOnly: true,
+			forceRemoteSettingsRefresh: true,
 		}), {
 			managedSettings: {
 				strictPluginOnlyCustomization: true,
 				allowManagedMcpServersOnly: true,
 				allowManagedHooksOnly: true,
+				forceRemoteSettingsRefresh: true,
 			},
 		});
 	});

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -476,6 +476,10 @@ suite('AccountPolicyService', () => {
 
 		constructor(public managedSettings: ManagedSettingsData = {}) { }
 
+		async initialize(): Promise<ManagedSettingsData> {
+			return this.managedSettings;
+		}
+
 		async updatePolicyDefinitions(policyDefinitions: Record<string, PolicyDefinition>): Promise<ManagedSettingsData> {
 			this.registeredManagedSettings = {};
 			for (const policyName in policyDefinitions) {


### PR DESCRIPTION
GitHub Copilot's managed-settings endpoint can require clients to bypass a fresh cached response with `forceRemoteSettingsRefresh`. VS Code previously projected only policy-backed keys and could serve its cache before native MDM initialization completed, so it could not honor this transport-level control.

This change:

- Registers `forceRemoteSettingsRefresh` as a transport-only managed setting without exporting a VS Code configuration policy.
- Resolves native MDM before the cache decision, with native values taking precedence over cached server values and an explicit native `false` disabling the control.
- Performs at most one forced fetch attempt per account and process, while preserving the merged runtime's fail-open behavior: a failed fetch retains cached policy data, and a failure without cache continues without remote managed settings.
- Makes native managed-settings IPC initialization race-safe and retryable after transient failures, with a null implementation for web environments.
- Adds unit coverage for normalization, precedence, native watching, IPC startup and retry behavior, and account refresh decisions. Contributor guidance now documents this transport-control exception.

## Testing

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/platform/policy/test/common/copilotManagedSettings.test.ts --run src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts --run src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts --run src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts`

Related to github/copilot-agent-runtime#14012 and github/copilot-agent-runtime#14218.