### PR TITLE
Add Agent Host PowerShell nested script-block auto-approval regressions

### DIFF
--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -523,7 +523,7 @@ suite('CommandAutoApprover', () => {
 				approver.shouldAutoApprove('Get-ChildItem | Where-Object { Start-Process notepad }', rules),
 				// Visible separators already rejected nested denied commands.
 				approver.shouldAutoApprove('Write-Host hi; Set-Content -Path out.txt -Value pwned', rules),
-				// Wrong dialect must not recreate the opaque-block bypass.
+				// The wrong dialect demonstrates the opaque-block bypass.
 				approver.shouldAutoApprove('Measure-Command { Set-Content -Path out.txt -Value pwned }', { language: 'bash', autoApproveRules: rules.autoApproveRules }),
 			], ['denied', 'denied', 'denied', 'denied', 'approved']);
 		});

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -502,6 +502,32 @@ suite('CommandAutoApprover', () => {
 			], ['denied', 'denied']);
 		});
 
+		// Reported PowerShell wrapper shapes: an outer allowed cmdlet must not
+		// hide nested denied/non-allowed commands inside a script block. The Bash
+		// grammar keeps `{ ... }` opaque, so the same rules can incorrectly
+		// approve the line when the wrong dialect is selected.
+		test('does not auto-approve denied commands nested in Measure-Command script blocks', () => {
+			const rules = {
+				...pwsh,
+				autoApproveRules: {
+					'Measure-Command': true,
+					'Where-Object': true,
+					'Set-Content': false,
+					'Start-Process': false,
+					'Invoke-Expression': false,
+				},
+			};
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('Measure-Command { Set-Content -Path out.txt -Value pwned }', rules),
+				approver.shouldAutoApprove('Measure-Command { Invoke-Expression "Write-Output hi" }', rules),
+				approver.shouldAutoApprove('Get-ChildItem | Where-Object { Start-Process notepad }', rules),
+				// Visible separators already rejected nested denied commands.
+				approver.shouldAutoApprove('Write-Host hi; Set-Content -Path out.txt -Value pwned', rules),
+				// Wrong dialect must not recreate the opaque-block bypass.
+				approver.shouldAutoApprove('Measure-Command { Set-Content -Path out.txt -Value pwned }', { language: 'bash', autoApproveRules: rules.autoApproveRules }),
+			], ['denied', 'denied', 'denied', 'denied', 'approved']);
+		});
+
 		// An unquoted `$null` discards PowerShell output; both the spaced form (a
 		// `redirection` node) and the no-space form (a `generic_token`) must be
 		// recognized. POSIX sinks and real file targets still require confirmation.

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -313,6 +313,23 @@ suite('SessionPermissionManager', () => {
 		], [ToolCallConfirmationReason.NotNeeded, undefined, false, true]);
 	});
 
+	test('PowerShell script-block payloads with nested denials require confirmation', async () => {
+		configService.updateRootConfig({
+			[AgentHostTerminalAutoApproveRulesConfigKey]: {
+				'Measure-Command': true,
+				'Set-Content': false,
+				'Invoke-Expression': false,
+			},
+		});
+		assert.deepStrictEqual([
+			await permissions.getAutoApproval(powershellEvent('Measure-Command { Set-Content -Path out.txt -Value pwned }'), sessionUri),
+			await permissions.getAutoApproval(powershellEvent('Measure-Command { Invoke-Expression "Write-Output hi" }'), sessionUri),
+			await permissions.getAutoApproval(shellEvent('Write-Host hi; Set-Content -Path out.txt -Value pwned', 'powershell'), sessionUri),
+			// Missing dialect remains fail-closed even for an otherwise allowlisted outer command.
+			await permissions.getAutoApproval(shellEvent('Measure-Command { Get-ChildItem }', undefined), sessionUri),
+		], [undefined, undefined, undefined, undefined]);
+	});
+
 	test('PowerShell redirects require a literal approved destination', async () => {
 		const dynamicResults = [];
 		for (const dest of ['$HOME/outside.txt', '$env:TEMP/x.txt', '$(Get-Location)/x.txt', '`pwd`/x.txt', '${HOME}/x.txt', '%APPDATA%/x.txt']) {


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/pull/328133

- Add Agent Host PowerShell regressions for nested commands inside `Measure-Command` and related script-block wrappers.
- Keep an outer allow rule from hiding nested denied cmdlets such as `Set-Content`, `Invoke-Expression`, and `Start-Process`.
- Cover the visible-separator control path and show that selecting the Bash grammar can still make the same rules opaque.
- Add a session-permission proof that PowerShell script-block payloads with nested denials require confirmation, including when shell language is missing.

-----------------------------------------
Inspirations from:

- Nested script-block coverage starts from the existing [`denies commands nested inside script blocks`](https://github.com/microsoft/vscode/blob/dc32a5902c492e288e96881cc04d3f8119d67121/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts#L492-L503) test.
- PowerShell dialect selection comes from [`CommandAutoApprover` language handling](https://github.com/microsoft/vscode/blob/dc32a5902c492e288e96881cc04d3f8119d67121/src/vs/platform/agentHost/node/commandAutoApprover.ts#L241-L245) and the PowerShell capture query in [`_extractSubCommands`](https://github.com/microsoft/vscode/blob/dc32a5902c492e288e96881cc04d3f8119d67121/src/vs/platform/agentHost/node/commandAutoApprover.ts#L351-L352).
- Session-level fail-closed missing dialect behavior comes from [`SessionPermissionManager.getAutoApproval`](https://github.com/microsoft/vscode/blob/dc32a5902c492e288e96881cc04d3f8119d67121/src/vs/platform/agentHost/node/sessionPermissions.ts#L310-L325).
- The production fix this protects is [#328133](https://github.com/microsoft/vscode/pull/328133).
