### PR TITLE
Don't flash sign-in modal at signed-in users during Agents window startup

### DIFF
--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -20,6 +20,38 @@ export function isAllowSignedOutWhenUsableEnabled(configurationService: IConfigu
 }
 
 /**
+ * How the conditional-auth UI should treat the current default-account snapshot.
+ * The crucial distinction is {@link Unresolved}: on startup
+ * {@link IDefaultAccountService.currentDefaultAccount} reads `null` for everyone
+ * until the first async resolution completes — and that resolution fires no
+ * change event. Treating that transient `null` as {@link SignedOut} flashes a
+ * sign-in modal / nudge at a signed-in user during the gap, one that nothing then
+ * retires. So consumers must ignore the account while {@link Unresolved}.
+ */
+export const enum ConditionalAuthState {
+	/** Not resolved yet — treat as unknown; act on neither the signed-in nor signed-out branch. */
+	Unresolved,
+	/** Resolved: a GitHub account is signed in. */
+	SignedIn,
+	/** Resolved: no GitHub account is signed in. */
+	SignedOut,
+}
+
+/**
+ * Collapse "has the account resolved yet?" and "is one signed in?" into the
+ * single state the conditional-auth consumers branch on, so neither re-derives it
+ * (and neither can independently regress the unresolved-vs-signed-out
+ * distinction). `signedIn` must be read from the account snapshot only; this
+ * helper decides whether that snapshot can be trusted yet.
+ */
+export function conditionalAuthState(accountResolved: boolean, signedIn: boolean): ConditionalAuthState {
+	if (!accountResolved) {
+		return ConditionalAuthState.Unresolved;
+	}
+	return signedIn ? ConditionalAuthState.SignedIn : ConditionalAuthState.SignedOut;
+}
+
+/**
  * Whether a signed-out user can work without GitHub right now: the opt-in is on
  * and some registered session type reports that it runs without a GitHub
  * account (e.g. an agent-host agent that discovered an existing native

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -28,7 +28,7 @@ import { IMarkdownRendererService } from '../../platform/markdown/browser/markdo
 import { WELCOME_COMPLETE_KEY } from '../common/welcome.js';
 import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
-import { observeUsableWithoutGitHub } from './sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, observeUsableWithoutGitHub } from './sessionsAuthGate.js';
 
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { Codicon } from '../../base/common/codicons.js';
@@ -76,6 +76,15 @@ class SessionsSetUpWidget extends Disposable {
 	private _initialSetupFlow = true;
 	/** True while the window is open for a signed-out user via the conditional-auth opt-in. */
 	private _proceedingSignedOut = false;
+	/**
+	 * Set once the initial default-account resolution has completed. Until then
+	 * the synchronous {@link IDefaultAccountService.currentDefaultAccount} snapshot
+	 * is `null` even for a signed-in user, so a `null` reading means "not known
+	 * yet", not "signed out". The conditional-auth reaction stays inert until this
+	 * flips, otherwise it forces a sign-in modal on a signed-in user during the
+	 * startup gap — one nothing can retire, since the account resolves silently.
+	 */
+	private _accountResolved = false;
 	/** Whether a signed-out user can work without GitHub right now. */
 	private readonly _usableWithoutGitHub: IObservable<boolean>;
 
@@ -112,13 +121,17 @@ class SessionsSetUpWidget extends Disposable {
 	}
 
 	/**
-	 * The last-resort gate's answer changed while the window is open. Signed-in
-	 * users are unaffected. Becoming usable retires an already-open sign-in
-	 * modal (it was raised before the answer resolved); becoming unusable falls
-	 * back to demanding sign-in.
+	 * The last-resort gate's answer changed while the window is open. Ignored
+	 * until the account has resolved (see {@link _accountResolved}) and for
+	 * signed-in users. For a signed-out user, becoming usable retires an
+	 * already-open sign-in modal (it was raised before the answer resolved);
+	 * becoming unusable falls back to demanding sign-in.
 	 */
 	private _onUsableWithoutGitHubChanged(usable: boolean): void {
-		if (this.defaultAccountService.currentDefaultAccount !== null) {
+		// Only act once the account has resolved AND the user is signed out; while
+		// unresolved or signed in, the sign-in watch owns the decision.
+		const signedIn = this.defaultAccountService.currentDefaultAccount !== null;
+		if (conditionalAuthState(this._accountResolved, signedIn) !== ConditionalAuthState.SignedOut) {
 			return;
 		}
 		if (!usable) {
@@ -140,6 +153,17 @@ class SessionsSetUpWidget extends Disposable {
 			this.onCompleted();
 			return;
 		}
+
+		// Learn when the default account resolves so the conditional-auth reaction
+		// can tell "signed out" from "not resolved yet". On first load the account
+		// is populated silently (no change event fires), so awaiting it once is the
+		// only signal that resolution has happened.
+		this.defaultAccountService.getDefaultAccount().then(() => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			this._accountResolved = true;
+		});
 
 		if (isWeb) {
 			void this._checkWebAuth().finally(() => this._initialSetupFlow = false);

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -163,6 +163,16 @@ class SessionsSetUpWidget extends Disposable {
 				return;
 			}
 			this._accountResolved = true;
+			// A `_usableWithoutGitHub` change during the unresolved window was
+			// ignored above. If the agent ended up usable, replay it now so a
+			// signed-out user is let in rather than stranded on a sign-in dialog
+			// nothing else retires — the web path has no post-resolution re-check
+			// of its own (the native paths re-read usability after they await the
+			// account). While not usable, the initial setup flow still owns the
+			// dialog, so there is nothing to replay.
+			if (this._usableWithoutGitHub.get()) {
+				this._onUsableWithoutGitHubChanged(true);
+			}
 		});
 
 		if (isWeb) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
@@ -16,7 +16,7 @@ import { SessionType } from '../../../../../workbench/contrib/chat/common/chatSe
 import { SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ChatInputNotificationActionKind, ChatInputNotificationSeverity, IChatInputNotificationService } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputNotificationService.js';
-import { isAllowSignedOutWhenUsableEnabled, shouldShowDiscoveredConfigNudge } from '../../../../browser/sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, isAllowSignedOutWhenUsableEnabled, shouldShowDiscoveredConfigNudge } from '../../../../browser/sessionsAuthGate.js';
 
 const DISCOVERED_CONFIG_NOTIFICATION_ID = 'agentHost.discoveredConfig.claude';
 
@@ -54,6 +54,13 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 	static readonly ID = 'sessions.contrib.agentHostDiscoveredConfigNotification';
 
 	private _shown = false;
+	/**
+	 * Set once the initial default-account resolution has completed. Until then
+	 * {@link IDefaultAccountService.currentDefaultAccount} reads as `null` even for
+	 * a signed-in user, so the nudge stays suppressed to avoid flashing at a
+	 * signed-in user during the startup gap.
+	 */
+	private _accountResolved = false;
 
 	constructor(
 		@IChatInputNotificationService private readonly _chatInputNotificationService: IChatInputNotificationService,
@@ -81,10 +88,28 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 			this._storageService.onDidChangeValue(StorageScope.APPLICATION, MUTED_STORAGE_KEY, this._store),
 		)(() => this._update()));
 
-		this._update();
+		// Until the account resolves, `currentDefaultAccount === null` reads as
+		// "signed out" and would flash this signed-out nudge at a signed-in user
+		// during startup. The account loads silently (no change event fires), so
+		// await the first resolution, then re-evaluate.
+		this._defaultAccountService.getDefaultAccount().then(() => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			this._accountResolved = true;
+			this._update();
+		});
 	}
 
 	private _update(): void {
+		// While the account is unresolved, `currentDefaultAccount` is null for
+		// everyone; treating that as "signed out" flashes the nudge at a signed-in
+		// user. Nothing is shown yet, so there is nothing to tear down — just wait.
+		const authState = conditionalAuthState(this._accountResolved, this._defaultAccountService.currentDefaultAccount !== null);
+		if (authState === ConditionalAuthState.Unresolved) {
+			return;
+		}
+
 		// The Claude agent-host session type, once the host has advertised it.
 		// Two providers (local / remote agent host) can offer the same id, so
 		// prefer a usable instance and fall back to any for the display label.
@@ -94,7 +119,7 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 		const claude = claudeTypes.find(type => type.authRequirement === SessionTypeAuthRequirement.None) ?? claudeTypes[0];
 
 		const show = shouldShowDiscoveredConfigNudge({
-			signedIn: this._defaultAccountService.currentDefaultAccount !== null,
+			signedIn: authState === ConditionalAuthState.SignedIn,
 			allowSignedOutWhenUsable: isAllowSignedOutWhenUsableEnabled(this._configurationService),
 			usableWithoutGitHub: claude?.authRequirement === SessionTypeAuthRequirement.None,
 			muted: this._storageService.getBoolean(MUTED_STORAGE_KEY, StorageScope.APPLICATION, false),

--- a/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
+++ b/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
@@ -5,11 +5,32 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
-import { shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
 
 suite('Sessions - Auth Gate', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('conditionalAuthState treats an unresolved account as unknown, never signed out', () => {
+		// The root-cause distinction: before the account resolves, its snapshot is
+		// null for signed-in and signed-out users alike, so `accountResolved: false`
+		// must map to Unresolved regardless of the (untrustworthy) signedIn snapshot —
+		// otherwise the conditional-auth UI flashes a sign-in modal at a signed-in
+		// user during startup.
+		const cases = [
+			{ accountResolved: false, signedIn: false },
+			{ accountResolved: false, signedIn: true },
+			{ accountResolved: true, signedIn: false },
+			{ accountResolved: true, signedIn: true },
+		];
+
+		assert.deepStrictEqual(cases.map(c => conditionalAuthState(c.accountResolved, c.signedIn)), [
+			ConditionalAuthState.Unresolved,
+			ConditionalAuthState.Unresolved,
+			ConditionalAuthState.SignedOut,
+			ConditionalAuthState.SignedIn,
+		]);
+	});
 
 	test('shows the discovered-config nudge only when signed out, opted in, the type is usable without GitHub, and not muted', () => {
 		// Independent source of truth: the nudge is the calm inverse of the gate —


### PR DESCRIPTION
### The bug

With `chat.agentHost.allowSignedOutWhenUsable: true` and **already signed in to GitHub**, launching the Agents window produced a broken sequence:

1. Window launches (auth state not loaded yet)
2. A Claude discovered-config notification flashes
3. The sign-in **modal dialog** appears
4. In the background, auth finally resolves
5. …but the modal **stays up** — nothing retires it.

### Root cause

The conditional-auth UI added in #328990 conflates *"auth not resolved yet"* with *"signed out."*

`IDefaultAccountService.currentDefaultAccount` is a **synchronous** getter that returns `null` for everyone until the first async resolution completes — and that initial `null → account` assignment fires **no** `onDidChangeDefaultAccount` event. So during the startup gap a signed-in user reads as signed-out. Meanwhile Claude churns native → proxy as the host forwards the token (advertising `required:false`, then `required:true`), repeatedly re-driving the reaction. The modal gets raised on the transient `null`, and because resolution is event-silent, nothing ever tears it back down.

### The fix

Gate both reactive consumers on a **resolved-auth** signal, learned via a one-shot `getDefaultAccount()` await — the only reliable indicator that resolution happened, since the initial assignment is event-silent:

- **`sessionsSetUpService.ts`** (the modal): `_onUsableWithoutGitHubChanged` now no-ops unless the state is genuinely `SignedOut`, so gap-time Claude churn is inert and the normal sign-in watch owns the signed-in path.
- **`agentHostDiscoveredConfigNotification.ts`** (the nudge): `_update()` returns early while `Unresolved` instead of flashing the signed-out nudge.
- Shared logic both consumers were duplicating is consolidated into a unit-tested `conditionalAuthState()` helper (`Unresolved | SignedIn | SignedOut`) in `sessionsAuthGate.ts` — single source of truth for the unresolved-vs-signed-out distinction.

The intended **signed-out** conditional-auth behaviour from #328990 is fully preserved; the change only suppresses action during the *unresolved* window.

### Validation

- **Unit:** new `conditionalAuthState` test covers all four `(resolved, signedIn)` combinations; existing nudge test still passes (2/2).
- **Live** (signed-in, `allowSignedOutWhenUsable: true`):
  - `Showing sign-in dialog` log lines: **0** — modal never raised.
  - Claude churn confirmed active during the gap (**26** `required:false` + **10** `required:true` protected-resource transitions, plus token-forward/proxy markers) — so the reaction *was* exercised repeatedly and stayed inert.
  - Steady-state DOM: `dialogCount:0`, no "Sign in to use Agents" text, no loading overlay, signed-in button present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)