### PR TITLE
agentHost: Harden E2E session reference replay

### DIFF
--- a/.github/skills/agent-host-e2e-tests/SKILL.md
+++ b/.github/skills/agent-host-e2e-tests/SKILL.md
@@ -19,7 +19,7 @@ It documents the mental model, the fixture format, every config flag, and a symp
 3. **Recording needs a real token** (`GITHUB_TOKEN` or `gh auth token`) and talks to real CAPI. Only run it intentionally, with trivial/read-only prompts in temp dirs.
 4. **Never hand-write or hand-edit fixture contents** (especially not secrets/paths). Fixtures are always produced by recording; normalization/redaction is the proxy's job.
 5. **Gate, don't fight.** If a behavior can't replay deterministically, gate the test (see Workflow C) instead of loosening timeouts or the strict check.
-6. **Track every disabled variant.** Keep `e2e/KNOWN_ISSUES.md` current with the test title, scope, expected and observed behavior, and a focused reproduction command. Record symptoms, not speculative root causes.
+6. **Track every disabled variant.** Keep `e2e/KNOWN_ISSUES.md` current with the test title, scope, expected and observed behavior, and a focused reproduction command. For suspected product bugs, begin with a self-contained explanation in complete sentences of what the user is trying to do, what fails, and the likely user impact; define feature-specific terms instead of relying on test names or implementation details. Record symptoms, not speculative root causes.
 
 ## Workflow A — Add a cross-provider test
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -8,10 +8,11 @@ When a valid E2E scenario exposes a gap:
 
 1. Minimize it and identify the affected provider, platform, and mode.
 2. Keep the test, but gate only the affected variant.
-3. Record the exact title, scope, expected and observed behavior, gate, and focused reproduction here.
-4. Record symptoms, not unverified root-cause hypotheses.
-5. Keep generated captures for variants expected to run again; never hand-edit them.
-6. Remove the gate, entry, stale comments, and orphaned artifacts together when the gap closes.
+3. For a suspected product bug, first explain in complete sentences what the user is trying to do, what fails, and how that failure is likely to affect the user. Define feature-specific terms instead of assuming that the test title or an implementation detail such as "full context" is self-explanatory.
+4. After the user-facing explanation, record the exact test title, scope, expected and observed behavior, gate, and focused reproduction.
+5. Record symptoms, not unverified root-cause hypotheses.
+6. Keep generated captures for variants expected to run again; never hand-edit them.
+7. Remove the gate, entry, stale comments, and orphaned artifacts together when the gap closes.
 
 Capability skips are tracked separately from suspected bugs. A provider that does not advertise a capability is expected to skip positive-path tests for that capability.
 
@@ -211,6 +212,90 @@ A capture that genuinely cannot be refreshed goes in `STALE_RECORDED_REQUEST_EXC
     --grep "server tool: viewUnreviewedComments"
   ```
 
+### Claude omits important tool details when reading another session's transcript
+
+The `get_session_context` tool lets an agent read the conversation history of an existing session. Its most detailed mode includes the tools used in earlier turns and the arguments passed to those tools, which helps the agent understand what work has already been performed.
+
+With Claude, that detailed history omits the arguments of a previous `list_sessions` call and exposes the provider's internal name, `mcp__host__list_sessions`, instead of the product-facing name. An agent using this history may be unable to tell what an earlier tool call did, causing it to repeat work or make decisions from an incomplete account of the session.
+
+- Test: `server tool: get_session_context full includes prior server-tool input`.
+- Scope: Claude.
+- Expected: the returned transcript identifies the earlier tool as `list_sessions` and includes its `{}` input.
+- Observed: the transcript identifies it as `mcp__host__list_sessions` and omits the input.
+- Gate: `supportsFullSessionContext` in `serverToolsSuite.ts`.
+- Reproduce: record the exact test with the Claude provider.
+
+### Claude reports that another session was deleted but leaves it available
+
+The `delete_session` tool lets an agent delete a different Agent Host session. Claude reports that this operation succeeded, but the supposedly deleted session remains in the session list.
+
+For users, this means a request to clean up an obsolete session may appear successful even though nothing was removed. The stale session can remain visible and available for later operations, contradicting the agent's confirmation.
+
+- Test: `server tool: delete_session removes a non-current session`.
+- Scope: Claude.
+- Expected: after the tool reports success, the target no longer appears in `listSessions`.
+- Observed: the target is still listed after the tool completes and remains listed after repeated checks.
+- Gate: `supportsCrossSessionDelete` in `serverToolsSuite.ts`.
+- Reproduce: record the exact test with the Claude provider.
+
+### Claude can send a message to the chat that is already running the tool
+
+The `send_message` tool is intended for contacting another session or chat. The host rejects attempts to target the same chat that is currently invoking the tool, because doing so can recursively start more work in an already active conversation.
+
+Claude bypasses that protection and starts another turn in the current chat. A user could therefore see unexpected duplicate work, recursive agent activity, or a conversation that repeatedly messages itself.
+
+- Test: `server tool: send_message refuses to target the invoking chat`.
+- Scope: Claude.
+- Expected: the tool fails with an error explaining that it cannot send a message to the current chat.
+- Observed: another turn starts in the current chat instead of the tool returning the safety error.
+- Gate: `supportsSelfSendRejection` in `serverToolsSuite.ts`.
+- Reproduce: record the exact test with the Claude provider.
+
+For all three Claude tests:
+
+```bash
+AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run \
+  src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts \
+  --grep "server tool: (get_session_context full|delete_session removes|send_message refuses)"
+```
+
+### Codex cannot complete several workflows that refer to another session
+
+Agent Host gives sessions stable links so an agent can look up a particular session, send work to another session, or delete another session. In the affected Codex workflows, the provider fails a model request with `Authorization header is badly formatted` before the requested session tool can run.
+
+Users may be unable to use session links or ask a Codex agent to coordinate with or remove another session. The failure currently appears as an authentication error rather than a useful explanation of which cross-session operation could not be completed. It is not yet known whether the malformed authorization originates in Codex's handling of additional sessions or in the Agent Host integration.
+
+- Tests:
+  - `server tool: list_sessions direct lookup accepts an open-session link`
+  - `server tool: send_message starts a turn in another session`
+  - `server tool: delete_session removes a non-current session`
+- Scope: Codex.
+- Expected: Codex completes the model turn and invokes the requested session tool with the referenced session.
+- Observed: direct lookup fails its first model request; send and delete fail while preparing the additional target session. Each failure reports `Authorization header is badly formatted`.
+- Gates: `supportsDirectSessionLookup`, `supportsCrossSessionSend`, and `supportsCrossSessionDelete` in `serverToolsSuite.ts`.
+- Reproduce: record the affected tests with the Codex provider.
+
+### Codex can send a message to the chat that is already running the tool
+
+As with Claude, Codex does not enforce the `send_message` protection that prevents an active chat from messaging itself. Instead of rejecting the call, Codex starts another turn in the current chat.
+
+This can produce unexpected duplicate or recursive agent work for users and defeats the host's loop-prevention contract.
+
+- Test: `server tool: send_message refuses to target the invoking chat`.
+- Scope: Codex.
+- Expected: the tool fails with an error explaining that it cannot send a message to the current chat.
+- Observed: another turn starts in the current chat instead of the tool returning the safety error.
+- Gate: `supportsSelfSendRejection` in `serverToolsSuite.ts`.
+- Reproduce: record the exact test with the Codex provider.
+
+For the affected Codex tests:
+
+```bash
+AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run \
+  src/vs/platform/agentHost/test/node/e2e/providers/codexAgentHostE2E.integrationTest.ts \
+  --grep "server tool: (list_sessions direct lookup|send_message|delete_session removes)"
+```
+
 ### Claude provider-context fork
 
 - Tests:
@@ -318,40 +403,6 @@ Use the affected provider command with `--grep "<exact test title>"` and tempora
 - Gate: `subagentReplayUnstableOnWindows: true`.
 - Related investigation: [#325284](https://github.com/microsoft/vscode/pull/325284).
 - Reproduce: temporarily clear the gate and run the exact title with `scripts\test-integration.bat`.
-
-### Git-status snapshot ordering
-
-- Test: `inspects git status`.
-- Scope: Claude and Codex.
-- Expected: the behavior snapshot contains stable semantic tool traffic.
-- Observed: customization and changeset notifications occur at nondeterministic points in the snapshot.
-- Gate: enabled only for Copilot, subject to shell-platform gates.
-- Reproduce: enable the provider variant and record the exact title with `AGENT_HOST_UPDATE_SNAPSHOTS=1`.
-
-### Server-tool session references cannot replay across UUID-only providers
-
-- Tests:
-  - `server tool: list_sessions direct lookup accepts an open-session link`
-  - `server tool: get_session_context summary includes a completed prior turn`
-  - `server tool: get_session_context full includes prior server-tool input`
-  - `server tool: get_session_context transcriptLimit keeps only the newest turn`
-  - `server tool: send_message starts a turn in another session`
-  - `server tool: delete_session removes a non-current session`
-  - `server tool: send_message refuses to target the invoking chat`
-  - `server tool: delete_session refuses to delete the invoking session`
-- Scope: Claude and Codex deterministic E2E replay.
-- Expected: the model can pass a session URI returned by the host back into a later server-tool invocation.
-- Observed: Claude requires UUID-shaped session resources. The capture normalizer rewrites those UUIDs to `${uuid_N}`, but replay cannot map that placeholder to the fresh run's session URI when it appears in a later tool argument. Copilot accepts stable non-UUID test resources, so these scenarios replay there.
-- Gate: `supportsReplayableSessionReferences` in `serverToolsSuite.ts`.
-- Reproduce: temporarily enable the selected provider and record one test, then replay it:
-
-  ```bash
-  AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run \
-    src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts \
-    --grep "server tool: get_session_context summary"
-  ```
-
-The remaining server-tool scenarios use no session URI in model-generated tool arguments and remain enabled for every provider.
 
 ### Mid-turn abort is record-only
 

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -113,6 +113,8 @@ The residual case is `providerHostOnlyTest(...)`: per-provider, but no model tra
 
 Use these deterministic E2E tests when the value comes from running the bundled provider process with realistic captured model behavior: SDK event ordering, tool schemas and execution, provider persistence, protocol-to-provider mapping, or cross-provider parity. Use `../providerIntegration/` for a bundled provider with a synthetic local LLM, and an ordinary unit test when no server process is required. `../protocol/` is frozen; do not add to it.
 
+Entries under `KNOWN_ISSUES.md`'s suspected-product-bug section must be understandable without reading the test or knowing Agent Host implementation terminology. Begin with complete sentences that explain the user workflow, the failure, and its likely user impact. Put test titles, protocol actions, provider-specific names, gates, and reproduction commands after that explanation.
+
 ---
 
 ## Fixture format
@@ -150,8 +152,11 @@ exchanges:
   | `${capi}` | the upstream CAPI origin (rewritten back to the proxy URL on replay) |
   | `${redacted}` | minted session tokens (`token` / `session_token` fields) |
   | `${system}` | the echoed system prompt (Responses API echoes `instructions`) |
+  | `${uuid_N}` | the Nth runtime UUID captured across requests and responses |
 
   Tool-call ids are also normalized to stable ordinals (`toolcall_0`, `toolcall_1`, …).
+
+  UUID placeholders are rebound dynamically during replay. The proxy aligns each recorded request with the live request, learns the fresh UUID corresponding to `${uuid_N}`, normalizes the request before comparison, and expands later model tool arguments with the learned value. Bindings are cleared whenever the shared proxy switches fixtures.
 
 ---
 

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-inspects-git-status.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-inspects-git-status.yaml
@@ -1,0 +1,43 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Inspect git status. Reply with the names of the modified and untracked files only.
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: Bash
+          input:
+            command: git status --short
+            description: Check git status
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Inspect git status. Reply with the names of the modified and untracked files only.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: Bash
+              input:
+                command: git status --short
+                description: Check git status
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: |-
+                M tracked.txt
+                ?? untracked.txt
+    response:
+      content: |-
+        Modified: tracked.txt
+        Untracked: untracked.txt
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-delete-session-refuses-to-delete-the-invoking-session.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-delete-session-refuses-to-delete-the-invoking-session.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: You must call delete_session exactly once with session "claude:/${uuid_0}" so its safety check can reject the call. Do not refuse on your own. After the tool fails, reply exactly "refused".
+    response:
+      content:
+        - type: text
+          text: I'll make that call.
+        - type: tool_use
+          id: toolcall_0
+          name: mcp__host__delete_session
+          input:
+            session: claude:/${uuid_0}
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: You must call delete_session exactly once with session "claude:/${uuid_0}" so its safety check can reject the call. Do not refuse on your own. After the tool fails, reply exactly "refused".
+        - role: assistant
+          content:
+            - type: text
+              text: I'll make that call.
+            - type: tool_use
+              name: mcp__host__delete_session
+              input:
+                session: claude:/${uuid_0}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'Invalid delete_session input: refusing to delete the current session.'
+    response:
+      content: refused
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-get-session-context-summary-includes-a-completed-prior-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-get-session-context-summary-includes-a-completed-prior-turn.yaml
@@ -1,0 +1,54 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+    response:
+      content: CONTEXT_READY
+      stopReason: end_turn
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+        - role: assistant
+          content: CONTEXT_READY
+        - role: user
+          content: Call get_session_context exactly once with session "claude:/${uuid_0}", then reply exactly "read".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: mcp__host__get_session_context
+          input:
+            session: claude:/${uuid_0}
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+        - role: assistant
+          content: CONTEXT_READY
+        - role: user
+          content: Call get_session_context exactly once with session "claude:/${uuid_0}", then reply exactly "read".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: mcp__host__get_session_context
+              input:
+                session: claude:/${uuid_0}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"session":"claude:/${uuid_0}","openLink":"agent-host-session://claude/${uuid_0}","detail":"summary","transcript":[{"turn":1,"state":"complete","user":"Reply exactly \"CONTEXT_READY\".","assistant":"CONTEXT_READY"},{"turn":2,"state":"inProgress","user":"Call get_session_context exactly once with session \"claude:/${uuid_0}\", then reply exactly \"read\"."}],"hasMoreHistory":false,"truncated":false}'
+    response:
+      content: read
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-get-session-context-transcriptlimit-keeps-only-the-newest-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-get-session-context-transcriptlimit-keeps-only-the-newest-turn.yaml
@@ -1,0 +1,77 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+    response:
+      content: OLD
+      stopReason: end_turn
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+    response:
+      content: NEW
+      stopReason: end_turn
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+        - role: assistant
+          content: NEW
+        - role: user
+          content: Call get_session_context exactly once with session "claude:/${uuid_0}" and transcriptLimit 1, then reply exactly "read".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: mcp__host__get_session_context
+          input:
+            session: claude:/${uuid_0}
+            transcriptLimit: 1
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+        - role: assistant
+          content: NEW
+        - role: user
+          content: Call get_session_context exactly once with session "claude:/${uuid_0}" and transcriptLimit 1, then reply exactly "read".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: mcp__host__get_session_context
+              input:
+                session: claude:/${uuid_0}
+                transcriptLimit: 1
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"session":"claude:/${uuid_0}","openLink":"agent-host-session://claude/${uuid_0}","detail":"summary","transcript":[{"turn":3,"state":"inProgress","user":"Call get_session_context exactly once with session \"claude:/${uuid_0}\" and transcriptLimit 1, then reply exactly \"read\"."}],"hasMoreHistory":false,"truncated":true}'
+    response:
+      content: read
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-list-sessions-direct-lookup-accepts-an-open-session-link.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-list-sessions-direct-lookup-accepts-an-open-session-link.yaml
@@ -1,0 +1,37 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with session "agent-host-session://claude/${uuid_0}", then reply exactly "found".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: mcp__host__list_sessions
+          input:
+            session: agent-host-session://claude/${uuid_0}
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with session "agent-host-session://claude/${uuid_0}", then reply exactly "found".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: mcp__host__list_sessions
+              input:
+                session: agent-host-session://claude/${uuid_0}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"sessions":[{"session":"claude:/${uuid_0}","title":"Call list_sessions exactly once with session \"agent-host-session://claude/${uuid_0}\", then reply exactly \"found\".","status":"inProgress","workingDirectory":"file://${workdir}","unread":true,"createdAt":"2026-08-05T22:45:39.182Z","modifiedAt":"2026-08-05T22:45:38.161Z","changesets":[{"label":"All Changes","changeKind":"session","uriTemplate":"claude:/${uuid_0}/changeset/session","description":"Show all changes made in this session"},{"label":"This Turn","changeKind":"turn","uriTemplate":"claude:/${uuid_0}/changeset/turn/{turnId}","description":"Show changes made in this turn"}]}]}'
+    response:
+      content: found
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-send-message-starts-a-turn-in-another-session.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/claude-server-tool-send-message-starts-a-turn-in-another-session.yaml
@@ -1,0 +1,52 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "TARGET_MATERIALIZED".
+    response:
+      content: TARGET_MATERIALIZED
+      stopReason: end_turn
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call send_message exactly once with session "claude:/${uuid_0}" and message "/rename Target Via Send", then reply exactly "sent".
+    response:
+      content:
+        - type: text
+          text: I'll send that message.
+        - type: tool_use
+          id: toolcall_0
+          name: mcp__host__send_message
+          input:
+            session: claude:/${uuid_0}
+            message: /rename Target Via Send
+      stopReason: tool_use
+  - request:
+      model: claude-opus-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Call send_message exactly once with session "claude:/${uuid_0}" and message "/rename Target Via Send", then reply exactly "sent".
+        - role: assistant
+          content:
+            - type: text
+              text: I'll send that message.
+            - type: tool_use
+              name: mcp__host__send_message
+              input:
+                session: claude:/${uuid_0}
+                message: /rename Target Via Send
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: Message sent (agent-host-session://claude/${uuid_0}). Reply with one short sentence confirming the message was sent; do not print the URL or mention a button.
+    response:
+      content: sent
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-inspects-git-status.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-inspects-git-status.yaml
@@ -1,0 +1,52 @@
+version: 1
+dialect: responses
+exchanges:
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Inspect git status. Reply with the names of the modified and untracked files only.
+    response:
+      content:
+        - type: text
+          text: Got it — I’ll check `git status` and list only modified/untracked filenames.
+        - type: tool_use
+          id: toolcall_0
+          name: exec_command
+          input:
+            cmd: git status --porcelain
+            workdir: ${workdir}
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Inspect git status. Reply with the names of the modified and untracked files only.
+        - role: assistant
+          content: Got it — I’ll check `git status` and list only modified/untracked filenames.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: exec_command
+              input:
+                cmd: git status --porcelain
+                workdir: ${workdir}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: |-
+                Chunk ID: 85d91d
+                Wall time: 0.0000 seconds
+                Process exited with code 0
+                Original token count: 8
+                Output:
+                 M tracked.txt
+                ?? untracked.txt
+    response:
+      content: |-
+        tracked.txt
+        untracked.txt
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-delete-session-refuses-to-delete-the-invoking-session.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-delete-session-refuses-to-delete-the-invoking-session.yaml
@@ -1,0 +1,41 @@
+version: 1
+dialect: responses
+exchanges:
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: You must call delete_session exactly once with session "codex:/${uuid_0}" so its safety check can reject the call. Do not refuse on your own. After the tool fails, reply exactly "refused".
+    response:
+      content:
+        - type: text
+          text: I’ll run that single `delete_session` call now.
+        - type: tool_use
+          id: toolcall_0
+          name: delete_session
+          input:
+            session: codex:/${uuid_0}
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: You must call delete_session exactly once with session "codex:/${uuid_0}" so its safety check can reject the call. Do not refuse on your own. After the tool fails, reply exactly "refused".
+        - role: assistant
+          content: I’ll run that single `delete_session` call now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: delete_session
+              input:
+                session: codex:/${uuid_0}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: 'Server tool delete_session failed: Invalid delete_session input: refusing to delete the current session.'
+    response:
+      content: refused
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-full-includes-prior-server-tool-input.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-full-includes-prior-server-tool-input.yaml
@@ -1,0 +1,111 @@
+version: 1
+dialect: responses
+exchanges:
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with no filters, then reply exactly "SEEDED".
+    response:
+      content:
+        - type: text
+          text: Got it — I’ll fetch sessions once now.
+        - type: tool_use
+          id: toolcall_0
+          name: list_sessions
+          input: {}
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with no filters, then reply exactly "SEEDED".
+        - role: assistant
+          content: Got it — I’ll fetch sessions once now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: list_sessions
+              input: {}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"sessions":[{"session":"codex:/${uuid_0}","title":"Call list_sessions exactly once with no filters, then reply exactly \"SEEDED\".","status":"inProgress","workingDirectory":"file://${workdir}","unread":true,"createdAt":"2026-08-05T22:51:25.232Z","modifiedAt":"2026-08-05T22:51:25.255Z"}]}'
+    response:
+      content: SEEDED
+      stopReason: end_turn
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with no filters, then reply exactly "SEEDED".
+        - role: assistant
+          content: Got it — I’ll fetch sessions once now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: list_sessions
+              input: {}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"sessions":[{"session":"codex:/${uuid_0}","title":"Call list_sessions exactly once with no filters, then reply exactly \"SEEDED\".","status":"inProgress","workingDirectory":"file://${workdir}","unread":true,"createdAt":"2026-08-05T22:51:25.232Z","modifiedAt":"2026-08-05T22:51:25.255Z"}]}'
+        - role: assistant
+          content: SEEDED
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}" and detail "full", then reply exactly "read".
+    response:
+      content:
+        - type: text
+          text: Understood — I’ll read that session context once now.
+        - type: tool_use
+          id: toolcall_1
+          name: get_session_context
+          input:
+            session: codex:/${uuid_0}
+            detail: full
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Call list_sessions exactly once with no filters, then reply exactly "SEEDED".
+        - role: assistant
+          content: Got it — I’ll fetch sessions once now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: list_sessions
+              input: {}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"sessions":[{"session":"codex:/${uuid_0}","title":"Call list_sessions exactly once with no filters, then reply exactly \"SEEDED\".","status":"inProgress","workingDirectory":"file://${workdir}","unread":true,"createdAt":"2026-08-05T22:51:25.232Z","modifiedAt":"2026-08-05T22:51:25.255Z"}]}'
+        - role: assistant
+          content: SEEDED
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}" and detail "full", then reply exactly "read".
+        - role: assistant
+          content: Understood — I’ll read that session context once now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: get_session_context
+              input:
+                session: codex:/${uuid_0}
+                detail: full
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: '{"session":"codex:/${uuid_0}","openLink":"agent-host-session://codex/${uuid_0}","detail":"full","transcript":[{"turn":1,"state":"complete","user":"Call list_sessions exactly once with no filters, then reply exactly \"SEEDED\".","assistant":"Got it — I’ll fetch sessions once now.\n\nSEEDED","toolCalls":[{"name":"list_sessions","input":"{}"}]},{"turn":2,"state":"inProgress","user":"Call get_session_context exactly once with session \"codex:/${uuid_0}\" and detail \"full\", then reply exactly \"read\".","assistant":"Understood — I’ll read that session context once now.","toolCalls":[{"name":"get_session_context","input":"{\n  \"session\": \"codex:/${uuid_0}\",\n  \"detail\": \"full\"\n}"}]}],"hasMoreHistory":false,"truncated":false}'
+    response:
+      content: read
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-summary-includes-a-completed-prior-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-summary-includes-a-completed-prior-turn.yaml
@@ -1,0 +1,58 @@
+version: 1
+dialect: responses
+exchanges:
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+    response:
+      content: CONTEXT_READY
+      stopReason: end_turn
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+        - role: assistant
+          content: CONTEXT_READY
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}", then reply exactly "read".
+    response:
+      content:
+        - type: text
+          text: Got it — I’ll fetch that session context once now.
+        - type: tool_use
+          id: toolcall_0
+          name: get_session_context
+          input:
+            session: codex:/${uuid_0}
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "CONTEXT_READY".
+        - role: assistant
+          content: CONTEXT_READY
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}", then reply exactly "read".
+        - role: assistant
+          content: Got it — I’ll fetch that session context once now.
+        - role: assistant
+          content:
+            - type: tool_use
+              name: get_session_context
+              input:
+                session: codex:/${uuid_0}
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"session":"codex:/${uuid_0}","openLink":"agent-host-session://codex/${uuid_0}","detail":"summary","transcript":[{"turn":1,"state":"complete","user":"Reply exactly \"CONTEXT_READY\".","assistant":"CONTEXT_READY"},{"turn":2,"state":"inProgress","user":"Call get_session_context exactly once with session \"codex:/${uuid_0}\", then reply exactly \"read\".","assistant":"Got it — I’ll fetch that session context once now."}],"hasMoreHistory":false,"truncated":false}'
+    response:
+      content: read
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-transcriptlimit-keeps-only-the-newest-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/codex-server-tool-get-session-context-transcriptlimit-keeps-only-the-newest-turn.yaml
@@ -1,0 +1,77 @@
+version: 1
+dialect: responses
+exchanges:
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+    response:
+      content: OLD
+      stopReason: end_turn
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+    response:
+      content: NEW
+      stopReason: end_turn
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+        - role: assistant
+          content: NEW
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}" and transcriptLimit 1, then reply exactly "read".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: get_session_context
+          input:
+            session: codex:/${uuid_0}
+            transcriptLimit: 1
+      stopReason: tool_use
+  - request:
+      model: gpt-5.3-codex
+      system: ${system}
+      messages:
+        - role: user
+          content: Reply exactly "OLD".
+        - role: assistant
+          content: OLD
+        - role: user
+          content: Reply exactly "NEW".
+        - role: assistant
+          content: NEW
+        - role: user
+          content: Call get_session_context exactly once with session "codex:/${uuid_0}" and transcriptLimit 1, then reply exactly "read".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: get_session_context
+              input:
+                session: codex:/${uuid_0}
+                transcriptLimit: 1
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '{"session":"codex:/${uuid_0}","openLink":"agent-host-session://codex/${uuid_0}","detail":"summary","transcript":[{"turn":3,"state":"inProgress","user":"Call get_session_context exactly once with session \"codex:/${uuid_0}\" and transcriptLimit 1, then reply exactly \"read\"."}],"hasMoreHistory":false,"truncated":true}'
+    response:
+      content: read
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/capiReplayProxy.ts
@@ -62,6 +62,8 @@ const WORKDIR_PLACEHOLDER = '${workdir}';
 const HOMEDIR_PLACEHOLDER = '${homedir}';
 const TEMP_DIR_SUFFIX_PLACEHOLDER = '${temp}';
 const TEMP_DIR_SUFFIX_RE = /(\$\{workdir\}(?:\/|\\\\)(?:ahp-(?:snapshot|perm-test|plan-test|abort|test|wt-test|subagent-test|subagent-replay|attachment-test|cd-strip-test|coverage-[a-z-]+)-|copilot-(?:cost-report|text-blob)-|read-sdk-simple))[A-Za-z0-9]{6}/g;
+const UUID_PLACEHOLDER_RE = /\$\{uuid_\d+\}/g;
+const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 const FILE_LISTING_DATE_RE = /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{2}:\d{2}|\d{4})\b/g;
 
 /**
@@ -247,6 +249,7 @@ export class CapiReplayProxy {
 	private readonly _observedModelRequestBodies: string[] = [];
 	private readonly _cacheMisses: string[] = [];
 	private readonly _requestMismatches: string[] = [];
+	private readonly _replayPlaceholderValues = new Map<string, string>();
 	private _modelTurnCount = 0;
 	private _workingDirectory: string | undefined;
 
@@ -357,6 +360,7 @@ export class CapiReplayProxy {
 		this._observedModelRequestBodies.length = 0;
 		this._cacheMisses.length = 0;
 		this._requestMismatches.length = 0;
+		this._replayPlaceholderValues.clear();
 		this._modelTurnCount = 0;
 		this._loadFixture();
 	}
@@ -515,19 +519,33 @@ export class CapiReplayProxy {
 	 */
 	private _assertRecordedRequest(dialect: TurnDialect, recorded: IReadableAnthropicRequest, body: string): void {
 		const turnIndex = this._modelTurnCount++;
-		if (this._allowStaleRecordedRequest) {
-			return;
-		}
 		const summarize = dialect === 'responses' ? summarizeResponsesRequest : summarizeAnthropicRequest;
-		const observed = summarize(this._normalize(body));
+		const normalizedBody = this._normalize(body);
+		const observed = summarize(normalizedBody);
 		if (!observed) {
 			return;
 		}
+		captureReplayPlaceholderValues(recorded, observed, this._replayPlaceholderValues);
+		if (this._allowStaleRecordedRequest) {
+			return;
+		}
+		const normalizedObserved = summarize(this._normalizeReplayPlaceholderValues(normalizedBody));
+		if (!normalizedObserved) {
+			return;
+		}
 		const expected = projectModelRequest(recorded);
-		const actual = projectModelRequest(observed);
+		const actual = projectModelRequest(normalizedObserved);
 		if (!modelRequestsMatch(expected, actual)) {
 			this._requestMismatches.push(formatModelRequestMismatch(turnIndex, expected, actual));
 		}
+	}
+
+	private _normalizeReplayPlaceholderValues(text: string): string {
+		let result = text;
+		for (const [placeholder, value] of this._replayPlaceholderValues) {
+			result = replaceAll(result, value, placeholder);
+		}
+		return result;
 	}
 
 	private _record(req: http.IncomingMessage, body: string, res: http.ServerResponse): void {
@@ -943,8 +961,67 @@ export class CapiReplayProxy {
 		if (this._options.userName) {
 			result = replaceAll(result, USER_PLACEHOLDER, this._options.userName);
 		}
+		for (const [placeholder, value] of this._replayPlaceholderValues) {
+			result = replaceAll(result, placeholder, value);
+		}
 		return result;
 	}
+}
+
+function captureReplayPlaceholderValues(recorded: unknown, observed: unknown, values: Map<string, string>): void {
+	if (typeof recorded === 'string' && typeof observed === 'string') {
+		captureReplayPlaceholderValuesFromString(recorded, observed, values);
+		return;
+	}
+	if (Array.isArray(recorded) && Array.isArray(observed)) {
+		for (let index = 0; index < Math.min(recorded.length, observed.length); index++) {
+			captureReplayPlaceholderValues(recorded[index], observed[index], values);
+		}
+		return;
+	}
+	if (!isRecord(recorded) || !isRecord(observed)) {
+		return;
+	}
+	for (const [key, value] of Object.entries(recorded)) {
+		captureReplayPlaceholderValues(value, observed[key], values);
+	}
+}
+
+function captureReplayPlaceholderValuesFromString(recorded: string, observed: string, values: Map<string, string>): void {
+	const placeholders: string[] = [];
+	let pattern = '^';
+	let offset = 0;
+	for (const match of recorded.matchAll(UUID_PLACEHOLDER_RE)) {
+		pattern += escapeRegExpCharacters(recorded.slice(offset, match.index));
+		pattern += `(${UUID_PATTERN})`;
+		placeholders.push(match[0]);
+		offset = match.index + match[0].length;
+	}
+	if (placeholders.length === 0) {
+		return;
+	}
+	pattern += `${escapeRegExpCharacters(recorded.slice(offset))}$`;
+	const match = new RegExp(pattern, 'i').exec(observed);
+	if (!match) {
+		return;
+	}
+	const captured = new Map<string, string>();
+	for (let index = 0; index < placeholders.length; index++) {
+		const placeholder = placeholders[index];
+		const value = match[index + 1];
+		if ((captured.has(placeholder) && captured.get(placeholder) !== value)
+			|| (values.has(placeholder) && values.get(placeholder) !== value)) {
+			return;
+		}
+		captured.set(placeholder, value);
+	}
+	for (const [placeholder, value] of captured) {
+		values.set(placeholder, value);
+	}
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function replaceAll(text: string, search: string, replacement: string): string {

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_inspects_git_status.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Claude_inspects_git_status.traffic.ahp.yaml
@@ -1,0 +1,53 @@
+version: 1
+rounds:
+  - clientToServer:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: Inspect git status. Reply with the names of the modified and untracked files only.
+            origin:
+              kind: user
+    serverToClient:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: Inspect git status. Reply with the names of the modified and untracked files only.
+            origin:
+              kind: user
+      - channel: ${session_0}
+        action:
+          type: session/titleChanged
+      - method: root/sessionAdded
+      - channel: ${session_0}
+        action:
+          type: session/ready
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          toolName: Bash
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          result:
+            success: true
+      - channel: ${chat_0}
+        action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: |-
+              Modified: tracked.txt
+              Untracked: untracked.txt
+      - channel: ${chat_0}
+        action:
+          type: chat/turnComplete
+          turnId: ${turn_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_inspects_git_status.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Codex_inspects_git_status.traffic.ahp.yaml
@@ -1,0 +1,60 @@
+version: 1
+rounds:
+  - clientToServer:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: Inspect git status. Reply with the names of the modified and untracked files only.
+            origin:
+              kind: user
+    serverToClient:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: Inspect git status. Reply with the names of the modified and untracked files only.
+            origin:
+              kind: user
+      - channel: ${session_0}
+        action:
+          type: session/titleChanged
+      - method: root/sessionAdded
+      - channel: ${session_0}
+        action:
+          type: session/ready
+      - channel: ${chat_0}
+        action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: Got it — I’ll check `git status` and list only modified/untracked filenames.
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          toolName: shell
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+      - channel: ${chat_0}
+        action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: |-
+
+
+              tracked.txt
+              untracked.txt
+      - channel: ${chat_0}
+        action:
+          type: chat/turnComplete
+          turnId: ${turn_0}

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -394,8 +394,7 @@ Use your file creation tool; do not run a shell command. Then reply exactly "don
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
 	});
 
-	// Claude and Codex emit customization/changeset updates at nondeterministic points in this snapshot.
-	(portableShellToolReplayEnabled && shellOutputOracleAvailable && config.provider === 'copilotcli' ? test : test.skip)('inspects git status', async function () {
+	(portableShellToolReplayEnabled && shellOutputOracleAvailable ? test : test.skip)('inspects git status', async function () {
 		this.timeout(180_000);
 		const workspace = mkdtempSync(join(tmpdir(), 'ahp-coverage-git-'));
 		tempDirs.push(workspace);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
@@ -67,10 +67,15 @@ const sessionToolNames = [
 
 export function defineServerToolsTests(context: IAgentHostE2ETestContext): void {
 	const { config, createdSessions, tempDirs } = context;
+	// Codex fails model authentication before a direct session lookup reaches the server tool.
 	const supportsDirectSessionLookup = config.provider !== 'codex';
+	// Claude omits the prior server-tool input from detailed session context.
 	const supportsFullSessionContext = config.provider !== 'claude';
+	// Codex fails model authentication while materializing the target session.
 	const supportsCrossSessionSend = config.provider !== 'codex';
+	// Claude leaves the target listed; Codex fails authentication while materializing it.
 	const supportsCrossSessionDelete = config.provider === 'copilotcli';
+	// Claude and Codex start another turn instead of rejecting a message to the current chat.
 	const supportsSelfSendRejection = config.provider === 'copilotcli';
 	// Model ids are not provider-qualified; Claude and Codex selections currently resolve to Copilot.
 	const supportsProviderModelSessionCreation = config.provider === 'copilotcli';

--- a/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
@@ -67,8 +67,11 @@ const sessionToolNames = [
 
 export function defineServerToolsTests(context: IAgentHostE2ETestContext): void {
 	const { config, createdSessions, tempDirs } = context;
-	// Session-reference captures need stable non-UUID resources, which only Copilot accepts.
-	const supportsReplayableSessionReferences = config.provider === 'copilotcli';
+	const supportsDirectSessionLookup = config.provider !== 'codex';
+	const supportsFullSessionContext = config.provider !== 'claude';
+	const supportsCrossSessionSend = config.provider !== 'codex';
+	const supportsCrossSessionDelete = config.provider === 'copilotcli';
+	const supportsSelfSendRejection = config.provider === 'copilotcli';
 	// Model ids are not provider-qualified; Claude and Codex selections currently resolve to Copilot.
 	const supportsProviderModelSessionCreation = config.provider === 'copilotcli';
 	// Codex executes this server tool without surfacing its required confirmation.
@@ -84,7 +87,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 	}
 
 	async function addSession(prefix: string, workspace: string, stableResource = false): Promise<IServerToolTestSession> {
-		const id = stableResource ? `e2e-server-tools-${prefix}` : generateUuid();
+		const id = stableResource && config.provider === 'copilotcli' ? `e2e-server-tools-${prefix}` : generateUuid();
 		const sessionUri = URI.from({ scheme: config.scheme, path: `/${id}` }).toString();
 		await context.client.call('createSession', {
 			channel: sessionUri,
@@ -457,7 +460,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 		);
 		const result = JSON.parse(tool.resultText) as { sessions: readonly { session: string }[] };
 		assert.deepStrictEqual(result.sessions.map(item => item.session), [session.sessionUri]);
-	}, supportsReplayableSessionReferences);
+	}, supportsDirectSessionLookup);
 
 	serverToolTest('server tool: list_sessions workspace filter excludes sessions in other folders', async function () {
 		const session = await createSession('sessions-workspace');
@@ -601,7 +604,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			detail: 'summary',
 			first: { turn: 1, state: 'complete', user: 'Reply exactly "CONTEXT_READY".', assistant: 'CONTEXT_READY' },
 		});
-	}, supportsReplayableSessionReferences);
+	});
 
 	serverToolTest('server tool: get_session_context full includes prior server-tool input', async function () {
 		const session = await createSession('context-full', true);
@@ -619,7 +622,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 		);
 		const result = JSON.parse(tool.resultText) as { transcript: readonly { toolCalls?: readonly { name: string; input?: string }[] }[] };
 		assert.deepStrictEqual(result.transcript[0]?.toolCalls, [{ name: SessionServerToolName.ListSessions, input: '{}' }]);
-	}, supportsReplayableSessionReferences);
+	}, supportsFullSessionContext);
 
 	serverToolTest('server tool: get_session_context transcriptLimit keeps only the newest turn', async function () {
 		const session = await createSession('context-limit', true);
@@ -639,7 +642,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			users: [`Call get_session_context exactly once with session "${session.sessionUri}" and transcriptLimit 1, then reply exactly "read".`],
 			truncated: true,
 		});
-	}, supportsReplayableSessionReferences);
+	});
 
 	serverToolTest('server tool: send_message starts a turn in another session', async function () {
 		const session = await createSession('send-message', true);
@@ -660,7 +663,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			sawPendingConfirmation: true,
 			messages: ['Reply exactly "TARGET_MATERIALIZED".', '/rename Target Via Send'],
 		});
-	}, supportsReplayableSessionReferences);
+	}, supportsCrossSessionSend);
 
 	serverToolTest('server tool: create_session materializes a selected-model child session and starts its prompt', async function () {
 		const session = await createSession('create-session');
@@ -730,7 +733,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 		if (trackedIndex >= 0) {
 			createdSessions.splice(trackedIndex, 1);
 		}
-	}, supportsReplayableSessionReferences);
+	}, supportsCrossSessionDelete);
 
 	serverToolTest('server tool: send_message refuses to target the invoking chat', async function () {
 		const session = await createSession('send-self', true);
@@ -753,7 +756,7 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			queuedMessages: undefined,
 			steeringMessage: undefined,
 		});
-	}, supportsReplayableSessionReferences);
+	}, supportsSelfSendRejection);
 
 	serverToolTest('server tool: delete_session refuses to delete the invoking session', async function () {
 		const session = await createSession('delete-current', true);
@@ -766,5 +769,5 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 		);
 		const result = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
 		assert.strictEqual(result.items.some(item => item.resource === session.sessionUri), true);
-	}, supportsReplayableSessionReferences);
+	});
 }


### PR DESCRIPTION
## Summary

- rebind normalized UUID placeholders to each replay run's live session IDs
- enable nine previously gated Claude/Codex session-reference variants
- enable the git-status E2E scenario for Claude and Codex using the existing behavior snapshot profile
- replace the broad session-reference gate with focused provider behavior gates
- document the remaining suspected product bugs in terms of user workflows and likely impact

## Validation

- `npm run typecheck-client`
- targeted ESLint for the three changed TypeScript files
- `npm run valid-layers-check`
- full deterministic Claude E2E suite: 68 passing
- full deterministic Codex E2E suite: 43 passing
- full deterministic Copilot E2E suite: 90 passing
- fixture secret/path hygiene checks
- `git diff --check`

## Reviewer notes

The UUID issue was in the deterministic replay harness, not the product. Fixing it exposed a smaller set of provider-specific behaviors that still fail live recording. Those variants remain narrowly gated and are described in `KNOWN_ISSUES.md`; this PR does not claim that those remaining failures originate in the provider SDKs.

(Written by Copilot)