### PR TITLE
Scope reasoning effort override setting to Copilot

### DIFF
--- a/src/vs/platform/agentHost/common/copilotCliConfig.ts
+++ b/src/vs/platform/agentHost/common/copilotCliConfig.ts
@@ -46,7 +46,7 @@ export const AgentHostToolSearchEnabledSettingId = 'chat.agentHost.copilot.toolS
 
 export const AgentHostToolSearchDeferThresholdSettingId = 'chat.agentHost.copilot.toolSearch.deferThreshold';
 
-export const AgentHostReasoningEffortOverrideSettingId = 'chat.agentHost.reasoningEffortOverride';
+export const AgentHostReasoningEffortOverrideSettingId = 'chat.agentHost.copilot.reasoningEffortOverride';
 
 export const AgentHostModelCapabilityOverridesSettingId = 'chat.agentHost.modelCapabilityOverrides';
 


### PR DESCRIPTION
## Summary

Rename `chat.agentHost.reasoningEffortOverride` to `chat.agentHost.copilot.reasoningEffortOverride` so the Copilot-only setting follows the namespace used by other Copilot Agent Host settings.

## Testing

- Pre-commit hygiene passed.