### PR TITLE
editor: don't reindent the line following a pasted block (real-world bug)

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -549,6 +549,11 @@ export interface IPasteEvent {
 	readonly range: Range;
 	readonly languageId: string | null;
 	readonly clipboardEvent?: ClipboardEvent;
+	/**
+	 * The selection the pasted text replaced. Empty when pasting at a cursor.
+	 * @internal
+	 */
+	readonly replacedSelection?: Selection;
 }
 
 /**

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1209,14 +1209,16 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 			return;
 		}
 		const viewModel = this._modelData.viewModel;
-		const startPosition = viewModel.getSelection().getStartPosition();
+		const replacedSelection = viewModel.getSelection();
+		const startPosition = replacedSelection.getStartPosition();
 		viewModel.paste(text, pasteOnNewLine, multicursorText, source);
 		const endPosition = viewModel.getSelection().getStartPosition();
 		if (source === 'keyboard') {
 			this._onDidPaste.fire({
 				clipboardEvent,
 				range: new Range(startPosition.lineNumber, startPosition.column, endPosition.lineNumber, endPosition.column),
-				languageId: mode
+				languageId: mode,
+				replacedSelection
 			});
 		}
 	}

--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -397,12 +397,12 @@ export class AutoIndentOnPaste implements IEditorContribution {
 			return;
 		}
 
-		this.callOnModel.add(this.editor.onDidPaste(({ range }) => {
-			this.trigger(range);
+		this.callOnModel.add(this.editor.onDidPaste(({ range, replacedSelection }) => {
+			this.trigger(range, replacedSelection);
 		}));
 	}
 
-	public trigger(range: Range): void {
+	public trigger(range: Range, replacedSelection?: Selection): void {
 		const selections = this.editor.getSelections();
 		if (selections === null || selections.length > 1) {
 			return;
@@ -469,8 +469,20 @@ export class AutoIndentOnPaste implements IEditorContribution {
 
 		const firstLineNumber = startLineNumber;
 
+		// When the pasted text ends with a line break, the last line of the range holds no pasted
+		// characters. If whole lines were replaced, that line is a pre-existing line pushed down
+		// with its indentation intact, so leave it alone. If part of a line was replaced, the last
+		// line is that line's remainder, which lost its leading text and does need reindenting.
+		const replacedWholeLines = !!replacedSelection && replacedSelection.startColumn === 1 && replacedSelection.endColumn === 1;
+		let endLineNumber = range.endLineNumber;
+		if (replacedWholeLines && range.endColumn === 1
+			&& endLineNumber > range.startLineNumber
+			&& model.getLineContent(endLineNumber).length > 0) {
+			endLineNumber--;
+		}
+
 		// ignore empty or ignored lines
-		while (startLineNumber < range.endLineNumber) {
+		while (startLineNumber < endLineNumber) {
 			if (!/\S/.test(model.getLineContent(startLineNumber + 1))) {
 				startLineNumber++;
 				continue;
@@ -478,7 +490,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 			break;
 		}
 
-		if (startLineNumber !== range.endLineNumber) {
+		if (startLineNumber !== endLineNumber) {
 			const virtualModel = {
 				tokenization: {
 					getLineTokens: (lineNumber: number) => {
@@ -506,7 +518,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 
 				if (newSpaceCntOfSecondLine !== oldSpaceCntOfSecondLine) {
 					const spaceCntOffset = newSpaceCntOfSecondLine - oldSpaceCntOfSecondLine;
-					for (let i = startLineNumber + 1; i <= range.endLineNumber; i++) {
+					for (let i = startLineNumber + 1; i <= endLineNumber; i++) {
 						const lineContent = model.getLineContent(i);
 						const originalIndent = strings.getLeadingWhitespace(lineContent);
 						const originalSpacesCnt = indentUtils.getSpaceCnt(originalIndent, tabSize);

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -419,6 +419,38 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	test('replacing part of a line still reindents that line\'s remainder', () => {
+
+		// the paste replaces the leading whitespace of `old()`, so the trailing line of the
+		// range is that line's remainder, which lost its indentation and has to get it back
+
+		const model = createTextModel([
+			'function f() {',
+			'    old()',
+			'}',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(2, 1, 2, 5));
+			const text = 'foo\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			assert.deepStrictEqual(pasteRange, new Range(2, 1, 3, 1));
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'function f() {',
+				'    foo',
+				'    old()',
+				'}',
+			].join('\n'));
+		});
+	});
+
 	test('issue #119225: Do not add extra leading space when pasting JSDoc', () => {
 
 		const model = createTextModel('', languageId, {});
@@ -1450,6 +1482,161 @@ suite('Auto Indent On Type - Ruby', () => {
 	});
 });
 
+suite('Auto Indent On Paste - Ruby', () => {
+
+	const languageId = Language.Ruby;
+	let disposables: DisposableStore;
+	let serviceCollection: ServiceCollection;
+
+	setup(() => {
+		disposables = new DisposableStore();
+		const languageService = new LanguageService();
+		const languageConfigurationService = new TestLanguageConfigurationService();
+		disposables.add(languageService);
+		disposables.add(languageConfigurationService);
+		disposables.add(registerLanguage(languageService, languageId));
+		disposables.add(registerLanguageConfiguration(languageConfigurationService, languageId));
+		serviceCollection = new ServiceCollection(
+			[ILanguageService, languageService],
+			[ILanguageConfigurationService, languageConfigurationService]
+		);
+	});
+
+	teardown(() => {
+		disposables.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('issue #143573: pasting a block does not reindent the line after the paste', () => {
+
+		// https://github.com/microsoft/vscode/issues/143573
+
+		const model = createTextModel([
+			'    def foo; end',
+			'    def baz; end',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(2, 1, 2, 1));
+			const text = 'def bar\nend\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			// the pasted text ends with a line break, so the range ends at column 1 of the
+			// following line, which holds no pasted content
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			assert.deepStrictEqual(pasteRange, new Range(2, 1, 4, 1));
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'    def foo; end',
+				'    def bar',
+				'    end',
+				'    def baz; end',
+			].join('\n'));
+		});
+	});
+
+	test('issue #143573: pasting into an array literal does not move the closing bracket', () => {
+
+		// https://github.com/microsoft/vscode/issues/143573
+
+		const model = createTextModel([
+			'array = [',
+			'  "foo",',
+			']',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(3, 1, 3, 1));
+			const text = '"bar",\n"baz",\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			assert.deepStrictEqual(pasteRange, new Range(3, 1, 5, 1));
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'array = [',
+				'  "foo",',
+				'  "bar",',
+				'  "baz",',
+				']',
+			].join('\n'));
+		});
+	});
+
+	test('issue #143573: a whitespace only line after the paste keeps its indentation', () => {
+
+		// https://github.com/microsoft/vscode/issues/143573
+		// the line after the paste holds no pasted characters even when it is only whitespace
+
+		const model = createTextModel([
+			'def foo',
+			'    ',
+			'end',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(2, 1, 2, 1));
+			const text = 'bar\nbaz\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'def foo',
+				'    bar',
+				'    baz',
+				'    ',
+				'end',
+			].join('\n'));
+		});
+	});
+
+	test('issue #143573: the remainder of a split line is still reindented', () => {
+
+		// https://github.com/microsoft/vscode/issues/143573
+		// the paste starts mid line, so the trailing line of the range lost its leading
+		// whitespace to the line above and does need to be reindented
+
+		const model = createTextModel([
+			'    def foo; end',
+			'    def baz; end',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(2, 5, 2, 5));
+			const text = 'def bar\nend\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			assert.deepStrictEqual(pasteRange, new Range(2, 5, 4, 1));
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'    def foo; end',
+				'    def bar',
+				'    end',
+				'    def baz; end',
+			].join('\n'));
+		});
+	});
+});
+
 suite('Auto Indent On Type - PHP', () => {
 
 	const languageId = Language.PHP;
@@ -1704,6 +1891,66 @@ suite('Auto Indent On Type - HTML', () => {
 				'  foo //I press <Enter> at the end of this line',
 				'  ',
 				'</pre>',
+			].join('\n'));
+		});
+	});
+});
+
+suite('Auto Indent On Paste - PHP', () => {
+
+	const languageId = Language.PHP;
+	let disposables: DisposableStore;
+	let serviceCollection: ServiceCollection;
+
+	setup(() => {
+		disposables = new DisposableStore();
+		const languageService = new LanguageService();
+		const languageConfigurationService = new TestLanguageConfigurationService();
+		disposables.add(languageService);
+		disposables.add(languageConfigurationService);
+		disposables.add(registerLanguage(languageService, languageId));
+		disposables.add(registerLanguageConfiguration(languageConfigurationService, languageId));
+		serviceCollection = new ServiceCollection(
+			[ILanguageService, languageService],
+			[ILanguageConfigurationService, languageConfigurationService]
+		);
+	});
+
+	teardown(() => {
+		disposables.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('issue #221574: replacing a line does not reindent the closing tag below it', () => {
+
+		// https://github.com/microsoft/vscode/issues/221574
+		// the reporter's file is a php template, where `</div>` matches neither the increase
+		// nor the decrease pattern, so the closing tag inherits the pasted line's indentation
+
+		const model = createTextModel([
+			'\t\t\t<button type="button">Peruuta</button>',
+			'\t\t\t<input type="submit" value="Hyväksy" disabled>',
+			'\t\t</div>',
+		].join('\n'), languageId, { insertSpaces: false });
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			// the whole input line, trailing line break included, is replaced by the paste
+			editor.setSelection(new Selection(2, 1, 3, 1));
+			const text = '<input type="submit" id="hyvaksy_nappi" value="Hyväksy" disabled>\n';
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			const replacedSelection = viewModel.getSelection();
+			const startPosition = replacedSelection.getStartPosition();
+			viewModel.paste(text, false, undefined, 'keyboard');
+			const endPosition = viewModel.getSelection().getStartPosition();
+			const pasteRange = Range.fromPositions(startPosition, endPosition);
+			assert.deepStrictEqual(pasteRange, new Range(2, 1, 3, 1));
+			autoIndentOnPasteController.trigger(pasteRange, replacedSelection);
+			assert.strictEqual(model.getValue(), [
+				'\t\t\t<button type="button">Peruuta</button>',
+				'\t\t\t<input type="submit" id="hyvaksy_nappi" value="Hyväksy" disabled>',
+				'\t\t</div>',
 			].join('\n'));
 		});
 	});


### PR DESCRIPTION
Hi!

This fixes a long-standing paste bug: when you paste a block of code, the line *after* the pasted text gets reindented, even though it wasn't part of the paste.

This is a real-world bug, not a synthetic edge case. It's been reported twice by two unrelated people:

- #143573 (2022, Ruby) — closed as wont-fix on the assumption that Ruby's indentation rules were at fault
- #221574 (2024, PHP) — still open, hit while editing a WordPress theme template

Here's the PHP report from #221574. Paste a replacement `<input>` line, and the closing `</div>` below it silently moves one tab to the right:

```html
			<button type="button" onclick="...">Peruuta</button>
			<input type="submit" id="hyvaksy_nappi" value="Hyväksy" disabled>
			</div>          <!-- was two tabs before the paste -->
```

## Cause

It's not language-specific — it reproduces on Ruby, PHP and others.

The paste range is built as *pre-paste cursor → post-paste cursor*. So when the pasted text ends with a line break, the range ends at **column 1 of the following line** — a line that received no pasted characters at all. `AutoIndentOnPaste.trigger` then applies its indentation offset to every line up to and including `range.endLineNumber`, which sweeps up that innocent following line.

## Fix

Exclude that last line from the reindent when it holds no pasted characters *and* the paste started at the beginning of a line, so the line kept its own indentation intact.

The "started at the beginning of a line" part matters: if the paste starts mid-line, the final line of the range is the remainder of the line that got split, which really did lose its leading whitespace and should still be reindented. There's a test covering that.

## Tests

Four new tests in `indentation.test.ts`, from the two issues:

- `Auto Indent On Paste - Ruby` — the two repros from #143573, plus the mid-line split case
- `Auto Indent On Paste - PHP` — the repro from #221574

All four fail before the change and pass after it. The full editor test suite is green (5160 passing).

## Note on #221574

This fixes the first scenario in that issue, but not its headline request. That issue also asks for the pasted block's *relative* indentation to be preserved and the block shifted as a unit, which is a separate gap and still belongs to the tree-sitter indentation work.
