### PR TITLE
Harden Claude subagent transcript replay E2E

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -27,7 +27,7 @@ import { TerminalClaimKind } from '../../../../common/state/protocol/channels-te
 import {
 	ActionType,
 	type ChatInputRequestedAction, type ChatToolCallReadyAction,
-	type ChatToolCallCompleteAction, type ChatToolCallStartAction,
+	type ChatErrorAction, type ChatToolCallCompleteAction, type ChatToolCallStartAction,
 } from '../../../../common/state/sessionActions.js';
 import { CopilotCliConfigKey } from '../../../../common/copilotCliConfig.js';
 import { AgentHostSessionReleaseGraceMsEnvVar } from '../../../../common/agentService.js';
@@ -517,7 +517,8 @@ async function driveTurn(c: TestProtocolClient, session: string, turnId: string,
 		seenNotifications.add(notification as object);
 
 		if (isActionNotification(notification, 'chat/error')) {
-			throw new Error(`Session error while driving ${turnId}`);
+			const action = getActionEnvelope(notification).action as ChatErrorAction;
+			throw new Error(`Session error while driving ${turnId}: ${action.error.errorType}: ${action.error.message}`);
 		}
 
 		if (isActionNotification(notification, 'chat/toolCallReady')) {

--- a/src/vs/platform/agentHost/test/node/e2e/suites/subagentSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/subagentSuite.ts
@@ -229,7 +229,13 @@ export function defineSubagentTests(context: IAgentHostE2ETestContext): void {
 
 		const unsubscribeSessionTree = () => {
 			// The parent-session unsubscribe is sent last so it triggers eviction.
-			for (const channel of [subagentChatUri, buildDefaultChatUri(sessionUri), sessionUri]) {
+			for (const channel of [
+				subagentChatUri,
+				buildDefaultChatUri(replaySubagentSessionUri),
+				replaySubagentSessionUri,
+				buildDefaultChatUri(sessionUri),
+				sessionUri,
+			]) {
 				context.client.notify('unsubscribe', { channel });
 			}
 		};

--- a/src/vs/platform/agentHost/test/node/e2e/suites/subagentSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/subagentSuite.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { mkdtempSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
+import { retry } from '../../../../../../base/common/async.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { SubscribeResult } from '../../../../common/state/protocol/commands.js';
 import { ActionType, type ChatToolCallStartAction } from '../../../../common/state/sessionActions.js';
@@ -223,31 +224,38 @@ export function defineSubagentTests(context: IAgentHostE2ETestContext): void {
 		approvalsActive = false;
 		await approvalLoop;
 
+		const assistantText = (turns: ISessionWithDefaultChat['turns']): string =>
+			turns.map(t => t.responseParts.map(p => p.kind === ResponsePartKind.Markdown ? p.content : '').join('')).join('\n');
+
+		const unsubscribeSessionTree = () => {
+			// The parent-session unsubscribe is sent last so it triggers eviction.
+			for (const channel of [subagentChatUri, buildDefaultChatUri(sessionUri), sessionUri]) {
+				context.client.notify('unsubscribe', { channel });
+			}
+		};
+
 		// Force a reopen: drop the subagent chat and parent-session
 		// subscriptions so the agent host evicts the cached, live-built state,
 		// then re-fetch — which rebuilds the turns from the persisted SDK event
 		// log through `mapSessionEvents` (the path the regression lived in).
-		// The parent-session unsubscribe is sent last so it triggers eviction.
-		for (const channel of [subagentChatUri, buildDefaultChatUri(sessionUri), sessionUri]) {
-			context.client.notify('unsubscribe', { channel });
-		}
+		unsubscribeSessionTree();
 
-		const reopenedParent = await fetchSessionWithChat(context.client, sessionUri);
-		// Persisted SDK replay still restores subagents through their derived
-		// session resource, while the live path exposes the dedicated chat
-		// resource above.
-		const reopenedSubagent = await fetchSessionWithChat(context.client, replaySubagentSessionUri);
-
-		const assistantText = (turns: ISessionWithDefaultChat['turns']): string =>
-			turns.map(t => t.responseParts.map(p => p.kind === ResponsePartKind.Markdown ? p.content : '').join('')).join('\n');
-
-		const subagentText = assistantText(reopenedSubagent.turns);
+		const reopenedParent = await retry(async () => {
+			const reopenedParent = await fetchSessionWithChat(context.client, sessionUri);
+			// Persisted SDK replay still restores subagents through their derived
+			// session resource, while the live path exposes the dedicated chat
+			// resource above.
+			const reopenedSubagent = await fetchSessionWithChat(context.client, replaySubagentSessionUri);
+			const subagentText = assistantText(reopenedSubagent.turns);
+			const hasSentinel = subagentText.includes(sentinel);
+			if (!hasSentinel) {
+				unsubscribeSessionTree();
+			}
+			assert.ok(hasSentinel,
+				`sub-agent transcript should contain the phrase after reopen; got: ${JSON.stringify(subagentText).slice(0, 500)}`);
+			return reopenedParent;
+		}, 50, 20);
 		const parentText = assistantText(reopenedParent.turns);
-
-		// Precondition: the sub-agent emitted the phrase and it is routed to the
-		// sub-agent transcript on the replay path.
-		assert.ok(subagentText.includes(sentinel),
-			`sub-agent transcript should contain the phrase after reopen; got: ${JSON.stringify(subagentText).slice(0, 500)}`);
 
 		// The regression: the sub-agent's assistant.message must NOT leak into
 		// the parent transcript when the session is reopened.


### PR DESCRIPTION
## Summary

- retry the forced idle-session eviction and restore cycle until Claude's persisted subagent transcript is available
- keep the parent-transcript leak assertion strict after restoration
- include provider error type and message when an Agent Host E2E turn fails

This addresses the recurring `sub-agent transcript should contain the phrase after reopen; got: ""` failure observed across 16 unrelated PR runs and the main build [461716](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=461716). The E2E harness sets the idle-session release grace to zero, so slower CI filesystems could reopen before the Claude SDK history was readable.

## Validation

- focused Claude replay-path test: 10 consecutive passes
- full Claude Agent Host E2E suite: 62 passing
- fresh source transpile and final focused replay run

(Written by Copilot)