### PR TITLE
Fix agent host tool search candidate race

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3899,6 +3899,7 @@ export class CopilotAgentSession extends Disposable {
 			const parentToolCallId = streamed?.parentToolCallId ?? this._parentToolCallIdForSubagentEvent(e);
 			const clientToolName = this._clientToolName(e.data.toolName);
 			const isClientTool = this._clientToolNames.has(clientToolName);
+			const isToolSearch = this._isToolSearchActive() && e.data.toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME;
 			const contributor = this._getToolCallContributor(e.data.toolName, e.data.mcpServerName);
 			const intention = getShellIntention(e.data.toolName, parameters);
 			this._activeToolCalls.set(e.data.toolCallId, {
@@ -4011,9 +4012,12 @@ export class CopilotAgentSession extends Disposable {
 			}
 
 			const clientToolAutoApproved = contributor?.kind === ToolCallContributorKind.Client && this._lastAppliedPermissionMode === 'on';
+			if (isToolSearch && clientToolAutoApproved) {
+				meta.autoApproveBySetting = true;
+			}
 			const shouldWaitForClientToolReady = contributor?.kind === ToolCallContributorKind.Client
 				&& !isAgentCoordinationTool(e.data.toolName)
-				&& !clientToolAutoApproved;
+				&& (isToolSearch || !clientToolAutoApproved);
 			if (shouldWaitForClientToolReady) {
 				return;
 			}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -6786,7 +6786,7 @@ suite('CopilotAgentSession', () => {
 			});
 		});
 
-		test('tool-search override routes to the client and injects deferred candidates', async () => {
+		async function createToolSearchSession(autoApprove: boolean) {
 			const toolSearchSnapshot: IActiveClientSnapshot = {
 				tools: [{ name: 'toolSearch', description: 'Search tools', inputSchema: { type: 'object', properties: { query: { type: 'string' } } } }],
 				plugins: [],
@@ -6794,12 +6794,21 @@ suite('CopilotAgentSession', () => {
 			};
 			const activeClientToolSet = new ActiveClientToolSet();
 			activeClientToolSet.set('tool-search-client', toolSearchSnapshot.tools);
-			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, {
+			const created = await createAgentSession(disposables, {
 				clientSnapshot: toolSearchSnapshot,
 				activeClientToolSet,
 				modelId: 'claude-opus-4.8',
+				...(autoApprove ? { configValues: { [SessionConfigKey.AutoApprove]: 'autoApprove' } } : {}),
 				rootValues: { [CopilotCliConfigKey.ToolSearchEnabled]: true },
 			});
+			if (autoApprove) {
+				await created.session.syncPermissionMode('turn-start');
+			}
+			return created;
+		}
+
+		test('tool-search override routes to the client and injects deferred candidates', async () => {
+			const { session, runtime, mockSession, signals, waitForSignal } = await createToolSearchSession(false);
 
 			const [override] = runtime.createClientSdkTools();
 			assert.strictEqual(override.name, 'tool_search_tool');
@@ -6816,6 +6825,7 @@ suite('CopilotAgentSession', () => {
 			const start = signals.find(s => isAction(s, ActionType.ChatToolCallStart));
 			assert.ok(start && isAction(start, ActionType.ChatToolCallStart));
 			assert.deepStrictEqual((start.action as ChatToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: 'tool-search-client' });
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.ChatToolCallReady)).length, 0);
 
 			const handlerPromise = invokeClientToolHandler(override, 'tc-tool-search', { query: 'add numbers' }, [
 				{ name: 'everything-get-sum', description: 'Adds numbers', deferLoading: true },
@@ -6825,8 +6835,17 @@ suite('CopilotAgentSession', () => {
 			const readySignal = await waitForSignal(s => isAction(s, ActionType.ChatToolCallReady));
 			assert.ok(isAction(readySignal, ActionType.ChatToolCallReady));
 			const ready = readySignal.action as ChatToolCallReadyAction;
-			assert.strictEqual(ready.confirmed, ToolCallConfirmationReason.NotNeeded);
-			assert.deepStrictEqual(ready._meta?.['toolSearchCandidates'], [{ name: 'everything-get-sum', description: 'Adds numbers' }]);
+			assert.deepStrictEqual({
+				readyCount: signals.filter(s => isAction(s, ActionType.ChatToolCallReady)).length,
+				confirmed: ready.confirmed,
+				meta: ready._meta,
+			}, {
+				readyCount: 1,
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				meta: {
+					toolSearchCandidates: [{ name: 'everything-get-sum', description: 'Adds numbers' }],
+				},
+			});
 
 			session.handleClientToolCallComplete('tc-tool-search', {
 				success: true,
@@ -6837,6 +6856,45 @@ suite('CopilotAgentSession', () => {
 			const result = await handlerPromise;
 			assert.strictEqual(result.resultType, 'success');
 			assert.deepStrictEqual(result.toolReferences, ['everything-get-sum']);
+		});
+
+		test('auto-approved tool search defers its only ready until candidates are available', async () => {
+			const { session, runtime, mockSession, signals, waitForSignal } = await createToolSearchSession(true);
+			const [override] = runtime.createClientSdkTools();
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-tool-search',
+				toolName: 'tool_search_tool',
+				arguments: { query: 'add numbers' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.ChatToolCallReady)).length, 0);
+
+			const handlerPromise = invokeClientToolHandler(override, 'tc-tool-search', { query: 'add numbers' }, [
+				{ name: 'everything-get-sum', description: 'Adds numbers', deferLoading: true },
+			]);
+
+			const readySignal = await waitForSignal(s => isAction(s, ActionType.ChatToolCallReady));
+			assert.ok(isAction(readySignal, ActionType.ChatToolCallReady));
+			const ready = readySignal.action as ChatToolCallReadyAction;
+			assert.deepStrictEqual({
+				readyCount: signals.filter(s => isAction(s, ActionType.ChatToolCallReady)).length,
+				confirmed: ready.confirmed,
+				meta: ready._meta,
+			}, {
+				readyCount: 1,
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				meta: {
+					autoApproveBySetting: true,
+					toolSearchCandidates: [{ name: 'everything-get-sum', description: 'Adds numbers' }],
+				},
+			});
+
+			session.handleClientToolCallComplete('tc-tool-search', {
+				success: true,
+				pastTenseMessage: 'Searched tools',
+				content: [{ type: ToolResultContentType.Text, text: '["everything-get-sum"]' }],
+			});
+			await handlerPromise;
 		});
 
 		test('toolSearch is omitted when the flag is off or the model is unsupported', async () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2157,6 +2157,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					if (startedRequest) {
 						return;
 					}
+					if (request.toolCall.toolName === RUNTIME_TOOL_SEARCH_TOOL_NAME
+						&& readToolCallMeta(request.toolCall).toolSearchCandidates === undefined) {
+						return;
+					}
 					const execute = (contextSessionResource: URI | undefined) => {
 						startedRequest = request;
 						unobservedTimer.clear();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -1152,11 +1152,12 @@ suite('AgentHostClientTools', () => {
 			});
 		});
 
-		test('tool-search completion drops candidates while preserving unknown metadata', async () => {
+		test('waits for tool-search candidates and drops them from completion metadata', async () => {
 			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testToolSearchTool]);
 			const sessionResource = URI.parse('agent-host-copilot:/session-1');
 			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
 			const chatURI = URI.parse(buildDefaultChatUri(backendSession));
+			const toolSearchCandidates = [{ name: 'calculator', description: 'Adds numbers' }];
 
 			connection.applySessionAction(chatURI, {
 				type: ActionType.ChatTurnStarted,
@@ -1180,7 +1181,6 @@ suite('AgentHostClientTools', () => {
 				toolInput: '{"query":"calculator"}',
 				confirmed: ToolCallConfirmationReason.NotNeeded,
 				_meta: {
-					toolSearchCandidates: [{ name: 'calculator', description: 'Adds numbers' }],
 					futureMetadata: { preserve: true },
 				},
 			} as ChatAction);
@@ -1193,7 +1193,32 @@ suite('AgentHostClientTools', () => {
 				invocationMessage: 'Search Tools',
 				toolInput: '{"query":"calculator"}',
 				_meta: {
-					toolSearchCandidates: [{ name: 'calculator', description: 'Adds numbers' }],
+					futureMetadata: { preserve: true },
+				},
+			});
+			await timeout(0);
+			assert.strictEqual(toolsService.invokedToolCalls.length, 0);
+
+			connection.applySessionAction(chatURI, {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-search-call-1',
+				invocationMessage: 'Search Tools',
+				toolInput: '{"query":"calculator"}',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				_meta: {
+					toolSearchCandidates,
+					futureMetadata: { preserve: true },
+				},
+			} as ChatAction);
+			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
+				toolCallId: 'tool-search-call-1',
+				toolName: RUNTIME_TOOL_SEARCH_TOOL_NAME,
+				displayName: 'Search Tools',
+				invocationMessage: 'Search Tools',
+				toolInput: '{"query":"calculator"}',
+				_meta: {
+					toolSearchCandidates,
 					futureMetadata: { preserve: true },
 				},
 			});
@@ -1210,7 +1235,7 @@ suite('AgentHostClientTools', () => {
 			}, {
 				parameters: {
 					query: 'calculator',
-					candidateTools: [{ name: 'calculator', description: 'Adds numbers' }],
+					candidateTools: toolSearchCandidates,
 				},
 				meta: { futureMetadata: { preserve: true } },
 			});


### PR DESCRIPTION
## Summary
- emit a single candidate-bearing ready action for auto-approved tool search
- wait for candidates when interoperating with older two-phase hosts
- cover producer and client dispatch ordering

## Testing
- targeted Copilot agent session tool-search tests
- agentHostClientTools.test.ts (48 passing)