### PR TITLE
agentHost: restore client tool confirmations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3751,20 +3751,20 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 		}));
 
-		// Presentational: keep subagent observation current, and if the
-		// protocol call reaches a terminal state while the shared invocation is
-		// still streaming (the watcher never ran it), settle the card so the UI
-		// is not stuck.
 		store.add(autorun(reader => {
 			const tc = part$.read(reader).toolCall;
+			const state = invocation.state.read(reader);
 			this._tryObserveSubagentToolCall(tc, invocation, store, opts, subagentContext);
+			if (tc.status === ToolCallStatus.PendingConfirmation && state.type === IChatToolInvocation.StateKind.Streaming) {
+				const prepared = toolCallStateToPreparedInvocation(tc, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority);
+				invocation.transitionFromStreaming(prepared, invocation.parameters, getClientToolPreApproval(tc));
+			}
 			if ((tc.status === ToolCallStatus.Cancelled || tc.status === ToolCallStatus.Completed)
-				&& invocation.state.read(reader).type === IChatToolInvocation.StateKind.Streaming) {
+				&& !IChatToolInvocation.isComplete(invocation, reader)) {
 				const fileEdits = finalizeToolInvocation(invocation, tc, opts.backendSession, this._config.connectionAuthority);
 				if (fileEdits.length > 0) {
 					opts.onFileEdits?.(tc, fileEdits);
 				}
-				invocation.cancelFromStreaming(ToolConfirmKind.Skipped);
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -634,8 +634,11 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				// be in the chat response in the `NeedsConfirmation` state, even briefly,
 				// as that triggers notifications and causes issues in eval.
 				if (hadPendingInvocation && toolInvocation) {
-					// Transition from streaming to executing/waiting state
-					toolInvocation.transitionFromStreaming(preparedInvocation, dto.parameters, autoConfirmed);
+					if (toolInvocation.state.get().type === IChatToolInvocation.StateKind.Streaming) {
+						toolInvocation.transitionFromStreaming(preparedInvocation, dto.parameters, autoConfirmed);
+					} else {
+						toolInvocation.updatePreparedInvocation(preparedInvocation, dto.parameters);
+					}
 				} else {
 					// Create a new tool invocation (no streaming phase)
 					toolInvocation = new ChatToolInvocation(preparedInvocation, tool.data, dto.chatStreamToolCallId ?? dto.callId, dto.subAgentInvocationId, dto.parameters);

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -242,17 +242,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			this.invocationMessage = lastStreamingMessage;
 		}
 
-		// Update fields from prepared invocation
-		this.parameters = parameters;
-		if (preparedInvocation) {
-			if (preparedInvocation.invocationMessage) {
-				this.invocationMessage = preparedInvocation.invocationMessage;
-			}
-			this.pastTenseMessage = preparedInvocation.pastTenseMessage;
-			this.confirmationMessages = preparedInvocation.confirmationMessages;
-			this.presentation = preparedInvocation.presentation;
-			this.toolSpecificData = preparedInvocation.toolSpecificData;
-		}
+		this._updatePreparedInvocation(preparedInvocation, parameters);
 
 		// Transition to the appropriate state
 		if (autoConfirmed) {
@@ -273,6 +263,41 @@ export class ChatToolInvocation implements IChatToolInvocation {
 				confirm: reason => this._confirm(reason),
 			}, undefined);
 		}
+	}
+
+	/**
+	 * Applies locally prepared parameters and presentation without changing an
+	 * invocation state already established by an external protocol.
+	 */
+	public updatePreparedInvocation(preparedInvocation: IPreparedToolInvocation | undefined, parameters: unknown): boolean {
+		const currentState = this._state.get();
+		if (currentState.type === IChatToolInvocation.StateKind.Streaming
+			|| currentState.type === IChatToolInvocation.StateKind.Completed
+			|| currentState.type === IChatToolInvocation.StateKind.Cancelled) {
+			return false;
+		}
+
+		this._updatePreparedInvocation(preparedInvocation, parameters);
+		this._state.set({
+			...currentState,
+			parameters: this.parameters,
+			confirmationMessages: this.confirmationMessages,
+		}, undefined);
+		return true;
+	}
+
+	private _updatePreparedInvocation(preparedInvocation: IPreparedToolInvocation | undefined, parameters: unknown): void {
+		this.parameters = parameters;
+		if (!preparedInvocation) {
+			return;
+		}
+		if (preparedInvocation.invocationMessage) {
+			this.invocationMessage = preparedInvocation.invocationMessage;
+		}
+		this.pastTenseMessage = preparedInvocation.pastTenseMessage;
+		this.confirmationMessages = preparedInvocation.confirmationMessages;
+		this.presentation = preparedInvocation.presentation;
+		this.toolSpecificData = preparedInvocation.toolSpecificData;
 	}
 
 	/** Moves an active invocation into confirmation while preserving the same tool card. */

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -976,6 +976,11 @@ suite('AgentHostClientTools', () => {
 			await timeout(0);
 			assert.strictEqual(connection.resourceReadUris.length, 0);
 
+			IChatToolInvocation.confirmWith(
+				toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1'),
+				{ type: ToolConfirmKind.UserAction },
+			);
+			await timeout(0);
 			connection.resourceReadData = '{"task":"confirmed"}';
 			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
 				toolCallId: 'tool-call-1',
@@ -1528,10 +1533,6 @@ suite('AgentHostClientTools', () => {
 				displayName: 'Run Task',
 				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
 			} as ChatAction);
-			// No `confirmed` and no auto-approve metadata: the protocol call
-			// stays `PendingConfirmation`. Under the single-watcher model the
-			// client never drives a local confirmation gate, so nothing runs
-			// until the host surfaces a running client-execution record.
 			connection.applySessionAction(chatURI, {
 				type: ActionType.ChatToolCallReady,
 				turnId: 'turn-1',
@@ -1547,7 +1548,71 @@ suite('AgentHostClientTools', () => {
 			return chatURI;
 		}
 
-		test('confirms and completes a client tool once the agent host surfaces it as running, preserving the reason', async () => {
+		test('confirms a pending client tool before executing it exactly once', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
+			const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
+			connection.applySessionAction(AgentSession.uri('copilot', 'session-1'), {
+				type: ActionType.SessionInputNeededSet,
+				request: {
+					id: 'confirmation-tool-call-1',
+					kind: SessionInputRequestKind.ToolConfirmation,
+					chat: chatURI.toString(),
+					turnId: 'turn-1',
+					toolCall: {
+						status: ToolCallStatus.PendingConfirmation,
+						toolCallId: 'tool-call-1',
+						toolName: 'runTask',
+						displayName: 'Run Task',
+						invocationMessage: 'Run Task',
+						toolInput: '{"task":"build"}',
+						confirmationTitle: 'Run Task',
+					},
+				},
+			});
+			await timeout(0);
+
+			const invocation = toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1');
+			const stateBeforeApproval = invocation?.state.get().type;
+			const confirmationAccepted = IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
+			await timeout(0);
+			const invocationsBeforeClientExecution = toolsService.invokedToolCalls.length;
+
+			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
+				toolCallId: 'tool-call-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmed: ToolCallConfirmationReason.UserAction,
+			});
+			await timeout(0);
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				stateBeforeApproval,
+				confirmationAccepted,
+				invocationsBeforeClientExecution,
+				invocationsAfterClientExecution: toolsService.invokedToolCalls.length,
+				actions: connection.dispatchedActions
+					.filter(entry => isChatAction(entry.action)
+						&& (entry.action.type === ActionType.ChatToolCallConfirmed || entry.action.type === ActionType.ChatToolCallComplete)
+						&& entry.action.toolCallId === 'tool-call-1')
+					.map(entry => entry.action.type === ActionType.ChatToolCallConfirmed
+						? { type: entry.action.type, approved: entry.action.approved, confirmed: entry.action.approved ? entry.action.confirmed : undefined }
+						: { type: entry.action.type, success: entry.action.result.success }),
+			}, {
+				stateBeforeApproval: IChatToolInvocation.StateKind.WaitingForConfirmation,
+				confirmationAccepted: true,
+				invocationsBeforeClientExecution: 0,
+				invocationsAfterClientExecution: 1,
+				actions: [
+					{ type: ActionType.ChatToolCallConfirmed, approved: true, confirmed: ToolCallConfirmationReason.UserAction },
+					{ type: ActionType.ChatToolCallComplete, success: true },
+				],
+			});
+		});
+
+		test('preserves the client tool confirmation reason through execution', async () => {
 			const reasons = [
 				ToolCallConfirmationReason.NotNeeded,
 				ToolCallConfirmationReason.Setting,
@@ -1557,12 +1622,19 @@ suite('AgentHostClientTools', () => {
 			const results: unknown[] = [];
 			for (const reason of reasons) {
 				const local = disposables.add(new DisposableStore());
-				const { handler, connection } = createHandlerWithMocks(local, [testRunTaskTool], { requireConfirmation: true });
+				const { handler, connection, toolsService } = createHandlerWithMocks(local, [testRunTaskTool], { requireConfirmation: true });
 				const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
+				const confirmedReason = reason === ToolCallConfirmationReason.NotNeeded
+					? { type: ToolConfirmKind.ConfirmationNotNeeded as const }
+					: reason === ToolCallConfirmationReason.Setting
+						? { type: ToolConfirmKind.Setting as const, id: 'test-setting' }
+						: { type: ToolConfirmKind.UserAction as const };
 
-				// The agent host confirms the call by surfacing it as a running
-				// client execution with the resolved reason; the watcher then
-				// runs it pre-approved, so it never re-prompts locally.
+				IChatToolInvocation.confirmWith(
+					toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1'),
+					confirmedReason,
+				);
+				await timeout(0);
 				applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
 					toolCallId: 'tool-call-1',
 					toolName: 'runTask',

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -53,7 +53,7 @@ import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHos
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostSessionWorkingDirectorySynchronizer } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectorySynchronizer.js';
 import { IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
-import { ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult, ToolAndToolSetEnablementMap, ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
+import { ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult, ToolAndToolSetEnablementMap, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { IChatWidgetService } from '../../../browser/chat.js';
 import { ICustomizationHarnessService } from '../../../common/customizationHarnessService.js';
@@ -317,17 +317,29 @@ suite('AgentHostClientTools', () => {
 						throw options.throwBeforeConfirmation;
 					}
 					if (options?.requireConfirmation && toolInvocation) {
-						// Mirror the real service: a caller-provided `preApproved`
-						// reason is treated as auto-confirmation so the invocation
-						// transitions straight to executing without ever entering
-						// `WaitingForConfirmation`.
-						toolInvocation.transitionFromStreaming({
-							invocationMessage: 'Run Task',
+						const prepared = {
+							invocationMessage: `Run ${(invocation.parameters as { task?: string }).task}`,
 							confirmationMessages: {
 								title: 'Confirm tool execution',
 								message: 'Run the task?',
+								approveCombination: {
+									label: `Approve ${(invocation.parameters as { task?: string }).task}`,
+									key: JSON.stringify(invocation.parameters),
+									arguments: JSON.stringify(invocation.parameters),
+								},
 							},
-						}, invocation.parameters, invocation.preApproved);
+							presentation: ToolInvocationPresentation.HiddenAfterComplete,
+							toolSpecificData: {
+								kind: 'simpleToolInvocation' as const,
+								input: JSON.stringify(invocation.parameters),
+								output: '',
+							},
+						};
+						if (toolInvocation.state.get().type === IChatToolInvocation.StateKind.Streaming) {
+							toolInvocation.transitionFromStreaming(prepared, invocation.parameters, invocation.preApproved);
+						} else {
+							toolInvocation.updatePreparedInvocation(prepared, invocation.parameters);
+						}
 						const confirmed = await IChatToolInvocation.awaitConfirmation(toolInvocation, token ?? CancellationToken.None);
 						// Mirror the real service: a cancelled/denied confirmation
 						// aborts execution instead of producing a result. A token
@@ -1548,7 +1560,7 @@ suite('AgentHostClientTools', () => {
 			return chatURI;
 		}
 
-		test('confirms a pending client tool before executing it exactly once', async () => {
+		test('hydrates and confirms a pending client tool before executing it exactly once', async () => {
 			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
 			const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
 			connection.applySessionAction(AgentSession.uri('copilot', 'session-1'), {
@@ -1573,9 +1585,7 @@ suite('AgentHostClientTools', () => {
 
 			const invocation = toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1');
 			const stateBeforeApproval = invocation?.state.get().type;
-			const confirmationAccepted = IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
-			await timeout(0);
-			const invocationsBeforeClientExecution = toolsService.invokedToolCalls.length;
+			const parametersBeforeExecution = invocation?.parameters;
 
 			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
 				toolCallId: 'tool-call-1',
@@ -1588,22 +1598,59 @@ suite('AgentHostClientTools', () => {
 			await timeout(0);
 			await timeout(0);
 
+			const hydratedInvocation = invocation && {
+				state: invocation.state.get().type,
+				parameters: invocation.parameters,
+				invocationMessage: invocation.invocationMessage,
+				confirmationTitle: invocation.confirmationMessages?.title,
+				approveCombination: invocation.confirmationMessages?.approveCombination,
+				presentation: invocation.presentation,
+				toolSpecificData: invocation.toolSpecificData,
+			};
+			const confirmationAccepted = IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
+			await timeout(0);
+			await timeout(0);
+
 			assert.deepStrictEqual({
 				stateBeforeApproval,
+				parametersBeforeExecution,
+				hydratedInvocation,
 				confirmationAccepted,
-				invocationsBeforeClientExecution,
 				invocationsAfterClientExecution: toolsService.invokedToolCalls.length,
 				actions: connection.dispatchedActions
 					.filter(entry => isChatAction(entry.action)
 						&& (entry.action.type === ActionType.ChatToolCallConfirmed || entry.action.type === ActionType.ChatToolCallComplete)
 						&& entry.action.toolCallId === 'tool-call-1')
-					.map(entry => entry.action.type === ActionType.ChatToolCallConfirmed
-						? { type: entry.action.type, approved: entry.action.approved, confirmed: entry.action.approved ? entry.action.confirmed : undefined }
-						: { type: entry.action.type, success: entry.action.result.success }),
+					.map(entry => {
+						if (entry.action.type === ActionType.ChatToolCallConfirmed) {
+							return { type: entry.action.type, approved: entry.action.approved, confirmed: entry.action.approved ? entry.action.confirmed : undefined };
+						}
+						if (entry.action.type === ActionType.ChatToolCallComplete) {
+							return { type: entry.action.type, success: entry.action.result.success };
+						}
+						throw new Error(`Unexpected action type: ${entry.action.type}`);
+					}),
 			}, {
 				stateBeforeApproval: IChatToolInvocation.StateKind.WaitingForConfirmation,
+				parametersBeforeExecution: undefined,
+				hydratedInvocation: {
+					state: IChatToolInvocation.StateKind.WaitingForConfirmation,
+					parameters: { task: 'build' },
+					invocationMessage: 'Run build',
+					confirmationTitle: 'Confirm tool execution',
+					approveCombination: {
+						label: 'Approve build',
+						key: '{"task":"build"}',
+						arguments: '{"task":"build"}',
+					},
+					presentation: ToolInvocationPresentation.HiddenAfterComplete,
+					toolSpecificData: {
+						kind: 'simpleToolInvocation',
+						input: '{"task":"build"}',
+						output: '',
+					},
+				},
 				confirmationAccepted: true,
-				invocationsBeforeClientExecution: 0,
 				invocationsAfterClientExecution: 1,
 				actions: [
 					{ type: ActionType.ChatToolCallConfirmed, approved: true, confirmed: ToolCallConfirmationReason.UserAction },


### PR DESCRIPTION
## Problem

Client-provided tools that entered protocol confirmation remained in the streaming UI state. The inline confirmation gate was never surfaced, so the client never dispatched `ChatToolCallConfirmed`, the session-level input watcher never received `ToolClientExecution`, and the turn stalled indefinitely.

## Fix

- Transition the shared client-tool invocation when the protocol enters pending confirmation.
- Preserve protocol pre-approval reasons so auto-approved calls do not flicker through confirmation.
- Settle terminal protocol calls from any incomplete invocation state.
- Cover confirmation, execution ordering, exactly-once invocation, and confirmation-reason preservation.

## Validation

- AgentHostClientTools: 49 passing
- ESLint passed for the changed files
- `git diff --check` passed