### PR TITLE
Enable Voice Mode progress updates by default

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -586,7 +586,7 @@ configurationRegistry.registerConfiguration({
 		[VOICE_AGENT_PROGRESS_SETTING]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('agents.voice.agentProgress', "Allow Agent mode to speak brief semantic progress updates while it investigates, plans, edits, validates, or recovers from a problem."),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 			scope: ConfigurationScope.APPLICATION,
 		},


### PR DESCRIPTION
Enable `agents.voice.agentProgress` by default so Voice Mode speaks brief semantic progress updates during Agent requests.

Testing: Not run (configuration-only change).