### PR TITLE
agentHost: Include Copilot versions in telemetry

### DIFF
--- a/.eslint-plugin-local/code-no-telemetry-common-property.ts
+++ b/.eslint-plugin-local/code-no-telemetry-common-property.ts
@@ -47,6 +47,8 @@ const commonTelemetryProperties = new Set([
 	'common.useragent',
 	'common.istouchdevice',
 	'common.copilottrackingid',
+	'common.copilotsdkversion',
+	'common.copilotruntimeversion',
 	'common.isagentswindow',
 ]);
 

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -59,10 +59,20 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 	constructor(
 		private readonly _delegate: ITelemetryService,
 		private readonly _restricted?: IAgentHostRestrictedTelemetry,
+		copilotSdkVersion?: string,
+		copilotRuntimeVersion?: string,
 	) {
 		super();
 		if (isDisposable(_delegate)) {
 			this._register(_delegate);
+		}
+		if (copilotSdkVersion) {
+			// __GDPR__COMMON__ "common.copilotSdkVersion" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The version of the Copilot SDK used by the Agent Host process." }
+			this._delegate.setCommonProperty('common.copilotSdkVersion', copilotSdkVersion);
+		}
+		if (copilotRuntimeVersion) {
+			// __GDPR__COMMON__ "common.copilotRuntimeVersion" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The version of the Copilot runtime used by the Agent Host process." }
+			this._delegate.setCommonProperty('common.copilotRuntimeVersion', copilotRuntimeVersion);
 		}
 	}
 
@@ -263,5 +273,5 @@ export async function createAgentHostTelemetryService(options: IAgentHostTelemet
 	const internalSender = loggingOnly ? undefined : disposables.add(new AgentHostInternalTelemetrySender({ requestService: options.requestService, commonProperties, extensionVersion }));
 	const restricted = loggingOnly ? undefined : new AgentHostRestrictedTelemetrySender(commonProperties, logService, undefined, internalSender, options.fetchFn);
 
-	return disposables.add(new AgentHostTelemetryService(telemetryService, restricted));
+	return disposables.add(new AgentHostTelemetryService(telemetryService, restricted, productService.copilotVersions?.sdk, productService.copilotVersions?.runtime));
 }

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
@@ -32,6 +32,7 @@ class TestTelemetryService implements ITelemetryService {
 	firstSessionDate = 'firstSessionDate';
 	readonly events: { eventName: string; data: ITelemetryData | undefined }[] = [];
 	readonly errorEvents: { eventName: string; data: ITelemetryData | undefined }[] = [];
+	readonly commonProperties: Record<string, string | boolean> = {};
 
 	publicLog(eventName: string, data?: ITelemetryData): void {
 		this.events.push({ eventName, data });
@@ -50,7 +51,9 @@ class TestTelemetryService implements ITelemetryService {
 	}
 
 	setExperimentProperty(): void { }
-	setCommonProperty(): void { }
+	setCommonProperty(name: string, value: string | boolean): void {
+		this.commonProperties[name] = value;
+	}
 }
 
 class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
@@ -190,6 +193,16 @@ suite('AgentHostTelemetryService', () => {
 		service.updateTelemetryLevel(TelemetryLevel.USAGE);
 
 		assert.strictEqual(service.telemetryLevel, TelemetryLevel.ERROR);
+	});
+
+	test('adds the Copilot SDK and runtime versions as common properties', () => {
+		const delegate = new TestTelemetryService();
+		disposables.add(new AgentHostTelemetryService(delegate, undefined, '1.0.9-preview.3', '1.0.78'));
+
+		assert.deepStrictEqual(delegate.commonProperties, {
+			'common.copilotSdkVersion': '1.0.9-preview.3',
+			'common.copilotRuntimeVersion': '1.0.78',
+		});
 	});
 
 	test('updates telemetry level from root config string enum', () => {


### PR DESCRIPTION
## Summary

- add the Copilot SDK version to all Agent Host product telemetry events
- add the independently versioned Copilot runtime package version
- classify both values as common system metadata and prevent event-level collisions

## Validation

- `npm run compile`
- `npm run hygiene`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts`
- targeted ESLint for the changed files

(Written by Copilot)