### PR TITLE
Gate Dictation on Copilot entitlement

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -35,6 +35,7 @@ import { ChatMessageRole, ILanguageModelsService } from '../../common/languageMo
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 import { createPcmCaptureNode } from '../pcmCaptureWorklet.js';
 import { resolveDictationLanguage } from './dictationLanguage.js';
+import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../../services/chat/common/chatEntitlementService.js';
 
 export const IChatSpeechToTextService = createDecorator<IChatSpeechToTextService>('chatSpeechToTextService');
 
@@ -131,6 +132,10 @@ const LLM_CLEANUP_MODEL_SELECTOR = { vendor: 'copilot', id: 'copilot-utility-sma
  * - `mai`: the cloud voice service used by Voice Mode, via {@link IVoiceClientService}.
  */
 type DictationBackend = 'nemo' | 'mai';
+
+export function isDictationEntitled(entitlement: ChatEntitlement, isInternal: boolean, usesMai: boolean): boolean {
+	return isProUser(entitlement) && (!usesMai || entitlement !== ChatEntitlement.Enterprise || isInternal);
+}
 
 /** How long to wait for the voice websocket to connect before failing an MAI session. */
 const MAI_CONNECT_TIMEOUT_MS = 8000;
@@ -273,8 +278,8 @@ export interface IChatSpeechToTextService {
 	switchMicrophone(window: Window & typeof globalThis, deviceId: string): Promise<AnalyserNode | undefined>;
 
 	/**
-	 * Whether on-device speech-to-text is available on this platform. Callers
-	 * gate the dictation UI on this.
+	 * Whether speech-to-text is available for the current Copilot entitlement,
+	 * selected backend, and platform. Callers gate the dictation UI on this.
 	 */
 	readonly isConfigured: boolean;
 
@@ -424,7 +429,11 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		if (this._configurationService.getValue<boolean>(ENABLED_SETTING) === false) {
 			return false;
 		}
-		if (this._getBackend() === 'mai') {
+		const backend = this._getBackend();
+		if (!isDictationEntitled(this._chatEntitlementService.entitlement, this._chatEntitlementService.isInternal, backend === 'mai')) {
+			return false;
+		}
+		if (backend === 'mai') {
 			// The cloud backend needs a configured voice websocket endpoint;
 			// GitHub sign-in and connectivity are validated when a session starts.
 			return !!this._voiceWsUrl();
@@ -489,6 +498,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IPromptsService private readonly _promptsService: IPromptsService,
+		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 		this._recordingContextKey = ChatContextKeys.speechToTextRecording.bindTo(contextKeyService);
@@ -498,6 +508,12 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ENABLED_SETTING) || e.affectsConfiguration(DICTATION_MODEL_SETTING)) {
 				this._updateConfiguredContextKey();
+			}
+		}));
+		this._register(this._chatEntitlementService.onDidChangeEntitlement(() => {
+			this._updateConfiguredContextKey();
+			if (!this.isConfigured && this._state !== ChatSpeechToTextState.Idle) {
+				this.cancel();
 			}
 		}));
 	}
@@ -638,6 +654,13 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 
 		const backend = this._getBackend();
 		this._activeBackend = backend;
+
+		if (!isDictationEntitled(this._chatEntitlementService.entitlement, this._chatEntitlementService.isInternal, backend === 'mai')) {
+			this._notificationService.warn(backend === 'mai' && this._chatEntitlementService.entitlement === ChatEntitlement.Enterprise
+				? localize('chatStt.maiEnterpriseUnavailable', "Cloud speech-to-text is not available for GitHub Copilot Enterprise accounts.")
+				: localize('chatStt.requiresPaidPlan', "Dictation requires a paid GitHub Copilot plan."));
+			return;
+		}
 
 		if (backend === 'nemo' && !this._localTranscription.isSupported) {
 			this._notificationService.notify({

--- a/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService.ts
@@ -394,6 +394,9 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	get state(): ChatSpeechToTextState {
 		return this._state;
 	}
+	private _entitlementCheckScheduled = false;
+	private _startGeneration = 0;
+	private _startInProgress: number | undefined;
 
 	private readonly _recordingContextKey: IContextKey<boolean>;
 	private readonly _configuredContextKey: IContextKey<boolean>;
@@ -430,7 +433,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			return false;
 		}
 		const backend = this._getBackend();
-		if (!isDictationEntitled(this._chatEntitlementService.entitlement, this._chatEntitlementService.isInternal, backend === 'mai')) {
+		if (!this._isEntitledForBackend(backend)) {
 			return false;
 		}
 		if (backend === 'mai') {
@@ -511,16 +514,32 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			}
 		}));
 		this._register(this._chatEntitlementService.onDidChangeEntitlement(() => {
-			this._updateConfiguredContextKey();
-			if (!this.isConfigured && this._state !== ChatSpeechToTextState.Idle) {
-				this.cancel();
+			if (this._entitlementCheckScheduled) {
+				return;
 			}
+			this._entitlementCheckScheduled = true;
+			queueMicrotask(() => {
+				this._entitlementCheckScheduled = false;
+				if (this._store.isDisposed) {
+					return;
+				}
+				this._updateConfiguredContextKey();
+				const hasActiveOrStartingSession = this._state !== ChatSpeechToTextState.Idle || this._startInProgress !== undefined;
+				const backend = hasActiveOrStartingSession ? this._activeBackend : this._getBackend();
+				if (hasActiveOrStartingSession && !this._isEntitledForBackend(backend)) {
+					this.cancel();
+				}
+			});
 		}));
 	}
 
 	/** Read the configured dictation backend, derived from the selected model. */
 	private _getBackend(): DictationBackend {
 		return this._configurationService.getValue<string>(DICTATION_MODEL_SETTING) === DICTATION_MAI_MODEL_ID ? 'mai' : 'nemo';
+	}
+
+	private _isEntitledForBackend(backend: DictationBackend): boolean {
+		return isDictationEntitled(this._chatEntitlementService.entitlement, this._chatEntitlementService.isInternal, backend === 'mai');
 	}
 
 	get currentBackend(): string {
@@ -644,7 +663,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 	}
 
 	async start(window: Window & typeof globalThis, surface: ChatDictationSurface = 'chat'): Promise<void> {
-		if (this._state !== ChatSpeechToTextState.Idle) {
+		if (this._state !== ChatSpeechToTextState.Idle || this._startInProgress !== undefined) {
 			return;
 		}
 
@@ -655,7 +674,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		const backend = this._getBackend();
 		this._activeBackend = backend;
 
-		if (!isDictationEntitled(this._chatEntitlementService.entitlement, this._chatEntitlementService.isInternal, backend === 'mai')) {
+		if (!this._isEntitledForBackend(backend)) {
 			this._notificationService.warn(backend === 'mai' && this._chatEntitlementService.entitlement === ChatEntitlement.Enterprise
 				? localize('chatStt.maiEnterpriseUnavailable', "Cloud speech-to-text is not available for GitHub Copilot Enterprise accounts.")
 				: localize('chatStt.requiresPaidPlan', "Dictation requires a paid GitHub Copilot plan."));
@@ -677,6 +696,18 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			return;
 		}
 
+		const startGeneration = ++this._startGeneration;
+		this._startInProgress = startGeneration;
+		try {
+			await this._startEntitled(window, surface, backend, startGeneration);
+		} finally {
+			if (this._startInProgress === startGeneration) {
+				this._startInProgress = undefined;
+			}
+		}
+	}
+
+	private async _startEntitled(window: Window & typeof globalThis, surface: ChatDictationSurface, backend: DictationBackend, startGeneration: number): Promise<void> {
 		this._sessionStartMs = Date.now();
 		this._sessionSegments = 0;
 		this._sessionPartialUpdates = 0;
@@ -696,11 +727,18 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		try {
 			stream = await this._acquireStream(window);
 		} catch (err) {
+			if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+				return;
+			}
 			this._sessionErrorCode = this._sessionErrorCode || 'microphone';
 			this._logSessionTelemetry('error');
 			this._logService.error('[chat-stt] microphone acquisition failed', err);
 			this._notificationService.error(localize('chatStt.micError', "Could not access the microphone for speech-to-text: {0}", toErrorMessage(err)));
 			throw err;
+		}
+		if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+			stream.getTracks().forEach(track => track.stop());
+			return;
 		}
 
 		this._mediaStream = stream;
@@ -709,11 +747,19 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			await this._startBackendSession(window);
 		} catch (err) {
 			this._teardown();
+			if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+				return;
+			}
 			this._sessionErrorCode = this._sessionErrorCode || 'connect';
 			this._logSessionTelemetry('error');
 			this._logService.error('[chat-stt] failed to start transcription', err);
 			this._notificationService.error(localize('chatStt.connectError', "Could not start speech-to-text: {0}", toErrorMessage(err)));
 			throw err;
+		}
+		if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+			this._cancelBackend();
+			this._teardown();
+			return;
 		}
 
 		try {
@@ -724,11 +770,19 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 			// down instead of leaking an active recording in the Idle state.
 			this._cancelBackend();
 			this._teardown();
+			if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+				return;
+			}
 			this._sessionErrorCode = this._sessionErrorCode || 'capture';
 			this._logSessionTelemetry('error');
 			this._logService.error('[chat-stt] failed to start audio capture', err);
 			this._notificationService.error(localize('chatStt.captureError', "Could not start audio capture for speech-to-text: {0}", toErrorMessage(err)));
 			throw err;
+		}
+		if (!this._isCurrentEntitledStart(startGeneration, backend)) {
+			this._cancelBackend();
+			this._teardown();
+			return;
 		}
 		this._setState(ChatSpeechToTextState.Recording);
 		// Only cue "recording started" once we are actually listening. If the
@@ -738,6 +792,10 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 		if (!this._isPreparingModel) {
 			this._accessibilitySignalService.playSignal(AccessibilitySignal.voiceRecordingStarted);
 		}
+	}
+
+	private _isCurrentEntitledStart(startGeneration: number, backend: DictationBackend): boolean {
+		return startGeneration === this._startGeneration && this._isEntitledForBackend(backend);
 	}
 
 	/** Start the transcription session for the active backend. */
@@ -1342,6 +1400,7 @@ export class ChatSpeechToTextService extends Disposable implements IChatSpeechTo
 
 	cancel(): void {
 		const wasRecording = this._state === ChatSpeechToTextState.Recording;
+		this._startGeneration++;
 		this._cleanupCts.value?.cancel();
 		this._logSessionTelemetry('cancelled');
 		this._cancelBackend();

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputMode.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputMode.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Event } from '../../../../../base/common/event.js';
 import { IObservable, ISettableObservable, autorun, observableFromEvent, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -147,7 +148,7 @@ export class VoiceInputModeService extends Disposable implements IVoiceInputMode
 		// `chat.speechToText.enabled` kill-switch, so the segment only appears
 		// where clicking it can actually dictate.
 		this.dictationAvailable = observableFromEvent(this,
-			configurationService.onDidChangeConfiguration,
+			Event.any(configurationService.onDidChangeConfiguration, contextKeyService.onDidChangeContext),
 			() => chatSpeechToTextService.isConfigured
 				&& configurationService.getValue<boolean>(DictationSettingId.ShowButton) !== false);
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSpeechToTextService.test.ts
@@ -5,12 +5,31 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { createDictationCleanupSystemPrompt, stripDictationFillers } from '../../browser/speechToText/chatSpeechToTextService.js';
+import { createDictationCleanupSystemPrompt, isDictationEntitled, stripDictationFillers } from '../../browser/speechToText/chatSpeechToTextService.js';
 import { resolveDictationLanguage } from '../../browser/speechToText/dictationLanguage.js';
+import { ChatEntitlement } from '../../../../services/chat/common/chatEntitlementService.js';
 
 suite('ChatSpeechToTextService', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('requires a paid plan and restricts MAI for external Enterprise users', () => {
+		assert.deepStrictEqual({
+			freeLocal: isDictationEntitled(ChatEntitlement.Free, false, false),
+			proLocal: isDictationEntitled(ChatEntitlement.Pro, false, false),
+			proMai: isDictationEntitled(ChatEntitlement.Pro, false, true),
+			enterpriseLocal: isDictationEntitled(ChatEntitlement.Enterprise, false, false),
+			enterpriseMai: isDictationEntitled(ChatEntitlement.Enterprise, false, true),
+			internalEnterpriseMai: isDictationEntitled(ChatEntitlement.Enterprise, true, true),
+		}, {
+			freeLocal: false,
+			proLocal: true,
+			proMai: true,
+			enterpriseLocal: true,
+			enterpriseMai: false,
+			internalEnterpriseMai: true,
+		});
+	});
 
 	test('resolves the dictation language from Voice Mode configuration, display language, and browser locale', () => {
 		assert.deepStrictEqual({


### PR DESCRIPTION
## Summary

- expose built-in Dictation only for paid Copilot plans
- keep local Dictation available for eligible Enterprise users, but disable the MAI backend for external Enterprise accounts
- preserve MAI access for internal Enterprise users through the existing internal-organization entitlement signal
- reject direct ineligible starts, cancel active sessions when entitlement is lost, and refresh the segmented input control when entitlement changes

This is client-side product gating only; MAI must continue to authenticate requests and enforce entitlement server-side.

## Testing

- `npm run transpile-client`
- ESLint on changed files
- Dictation, speech-to-text action, Voice input mode, and Dictation session unit tests (19 passing)