### PR TITLE
Set medium verbosity for GPT-5.6 Agent Host sessions

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotClient, ExitPlanModeRequest, ExitPlanModeResult, NamedProviderConfig, PermissionRequestResult, ProviderModelConfig, ResumeSessionConfig, SessionConfig, Tool } from '@github/copilot-sdk';
+import type { CopilotClient, ExitPlanModeRequest, ExitPlanModeResult, NamedProviderConfig, PermissionRequestResult, ProviderModelConfig, ResumeSessionConfig, SessionConfig, Tool, Verbosity } from '@github/copilot-sdk';
 import { coalesce } from '../../../../base/common/arrays.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -33,6 +33,7 @@ import { describeSystemMessageConfig } from './prompts/systemMessage.js';
 import './prompts/allPrompts.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import type { ReasoningEffortLevel } from '../../common/reasoningEffort.js';
+import { isGpt56Model } from './modelIdentifiers.js';
 
 export const ThinkingLevelConfigKey = 'thinkingLevel';
 /**
@@ -482,7 +483,23 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			workingDirectory: plan.workingDirectory?.fsPath,
 		}));
 		await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
+		// TODO: Remove this post-create update once the SDK exposes verbosity in
+		// SessionConfig, alongside create-session options such as reasoningEffort.
+		if (isGpt56Model(plan.model?.id)) {
+			await this._applyVerbosity(raw, 'medium', plan.sessionId);
+		}
+
 		return new CopilotSessionWrapper(raw);
+	}
+
+	/** Sets output verbosity after session creation. */
+	private async _applyVerbosity(session: CopilotSessionWrapper['session'], verbosity: Verbosity, sessionId: string): Promise<void> {
+		try {
+			await session.rpc.options.update({ verbosity });
+			this._logService.info(`[Copilot:${sessionId}] Applied '${verbosity}' verbosity`);
+		} catch (err) {
+			this._logService.warn(`[Copilot:${sessionId}] Failed to apply '${verbosity}' verbosity`, err);
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/modelIdentifiers.ts
+++ b/src/vs/platform/agentHost/node/copilot/modelIdentifiers.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const GPT_56_MODEL_IDS: ReadonlySet<string> = new Set([
+	'gpt-5.6-sol',
+	'gpt-5.6-terra',
+	'gpt-5.6-luna',
+]);
+
+export function isGpt56Model(modelId: string | undefined): boolean {
+	return modelId !== undefined && GPT_56_MODEL_IDS.has(modelId.toLowerCase());
+}

--- a/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
+++ b/src/vs/platform/agentHost/node/copilot/toolSearchDeferral.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isGpt56Model } from './modelIdentifiers.js';
+
 export { CLIENT_TOOL_SEARCH_REFERENCE_NAME, RUNTIME_TOOL_SEARCH_TOOL_NAME } from '../../common/toolSearchConstants.js';
 
 /**
@@ -22,8 +24,7 @@ export function agentHostModelSupportsToolSearch(modelId: string | undefined): b
 	}
 	const id = modelId.toLowerCase();
 	const normalizedId = id.replace(/\./g, '-');
-	const isGpt56 = id === 'gpt-5.6-sol' || id === 'gpt-5.6-terra' || id === 'gpt-5.6-luna';
-	if (normalizedId === 'gpt-5-4' || normalizedId === 'gpt-5-5' || isGpt56) {
+	if (normalizedId === 'gpt-5-4' || normalizedId === 'gpt-5-5' || isGpt56Model(id)) {
 		return true;
 	}
 	if (!normalizedId.startsWith('claude')) {

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import type { CopilotClient, CopilotSession } from '@github/copilot-sdk';
+import type { CopilotClient, CopilotSession, Verbosity } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -516,6 +516,35 @@ suite('CopilotSessionLauncher resume fallback', () => {
 		} finally {
 			await launcher.disposeByokProxyHandle();
 		}
+	});
+});
+
+suite('CopilotSessionLauncher verbosity', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function applyVerbosity(verbosity: Verbosity): Promise<void> {
+		const launcher = createTestLauncher() as unknown as {
+			_applyVerbosity(session: CopilotSession, verbosity: Verbosity, sessionId: string): Promise<void>;
+		};
+		const session = {
+			rpc: {
+				options: {
+					update: async (options: unknown) => updates.push(options),
+				},
+			},
+		} as unknown as CopilotSession;
+		return launcher._applyVerbosity(session, verbosity, 'session-1');
+	}
+
+	const updates: unknown[] = [];
+
+	setup(() => updates.length = 0);
+
+	test('forwards the requested verbosity', async () => {
+		await applyVerbosity('high');
+
+		assert.deepStrictEqual(updates, [{ verbosity: 'high' }]);
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/modelIdentifiers.test.ts
+++ b/src/vs/platform/agentHost/test/node/modelIdentifiers.test.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { isGpt56Model } from '../../node/copilot/modelIdentifiers.js';
+
+suite('modelIdentifiers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('identifies GPT-5.6 variants case-insensitively', () => {
+		for (const id of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'GPT-5.6-SOL']) {
+			assert.strictEqual(isGpt56Model(id), true, id);
+		}
+	});
+
+	test('rejects other and absent model identifiers', () => {
+		for (const id of ['gpt-5.5', 'gpt-5-6-luna', 'claude-sonnet-4.6', '']) {
+			assert.strictEqual(isGpt56Model(id), false, id);
+		}
+		assert.strictEqual(isGpt56Model(undefined), false);
+	});
+});


### PR DESCRIPTION
## Summary

Set Copilot SDK output verbosity to `medium` for newly created GPT-5.6 Agent Host sessions.

## Details

- Apply `session.rpc.options.update({ verbosity: 'medium' })` after creating sessions for the supported GPT-5.6 model variants:
  - `gpt-5.6-sol`
  - `gpt-5.6-terra`
  - `gpt-5.6-luna`
- Keep the post-create update best-effort so a verbosity update failure is logged without preventing session creation.
- Use the SDK's exported `Verbosity` type for the update helper.
- Centralize GPT-5.6 model identification in `modelIdentifiers.ts` and reuse it from tool-search capability detection.
- Document that the post-create workaround can be removed once the SDK exposes verbosity in `SessionConfig`, alongside create-session options such as `reasoningEffort`.
- Add focused coverage for verbosity forwarding and case-insensitive GPT-5.6 model matching.

## Testing

- `./scripts/test.bat --grep "CopilotSessionLauncher verbosity|modelIdentifiers"`
  - 3 passing
- Pre-commit hygiene check passed for all 5 changed files.
- VS Code diagnostics report no errors in the changed source and test files.