### PR TITLE
Support running sanity tests against build pipeline artifacts

### DIFF
--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -17,11 +17,19 @@ parameters:
   - name: args
     type: string
     default: ""
+  # Build pipeline artifacts to download before running. When set, targets resolve from them
+  # instead of the update service, which only serves published builds.
+  - name: artifacts
+    type: object
+    default: []
+  - name: continueOnError
+    type: boolean
+    default: true
 
 jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
-    continueOnError: true
+    continueOnError: ${{ parameters.continueOnError }}
     pool:
       name: ${{ parameters.poolName }}
       os: ${{ parameters.os }}
@@ -43,10 +51,24 @@ jobs:
           continueOnError: true
           sbomEnabled: false
     variables:
-      TEST_DIR: $(Build.SourcesDirectory)/test/sanity
-      LOG_FILE: $(TEST_DIR)/results.xml
-      SCREENSHOTS_DIR: $(TEST_DIR)/screenshots
-      CRASH_DUMPS_DIR: $(TEST_DIR)/crash-dumps
+      - name: TEST_DIR
+        value: $(Build.SourcesDirectory)/test/sanity
+      - name: LOG_FILE
+        value: $(TEST_DIR)/results.xml
+      - name: SCREENSHOTS_DIR
+        value: $(TEST_DIR)/screenshots
+      - name: CRASH_DUMPS_DIR
+        value: $(TEST_DIR)/crash-dumps
+      # Kept under TEST_DIR so container runs see it through the volume run-docker.sh mounts at /root.
+      - name: ARTIFACTS_DIR
+        value: $(TEST_DIR)/artifacts
+      - name: ARTIFACTS_ARG
+        ${{ if eq(length(parameters.artifacts), 0) }}:
+          value: ""
+        ${{ elseif ne(parameters.container, '') }}:
+          value: --artifacts-dir /root/artifacts
+        ${{ else }}:
+          value: --artifacts-dir $(ARTIFACTS_DIR)
     steps:
       - checkout: self
         fetchDepth: 1
@@ -54,6 +76,14 @@ jobs:
         sparseCheckoutDirectories: build/azure-pipelines/config test/sanity .nvmrc
         retryCountOnTaskFailure: 3
         displayName: Checkout test/sanity
+
+      - ${{ each artifact in parameters.artifacts }}:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifact: ${{ artifact }}
+            path: $(ARTIFACTS_DIR)/${{ artifact }}
+          retryCountOnTaskFailure: 3
+          displayName: Download ${{ artifact }}
 
       - ${{ if eq(parameters.os, 'windows') }}:
         - script: mkdir "$(SCREENSHOTS_DIR)"
@@ -147,7 +177,7 @@ jobs:
 
       # Windows
       - ${{ if eq(parameters.os, 'windows') }}:
-        - script: $(TEST_DIR)/scripts/run-win32.cmd -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v ${{ parameters.args }}
+        - script: $(TEST_DIR)/scripts/run-win32.cmd -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v $(ARTIFACTS_ARG) ${{ parameters.args }}
           workingDirectory: $(TEST_DIR)
           displayName: Run Sanity Tests
           env:
@@ -156,7 +186,7 @@ jobs:
 
       # macOS
       - ${{ if eq(parameters.os, 'macOS') }}:
-        - bash: $(TEST_DIR)/scripts/run-macOS.sh -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v ${{ parameters.args }}
+        - bash: $(TEST_DIR)/scripts/run-macOS.sh -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v $(ARTIFACTS_ARG) ${{ parameters.args }}
           workingDirectory: $(TEST_DIR)
           displayName: Run Sanity Tests
           env:
@@ -165,7 +195,7 @@ jobs:
 
       # Native Linux host
       - ${{ if and(eq(parameters.container, ''), eq(parameters.os, 'linux')) }}:
-        - bash: $(TEST_DIR)/scripts/run-ubuntu.sh -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v ${{ parameters.args }}
+        - bash: $(TEST_DIR)/scripts/run-ubuntu.sh -c $(BUILD_COMMIT) -q $(BUILD_QUALITY) -t $(LOG_FILE) -s $(SCREENSHOTS_DIR) -d $(CRASH_DUMPS_DIR) -v $(ARTIFACTS_ARG) ${{ parameters.args }}
           workingDirectory: $(TEST_DIR)
           displayName: Run Sanity Tests
           env:
@@ -191,6 +221,7 @@ jobs:
               --screenshots-dir "/root/screenshots" \
               --crash-dumps-dir "/root/crash-dumps" \
               --verbose \
+              $(ARTIFACTS_ARG) \
               ${{ parameters.args }}
           workingDirectory: $(TEST_DIR)
           displayName: Run Sanity Tests

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -115,6 +115,13 @@ parameters:
     displayName: "Use legacy OSS Notice"
     type: boolean
     default: false
+  # Opt-in for validation builds that never publish (SDK canary runs, SDK bump PR
+  # validation): runs the sanity suite against this build's own pipeline artifacts
+  # rather than the update service, which only serves published builds.
+  - name: VSCODE_RUN_ARTIFACT_SANITY_TESTS
+    displayName: "Run sanity tests against this build's artifacts (for unpublished builds)"
+    type: boolean
+    default: false
   # SDK -> VS Code integration: override the Copilot dependencies to a version
   # already published to the private feed. 'none'/'auto' = normal build.
   # See microsoft/vscode-engineering specs/sdk-vscode-integration.spec.md.
@@ -802,6 +809,217 @@ extends:
                   poolName: 1es-azure-linux-3-arm64
                   container: ubuntu-24
                   arch: arm64
+
+      # Validation builds that never publish (SDK canary runs, SDK bump PR validation) cannot use
+      # the SanityTests stage above, which resolves builds through the update service. Run the same
+      # suite against this build's own artifacts instead. Each job's grep is scoped to exactly the
+      # targets its artifacts cover, and each stage depends only on the build stage producing them
+      # so one platform failing does not skip the rest.
+      - ${{ if and(eq(parameters.VSCODE_RUN_ARTIFACT_SANITY_TESTS, true), eq(variables['VSCODE_BUILD_STAGE_MACOS'], true)) }}:
+        - stage: ArtifactSanityTestsMacOS
+          displayName: Sanity Tests (Artifacts, macOS)
+          dependsOn:
+            - macOS
+          variables:
+            - name: BUILD_COMMIT
+              value: $(Build.SourceVersion)
+            - name: BUILD_QUALITY
+              value: ${{ variables.VSCODE_QUALITY }}
+          jobs:
+            - ${{ if eq(parameters.VSCODE_BUILD_MACOS, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_macos_x64
+                  displayName: macOS x64 (no runtime)
+                  poolName: AcesShared
+                  os: macOS
+                  continueOnError: false
+                  args: --no-detection --grep "darwin-x64"
+                  artifacts:
+                    - vscode_cli_darwin_x64_cli
+                    - vscode_client_darwin_x64_archive
+                    - vscode_client_darwin_x64_dmg
+                    - vscode_server_darwin_x64_archive
+                    - vscode_web_darwin_x64_archive
+
+            - ${{ if eq(parameters.VSCODE_BUILD_MACOS_ARM64, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_macos_arm64
+                  displayName: macOS arm64
+                  poolName: AcesShared
+                  os: macOS
+                  continueOnError: false
+                  args: --grep "darwin-arm64"
+                  artifacts:
+                    - vscode_cli_darwin_arm64_cli
+                    - vscode_client_darwin_arm64_archive
+                    - vscode_client_darwin_arm64_dmg
+                    - vscode_server_darwin_arm64_archive
+                    - vscode_web_darwin_arm64_archive
+
+            - ${{ if eq(variables['VSCODE_BUILD_MACOS_UNIVERSAL'], true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_macos_universal
+                  displayName: macOS universal
+                  poolName: AcesShared
+                  os: macOS
+                  continueOnError: false
+                  args: --grep "darwin-universal"
+                  artifacts:
+                    - vscode_client_darwin_universal_archive
+                    - vscode_client_darwin_universal_dmg
+
+      - ${{ if and(eq(parameters.VSCODE_RUN_ARTIFACT_SANITY_TESTS, true), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:
+        - stage: ArtifactSanityTestsWindows
+          displayName: Sanity Tests (Artifacts, Windows)
+          dependsOn:
+            - Windows
+          variables:
+            - name: BUILD_COMMIT
+              value: $(Build.SourceVersion)
+            - name: BUILD_QUALITY
+              value: ${{ variables.VSCODE_QUALITY }}
+          jobs:
+            - ${{ if eq(parameters.VSCODE_BUILD_WIN32, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_windows_x64
+                  displayName: Windows x64
+                  poolName: 1es-windows-2022-x64
+                  os: windows
+                  continueOnError: false
+                  args: --grep "win32-x64"
+                  artifacts:
+                    - vscode_cli_win32_x64_cli
+                    - vscode_client_win32_x64_archive
+                    - vscode_client_win32_x64_setup
+                    - vscode_client_win32_x64_user-setup
+                    - vscode_server_win32_x64_archive
+                    - vscode_web_win32_x64_archive
+
+            - ${{ if eq(parameters.VSCODE_BUILD_WIN32_ARM64, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_windows_arm64
+                  displayName: Windows arm64
+                  poolName: 1es-windows-2022-arm64
+                  os: windows
+                  # Non-blocking: arm64 binaries are missing VersionInfo ProductName, which fails
+                  # the published SanityTests run on main too.
+                  continueOnError: true
+                  args: --grep "win32-arm64"
+                  artifacts:
+                    - vscode_cli_win32_arm64_cli
+                    - vscode_client_win32_arm64_archive
+                    - vscode_client_win32_arm64_setup
+                    - vscode_client_win32_arm64_user-setup
+                    - vscode_server_win32_arm64_archive
+                    - vscode_web_win32_arm64_archive
+
+      # The SDK ships linuxmusl prebuilds that only the Alpine jobs exercise.
+      - ${{ if and(eq(parameters.VSCODE_RUN_ARTIFACT_SANITY_TESTS, true), eq(variables['VSCODE_BUILD_STAGE_ALPINE'], true)) }}:
+        - stage: ArtifactSanityTestsAlpine
+          displayName: Sanity Tests (Artifacts, Alpine)
+          dependsOn:
+            - Alpine
+          variables:
+            - name: BUILD_COMMIT
+              value: $(Build.SourceVersion)
+            - name: BUILD_QUALITY
+              value: ${{ variables.VSCODE_QUALITY }}
+          jobs:
+            - ${{ if eq(parameters.VSCODE_BUILD_ALPINE, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_alpine_x64
+                  displayName: Alpine 3.22 amd64
+                  poolName: 1es-ubuntu-22.04-x64
+                  container: alpine
+                  arch: amd64
+                  continueOnError: false
+                  args: --grep "alpine-x64$"
+                  artifacts:
+                    - vscode_cli_alpine_x64_cli
+                    - vscode_server_linux_alpine_archive-unsigned
+                    - vscode_web_linux_alpine_archive-unsigned
+
+            - ${{ if eq(parameters.VSCODE_BUILD_ALPINE_ARM64, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_alpine_arm64
+                  displayName: Alpine 3.22 arm64
+                  poolName: 1es-azure-linux-3-arm64
+                  container: alpine
+                  arch: arm64
+                  continueOnError: false
+                  args: --grep "alpine-arm64$"
+                  artifacts:
+                    - vscode_cli_alpine_arm64_cli
+                    - vscode_server_alpine_arm64_archive-unsigned
+                    - vscode_web_alpine_arm64_archive-unsigned
+
+      # rpm targets are excluded, there is no dnf/yum on the Ubuntu hosts.
+      - ${{ if and(eq(parameters.VSCODE_RUN_ARTIFACT_SANITY_TESTS, true), eq(variables['VSCODE_BUILD_STAGE_LINUX'], true)) }}:
+        - stage: ArtifactSanityTestsLinux
+          displayName: Sanity Tests (Artifacts, Linux)
+          dependsOn:
+            - Linux
+          variables:
+            - name: BUILD_COMMIT
+              value: $(Build.SourceVersion)
+            - name: BUILD_QUALITY
+              value: ${{ variables.VSCODE_QUALITY }}
+          jobs:
+            - ${{ if eq(parameters.VSCODE_BUILD_LINUX, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_ubuntu_x64
+                  displayName: Ubuntu 22.04 x64
+                  poolName: 1es-ubuntu-22.04-x64
+                  os: linux
+                  continueOnError: false
+                  args: --grep "linux(-deb|-snap)?-x64$"
+                  artifacts:
+                    - vscode_cli_linux_x64_cli
+                    - vscode_client_linux_x64_archive-unsigned
+                    - vscode_client_linux_x64_deb-package
+                    - vscode_client_linux_x64_snap
+                    - vscode_server_linux_x64_archive-unsigned
+                    - vscode_web_linux_x64_archive-unsigned
+
+            - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARM64, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_ubuntu_arm64
+                  displayName: Ubuntu 24.04 arm64
+                  poolName: 1es-azure-linux-3-arm64
+                  container: ubuntu-24
+                  arch: arm64
+                  continueOnError: false
+                  args: --grep "linux(-deb)?-arm64$"
+                  artifacts:
+                    - vscode_cli_linux_arm64_cli
+                    - vscode_client_linux_arm64_archive-unsigned
+                    - vscode_client_linux_arm64_deb-package
+                    - vscode_server_linux_arm64_archive-unsigned
+                    - vscode_web_linux_arm64_archive-unsigned
+
+            - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true) }}:
+              - template: build/azure-pipelines/common/sanity-tests.yml@self
+                parameters:
+                  name: artifact_ubuntu_armhf
+                  displayName: Ubuntu 24.04 arm32
+                  poolName: 1es-azure-linux-3-arm64
+                  container: ubuntu-24
+                  arch: arm
+                  continueOnError: false
+                  args: --grep "linux(-deb)?-armhf$"
+                  artifacts:
+                    - vscode_cli_linux_armhf_cli
+                    - vscode_client_linux_armhf_archive-unsigned
+                    - vscode_client_linux_armhf_deb-package
 
         - ${{ if and(parameters.VSCODE_RELEASE, eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['VSCODE_PRIVATE_BUILD'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
           - stage: ApproveRelease

--- a/test/sanity/.gitignore
+++ b/test/sanity/.gitignore
@@ -2,6 +2,7 @@
 .dbus
 .dotnet
 .DS_Store
+artifacts/
 .local
 .mozilla
 .pki

--- a/test/sanity/README.md
+++ b/test/sanity/README.md
@@ -28,6 +28,7 @@ Use -g or -f command-line options to filter tests to match the host platform.
 |`--fgrep <string>`|`-f`|Only run tests containing the given string (Mocha fgrep)|
 |`--test-results <path>`|`-t`|Output test results in JUnit format to the specified path|
 |`--timeout <sec>`||Set the test-case timeout in seconds (default: 600 seconds)|
+|`--artifacts-dir <path>`||Resolve builds from downloaded pipeline artifacts instead of the update service|
 |`--verbose`|`-v`|Enable verbose logging|
 |`--help`|`-h`|Show this help message|
 
@@ -38,6 +39,22 @@ To run CLI tests for all platforms on given commit of Insiders build, from the r
 ```bash
 npm run sanity-test -- --commit 19228f26df517fecbfda96c20956f7c521e072be --quality insider -g "cli*"
 ```
+
+### Testing Unpublished Builds
+
+By default targets are resolved through `update.code.visualstudio.com`, which only serves published
+builds. Validation builds that never publish — such as the Copilot SDK canary runs — can be tested by
+passing `--artifacts-dir`, which resolves each target from downloaded build pipeline artifacts laid out
+as `<artifacts-dir>/<artifact-name>/<file>`:
+
+```bash
+npm run sanity-test -- --commit <commit> --quality insider --artifacts-dir /tmp/artifacts -g "linux.*x64"
+```
+
+Every target has a `targetArtifacts` mapping in `src/context.ts`; an unmapped target fails with an
+explicit error rather than falling back to the update service, so runs must be scoped with `-g`/`-f`
+to the artifacts that were actually downloaded. The SHA-256 check is skipped in this mode because
+there is no update service metadata to compare against.
 
 ## Scripts
 

--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -28,6 +28,61 @@ interface ITargetMetadata {
 }
 
 /**
+ * Maps a sanity test target to the build pipeline artifact that carries it, for `--artifacts-dir`
+ * runs against builds that were never published. An unmapped target fails loudly rather than
+ * silently falling back to the update service.
+ */
+const targetArtifacts: Readonly<Record<string, string>> = {
+	'cli-alpine-arm64': 'vscode_cli_alpine_arm64_cli',
+	'cli-alpine-x64': 'vscode_cli_alpine_x64_cli',
+	'cli-darwin-arm64': 'vscode_cli_darwin_arm64_cli',
+	'cli-darwin-x64': 'vscode_cli_darwin_x64_cli',
+	'cli-linux-arm64': 'vscode_cli_linux_arm64_cli',
+	'cli-linux-armhf': 'vscode_cli_linux_armhf_cli',
+	'cli-linux-x64': 'vscode_cli_linux_x64_cli',
+	'cli-win32-arm64': 'vscode_cli_win32_arm64_cli',
+	'cli-win32-x64': 'vscode_cli_win32_x64_cli',
+	'darwin': 'vscode_client_darwin_x64_archive',
+	'darwin-arm64': 'vscode_client_darwin_arm64_archive',
+	'darwin-arm64-dmg': 'vscode_client_darwin_arm64_dmg',
+	'darwin-universal': 'vscode_client_darwin_universal_archive',
+	'darwin-universal-dmg': 'vscode_client_darwin_universal_dmg',
+	'darwin-x64-dmg': 'vscode_client_darwin_x64_dmg',
+	'linux-arm64': 'vscode_client_linux_arm64_archive-unsigned',
+	'linux-armhf': 'vscode_client_linux_armhf_archive-unsigned',
+	'linux-deb-arm64': 'vscode_client_linux_arm64_deb-package',
+	'linux-deb-armhf': 'vscode_client_linux_armhf_deb-package',
+	'linux-deb-x64': 'vscode_client_linux_x64_deb-package',
+	'linux-rpm-arm64': 'vscode_client_linux_arm64_rpm-package',
+	'linux-rpm-armhf': 'vscode_client_linux_armhf_rpm-package',
+	'linux-rpm-x64': 'vscode_client_linux_x64_rpm-package',
+	'linux-snap-x64': 'vscode_client_linux_x64_snap',
+	'linux-x64': 'vscode_client_linux_x64_archive-unsigned',
+	'server-alpine-arm64': 'vscode_server_alpine_arm64_archive-unsigned',
+	'server-alpine-arm64-web': 'vscode_web_alpine_arm64_archive-unsigned',
+	'server-darwin': 'vscode_server_darwin_x64_archive',
+	'server-darwin-arm64': 'vscode_server_darwin_arm64_archive',
+	'server-darwin-arm64-web': 'vscode_web_darwin_arm64_archive',
+	'server-darwin-web': 'vscode_web_darwin_x64_archive',
+	'server-linux-alpine': 'vscode_server_linux_alpine_archive-unsigned',
+	'server-linux-alpine-web': 'vscode_web_linux_alpine_archive-unsigned',
+	'server-linux-arm64': 'vscode_server_linux_arm64_archive-unsigned',
+	'server-linux-arm64-web': 'vscode_web_linux_arm64_archive-unsigned',
+	'server-linux-x64': 'vscode_server_linux_x64_archive-unsigned',
+	'server-linux-x64-web': 'vscode_web_linux_x64_archive-unsigned',
+	'server-win32-arm64': 'vscode_server_win32_arm64_archive',
+	'server-win32-arm64-web': 'vscode_web_win32_arm64_archive',
+	'server-win32-x64': 'vscode_server_win32_x64_archive',
+	'server-win32-x64-web': 'vscode_web_win32_x64_archive',
+	'win32-arm64': 'vscode_client_win32_arm64_setup',
+	'win32-arm64-archive': 'vscode_client_win32_arm64_archive',
+	'win32-arm64-user': 'vscode_client_win32_arm64_user-setup',
+	'win32-x64': 'vscode_client_win32_x64_setup',
+	'win32-x64-archive': 'vscode_client_win32_x64_archive',
+	'win32-x64-user': 'vscode_client_win32_x64_user-setup',
+};
+
+/**
  * Provides context and utilities for VS Code sanity tests.
  */
 export class TestContext {
@@ -57,6 +112,7 @@ export class TestContext {
 		downloadOnly: boolean;
 		screenshotsDir: string | undefined;
 		crashDumpsDir: string | undefined;
+		artifactsDir: string | undefined;
 	}>) {
 	}
 
@@ -356,6 +412,10 @@ export class TestContext {
 	 * @returns The path to the downloaded file.
 	 */
 	public async downloadTarget(target: string): Promise<string> {
+		if (this.options.artifactsDir) {
+			return this.resolveArtifact(target);
+		}
+
 		const { url, sha256hash } = await this.fetchMetadata(target);
 		const filePath = path.join(this.createTempDir(), path.basename(url));
 
@@ -365,6 +425,51 @@ export class TestContext {
 
 		this.validateSha256Hash(filePath, sha256hash);
 		return filePath;
+	}
+
+	/**
+	 * Resolves a target from a directory of downloaded build pipeline artifacts, laid out as
+	 * `<artifacts-dir>/<artifact-name>/<file>`. There is no update service metadata for these
+	 * builds, so the SHA-256 check is skipped.
+	 * @param target The target platform (e.g., 'cli-linux-x64').
+	 * @returns The path to the artifact file.
+	 */
+	private resolveArtifact(target: string): string {
+		const artifact = targetArtifacts[target];
+		if (!artifact) {
+			this.error(`No pipeline artifact is mapped for target ${target}. Add it to 'targetArtifacts', or exclude the test from this run.`);
+		}
+
+		const artifactDir = path.join(this.options.artifactsDir!, artifact);
+		if (!fs.existsSync(artifactDir)) {
+			this.error(`Artifact ${artifact} for target ${target} was not downloaded to ${artifactDir}`);
+		}
+
+		const files: string[] = [];
+		this.collectFiles(artifactDir, files);
+		if (files.length !== 1) {
+			this.error(`Expected exactly one file in artifact ${artifact}, found ${files.length}: ${files.join(', ')}`);
+		}
+
+		this.log(`Resolved target ${target} to ${files[0]} from artifact ${artifact}`);
+		return files[0];
+	}
+
+	/**
+	 * Collects all files from the specified directory recursively, skipping the SBOM manifest
+	 * that 1ES injects into every published artifact.
+	 */
+	private collectFiles(dir: string, files: string[]): void {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const filePath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (entry.name !== '_manifest') {
+					this.collectFiles(filePath, files);
+				}
+			} else {
+				files.push(filePath);
+			}
+		}
 	}
 
 	/**

--- a/test/sanity/src/index.ts
+++ b/test/sanity/src/index.ts
@@ -30,6 +30,7 @@ if (options.help) {
 	console.info('  --timeout <sec>                 Set the test-case timeout in seconds (default: 600 seconds)');
 	console.info('  --screenshots-dir, -s <path>    Save failure screenshots to the specified directory');
 	console.info('  --crash-dumps-dir, -d <path>    Save crash dumps from desktop app runs to the specified directory');
+	console.info('  --artifacts-dir <path>          Resolve builds from downloaded pipeline artifacts instead of the update service');
 	console.info('  --verbose, -v                   Enable verbose logging');
 	console.info('  --help, -h                      Show this help message');
 	process.exit(0);

--- a/test/sanity/src/main.ts
+++ b/test/sanity/src/main.ts
@@ -14,7 +14,7 @@ import { setup as setupWSLTests } from './wsl.test.js';
 import { setup as setupDevTunnelTests } from './devTunnel.test.js';
 
 const options = minimist(process.argv.slice(2), {
-	string: ['commit', 'quality', 'screenshots-dir', 'crash-dumps-dir'],
+	string: ['commit', 'quality', 'screenshots-dir', 'crash-dumps-dir', 'artifacts-dir'],
 	boolean: ['cleanup', 'verbose', 'signing-check', 'headless', 'detection'],
 	alias: { commit: 'c', quality: 'q', verbose: 'v', 'screenshots-dir': 's', 'crash-dumps-dir': 'd' },
 	default: { cleanup: true, verbose: false, 'signing-check': true, headless: true, 'detection': true },
@@ -38,6 +38,7 @@ const context = new TestContext({
 	downloadOnly: !options['detection'],
 	screenshotsDir: options['screenshots-dir'],
 	crashDumpsDir: options['crash-dumps-dir'],
+	artifactsDir: options['artifacts-dir'],
 });
 
 context.log(`Arguments: ${process.argv.slice(2).join(' ')}`);


### PR DESCRIPTION
## Problem

Validation builds that never publish — SDK canary runs and SDK bump PR validation — can't run platform sanity tests. The `SanityTests` stage requires `VSCODE_PUBLISH=true`, and the suite resolves every target through `update.code.visualstudio.com`, which only serves published builds.

Publishing them isn't a safe workaround: `createBuild.ts` keys the build document by commit, and these runs are queued on `refs/heads/main` at the same commit as a real publishing insider build, so their assets could land on a record that a later scheduled run releases.

The gap is real. `build/lib/copilot.ts` materializes the Copilot SDK's native payload (`prebuilds/`, `tgrep/bin/`, `ripgrep/bin/`) into the packaged app, so an SDK bump can break packaging or signing — and nothing on these runs verified the installed, signed artifact.

## Change

Adds `--artifacts-dir` to `test/sanity`. When set, each target resolves from a downloaded pipeline artifact instead of the update service. The SHA-256 check is skipped (no update metadata), the 1ES-injected `_manifest` SBOM folder is ignored, and anything other than exactly one payload file fails loudly. Unmapped targets are an explicit error rather than a silent fallback, so runs must be scoped with `--grep`.

Exposed as an opt-in `VSCODE_RUN_ARTIFACT_SANITY_TESTS` pipeline parameter — deliberately not keyed off the canary override, so the bump-PR flow (which uses no override) can request it too. See microsoft/vscode-engineering#3525 for the callers.

10 jobs across macOS, Windows, Alpine and Linux, covering 53 of the suite's 62 tests. Each stage depends only on the build stage producing its artifacts, so one platform failing doesn't skip the rest.

Signing coverage is unaffected: the only `-unsigned` artifacts are the linux/alpine client, server and web archives, which are exactly the targets with no signature assertions.

## Validation

**Artifact mode** — build [462073](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462073), 9 of 10 jobs green, exercising real dpkg/snap/dmg/setup installs plus Authenticode and codesign validation against canary-SDK bits.

Windows arm64 fails on `VersionInfo ProductName is missing or empty` for third-party natives. That's pre-existing — the published `SanityTests` run fails identically on `main` — so that job is non-blocking.

**No regression to normal builds** — build [462282](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462282) with `VSCODE_PUBLISH=true` and the new parameter left at its default. The artifact stages compile out, and the regular `Sanity Tests` stage passes all 10 jobs (1 native host + 9 distro containers), confirming the shared template change is inert when no artifacts are requested.
