### PR TITLE
Offload large Copilot CLI tool results to disk above 8KB

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -660,6 +660,9 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			additionalDirectories,
 			systemMessage,
 			toolSearch: toolSearchActive ? { enabled: true, deferThreshold: toolSearchDeferThreshold } : { enabled: false },
+			largeOutput: {
+				maxSizeBytes: 8 * 1024,
+			},
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -317,11 +317,11 @@ suite('CopilotSessionLauncher BYOK proxy lifecycle', () => {
 	});
 });
 
-suite('CopilotSessionLauncher client identity', () => {
+suite('CopilotSessionLauncher shared session config', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('passes the Agent Host client name to create and resume', async () => {
+	test('passes Agent Host defaults to create and resume', async () => {
 		const createConfigs: Parameters<CopilotClient['createSession']>[0][] = [];
 		const resumeConfigs: Parameters<CopilotClient['resumeSession']>[1][] = [];
 		const session = {
@@ -392,22 +392,26 @@ suite('CopilotSessionLauncher client identity', () => {
 				createPluginDirectories: createConfigs[0].pluginDirectories,
 				createSkillDirectories: createConfigs[0].skillDirectories,
 				createInstructionDirectories: createConfigs[0].instructionDirectories,
+				createLargeOutput: createConfigs[0].largeOutput,
 				resumeClientName: resumeConfigs[0].clientName,
 				resumeGitHubMcpToolConfig: resumeConfigs[0].githubMcpToolConfig,
 				resumePluginDirectories: resumeConfigs[0].pluginDirectories,
 				resumeSkillDirectories: resumeConfigs[0].skillDirectories,
 				resumeInstructionDirectories: resumeConfigs[0].instructionDirectories,
+				resumeLargeOutput: resumeConfigs[0].largeOutput,
 			}, {
 				createClientName: 'vscode-agent-host',
 				createGitHubMcpToolConfig: { disableFormDeferral: true },
 				createPluginDirectories: [pluginDir.fsPath],
 				createSkillDirectories: [],
 				createInstructionDirectories: [URI.joinPath(pluginDir, 'rules').fsPath],
+				createLargeOutput: { maxSizeBytes: 8192 },
 				resumeClientName: 'vscode-agent-host',
 				resumeGitHubMcpToolConfig: { disableFormDeferral: true },
 				resumePluginDirectories: [pluginDir.fsPath],
 				resumeSkillDirectories: [],
 				resumeInstructionDirectories: [URI.joinPath(pluginDir, 'rules').fsPath],
+				resumeLargeOutput: { maxSizeBytes: 8192 },
 			});
 		} finally {
 			sessions.dispose();


### PR DESCRIPTION
Agent Host Copilot CLI sessions inherited the runtime's default 20KB large-output threshold. This lowers it to 8KB — the same threshold the Copilot extension uses for `chat.agent.largeToolResultsToDisk.thresholdBytes` — so verbose tool results are written to a temp file and replaced with a path + preview instead of consuming the context window.

### What changed

`CopilotSessionLauncher._buildSessionConfig` now sets the SDK's `largeOutput` session option:

```ts
largeOutput: {
    maxSizeBytes: 8 * 1024,
},
```

Because this lives in the shared config builder, it applies to every launch route: `createSession`, `resumeSession`, the custom-agent resume retry, and the empty-session fallback create.


### Known follow-up (not addressed here)

The runtime's `view` tool description and Claude exploration instructions statically say files truncate at 20KB, but the configured session threshold is what `view` actually enforces. With this change a 12KB file is documented as readable yet returns large-file guidance. That is a runtime-side wording issue tracked separately; it does not affect the generic tool-result offload message, which reports the real size.
