### PR TITLE
Fix Allow All sandbox confirmations

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3023,7 +3023,7 @@ export class CopilotAgentSession extends Disposable {
 	private async _syncPermissionModeAfterConfigChange(): Promise<void> {
 		try {
 			await this.syncPermissionMode('config-change');
-			await this._applyEffectiveSandboxConfig();
+			await this._applyEffectiveSandboxConfig(true);
 		} catch (error) {
 			this._logService.error(error, `[Copilot:${this.sessionId}] Failed to apply permission config change; aborting active turn`);
 			try {
@@ -3086,7 +3086,7 @@ export class CopilotAgentSession extends Disposable {
 	 * explicitly disabled sandbox when no sandbox is configured (setting off,
 	 * or Windows).
 	 */
-	private async _applyEffectiveSandboxConfig(): Promise<void> {
+	private async _applyEffectiveSandboxConfig(failOnError = false): Promise<void> {
 		if (this._isCustomTerminalToolEnabled()) {
 			return;
 		}
@@ -3094,8 +3094,14 @@ export class CopilotAgentSession extends Disposable {
 		const base = buildSandboxConfigForSdk(this._platform, sandbox);
 		const sandboxConfig: ISdkSandboxConfig | { enabled: false } = (base && !this._isBypassApprovals()) ? base : { enabled: false };
 		try {
-			await this._wrapper.session.rpc.options.update({ sandboxConfig });
+			const result = await this._wrapper.session.rpc.options.update({ sandboxConfig });
+			if (!result.success) {
+				throw new Error('Copilot SDK rejected sandbox config update');
+			}
 		} catch (err) {
+			if (failOnError) {
+				throw err;
+			}
 			this._logService.warn(`[Copilot:${this.sessionId}] Failed to update sandbox config for request`, err);
 		}
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3023,6 +3023,7 @@ export class CopilotAgentSession extends Disposable {
 	private async _syncPermissionModeAfterConfigChange(): Promise<void> {
 		try {
 			await this.syncPermissionMode('config-change');
+			await this._applyEffectiveSandboxConfig();
 		} catch (error) {
 			this._logService.error(error, `[Copilot:${this.sessionId}] Failed to apply permission config change; aborting active turn`);
 			try {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -75,6 +75,7 @@ class MockCopilotSession {
 	permissionModeSetSuccess = true;
 	readonly experimentalModeUpdates: boolean[] = [];
 	experimentalModeUpdateSuccess = true;
+	sandboxConfigUpdateSuccess = true;
 	abortCalls = 0;
 	abortGate: Promise<void> | undefined;
 	readonly compactCalls: unknown[] = [];
@@ -310,7 +311,7 @@ class MockCopilotSession {
 				if (params.isExperimentalMode !== undefined) {
 					this.experimentalModeUpdates.push(params.isExperimentalMode);
 				}
-				return { success: this.experimentalModeUpdateSuccess };
+				return { success: params.sandboxConfig !== undefined ? this.sandboxConfigUpdateSuccess : this.experimentalModeUpdateSuccess };
 			},
 		},
 		instructions: {
@@ -3446,6 +3447,24 @@ suite('CopilotAgentSession', () => {
 			await timeout(0);
 
 			assert.strictEqual(mockSession.abortCalls, 1);
+		});
+
+		test('aborts when a live sandbox update fails', async () => {
+			const { session, mockSession, setConfigValue, fireSessionConfigChange } = await createAgentSession(disposables);
+			await session.syncPermissionMode('turn-start');
+			mockSession.sandboxConfigUpdateSuccess = false;
+			setConfigValue(SessionConfigKey.AutoApprove, 'autoApprove');
+
+			fireSessionConfigChange({ [SessionConfigKey.AutoApprove]: 'autoApprove' });
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				permissionModes: mockSession.permissionModeSetCalls,
+				abortCalls: mockSession.abortCalls,
+			}, {
+				permissionModes: ['off', 'on'],
+				abortCalls: 1,
+			});
 		});
 
 		test('per-request permissions: Autopilot with Ask When Needed keeps SDK approval mode off', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3374,6 +3374,42 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(mockSession.permissionModeSetCalls, ['auto', 'off']);
 		});
 
+		test('syncs sandbox when the session approval level changes', async () => {
+			const { session, mockSession, setConfigValue, fireSessionConfigChange } = await createAgentSession(disposables, {
+				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },
+				configValues: { [SessionConfigKey.AutoApprove]: 'default' },
+			});
+			await session.send('hello', undefined, 'turn-1');
+
+			setConfigValue(SessionConfigKey.AutoApprove, 'autoApprove');
+			fireSessionConfigChange({ [SessionConfigKey.AutoApprove]: 'autoApprove' });
+			await timeout(0);
+
+			setConfigValue(SessionConfigKey.AutoApprove, 'default');
+			fireSessionConfigChange({ [SessionConfigKey.AutoApprove]: 'default' });
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				permissionModes: mockSession.permissionModeSetCalls,
+				sandboxConfigs: mockSession.sandboxConfigUpdates,
+			}, {
+				permissionModes: ['off', 'on', 'off'],
+				sandboxConfigs: [
+					{
+						enabled: true,
+						allowBypass: true,
+						userPolicy: { filesystem: {}, network: { allowOutbound: false } },
+					},
+					{ enabled: false },
+					{
+						enabled: true,
+						allowBypass: true,
+						userPolicy: { filesystem: {}, network: { allowOutbound: false } },
+					},
+				],
+			});
+		});
+
 		test('ignores approval changes for other sessions', async () => {
 			const { session, mockSession, setConfigValue, fireSessionConfigChange } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'assisted' },


### PR DESCRIPTION
fyi @dileepyavan 

## Summary
- update the Copilot SDK sandbox immediately when the session approval level changes
- prevent stale sandbox-bypass confirmations after switching to Allow All
- add regression coverage for toggling approval levels in both directions

## Testing
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts --grep "syncs permission mode|syncs sandbox|aborts when a live permission"`

(Written by Copilot)