### PR TITLE
editor: Raise language configuration listener threshold

### DIFF
--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -61,7 +61,10 @@ export class LanguageConfigurationService extends Disposable implements ILanguag
 
 	private readonly _registry = this._register(new LanguageConfigurationRegistry());
 
-	private readonly onDidChangeEmitter = this._register(new Emitter<LanguageConfigurationServiceChangeEvent>({ leakWarningThreshold: 500, leakWarningName: 'LanguageConfigurationService.onDidChange' /* increased for multi-diff editors with hundreds of text models */ }));
+	private readonly onDidChangeEmitter = this._register(new Emitter<LanguageConfigurationServiceChangeEvent>({
+		leakWarningThreshold: 500,
+		leakWarningName: 'LanguageConfigurationService.onDidChange' /* increased for multi-diff editors with hundreds of text models */
+	}));
 	public readonly onDidChange = this.onDidChangeEmitter.event;
 
 	private readonly configurations = new Map<string, ResolvedLanguageConfiguration>();

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -61,7 +61,7 @@ export class LanguageConfigurationService extends Disposable implements ILanguag
 
 	private readonly _registry = this._register(new LanguageConfigurationRegistry());
 
-	private readonly onDidChangeEmitter = this._register(new Emitter<LanguageConfigurationServiceChangeEvent>());
+	private readonly onDidChangeEmitter = this._register(new Emitter<LanguageConfigurationServiceChangeEvent>({ leakWarningThreshold: 500, leakWarningName: 'LanguageConfigurationService.onDidChange' /* increased for multi-diff editors with hundreds of text models */ }));
 	public readonly onDidChange = this.onDidChangeEmitter.event;
 
 	private readonly configurations = new Map<string, ResolvedLanguageConfiguration>();


### PR DESCRIPTION
cc @hediet

Large multi-diff editors legitimately create hundreds of text models. Each text model listens for language configuration changes, causing the global 175-listener threshold to report false-positive leak warnings.

This raises the threshold for the language configuration service emitter to 500 and gives the emitter a diagnostic name. Leak detection remains active for unexpectedly high listener counts.

Validation:
- Targeted ESLint
- Pre-commit hygiene
- `git diff --check`

(Written by Copilot)