### PR TITLE
agentHost: mirror settings into the host declaratively

### DIFF
--- a/.agents/skills/launch/SKILL.md
+++ b/.agents/skills/launch/SKILL.md
@@ -14,14 +14,14 @@ You're working on VS Code itself and you want to:
 
 This skill provides a launcher that clones an authenticated user-data-dir to a throwaway temp folder, picks free ports for every debug surface, and prints them as JSON so you can pick them up programmatically.
 
-The clone is **slim**: workspace storage, browser caches, file history, cached VSIX backups, and old logs are excluded by default. Auth tokens themselves live in the OS keychain (shared automatically) plus small files inside `User/globalStorage` - both of which *are* preserved.
+The clone is **slim**: workspace storage, browser caches, file history, cached VSIX backups, and old logs are excluded by default. On macOS, auth tokens live in the OS keychain plus small files inside `User/globalStorage` - both of which *are* preserved.
 
 ## Prerequisites
 
 - macOS or Linux. The launcher is a bash script and depends on `rsync`, `curl`, `nohup`, and Node on `PATH`. The example caller snippets below also use `jq` (parse the JSON output) and `lsof` (kill-by-port fallback) — install those if you plan to use them, but the launcher itself does not require them.
 - A VS Code checkout with `node_modules/` installed (`npm install` if missing — do **not** symlink from a sibling worktree; that breaks builds in subtle ways).
 - A VS Code checkout with sources built. Run `npm run compile` once (one-shot) or `npm run watch` for incremental rebuilds. Both build the full client **and** all built-in extensions under `extensions/`. You must build the full product to run successfully, building just the client is not enough.
-- An **authenticated** Code OSS profile to seed from. By default the launcher uses `~/.vscode-oss-dev`, which is the user-data-dir the repo's `launch.json` configs use - if the user has ever signed in to Copilot in a dev build, this should work. Only pass `--source-user-data-dir <path>` (or set `$CODE_OSS_DEV_AUTHED_USER_DATA_DIR`) when you specifically want to seed from a different profile (e.g. your regular `~/Library/Application Support/Code` install).
+- An **authenticated** Code OSS profile to seed from. By default the launcher uses `~/.vscode-oss-dev` on macOS/Linux or `$env:USERPROFILE\.vscode-oss-dev` on Windows, which is the user-data-dir the repo's `launch.json` configs use - if the user has ever signed in to Copilot in a dev build, this should work. Only pass `--source-user-data-dir <path>` (or set `$CODE_OSS_DEV_AUTHED_USER_DATA_DIR`) when you specifically want to seed from a different profile (e.g. your regular `~/Library/Application Support/Code` install).
   - If Code OSS launches and needs a sign-in, don't give up! Use the questions tool to ask the user to sign in.
 - `@playwright/cli` available (it's a devDependency in the vscode repo - `npm install` then use `npx @playwright/cli`).
 - For debugger work: `dap-cli` on `PATH`. If debugger support would be useful but the `dap-cli` skill is not present, prompt the user to install it from https://github.com/roblourens/dap-cli.
@@ -33,7 +33,7 @@ The clone is **slim**: workspace storage, browser caches, file history, cached V
 
 ## Launch
 
-The launcher script lives next to this SKILL.md at `scripts/launch.sh`. Resolve it relative to wherever this skill file is installed - do not hardcode an absolute path.
+The launcher script lives next to this SKILL.md at `scripts/launch.sh` (macOS/Linux) or `scripts\launch.ps1` (Windows). Resolve it relative to wherever this skill file is installed - do not hardcode an absolute path.
 
 ```bash
 # LAUNCH=<dir-of-this-SKILL.md>/scripts/launch.sh
@@ -46,9 +46,29 @@ The launcher script lives next to this SKILL.md at `scripts/launch.sh`. Resolve 
 "$LAUNCH" --full                             # skip slim excludes; copy everything
 ```
 
+On Windows, invoke the PowerShell launcher with the same flags:
+
+```powershell
+$skillDir = '<dir-of-this-SKILL.md>'
+$launch = Join-Path $skillDir 'scripts\launch.ps1'
+& $launch                                      # default: workbench
+& $launch --agents                             # Agents window
+& $launch -- --use-mock-keychain               # forward extra args to code.bat
+& $launch --source-user-data-dir C:\path\to\profile
+& $launch --repo C:\path\to\vscode
+& $launch --clone-extensions
+& $launch --full
+```
+
+If the local execution policy blocks scripts, invoke it with `powershell -ExecutionPolicy Bypass -File <path-to-launch.ps1>`. The Windows implementation has the same profile isolation, slim-copy excludes, settings merge, port allocation, foreground pre-launch, and CDP-ready contract as the bash launcher; only the shell commands and path syntax differ.
+
 ### What gets copied (slim mode, the default)
 
-The exclude list mirrors the one used by VS Code's own perf-test skill (`.github/skills/auto-perf-optimize`), which is known to keep Copilot auth and language-model availability working. Specifically `WebStorage/`, `Service Worker/`, `Local Storage/`, `Cookies`, `Network Persistent State`, `TransportSecurity`, `Trust Tokens`, `Preferences`, `machineid`, and the entire `User/globalStorage/` (which holds `state.vscdb` - where extension `SecretStorage` blobs live, encrypted with the OS keychain key) are all preserved. Auth tokens themselves stay in the OS keychain, which is per-user, so they follow automatically.
+The exclude list mirrors the one used by VS Code's own perf-test skill (`.github/skills/auto-perf-optimize`), which is known to keep Copilot auth and language-model availability working. Specifically `WebStorage/`, `Service Worker/`, `Local Storage/`, `Cookies`, `Network Persistent State`, `TransportSecurity`, `Trust Tokens`, `Preferences`, `machineid`, and the entire `User/globalStorage/` (which holds `state.vscdb`) are all preserved.
+
+#### Windows authentication
+
+Windows has no shared per-app keychain for these secrets. They live in the copied profile, notably `User/globalStorage/state.vscdb` and root `Local State`, so the launcher verifies that they (plus `machineid` and `Network`) survived the copy. If a launched instance prompts for sign-in, launch `.\scripts\code.bat --user-data-dir=<source-udd>` directly, sign in once, and close it; every later launch copies that source profile and inherits the session.
 
 Excluded (transient, regenerable, or known-not-needed):
 - `User/workspaceStorage/` - per-workspace state, **including stored chat sessions** (often multi-GB)
@@ -81,6 +101,18 @@ MAIN=$(jq -r .mainPort      <<<"$INFO")
 AGENT=$(jq -r .agentHostPort <<<"$INFO")
 LOG=$(jq -r .logFile        <<<"$INFO")
 PID=$(jq -r .pid            <<<"$INFO")
+```
+
+On Windows, capture and parse the JSON without `jq`:
+
+```powershell
+$info = & $launch | Select-Object -Last 1 | ConvertFrom-Json
+$cdp = $info.cdpPort
+$ext = $info.extHostPort
+$main = $info.mainPort
+$agent = $info.agentHostPort
+$log = $info.logFile
+$pid = $info.pid
 ```
 
 ### What each port is for
@@ -335,4 +367,4 @@ Code OSS is a full Electron app and easily eats 1-4 GB. Always clean up.
 - **`launch.sh` exits non-zero with a log tail** - either pre-launch failed, `code.sh` died before CDP came up, or CDP never opened within 90s. The tail printed to stderr is from `runDir/code.log` - read it to diagnose.
 - **Snapshot shows the wrong page or no expected controls** - use `tab-list`, switch with `tab-select <index>` if needed, then re-snapshot before interacting.
 - **CLI typing commands complete but the input stays empty** - focus chat with the platform shortcut, use `press` or clipboard paste rather than `fill` / `type`, then verify the input state before sending.
-- **Auth missing in the launched window** - confirm the source profile is actually authed (`ls "$SOURCE_UDD"` should contain `User/`, and `ls "$SOURCE_UDD/User/globalStorage"` should show persisted extension state). Some auth lives in the OS keychain - that's per-user, so it follows automatically as long as you're running as the same user.
+- **Auth missing in the launched window** - confirm the source profile is actually authed (`ls "$SOURCE_UDD"` should contain `User/`, and `ls "$SOURCE_UDD/User/globalStorage"` should show persisted extension state). On Windows, sign in directly against the source profile once so its copied `state.vscdb` and `Local State` contain the session.

--- a/.agents/skills/launch/SKILL.md
+++ b/.agents/skills/launch/SKILL.md
@@ -18,7 +18,13 @@ The clone is **slim**: workspace storage, browser caches, file history, cached V
 
 ## Prerequisites
 
-- macOS or Linux. The launcher is a bash script and depends on `rsync`, `curl`, `nohup`, and Node on `PATH`. The example caller snippets below also use `jq` (parse the JSON output) and `lsof` (kill-by-port fallback) — install those if you plan to use them, but the launcher itself does not require them.
+- macOS, Linux, or Windows.
+  - **macOS / Linux**: the launcher is a bash script (`scripts/launch.sh`) and depends on `rsync`, `curl`, `nohup`, and Node on `PATH`. The example caller snippets below also use `jq` (parse the JSON output) and `lsof` (kill-by-port fallback) — install those if you plan to use them, but the launcher itself does not require them.
+  - **Windows**: use `scripts\launch.ps1` instead. It needs no extra tooling beyond Node on `PATH`, and works on both Windows PowerShell 5.1 and PowerShell 7+. `jq` is not needed — parse the JSON with `ConvertFrom-Json`. If Node is managed with [fnm](https://github.com/Schniz/fnm), put it on `PATH` first:
+    ```powershell
+    fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+    fnm use   # picks up the repo's .nvmrc
+    ```
 - A VS Code checkout with `node_modules/` installed (`npm install` if missing — do **not** symlink from a sibling worktree; that breaks builds in subtle ways).
 - A VS Code checkout with sources built. Run `npm run compile` once (one-shot) or `npm run watch` for incremental rebuilds. Both build the full client **and** all built-in extensions under `extensions/`. You must build the full product to run successfully, building just the client is not enough.
 - An **authenticated** Code OSS profile to seed from. By default the launcher uses `~/.vscode-oss-dev` on macOS/Linux or `$env:USERPROFILE\.vscode-oss-dev` on Windows, which is the user-data-dir the repo's `launch.json` configs use - if the user has ever signed in to Copilot in a dev build, this should work. Only pass `--source-user-data-dir <path>` (or set `$CODE_OSS_DEV_AUTHED_USER_DATA_DIR`) when you specifically want to seed from a different profile (e.g. your regular `~/Library/Application Support/Code` install).

--- a/.agents/skills/launch/scripts/launch.ps1
+++ b/.agents/skills/launch/scripts/launch.ps1
@@ -1,0 +1,501 @@
+# Launch Code OSS (VS Code from sources) with an isolated, slimmed copy of a
+# user-data-dir and unique debugger ports. Prints exactly one JSON line to
+# stdout after the renderer CDP endpoint is ready; all diagnostics use stderr.
+
+[CmdletBinding()]
+param(
+	[Parameter(ValueFromRemainingArguments = $true)]
+	[string[]]$cliArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$agents = $false
+$sourceUserDataDir = ''
+$repo = ''
+$cloneExtensions = $false
+$full = $false
+if ($null -eq $cliArgs) {
+	$cliArgs = @()
+}
+
+function Write-LaunchError([string]$message) {
+	[Console]::Error.WriteLine($message)
+}
+
+function Exit-Usage([string]$message) {
+	Write-LaunchError $message
+	exit 2
+}
+
+function Get-UsableNode([string]$repoPath) {
+	$command = Get-Command node -CommandType Application -ErrorAction SilentlyContinue
+	$nvmrcPath = Join-Path $repoPath '.nvmrc'
+	$requiredVersion = if (Test-Path -LiteralPath $nvmrcPath -PathType Leaf) {
+		(Get-Content -LiteralPath $nvmrcPath -Raw).Trim().TrimStart('v')
+	} else {
+		'20.0.0'
+	}
+
+	$setupMessage = "Run in PowerShell from $repoPath`: fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression; fnm use"
+	if ($null -eq $command) {
+		throw "Node.js $requiredVersion or newer is required on PATH. $setupMessage"
+	}
+
+	try {
+		$version = & $command.Source --version 2>$null
+		if ($LASTEXITCODE -ne 0 -or $version -notmatch '^v(?<version>\d+\.\d+\.\d+)') {
+			throw 'could not determine its version'
+		}
+		if ([version]$Matches.version -lt [version]$requiredVersion) {
+			throw "found $version"
+		}
+		return $command.Source
+	} catch {
+		throw "Node.js $requiredVersion or newer is required on PATH ($($_.Exception.Message)). $setupMessage"
+	}
+}
+
+function Get-FreePort {
+	$listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+	try {
+		$listener.Start()
+		return ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+	} finally {
+		$listener.Stop()
+	}
+}
+
+function Get-FreePorts {
+	$ports = [System.Collections.Generic.List[int]]::new()
+	while ($ports.Count -lt 4) {
+		$port = Get-FreePort
+		if (-not $ports.Contains($port)) {
+			$ports.Add($port)
+		}
+	}
+	return $ports
+}
+
+function Test-Glob([string]$value, [string]$pattern) {
+	return $value -like $pattern
+}
+
+function Test-ExcludedPath([string]$relativePath) {
+	$relativePath = $relativePath.Replace('\', '/')
+	$patterns = @(
+		'/extensions',
+		'/workspaceStorage', 'User/workspaceStorage',
+		'User/History',
+		'/CachedExtensionVSIXs',
+		'/logs',
+		'/Cache', '/Code Cache', '/CachedData', '/component_crx_cache',
+		'/GPUCache', '/ShaderCache', '/Dawn*Cache',
+		'/Backups', '/blob_storage', '/BrowserMetrics', '/Crashpad',
+		'/Session Storage',
+		'/Singleton*',
+		'*.lock', '*.sock'
+	)
+
+	foreach ($pattern in $patterns) {
+		if ($pattern.StartsWith('/')) {
+			if (-not $relativePath.Contains('/') -and (Test-Glob $relativePath $pattern.Substring(1))) {
+				return $true
+			}
+			continue
+		}
+
+		if ($pattern.Contains('/')) {
+			$segments = $relativePath.Split('/')
+			$patternSegments = $pattern.Split('/')
+			for ($start = 0; $start -le $segments.Length - $patternSegments.Length; $start++) {
+				$matches = $true
+				for ($index = 0; $index -lt $patternSegments.Length; $index++) {
+					if (-not (Test-Glob $segments[$start + $index] $patternSegments[$index])) {
+						$matches = $false
+						break
+					}
+				}
+				if ($matches) {
+					return $true
+				}
+			}
+		} elseif (Test-Glob ([IO.Path]::GetFileName($relativePath)) $pattern) {
+			return $true
+		}
+	}
+
+	return $false
+}
+
+function Copy-ProfileDirectory([string]$source, [string]$destination, [bool]$useExcludes) {
+	New-Item -ItemType Directory -Force -Path $destination | Out-Null
+
+	function Copy-ProfileEntry([System.IO.FileSystemInfo]$entry, [string]$relativePath) {
+		if ($useExcludes -and (Test-ExcludedPath $relativePath)) {
+			return
+		}
+
+		$target = Join-Path $destination $relativePath
+		if ($entry.PSIsContainer) {
+			New-Item -ItemType Directory -Force -Path $target | Out-Null
+			foreach ($child in Get-ChildItem -LiteralPath $entry.FullName -Force) {
+				Copy-ProfileEntry $child (Join-Path $relativePath $child.Name)
+			}
+		} else {
+			$targetParent = Split-Path -Parent $target
+			New-Item -ItemType Directory -Force -Path $targetParent | Out-Null
+			[IO.File]::Copy($entry.FullName, $target, $true)
+			[IO.File]::SetLastWriteTimeUtc($target, $entry.LastWriteTimeUtc)
+		}
+	}
+
+	foreach ($entry in Get-ChildItem -LiteralPath $source -Force) {
+		Copy-ProfileEntry $entry $entry.Name
+	}
+}
+
+function Assert-AuthCriticalProfileFiles([string]$destination) {
+	$requiredPaths = @(
+		'Local State',
+		'machineid',
+		'User\globalStorage\state.vscdb',
+		'Network'
+	)
+	$missingPaths = @($requiredPaths | Where-Object {
+		-not (Test-Path -LiteralPath (Join-Path $destination $_))
+	})
+	if ($missingPaths.Count -gt 0) {
+		throw "Profile copy is missing auth-critical path(s): $($missingPaths -join ', '). Refusing to launch a profile that cannot preserve Windows authentication."
+	}
+}
+
+function Test-SourceHasGitHubAuthenticationSecret([string]$node, [string]$source, [string]$temporaryDb) {
+	$sourceDb = Join-Path $source 'User\globalStorage\state.vscdb'
+	if (-not (Test-Path -LiteralPath $sourceDb -PathType Leaf)) {
+		return $null
+	}
+
+	try {
+		[IO.File]::Copy($sourceDb, $temporaryDb, $true)
+		$script = @'
+import { DatabaseSync } from 'node:sqlite';
+
+const db = new DatabaseSync(process.argv[1], { readOnly: true });
+try {
+	const row = db.prepare('SELECT 1 FROM ItemTable WHERE key LIKE ? LIMIT 1').get('secret://%github-authentication%');
+	process.stdout.write(row ? 'present' : 'absent');
+} finally {
+	db.close();
+}
+'@
+		$result = @(& $node '--input-type=module' '-e' $script $temporaryDb 2>$null)
+		if ($LASTEXITCODE -ne 0) {
+			return $null
+		}
+		switch ($result -join '') {
+			'present' { return $true }
+			'absent' { return $false }
+			default { return $null }
+		}
+	} catch {
+		return $null
+	} finally {
+		Remove-Item -LiteralPath $temporaryDb -Force -ErrorAction SilentlyContinue
+	}
+}
+
+function Ensure-SimpleDialogSetting([string]$settingsFile) {
+	$key = 'files.simpleDialog.enable'
+	$settingsDirectory = Split-Path -Parent $settingsFile
+	New-Item -ItemType Directory -Force -Path $settingsDirectory | Out-Null
+
+	if (Test-Path -LiteralPath $settingsFile -PathType Leaf) {
+		$text = [IO.File]::ReadAllText($settingsFile)
+	} else {
+		$text = ''
+	}
+
+	if ([string]::IsNullOrWhiteSpace($text)) {
+		[IO.File]::WriteAllText($settingsFile, "{`n  `"$key`": true`n}`n", [Text.UTF8Encoding]::new($false))
+		return
+	}
+
+	$keyPattern = [regex]::Escape($key)
+	$keyValueRegex = [regex]::new("(`"$keyPattern`"\s*:\s*)(true|false|null|`"[^`"`r`n]*`"|-?\d+(?:\.\d+)?)")
+	if ($keyValueRegex.IsMatch($text)) {
+		$updated = $keyValueRegex.Replace($text, '${1}true')
+		[IO.File]::WriteAllText($settingsFile, $updated, [Text.UTF8Encoding]::new($false))
+		return
+	}
+
+	$lastBrace = $text.LastIndexOf('}')
+	if ($lastBrace -eq -1) {
+		throw "settings.json has no closing brace — refusing to clobber it: $settingsFile"
+	}
+	$firstBrace = $text.IndexOf('{')
+	if ($firstBrace -eq -1 -or $firstBrace -ge $lastBrace) {
+		throw "settings.json has no opening brace — refusing to clobber it: $settingsFile"
+	}
+
+	$between = $text.Substring($firstBrace + 1, $lastBrace - $firstBrace - 1)
+	$between = [regex]::Replace($between, '/\*[\s\S]*?\*/', '')
+	$between = [regex]::Replace($between, '//[^\r\n]*', '').Trim()
+	$separator = if ($between.Length -eq 0 -or $between.EndsWith(',')) { '' } else { ',' }
+	$insertion = "$separator`n  `"$key`": true`n"
+	$updated = $text.Substring(0, $lastBrace) + $insertion + $text.Substring($lastBrace)
+	[IO.File]::WriteAllText($settingsFile, $updated, [Text.UTF8Encoding]::new($false))
+}
+
+function Write-LogTail([string]$logFile) {
+	if (Test-Path -LiteralPath $logFile) {
+		Get-Content -LiteralPath $logFile -Tail 80 | ForEach-Object { [Console]::Error.WriteLine($_) }
+	}
+}
+
+function Quote-CmdArgument([string]$argument) {
+	if ($argument.Length -gt 0 -and $argument -notmatch '[\s"]') {
+		return $argument
+	}
+
+	$quoted = [Text.StringBuilder]::new('"')
+	$backslashCount = 0
+	foreach ($character in $argument.ToCharArray()) {
+		if ($character -eq '\') {
+			$backslashCount++
+		} elseif ($character -eq '"') {
+			[void]$quoted.Append(('\' * ($backslashCount * 2 + 1)))
+			[void]$quoted.Append('"')
+			$backslashCount = 0
+		} else {
+			[void]$quoted.Append(('\' * $backslashCount))
+			[void]$quoted.Append($character)
+			$backslashCount = 0
+		}
+	}
+	[void]$quoted.Append(('\' * ($backslashCount * 2)))
+	[void]$quoted.Append('"')
+	return $quoted.ToString()
+}
+
+function Start-Code([string]$codeBat, [string[]]$arguments, [string]$logFile) {
+	$quotedCodeBat = Quote-CmdArgument $codeBat
+	if (-not $quotedCodeBat.StartsWith('"')) {
+		$quotedCodeBat = "`"$quotedCodeBat`""
+	}
+	$commandLine = ((@($quotedCodeBat) + @($arguments | ForEach-Object { Quote-CmdArgument $_ })) -join ' ') + " >> $(Quote-CmdArgument $logFile) 2>&1"
+	$processInfo = [Diagnostics.ProcessStartInfo]::new()
+	$processInfo.FileName = $env:ComSpec
+	$processInfo.UseShellExecute = $false
+	$processInfo.CreateNoWindow = $true
+	$processInfo.WindowStyle = [Diagnostics.ProcessWindowStyle]::Hidden
+	$processInfo.Arguments = '/d /s /c "' + $commandLine + '"'
+	[void]($processInfo.Environment['VSCODE_SKIP_PRELAUNCH'] = '1')
+	[void]$processInfo.Environment.Remove('ELECTRON_RUN_AS_NODE')
+
+	$process = [Diagnostics.Process]::new()
+	$process.StartInfo = $processInfo
+	if (-not $process.Start()) {
+		throw "Failed to start $codeBat."
+	}
+
+	return $process
+}
+
+$extraArgs = [System.Collections.Generic.List[string]]::new()
+for ($index = 0; $index -lt $cliArgs.Count; $index++) {
+	$argument = $cliArgs[$index]
+	switch ($argument) {
+		'--agents' {
+			$agents = $true
+			continue
+		}
+		'--source-user-data-dir' {
+			if ($index + 1 -ge $cliArgs.Count) {
+				Exit-Usage 'Missing value for --source-user-data-dir.'
+			}
+			$sourceUserDataDir = $cliArgs[++$index]
+			continue
+		}
+		'--repo' {
+			if ($index + 1 -ge $cliArgs.Count) {
+				Exit-Usage 'Missing value for --repo.'
+			}
+			$repo = $cliArgs[++$index]
+			continue
+		}
+		'--clone-extensions' {
+			$cloneExtensions = $true
+			continue
+		}
+		'--copy-extensions' {
+			$cloneExtensions = $true
+			continue
+		}
+		'--full' {
+			$full = $true
+			continue
+		}
+		'--' {
+			for ($forwardIndex = $index + 1; $forwardIndex -lt $cliArgs.Count; $forwardIndex++) {
+				$extraArgs.Add($cliArgs[$forwardIndex])
+			}
+			$index = $cliArgs.Count
+			continue
+		}
+		default {
+			Exit-Usage "Unknown arg: $argument"
+		}
+	}
+}
+
+try {
+	if ([string]::IsNullOrWhiteSpace($repo)) {
+		$candidateRepo = (Get-Location).Path
+		if (Test-Path -LiteralPath (Join-Path $candidateRepo 'scripts\code.bat') -PathType Leaf) {
+			$repo = $candidateRepo
+		} else {
+			Exit-Usage "Could not find a vscode checkout in $candidateRepo. Pass --repo <vscode-repo-root>."
+		}
+	}
+	$repo = [IO.Path]::GetFullPath($repo)
+
+	$codeBat = Join-Path $repo 'scripts\code.bat'
+	if (-not (Test-Path -LiteralPath $codeBat -PathType Leaf)) {
+		Exit-Usage "Could not find a Code OSS launcher at $codeBat. Pass --repo <vscode-repo-root>."
+	}
+
+	if ([string]::IsNullOrWhiteSpace($sourceUserDataDir)) {
+		$sourceUserDataDir = if ($env:CODE_OSS_DEV_AUTHED_USER_DATA_DIR) {
+			$env:CODE_OSS_DEV_AUTHED_USER_DATA_DIR
+		} else {
+			Join-Path $env:USERPROFILE '.vscode-oss-dev'
+		}
+	}
+	if (-not (Test-Path -LiteralPath $sourceUserDataDir -PathType Container)) {
+		Exit-Usage "Source user-data-dir does not exist: $sourceUserDataDir`nPass --source-user-data-dir <path> or set CODE_OSS_DEV_AUTHED_USER_DATA_DIR."
+	}
+	$sourceUserDataDir = [IO.Path]::GetFullPath($sourceUserDataDir)
+
+	$node = Get-UsableNode $repo
+	Write-LaunchError "[launch.ps1] using Node: $node"
+	$ports = Get-FreePorts
+	$cdpPort = $ports[0]
+	$extHostPort = $ports[1]
+	$mainPort = $ports[2]
+	$agentHostPort = $ports[3]
+
+	$stamp = '{0:yyyyMMdd-HHmmss}-{1}' -f (Get-Date), $PID
+	$runDir = Join-Path (Join-Path $env:TEMP 'code-oss-dev') $stamp
+	$destinationUdd = Join-Path $runDir 'user-data'
+	$extensionsDir = Join-Path $destinationUdd 'extensions'
+	$sharedDataDir = Join-Path $runDir 'shared-data'
+	$logFile = Join-Path $runDir 'code.log'
+	New-Item -ItemType Directory -Force -Path $runDir, $sharedDataDir | Out-Null
+	[IO.File]::WriteAllText($logFile, '', [Text.UTF8Encoding]::new($false))
+	$hasGitHubAuthenticationSecret = Test-SourceHasGitHubAuthenticationSecret $node $sourceUserDataDir (Join-Path $runDir 'auth-preflight.vscdb')
+	if ($hasGitHubAuthenticationSecret -eq $false) {
+		Write-LaunchError "[launch.ps1] WARNING: source profile $sourceUserDataDir has no stored GitHub session; the launched instance will prompt you to sign in."
+		Write-LaunchError 'To fix once and for all, launch Code OSS directly against the source profile (no copy), sign in, then close it:'
+		Write-LaunchError "  .\scripts\code.bat --user-data-dir=$sourceUserDataDir"
+		Write-LaunchError 'Every future launch copies that profile and inherits the session.'
+	}
+
+	if ($full) {
+		Write-LaunchError "[launch.ps1] full copy: $sourceUserDataDir -> $destinationUdd"
+		Copy-ProfileDirectory $sourceUserDataDir $destinationUdd $false
+	} else {
+		Write-LaunchError "[launch.ps1] slim copy: $sourceUserDataDir -> $destinationUdd"
+		Copy-ProfileDirectory $sourceUserDataDir $destinationUdd $true
+	}
+	Assert-AuthCriticalProfileFiles $destinationUdd
+
+	New-Item -ItemType Directory -Force -Path $extensionsDir | Out-Null
+	if (-not $full -and $cloneExtensions) {
+		$sourceExtensions = Join-Path $sourceUserDataDir 'extensions'
+		Write-LaunchError "[launch.ps1] copying extensions: $sourceExtensions -> $extensionsDir"
+		Copy-ProfileDirectory $sourceExtensions $extensionsDir $false
+	}
+
+	$settingsFile = Join-Path $destinationUdd 'User\settings.json'
+	Ensure-SimpleDialogSetting $settingsFile
+	Write-LaunchError "[launch.ps1] ensured files.simpleDialog.enable=true in $settingsFile"
+
+	$launchArgs = [System.Collections.Generic.List[string]]::new()
+	if ($agents) {
+		$launchArgs.Add('--agents')
+	}
+	$launchArgs.Add("--user-data-dir=$destinationUdd")
+	$launchArgs.Add("--extensions-dir=$extensionsDir")
+	$launchArgs.Add("--shared-data-dir=$sharedDataDir")
+	$launchArgs.Add("--remote-debugging-port=$cdpPort")
+	$launchArgs.Add("--inspect-extensions=$extHostPort")
+	$launchArgs.Add("--inspect=$mainPort")
+	$launchArgs.Add("--inspect-agenthost=$agentHostPort")
+	foreach ($argument in $extraArgs) {
+		$launchArgs.Add($argument)
+	}
+
+	Write-LaunchError "[launch.ps1] launching: $codeBat $($launchArgs -join ' ')"
+	Write-LaunchError "[launch.ps1] logs: $logFile"
+	Write-LaunchError '[launch.ps1] running pre-launch (ensures electron + compiled output + built-ins)...'
+	Push-Location -LiteralPath $repo
+	try {
+		& $node 'build/lib/preLaunch.ts' *>> $logFile
+		$preLaunchExitCode = $LASTEXITCODE
+	} finally {
+		Pop-Location
+	}
+	if ($preLaunchExitCode -ne 0) {
+		Write-LaunchError '[launch.ps1] pre-launch FAILED. Log tail:'
+		Write-LogTail $logFile
+		exit 1
+	}
+
+	$process = Start-Code $codeBat $launchArgs.ToArray() $logFile
+	Write-LaunchError "[launch.ps1] waiting for CDP on port $cdpPort (timeout 90s)..."
+	$ready = $false
+	for ($second = 1; $second -le 90; $second++) {
+		if ($process.HasExited) {
+			Write-LaunchError "[launch.ps1] code.bat (PID $($process.Id)) exited before CDP came up. Log tail:"
+			Write-LogTail $logFile
+			exit 1
+		}
+
+		try {
+			$request = [Net.WebRequest]::Create("http://127.0.0.1:$cdpPort/json/version")
+			$request.Timeout = 1000
+			$response = $request.GetResponse()
+			$response.Close()
+			$ready = $true
+			Write-LaunchError "[launch.ps1] CDP ready after ${second}s"
+			break
+		} catch {
+			Start-Sleep -Seconds 1
+		}
+	}
+	if (-not $ready) {
+		Write-LaunchError "[launch.ps1] timed out waiting for CDP on port $cdpPort. Log tail:"
+		Write-LogTail $logFile
+		exit 1
+	}
+
+	[PSCustomObject]@{
+		pid = $process.Id
+		cdpPort = $cdpPort
+		extHostPort = $extHostPort
+		mainPort = $mainPort
+		agentHostPort = $agentHostPort
+		userDataDir = $destinationUdd
+		extensionsDir = $extensionsDir
+		sharedDataDir = $sharedDataDir
+		runDir = $runDir
+		logFile = $logFile
+		repo = $repo
+		agents = [bool]$agents
+	} | ConvertTo-Json -Compress
+} catch {
+	Write-LaunchError "[launch.ps1] $($_.Exception.Message)"
+	exit 1
+}

--- a/.agents/skills/launch/scripts/launch.ps1
+++ b/.agents/skills/launch/scripts/launch.ps1
@@ -206,6 +206,54 @@ try {
 	}
 }
 
+function Get-JsoncCodeMask([string]$text) {
+	# Returns a same-length copy of $text with every comment span blanked out.
+	# Offsets are preserved so a match found in the mask can be applied to the
+	# original. String contents are respected, so a `//` inside a value (a URL,
+	# say) is not mistaken for a comment.
+	$chars = $text.ToCharArray()
+	$masked = [char[]]::new($chars.Length)
+	[Array]::Copy($chars, $masked, $chars.Length)
+
+	$inString = $false
+	$inLineComment = $false
+	$inBlockComment = $false
+	$escaped = $false
+
+	for ($i = 0; $i -lt $chars.Length; $i++) {
+		$current = $chars[$i]
+		$next = if ($i + 1 -lt $chars.Length) { $chars[$i + 1] } else { [char]0 }
+
+		if ($inLineComment) {
+			if ($current -eq "`n") { $inLineComment = $false } else { $masked[$i] = ' ' }
+			continue
+		}
+		if ($inBlockComment) {
+			if ($current -eq '*' -and $next -eq '/') {
+				$masked[$i] = ' '
+				$masked[$i + 1] = ' '
+				$i++
+				$inBlockComment = $false
+			} elseif ($current -ne "`n") {
+				$masked[$i] = ' '
+			}
+			continue
+		}
+		if ($inString) {
+			if ($escaped) { $escaped = $false }
+			elseif ($current -eq '\') { $escaped = $true }
+			elseif ($current -eq '"') { $inString = $false }
+			continue
+		}
+
+		if ($current -eq '"') { $inString = $true }
+		elseif ($current -eq '/' -and $next -eq '/') { $masked[$i] = ' '; $inLineComment = $true }
+		elseif ($current -eq '/' -and $next -eq '*') { $masked[$i] = ' '; $masked[$i + 1] = ' '; $i++; $inBlockComment = $true }
+	}
+
+	return (-join $masked)
+}
+
 function Ensure-SimpleDialogSetting([string]$settingsFile) {
 	$key = 'files.simpleDialog.enable'
 	$settingsDirectory = Split-Path -Parent $settingsFile
@@ -222,26 +270,33 @@ function Ensure-SimpleDialogSetting([string]$settingsFile) {
 		return
 	}
 
+	# Match against a comment-masked copy so a commented-out occurrence such as
+	# `// "files.simpleDialog.enable": false` is not mistaken for the real
+	# setting. Offsets line up with the original, so the value is rewritten in
+	# place without disturbing comments.
+	$maskedText = Get-JsoncCodeMask $text
 	$keyPattern = [regex]::Escape($key)
 	$keyValueRegex = [regex]::new("(`"$keyPattern`"\s*:\s*)(true|false|null|`"[^`"`r`n]*`"|-?\d+(?:\.\d+)?)")
-	if ($keyValueRegex.IsMatch($text)) {
-		$updated = $keyValueRegex.Replace($text, '${1}true')
+	$keyMatch = $keyValueRegex.Match($maskedText)
+	if ($keyMatch.Success) {
+		$valueGroup = $keyMatch.Groups[2]
+		$updated = $text.Substring(0, $valueGroup.Index) + 'true' + $text.Substring($valueGroup.Index + $valueGroup.Length)
 		[IO.File]::WriteAllText($settingsFile, $updated, [Text.UTF8Encoding]::new($false))
 		return
 	}
 
-	$lastBrace = $text.LastIndexOf('}')
+	$lastBrace = $maskedText.LastIndexOf('}')
 	if ($lastBrace -eq -1) {
 		throw "settings.json has no closing brace — refusing to clobber it: $settingsFile"
 	}
-	$firstBrace = $text.IndexOf('{')
+	$firstBrace = $maskedText.IndexOf('{')
 	if ($firstBrace -eq -1 -or $firstBrace -ge $lastBrace) {
 		throw "settings.json has no opening brace — refusing to clobber it: $settingsFile"
 	}
 
-	$between = $text.Substring($firstBrace + 1, $lastBrace - $firstBrace - 1)
-	$between = [regex]::Replace($between, '/\*[\s\S]*?\*/', '')
-	$between = [regex]::Replace($between, '//[^\r\n]*', '').Trim()
+	# Whether a leading comma is needed depends only on real content, so decide
+	# it from the masked copy too.
+	$between = $maskedText.Substring($firstBrace + 1, $lastBrace - $firstBrace - 1).Trim()
 	$separator = if ($between.Length -eq 0 -or $between.EndsWith(',')) { '' } else { ',' }
 	$insertion = "$separator`n  `"$key`": true`n"
 	$updated = $text.Substring(0, $lastBrace) + $insertion + $text.Substring($lastBrace)
@@ -291,8 +346,11 @@ function Start-Code([string]$codeBat, [string[]]$arguments, [string]$logFile) {
 	$processInfo.CreateNoWindow = $true
 	$processInfo.WindowStyle = [Diagnostics.ProcessWindowStyle]::Hidden
 	$processInfo.Arguments = '/d /s /c "' + $commandLine + '"'
-	[void]($processInfo.Environment['VSCODE_SKIP_PRELAUNCH'] = '1')
-	[void]$processInfo.Environment.Remove('ELECTRON_RUN_AS_NODE')
+	# `EnvironmentVariables` (not `Environment`) so this works on Windows
+	# PowerShell 5.1 as well as PowerShell 7+ — the latter property is .NET
+	# Core only, and `powershell.exe` is still the built-in Windows shell.
+	[void]($processInfo.EnvironmentVariables['VSCODE_SKIP_PRELAUNCH'] = '1')
+	[void]$processInfo.EnvironmentVariables.Remove('ELECTRON_RUN_AS_NODE')
 
 	$process = [Diagnostics.Process]::new()
 	$process.StartInfo = $processInfo

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -18,7 +18,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
-import { AgentSession, AgentHostCodexAgentEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { AgentSession, IAgentConnection, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkFetchResult, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
 import { AMBIENT_AGENT_HOST_AUTHORITY } from '../common/agentHostConnectionsService.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
 import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
@@ -38,7 +38,8 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, AUTO_REPLY_SETTING_ID, PREFER_LONG_CONTEXT_SETTING_ID, MIGRATE_LEGACY_COPILOT_CLI_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { getAgentHostConfigurationSyncEntries, resolveAgentHostConfigurationSyncPatch, resolveAgentHostConfigurationSyncValue } from '../common/agentHostConfigurationSync.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { Implementation, InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -340,94 +341,35 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		}));
 
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(TELEMETRY_SETTING_ID) || e.affectsConfiguration(TELEMETRY_OLD_SETTING_ID) || e.affectsConfiguration(TELEMETRY_CRASH_REPORTER_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
+			if (this._state.kind !== AgentHostClientState.Connected) {
+				return;
+			}
+			const patch: Record<string, unknown> = {};
+			for (const entry of getAgentHostConfigurationSyncEntries(this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY)) {
+				if (!e.affectsConfiguration(entry.settingId)) {
+					continue;
 				}
+				const value = resolveAgentHostConfigurationSyncValue(this._configurationService, entry);
+				if (value !== undefined) {
+					patch[entry.sync.key] = value;
+				}
+			}
+			if (Object.keys(patch).length) {
+				this._dispatchRootConfig(patch);
+			}
+			if (e.affectsConfiguration(TELEMETRY_SETTING_ID) || e.affectsConfiguration(TELEMETRY_OLD_SETTING_ID) || e.affectsConfiguration(TELEMETRY_CRASH_REPORTER_SETTING_ID)) {
 				this._updateTelemetryLevel();
 			}
-			if (e.affectsConfiguration(EDIT_TELEMETRY_ENABLED_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateEditTelemetryEnabled();
-			}
-			if (e.affectsConfiguration(SESSION_SYNC_ENABLED_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateSessionSyncEnabled();
-			}
-			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateTerminalAutoApproveEnabled();
-			}
-			if (e.affectsConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateGlobalAutoApproveEnabled();
-			}
-			if (e.affectsConfiguration(AUTO_REPLY_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateAutoReplyEnabled();
-			}
 			if (e.affectsConfiguration(PREFER_LONG_CONTEXT_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
 				this._updatePreferLongContextEnabled();
 			}
-			if (e.affectsConfiguration(AgentHostSystemProxyEnabledSettingId)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateSystemProxyEnabled();
-			}
-			if (e.affectsConfiguration(MIGRATE_LEGACY_COPILOT_CLI_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateMigrateLegacyCopilotCliEnabled();
-			}
-			if (e.affectsConfiguration(AgentHostCopilotMultiRootEnabledSettingId)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateCopilotMultiRootEnabled();
-			}
-			if (e.affectsConfiguration(AgentHostClaudeMultiRootEnabledSettingId)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateClaudeMultiRootEnabled();
-			}
-			if (e.affectsConfiguration(AgentHostCodexMultiRootEnabledSettingId)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateCodexMultiRootEnabled();
+			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID)) {
+				this._updateTerminalAutoApproveEnabled();
 			}
 			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID) || e.affectsConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
 				this._updateTerminalAutoApproveRules();
 			}
-			if (e.affectsConfiguration(AgentHostCodexAgentEnabledSettingId)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
-				this._updateCodexEnabled();
-			}
 			if (e.affectsConfiguration(DISABLE_REPO_INFO_TELEMETRY_SETTING_ID)) {
-				if (this._state.kind !== AgentHostClientState.Connected) {
-					return;
-				}
 				this._updateDisableRepoInfoTelemetry();
 			}
 		}));
@@ -732,22 +674,18 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * restarted process (or one that lost these values), and re-pushing is a cheap
 	 * no-op when nothing changed. Without this, a value read early — like the
 	 * migrate flag in `listSessions` — can be missing after a window reload.
+	 *
+	 * Most settings arrive here declaratively, via `agentHost` on their
+	 * configuration schema. The explicit calls below cover the cases a single
+	 * key-plus-transform can't express: values derived from several settings, and
+	 * settings contributed by an extension rather than by core.
 	 */
 	private _forwardClientConfig(): void {
+		this._dispatchRootConfig(resolveAgentHostConfigurationSyncPatch(this._configurationService, this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY));
 		this._updateTelemetryLevel();
-		this._updateEditTelemetryEnabled();
-		this._updateSessionSyncEnabled();
-		this._updateTerminalAutoApproveEnabled();
-		this._updateGlobalAutoApproveEnabled();
-		this._updateAutoReplyEnabled();
 		this._updatePreferLongContextEnabled();
-		this._updateSystemProxyEnabled();
-		this._updateMigrateLegacyCopilotCliEnabled();
-		this._updateCopilotMultiRootEnabled();
-		this._updateClaudeMultiRootEnabled();
-		this._updateCodexMultiRootEnabled();
+		this._updateTerminalAutoApproveEnabled();
 		this._updateTerminalAutoApproveRules();
-		this._updateCodexEnabled();
 		this._updateDisableRepoInfoTelemetry();
 	}
 
@@ -1529,123 +1467,39 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	private _updateTelemetryLevel(): void {
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(getTelemetryLevel(this._configurationService)) },
-		}, this._clientId, 0);
+		this._dispatchRootConfig({ [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(getTelemetryLevel(this._configurationService)) });
 	}
 
-	private _updateEditTelemetryEnabled(): void {
+	/** Merge a patch into the agent host's root configuration. */
+	private _dispatchRootConfig(config: Record<string, unknown>): void {
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
-			config: { [AgentHostEditTelemetryEnabledConfigKey]: this._configurationService.getValue<boolean>(EDIT_TELEMETRY_ENABLED_SETTING_ID) !== false },
+			config,
 		}, this._clientId, 0);
 	}
 
 	private _updateDisableRepoInfoTelemetry(): void {
 		const disabled = this._configurationService.getValue<boolean>(DISABLE_REPO_INFO_TELEMETRY_SETTING_ID) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostDisableRepoInfoTelemetryConfigKey]: disabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateSessionSyncEnabled(): void {
-		const enabled = !!this._configurationService.getValue<boolean>(SESSION_SYNC_ENABLED_SETTING_ID);
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostSessionSyncEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateTerminalAutoApproveEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID) !== false;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateGlobalAutoApproveEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostGlobalAutoApproveEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateAutoReplyEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(AUTO_REPLY_SETTING_ID) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostAutoReplyEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
+		this._dispatchRootConfig({ [AgentHostDisableRepoInfoTelemetryConfigKey]: disabled });
 	}
 
 	private _updatePreferLongContextEnabled(): void {
 		const enabled = this._configurationService.getValue<boolean>(PREFER_LONG_CONTEXT_SETTING_ID) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostPreferLongContextEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
+		this._dispatchRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: enabled });
 	}
 
-	private _updateSystemProxyEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(AgentHostSystemProxyEnabledSettingId) !== false;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostSystemProxyEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateMigrateLegacyCopilotCliEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(MIGRATE_LEGACY_COPILOT_CLI_SETTING_ID) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostMigrateLegacyCopilotCliEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateCopilotMultiRootEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(AgentHostCopilotMultiRootEnabledSettingId) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostCopilotMultiRootEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateClaudeMultiRootEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(AgentHostClaudeMultiRootEnabledSettingId) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostClaudeMultiRootEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateCodexMultiRootEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(AgentHostCodexMultiRootEnabledSettingId) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostCodexMultiRootEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
-	}
-
-	private _updateCodexEnabled(): void {
-		// Always forwards the current value; the host only acts on enable, so a
-		// forwarded `false` only takes effect on the next agent host restart
-		// (otherwise in-progress Codex sessions would have to be stopped).
-		const enabled = this._configurationService.getValue<boolean>(AgentHostCodexAgentEnabledSettingId) === true;
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostCodexEnabledConfigKey]: enabled },
-		}, this._clientId, 0);
+	private _updateTerminalAutoApproveEnabled(): void {
+		// Deliberately on the manual, workspace-aware path rather than declaring
+		// `agentHost` on its schema: the setting is `restricted` and settable per
+		// workspace, and its companion rule set (`terminalAutoApproveRules`) is
+		// workspace-aware too. Resolving only the global value here would let a
+		// workspace that turned auto-approval off still have it applied.
+		const enabled = this._configurationService.getValue<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID) !== false;
+		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled });
 	}
 
 	private _updateTerminalAutoApproveRules(): void {
-		this.dispatchAction(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) },
-		}, this._clientId, 0);
+		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) });
 	}
 
 	/**

--- a/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
+++ b/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from '../../configuration/common/configuration.js';
+import { Extensions as ConfigurationExtensions, IAgentHostConfigurationSync, IConfigurationPropertySchema, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import { Registry } from '../../registry/common/platform.js';
+
+function getRegistry(): IConfigurationRegistry {
+	return Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+}
+
+/**
+ * The schema a setting was registered with, looked up in both the visible and
+ * the excluded buckets — settings hidden with `included: false` still mirror.
+ */
+function getPropertySchema(settingId: string): IConfigurationPropertySchema | undefined {
+	const registry = getRegistry();
+	return registry.getConfigurationProperties()[settingId] ?? registry.getExcludedConfigurationProperties()[settingId];
+}
+
+/** Whether `value` conforms to a JSON-schema `type` declaration. */
+function matchesSchemaType(value: unknown, type: IConfigurationPropertySchema['type']): boolean {
+	if (type === undefined) {
+		return true;
+	}
+	if (Array.isArray(type)) {
+		return type.some(candidate => matchesSchemaType(value, candidate));
+	}
+	switch (type) {
+		case 'boolean': return typeof value === 'boolean';
+		case 'string': return typeof value === 'string';
+		case 'number': return typeof value === 'number';
+		case 'integer': return typeof value === 'number' && Number.isInteger(value);
+		case 'array': return Array.isArray(value);
+		case 'object': return typeof value === 'object' && value !== null && !Array.isArray(value);
+		case 'null': return value === null;
+		default: return true;
+	}
+}
+
+/**
+ * Resolves the *globally-scoped* value of `settingId`, ignoring any workspace or
+ * folder value.
+ *
+ * The agent host root config is shared by every window connected to a host, so
+ * forwarding a workspace value would let one window's workspace settings leak
+ * into unrelated windows on a last-writer-wins basis. Resolution order mirrors
+ * the platform's own precedence for the layers we keep — policy overrides
+ * everything, then user (local merged with remote), then application.
+ *
+ * A layer whose value does not conform to the setting's declared `type` is
+ * skipped, so a malformed `settings.json` entry falls through to the next layer
+ * and ultimately to the registered default rather than being mirrored verbatim.
+ * This mirrors how `AgentConfigurationService.getEffectiveValue` skips layers
+ * that fail schema validation on the host side.
+ */
+export function getGlobalConfigurationValue<T>(configurationService: IConfigurationService, settingId: string): T | undefined {
+	const inspected = configurationService.inspect<T>(settingId);
+	const property = getPropertySchema(settingId);
+	for (const value of [inspected.policyValue, inspected.userValue, inspected.applicationValue]) {
+		if (value !== undefined && matchesSchemaType(value, property?.type)) {
+			return value;
+		}
+	}
+	// `inspect` reports the default from the default-configuration model, which is
+	// built only from *visible* properties — a setting hidden with `included: false`
+	// has no entry there. Fall back to the declared default so hidden and visible
+	// settings mirror identically.
+	return inspected.defaultValue ?? property?.default as T | undefined;
+}
+
+/**
+ * A setting that declares {@link IAgentHostConfigurationSync}, paired with the
+ * setting id it was declared on.
+ */
+export interface IAgentHostConfigurationSyncEntry {
+	readonly settingId: string;
+	readonly sync: IAgentHostConfigurationSync;
+}
+
+/**
+ * Returns every setting that declares agent-host mirroring and applies to a host
+ * of this locality.
+ *
+ * @param isLocalAgentHost Whether the target host runs on the user's own
+ * machine. Entries marked `localOnly` are omitted for remote hosts.
+ */
+export function getAgentHostConfigurationSyncEntries(isLocalAgentHost: boolean): IAgentHostConfigurationSyncEntry[] {
+	const entries: IAgentHostConfigurationSyncEntry[] = [];
+	for (const [settingId, sync] of getRegistry().getAgentHostSyncConfigurations()) {
+		if (sync.localOnly && !isLocalAgentHost) {
+			continue;
+		}
+		entries.push({ settingId, sync });
+	}
+	return entries;
+}
+
+/**
+ * Reads the current globally-scoped value for `entry` and maps it through the
+ * entry's transform, producing the single-key patch to merge into the agent
+ * host's root config.
+ */
+export function resolveAgentHostConfigurationSyncValue(configurationService: IConfigurationService, entry: IAgentHostConfigurationSyncEntry): unknown {
+	const value = getGlobalConfigurationValue(configurationService, entry.settingId);
+	return entry.sync.transform ? entry.sync.transform(value) : value;
+}
+
+/**
+ * Builds the full root-config patch mirroring every applicable setting. Used on
+ * connect and reconnect, where the host may be a freshly restarted process that
+ * has none of these values.
+ */
+export function resolveAgentHostConfigurationSyncPatch(configurationService: IConfigurationService, isLocalAgentHost: boolean): Record<string, unknown> {
+	const patch: Record<string, unknown> = {};
+	for (const entry of getAgentHostConfigurationSyncEntries(isLocalAgentHost)) {
+		const value = resolveAgentHostConfigurationSyncValue(configurationService, entry);
+		// A setting with no value in any global layer and no registered default has
+		// nothing to mirror; leave the key absent so a previously stored host value
+		// is preserved rather than clobbered with `undefined`.
+		if (value !== undefined) {
+			patch[entry.sync.key] = value;
+		}
+	}
+	return patch;
+}

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -390,9 +390,6 @@ export const AgentHostTelemetryLevelConfigKey = 'telemetryLevel';
 /** Whether Agent Host edit attribution telemetry is enabled. */
 export const AgentHostEditTelemetryEnabledConfigKey = 'editTelemetryEnabled';
 
-/** VS Code setting forwarded into {@link AgentHostEditTelemetryEnabledConfigKey}. */
-export const EDIT_TELEMETRY_ENABLED_SETTING_ID = 'telemetry.editStats.enabled';
-
 /** Legacy Copilot Chat debug switch that disables `request.repoInfo` collection. */
 export const AgentHostDisableRepoInfoTelemetryConfigKey = 'disableRepoInfoTelemetry';
 
@@ -437,12 +434,6 @@ export const TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID = 'chat.tools.terminal.ena
 export const AgentHostGlobalAutoApproveEnabledConfigKey = 'globalAutoApproveEnabled';
 
 /**
- * The VS Code setting ID for global auto approve. Defined here so renderer-side
- * agent-host clients can forward it without importing from `workbench/contrib/chat`.
- */
-export const GLOBAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.global.autoApprove';
-
-/**
  * Root config key forwarded from the renderer when VS Code's `chat.autoReply`
  * setting changes. When `true`, the agent host auto-answers `ask_user`
  * questions instead of blocking on the user — the user is treated as
@@ -452,12 +443,6 @@ export const GLOBAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.global.autoApprove';
 export const AgentHostAutoReplyEnabledConfigKey = 'autoReplyEnabled';
 
 export const AgentHostAutoReplyAnswer = 'The user is not available to answer your question. Choose a pragmatic option best aligned with the context of the request.';
-
-/**
- * The VS Code setting ID for auto-reply. Defined here so renderer-side
- * agent-host clients can forward it without importing from `workbench/contrib/chat`.
- */
-export const AUTO_REPLY_SETTING_ID = 'chat.autoReply';
 
 // Root config key forwarded from the renderer when Copilot Chat's `github.copilot.chat.preferLongContext.enabled` setting changes.
 export const AgentHostPreferLongContextEnabledConfigKey = 'preferLongContextEnabled';
@@ -472,10 +457,6 @@ export const AgentHostSystemProxyEnabledConfigKey = 'systemProxyEnabled';
 // setting changes. When `true`, `listSessions` surfaces un-adopted extension-host Copilot CLI
 // sessions as adoptable agent-host sessions, and opening one adopts it in place. Experimental; off.
 export const AgentHostMigrateLegacyCopilotCliEnabledConfigKey = 'migrateLegacyCopilotCliEnabled';
-
-// The VS Code setting ID gating legacy Copilot CLI migration, forwarded into the agent host root
-// config. Kept in sync with `ChatConfiguration.MigrateLegacyCopilotCliSessions` (workbench layer).
-export const MIGRATE_LEGACY_COPILOT_CLI_SETTING_ID = 'chat.agentSessions.migrateLegacyCopilotCli';
 
 /**
  * Root config key forwarded from the renderer that gates multiple-working-directory
@@ -594,13 +575,6 @@ export const AgentHostMcpServersConfigKey = 'mcpServers';
  * {@link AgentHostMcpServersConfigKey} root config value.
  */
 export type AgentHostMcpServers = Record<string, IMcpServerConfiguration>;
-
-/**
- * The VS Code setting ID for session sync. Defined here so the platform
- * layer (renderer-side forwarding) can reference it without importing from
- * `workbench/contrib/chat`.
- */
-export const SESSION_SYNC_ENABLED_SETTING_ID = 'chat.sessionSync.enabled';
 
 export function telemetryLevelToAgentHostConfigValue(telemetryLevel: TelemetryLevel): TelemetryConfiguration {
 	switch (telemetryLevel) {

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -31,6 +31,13 @@ import {
 	AgentHostOTelServiceNameSettingId,
 	AgentHostSystemProxyEnabledSettingId,
 } from './agentService.js';
+import {
+	AgentHostClaudeMultiRootEnabledConfigKey,
+	AgentHostCodexEnabledConfigKey,
+	AgentHostCodexMultiRootEnabledConfigKey,
+	AgentHostCopilotMultiRootEnabledConfigKey,
+	AgentHostSystemProxyEnabledConfigKey,
+} from './agentHostSchema.js';
 
 // Settings consumed by the agent host starter (`electronAgentHostStarter.ts`
 // and `nodeAgentHostStarter.ts`) to populate the spawned agent host process's
@@ -94,6 +101,7 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			tags: ['experimental', 'advanced'],
 			experiment: { mode: 'startup' },
+			agentHost: { key: AgentHostSystemProxyEnabledConfigKey },
 		},
 		[AgentHostCopilotMultiRootEnabledSettingId]: {
 			type: 'boolean',
@@ -103,6 +111,7 @@ configurationRegistry.registerConfiguration({
 			// Still settable via `settings.json`; flip `default` (e.g. to
 			// `product.quality !== 'stable'`) to enable it for a build channel.
 			included: false,
+			agentHost: { key: AgentHostCopilotMultiRootEnabledConfigKey },
 		},
 		[AgentHostClaudeMultiRootEnabledSettingId]: {
 			type: 'boolean',
@@ -112,12 +121,14 @@ configurationRegistry.registerConfiguration({
 			// Still settable via `settings.json`; flip `default` (e.g. to
 			// `product.quality !== 'stable'`) to enable it for a build channel.
 			included: false,
+			agentHost: { key: AgentHostClaudeMultiRootEnabledConfigKey },
 		},
 		[AgentHostCodexMultiRootEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.codexAgent.multiRootEnabled', "When enabled, Codex agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host."),
 			default: false,
 			included: false,
+			agentHost: { key: AgentHostCodexMultiRootEnabledConfigKey },
 		},
 		[AgentHostClaudeAgentEnabledSettingId]: {
 			type: 'boolean',
@@ -157,6 +168,10 @@ configurationRegistry.registerConfiguration({
 			// Allow the default to be overridden by an experiment. Uses `startup`
 			// to match the sibling agent-host provider settings.
 			experiment: { mode: 'startup' },
+			// Always mirrored, including when `false`: the host only acts on enable, so a
+			// forwarded `false` takes effect on the next agent host restart (otherwise
+			// in-progress Codex sessions would have to be stopped).
+			agentHost: { key: AgentHostCodexEnabledConfigKey },
 			// Owns the `Codex3PIntegration` policy; gating here disables Codex across all agent-host surfaces.
 			policy: {
 				name: 'Codex3PIntegration',

--- a/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IConfigurationService, IConfigurationValue } from '../../../configuration/common/configuration.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
+import { Registry } from '../../../registry/common/platform.js';
+import { getAgentHostConfigurationSyncEntries, getGlobalConfigurationValue, resolveAgentHostConfigurationSyncPatch } from '../../common/agentHostConfigurationSync.js';
+
+const ALL_HOSTS_SETTING = 'test.agentHostSync.allHosts';
+const LOCAL_ONLY_SETTING = 'test.agentHostSync.localOnly';
+const HIDDEN_SETTING = 'test.agentHostSync.hidden';
+const UNSYNCED_SETTING = 'test.agentHostSync.unsynced';
+
+/**
+ * Stands in for `IConfigurationService` with per-layer control over `inspect`,
+ * which the global-value resolution depends on. `TestConfigurationService`
+ * collapses every layer onto `userValue`, so it cannot express the workspace
+ * layer this suite needs to assert is ignored.
+ */
+function createConfigurationService(values: Record<string, IConfigurationValue<unknown>>): IConfigurationService {
+	return {
+		inspect: <T>(key: string) => (values[key] ?? {}) as IConfigurationValue<T>,
+	} as IConfigurationService;
+}
+
+suite('AgentHostConfigurationSync', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+	const node = {
+		id: 'testAgentHostSync',
+		type: 'object' as const,
+		properties: {
+			[ALL_HOSTS_SETTING]: {
+				type: 'boolean' as const,
+				default: true,
+				agentHost: { key: 'allHostsValue' },
+			},
+			[LOCAL_ONLY_SETTING]: {
+				type: 'boolean' as const,
+				default: false,
+				agentHost: { key: 'localOnlyValue', localOnly: true },
+			},
+			[HIDDEN_SETTING]: {
+				type: 'boolean' as const,
+				default: false,
+				// Hidden settings land in the registry's excluded bucket; mirroring
+				// must still pick them up.
+				included: false,
+				agentHost: { key: 'hiddenValue', transform: (value: unknown) => value === true ? 'on' : 'off' },
+			},
+			[UNSYNCED_SETTING]: {
+				type: 'boolean' as const,
+				default: true,
+			},
+		},
+	};
+
+	suiteSetup(() => registry.registerConfiguration(node));
+	suiteTeardown(() => registry.deregisterConfigurations([node]));
+
+	test('resolves the global value, ignoring workspace and folder layers', () => {
+		const configurationService = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, userValue: false, workspaceValue: true, workspaceFolderValue: true },
+		});
+
+		assert.strictEqual(getGlobalConfigurationValue(configurationService, ALL_HOSTS_SETTING), false);
+	});
+
+	test('prefers policy over user, user over application, and falls back to the default', () => {
+		const policyWins = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: true, userValue: true, policyValue: false },
+		});
+		const userWins = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: true, userValue: false },
+		});
+		const applicationWins = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: false },
+		});
+		const defaultWins = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true },
+		});
+
+		assert.deepStrictEqual([
+			getGlobalConfigurationValue(policyWins, ALL_HOSTS_SETTING),
+			getGlobalConfigurationValue(userWins, ALL_HOSTS_SETTING),
+			getGlobalConfigurationValue(applicationWins, ALL_HOSTS_SETTING),
+			getGlobalConfigurationValue(defaultWins, ALL_HOSTS_SETTING),
+		], [false, false, false, true]);
+	});
+
+	test('builds a patch applying transforms, including for hidden settings', () => {
+		const configurationService = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true },
+			[LOCAL_ONLY_SETTING]: { defaultValue: false, userValue: true },
+			[HIDDEN_SETTING]: { defaultValue: false, userValue: true },
+		});
+
+		const patch = resolveAgentHostConfigurationSyncPatch(configurationService, true);
+
+		assert.deepStrictEqual({
+			allHostsValue: patch.allHostsValue,
+			localOnlyValue: patch.localOnlyValue,
+			hiddenValue: patch.hiddenValue,
+		}, {
+			allHostsValue: true,
+			localOnlyValue: true,
+			hiddenValue: 'on',
+		});
+	});
+
+	test('omits localOnly settings for a remote host', () => {
+		const configurationService = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true },
+			[LOCAL_ONLY_SETTING]: { defaultValue: false, userValue: true },
+		});
+
+		const patch = resolveAgentHostConfigurationSyncPatch(configurationService, false);
+
+		assert.deepStrictEqual({
+			allHostsValue: patch.allHostsValue,
+			mirroredKeys: Object.keys(patch).filter(key => key === 'localOnlyValue'),
+		}, {
+			allHostsValue: true,
+			mirroredKeys: [],
+		});
+	});
+
+	test('only settings declaring `agentHost` are mirrored', () => {
+		const settingIds = getAgentHostConfigurationSyncEntries(true).map(entry => entry.settingId);
+
+		assert.deepStrictEqual({
+			hasSynced: settingIds.includes(ALL_HOSTS_SETTING),
+			hasHidden: settingIds.includes(HIDDEN_SETTING),
+			hasUnsynced: settingIds.includes(UNSYNCED_SETTING),
+		}, {
+			hasSynced: true,
+			hasHidden: true,
+			hasUnsynced: false,
+		});
+	});
+
+	test('skips layers whose value does not match the declared type', () => {
+		// Replaces the per-setting `value === true` / `value !== false` transforms:
+		// a malformed layer is skipped, so resolution lands on the next valid layer
+		// and ultimately on the registered default.
+		const malformedUser = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, userValue: 'yes' as unknown as boolean },
+		});
+		const malformedUserValidApplication = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: false, userValue: 'yes' as unknown as boolean },
+		});
+		const validFalse = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, userValue: false },
+		});
+
+		assert.deepStrictEqual([
+			getGlobalConfigurationValue(malformedUser, ALL_HOSTS_SETTING),
+			getGlobalConfigurationValue(malformedUserValidApplication, ALL_HOSTS_SETTING),
+			getGlobalConfigurationValue(validFalse, ALL_HOSTS_SETTING),
+		], [true, false, false]);
+	});
+
+	test('falls back to the declared default for hidden settings', () => {
+		// `included: false` settings are absent from the default-configuration
+		// model, so `inspect().defaultValue` is undefined for them. Without the
+		// schema-default fallback they would be silently omitted from the patch
+		// while visible siblings are mirrored — verified against a live agent host.
+		const configurationService = createConfigurationService({});
+
+		assert.deepStrictEqual({
+			hidden: getGlobalConfigurationValue(configurationService, HIDDEN_SETTING),
+			visible: getGlobalConfigurationValue(configurationService, ALL_HOSTS_SETTING),
+			mirrored: Object.keys(resolveAgentHostConfigurationSyncPatch(configurationService, true)).includes('hiddenValue'),
+		}, {
+			hidden: false,
+			visible: true,
+			mirrored: true,
+		});
+	});
+
+	test('deregistering drops mirroring entries, including for hidden settings', () => {
+		const node = {
+			id: 'testAgentHostSyncTransient',
+			type: 'object' as const,
+			properties: {
+				'test.agentHostSync.transient': {
+					type: 'boolean' as const,
+					default: false,
+					agentHost: { key: 'transientValue' },
+				},
+				'test.agentHostSync.transientHidden': {
+					type: 'boolean' as const,
+					default: false,
+					// Registration strips hidden keys from `node.properties`, so
+					// deregistration has to find them another way.
+					included: false,
+					agentHost: { key: 'transientHiddenValue' },
+				},
+			},
+		};
+
+		registry.registerConfiguration(node);
+		const whileRegistered = getAgentHostConfigurationSyncEntries(true).map(entry => entry.settingId);
+		registry.deregisterConfigurations([node]);
+		const afterDeregister = getAgentHostConfigurationSyncEntries(true).map(entry => entry.settingId);
+
+		assert.deepStrictEqual({
+			registeredVisible: whileRegistered.includes('test.agentHostSync.transient'),
+			registeredHidden: whileRegistered.includes('test.agentHostSync.transientHidden'),
+			leakedVisible: afterDeregister.includes('test.agentHostSync.transient'),
+			leakedHidden: afterDeregister.includes('test.agentHostSync.transientHidden'),
+		}, {
+			registeredVisible: true,
+			registeredHidden: true,
+			leakedVisible: false,
+			leakedHidden: false,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -29,8 +29,11 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostCodexAgentEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AUTO_REPLY_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, EDIT_TELEMETRY_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostCodexAgentEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
+import { AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+// Registers the agent-host settings that declare `agentHost` mirroring, which the
+// client reads off the configuration registry when forwarding config to the host.
+import '../../common/agentHostStarter.config.contribution.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -74,6 +77,11 @@ function getRootConfig(notification: JsonRpcNotification): Record<string, RootCo
 
 function findLastRootConfigNotification(messages: readonly ProtocolTransportMessage[], configKey: string): JsonRpcNotification {
 	return findRootConfigNotification([...messages].reverse(), configKey);
+}
+
+/** The value forwarded for `configKey` in the first root-config notification carrying it. */
+function findRootConfigValue(messages: readonly ProtocolTransportMessage[], configKey: string): RootConfigValue {
+	return getRootConfig(findRootConfigNotification(messages, configKey))[configKey];
 }
 
 class TestProtocolTransport extends Disposable implements IProtocolTransport {
@@ -814,7 +822,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 			result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
 		});
 		await connectPromise;
-		const telemetryLevel = transport.sentMessages[1] as JsonRpcNotification;
+		const telemetryLevel = findRootConfigNotification(transport.sentMessages, AgentHostTelemetryLevelConfigKey);
 		assert.deepStrictEqual(telemetryLevel, {
 			jsonrpc: '2.0',
 			method: 'dispatchAction',
@@ -824,45 +832,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 				action: {
 					type: ActionType.RootConfigChanged,
 					config: { [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(TelemetryLevel.USAGE) },
-				},
-			},
-		});
-		const editTelemetryEnabled = findRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
-		assert.deepStrictEqual(editTelemetryEnabled, {
-			jsonrpc: '2.0',
-			method: 'dispatchAction',
-			params: {
-				channel: ROOT_STATE_URI,
-				clientSeq: 0,
-				action: {
-					type: ActionType.RootConfigChanged,
-					config: { [AgentHostEditTelemetryEnabledConfigKey]: true },
-				},
-			},
-		});
-		const terminalAutoApproveEnabled = findRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveEnabledConfigKey);
-		assert.deepStrictEqual(terminalAutoApproveEnabled, {
-			jsonrpc: '2.0',
-			method: 'dispatchAction',
-			params: {
-				channel: ROOT_STATE_URI,
-				clientSeq: 0,
-				action: {
-					type: ActionType.RootConfigChanged,
-					config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: true },
-				},
-			},
-		});
-		const globalAutoApproveEnabled = findRootConfigNotification(transport.sentMessages, AgentHostGlobalAutoApproveEnabledConfigKey);
-		assert.deepStrictEqual(globalAutoApproveEnabled, {
-			jsonrpc: '2.0',
-			method: 'dispatchAction',
-			params: {
-				channel: ROOT_STATE_URI,
-				clientSeq: 0,
-				action: {
-					type: ActionType.RootConfigChanged,
-					config: { [AgentHostGlobalAutoApproveEnabledConfigKey]: false },
 				},
 			},
 		});
@@ -876,19 +845,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 				action: {
 					type: ActionType.RootConfigChanged,
 					config: { [AgentHostTerminalAutoApproveRulesConfigKey]: {} },
-				},
-			},
-		});
-		const codexEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCodexEnabledConfigKey);
-		assert.deepStrictEqual(codexEnabled, {
-			jsonrpc: '2.0',
-			method: 'dispatchAction',
-			params: {
-				channel: ROOT_STATE_URI,
-				clientSeq: 0,
-				action: {
-					type: ActionType.RootConfigChanged,
-					config: { [AgentHostCodexEnabledConfigKey]: false },
 				},
 			},
 		});
@@ -913,93 +869,41 @@ suite('RemoteAgentHostProtocolClient', () => {
 		});
 		await connectPromise;
 
-		const codexEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCodexEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(codexEnabled), { [AgentHostCodexEnabledConfigKey]: true });
+		const codexEnabled = findRootConfigValue(transport.sentMessages, AgentHostCodexEnabledConfigKey);
+		assert.strictEqual(codexEnabled, true);
 	});
 
-	test('forwards system proxy enablement on connect and when the setting changes', async () => {
-		const configurationService = new TestConfigurationService();
+	test('forwards every setting declaring `agentHost` on connect and when one changes', async () => {
+		const configurationService = new TestConfigurationService({
+			[AgentHostCopilotMultiRootEnabledSettingId]: true,
+			[AgentHostClaudeMultiRootEnabledSettingId]: false,
+			[AgentHostCodexMultiRootEnabledSettingId]: true,
+			[AgentHostSystemProxyEnabledSettingId]: false,
+		});
 		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
 
 		await connectClient(client, transport);
 
-		const systemProxyEnabled = findRootConfigNotification(transport.sentMessages, AgentHostSystemProxyEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(systemProxyEnabled), { [AgentHostSystemProxyEnabledConfigKey]: true });
-
-		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(AgentHostSystemProxyEnabledSettingId, false);
-		fireConfigurationChange(configurationService, AgentHostSystemProxyEnabledSettingId);
-
-		const updatedSystemProxyEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostSystemProxyEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(updatedSystemProxyEnabled), { [AgentHostSystemProxyEnabledConfigKey]: false });
-	});
-
-	test('forwards Copilot multi-root enablement on connect and when the setting changes', async () => {
-		const configurationService = new TestConfigurationService({ [AgentHostCopilotMultiRootEnabledSettingId]: true });
-		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
-
-		await connectClient(client, transport);
-
-		const multiRootEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(multiRootEnabled), { [AgentHostCopilotMultiRootEnabledConfigKey]: true });
+		assert.deepStrictEqual({
+			copilotMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey),
+			claudeMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostClaudeMultiRootEnabledConfigKey),
+			codexMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey),
+			systemProxy: findRootConfigValue(transport.sentMessages, AgentHostSystemProxyEnabledConfigKey),
+		}, {
+			copilotMultiRoot: true,
+			claudeMultiRoot: false,
+			codexMultiRoot: true,
+			systemProxy: false,
+		});
 
 		transport.sentMessages.length = 0;
 		await configurationService.setUserConfiguration(AgentHostCopilotMultiRootEnabledSettingId, false);
 		fireConfigurationChange(configurationService, AgentHostCopilotMultiRootEnabledSettingId);
 
-		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostCopilotMultiRootEnabledConfigKey]: false });
-	});
-
-	test('forwards Claude multi-root enablement on connect and when the setting changes', async () => {
-		const configurationService = new TestConfigurationService({ [AgentHostClaudeMultiRootEnabledSettingId]: true });
-		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
-
-		await connectClient(client, transport);
-
-		const multiRootEnabled = findRootConfigNotification(transport.sentMessages, AgentHostClaudeMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(multiRootEnabled), { [AgentHostClaudeMultiRootEnabledConfigKey]: true });
-
-		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(AgentHostClaudeMultiRootEnabledSettingId, false);
-		fireConfigurationChange(configurationService, AgentHostClaudeMultiRootEnabledSettingId);
-
-		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostClaudeMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostClaudeMultiRootEnabledConfigKey]: false });
-	});
-
-	test('forwards Codex multi-root enablement on connect and when the setting changes', async () => {
-		const configurationService = new TestConfigurationService({ [AgentHostCodexMultiRootEnabledSettingId]: true });
-		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
-
-		await connectClient(client, transport);
-
-		const multiRootEnabled = findRootConfigNotification(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(multiRootEnabled), { [AgentHostCodexMultiRootEnabledConfigKey]: true });
-
-		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(AgentHostCodexMultiRootEnabledSettingId, false);
-		fireConfigurationChange(configurationService, AgentHostCodexMultiRootEnabledSettingId);
-
-		const updatedMultiRootEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(updatedMultiRootEnabled), { [AgentHostCodexMultiRootEnabledConfigKey]: false });
-	});
-
-	test('forwards auto-reply on connect and when the setting changes', async () => {
-		const configurationService = new TestConfigurationService({ [AUTO_REPLY_SETTING_ID]: true });
-		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
-
-		await connectClient(client, transport);
-
-		const autoReplyEnabled = findRootConfigNotification(transport.sentMessages, AgentHostAutoReplyEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(autoReplyEnabled), { [AgentHostAutoReplyEnabledConfigKey]: true });
-
-		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(AUTO_REPLY_SETTING_ID, false);
-		fireConfigurationChange(configurationService, AUTO_REPLY_SETTING_ID);
-
-		const updatedAutoReplyEnabled = findLastRootConfigNotification(transport.sentMessages, AgentHostAutoReplyEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(updatedAutoReplyEnabled), { [AgentHostAutoReplyEnabledConfigKey]: false });
+		// Only the affected setting is re-forwarded.
+		assert.deepStrictEqual(getRootConfig(findLastRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey)), {
+			[AgentHostCopilotMultiRootEnabledConfigKey]: false,
+		});
 	});
 
 	test('forwards the repo-info telemetry debug switch on connect and change', async () => {
@@ -1017,23 +921,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		const enabled = findLastRootConfigNotification(transport.sentMessages, AgentHostDisableRepoInfoTelemetryConfigKey);
 		assert.deepStrictEqual(getRootConfig(enabled), { [AgentHostDisableRepoInfoTelemetryConfigKey]: false });
-	});
-
-	test('forwards edit telemetry on connect and change', async () => {
-		const configurationService = new TestConfigurationService({ [EDIT_TELEMETRY_ENABLED_SETTING_ID]: false });
-		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
-
-		await connectClient(client, transport);
-
-		const disabled = findRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(disabled), { [AgentHostEditTelemetryEnabledConfigKey]: false });
-
-		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(EDIT_TELEMETRY_ENABLED_SETTING_ID, true);
-		fireConfigurationChange(configurationService, EDIT_TELEMETRY_ENABLED_SETTING_ID);
-
-		const enabled = findLastRootConfigNotification(transport.sentMessages, AgentHostEditTelemetryEnabledConfigKey);
-		assert.deepStrictEqual(getRootConfig(enabled), { [AgentHostEditTelemetryEnabledConfigKey]: true });
 	});
 
 	test('forwards terminal auto-approve rules on connect', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -29,11 +29,36 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostCodexAgentEnabledSettingId, AgentHostClaudeMultiRootEnabledSettingId, AgentHostCodexMultiRootEnabledSettingId, AgentHostCopilotMultiRootEnabledSettingId, AgentHostSystemProxyEnabledSettingId } from '../../common/agentService.js';
-import { AgentHostCodexEnabledConfigKey, AgentHostCodexMultiRootEnabledConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostClaudeMultiRootEnabledConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
-// Registers the agent-host settings that declare `agentHost` mirroring, which the
-// client reads off the configuration registry when forwarding config to the host.
-import '../../common/agentHostStarter.config.contribution.js';
+import { AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
+import { Registry } from '../../../registry/common/platform.js';
+
+// Settings used to exercise declarative agent-host mirroring. Registered by this
+// suite rather than pulling in a product configuration contribution: the
+// configuration registry is a process-wide singleton, so a side-effect import
+// here would leak its registrations (and their `managedSettings` policies) into
+// every other suite in the run.
+const SYNC_SETTING_A = 'test.remoteAgentHostProtocolClient.syncA';
+const SYNC_CONFIG_KEY_A = 'testSyncValueA';
+const SYNC_SETTING_B = 'test.remoteAgentHostProtocolClient.syncB';
+const SYNC_CONFIG_KEY_B = 'testSyncValueB';
+
+const syncTestConfigurationNode = {
+	id: 'testRemoteAgentHostProtocolClientSync',
+	type: 'object' as const,
+	properties: {
+		[SYNC_SETTING_A]: {
+			type: 'boolean' as const,
+			default: false,
+			agentHost: { key: SYNC_CONFIG_KEY_A },
+		},
+		[SYNC_SETTING_B]: {
+			type: 'boolean' as const,
+			default: false,
+			agentHost: { key: SYNC_CONFIG_KEY_B },
+		},
+	},
+};
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -148,6 +173,10 @@ class TerminalAutoApproveConfigurationService extends TestConfigurationService {
 
 suite('RemoteAgentHostProtocolClient', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+	suiteSetup(() => configurationRegistry.registerConfiguration(syncTestConfigurationNode));
+	suiteTeardown(() => configurationRegistry.deregisterConfigurations([syncTestConfigurationNode]));
 
 	function createPermissionService(allow = true): IAgentHostResourceService {
 		return createResourceServiceStub({ granted: () => allow });
@@ -850,59 +879,30 @@ suite('RemoteAgentHostProtocolClient', () => {
 		});
 	});
 
-	test('forwards codex enablement on connect when the experiment-aware setting is on', async () => {
-		const transport = disposables.add(new TestClientProtocolTransport());
-		const configurationService = new TestConfigurationService({ [AgentHostCodexAgentEnabledSettingId]: true });
-		const { client } = createClient(transport, undefined, undefined, undefined, configurationService);
-		const connectPromise = client.connect();
-
-		transport.connectDeferred.complete();
-		while (transport.sentMessages.length === 0) {
-			await Promise.resolve();
-		}
-
-		const sent = transport.sentMessages[0] as JsonRpcRequest;
-		transport.fireMessage({
-			jsonrpc: '2.0',
-			id: sent.id,
-			result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
-		});
-		await connectPromise;
-
-		const codexEnabled = findRootConfigValue(transport.sentMessages, AgentHostCodexEnabledConfigKey);
-		assert.strictEqual(codexEnabled, true);
-	});
-
 	test('forwards every setting declaring `agentHost` on connect and when one changes', async () => {
 		const configurationService = new TestConfigurationService({
-			[AgentHostCopilotMultiRootEnabledSettingId]: true,
-			[AgentHostClaudeMultiRootEnabledSettingId]: false,
-			[AgentHostCodexMultiRootEnabledSettingId]: true,
-			[AgentHostSystemProxyEnabledSettingId]: false,
+			[SYNC_SETTING_A]: true,
+			[SYNC_SETTING_B]: false,
 		});
 		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
 
 		await connectClient(client, transport);
 
 		assert.deepStrictEqual({
-			copilotMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey),
-			claudeMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostClaudeMultiRootEnabledConfigKey),
-			codexMultiRoot: findRootConfigValue(transport.sentMessages, AgentHostCodexMultiRootEnabledConfigKey),
-			systemProxy: findRootConfigValue(transport.sentMessages, AgentHostSystemProxyEnabledConfigKey),
+			a: findRootConfigValue(transport.sentMessages, SYNC_CONFIG_KEY_A),
+			b: findRootConfigValue(transport.sentMessages, SYNC_CONFIG_KEY_B),
 		}, {
-			copilotMultiRoot: true,
-			claudeMultiRoot: false,
-			codexMultiRoot: true,
-			systemProxy: false,
+			a: true,
+			b: false,
 		});
 
 		transport.sentMessages.length = 0;
-		await configurationService.setUserConfiguration(AgentHostCopilotMultiRootEnabledSettingId, false);
-		fireConfigurationChange(configurationService, AgentHostCopilotMultiRootEnabledSettingId);
+		await configurationService.setUserConfiguration(SYNC_SETTING_A, false);
+		fireConfigurationChange(configurationService, SYNC_SETTING_A);
 
 		// Only the affected setting is re-forwarded.
-		assert.deepStrictEqual(getRootConfig(findLastRootConfigNotification(transport.sentMessages, AgentHostCopilotMultiRootEnabledConfigKey)), {
-			[AgentHostCopilotMultiRootEnabledConfigKey]: false,
+		assert.deepStrictEqual(getRootConfig(findLastRootConfigNotification(transport.sentMessages, SYNC_CONFIG_KEY_A)), {
+			[SYNC_CONFIG_KEY_A]: false,
 		});
 	});
 

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -32,6 +32,44 @@ export interface IConfigurationDelta {
 	addedConfigurations?: IConfigurationNode[];
 }
 
+/**
+ * Declares that a setting's value should be mirrored into the agent host's root
+ * configuration, removing the need to hand-write a forwarder per setting.
+ *
+ * Only the setting's *globally-scoped* value is mirrored — the resolution order
+ * is policy, then user, then application, then default. Workspace and folder
+ * values are deliberately ignored: the agent host root config is shared by every
+ * window connected to a host, so a workspace-specific value would leak across
+ * unrelated windows on a last-writer-wins basis.
+ *
+ * A setting that genuinely needs per-workspace behavior should not use this;
+ * push it through session config instead, where the session → parent → host
+ * chain resolves precedence correctly.
+ */
+export interface IAgentHostConfigurationSync {
+
+	/** The agent host root configuration key to write the value to. */
+	readonly key: string;
+
+	/**
+	 * Maps the globally-scoped setting value to the value written to {@link key}.
+	 * Defaults to the identity, which is what most settings want: the resolver
+	 * already skips layers whose value does not conform to the declared `type`
+	 * and falls back to the registered default, so a transform is only needed to
+	 * change the *shape* of the value (for example mapping an enum to a
+	 * different representation the agent host expects).
+	 */
+	readonly transform?: (value: unknown) => unknown;
+
+	/**
+	 * When `true`, the value is only mirrored to a local agent host, and never to
+	 * a remote one. Use for settings that describe the client's own machine —
+	 * filesystem paths, machine identity — which are meaningless on a remote
+	 * host. Defaults to `false`, mirroring to every agent host.
+	 */
+	readonly localOnly?: boolean;
+}
+
 export interface IConfigurationRegistry {
 
 	/**
@@ -119,6 +157,14 @@ export interface IConfigurationRegistry {
 	 * Returns the referencing setting keys per policy name.
 	 */
 	getPolicyReferenceConfigurations(): Map<PolicyName, Set<string>>;
+
+	/**
+	 * Returns the {@link IAgentHostConfigurationSync} descriptor per setting key
+	 * for every setting that declares one. Includes settings hidden from the
+	 * Settings UI via `included: false`, which are absent from
+	 * {@link getConfigurationProperties}.
+	 */
+	getAgentHostSyncConfigurations(): Map<string, IAgentHostConfigurationSync>;
 
 	/**
 	 * Returns all excluded configurations settings of all configuration nodes contributed to this registry.
@@ -234,6 +280,13 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	 * The type must match the owning setting (enforced when exporting the policy catalog).
 	 */
 	policyReference?: IPolicyReference;
+
+	/**
+	 * When specified, this setting's globally-scoped value is mirrored into the
+	 * agent host's root configuration automatically, without any per-setting
+	 * plumbing. See {@link IAgentHostConfigurationSync}.
+	 */
+	agentHost?: IAgentHostConfigurationSync;
 
 	/**
 	 * When specified, this setting's default value can always be overwritten by
@@ -356,6 +409,13 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 	private readonly configurationProperties: IStringDictionary<IRegisteredConfigurationPropertySchema>;
 	private readonly policyConfigurations: Map<PolicyName, string>;
 	private readonly policyReferenceConfigurations: Map<PolicyName, Set<string>>;
+	private readonly agentHostSyncConfigurations: Map<string, IAgentHostConfigurationSync>;
+	/**
+	 * Agent-host-mirrored setting keys per node that were hidden with
+	 * `included: false`. Registration deletes those keys from the node's
+	 * `properties`, so deregistration has no other way to find them.
+	 */
+	private readonly excludedAgentHostSyncKeys = new Map<IConfigurationNode, Set<string>>();
 	private readonly excludedConfigurationProperties: IStringDictionary<IRegisteredConfigurationPropertySchema>;
 	private readonly resourceLanguageSettingsSchema: IJSONSchema;
 	private readonly overrideIdentifiers = new Set<string>();
@@ -385,6 +445,7 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 		this.configurationProperties = {};
 		this.policyConfigurations = new Map<PolicyName, string>();
 		this.policyReferenceConfigurations = new Map<PolicyName, Set<string>>();
+		this.agentHostSyncConfigurations = new Map<string, IAgentHostConfigurationSync>();
 		this.excludedConfigurationProperties = {};
 
 		contributionRegistry.registerSchema(resourceLanguageSettingsSchemaId, this.resourceLanguageSettingsSchema);
@@ -692,6 +753,18 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 	private doDeregisterConfigurations(configurations: IConfigurationNode[], bucket: Set<string>): void {
 
 		const deregisterConfiguration = (configuration: IConfigurationNode) => {
+			// Properties hidden with `included: false` are stripped from
+			// `configuration.properties` at registration time, so the loop below
+			// cannot see them. Clean their mirroring entries from the side table
+			// recorded when they were excluded.
+			const excludedSyncKeys = this.excludedAgentHostSyncKeys.get(configuration);
+			if (excludedSyncKeys) {
+				for (const key of excludedSyncKeys) {
+					bucket.add(key);
+					this.agentHostSyncConfigurations.delete(key);
+				}
+				this.excludedAgentHostSyncKeys.delete(configuration);
+			}
 			if (configuration.properties) {
 				for (const key in configuration.properties) {
 					bucket.add(key);
@@ -699,6 +772,7 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 					if (property?.policy?.name) {
 						this.policyConfigurations.delete(property.policy.name);
 					}
+					this.agentHostSyncConfigurations.delete(key);
 					if (property?.policyReference?.name) {
 						const refs = this.policyReferenceConfigurations.get(property.policyReference.name);
 						if (refs) {
@@ -767,6 +841,11 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 				const excluded = properties[key].hasOwnProperty('included') && !properties[key].included;
 				const policyName = properties[key].policy?.name;
 				const policyReferenceName = properties[key].policyReference?.name;
+				const agentHostSync = properties[key].agentHost;
+
+				if (agentHostSync) {
+					this.agentHostSyncConfigurations.set(key, agentHostSync);
+				}
 
 				if (excluded) {
 					this.excludedConfigurationProperties[key] = properties[key];
@@ -777,6 +856,19 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 					if (policyReferenceName) {
 						this.addPolicyReferenceConfiguration(policyReferenceName, key);
 						bucket.add(key);
+					}
+					if (agentHostSync) {
+						// Hidden settings still mirror to the agent host; the bucket
+						// entry is what makes the change observable to the syncer.
+						bucket.add(key);
+						// `delete properties[key]` below erases the only link back to
+						// this node, so remember the key for deregistration.
+						let excludedSyncKeys = this.excludedAgentHostSyncKeys.get(configuration);
+						if (!excludedSyncKeys) {
+							excludedSyncKeys = new Set<string>();
+							this.excludedAgentHostSyncKeys.set(configuration, excludedSyncKeys);
+						}
+						excludedSyncKeys.add(key);
 					}
 					delete properties[key];
 				} else {
@@ -829,6 +921,10 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 
 	getPolicyReferenceConfigurations(): Map<PolicyName, Set<string>> {
 		return this.policyReferenceConfigurations;
+	}
+
+	getAgentHostSyncConfigurations(): Map<string, IAgentHostConfigurationSync> {
+		return this.agentHostSyncConfigurations;
 	}
 
 	getExcludedConfigurationProperties(): IStringDictionary<IRegisteredConfigurationPropertySchema> {
@@ -1037,6 +1133,13 @@ export function validateProperty(property: string, schema: IRegisteredConfigurat
 	}
 	if (schema.policy?.name && configurationRegistry.getPolicyConfigurations().get(schema.policy?.name) !== undefined) {
 		return nls.localize('config.policy.duplicate', "Cannot register '{0}'. The associated policy {1} is already registered with {2}. To attach another setting to the same policy, use 'policyReference'.", property, schema.policy?.name, configurationRegistry.getPolicyConfigurations().get(schema.policy?.name));
+	}
+	if (schema.agentHost) {
+		for (const [owner, sync] of configurationRegistry.getAgentHostSyncConfigurations()) {
+			if (sync.key === schema.agentHost.key && owner !== property) {
+				return nls.localize('config.agentHost.duplicate', "Cannot register '{0}'. The agent host configuration key '{1}' is already mirrored from '{2}'.", property, schema.agentHost.key, owner);
+			}
+		}
 	}
 	return null;
 }

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -327,6 +327,10 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 					extension.collector.error(nls.localize('config.property.agentsWindow.proposed', "Extension '{0}' CANNOT use 'agentsWindow' property on configuration '{1}' without enabling the 'agentsWindowConfiguration' API proposal.", extension.description.identifier.value, key));
 					delete propertyConfiguration.agentsWindow;
 				}
+				if (propertyConfiguration.agentHost) {
+					extension.collector.error(nls.localize('config.property.agentHost.unsupported', "Extension '{0}' CANNOT use the 'agentHost' property on configuration '{1}'.", extension.description.identifier.value, key));
+					delete propertyConfiguration.agentHost;
+				}
 				seenProperties.add(key);
 				propertyConfiguration.scope = propertyConfiguration.scope ? parseScope(propertyConfiguration.scope.toString()) : ConfigurationScope.WINDOW;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -14,6 +14,7 @@ import '../../../../platform/agentHost/browser/agentHostEnablementService.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostAllowSignedOutWhenUsableSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchDeferThresholdSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
 import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../platform/localTranscription/common/localTranscription.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
@@ -375,6 +376,7 @@ configurationRegistry.registerConfiguration({
 			experiment: {
 				mode: 'startup'
 			},
+			agentHost: { key: AgentHostMigrateLegacyCopilotCliEnabledConfigKey },
 		},
 		'chat.implicitContext.enabled': {
 			type: 'object',
@@ -554,6 +556,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			scope: ConfigurationScope.APPLICATION_MACHINE,
 			tags: ['experimental', 'advanced'],
+			agentHost: { key: AgentHostAutoReplyEnabledConfigKey },
 		},
 		[ChatConfiguration.AutopilotAdvancedEnabled]: {
 			type: 'boolean',
@@ -654,6 +657,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			scope: ConfigurationScope.APPLICATION_MACHINE,
 			tags: ['experimental'],
+			agentHost: { key: AgentHostGlobalAutoApproveEnabledConfigKey },
 			policy: {
 				name: 'ChatToolsAutoApprove',
 				category: PolicyCategory.InteractiveSession,
@@ -689,7 +693,8 @@ configurationRegistry.registerConfiguration({
 						value: nls.localize('chat.sessionSync.enabled.policy', "Enable session sync to GitHub.com for cross-device Copilot session history. When disabled by organization policy, session data is kept local only."),
 					}
 				},
-			}
+			},
+			agentHost: { key: AgentHostSessionSyncEnabledConfigKey },
 		},
 		[ChatConfiguration.SessionSyncExcludeRepositories]: {
 			type: 'array',

--- a/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
@@ -14,6 +14,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { IAiEditTelemetryService } from './telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { AiEditTelemetryServiceImpl } from './telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.js';
 import { IRandomService, RandomService } from './randomService.js';
+import { AgentHostEditTelemetryEnabledConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
 
 registerWorkbenchContribution2('EditTelemetryContribution', EditTelemetryContribution, WorkbenchPhase.AfterRestored);
 
@@ -31,7 +32,8 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 			experiment: {
 				mode: 'auto'
-			}
+			},
+			agentHost: { key: AgentHostEditTelemetryEnabledConfigKey },
 		},
 		[AI_STATS_SETTING_ID]: {
 			markdownDescription: localize('editor.aiStats.enabled', "Controls whether to enable AI statistics in the editor. The gauge shows the average AI rate across 5-minute sessions, where each session's rate is calculated as AI-inserted characters divided by total inserted characters."),


### PR DESCRIPTION
Settings that the agent host needs were forwarded by ~15 near-identical methods in `remoteAgentHostProtocolClient.ts`. Adding one meant editing four places — a setting-id constant, a config-key constant, a change handler, and the connect-time forwarder — with nothing enforcing that you did all four. This replaces that with a declarative field on the setting itself.

## How to mirror a setting into the agent host

Add `agentHost` to the setting's configuration schema, the same way `policy` works today:

```ts
[ChatConfiguration.AutoReply]: {
    type: 'boolean',
    default: false,
    agentHost: { key: AgentHostAutoReplyEnabledConfigKey },
},
```

That's the whole change. The setting is now sent to the agent host on connect and re-sent whenever it changes. Read it host-side as usual:

```ts
this._configurationService.getRootValue(platformRootSchema, AgentHostAutoReplyEnabledConfigKey) === true;
```

### Options

| Field | Meaning |
|---|---|
| `key` | **Required.** The agent host root-config key to write to. |
| `transform` | Maps the value before sending. Defaults to identity — you rarely need this (see below). |
| `localOnly` | `true` mirrors only to a *local* agent host. Use for values describing the client's own machine (filesystem paths, machine identity) that are meaningless remotely. Defaults to `false`. |

### You usually don't need `transform`

The resolver skips any layer whose value doesn't match the setting's declared `type` and falls back to the registered default. That reproduces the `value === true` / `value !== false` coercions these forwarders used to carry, so identity is normally right. Reach for `transform` only to change the *shape* of a value, e.g. mapping an enum to a different representation.

### Only globally-scoped values are mirrored

Resolution reads `inspect()` and takes **policy → user → application → default**, deliberately ignoring workspace and folder values.

The agent host's root config is shared by every window connected to it, so mirroring a workspace value would let one window's workspace settings leak into unrelated windows on a last-writer-wins basis. If a setting genuinely needs per-workspace behavior, it does **not** belong here — push it through session config instead, where the session → parent → host chain resolves precedence correctly.

### What stays on the explicit path

Some settings can't be expressed as one key plus a transform, and keep their hand-written forwarder:

- `telemetryLevel` — derived from three settings
- `terminalAutoApproveRules` — two settings collapsing into one key
- `preferLongContextEnabled`, `disableRepoInfoTelemetry` — extension-contributed
- `terminalAutoApproveEnabled` — deliberate: it's `restricted` and workspace-settable, so global-only resolution would let a workspace that turned terminal auto-approval *off* still have it applied, and would split it from its companion rule set

Extensions can't declare `agentHost` from `package.json`. The root config is shared across windows, so writing to it stays in-code.

## Behavior changes

- Mirrored settings now arrive in a **single** `RootConfigChanged` action on connect instead of one action per setting; a change re-sends **only** the affected key.
- Settings hidden with `included: false` are absent from the default-configuration model, so their declared default is read from the schema directly — otherwise they'd be silently omitted while visible siblings were mirrored.

## Also included: Windows support for the `launch` skill

`launch.sh` is bash and depends on `rsync`/`curl`/`nohup`, so the skill couldn't be used on Windows. This adds `launch.ps1` alongside it (`launch.sh` is unchanged) with the same flags, the same single-line JSON stdout contract, the same slim-copy excludes, and the same comment-preserving `settings.json` merge.

The auth model needed rethinking rather than translating. `launch.sh` assumes auth "comes from the OS keychain (per-app, shared automatically)" — a macOS property. Windows has no shared per-app keychain, so the secret material lives inside the user-data-dir and only survives if the copy carries it. The Windows launcher asserts `Local State`, `machineid`, `User/globalStorage/state.vscdb`, and `Network/` all reach the destination and fails loudly otherwise. It also warns when the source profile has no stored GitHub session, since that produces an otherwise puzzling sign-in prompt; that check opens a temporary copy of `state.vscdb` read-only and looks only for the presence of a key, never reading secret values.

## Verification

- 1710 agentHost unit tests, 726 configuration tests, typecheck, layer check, and eslint all clean.
- Exercised against a **live Agents window**, reading the real AHP transport log: confirmed connect-time batching, single-key targeted updates, and that the explicit-path settings still dispatch their own separate actions. That run is what surfaced the hidden-settings default issue noted above.
