### PR TITLE
agentHost: Expand Copilot failure telemetry

### DIFF
--- a/src/vs/platform/agentHost/common/agentTelemetryCorrelation.ts
+++ b/src/vs/platform/agentHost/common/agentTelemetryCorrelation.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { hash } from '../../../base/common/hash.js';
+import type { URI } from '../../../base/common/uri.js';
+import { DEFAULT_CHAT_ID, parseChatUri } from './state/sessionState.js';
+
+export function getTelemetryChatSessionId(chat: string | URI): string {
+	return String(hash(parseChatUri(chat)?.chatId ?? DEFAULT_CHAT_ID));
+}

--- a/src/vs/platform/agentHost/common/meta/agentErrorMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentErrorMeta.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ErrorInfo } from '../state/protocol/common/state.js';
+
+export interface IAgentErrorTelemetryMeta {
+	readonly providerCallId?: string;
+	readonly serviceRequestId?: string;
+}
+
+export function readAgentErrorTelemetryMeta(error: ErrorInfo): IAgentErrorTelemetryMeta {
+	const meta = error._meta;
+	if (!meta) {
+		return {};
+	}
+	const chatError = meta['chatError'];
+	const fetchError = chatError && typeof chatError === 'object' ? (chatError as { fetchError?: unknown }).fetchError : undefined;
+	const providerCallId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { requestId?: unknown }).requestId === 'string'
+		? (fetchError as { requestId: string }).requestId
+		: undefined;
+	const serviceRequestId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { serverRequestId?: unknown }).serverRequestId === 'string'
+		? (fetchError as { serverRequestId: string }).serverRequestId
+		: undefined;
+	return { providerCallId, serviceRequestId };
+}

--- a/src/vs/platform/agentHost/common/meta/agentErrorMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentErrorMeta.ts
@@ -17,10 +17,10 @@ export function readAgentErrorTelemetryMeta(error: ErrorInfo): IAgentErrorTeleme
 	}
 	const chatError = meta['chatError'];
 	const fetchError = chatError && typeof chatError === 'object' ? (chatError as { fetchError?: unknown }).fetchError : undefined;
-	const providerCallId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { requestId?: unknown }).requestId === 'string'
+	const providerCallId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { requestId?: unknown }).requestId === 'string' && (fetchError as { requestId: string }).requestId.length > 0
 		? (fetchError as { requestId: string }).requestId
 		: undefined;
-	const serviceRequestId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { serverRequestId?: unknown }).serverRequestId === 'string'
+	const serviceRequestId = fetchError && typeof fetchError === 'object' && typeof (fetchError as { serverRequestId?: unknown }).serverRequestId === 'string' && (fetchError as { serverRequestId: string }).serverRequestId.length > 0
 		? (fetchError as { serverRequestId: string }).serverRequestId
 		: undefined;
 	return { providerCallId, serviceRequestId };

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -9,9 +9,10 @@ import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js'
 import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
 import type { SessionMode } from '../common/agentHostSchema.js';
+import { getTelemetryChatSessionId } from '../common/agentTelemetryCorrelation.js';
 import { readAgentErrorTelemetryMeta } from '../common/meta/agentErrorMeta.js';
 import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
-import { DEFAULT_CHAT_ID, isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseChatUri, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
+import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry, type IAgentHostRestrictedTelemetryContext } from './agentHostRestrictedTelemetry.js';
 import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
@@ -787,7 +788,7 @@ export class AgentHostTelemetryReporter {
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
-		const chatSessionId = parseChatUri(report.session)?.chatId ?? DEFAULT_CHAT_ID;
+		const chatSessionId = getTelemetryChatSessionId(report.session);
 		const model = toTelemetryModel(report.model, report.modelTelemetryKind);
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -9,8 +9,9 @@ import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js'
 import { hash } from '../../../base/common/hash.js';
 import { AgentSession } from '../common/agentService.js';
 import type { SessionMode } from '../common/agentHostSchema.js';
+import { readAgentErrorTelemetryMeta } from '../common/meta/agentErrorMeta.js';
 import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
-import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
+import { DEFAULT_CHAT_ID, isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseChatUri, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry, type IAgentHostRestrictedTelemetryContext } from './agentHostRestrictedTelemetry.js';
 import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
@@ -73,6 +74,7 @@ export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'mod
 export interface IAgentHostTurnCompletedEvent {
 	provider: string;
 	agentSessionId: string;
+	chatSessionId: string;
 	turnId: string;
 	timeToFirstProgress: number | undefined;
 	totalTime: number;
@@ -87,6 +89,7 @@ export interface IAgentHostTurnCompletedEvent {
 export type IAgentHostTurnCompletedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat identifier within the agent host session.' };
 	turnId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the turn within the agent host session.' };
 	timeToFirstProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from turn start to the first visible progress (text delta, response part, tool call start, or reasoning).' };
 	totalTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time in milliseconds from turn start to turn completion.' };
@@ -103,11 +106,14 @@ export type IAgentHostTurnCompletedClassification = {
 export interface IAgentHostTurnFailedEvent {
 	provider: string;
 	agentSessionId: string;
+	chatSessionId: string;
 	turnId: string;
 	failureStage: AgentHostTurnFailureStage;
 	errorType: string;
 	errorName: string | undefined;
 	errorCode: string | undefined;
+	providerCallId: string | undefined;
+	serviceRequestId: string | undefined;
 	msg: string;
 	callstack: string | undefined;
 }
@@ -115,11 +121,14 @@ export interface IAgentHostTurnFailedEvent {
 export type IAgentHostTurnFailedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the failed agent host turn.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
 	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the failed turn within the agent host session.' };
 	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded stage at which the agent host turn failed.' };
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type.' };
 	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the exception, when available.' };
 	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The exception or protocol error code, when available.' };
+	providerCallId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The GitHub provider request identifier, when available.' };
+	serviceRequestId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot service request identifier, when available.' };
 	msg: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
 	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
 	owner: 'roblourens';
@@ -778,10 +787,12 @@ export class AgentHostTelemetryReporter {
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		const chatSessionId = parseChatUri(report.session)?.chatId ?? DEFAULT_CHAT_ID;
 		const model = toTelemetryModel(report.model, report.modelTelemetryKind);
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,
 			agentSessionId: AgentSession.id(session),
+			chatSessionId,
 			turnId: report.turnId,
 			timeToFirstProgress: report.timeToFirstProgress,
 			totalTime: report.totalTime,
@@ -793,14 +804,18 @@ export class AgentHostTelemetryReporter {
 			failureStage: report.failure?.stage,
 		});
 		if (report.failure) {
+			const { providerCallId, serviceRequestId } = readAgentErrorTelemetryMeta(report.failure.error);
 			this._telemetryService.publicLogError2<IAgentHostTurnFailedEvent, IAgentHostTurnFailedClassification>('agentHost.turnFailed', {
 				provider: report.provider,
 				agentSessionId: AgentSession.id(session),
+				chatSessionId,
 				turnId: report.turnId,
 				failureStage: report.failure.stage,
 				errorType: report.failure.error.errorType,
 				errorName: report.failure.errorName,
 				errorCode: report.failure.errorCode,
+				providerCallId,
+				serviceRequestId,
 				msg: report.failure.error.message,
 				callstack: report.failure.errorStack ?? report.failure.error.stack,
 			});

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -21,6 +21,7 @@ import { delimiter, dirname, join } from '../../../../base/common/path.js';
 import { basename as resourceBasename, isEqual, isEqualOrParent, joinPath as resourceJoinPath, relativePath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { rgDiskPath } from '../../../../base/node/ripgrep.js';
 import { localize } from '../../../../nls.js';
 import { IParsedAgent, IParsedPlugin, IParsedRule, IParsedSkill, parseAgentFile, parsePlugin, parseRuleFile, parseSkillFile, PluginFormat } from '../../../agentPlugins/common/pluginParsers.js';
@@ -90,36 +91,18 @@ import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectories
 import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
 import { getAppNodeModulesPath } from '../appNodeModules.js';
 import { CopilotSlashCommandProvider } from './copilotSlashCommandProvider.js';
+import { classifyCopilotClientFailure, createCopilotFailureCorrelation, reportCopilotClientFailure, reportCopilotClientRecovery, reportCopilotClientRecoveryTurn, type CopilotClientFailureKind, type CopilotClientFailureOperation, type ICopilotFailureCorrelation } from './copilotFailureTelemetry.js';
 
 const RUNTIME_SLASH_COMMAND_COMPLETION_WAIT_MS = 300;
 const COPILOT_CAPI_URL = 'https://api.githubcopilot.com';
-const COPILOT_CONNECTION_CLOSED_ERROR_MESSAGE = 'Connection is closed.';
-
-type CopilotClientFailureOperation = 'abort' | 'changeAgent' | 'changeModel' | 'getSessionMetadata' | 'listSessions' | 'modelRefresh' | 'sendMessage';
-type CopilotClientFailureKind = 'connectionClosed';
-
-type CopilotClientFailureEvent = {
-	failureKind: CopilotClientFailureKind;
-	operation: CopilotClientFailureOperation;
-	activeTurnCount: number;
-	recoveryStarted: boolean;
-};
-
-type CopilotClientFailureClassification = {
-	failureKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded category of Copilot client failure that was detected.' };
-	operation: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot provider operation that detected the client failure.' };
-	activeTurnCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of Copilot chats with an active turn when the client failure was detected.' };
-	recoveryStarted: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this detection started client recovery instead of joining recovery already in progress.' };
-	owner: 'roblourens';
-	comment: 'Tracks detected Copilot client failures and whether recovery was started.';
-};
 
 interface ICopilotClosedConnectionRecoveryResult {
 	readonly failedTurnIds: ReadonlySet<string>;
+	readonly stopSucceeded: boolean;
 }
 
 function isCopilotConnectionClosedError(error: unknown): boolean {
-	return error instanceof Error && error.message === COPILOT_CONNECTION_CLOSED_ERROR_MESSAGE;
+	return classifyCopilotClientFailure(error) === 'connectionClosed';
 }
 
 /**
@@ -602,7 +585,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * {@link _requestClientRestart}; drained by {@link _applyPendingClientRestart}.
 	 */
 	private readonly _pendingClientRestartReasons = new Set<string>();
-	private _closedConnectionRecovery: Promise<ICopilotClosedConnectionRecoveryResult> | undefined;
+	private _closedConnectionRecovery: { readonly clientFailureId: string; readonly promise: Promise<ICopilotClosedConnectionRecoveryResult> } | undefined;
+	private readonly _reportedClientFailures = new WeakSet<Error>();
 	private _githubToken: string | undefined;
 	private _serverToolHost: IAgentServerToolHost | undefined;
 
@@ -911,37 +895,50 @@ export class CopilotAgent extends Disposable implements IAgent {
 		});
 	}
 
-	private async _recoverFromClosedConnection(error: unknown, operation: CopilotClientFailureOperation): Promise<ICopilotClosedConnectionRecoveryResult | undefined> {
-		if (!isCopilotConnectionClosedError(error)) {
+	private async _recoverFromClosedConnection(error: unknown, operation: CopilotClientFailureOperation, correlation?: ICopilotFailureCorrelation): Promise<ICopilotClosedConnectionRecoveryResult | undefined> {
+		const failureKind = classifyCopilotClientFailure(error);
+		if (!failureKind) {
+			return undefined;
+		}
+		if (error instanceof Error && this._reportedClientFailures.has(error)) {
 			return undefined;
 		}
 
-		const recoveryStarted = !this._shutdownPromise && this._closedConnectionRecovery === undefined;
-		this._telemetryService.publicLogError2<CopilotClientFailureEvent, CopilotClientFailureClassification>('agentHost.copilotClientFailure', {
-			failureKind: 'connectionClosed',
-			operation,
-			activeTurnCount: this._chatsWithActiveTurn(),
-			recoveryStarted,
-		});
-		if (this._shutdownPromise) {
+		const clientFailureId = this._closedConnectionRecovery?.clientFailureId ?? generateUuid();
+		const recoveryStarted = failureKind === 'connectionClosed' && !this._shutdownPromise && this._closedConnectionRecovery === undefined;
+		reportCopilotClientFailure(this._telemetryService, clientFailureId, failureKind, operation, this._chatsWithActiveTurn(), recoveryStarted, error, correlation);
+		if (failureKind !== 'connectionClosed' || this._shutdownPromise) {
 			return undefined;
 		}
 
 		if (!this._closedConnectionRecovery) {
-			const recovery = this._doRecoverFromClosedConnection();
-			this._closedConnectionRecovery = recovery;
+			const recovery = this._runClosedConnectionRecovery(clientFailureId, failureKind);
+			this._closedConnectionRecovery = { clientFailureId, promise: recovery };
 			const cleanup = () => {
-				if (this._closedConnectionRecovery === recovery) {
+				if (this._closedConnectionRecovery?.promise === recovery) {
 					this._closedConnectionRecovery = undefined;
 				}
 			};
 			recovery.then(cleanup, cleanup);
 		}
 
-		return this._closedConnectionRecovery;
+		return this._closedConnectionRecovery.promise;
 	}
 
-	private async _doRecoverFromClosedConnection(): Promise<ICopilotClosedConnectionRecoveryResult> {
+	private async _runClosedConnectionRecovery(clientFailureId: string, failureKind: CopilotClientFailureKind): Promise<ICopilotClosedConnectionRecoveryResult> {
+		const stopWatch = StopWatch.create();
+		const result = await this._doRecoverFromClosedConnection(clientFailureId);
+		reportCopilotClientRecovery(this._telemetryService, {
+			clientFailureId,
+			failureKind,
+			durationMs: stopWatch.elapsed(),
+			failedTurnCount: result.failedTurnIds.size,
+			stopSucceeded: result.stopSucceeded,
+		});
+		return result;
+	}
+
+	private async _doRecoverFromClosedConnection(clientFailureId: string): Promise<ICopilotClosedConnectionRecoveryResult> {
 		this._logService.error('[Copilot] Recovering from closed SDK connection');
 		const failedTurnIds = new Set<string>();
 		const error: ErrorInfo = {
@@ -953,6 +950,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 				const failedTurnId = chat.failActiveTurn(error);
 				if (failedTurnId) {
 					failedTurnIds.add(failedTurnId);
+					reportCopilotClientRecoveryTurn(
+						this._telemetryService,
+						clientFailureId,
+						createCopilotFailureCorrelation(chat.sessionUri, chat.chatUri, failedTurnId, chat.sessionId),
+					);
 				}
 			}
 		}
@@ -960,25 +962,33 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._sessions.clearAndDisposeAll();
 		this._sdkSessionsById.clear();
 		this._mcpNotificationSubs.clearAndDisposeAll();
+		let stopSucceeded = true;
 		try {
 			await this._stopClient();
 		} catch (error) {
+			stopSucceeded = false;
 			this._logService.error(error, '[Copilot] Failed to stop closed SDK client');
 		}
 		this._capiModels = [];
 		this._publishModels();
-		return { failedTurnIds };
+		return { failedTurnIds, stopSucceeded };
 	}
 
-	private async _retryAfterClosedConnection<T>(operation: CopilotClientFailureOperation, task: () => Promise<T>): Promise<T> {
+	private async _retryAfterClosedConnection<T>(operation: CopilotClientFailureOperation, task: () => Promise<T>, correlation?: ICopilotFailureCorrelation): Promise<T> {
 		try {
 			return await task();
 		} catch (error) {
-			if (!await this._recoverFromClosedConnection(error, operation)) {
+			if (!await this._recoverFromClosedConnection(error, operation, correlation)) {
 				throw error;
 			}
 			return task();
 		}
+	}
+
+	private _clientFailureCorrelation(chat: URI, turnId?: string): ICopilotFailureCorrelation {
+		const context = this._getChatContext(chat);
+		const chatUri = URI.parse(context.chatKey);
+		return createCopilotFailureCorrelation(context.session, chatUri, turnId, context.target?.sessionId ?? context.sessionId);
 	}
 
 	/** Number of live chats (default or peer, across all sessions) with an in-flight turn. */
@@ -1673,7 +1683,16 @@ export class CopilotAgent extends Disposable implements IAgent {
 				onGitHubTelemetry: notification => { void this._routeGitHubTelemetry(notification).catch(err => this._logService.trace(`[Copilot] GitHub telemetry routing failed: ${err instanceof Error ? err.message : String(err)}`)); },
 			};
 			const client = this._createCopilotClient(clientOptions);
-			await client.start();
+			try {
+				await client.start();
+			} catch (error) {
+				const failureKind = classifyCopilotClientFailure(error);
+				if (failureKind && error instanceof Error) {
+					reportCopilotClientFailure(this._telemetryService, generateUuid(), failureKind, 'startClient', this._chatsWithActiveTurn(), false, error);
+					this._reportedClientFailures.add(error);
+				}
+				throw error;
+			}
 			if (this._shutdownPromise) {
 				await client.stop();
 				throw new CancellationError();
@@ -1947,7 +1966,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const sessionMetadata = await this._retryAfterClosedConnection('getSessionMetadata', async () => {
 			const client = await this._ensureClient();
 			return client.getSessionMetadata(sessionId);
-		});
+		}, createCopilotFailureCorrelation(session, URI.parse(buildDefaultChatUri(session)), undefined, sessionId));
 		if (!sessionMetadata) {
 			return undefined;
 		}
@@ -2710,7 +2729,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		try {
 			await this._sendMessageOnce(chat, prompt, attachments, turnId, senderClientId, clientType, workingDirectories);
 		} catch (error) {
-			const recovery = await this._recoverFromClosedConnection(error, 'sendMessage');
+			const recovery = await this._recoverFromClosedConnection(error, 'sendMessage', this._clientFailureCorrelation(chat, turnId));
 			if (turnId && recovery?.failedTurnIds.has(turnId)) {
 				return;
 			}
@@ -3006,10 +3025,12 @@ export class CopilotAgent extends Disposable implements IAgent {
 			});
 		} catch (error) {
 			if (!isCopilotConnectionClosedError(error)) {
+				await this._recoverFromClosedConnection(error, 'abort', this._clientFailureCorrelation(chat));
 				throw error;
 			}
+			const correlation = this._clientFailureCorrelation(chat);
 			this._getChatContext(chat).target?.discardActiveTurn();
-			if (!await this._recoverFromClosedConnection(error, 'abort')) {
+			if (!await this._recoverFromClosedConnection(error, 'abort', correlation)) {
 				throw error;
 			}
 		}
@@ -3492,7 +3513,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		try {
 			await this._changeModelOnce(chat, model);
 		} catch (error) {
-			if (!await this._recoverFromClosedConnection(error, 'changeModel')) {
+			if (!await this._recoverFromClosedConnection(error, 'changeModel', this._clientFailureCorrelation(chat))) {
 				throw error;
 			}
 			await this._changeModelOnce(chat, model);
@@ -3532,7 +3553,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		try {
 			await this._changeAgentOnce(chat, agent);
 		} catch (error) {
-			if (!await this._recoverFromClosedConnection(error, 'changeAgent')) {
+			if (!await this._recoverFromClosedConnection(error, 'changeAgent', this._clientFailureCorrelation(chat))) {
 				throw error;
 			}
 			await this._changeAgentOnce(chat, agent);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -76,6 +76,7 @@ import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import { McpAuthRequiredReason, McpServerStatus, type McpAuthRequirement, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 import type { ErrorInfo, ProtectedResourceMetadata } from '../../common/state/protocol/common/state.js';
 import { CopilotSlashCommandProvider } from './copilotSlashCommandProvider.js';
+import { createCopilotFailureCorrelation, reportCopilotModelCallFailure, reportCopilotSdkSessionError } from './copilotFailureTelemetry.js';
 
 /**
  * The full set of agent modes the Copilot SDK accepts. AHP now exposes the
@@ -4265,6 +4266,7 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onSessionError(e => {
 			this._logService.error(`[Copilot:${sessionId}] Session error: ${e.data.errorType} - ${e.data.message}`);
+			reportCopilotSdkSessionError(this._telemetryService, e, createCopilotFailureCorrelation(this.sessionUri, this._chatChannelUri, this._turnId, this.sessionId));
 			if (this._currentTurn) {
 				this._reportToolCallDetails(this._currentTurn, 'failed');
 			}
@@ -4282,6 +4284,10 @@ export class CopilotAgentSession extends Disposable {
 					...(meta ? { _meta: meta } : {}),
 				},
 			});
+		}));
+
+		this._register(wrapper.onModelCallFailure(e => {
+			reportCopilotModelCallFailure(this._telemetryService, e, createCopilotFailureCorrelation(this.sessionUri, this._chatChannelUri, this._turnId, this.sessionId));
 		}));
 
 		// Tracks the last parent-scope usage so the async attribution enrichment

--- a/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SessionEventPayload } from '@github/copilot-sdk';
+import { getErrorCode } from '../../../../base/common/errors.js';
+import type { URI } from '../../../../base/common/uri.js';
+import { packErrorForTelemetry } from '../../../telemetry/common/errorTelemetry.js';
+import type { ITelemetryService } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
+import { DEFAULT_CHAT_ID, parseChatUri } from '../../common/state/sessionState.js';
+
+export type CopilotClientFailureOperation = 'abort' | 'changeAgent' | 'changeModel' | 'getSessionMetadata' | 'listSessions' | 'modelRefresh' | 'sendMessage' | 'startClient';
+export type CopilotClientFailureKind = 'clientNotConnected' | 'connectionClosed' | 'connectionDisposed' | 'runtimeConnectionClosed' | 'startupFailed';
+
+export interface ICopilotFailureCorrelation {
+	readonly agentSessionId?: string;
+	readonly chatSessionId?: string;
+	readonly turnId?: string;
+	readonly sdkSessionId?: string;
+}
+
+type CopilotSessionFailureCorrelation = {
+	readonly agentSessionId: string;
+	readonly chatSessionId: string;
+	readonly turnId: string | undefined;
+	readonly sdkSessionId: string;
+};
+
+export function createCopilotFailureCorrelation(sessionUri: URI, chatUri: URI, turnId: string | undefined, sdkSessionId: string): CopilotSessionFailureCorrelation {
+	return {
+		agentSessionId: AgentSession.id(sessionUri),
+		chatSessionId: parseChatUri(chatUri)?.chatId ?? DEFAULT_CHAT_ID,
+		turnId: turnId || undefined,
+		sdkSessionId,
+	};
+}
+
+export function classifyCopilotClientFailure(error: unknown): CopilotClientFailureKind | undefined {
+	if (!(error instanceof Error)) {
+		return undefined;
+	}
+	switch (error.message) {
+		case 'Client not connected':
+			return 'clientNotConnected';
+		case 'Connection is closed.':
+			return 'connectionClosed';
+		case 'Connection is disposed.':
+			return 'connectionDisposed';
+		case 'The in-process runtime connection is closed.':
+			return 'runtimeConnectionClosed';
+	}
+	return error.message.startsWith('Failed to start CLI server:')
+		|| error.message.startsWith('CLI server exited with code ')
+		|| error.message.startsWith('CLI server exited unexpectedly with code ')
+		? 'startupFailed'
+		: undefined;
+}
+
+type CopilotClientFailureEvent = ICopilotFailureCorrelation & {
+	clientFailureId: string;
+	failureKind: CopilotClientFailureKind;
+	operation: CopilotClientFailureOperation;
+	activeTurnCount: number;
+	recoveryStarted: boolean;
+	errorName: string | undefined;
+	errorCode: string | undefined;
+	msg: string;
+	callstack: string | undefined;
+};
+
+type CopilotClientFailureClassification = {
+	clientFailureId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier shared by detections and recovery telemetry for one Copilot client failure episode.' };
+	failureKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded category of Copilot client failure that was detected.' };
+	operation: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot provider operation that detected the client failure.' };
+	agentSessionId?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host session identifier, when the failing operation targeted a session.' };
+	chatSessionId?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host chat identifier, when the failing operation targeted a chat.' };
+	turnId?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host turn identifier, when available.' };
+	sdkSessionId?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK session identifier, when available.' };
+	activeTurnCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The number of Copilot chats with an active turn when the client failure was detected.' };
+	recoveryStarted: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this detection started client recovery instead of joining recovery already in progress.' };
+	errorName: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The name of the client failure exception, when available.' };
+	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The client failure exception or protocol error code, when available.' };
+	msg: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The client failure message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The client failure stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	owner: 'roblourens';
+	comment: 'Tracks detected Copilot client failures and whether recovery was started.';
+};
+
+export function reportCopilotClientFailure(
+	telemetryService: ITelemetryService,
+	clientFailureId: string,
+	failureKind: CopilotClientFailureKind,
+	operation: CopilotClientFailureOperation,
+	activeTurnCount: number,
+	recoveryStarted: boolean,
+	error: unknown,
+	correlation?: ICopilotFailureCorrelation,
+): void {
+	const packed = packErrorForTelemetry(error);
+	telemetryService.publicLogError2<CopilotClientFailureEvent, CopilotClientFailureClassification>('agentHost.copilotClientFailure', {
+		clientFailureId,
+		failureKind,
+		operation,
+		...correlation,
+		activeTurnCount,
+		recoveryStarted,
+		errorName: error instanceof Error ? error.name : undefined,
+		errorCode: getErrorCode(error),
+		msg: packed.msg,
+		callstack: packed.callstack,
+	});
+}
+
+type CopilotClientRecoveryEvent = {
+	clientFailureId: string;
+	failureKind: CopilotClientFailureKind;
+	durationMs: number;
+	failedTurnCount: number;
+	stopSucceeded: boolean;
+};
+
+type CopilotClientRecoveryClassification = {
+	clientFailureId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier shared by detections and recovery telemetry for one Copilot client failure episode.' };
+	failureKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded category of Copilot client failure that initiated recovery.' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds spent recovering the failed Copilot client.' };
+	failedTurnCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of active Agent Host turns failed during client recovery.' };
+	stopSucceeded: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether stopping the failed Copilot client completed without throwing.' };
+	owner: 'roblourens';
+	comment: 'Tracks the outcome of Copilot client recovery.';
+};
+
+export function reportCopilotClientRecovery(telemetryService: ITelemetryService, event: CopilotClientRecoveryEvent): void {
+	telemetryService.publicLog2<CopilotClientRecoveryEvent, CopilotClientRecoveryClassification>('agentHost.copilotClientRecovery', event);
+}
+
+type CopilotClientRecoveryTurnEvent = CopilotSessionFailureCorrelation & {
+	clientFailureId: string;
+};
+
+type CopilotClientRecoveryTurnClassification = {
+	clientFailureId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier shared by all telemetry for one Copilot client failure episode.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host chat identifier.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host turn failed during client recovery.' };
+	sdkSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK session identifier.' };
+	owner: 'roblourens';
+	comment: 'Correlates each turn failed during Copilot client recovery with its client failure episode.';
+};
+
+export function reportCopilotClientRecoveryTurn(telemetryService: ITelemetryService, clientFailureId: string, correlation: CopilotSessionFailureCorrelation): void {
+	telemetryService.publicLogError2<CopilotClientRecoveryTurnEvent, CopilotClientRecoveryTurnClassification>('agentHost.copilotClientRecoveryTurnFailed', {
+		clientFailureId,
+		...correlation,
+	});
+}
+
+type CopilotSdkSessionErrorEvent = CopilotSessionFailureCorrelation & {
+	sdkEventId: string;
+	sdkParentEventId: string | undefined;
+	sdkAgentId: string | undefined;
+	errorType: string;
+	errorCode: string | undefined;
+	statusCode: number | undefined;
+	providerCallId: string | undefined;
+	serviceRequestId: string | undefined;
+	eligibleForAutoSwitch: boolean | undefined;
+	msg: string;
+	callstack: string | undefined;
+};
+
+type CopilotSdkSessionErrorClassification = {
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host chat identifier.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host turn identifier, when available.' };
+	sdkSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK session identifier.' };
+	sdkEventId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK event identifier.' };
+	sdkParentEventId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The preceding Copilot SDK event identifier, when available.' };
+	sdkAgentId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK subagent identifier, when applicable.' };
+	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured Copilot SDK session error type.' };
+	errorCode: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The upstream provider error code, when available.' };
+	statusCode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The upstream HTTP status code, when available.' };
+	providerCallId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The GitHub provider request identifier, when available.' };
+	serviceRequestId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot service request identifier, when available.' };
+	eligibleForAutoSwitch: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the error can trigger an Auto model switch.' };
+	msg: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The SDK session error message. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The SDK session error stack. VS Code telemetry scrubs file paths and likely secrets before transmission.' };
+	owner: 'roblourens';
+	comment: 'Captures Copilot SDK session errors with Agent Host, SDK, and provider correlation identifiers.';
+};
+
+export function reportCopilotSdkSessionError(telemetryService: ITelemetryService, event: SessionEventPayload<'session.error'>, correlation: CopilotSessionFailureCorrelation): void {
+	telemetryService.publicLogError2<CopilotSdkSessionErrorEvent, CopilotSdkSessionErrorClassification>('agentHost.copilotSdkSessionError', {
+		...correlation,
+		sdkEventId: event.id,
+		sdkParentEventId: event.parentId ?? undefined,
+		sdkAgentId: event.agentId,
+		errorType: event.data.errorType,
+		errorCode: event.data.errorCode,
+		statusCode: event.data.statusCode,
+		providerCallId: event.data.providerCallId,
+		serviceRequestId: event.data.serviceRequestId,
+		eligibleForAutoSwitch: event.data.eligibleForAutoSwitch,
+		msg: event.data.message,
+		callstack: event.data.stack,
+	});
+}
+
+type CopilotModelCallFailureEvent = CopilotSessionFailureCorrelation & {
+	sdkEventId: string;
+	sdkParentEventId: string | undefined;
+	sdkAgentId: string | undefined;
+	failureKind: string | undefined;
+	source: string;
+	transport: string | undefined;
+	apiEndpoint: string | undefined;
+	statusCode: number | undefined;
+	durationMs: number | undefined;
+	model: string | undefined;
+	reasoningEffort: string | undefined;
+	isAuto: boolean | undefined;
+	isByok: boolean | undefined;
+	rte: boolean | undefined;
+	badRequestKind: string | undefined;
+	apiCallId: string | undefined;
+	providerCallId: string | undefined;
+	serviceRequestId: string | undefined;
+	messageCount: number | undefined;
+	toolCallCount: number | undefined;
+	toolResultMessageCount: number | undefined;
+	namelessToolCallCount: number | undefined;
+	imagePartCount: number | undefined;
+	imagePartsMissingMediaType: number | undefined;
+};
+
+type CopilotModelCallFailureClassification = {
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host chat identifier.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Agent Host turn identifier, when available.' };
+	sdkSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK session identifier.' };
+	sdkEventId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK event identifier.' };
+	sdkParentEventId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The preceding Copilot SDK event identifier, when available.' };
+	sdkAgentId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot SDK subagent identifier, when applicable.' };
+	failureKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the SDK model call failed at the API or transport boundary.' };
+	source: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the model call came from the top-level agent, a subagent, or MCP sampling.' };
+	transport: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The HTTP or WebSocket transport used by the failed model call.' };
+	apiEndpoint: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded API endpoint used by the failed model call.' };
+	statusCode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The HTTP status code, when available.' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration of the failed model call in milliseconds.' };
+	model: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider model identifier used by the failed call.' };
+	reasoningEffort: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The reasoning effort used by the failed call, when applicable.' };
+	isAuto: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether Auto selected the model for the failed call.' };
+	isByok: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the failed call used a bring-your-own-key provider.' };
+	rte: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The SDK runtime RTE flag for the failed call, when available.' };
+	badRequestKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded HTTP 400 response category, when available.' };
+	apiCallId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The model-provider completion identifier, when available.' };
+	providerCallId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The GitHub provider request identifier, when available.' };
+	serviceRequestId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The Copilot service request identifier, when available.' };
+	messageCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of messages in the failing request.' };
+	toolCallCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of tool calls in the failing request.' };
+	toolResultMessageCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of tool-result messages in the failing request.' };
+	namelessToolCallCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of tool calls with no name in the failing request.' };
+	imagePartCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of image parts in the failing request.' };
+	imagePartsMissingMediaType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of image parts missing a media type in the failing request.' };
+	owner: 'roblourens';
+	comment: 'Captures structured Copilot SDK model-call failures. Raw model error messages remain restricted to SDK-owned telemetry and are not duplicated here.';
+};
+
+export function reportCopilotModelCallFailure(telemetryService: ITelemetryService, event: SessionEventPayload<'model.call_failure'>, correlation: CopilotSessionFailureCorrelation): void {
+	const fingerprint = event.data.requestFingerprint;
+	telemetryService.publicLogError2<CopilotModelCallFailureEvent, CopilotModelCallFailureClassification>('agentHost.copilotModelCallFailure', {
+		...correlation,
+		sdkEventId: event.id,
+		sdkParentEventId: event.parentId ?? undefined,
+		sdkAgentId: event.agentId,
+		failureKind: event.data.failureKind,
+		source: event.data.source,
+		transport: event.data.transport,
+		apiEndpoint: event.data.apiEndpoint,
+		statusCode: event.data.statusCode,
+		durationMs: event.data.durationMs,
+		model: event.data.isByok ? 'byokModel' : event.data.model,
+		reasoningEffort: event.data.reasoningEffort,
+		isAuto: event.data.isAuto,
+		isByok: event.data.isByok,
+		rte: event.data.rte,
+		badRequestKind: event.data.badRequestKind,
+		apiCallId: event.data.apiCallId,
+		providerCallId: event.data.providerCallId,
+		serviceRequestId: event.data.serviceRequestId,
+		messageCount: fingerprint?.messageCount,
+		toolCallCount: fingerprint?.toolCallCount,
+		toolResultMessageCount: fingerprint?.toolResultMessageCount,
+		namelessToolCallCount: fingerprint?.namelessToolCallCount,
+		imagePartCount: fingerprint?.imagePartCount,
+		imagePartsMissingMediaType: fingerprint?.imagePartsMissingMediaType,
+	});
+}

--- a/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
@@ -9,7 +9,7 @@ import type { URI } from '../../../../base/common/uri.js';
 import { packErrorForTelemetry } from '../../../telemetry/common/errorTelemetry.js';
 import type { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { AgentSession } from '../../common/agentService.js';
-import { DEFAULT_CHAT_ID, parseChatUri } from '../../common/state/sessionState.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 
 export type CopilotClientFailureOperation = 'abort' | 'changeAgent' | 'changeModel' | 'getSessionMetadata' | 'listSessions' | 'modelRefresh' | 'sendMessage' | 'startClient';
 export type CopilotClientFailureKind = 'clientNotConnected' | 'connectionClosed' | 'connectionDisposed' | 'runtimeConnectionClosed' | 'startupFailed';
@@ -31,7 +31,7 @@ type CopilotSessionFailureCorrelation = {
 export function createCopilotFailureCorrelation(sessionUri: URI, chatUri: URI, turnId: string | undefined, sdkSessionId: string): CopilotSessionFailureCorrelation {
 	return {
 		agentSessionId: AgentSession.id(sessionUri),
-		chatSessionId: parseChatUri(chatUri)?.chatId ?? DEFAULT_CHAT_ID,
+		chatSessionId: getTelemetryChatSessionId(chatUri),
 		turnId: turnId || undefined,
 		sdkSessionId,
 	};

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
@@ -212,6 +212,11 @@ export class CopilotSessionWrapper extends Disposable {
 		return this._onUsage ??= this._sdkEvent('assistant.usage');
 	}
 
+	private _onModelCallFailure: Event<SessionEventPayload<'model.call_failure'>> | undefined;
+	get onModelCallFailure(): Event<SessionEventPayload<'model.call_failure'>> {
+		return this._onModelCallFailure ??= this._sdkEvent('model.call_failure');
+	}
+
 	private _onAbort: Event<SessionEventPayload<'abort'>> | undefined;
 	get onAbort(): Event<SessionEventPayload<'abort'>> {
 		return this._onAbort ??= this._sdkEvent('abort');

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -211,6 +211,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		const data = events[0].data as Record<string, unknown>;
 		assert.strictEqual(data.provider, 'mock');
 		assert.strictEqual(data.agentSessionId, 'session-1');
+		assert.strictEqual(data.chatSessionId, 'default');
 		assert.strictEqual(data.turnId, 'turn-1');
 		assert.strictEqual(data.result, 'success');
 		assert.deepStrictEqual(capturedModel(data), { trusted: true, value: 'gpt-5.5' });
@@ -299,6 +300,45 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.strictEqual(events.length, 1);
 		assert.strictEqual((events[0].data as Record<string, unknown>).result, 'error');
 		assert.strictEqual((events[0].data as Record<string, unknown>).errorType, 'oops');
+	});
+
+	test('correlates turn failure with chat and provider request identifiers', () => {
+		setupSession();
+		startTurn('turn-1');
+		fire({
+			type: ActionType.ChatError,
+			turnId: 'turn-1',
+			duration: 1000,
+			error: {
+				errorType: 'quota',
+				message: 'quota exceeded',
+				_meta: {
+					chatError: {
+						fetchError: {
+							requestId: 'provider-request-id',
+							serverRequestId: 'service-request-id',
+						},
+					},
+				},
+			},
+		});
+
+		assert.deepStrictEqual(failedEvents().map(event => {
+			const data = event.data as Record<string, unknown>;
+			return {
+				agentSessionId: data.agentSessionId,
+				chatSessionId: data.chatSessionId,
+				turnId: data.turnId,
+				providerCallId: data.providerCallId,
+				serviceRequestId: data.serviceRequestId,
+			};
+		}), [{
+			agentSessionId: 'session-1',
+			chatSessionId: 'default',
+			turnId: 'turn-1',
+			providerCallId: 'provider-request-id',
+			serviceRequestId: 'service-request-id',
+		}]);
 	});
 
 	test('emits a single turnCompleted per turn even when followed by duplicate completions', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -14,6 +14,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.js';
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
 import { buildDefaultChatUri, MessageKind, PendingMessageKind, ResponsePartKind, SessionStatus } from '../../common/state/sessionState.js';
@@ -211,7 +212,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		const data = events[0].data as Record<string, unknown>;
 		assert.strictEqual(data.provider, 'mock');
 		assert.strictEqual(data.agentSessionId, 'session-1');
-		assert.strictEqual(data.chatSessionId, 'default');
+		assert.strictEqual(data.chatSessionId, getTelemetryChatSessionId(defaultChatUri));
 		assert.strictEqual(data.turnId, 'turn-1');
 		assert.strictEqual(data.result, 'success');
 		assert.deepStrictEqual(capturedModel(data), { trusted: true, value: 'gpt-5.5' });
@@ -334,7 +335,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 			};
 		}), [{
 			agentSessionId: 'session-1',
-			chatSessionId: 'default',
+			chatSessionId: getTelemetryChatSessionId(defaultChatUri),
 			turnId: 'turn-1',
 			providerCallId: 'provider-request-id',
 			serviceRequestId: 'service-request-id',

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -35,6 +35,7 @@ import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.
 import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
 import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentCreateChatForkSource, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { buildDefaultChatUri, buildChatUri, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, CustomizationLoadStatus, MessageKind, readSessionEhcliAdoptable, ResponsePartKind, ROOT_STATE_URI, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
@@ -1498,7 +1499,7 @@ suite('CopilotAgent', () => {
 					failureKind: 'connectionClosed',
 					operation: 'abort',
 					agentSessionId: 'cancelled',
-					chatSessionId: 'default',
+					chatSessionId: getTelemetryChatSessionId(cancelledChat),
 					turnId: undefined,
 					sdkSessionId: 'cancelled',
 					activeTurnCount: 1,
@@ -1521,7 +1522,7 @@ suite('CopilotAgent', () => {
 				recoveryTurns: [{
 					clientFailureId: 'string',
 					agentSessionId: 'failed',
-					chatSessionId: 'default',
+					chatSessionId: getTelemetryChatSessionId(failedChat),
 					turnId: 'failed-turn',
 					sdkSessionId: 'failed',
 					clientFailureIdMatches: true,
@@ -1571,7 +1572,7 @@ suite('CopilotAgent', () => {
 					failureKind: 'clientNotConnected',
 					operation: 'abort',
 					agentSessionId: 'abort-failure',
-					chatSessionId: 'default',
+					chatSessionId: getTelemetryChatSessionId(chat),
 					turnId: undefined,
 					sdkSessionId: 'abort-failure',
 					activeTurnCount: 1,

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -367,6 +367,7 @@ class TestCopilotClient implements ITestCopilotClient {
 	startCallCount = 0;
 	stopCallCount = 0;
 	startGate: Promise<void> | undefined;
+	startError: Error | undefined;
 	listSessionCallCount = 0;
 	readonly modelListRequests: Parameters<CopilotModelsList>[0][] = [];
 	readonly modelListErrors: Error[] = [];
@@ -386,6 +387,9 @@ class TestCopilotClient implements ITestCopilotClient {
 	async start(): Promise<void> {
 		this.startCallCount++;
 		await this.startGate;
+		if (this.startError) {
+			throw this.startError;
+		}
 	}
 	async stop(): ReturnType<ITestCopilotClient['stop']> {
 		this.stopCallCount++;
@@ -407,7 +411,12 @@ class TestCopilotClient implements ITestCopilotClient {
 }
 
 class RecordingTelemetryService extends NullTelemetryServiceShape {
+	readonly events: Array<{ eventName: string; data: unknown }> = [];
 	readonly errorEvents: Array<{ eventName: string; data: unknown }> = [];
+
+	override publicLog2(eventName?: string, data?: unknown): void {
+		this.events.push({ eventName: eventName ?? '', data });
+	}
 
 	override publicLogError2(eventName?: string, data?: unknown): void {
 		this.errorEvents.push({ eventName: eventName ?? '', data });
@@ -1297,29 +1306,82 @@ suite('CopilotAgent', () => {
 		try {
 			await agent.authenticate('https://api.github.com', 'token');
 			const models = await waitForState(agent.models, m => m.length > 0);
+			const failure = telemetryService.errorEvents[0].data as Record<string, unknown>;
+			const recovery = telemetryService.events[0].data as Record<string, unknown>;
 
 			assert.deepStrictEqual({
 				modelNames: models.map(model => model.name),
 				startCount: client.startCallCount,
 				stopCount: client.stopCallCount,
 				requestCount: client.modelListRequests.length,
-				errorEvents: telemetryService.errorEvents,
+				failure: {
+					...failure,
+					clientFailureId: typeof failure.clientFailureId,
+					callstack: typeof failure.callstack,
+				},
+				recovery: {
+					...recovery,
+					clientFailureIdMatches: recovery.clientFailureId === failure.clientFailureId,
+					clientFailureId: typeof recovery.clientFailureId,
+					durationMs: typeof recovery.durationMs,
+				},
 			}, {
 				modelNames: ['GPT-4o'],
 				startCount: 2,
 				stopCount: 1,
 				requestCount: 2,
-				errorEvents: [{
-					eventName: 'agentHost.copilotClientFailure',
-					data: {
-						failureKind: 'connectionClosed',
-						operation: 'modelRefresh',
-						activeTurnCount: 0,
-						recoveryStarted: true,
-					},
-				}],
+				failure: {
+					clientFailureId: 'string',
+					failureKind: 'connectionClosed',
+					operation: 'modelRefresh',
+					activeTurnCount: 0,
+					recoveryStarted: true,
+					errorName: 'Error',
+					errorCode: undefined,
+					msg: 'Connection is closed.',
+					callstack: 'string',
+				},
+				recovery: {
+					clientFailureId: 'string',
+					failureKind: 'connectionClosed',
+					durationMs: 'number',
+					failedTurnCount: 0,
+					stopSucceeded: true,
+					clientFailureIdMatches: true,
+				},
+			});
+
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('reports a classified Copilot client startup failure', async () => {
+		const client = new TestCopilotClient([]);
+		client.startError = new Error('Failed to start CLI server: spawn failed');
+		const telemetryService = new RecordingTelemetryService();
+		const agent = createTestAgent(disposables, { copilotClient: client, telemetryService });
+		try {
+			await assert.rejects(agent.listSessions(), /Failed to start CLI server/);
+			assert.strictEqual(telemetryService.errorEvents.length, 1);
+			const failure = telemetryService.errorEvents[0].data as Record<string, unknown>;
+			assert.deepStrictEqual({
+				...failure,
+				clientFailureId: typeof failure.clientFailureId,
+				callstack: typeof failure.callstack,
+			}, {
+				clientFailureId: 'string',
+				failureKind: 'startupFailed',
+				operation: 'startClient',
+				activeTurnCount: 0,
+				recoveryStarted: false,
+				errorName: 'Error',
+				errorCode: undefined,
+				msg: 'Failed to start CLI server: spawn failed',
+				callstack: 'string',
 			});
 		} finally {
+			client.startError = undefined;
 			await disposeAgent(agent);
 		}
 	});
@@ -1348,6 +1410,8 @@ suite('CopilotAgent', () => {
 		let cancelledActive = true;
 		let failedActive = true;
 		setDefaultSessionStub(agent, 'cancelled', {
+			sessionId: 'cancelled',
+			sessionUri: AgentSession.uri('copilotcli', 'cancelled'),
 			chatUri: cancelledChat,
 			get hasActiveTurn() { return cancelledActive; },
 			abort: async () => { throw new Error('Connection is closed.'); },
@@ -1363,6 +1427,8 @@ suite('CopilotAgent', () => {
 			dispose: () => calls.cancelled.dispose++,
 		});
 		setDefaultSessionStub(agent, 'failed', {
+			sessionId: 'failed',
+			sessionUri: AgentSession.uri('copilotcli', 'failed'),
 			chatUri: failedChat,
 			get hasActiveTurn() { return failedActive; },
 			discardActiveTurn: () => { calls.failed.discard++; failedActive = false; },
@@ -1388,6 +1454,13 @@ suite('CopilotAgent', () => {
 			const second = internals._recoverFromClosedConnection(new Error('Connection is closed.'), 'modelRefresh');
 			client.stopGate.complete();
 			const [, secondResult] = await Promise.all([abort, second]);
+			const failures = telemetryService.errorEvents
+				.filter(event => event.eventName === 'agentHost.copilotClientFailure')
+				.map(event => event.data as Record<string, unknown>);
+			const recoveryTurns = telemetryService.errorEvents
+				.filter(event => event.eventName === 'agentHost.copilotClientRecoveryTurnFailed')
+				.map(event => event.data as Record<string, unknown>);
+			const recovery = telemetryService.events[0].data as Record<string, unknown>;
 
 			assert.deepStrictEqual({
 				calls,
@@ -1395,7 +1468,22 @@ suite('CopilotAgent', () => {
 				stopCount: client.stopCallCount,
 				remainingSessions: sessionsMap(agent).size,
 				remainingSdkSessions: sdkSessionsMap(agent).size,
-				errorEvents: telemetryService.errorEvents,
+				failures: failures.map(failure => ({
+					...failure,
+					clientFailureId: typeof failure.clientFailureId,
+					callstack: typeof failure.callstack,
+				})),
+				recoveryTurns: recoveryTurns.map(recoveryTurn => ({
+					...recoveryTurn,
+					clientFailureIdMatches: recoveryTurn.clientFailureId === recovery.clientFailureId,
+					clientFailureId: typeof recoveryTurn.clientFailureId,
+				})),
+				recovery: {
+					...recovery,
+					clientFailureIdMatches: failures.every(failure => failure.clientFailureId === recovery.clientFailureId),
+					clientFailureId: typeof recovery.clientFailureId,
+					durationMs: typeof recovery.durationMs,
+				},
 			}, {
 				calls: {
 					cancelled: { discard: 1, fail: 0, dispose: 1 },
@@ -1405,48 +1493,94 @@ suite('CopilotAgent', () => {
 				stopCount: 1,
 				remainingSessions: 0,
 				remainingSdkSessions: 0,
-				errorEvents: [{
-					eventName: 'agentHost.copilotClientFailure',
-					data: {
-						failureKind: 'connectionClosed',
-						operation: 'abort',
-						activeTurnCount: 1,
-						recoveryStarted: true,
-					},
+				failures: [{
+					clientFailureId: 'string',
+					failureKind: 'connectionClosed',
+					operation: 'abort',
+					agentSessionId: 'cancelled',
+					chatSessionId: 'default',
+					turnId: undefined,
+					sdkSessionId: 'cancelled',
+					activeTurnCount: 1,
+					recoveryStarted: true,
+					errorName: 'Error',
+					errorCode: undefined,
+					msg: 'Connection is closed.',
+					callstack: 'string',
 				}, {
-					eventName: 'agentHost.copilotClientFailure',
-					data: {
-						failureKind: 'connectionClosed',
-						operation: 'modelRefresh',
-						activeTurnCount: 0,
-						recoveryStarted: false,
-					},
+					clientFailureId: 'string',
+					failureKind: 'connectionClosed',
+					operation: 'modelRefresh',
+					activeTurnCount: 0,
+					recoveryStarted: false,
+					errorName: 'Error',
+					errorCode: undefined,
+					msg: 'Connection is closed.',
+					callstack: 'string',
 				}],
+				recoveryTurns: [{
+					clientFailureId: 'string',
+					agentSessionId: 'failed',
+					chatSessionId: 'default',
+					turnId: 'failed-turn',
+					sdkSessionId: 'failed',
+					clientFailureIdMatches: true,
+				}],
+				recovery: {
+					clientFailureId: 'string',
+					failureKind: 'connectionClosed',
+					durationMs: 'number',
+					failedTurnCount: 1,
+					stopSucceeded: true,
+					clientFailureIdMatches: true,
+				},
 			});
 		} finally {
 			await disposeAgent(agent);
 		}
 	});
 
-	test('does not discard an active turn when abort fails for another reason', async () => {
-		const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
+	test('reports but does not recover or discard for another classified abort failure', async () => {
+		const telemetryService = new RecordingTelemetryService();
+		const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]), telemetryService });
 		const chat = defaultChatUri(AgentSession.uri('copilotcli', 'abort-failure'));
 		let discardCount = 0;
 		setDefaultSessionStub(agent, 'abort-failure', {
 			chatUri: chat,
 			hasActiveTurn: true,
-			abort: async () => { throw new Error('abort failed'); },
+			abort: async () => { throw new Error('Client not connected'); },
 			discardActiveTurn: () => discardCount++,
 			dispose: () => { },
 		});
 		try {
-			await assert.rejects(agent.chats.abort(chat), /abort failed/);
+			await assert.rejects(agent.chats.abort(chat), /Client not connected/);
+			const failure = telemetryService.errorEvents[0].data as Record<string, unknown>;
 			assert.deepStrictEqual({
 				discardCount,
 				remainingSessions: sessionsMap(agent).size,
+				failure: {
+					...failure,
+					clientFailureId: typeof failure.clientFailureId,
+					callstack: typeof failure.callstack,
+				},
 			}, {
 				discardCount: 0,
 				remainingSessions: 1,
+				failure: {
+					clientFailureId: 'string',
+					failureKind: 'clientNotConnected',
+					operation: 'abort',
+					agentSessionId: 'abort-failure',
+					chatSessionId: 'default',
+					turnId: undefined,
+					sdkSessionId: 'abort-failure',
+					activeTurnCount: 1,
+					recoveryStarted: false,
+					errorName: 'Error',
+					errorCode: undefined,
+					msg: 'Client not connected',
+					callstack: 'string',
+				},
 			});
 		} finally {
 			await disposeAgent(agent);

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -448,7 +448,9 @@ class CapturingTelemetryService implements ITelemetryService {
 		this.events.push({ eventName, data });
 	}
 	publicLogError(): void { }
-	publicLogError2(): void { }
+	publicLogError2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void {
+		this.events.push({ eventName, data });
+	}
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
 }
@@ -5484,12 +5486,18 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('error event is forwarded', async () => {
-			const { mockSession, signals } = await createAgentSession(disposables);
+			const telemetryService = new CapturingTelemetryService();
+			const { session, mockSession, signals } = await createAgentSession(disposables, { telemetryService });
+			session.resetTurnState('turn-1');
 			mockSession.fire('session.error', {
 				errorType: 'TestError',
+				errorCode: 'test-code',
 				message: 'something went wrong',
 				stack: 'Error: something went wrong',
-			} as SessionEventPayload<'session.error'>['data']);
+				statusCode: 500,
+				providerCallId: 'provider-request-id',
+				serviceRequestId: 'service-request-id',
+			} as SessionEventPayload<'session.error'>['data'], { id: 'session-error-event', parentId: 'previous-event', agentId: 'sdk-agent-id' });
 
 			assert.strictEqual(signals.length, 1);
 			assert.ok(isAction(signals[0], ActionType.ChatError));
@@ -5498,6 +5506,95 @@ suite('CopilotAgentSession', () => {
 				assert.strictEqual(action.error.errorType, 'TestError');
 				assert.strictEqual(action.error.message, 'something went wrong');
 			}
+			assert.deepStrictEqual(telemetryService.events.filter(event => event.eventName === 'agentHost.copilotSdkSessionError'), [{
+				eventName: 'agentHost.copilotSdkSessionError',
+				data: {
+					agentSessionId: 'test-session-1',
+					chatSessionId: 'default',
+					turnId: 'turn-1',
+					sdkSessionId: 'test-session-1',
+					sdkEventId: 'session-error-event',
+					sdkParentEventId: 'previous-event',
+					sdkAgentId: 'sdk-agent-id',
+					errorType: 'TestError',
+					errorCode: 'test-code',
+					statusCode: 500,
+					providerCallId: 'provider-request-id',
+					serviceRequestId: 'service-request-id',
+					eligibleForAutoSwitch: undefined,
+					msg: 'something went wrong',
+					callstack: 'Error: something went wrong',
+				},
+			}]);
+		});
+
+		test('model call failure emits structured correlation telemetry without the restricted error message', async () => {
+			const telemetryService = new CapturingTelemetryService();
+			const { session, mockSession } = await createAgentSession(disposables, { telemetryService });
+			session.resetTurnState('turn-1');
+			mockSession.fire('model.call_failure', {
+				source: 'subagent',
+				failureKind: 'transport',
+				transport: 'websocket',
+				apiEndpoint: 'ws:/responses',
+				statusCode: 502,
+				durationMs: 42,
+				model: 'private-deployment-name',
+				reasoningEffort: 'high',
+				isAuto: false,
+				isByok: true,
+				rte: true,
+				initiator: 'sub-agent',
+				badRequestKind: undefined,
+				errorType: 'websocket_error',
+				errorCode: 'connection_reset',
+				errorMessage: 'restricted provider detail',
+				apiCallId: 'api-call-id',
+				providerCallId: 'provider-request-id',
+				serviceRequestId: 'service-request-id',
+				requestFingerprint: {
+					messageCount: 4,
+					toolCallCount: 2,
+					toolResultMessageCount: 1,
+					namelessToolCallCount: 0,
+					imagePartCount: 1,
+					imagePartsMissingMediaType: 0,
+				},
+			}, { id: 'model-failure-event', parentId: 'previous-event', agentId: 'sdk-agent-id' });
+
+			assert.deepStrictEqual(telemetryService.events.filter(event => event.eventName === 'agentHost.copilotModelCallFailure'), [{
+				eventName: 'agentHost.copilotModelCallFailure',
+				data: {
+					agentSessionId: 'test-session-1',
+					chatSessionId: 'default',
+					turnId: 'turn-1',
+					sdkSessionId: 'test-session-1',
+					sdkEventId: 'model-failure-event',
+					sdkParentEventId: 'previous-event',
+					sdkAgentId: 'sdk-agent-id',
+					failureKind: 'transport',
+					source: 'subagent',
+					transport: 'websocket',
+					apiEndpoint: 'ws:/responses',
+					statusCode: 502,
+					durationMs: 42,
+					model: 'byokModel',
+					reasoningEffort: 'high',
+					isAuto: false,
+					isByok: true,
+					rte: true,
+					badRequestKind: undefined,
+					apiCallId: 'api-call-id',
+					providerCallId: 'provider-request-id',
+					serviceRequestId: 'service-request-id',
+					messageCount: 4,
+					toolCallCount: 2,
+					toolResultMessageCount: 1,
+					namelessToolCallCount: 0,
+					imagePartCount: 1,
+					imagePartsMissingMediaType: 0,
+				},
+			}]);
 		});
 
 		test('message delta is forwarded', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -22,6 +22,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from '../../../telemetry/common/gdprTypings.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import type { ChatInputRequestWithPlanReview } from '../../common/agentHostPlanReview.js';
@@ -5510,7 +5511,7 @@ suite('CopilotAgentSession', () => {
 				eventName: 'agentHost.copilotSdkSessionError',
 				data: {
 					agentSessionId: 'test-session-1',
-					chatSessionId: 'default',
+					chatSessionId: getTelemetryChatSessionId(URI.parse(buildDefaultChatUri(AgentSession.uri('copilot', 'test-session-1')))),
 					turnId: 'turn-1',
 					sdkSessionId: 'test-session-1',
 					sdkEventId: 'session-error-event',
@@ -5566,7 +5567,7 @@ suite('CopilotAgentSession', () => {
 				eventName: 'agentHost.copilotModelCallFailure',
 				data: {
 					agentSessionId: 'test-session-1',
-					chatSessionId: 'default',
+					chatSessionId: getTelemetryChatSessionId(URI.parse(buildDefaultChatUri(AgentSession.uri('copilot', 'test-session-1')))),
 					turnId: 'turn-1',
 					sdkSessionId: 'test-session-1',
 					sdkEventId: 'model-failure-event',

--- a/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
@@ -6,8 +6,10 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession } from '../../common/agentService.js';
-import { buildChatUri } from '../../common/state/sessionState.js';
+import { readAgentErrorTelemetryMeta } from '../../common/meta/agentErrorMeta.js';
+import { buildChatUri, buildSubagentSessionUri } from '../../common/state/sessionState.js';
 import { classifyCopilotClientFailure, createCopilotFailureCorrelation } from '../../node/copilot/copilotFailureTelemetry.js';
 
 suite('CopilotFailureTelemetry', () => {
@@ -41,9 +43,36 @@ suite('CopilotFailureTelemetry', () => {
 
 		assert.deepStrictEqual(createCopilotFailureCorrelation(session, chat, 'turn-id', 'sdk-session-id'), {
 			agentSessionId: 'agent-session-id',
-			chatSessionId: 'peer-chat-id',
+			chatSessionId: getTelemetryChatSessionId(chat),
 			turnId: 'turn-id',
 			sdkSessionId: 'sdk-session-id',
+		});
+	});
+
+	test('hashes subagent chat IDs without path-like telemetry values', () => {
+		const session = AgentSession.uri('copilotcli', 'agent-session-id');
+		const subagent = URI.parse(buildSubagentSessionUri(session, 'tool-call-id'));
+		const value = getTelemetryChatSessionId(subagent);
+
+		assert.strictEqual(value, String(Number(value)));
+		assert.strictEqual(value.includes('/'), false);
+	});
+
+	test('drops empty provider request identifiers', () => {
+		assert.deepStrictEqual(readAgentErrorTelemetryMeta({
+			errorType: 'test',
+			message: 'failed',
+			_meta: {
+				chatError: {
+					fetchError: {
+						requestId: '',
+						serverRequestId: '',
+					},
+				},
+			},
+		}), {
+			providerCallId: undefined,
+			serviceRequestId: undefined,
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { AgentSession } from '../../common/agentService.js';
+import { buildChatUri } from '../../common/state/sessionState.js';
+import { classifyCopilotClientFailure, createCopilotFailureCorrelation } from '../../node/copilot/copilotFailureTelemetry.js';
+
+suite('CopilotFailureTelemetry', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('classifies only known client lifecycle failures', () => {
+		assert.deepStrictEqual([
+			classifyCopilotClientFailure(new Error('Connection is closed.')),
+			classifyCopilotClientFailure(new Error('Connection is disposed.')),
+			classifyCopilotClientFailure(new Error('Client not connected')),
+			classifyCopilotClientFailure(new Error('The in-process runtime connection is closed.')),
+			classifyCopilotClientFailure(new Error('Failed to start CLI server: spawn failed')),
+			classifyCopilotClientFailure(new Error('CLI server exited with code 1')),
+			classifyCopilotClientFailure(new Error('CLI server exited unexpectedly with code 1')),
+			classifyCopilotClientFailure(new Error('429 too many requests')),
+		], [
+			'connectionClosed',
+			'connectionDisposed',
+			'clientNotConnected',
+			'runtimeConnectionClosed',
+			'startupFailed',
+			'startupFailed',
+			'startupFailed',
+			undefined,
+		]);
+	});
+
+	test('builds the Agent Host and SDK correlation tuple', () => {
+		const session = AgentSession.uri('copilotcli', 'agent-session-id');
+		const chat = URI.parse(buildChatUri(session, 'peer-chat-id'));
+
+		assert.deepStrictEqual(createCopilotFailureCorrelation(session, chat, 'turn-id', 'sdk-session-id'), {
+			agentSessionId: 'agent-session-id',
+			chatSessionId: 'peer-chat-id',
+			turnId: 'turn-id',
+			sdkSessionId: 'sdk-session-id',
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add correlated telemetry for Copilot client failures, recovery outcomes, SDK session errors, and model-call failures
- enrich generic Agent Host turn telemetry with chat and provider/service request identifiers
- correlate Agent Host, SDK, provider, and recovery layers using session/chat/turn, SDK event/session, API request, and client failure episode IDs
- keep SDK restricted-only model error strings out of standard telemetry and redact BYOK model names

## Validation
- `npm run transpile-client`
- 483 affected Agent Host tests
- `npm run typecheck-client`
- targeted hygiene checks
- two architecture/privacy review passes

## Telemetry verification
Production Kusto verification is still pending because `kusto_runQuery` was not exposed in the authoring session. Source and tests confirm emission/classification, but production ingestion and scrubbing rates were not claimed as verified.

(Written by Copilot)