### PR TITLE
NES: Generate scored edits with datagen

### DIFF
--- a/extensions/copilot/test/base/simulationOptions.ts
+++ b/extensions/copilot/test/base/simulationOptions.ts
@@ -62,6 +62,10 @@ export type NesDatagen = {
 	readonly sameFileJumpMinBelow: number;
 	/** Maximum number of samples selected from one raw workspace recording. */
 	readonly maxSamplesPerRecording?: number;
+	/** Whether to emit scoredEdits viewer files for generated samples. */
+	readonly generateScoredEdits: boolean;
+	/** Internal worker-only directory for staging scoredEdits files. */
+	readonly scoredEditsOutputDirectory?: string;
 	/** Internal worker-only subset of selected workspace-recording operation indices. */
 	readonly workspacePivotOperationIndices?: readonly number[];
 };
@@ -243,6 +247,8 @@ export class SimulationOptions {
 					'--max-samples-per-recording',
 					DEFAULT_WORKSPACE_RECORDING_SAMPLE_CAP,
 				),
+				generateScoredEdits: boolean(argv['generate-scored-edits'], false),
+				scoredEditsOutputDirectory: argv['scored-edits-output-directory'],
 				workspacePivotOperationIndices: SimulationOptions.parseWorkspacePivotOperationIndices(argv['workspace-pivot-operation-indices']),
 			}
 			: undefined;
@@ -333,6 +339,8 @@ export class SimulationOptions {
 			`                                       random             → pick a single eligible pivot uniformly at random`,
 			`  --seed                             Integer seed for the continuous pivot RNG (default: random, logged for reproducibility)`,
 			`  --max-samples-per-recording        Maximum samples selected from a workspace recording (default: 100)`,
+			`  --generate-scored-edits            Generate <sample-id>.scoredEdits.w.json files beside the output JSONL`,
+			`                                     Requires --sample-task=xtab`,
 			`  --sample-task                      Which target to generate (default: xtab)`,
 			`                                     Values: xtab, cursor-same-file, cursor-cross-file, cursor-both`,
 			`                                       xtab               → edit-prediction sample (assistant = an edit)`,
@@ -359,6 +367,7 @@ export class SimulationOptions {
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=continuous.jsonl --input-format=continuous`,
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=continuous.jsonl --input-format=continuous --pivot-strategy=random --seed=42`,
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=current.workspaceRecording.jsonl --input-format=workspace-recording`,
+			`  npm run simulate -- --config-file=config.json nes-datagen --input=current.workspaceRecording.jsonl --input-format=workspace-recording --generate-scored-edits`,
 			``,
 		].join('\n'));
 	}

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -25,6 +25,7 @@ import { loadAndParseInput } from './parseInput';
 import { generatePromptFromRecording, IGeneratedPrompt } from './promptStep';
 import { IProcessedRow, parseSuggestedEdit, processAllRows } from './replayRecording';
 import { generateAllResponses, generateResponse, IResponseGenerationInput, applyEditsToContent } from './responseStep';
+import { publishScoredEditsFiles, writeScoredEditsFiles } from './scoredEditsOutput';
 import { streamJsonRecords } from './streamJsonRecords';
 import { openWriteStream } from './writeStream';
 import type { WithRowIndex } from './withRowIndex';
@@ -179,6 +180,7 @@ async function loadAndProduceProcessedRows(nesDatagenOpts: NesDatagen, verbose: 
  */
 export async function runInputPipeline(opts: RunPipelineOptions, log = console.log.bind(console)): Promise<void> {
 	const nesDatagenOpts = opts.nesDatagen!;
+	validateScoredEditsOptions(nesDatagenOpts);
 	if (nesDatagenOpts.sampleTask !== NesDatagenSampleTask.Xtab) {
 		return runCursorPipeline(opts, log);
 	}
@@ -312,6 +314,10 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 
 		const writeResult = await writeSamples(outputPath, samples);
 		log(`  [5/5] Output written: ${writeResult.written} samples → ${writeResult.outputPath}`);
+		if (nesDatagenOpts.generateScoredEdits) {
+			const scoredEditsResult = await generateOrStageScoredEdits(nesDatagenOpts, outputPath, samples, processed);
+			log(`    Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
+		}
 		if (writeResult.skipped > 0) {
 			log(`    Structural validation dropped ${writeResult.skipped} samples`);
 			if (verbose) {
@@ -631,6 +637,7 @@ interface IWorkerPartition {
 interface IPipelineWorker extends IWorkerPartition {
 	readonly args: string[];
 	readonly resultPath: string;
+	readonly scoredEditsOutputDirectory?: string;
 }
 
 function partitionWork(itemCount: number, parallelism: number): IWorkerPartition[] {
@@ -684,7 +691,8 @@ async function mergeWorkerResults(workers: readonly IPipelineWorker[], outputPat
 			allSamples.push(sample);
 		}
 	}
-	return writeSamples(outputPath, allSamples);
+	const writeResult = await writeSamples(outputPath, allSamples);
+	return { allSamples, writeResult };
 }
 
 /**
@@ -693,6 +701,7 @@ async function mergeWorkerResults(workers: readonly IPipelineWorker[], outputPat
  */
 export async function runInputPipelineParallel(opts: SimulationOptions): Promise<void> {
 	const nesDatagenOpts = opts.nesDatagen!;
+	validateScoredEditsOptions(nesDatagenOpts);
 	if (nesDatagenOpts.inputFormat === NesDatagenInputFormat.WorkspaceRecording) {
 		return runWorkspaceRecordingPipelineParallel(opts);
 	}
@@ -731,15 +740,15 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 			...partition,
 			chunkPath: path.join(tmpDir, `chunk_${workerIndex}.json`),
 			resultPath: path.join(tmpDir, `result_${workerIndex}.jsonl`),
+			scoredEditsOutputDirectory: path.join(tmpDir, `scoredEdits_${workerIndex}`),
 		}));
 
 		// Distribute records into contiguous per-worker chunk files by streaming the
 		// input a second time, writing each chunk incrementally as a JSON array.
 		await writeChunkFiles(inputPath, chunkWorkers.map(worker => worker.chunkPath), chunkSize);
 
-		const workers: IPipelineWorker[] = chunkWorkers.map(worker => ({
-			...worker,
-			args: [
+		const workers: IPipelineWorker[] = chunkWorkers.map(worker => {
+			const args = [
 				'nes-datagen',
 				'--input', worker.chunkPath,
 				'--config-file', opts.configFile!,
@@ -755,8 +764,12 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 				'--same-file-jump-min-above', String(nesDatagenOpts.sameFileJumpMinAbove),
 				'--same-file-jump-min-below', String(nesDatagenOpts.sameFileJumpMinBelow),
 				'--worker',
-			],
-		}));
+			];
+			if (nesDatagenOpts.generateScoredEdits) {
+				args.push('--generate-scored-edits', '--scored-edits-output-directory', worker.scoredEditsOutputDirectory);
+			}
+			return { ...worker, args };
+		});
 		if (verbose) {
 			for (const worker of workers) {
 				worker.args.push('--verbose');
@@ -765,8 +778,16 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 
 		const elapsed = await runPipelineWorkers(workers, verbose, 'rows');
 		const outputPath = resolveOutputPath(inputPath, nesDatagenOpts.output);
-		const writeResult = await mergeWorkerResults(workers, outputPath);
+		const { allSamples, writeResult } = await mergeWorkerResults(workers, outputPath);
 		console.log(`  Output: ${writeResult.written} samples → ${writeResult.outputPath} (${elapsed})`);
+		if (nesDatagenOpts.generateScoredEdits) {
+			const scoredEditsResult = await publishScoredEditsFiles(
+				outputPath,
+				allSamples,
+				workers.map(worker => worker.scoredEditsOutputDirectory!),
+			);
+			console.log(`  Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
+		}
 	} finally {
 		await fs.promises.rm(tmpDir, { recursive: true, force: true });
 	}
@@ -801,6 +822,7 @@ async function runWorkspaceRecordingPipelineParallel(opts: SimulationOptions): P
 			const pivotOperationIndices = descriptors
 				.slice(partition.start, partition.start + partition.count)
 				.map(descriptor => descriptor.pivotOperationIndex);
+			const scoredEditsOutputDirectory = path.join(tmpDir, `scoredEdits_${workerIndex}`);
 			const args = [
 				'nes-datagen',
 				'--input', inputPath,
@@ -816,21 +838,64 @@ async function runWorkspaceRecordingPipelineParallel(opts: SimulationOptions): P
 				'--workspace-pivot-operation-indices', pivotOperationIndices.join(','),
 				'--worker',
 			];
+			if (nesDatagenOpts.generateScoredEdits) {
+				args.push('--generate-scored-edits', '--scored-edits-output-directory', scoredEditsOutputDirectory);
+			}
 			if (verbose) {
 				args.push('--verbose');
 			}
 			return {
 				...partition,
 				resultPath: path.join(tmpDir, `result_${workerIndex}.jsonl`),
+				scoredEditsOutputDirectory,
 				args,
 			};
 		});
 
 		const elapsed = await runPipelineWorkers(workers, verbose, 'samples');
 		const outputPath = resolveOutputPath(inputPath, nesDatagenOpts.output);
-		const writeResult = await mergeWorkerResults(workers, outputPath);
+		const { allSamples, writeResult } = await mergeWorkerResults(workers, outputPath);
 		console.log(`  Output: ${writeResult.written} samples → ${writeResult.outputPath} (${elapsed})`);
+		if (nesDatagenOpts.generateScoredEdits) {
+			const scoredEditsResult = await publishScoredEditsFiles(
+				outputPath,
+				allSamples,
+				workers.map(worker => worker.scoredEditsOutputDirectory!),
+			);
+			console.log(`  Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
+		}
 	} finally {
 		await fs.promises.rm(tmpDir, { recursive: true, force: true });
+	}
+}
+
+function validateScoredEditsOptions(options: NesDatagen): void {
+	if (!options.generateScoredEdits) {
+		return;
+	}
+	if (options.sampleTask !== NesDatagenSampleTask.Xtab) {
+		throw new Error('--generate-scored-edits requires --sample-task=xtab');
+	}
+	if (options.workerMode && !options.scoredEditsOutputDirectory) {
+		throw new Error('nes-datagen workers require --scored-edits-output-directory when generating scoredEdits');
+	}
+}
+
+async function generateOrStageScoredEdits(
+	options: NesDatagen,
+	samplesOutputPath: string,
+	samples: readonly ISample[],
+	processedRows: readonly IProcessedRow[],
+): Promise<{ readonly outputDirectory: string; readonly written: number }> {
+	if (options.scoredEditsOutputDirectory) {
+		return writeScoredEditsFiles(options.scoredEditsOutputDirectory, samples, processedRows, options.rowOffset);
+	}
+
+	const stagingDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nes-scored-edits-'));
+	try {
+		await writeScoredEditsFiles(stagingDirectory, samples, processedRows, options.rowOffset);
+		return await publishScoredEditsFiles(samplesOutputPath, samples, [stagingDirectory]);
+	} finally {
+		await fs.promises.rm(stagingDirectory, { recursive: true, force: true });
 	}
 }

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -20,7 +20,7 @@ import { processContinuousRecords } from './continuous/processContinuous';
 import { detectCrossFileJump, detectSameFileJump } from './cursorJump/detectJump';
 import { generateCursorPromptFromRecording, installCursorJumpCapturingFetcher } from './cursorJump/cursorJumpPromptStep';
 import { generateCrossFileResponse, generateSameFileResponse } from './cursorJump/cursorJumpResponseStep';
-import { assembleSample, ISample, SampleClassification, resolveOutputPath, writeSamples } from './output';
+import { assembleSample, ISample, IWriteResult, SampleClassification, resolveOutputPath, writeSamples } from './output';
 import { loadAndParseInput } from './parseInput';
 import { generatePromptFromRecording, IGeneratedPrompt } from './promptStep';
 import { IProcessedRow, parseSuggestedEdit, processAllRows } from './replayRecording';
@@ -312,10 +312,14 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 			log(`    Workspace recording rows rejected for partial edit-window labels: ${workspaceRowsWithDroppedOracleEdits}`);
 		}
 
-		const writeResult = await writeSamples(outputPath, samples);
+		const { writeResult, scoredEditsResult } = await writePipelineOutputs(
+			nesDatagenOpts,
+			outputPath,
+			samples,
+			{ kind: 'processedRows', rows: processed },
+		);
 		log(`  [5/5] Output written: ${writeResult.written} samples → ${writeResult.outputPath}`);
-		if (nesDatagenOpts.generateScoredEdits) {
-			const scoredEditsResult = await generateOrStageScoredEdits(nesDatagenOpts, outputPath, samples, processed);
+		if (scoredEditsResult) {
 			log(`    Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
 		}
 		if (writeResult.skipped > 0) {
@@ -684,15 +688,14 @@ async function runPipelineWorkers(workers: readonly IPipelineWorker[], verbose: 
 	return elapsed;
 }
 
-async function mergeWorkerResults(workers: readonly IPipelineWorker[], outputPath: string) {
+async function mergeWorkerResults(workers: readonly IPipelineWorker[]): Promise<ISample[]> {
 	const allSamples: ISample[] = [];
 	for (const worker of workers) {
 		for await (const sample of streamJsonRecords<ISample>(worker.resultPath)) {
 			allSamples.push(sample);
 		}
 	}
-	const writeResult = await writeSamples(outputPath, allSamples);
-	return { allSamples, writeResult };
+	return allSamples;
 }
 
 /**
@@ -778,14 +781,15 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 
 		const elapsed = await runPipelineWorkers(workers, verbose, 'rows');
 		const outputPath = resolveOutputPath(inputPath, nesDatagenOpts.output);
-		const { allSamples, writeResult } = await mergeWorkerResults(workers, outputPath);
+		const allSamples = await mergeWorkerResults(workers);
+		const { writeResult, scoredEditsResult } = await writePipelineOutputs(
+			nesDatagenOpts,
+			outputPath,
+			allSamples,
+			{ kind: 'stagingDirectories', directories: workers.map(worker => worker.scoredEditsOutputDirectory!) },
+		);
 		console.log(`  Output: ${writeResult.written} samples → ${writeResult.outputPath} (${elapsed})`);
-		if (nesDatagenOpts.generateScoredEdits) {
-			const scoredEditsResult = await publishScoredEditsFiles(
-				outputPath,
-				allSamples,
-				workers.map(worker => worker.scoredEditsOutputDirectory!),
-			);
+		if (scoredEditsResult) {
 			console.log(`  Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
 		}
 	} finally {
@@ -854,14 +858,15 @@ async function runWorkspaceRecordingPipelineParallel(opts: SimulationOptions): P
 
 		const elapsed = await runPipelineWorkers(workers, verbose, 'samples');
 		const outputPath = resolveOutputPath(inputPath, nesDatagenOpts.output);
-		const { allSamples, writeResult } = await mergeWorkerResults(workers, outputPath);
+		const allSamples = await mergeWorkerResults(workers);
+		const { writeResult, scoredEditsResult } = await writePipelineOutputs(
+			nesDatagenOpts,
+			outputPath,
+			allSamples,
+			{ kind: 'stagingDirectories', directories: workers.map(worker => worker.scoredEditsOutputDirectory!) },
+		);
 		console.log(`  Output: ${writeResult.written} samples → ${writeResult.outputPath} (${elapsed})`);
-		if (nesDatagenOpts.generateScoredEdits) {
-			const scoredEditsResult = await publishScoredEditsFiles(
-				outputPath,
-				allSamples,
-				workers.map(worker => worker.scoredEditsOutputDirectory!),
-			);
+		if (scoredEditsResult) {
 			console.log(`  Scored edits: ${scoredEditsResult.written} files → ${scoredEditsResult.outputDirectory}`);
 		}
 	} finally {
@@ -876,25 +881,67 @@ function validateScoredEditsOptions(options: NesDatagen): void {
 	if (options.sampleTask !== NesDatagenSampleTask.Xtab) {
 		throw new Error('--generate-scored-edits requires --sample-task=xtab');
 	}
+	if (!options.workerMode && options.scoredEditsOutputDirectory) {
+		throw new Error('--scored-edits-output-directory is only valid for nes-datagen workers');
+	}
 	if (options.workerMode && !options.scoredEditsOutputDirectory) {
 		throw new Error('nes-datagen workers require --scored-edits-output-directory when generating scoredEdits');
 	}
 }
 
-async function generateOrStageScoredEdits(
+type ScoredEditsSource =
+	| { readonly kind: 'processedRows'; readonly rows: readonly IProcessedRow[] }
+	| { readonly kind: 'stagingDirectories'; readonly directories: readonly string[] };
+
+async function writePipelineOutputs(
 	options: NesDatagen,
-	samplesOutputPath: string,
+	outputPath: string,
 	samples: readonly ISample[],
-	processedRows: readonly IProcessedRow[],
-): Promise<{ readonly outputDirectory: string; readonly written: number }> {
-	if (options.scoredEditsOutputDirectory) {
-		return writeScoredEditsFiles(options.scoredEditsOutputDirectory, samples, processedRows, options.rowOffset);
+	scoredEditsSource: ScoredEditsSource,
+): Promise<{
+	readonly writeResult: IWriteResult;
+	readonly scoredEditsResult?: { readonly outputDirectory: string; readonly written: number };
+}> {
+	if (!options.generateScoredEdits) {
+		return { writeResult: await writeSamples(outputPath, samples) };
 	}
 
-	const stagingDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nes-scored-edits-'));
+	if (options.workerMode) {
+		if (scoredEditsSource.kind !== 'processedRows') {
+			throw new Error('nes-datagen workers require processed rows to generate scoredEdits');
+		}
+		const writeResult = await writeSamples(outputPath, samples);
+		const scoredEditsResult = await writeScoredEditsFiles(
+			options.scoredEditsOutputDirectory!,
+			samples,
+			scoredEditsSource.rows,
+			options.rowOffset,
+		);
+		return { writeResult, scoredEditsResult };
+	}
+
+	const stagingDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nes-generated-output-'));
 	try {
-		await writeScoredEditsFiles(stagingDirectory, samples, processedRows, options.rowOffset);
-		return await publishScoredEditsFiles(samplesOutputPath, samples, [stagingDirectory]);
+		const stagedSamplesOutputPath = path.join(stagingDirectory, 'samples.jsonl');
+		const stagedWriteResult = await writeSamples(stagedSamplesOutputPath, samples);
+		let scoredEditsDirectories: readonly string[];
+		if (scoredEditsSource.kind === 'processedRows') {
+			const scoredEditsDirectory = path.join(stagingDirectory, 'scoredEdits');
+			await writeScoredEditsFiles(scoredEditsDirectory, samples, scoredEditsSource.rows, options.rowOffset);
+			scoredEditsDirectories = [scoredEditsDirectory];
+		} else {
+			scoredEditsDirectories = scoredEditsSource.directories;
+		}
+		const scoredEditsResult = await publishScoredEditsFiles(
+			outputPath,
+			stagedSamplesOutputPath,
+			samples,
+			scoredEditsDirectories,
+		);
+		return {
+			writeResult: { ...stagedWriteResult, outputPath: path.resolve(outputPath) },
+			scoredEditsResult,
+		};
 	} finally {
 		await fs.promises.rm(stagingDirectory, { recursive: true, force: true });
 	}

--- a/extensions/copilot/test/pipeline/scoredEditsOutput.ts
+++ b/extensions/copilot/test/pipeline/scoredEditsOutput.ts
@@ -1,0 +1,212 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { ISerializedEdit } from '../../src/platform/workspaceRecorder/common/workspaceLog';
+import { NesDatagenSampleTask } from '../base/simulationOptions';
+import { Scoring } from './alternativeAction/types';
+import { type ISample, validateSample } from './output';
+import type { IProcessedRow } from './replayRecording';
+
+const scoredEditsFilePattern = /^(?<sampleId>-?\d+)\.scoredEdits\.w\.json$/;
+
+export interface IWriteScoredEditsResult {
+	readonly outputDirectory: string;
+	readonly written: number;
+}
+
+export async function writeScoredEditsFiles(
+	outputDirectory: string,
+	samples: readonly ISample[],
+	processedRows: readonly IProcessedRow[],
+	rowOffset: number,
+): Promise<IWriteScoredEditsResult> {
+	const processedBySampleId = new Map(
+		processedRows.map(row => [row.originalRowIndex + rowOffset, row]),
+	);
+	const validSamples = samples.filter(sample => validateSample(sample).valid);
+	const fileNames = new Set<string>();
+	for (const sample of validSamples) {
+		const fileName = getScoredEditsFileName(sample);
+		if (fileNames.has(fileName)) {
+			throw new Error(`Multiple samples have ID ${sample.metadata.rowIndex}`);
+		}
+		fileNames.add(fileName);
+		validateProcessedRow(sample, processedBySampleId);
+	}
+
+	const resolvedOutputDirectory = path.resolve(outputDirectory);
+	await fs.mkdir(resolvedOutputDirectory, { recursive: true });
+	for (const sample of validSamples) {
+		const file = createScoredEditsFile(sample, processedBySampleId);
+		await fs.writeFile(
+			path.join(resolvedOutputDirectory, file.fileName),
+			JSON.stringify(file.scoring, null, '\t') + '\n',
+		);
+	}
+
+	return { outputDirectory: resolvedOutputDirectory, written: validSamples.length };
+}
+
+export async function publishScoredEditsFiles(
+	samplesOutputPath: string,
+	samples: readonly ISample[],
+	stagingDirectories: readonly string[],
+): Promise<IWriteScoredEditsResult> {
+	const validSamples = samples.filter(sample => validateSample(sample).valid);
+	const expectedIds = new Set(validSamples.map(sample => sample.metadata.rowIndex));
+	if (expectedIds.size !== validSamples.length) {
+		throw new Error('Generated samples contain duplicate IDs');
+	}
+
+	const stagedFiles = new Map<number, string>();
+	for (const stagingDirectory of stagingDirectories) {
+		const entries = await fs.readdir(stagingDirectory, { withFileTypes: true });
+		for (const entry of entries) {
+			if (!entry.isFile()) {
+				throw new Error(`Unexpected directory in scoredEdits staging output: ${path.join(stagingDirectory, entry.name)}`);
+			}
+			const match = scoredEditsFilePattern.exec(entry.name);
+			if (!match?.groups) {
+				throw new Error(`Unexpected file in scoredEdits staging output: ${path.join(stagingDirectory, entry.name)}`);
+			}
+			const sampleId = Number(match.groups['sampleId']);
+			if (stagedFiles.has(sampleId)) {
+				throw new Error(`Multiple staged scoredEdits files have sample ID ${sampleId}`);
+			}
+			stagedFiles.set(sampleId, path.join(stagingDirectory, entry.name));
+		}
+	}
+
+	for (const expectedId of expectedIds) {
+		if (!stagedFiles.has(expectedId)) {
+			throw new Error(`Missing staged scoredEdits file for sample ID ${expectedId}`);
+		}
+	}
+	for (const stagedId of stagedFiles.keys()) {
+		if (!expectedIds.has(stagedId)) {
+			throw new Error(`Staged scoredEdits file has no generated sample with ID ${stagedId}`);
+		}
+	}
+
+	const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
+	const parentDirectory = path.dirname(outputDirectory);
+	await fs.mkdir(parentDirectory, { recursive: true });
+	const pendingDirectory = await fs.mkdtemp(path.join(parentDirectory, `.${path.basename(outputDirectory)}.pending-`));
+	let pendingPublished = false;
+	try {
+		for (const [sampleId, stagedFile] of stagedFiles) {
+			await fs.copyFile(stagedFile, path.join(pendingDirectory, `${sampleId}.scoredEdits.w.json`));
+		}
+		await replaceDirectory(pendingDirectory, outputDirectory);
+		pendingPublished = true;
+	} finally {
+		if (!pendingPublished) {
+			await fs.rm(pendingDirectory, { recursive: true, force: true });
+		}
+	}
+
+	return { outputDirectory, written: stagedFiles.size };
+}
+
+export function resolveScoredEditsOutputDirectory(samplesOutputPath: string): string {
+	const parsed = path.parse(path.resolve(samplesOutputPath));
+	return path.join(parsed.dir, `${parsed.name}.scoredEdits`);
+}
+
+function createScoredEditsFile(
+	sample: ISample,
+	processedBySampleId: ReadonlyMap<number, IProcessedRow>,
+): { readonly fileName: string; readonly scoring: Scoring.t } {
+	const processedRow = validateProcessedRow(sample, processedBySampleId);
+	const oracleEdits: ISerializedEdit = sample.metadata.oracleEdits.map(
+		([start, endEx, text]) => [start, endEx, text],
+	);
+	const recording = {
+		log: [...processedRow.recordingInfo.log],
+		nextUserEdit: {
+			edit: oracleEdits,
+			relativePath: processedRow.nextUserEdit.relativePath,
+			originalOpIdx: processedRow.nextUserEdit.originalOpIdx,
+		},
+	};
+	return {
+		fileName: getScoredEditsFileName(sample),
+		scoring: Scoring.create(recording, [{
+			documentUri: processedRow.nextUserEdit.relativePath,
+			edit: oracleEdits,
+			scoreCategory: 'nextEdit',
+			score: 0,
+		}]),
+	};
+}
+
+function validateProcessedRow(
+	sample: ISample,
+	processedBySampleId: ReadonlyMap<number, IProcessedRow>,
+): IProcessedRow {
+	if (sample.metadata.task !== NesDatagenSampleTask.Xtab) {
+		throw new Error(`Sample ${sample.metadata.rowIndex} is not an xtab sample`);
+	}
+	const processedRow = processedBySampleId.get(sample.metadata.rowIndex);
+	if (!processedRow) {
+		throw new Error(`No processed row found for sample ${sample.metadata.rowIndex}`);
+	}
+	if (!serializedEditsEqual(sample.metadata.oracleEdits, processedRow.nextUserEdit.edit)) {
+		throw new Error(`Expected next edit does not match the recording for sample ${sample.metadata.rowIndex}`);
+	}
+	return processedRow;
+}
+
+function getScoredEditsFileName(sample: ISample): string {
+	return `${sample.metadata.rowIndex}.scoredEdits.w.json`;
+}
+
+async function replaceDirectory(sourceDirectory: string, targetDirectory: string): Promise<void> {
+	const backupDirectory = `${targetDirectory}.backup-${randomUUID()}`;
+	let targetMoved = false;
+	try {
+		await fs.rename(targetDirectory, backupDirectory);
+		targetMoved = true;
+	} catch (error) {
+		if (!isFileNotFoundError(error)) {
+			throw error;
+		}
+	}
+
+	try {
+		await fs.rename(sourceDirectory, targetDirectory);
+	} catch (publishError) {
+		if (targetMoved) {
+			try {
+				await fs.rename(backupDirectory, targetDirectory);
+			} catch (rollbackError) {
+				throw new AggregateError([publishError, rollbackError], `Failed to publish scoredEdits output and restore ${targetDirectory}`);
+			}
+		}
+		throw publishError;
+	}
+
+	if (targetMoved) {
+		await fs.rm(backupDirectory, { recursive: true, force: true });
+	}
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+	return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function serializedEditsEqual(
+	first: readonly (readonly [number, number, string])[],
+	second: readonly (readonly [number, number, string])[],
+): boolean {
+	return first.length === second.length && first.every((edit, index) =>
+		edit[0] === second[index][0]
+		&& edit[1] === second[index][1]
+		&& edit[2] === second[index][2]
+	);
+}

--- a/extensions/copilot/test/pipeline/scoredEditsOutput.ts
+++ b/extensions/copilot/test/pipeline/scoredEditsOutput.ts
@@ -54,8 +54,10 @@ export async function writeScoredEditsFiles(
 
 export async function publishScoredEditsFiles(
 	samplesOutputPath: string,
+	stagedSamplesOutputPath: string,
 	samples: readonly ISample[],
 	stagingDirectories: readonly string[],
+	rename: typeof fs.rename = fs.rename,
 ): Promise<IWriteScoredEditsResult> {
 	const validSamples = samples.filter(sample => validateSample(sample).valid);
 	const expectedIds = new Set(validSamples.map(sample => sample.metadata.rowIndex));
@@ -97,17 +99,23 @@ export async function publishScoredEditsFiles(
 	const parentDirectory = path.dirname(outputDirectory);
 	await fs.mkdir(parentDirectory, { recursive: true });
 	const pendingDirectory = await fs.mkdtemp(path.join(parentDirectory, `.${path.basename(outputDirectory)}.pending-`));
-	let pendingPublished = false;
 	try {
+		const pendingSamplesOutputPath = path.join(pendingDirectory, path.basename(samplesOutputPath));
+		const pendingScoredEditsDirectory = path.join(pendingDirectory, path.basename(outputDirectory));
+		await fs.copyFile(stagedSamplesOutputPath, pendingSamplesOutputPath);
+		await fs.mkdir(pendingScoredEditsDirectory);
 		for (const [sampleId, stagedFile] of stagedFiles) {
-			await fs.copyFile(stagedFile, path.join(pendingDirectory, `${sampleId}.scoredEdits.w.json`));
+			await fs.copyFile(stagedFile, path.join(pendingScoredEditsDirectory, `${sampleId}.scoredEdits.w.json`));
 		}
-		await replaceDirectory(pendingDirectory, outputDirectory);
-		pendingPublished = true;
+		await replaceGeneratedOutputs(
+			[
+				{ source: pendingSamplesOutputPath, target: path.resolve(samplesOutputPath) },
+				{ source: pendingScoredEditsDirectory, target: outputDirectory },
+			],
+			rename,
+		);
 	} finally {
-		if (!pendingPublished) {
-			await fs.rm(pendingDirectory, { recursive: true, force: true });
-		}
+		await fs.rm(pendingDirectory, { recursive: true, force: true });
 	}
 
 	return { outputDirectory, written: stagedFiles.size };
@@ -166,38 +174,78 @@ function getScoredEditsFileName(sample: ISample): string {
 	return `${sample.metadata.rowIndex}.scoredEdits.w.json`;
 }
 
-async function replaceDirectory(sourceDirectory: string, targetDirectory: string): Promise<void> {
-	const backupDirectory = `${targetDirectory}.backup-${randomUUID()}`;
-	let targetMoved = false;
+interface IOutputReplacement {
+	readonly source: string;
+	readonly target: string;
+}
+
+async function replaceGeneratedOutputs(replacements: readonly IOutputReplacement[], rename: typeof fs.rename): Promise<void> {
+	const backups = new Map<string, string>();
 	try {
-		await fs.rename(targetDirectory, backupDirectory);
-		targetMoved = true;
-	} catch (error) {
-		if (!isFileNotFoundError(error)) {
-			throw error;
+		for (const replacement of replacements) {
+			const backup = `${replacement.target}.backup-${randomUUID()}`;
+			try {
+				await rename(replacement.target, backup);
+				backups.set(replacement.target, backup);
+			} catch (error) {
+				if (!isFileNotFoundError(error)) {
+					throw error;
+				}
+			}
 		}
+	} catch (error) {
+		const rollbackErrors = await restoreBackups(backups, rename);
+		if (rollbackErrors.length > 0) {
+			throw new AggregateError([error, ...rollbackErrors], 'Failed to prepare generated output publication and restore existing outputs');
+		}
+		throw error;
 	}
 
+	const publishedTargets: string[] = [];
 	try {
-		await fs.rename(sourceDirectory, targetDirectory);
+		for (const replacement of replacements) {
+			await rename(replacement.source, replacement.target);
+			publishedTargets.push(replacement.target);
+		}
 	} catch (publishError) {
-		if (targetMoved) {
+		const rollbackErrors: Error[] = [];
+		for (const publishedTarget of publishedTargets.reverse()) {
 			try {
-				await fs.rename(backupDirectory, targetDirectory);
-			} catch (rollbackError) {
-				throw new AggregateError([publishError, rollbackError], `Failed to publish scoredEdits output and restore ${targetDirectory}`);
+				await fs.rm(publishedTarget, { recursive: true, force: true });
+			} catch (error) {
+				rollbackErrors.push(toError(error));
 			}
+		}
+		rollbackErrors.push(...await restoreBackups(backups, rename));
+		if (rollbackErrors.length > 0) {
+			throw new AggregateError([publishError, ...rollbackErrors], 'Failed to publish generated outputs and restore previous outputs');
 		}
 		throw publishError;
 	}
 
-	if (targetMoved) {
-		await fs.rm(backupDirectory, { recursive: true, force: true });
+	for (const backup of backups.values()) {
+		await fs.rm(backup, { recursive: true, force: true });
 	}
 }
 
 function isFileNotFoundError(error: unknown): boolean {
 	return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+async function restoreBackups(backups: ReadonlyMap<string, string>, rename: typeof fs.rename): Promise<Error[]> {
+	const errors: Error[] = [];
+	for (const [target, backup] of [...backups].reverse()) {
+		try {
+			await rename(backup, target);
+		} catch (error) {
+			errors.push(toError(error));
+		}
+	}
+	return errors;
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
 }
 
 function serializedEditsEqual(

--- a/extensions/copilot/test/pipeline/test/continuousPipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/continuousPipeline.e2e.spec.ts
@@ -7,6 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
+import type { Scoring } from '../alternativeAction/types';
 import { runInputPipeline, RunPipelineOptions } from '../pipeline';
 import { allContinuousRecords, continuousFixtures } from './fixtures/continuousFixtureData';
 
@@ -63,6 +64,7 @@ async function runContinuousPipeline(opts?: Partial<RunPipelineOptions>): Promis
 	samples: OutputSample[];
 	logs: string[];
 	output: string;
+	scoredEdits: { fileName: string; value: Scoring.t }[];
 }> {
 	const logs: string[] = [];
 	const log = (...args: unknown[]) => {
@@ -75,6 +77,7 @@ async function runContinuousPipeline(opts?: Partial<RunPipelineOptions>): Promis
 			output: outputPath,
 			rowOffset: 0,
 			workerMode: false,
+			generateScoredEdits: false,
 			sampleTask: NesDatagenSampleTask.Xtab,
 			sameFileJumpMinAbove: 5,
 			sameFileJumpMinBelow: 5,
@@ -91,7 +94,14 @@ async function runContinuousPipeline(opts?: Partial<RunPipelineOptions>): Promis
 	await runInputPipeline(pipelineOpts, log);
 
 	const output = await fs.readFile(outputPath, 'utf-8');
-	return { samples: parseJsonl<OutputSample>(output), logs, output };
+	const scoredEditsDirectory = path.join(tmpDir, 'output.scoredEdits');
+	const scoredEdits = pipelineOpts.nesDatagen?.generateScoredEdits
+		? await Promise.all((await fs.readdir(scoredEditsDirectory)).sort().map(async fileName => ({
+			fileName,
+			value: JSON.parse(await fs.readFile(path.join(scoredEditsDirectory, fileName), 'utf8')) as Scoring.t,
+		})))
+		: [];
+	return { samples: parseJsonl<OutputSample>(output), logs, output, scoredEdits };
 }
 
 describe('nes-datagen continuous pipeline e2e', () => {
@@ -170,6 +180,48 @@ describe('nes-datagen continuous pipeline e2e', () => {
 		expect(a.output).toBe(b.output);
 	});
 
+	test('generates scoredEdits files from continuous recordings', async () => {
+		const result = await runContinuousPipeline({
+			nesDatagen: {
+				input: inputPath,
+				output: outputPath,
+				rowOffset: 0,
+				workerMode: false,
+				generateScoredEdits: true,
+				sampleTask: NesDatagenSampleTask.Xtab,
+				sameFileJumpMinAbove: 5,
+				sameFileJumpMinBelow: 5,
+				inputFormat: NesDatagenInputFormat.Continuous,
+				pivotStrategy: PivotStrategy.Random,
+				seed: 42,
+			},
+		});
+		const samplesById = new Map(result.samples.map(sample => [sample.metadata.rowIndex, sample]));
+
+		expect(result.scoredEdits.map(({ fileName, value }) => {
+			const sampleId = Number(fileName.split('.')[0]);
+			return {
+				fileName,
+				expectedEdit: samplesById.get(sampleId)?.metadata.oracleEdits,
+				scoredEdit: value.edits[0]?.edit,
+				recordedEdit: value.scoringContext.recording.nextUserEdit.edit,
+			};
+		})).toEqual([
+			{
+				fileName: '0.scoredEdits.w.json',
+				expectedEdit: [[16, 19, 'sum']],
+				scoredEdit: [[16, 19, 'sum']],
+				recordedEdit: [[16, 19, 'sum']],
+			},
+			{
+				fileName: '1.scoredEdits.w.json',
+				expectedEdit: [[15, 15, ' -> str']],
+				scoredEdit: [[15, 15, ' -> str']],
+				recordedEdit: [[15, 15, ' -> str']],
+			},
+		]);
+	});
+
 	test('a slice whose oracle edit is malformed is isolated, not fatal', async () => {
 		// Overlapping replacements in the post-pivot `changed` make the split
 		// throw; the batch must still produce the sibling sample rather than abort.
@@ -196,6 +248,7 @@ describe('nes-datagen continuous pipeline e2e', () => {
 					output: mixedOutput,
 					rowOffset: 0,
 					workerMode: false,
+					generateScoredEdits: false,
 					sampleTask: NesDatagenSampleTask.Xtab,
 					sameFileJumpMinAbove: 5,
 					sameFileJumpMinBelow: 5,

--- a/extensions/copilot/test/pipeline/test/cursorJumpPipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/cursorJumpPipeline.e2e.spec.ts
@@ -78,6 +78,7 @@ async function runCursorPipeline(sampleTask: NesDatagenSampleTask, nesDatagenOve
 			output: outputPath,
 			rowOffset: 0,
 			workerMode: false,
+			generateScoredEdits: false,
 			sampleTask,
 			inputFormat: NesDatagenInputFormat.AlternativeAction,
 			pivotStrategy: PivotStrategy.Random,

--- a/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
@@ -361,6 +361,28 @@ describe('nes-datagen pipeline e2e', () => {
 		});
 	});
 
+	test('rejects the internal scoredEdits output directory outside worker mode', async () => {
+		await expect(runInputPipeline({
+			nesDatagen: {
+				input: inputPath,
+				output: outputPath,
+				rowOffset: 0,
+				workerMode: false,
+				generateScoredEdits: true,
+				scoredEditsOutputDirectory: path.join(tmpDir, 'unexpected-scored-edits'),
+				sampleTask: NesDatagenSampleTask.Xtab,
+				sameFileJumpMinAbove: 5,
+				sameFileJumpMinBelow: 5,
+				inputFormat: NesDatagenInputFormat.AlternativeAction,
+				pivotStrategy: PivotStrategy.Random,
+				seed: 0,
+			},
+			configFile: configPath,
+			verbose: false,
+			parallelism: 1,
+		})).rejects.toThrow('--scored-edits-output-directory is only valid for nes-datagen workers');
+	});
+
 	describe('row offset', () => {
 		test('applies rowOffset to sample rowIndex in metadata', async () => {
 			const offsetOutputPath = path.join(tmpDir, 'offset-output.jsonl');

--- a/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
@@ -74,6 +74,7 @@ interface OutputSample {
 async function runPipeline(opts?: Partial<RunPipelineOptions>): Promise<{
 	samples: OutputSample[];
 	logs: string[];
+	scoredEdits: { fileName: string; value: { edits: unknown[]; scoringContext: { recording: { nextUserEdit: unknown } } } }[];
 }> {
 	const logs: string[] = [];
 	const log = (...args: unknown[]) => {
@@ -85,7 +86,7 @@ async function runPipeline(opts?: Partial<RunPipelineOptions>): Promise<{
 			input: inputPath,
 			output: outputPath,
 			rowOffset: 0,
-			workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
+			workerMode: false, generateScoredEdits: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 		},
 		configFile: configPath,
 		verbose: true,
@@ -97,8 +98,15 @@ async function runPipeline(opts?: Partial<RunPipelineOptions>): Promise<{
 
 	const outputContents = await fs.readFile(outputPath, 'utf-8');
 	const samples = parseJsonl<OutputSample>(outputContents);
+	const scoredEditsDirectory = path.join(tmpDir, 'output.scoredEdits');
+	const scoredEdits = pipelineOpts.nesDatagen?.generateScoredEdits
+		? await Promise.all((await fs.readdir(scoredEditsDirectory)).sort().map(async fileName => ({
+			fileName,
+			value: JSON.parse(await fs.readFile(path.join(scoredEditsDirectory, fileName), 'utf8')),
+		})))
+		: [];
 
-	return { samples, logs };
+	return { samples, logs, scoredEdits };
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +120,59 @@ describe('nes-datagen pipeline e2e', () => {
 
 		beforeAll(async () => {
 			result = await runPipeline();
+		});
+
+		test('generates scoredEdits files from alternative-action recordings', async () => {
+			const result = await runPipeline({
+				nesDatagen: {
+					input: inputPath,
+					output: outputPath,
+					rowOffset: 0,
+					workerMode: false,
+					generateScoredEdits: true,
+					sampleTask: NesDatagenSampleTask.Xtab,
+					sameFileJumpMinAbove: 5,
+					sameFileJumpMinBelow: 5,
+					inputFormat: NesDatagenInputFormat.AlternativeAction,
+					pivotStrategy: PivotStrategy.Random,
+					seed: 0,
+				},
+			});
+
+			expect(result.scoredEdits.map(({ fileName, value }) => ({
+				fileName,
+				edit: value.edits,
+				nextUserEdit: value.scoringContext.recording.nextUserEdit,
+			}))).toEqual([
+				{
+					fileName: '0.scoredEdits.w.json',
+					edit: [{
+						documentUri: 'src/loader.ts',
+						edit: [[116, 120, 'contents'], [166, 170, 'contents']],
+						scoreCategory: 'nextEdit',
+						score: 0,
+					}],
+					nextUserEdit: {
+						edit: [[116, 120, 'contents'], [166, 170, 'contents']],
+						relativePath: 'src/loader.ts',
+						originalOpIdx: 3,
+					},
+				},
+				{
+					fileName: '1.scoredEdits.w.json',
+					edit: [{
+						documentUri: 'src/utils.py',
+						edit: [[15, 15, ' -> str']],
+						scoreCategory: 'nextEdit',
+						score: 0,
+					}],
+					nextUserEdit: {
+						edit: [[15, 15, ' -> str']],
+						relativePath: 'src/utils.py',
+						originalOpIdx: 3,
+					},
+				},
+			]);
 		});
 
 		test('produces output samples for valid rows', () => {
@@ -263,7 +324,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: invalidInputPath,
 						output: invalidOutputPath,
 						rowOffset: 0,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
+						workerMode: false, generateScoredEdits: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: configPath,
 					verbose: false,
@@ -290,7 +351,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: inputPath,
 						output: outputPath,
 						rowOffset: 0,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
+						workerMode: false, generateScoredEdits: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: undefined,
 					verbose: false,
@@ -309,7 +370,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: inputPath,
 						output: offsetOutputPath,
 						rowOffset: 100,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
+						workerMode: false, generateScoredEdits: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: configPath,
 					verbose: false,

--- a/extensions/copilot/test/pipeline/test/pipeline.spec.ts
+++ b/extensions/copilot/test/pipeline/test/pipeline.spec.ts
@@ -108,7 +108,7 @@ suite.skip('from csv to input rows to pipeline', () => {
 				input: inputRowsFilePath,
 				output: path.join(fixtures, 'output.jsonl'),
 				rowOffset: 0,
-				workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0
+				workerMode: false, generateScoredEdits: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0
 			},
 			configFile: configFilePath,
 			verbose: true,

--- a/extensions/copilot/test/pipeline/test/scoredEditsOutput.spec.ts
+++ b/extensions/copilot/test/pipeline/test/scoredEditsOutput.spec.ts
@@ -21,6 +21,7 @@ suite('scoredEdits output', () => {
 	test('publishes exactly the staged files associated with generated sample IDs', async () => {
 		const temporaryDirectory = await createTemporaryDirectory();
 		const samplesOutputPath = path.join(temporaryDirectory, 'samples.jsonl');
+		const stagedSamplesOutputPath = path.join(temporaryDirectory, 'staged-samples.jsonl');
 		const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
 		const firstStagingDirectory = path.join(temporaryDirectory, 'worker-1');
 		const secondStagingDirectory = path.join(temporaryDirectory, 'worker-2');
@@ -30,6 +31,8 @@ suite('scoredEdits output', () => {
 			fs.mkdir(secondStagingDirectory),
 		]);
 		await Promise.all([
+			fs.writeFile(samplesOutputPath, 'old samples'),
+			fs.writeFile(stagedSamplesOutputPath, 'new samples'),
 			fs.writeFile(path.join(outputDirectory, 'stale.scoredEdits.w.json'), 'stale'),
 			fs.writeFile(path.join(firstStagingDirectory, '0.scoredEdits.w.json'), 'sample 0'),
 			fs.writeFile(path.join(secondStagingDirectory, '2.scoredEdits.w.json'), 'sample 2'),
@@ -37,28 +40,32 @@ suite('scoredEdits output', () => {
 
 		const result = await publishScoredEditsFiles(
 			samplesOutputPath,
+			stagedSamplesOutputPath,
 			[createSample(2), createSample(0)],
 			[firstStagingDirectory, secondStagingDirectory],
 		);
 		const fileNames = (await fs.readdir(outputDirectory)).sort();
 		const contents = await Promise.all(fileNames.map(fileName => fs.readFile(path.join(outputDirectory, fileName), 'utf8')));
+		const samplesContents = await fs.readFile(samplesOutputPath, 'utf8');
 
-		expect({ result, fileNames, contents }).toEqual({
+		expect({ result, fileNames, contents, samplesContents }).toEqual({
 			result: { outputDirectory, written: 2 },
 			fileNames: ['0.scoredEdits.w.json', '2.scoredEdits.w.json'],
 			contents: ['sample 0', 'sample 2'],
+			samplesContents: 'new samples',
 		});
 	});
 
 	test('preserves the previous output when staged sample IDs do not match', async () => {
 		const temporaryDirectory = await createTemporaryDirectory();
 		const samplesOutputPath = path.join(temporaryDirectory, 'samples.jsonl');
+		const stagedSamplesOutputPath = path.join(temporaryDirectory, 'staged-samples.jsonl');
 		const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
 		const stagingDirectory = path.join(temporaryDirectory, 'worker');
 		await Promise.all([fs.mkdir(outputDirectory), fs.mkdir(stagingDirectory)]);
 		await fs.writeFile(path.join(outputDirectory, 'previous.scoredEdits.w.json'), 'previous');
 
-		const error = await publishScoredEditsFiles(samplesOutputPath, [createSample(1)], [stagingDirectory])
+		const error = await publishScoredEditsFiles(samplesOutputPath, stagedSamplesOutputPath, [createSample(1)], [stagingDirectory])
 			.then(() => undefined, value => value);
 		const fileNames = await fs.readdir(outputDirectory);
 		const contents = await fs.readFile(path.join(outputDirectory, fileNames[0]), 'utf8');
@@ -67,6 +74,54 @@ suite('scoredEdits output', () => {
 			message: 'Missing staged scoredEdits file for sample ID 1',
 			fileNames: ['previous.scoredEdits.w.json'],
 			contents: 'previous',
+		});
+	});
+
+	test('restores both previous outputs when publication fails after replacing samples', async () => {
+		const temporaryDirectory = await createTemporaryDirectory();
+		const samplesOutputPath = path.join(temporaryDirectory, 'samples.jsonl');
+		const stagedSamplesOutputPath = path.join(temporaryDirectory, 'staged-samples.jsonl');
+		const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
+		const stagingDirectory = path.join(temporaryDirectory, 'worker');
+		await Promise.all([fs.mkdir(outputDirectory), fs.mkdir(stagingDirectory)]);
+		await Promise.all([
+			fs.writeFile(samplesOutputPath, 'previous samples'),
+			fs.writeFile(stagedSamplesOutputPath, 'new samples'),
+			fs.writeFile(path.join(outputDirectory, 'previous.scoredEdits.w.json'), 'previous scored edit'),
+			fs.writeFile(path.join(stagingDirectory, '1.scoredEdits.w.json'), 'new scored edit'),
+		]);
+		const rename: typeof fs.rename = async (source, target) => {
+			if (target === outputDirectory && String(source).includes('.pending-')) {
+				throw new Error('injected scoredEdits publish failure');
+			}
+			await fs.rename(source, target);
+		};
+
+		const error = await publishScoredEditsFiles(
+			samplesOutputPath,
+			stagedSamplesOutputPath,
+			[createSample(1)],
+			[stagingDirectory],
+			rename,
+		).then(() => undefined, value => value);
+		const samplesContents = await fs.readFile(samplesOutputPath, 'utf8');
+		const fileNames = await fs.readdir(outputDirectory);
+		const scoredEditContents = await fs.readFile(path.join(outputDirectory, fileNames[0]), 'utf8');
+		const temporaryArtifacts = (await fs.readdir(temporaryDirectory))
+			.filter(fileName => fileName.includes('.pending-') || fileName.includes('.backup-'));
+
+		expect({
+			message: error instanceof Error ? error.message : undefined,
+			samplesContents,
+			fileNames,
+			scoredEditContents,
+			temporaryArtifacts,
+		}).toEqual({
+			message: 'injected scoredEdits publish failure',
+			samplesContents: 'previous samples',
+			fileNames: ['previous.scoredEdits.w.json'],
+			scoredEditContents: 'previous scored edit',
+			temporaryArtifacts: [],
 		});
 	});
 });

--- a/extensions/copilot/test/pipeline/test/scoredEditsOutput.spec.ts
+++ b/extensions/copilot/test/pipeline/test/scoredEditsOutput.spec.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, expect, suite, test } from 'vitest';
+import { NesDatagenSampleTask } from '../../base/simulationOptions';
+import type { ISample } from '../output';
+import { publishScoredEditsFiles, resolveScoredEditsOutputDirectory } from '../scoredEditsOutput';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })));
+});
+
+suite('scoredEdits output', () => {
+	test('publishes exactly the staged files associated with generated sample IDs', async () => {
+		const temporaryDirectory = await createTemporaryDirectory();
+		const samplesOutputPath = path.join(temporaryDirectory, 'samples.jsonl');
+		const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
+		const firstStagingDirectory = path.join(temporaryDirectory, 'worker-1');
+		const secondStagingDirectory = path.join(temporaryDirectory, 'worker-2');
+		await Promise.all([
+			fs.mkdir(outputDirectory),
+			fs.mkdir(firstStagingDirectory),
+			fs.mkdir(secondStagingDirectory),
+		]);
+		await Promise.all([
+			fs.writeFile(path.join(outputDirectory, 'stale.scoredEdits.w.json'), 'stale'),
+			fs.writeFile(path.join(firstStagingDirectory, '0.scoredEdits.w.json'), 'sample 0'),
+			fs.writeFile(path.join(secondStagingDirectory, '2.scoredEdits.w.json'), 'sample 2'),
+		]);
+
+		const result = await publishScoredEditsFiles(
+			samplesOutputPath,
+			[createSample(2), createSample(0)],
+			[firstStagingDirectory, secondStagingDirectory],
+		);
+		const fileNames = (await fs.readdir(outputDirectory)).sort();
+		const contents = await Promise.all(fileNames.map(fileName => fs.readFile(path.join(outputDirectory, fileName), 'utf8')));
+
+		expect({ result, fileNames, contents }).toEqual({
+			result: { outputDirectory, written: 2 },
+			fileNames: ['0.scoredEdits.w.json', '2.scoredEdits.w.json'],
+			contents: ['sample 0', 'sample 2'],
+		});
+	});
+
+	test('preserves the previous output when staged sample IDs do not match', async () => {
+		const temporaryDirectory = await createTemporaryDirectory();
+		const samplesOutputPath = path.join(temporaryDirectory, 'samples.jsonl');
+		const outputDirectory = resolveScoredEditsOutputDirectory(samplesOutputPath);
+		const stagingDirectory = path.join(temporaryDirectory, 'worker');
+		await Promise.all([fs.mkdir(outputDirectory), fs.mkdir(stagingDirectory)]);
+		await fs.writeFile(path.join(outputDirectory, 'previous.scoredEdits.w.json'), 'previous');
+
+		const error = await publishScoredEditsFiles(samplesOutputPath, [createSample(1)], [stagingDirectory])
+			.then(() => undefined, value => value);
+		const fileNames = await fs.readdir(outputDirectory);
+		const contents = await fs.readFile(path.join(outputDirectory, fileNames[0]), 'utf8');
+
+		expect({ message: error instanceof Error ? error.message : undefined, fileNames, contents }).toEqual({
+			message: 'Missing staged scoredEdits file for sample ID 1',
+			fileNames: ['previous.scoredEdits.w.json'],
+			contents: 'previous',
+		});
+	});
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'scored-edits-output-'));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function createSample(rowIndex: number): ISample {
+	return {
+		messages: [
+			{ role: 'system', content: 'system' },
+			{ role: 'user', content: 'user' },
+			{ role: 'assistant', content: 'assistant' },
+		],
+		metadata: {
+			rowIndex,
+			language: 'typescript',
+			strategy: 'customDiffPatch',
+			oracleEditCount: 1,
+			suggestionStatus: 'accepted',
+			filePath: 'src/file.ts',
+			docContent: 'value',
+			oracleEdits: [[0, 0, 'value']],
+			originalPrompt: [],
+			modelResponse: '',
+			task: NesDatagenSampleTask.Xtab,
+		},
+	};
+}

--- a/extensions/copilot/test/pipeline/test/workspaceRecordingPipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/workspaceRecordingPipeline.e2e.spec.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { HeaderLogEntry, LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
 import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
+import type { Scoring } from '../alternativeAction/types';
 import type { ISample } from '../output';
 import { runInputPipeline } from '../pipeline';
 
@@ -32,7 +33,11 @@ afterAll(async () => {
 	await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-async function runRecording(entries: readonly LogEntry[], sampleTask: NesDatagenSampleTask): Promise<{ samples: ISample[]; logs: string[] }> {
+async function runRecording(
+	entries: readonly LogEntry[],
+	sampleTask: NesDatagenSampleTask,
+	generateScoredEdits = false,
+): Promise<{ samples: ISample[]; logs: string[]; scoredEdits: { fileName: string; value: Scoring.t }[] }> {
 	const inputPath = path.join(tmpDir, `input-${sampleTask}.workspaceRecording.jsonl`);
 	const outputPath = path.join(tmpDir, `output-${sampleTask}.jsonl`);
 	await fs.writeFile(inputPath, `\n${entries.map(entry => JSON.stringify(entry)).join('\n')}\n`);
@@ -51,6 +56,7 @@ async function runRecording(entries: readonly LogEntry[], sampleTask: NesDatagen
 			sameFileJumpMinAbove: 2,
 			sameFileJumpMinBelow: 5,
 			maxSamplesPerRecording: 100,
+			generateScoredEdits,
 		},
 		configFile: configPath,
 		verbose: false,
@@ -63,7 +69,14 @@ async function runRecording(entries: readonly LogEntry[], sampleTask: NesDatagen
 		.split('\n')
 		.filter(line => line.length > 0)
 		.map(line => JSON.parse(line) as ISample);
-	return { samples, logs };
+	const scoredEditsDirectory = path.join(tmpDir, `output-${sampleTask}.scoredEdits`);
+	const scoredEdits = generateScoredEdits
+		? await Promise.all((await fs.readdir(scoredEditsDirectory)).sort().map(async fileName => ({
+			fileName,
+			value: JSON.parse(await fs.readFile(path.join(scoredEditsDirectory, fileName), 'utf8')) as Scoring.t,
+		})))
+		: [];
+	return { samples, logs, scoredEdits };
 }
 
 describe('nes-datagen workspace recording pipeline', () => {
@@ -72,6 +85,10 @@ describe('nes-datagen workspace recording pipeline', () => {
 			`export function add(a: number, b: number): number {\n` +
 			`\treturn a + b;\n` +
 			`}\n`;
+		const oracleEdits: [number, number, string][] = [
+			[16, 19, 'sum'],
+			[documentContent.length + 1, documentContent.length + 1, '// done\n'],
+		];
 		const entries: LogEntry[] = [
 			header,
 			{ kind: 'applicationStart', time: 1, commitHash: 'commit' },
@@ -90,35 +107,62 @@ describe('nes-datagen workspace recording pipeline', () => {
 				kind: 'changed',
 				id: 0,
 				time: 1004,
-				edit: [[16, 19, 'sum']],
+				edit: oracleEdits,
 				v: 3,
 				metadata: { source: 'cursor', kind: 'type', detailedSource: 'keyboard' },
 			},
 		];
 
-		const { samples, logs } = await runRecording(entries, NesDatagenSampleTask.Xtab);
-		expect(samples.map(sample => ({
-			task: sample.metadata.task,
-			language: sample.metadata.language,
-			filePath: sample.metadata.filePath,
-			oracleEdits: sample.metadata.oracleEdits,
-			workspaceRecording: sample.metadata.workspaceRecording,
-		})), logs.join('\n')).toEqual([{
-			task: NesDatagenSampleTask.Xtab,
-			language: 'typescript',
-			filePath: 'src/math.ts',
-			oracleEdits: [[16, 19, 'sum']],
-			workspaceRecording: {
-				sourceFormat: 'workspace-recording',
-				recordingRevision: 4,
-				policyVersion: 1,
-				pivotKind: 'user-edit',
-				pivotOperationIndex: 2,
-				oracleOperationCount: 1,
-				oracleStopReason: 'end-of-recording',
-				contextTruncated: false,
-			},
-		}]);
+		const { samples, logs, scoredEdits } = await runRecording(entries, NesDatagenSampleTask.Xtab, true);
+		expect({
+			samples: samples.map(sample => ({
+				id: sample.metadata.rowIndex,
+				task: sample.metadata.task,
+				language: sample.metadata.language,
+				filePath: sample.metadata.filePath,
+				oracleEdits: sample.metadata.oracleEdits,
+				workspaceRecording: sample.metadata.workspaceRecording,
+			})),
+			scoredEdits: scoredEdits.map(({ fileName, value }) => ({
+				fileName,
+				edits: value.edits,
+				historyKinds: value.scoringContext.recording.log.map(entry => entry.kind),
+				nextUserEdit: value.scoringContext.recording.nextUserEdit,
+			})),
+		}, logs.join('\n')).toEqual({
+			samples: [{
+				id: 0,
+				task: NesDatagenSampleTask.Xtab,
+				language: 'typescript',
+				filePath: 'src/math.ts',
+				oracleEdits,
+				workspaceRecording: {
+					sourceFormat: 'workspace-recording',
+					recordingRevision: 4,
+					policyVersion: 1,
+					pivotKind: 'user-edit',
+					pivotOperationIndex: 2,
+					oracleOperationCount: 1,
+					oracleStopReason: 'end-of-recording',
+					contextTruncated: false,
+				},
+			}],
+			scoredEdits: [{
+				fileName: '0.scoredEdits.w.json',
+				edits: [{
+					documentUri: 'src/math.ts',
+					edit: oracleEdits,
+					scoreCategory: 'nextEdit',
+					score: 0,
+				}],
+				historyKinds: ['meta', 'documentEncountered', 'setContent', 'selectionChanged', 'changed'],
+				nextUserEdit: {
+					edit: oracleEdits,
+					relativePath: 'src/math.ts',
+					originalOpIdx: 4,
+				},
+			}],
+		});
 	});
 
 	it('retains the first deliberate cursor boundary for cursor-task generation', async () => {


### PR DESCRIPTION
## Summary

- add `--generate-scored-edits` to NES datagen for alternative-action, continuous, and workspace-recording inputs
- stage scoredEdits output per worker, validate exact sample ID coverage, and publish the completed directory with rollback
- name each viewer file `<sample-rowIndex>.scoredEdits.w.json` with the full expected next edit
- document the workflow in the [vscode-copilot-evaluation wiki](https://github.com/microsoft/vscode-copilot-evaluation/wiki/NES-simulation-tests)

## Validation

- `npx tsc --noEmit --project tsconfig.json`
- targeted ESLint for changed files
- 36 targeted Vitest tests
- multi-worker alternative-action run: 20 samples / 20 scoredEdits files
- multi-worker workspace-recording run: 99 samples / 99 scoredEdits files
- pre-commit hygiene