### PR TITLE
agentHost: Classify SDK todo state telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -83,6 +83,27 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 	}
 */
 
+/* __GDPR__
+	"copilotCli/task_complete_todo_state": {
+		"owner": "amunger",
+		"comment": "Reports the aggregate state of the Copilot CLI todo list when task completion is recorded. Contains only todo-status counts and derived boolean indicators; it does not contain todo text or other user content.",
+		"${include}": [ "${CopilotCliForwardedTelemetry}" ],
+		"copilot_pid": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Process identifier for the Copilot CLI runtime." },
+		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
+		"engagement_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an engagement." },
+		"surface": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Telemetry-safe product surface that recorded task completion." },
+		"billable": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the interaction is billable." },
+		"had_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the Copilot CLI todo list contained at least one item when task completion was recorded." },
+		"has_open_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the Copilot CLI todo list contained at least one pending, in-progress, or blocked item when task completion was recorded." },
+		"pending_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of todo items in the pending state when task completion was recorded.", "isMeasurement": true },
+		"in_progress_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of todo items in the in-progress state when task completion was recorded.", "isMeasurement": true },
+		"blocked_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of todo items in the blocked state when task completion was recorded.", "isMeasurement": true },
+		"done_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of todo items in the done state when task completion was recorded.", "isMeasurement": true },
+		"open_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of todo items not yet done, comprising pending, in-progress, and blocked items, when task completion was recorded.", "isMeasurement": true },
+		"total_todos": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Total number of todo items when task completion was recorded.", "isMeasurement": true }
+	}
+*/
+
 /**
  * Re-emits GitHub-shaped telemetry events forwarded by the Copilot CLI runtime
  * (via the SDK's `onGitHubTelemetry` connection-global callback) through VS


### PR DESCRIPTION
## Overview

### What

Adds GDPR classification for the existing forwarded Copilot SDK `task_complete_todo_state` event. The event records aggregate todo status at task completion, including pending, in-progress, blocked, done, open, and total counts plus derived state indicators. No todo text or other user content is emitted, and the forwarding behavior and VS Code `todoListToolInvoked` emitter remain unchanged.

This event provides final-state coverage only. It does not include per-operation read/write activity or intermediate todo-list evolution. PR #328267 separately tracks successful Agent Host todo-store operations and complements rather than duplicates this event.

### Why

migrating agent telemetry to agent host usage as Tracked in microsoft/vscode-internalbacklog#8247.

---

## Data parity

Legend: SAME = same analytical signal, CLOSE = close analogue, GAP = Agent Host data omits.

| Analytical signal | Local event / source | SDK event / source or derivation | Parity |
|---|---|---|---|
| Todo list was used | `todoListToolInvoked` row exists | `had_todos` | CLOSE: Recorded at task completion rather than each list operation |
| Not-started items | `notStartedCount` | `pending_todos + blocked_todos` | CLOSE: SDK distinguishes blocked items |
| In-progress items | `inProgressCount` | `in_progress_todos` | SAME |
| Completed items | `completedCount` | `done_todos` | SAME |
| Read/write operation | `operation` | Not emitted | GAP: Covered separately for SQL store access by PR #328267 |
| Intermediate list evolution | One row per successful read/write | Final snapshot only | GAP |

---

## Row-count and dashboard implications

- **Historical local rows:** `todoListToolInvoked` emits once per successful `manage_todo_list` read or write.
- **SDK rows:** `copilotCli/task_complete_todo_state` emits approximately once per completed interaction for Copilot CLI sessions.
- **Query translation:** Union the event kinds and normalize local counts to the SDK status fields; do not compare their row counts as equivalent operation counts.
- **Data coverage:** Final status distributions are available, while per-operation adoption and intermediate state transitions require `todoListToolInvoked` or the complementary `todoStoreOperation` signal from PR #328267.

## Semantic-shift ledger

| Field | Shift | Impact |
|---|---|---|
| Event cadence | Per todo operation to final interaction snapshot | Cannot measure read/write frequency or intermediate transitions from the SDK event |
| `notStartedCount` | SDK splits pending and blocked states | Normalize by summing `pending_todos` and `blocked_todos` for historical comparison |
| `operation` | No SDK equivalent | Operation-level analysis must use another event |