### PR TITLE
Fix repeated task errors in Agents window

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -310,12 +310,16 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		this._providerTypes = new Map<number, string>();
 		this._taskSystemInfos = new Map<string, ITaskSystemInfo[]>();
 		this._register(this._contextService.onDidChangeWorkspaceFolders(() => {
+			const taskServiceInitialized = !!this._taskSystem || !!this._workspaceTasksPromise;
 			const folderSetup = this._computeWorkspaceFolderSetup();
 			if (this.executionEngine !== folderSetup[2]) {
 				this._disposeTaskSystemListeners();
 				this._taskSystem = undefined;
 			}
 			this._updateSetup(folderSetup);
+			if (!taskServiceInitialized) {
+				return;
+			}
 			return this._updateWorkspaceTasks(TaskRunSource.FolderOpen);
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(async (e) => {


### PR DESCRIPTION
Fixes #329094

Avoid eagerly reloading workspace tasks on Agents-window workspace-folder changes before the task service has been initialized. This prevents unavailable task-provider diagnostics from being emitted repeatedly while preserving refresh behavior after tasks are used.

Validation:
- Targeted ESLint passed
- Layer checker passed
- `git diff --check` passed
- Full typecheck was blocked by unrelated baseline SDK type mismatches in the available local dependency installation