### PR TITLE
tunnels: resume auto-reconnect on desktop and drop dead connections

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -64,6 +64,13 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _reconnectAttempts = new Map<string, number>();
 	/** Addresses whose auto-reconnect loop has paused after too many failures. */
 	private readonly _reconnectPaused = new Set<string>();
+	/**
+	 * Addresses whose provider currently holds a live connection. Tracked
+	 * separately from {@link _previousStatuses} so a drop is still detected when
+	 * the connection passes through an intermediate `connecting` state on its
+	 * way down.
+	 */
+	private readonly _wiredAddresses = new Set<string>();
 	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
 	private _lastResumeAt = 0;
 
@@ -99,12 +106,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Update connection statuses when connections change
 		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
-			// `_wireConnections` reads `_previousStatuses` to clear a stale provider
-			// after a disconnect, so it must run before `_handleConnectionChanges`
-			// updates that bookkeeping.
-			this._wireConnections();
 			this._handleConnectionChanges();
 			this._updateConnectionStatuses();
+			this._wireConnections();
 		}));
 
 		// Reconcile providers when the tunnel cache changes
@@ -137,8 +141,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 		}));
 
-		// `online` is a browser network signal; Electron does not provide an
-		// equivalent, so focus is the cross-platform recovery signal above.
+		// `online` is a browser-only network signal; focus above covers desktop.
 		if (isWeb) {
 			const onWake = () => this._resumeReconnects('wake');
 			mainWindow.addEventListener('online', onWake);
@@ -210,7 +213,10 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		store.add(this._sessionsProvidersService.registerProvider(provider));
 		store.add(watchForIncompatibleNotifications(provider, this._instantiationService, this._notificationService));
 		this._providerInstances.set(address, provider);
-		store.add(toDisposable(() => this._providerInstances.delete(address)));
+		store.add(toDisposable(() => {
+			this._providerInstances.delete(address);
+			this._wiredAddresses.delete(address);
+		}));
 		this._providerStores.set(address, store);
 	}
 
@@ -258,7 +264,8 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
-	 * Wire live connections to their providers so session operations work.
+	 * Wire live connections to their providers so session operations work, and
+	 * drop a provider's connection once its transport is gone.
 	 */
 	private _wireConnections(): void {
 		for (const [address, provider] of this._providerInstances) {
@@ -267,12 +274,11 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				const connection = this._remoteAgentHostService.getConnection(address);
 				if (connection) {
 					provider.setConnection(connection, connectionInfo.defaultDirectory);
+					this._wiredAddresses.add(address);
 				}
-			} else if (
-				RemoteAgentHostConnectionStatus.isConnected(this._previousStatuses.get(address))
-				&& !RemoteAgentHostConnectionStatus.isConnecting(connectionInfo?.status)
-			) {
+			} else if (this._wiredAddresses.has(address) && !RemoteAgentHostConnectionStatus.isConnecting(connectionInfo?.status)) {
 				// Keep the provider live while a replacement transport is connecting.
+				this._wiredAddresses.delete(address);
 				provider.clearConnection();
 			}
 		}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -17,6 +17,7 @@ import { INotificationService, Severity } from '../../../../../platform/notifica
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+import { IHostService } from '../../../../../workbench/services/host/browser/host.js';
 import { logTunnelConnectAttempt, logTunnelConnectResolved, logTunnelDiscoveryResult, TunnelConnectErrorCategory, TunnelConnectFailureReason, TunnelDiscoveryTrigger } from '../../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
@@ -32,12 +33,12 @@ const RECONNECT_INITIAL_DELAY = 1000;
 const RECONNECT_MAX_DELAY = 30_000;
 /**
  * Consecutive failures before pausing auto-reconnect. We resume immediately
- * on a network-online event or when the tab becomes visible, so this is
+ * when the window regains focus, so this is
  * mostly a guard against a permanently dead tunnel.
  */
 const RECONNECT_MAX_ATTEMPTS = 10;
 
-/** Minimum gap between wake/visibility-triggered resumes. */
+/** Minimum gap between event-triggered reconnect resumes. */
 const RESUME_RATE_LIMIT_MS = 10_000;
 
 export class TunnelAgentHostContribution extends Disposable implements IWorkbenchContribution {
@@ -63,8 +64,6 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _reconnectAttempts = new Map<string, number>();
 	/** Addresses whose auto-reconnect loop has paused after too many failures. */
 	private readonly _reconnectPaused = new Set<string>();
-	/** Addresses paused specifically because the remote host is offline. */
-	private readonly _hostOfflinePaused = new Set<string>();
 	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
 	private _lastResumeAt = 0;
 
@@ -85,6 +84,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		@ILogService private readonly _logService: ILogService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IHostService private readonly _hostService: IHostService,
 		@IAgentHostFilterService agentHostFilterService: IAgentHostFilterService,
 	) {
 		super();
@@ -99,9 +99,12 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Update connection statuses when connections change
 		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
+			// `_wireConnections` reads `_previousStatuses` to clear a stale provider
+			// after a disconnect, so it must run before `_handleConnectionChanges`
+			// updates that bookkeeping.
+			this._wireConnections();
 			this._handleConnectionChanges();
 			this._updateConnectionStatuses();
-			this._wireConnections();
 		}));
 
 		// Reconcile providers when the tunnel cache changes
@@ -128,22 +131,18 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			this._handleSessionsChange(e);
 		}));
 
-		// Wake-triggered retry: when the browser regains connectivity or
-		// the tab becomes visible again, immediately attempt to reconnect
-		// any disconnected tunnels. This covers laptop-sleep / Wi-Fi-drop
-		// scenarios where we may have paused the reconnect loop.
+		this._register(this._hostService.onDidChangeFocus(focused => {
+			if (focused) {
+				this._resumeReconnects('focus');
+			}
+		}));
+
+		// `online` is a browser network signal; Electron does not provide an
+		// equivalent, so focus is the cross-platform recovery signal above.
 		if (isWeb) {
 			const onWake = () => this._resumeReconnects('wake');
 			mainWindow.addEventListener('online', onWake);
 			this._register(toDisposable(() => mainWindow.removeEventListener('online', onWake)));
-
-			const onVisibilityChange = () => {
-				if (mainWindow.document.visibilityState === 'visible') {
-					this._resumeReconnects('visible');
-				}
-			};
-			mainWindow.document.addEventListener('visibilitychange', onVisibilityChange);
-			this._register(toDisposable(() => mainWindow.document.removeEventListener('visibilitychange', onVisibilityChange)));
 		}
 
 		// Cancel any pending reconnect timers on disposal.
@@ -263,14 +262,18 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	 */
 	private _wireConnections(): void {
 		for (const [address, provider] of this._providerInstances) {
-			const connectionInfo = this._remoteAgentHostService.connections.find(
-				c => c.address === address && RemoteAgentHostConnectionStatus.isConnected(c.status)
-			);
-			if (connectionInfo) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo && RemoteAgentHostConnectionStatus.isConnected(connectionInfo.status)) {
 				const connection = this._remoteAgentHostService.getConnection(address);
 				if (connection) {
 					provider.setConnection(connection, connectionInfo.defaultDirectory);
 				}
+			} else if (
+				RemoteAgentHostConnectionStatus.isConnected(this._previousStatuses.get(address))
+				&& !RemoteAgentHostConnectionStatus.isConnecting(connectionInfo?.status)
+			) {
+				// Keep the provider live while a replacement transport is connecting.
+				provider.clearConnection();
 			}
 		}
 	}
@@ -572,7 +575,6 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private _clearReconnectBackoff(address: string): void {
 		this._reconnectAttempts.delete(address);
 		this._reconnectPaused.delete(address);
-		this._hostOfflinePaused.delete(address);
 	}
 
 	/** Drop all reconnect + telemetry state for an address (e.g. on removal). */
@@ -616,21 +618,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
-	 * Stop auto-reconnecting for an address until a wake/online/visibility
-	 * event resumes us, and close out any active telemetry session.
+	 * Stop auto-reconnecting for an address until a recovery signal resumes us.
 	 */
 	private _pauseReconnect(address: string, reason: TunnelConnectFailureReason): void {
 		this._cancelReconnect(address);
 		this._reconnectAttempts.delete(address);
 		this._reconnectPaused.add(address);
-		if (reason === 'hostOffline') {
-			this._hostOfflinePaused.add(address);
-		} else {
-			this._hostOfflinePaused.delete(address);
-		}
 		this._logService.info(
 			`[TunnelAgentHost] Pausing auto-reconnect for ${address} (${reason}); ` +
-			`will resume on network-online, tab-visible, session change, or next status check.`
+			`will resume on ${isWeb ? 'network-online, ' : ''}window focus, session change, or a status check that confirms the host is online.`
 		);
 		const session = this._connectSessions.get(address);
 		if (session) {
@@ -708,7 +704,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
-	 * Invoked on `online` / `visibilitychange→visible`. Kicks off an
+	 * Invoked on a browser network, window-focus, or authentication event. Kicks off an
 	 * immediate attempt for any disconnected cached tunnel.
 	 *
 	 * Rate-limited: at most one resume per RESUME_RATE_LIMIT_MS so that
@@ -717,12 +713,12 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	 * sequence (by clearing the pause flag) rather than zeroing the
 	 * attempt counter.
 	 */
-	private _resumeReconnects(trigger: 'wake' | 'visible' | 'sessionAdded'): void {
+	private _resumeReconnects(trigger: 'wake' | 'focus' | 'sessionAdded'): void {
 		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
 			return;
 		}
 
-		// Rate-limit rapid wake/visibility events (e.g. alt-tab bursts or
+		// Rate-limit rapid recovery events (e.g. alt-tab bursts or
 		// flaky Wi-Fi toggling online/offline) so we don't hammer the relay
 		// with immediate retries. This is an event-smoothing gate, not an
 		// error-backoff — that's handled by `_scheduleReconnect`.
@@ -858,14 +854,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				if (info && info.hostConnectionCount > 0) {
 					provider.setConnectionStatus(RemoteAgentHostConnectionStatus.connected);
 
-					// If we paused reconnects because the host had gone
-					// offline, the status check is our cue to resume —
-					// don't wait for a wake/visibility event. Covers the
-					// common "my laptop came back, the remote host came
-					// back first" scenario deterministically.
-					if (this._hostOfflinePaused.has(address)) {
+					if (this._reconnectPaused.has(address)) {
 						this._logService.info(
-							`[TunnelAgentHost] Host came back online for ${address}; auto-resuming reconnect.`
+							`[TunnelAgentHost] Confirmed host online for paused ${address}; auto-resuming reconnect.`
 						);
 						this._clearReconnectBackoff(address);
 						this._scheduleReconnect(address, /*immediate*/ true);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
@@ -418,10 +418,18 @@ suite('TunnelAgentHostContribution', () => {
 		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.disconnected);
 		const afterDisconnect = provider.clearConnectionCalls.length;
 		remoteService.fireConnectionChange();
+		const afterRepeatDisconnect = provider.clearConnectionCalls.length;
+
+		// A transport that drops via an intermediate `connecting` state must
+		// still clear: the wired-provider bookkeeping has to survive statuses
+		// that are neither connected nor disconnected.
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.connected);
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.connecting);
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.disconnected);
 
 		assert.deepStrictEqual(
-			{ whileConnected, whileConnecting, afterDisconnect, afterRepeatDisconnect: provider.clearConnectionCalls.length },
-			{ whileConnected: 0, whileConnecting: 0, afterDisconnect: 1, afterRepeatDisconnect: 1 },
+			{ whileConnected, whileConnecting, afterDisconnect, afterRepeatDisconnect, afterConnectingDisconnect: provider.clearConnectionCalls.length },
+			{ whileConnected: 0, whileConnecting: 0, afterDisconnect: 1, afterRepeatDisconnect: 1, afterConnectingDisconnect: 2 },
 		);
 	});
 });

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
@@ -29,6 +29,7 @@ import { ILogService, NullLogService } from '../../../../../../platform/log/comm
 import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IAuthenticationService } from '../../../../../../workbench/services/authentication/common/authentication.js';
+import { IHostService } from '../../../../../../workbench/services/host/browser/host.js';
 import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../../../../services/agentHostFilter/common/agentHostFilter.js';
@@ -37,6 +38,7 @@ import { TunnelAgentHostContribution } from '../../browser/tunnelAgentHost.contr
 
 class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
 	readonly setConnectionCalls: Array<{ connection: IAgentConnection; defaultDirectory: string | undefined }> = [];
+	readonly clearConnectionCalls: undefined[] = [];
 
 	override readonly id: string;
 	override readonly remoteAddress: string;
@@ -61,6 +63,7 @@ class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
 	}
 
 	override unpublishCachedSessions(): void { /* noop */ }
+	override clearConnection(): void { this.clearConnectionCalls.push(undefined); }
 
 	override dispose(): void { /* noop */ }
 }
@@ -72,6 +75,7 @@ class StubTunnelService extends Disposable implements ITunnelAgentHostService {
 	readonly onDidChangeTunnels = this._onDidChangeTunnels.event;
 
 	private _cached: ICachedTunnel[] = [];
+	private _listed: ITunnelInfo[] | undefined;
 	private readonly _suppressed = new Set<string>();
 
 	/** Records every `connect()` call for assertions on the `userInitiated` threading. */
@@ -83,7 +87,8 @@ class StubTunnelService extends Disposable implements ITunnelAgentHostService {
 	}
 
 	getCachedTunnels(): ICachedTunnel[] { return this._cached; }
-	async listTunnels(): Promise<ITunnelInfo[]> { return []; }
+	setListed(tunnels: ITunnelInfo[] | undefined): void { this._listed = tunnels; }
+	async listTunnels(): Promise<ITunnelInfo[]> { return this._listed ?? []; }
 	readonly canDeleteTunnels = true;
 	async deleteTunnel(tunnel: ITunnelInfo): Promise<void> { this.removeCachedTunnel(tunnel.tunnelId); }
 	cacheTunnel(tunnel: ITunnelInfo, authProvider?: 'github' | 'microsoft'): void {
@@ -125,6 +130,27 @@ class StubRemoteAgentHostService extends Disposable {
 		this._connections.push(info);
 		this._agentConnections.set(info.address, connection);
 		this._onDidChangeConnections.fire();
+	}
+
+	setConnectionStatus(address: string, status: RemoteAgentHostConnectionStatus): void {
+		const index = this._connections.findIndex(connection => connection.address === address);
+		if (index >= 0) {
+			this._connections[index] = { ...this._connections[index], status };
+			this._onDidChangeConnections.fire();
+		}
+	}
+
+	fireConnectionChange(): void {
+		this._onDidChangeConnections.fire();
+	}
+}
+
+class StubHostService extends mock<IHostService>() {
+	private readonly _onDidChangeFocus = new Emitter<boolean>();
+	override readonly onDidChangeFocus = this._onDidChangeFocus.event;
+
+	fireFocus(focused: boolean): void {
+		this._onDidChangeFocus.fire(focused);
 	}
 }
 
@@ -182,6 +208,7 @@ suite('TunnelAgentHostContribution', () => {
 		const remoteService = store.add(new StubRemoteAgentHostService());
 		const providersService = store.add(new StubSessionsProvidersService());
 		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
+		const hostService = new StubHostService();
 
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ITunnelAgentHostService, tunnelService);
@@ -192,6 +219,7 @@ suite('TunnelAgentHostContribution', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
 		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IHostService, hostService);
 		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
 
 		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
@@ -236,6 +264,7 @@ suite('TunnelAgentHostContribution', () => {
 		const remoteService = store.add(new StubRemoteAgentHostService());
 		const providersService = store.add(new StubSessionsProvidersService());
 		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
+		const hostService = new StubHostService();
 
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ITunnelAgentHostService, tunnelService);
@@ -246,6 +275,7 @@ suite('TunnelAgentHostContribution', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
 		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IHostService, hostService);
 		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
 
 		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
@@ -269,5 +299,129 @@ suite('TunnelAgentHostContribution', () => {
 		await testable._connectTunnel(address, { userInitiated: true });
 		assert.strictEqual(tunnelService.connectCalls.length, 2);
 		assert.strictEqual(tunnelService.connectCalls[1].options?.userInitiated, true, 'explicit/user-initiated connect must pass userInitiated: true');
+	});
+
+	test('resumes a max-attempts pause on focus and rate-limits repeated focus changes', () => {
+		const tunnelService = store.add(new StubTunnelService());
+		const remoteService = store.add(new StubRemoteAgentHostService());
+		const providersService = store.add(new StubSessionsProvidersService());
+		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
+		const hostService = new StubHostService();
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ITunnelAgentHostService, tunnelService as unknown as ITunnelAgentHostService);
+		instantiationService.stub(IRemoteAgentHostService, remoteService as unknown as IRemoteAgentHostService);
+		instantiationService.stub(ISessionsProvidersService, providersService as unknown as ISessionsProvidersService);
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(INotificationService, { notify: () => ({ close() { } }) } as unknown as INotificationService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
+		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IHostService, hostService);
+		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
+		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
+		const address = `${TUNNEL_ADDRESS_PREFIX}tunnel-focus`;
+		tunnelService.setCached([{ tunnelId: 'tunnel-focus', clusterId: 'use', name: 'Focus Tunnel' }]);
+		const testable = contribution as unknown as {
+			_reconnectPaused: Set<string>;
+			_reconnectTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+		};
+
+		testable._reconnectPaused.add(address);
+		hostService.fireFocus(true);
+		const firstResume = {
+			paused: testable._reconnectPaused.has(address),
+			timers: [...testable._reconnectTimeouts.keys()],
+		};
+
+		testable._reconnectPaused.add(address);
+		hostService.fireFocus(true);
+		const rateLimitedResume = {
+			paused: testable._reconnectPaused.has(address),
+			timers: [...testable._reconnectTimeouts.keys()],
+		};
+
+		assert.deepStrictEqual(
+			{ firstResume, rateLimitedResume },
+			{
+				firstResume: { paused: false, timers: [address] },
+				rateLimitedResume: { paused: true, timers: [address] },
+			},
+		);
+	});
+
+	test('confirmed online tunnel resumes a max-attempts pause during status check', async () => {
+		const tunnelService = store.add(new StubTunnelService());
+		const remoteService = store.add(new StubRemoteAgentHostService());
+		const providersService = store.add(new StubSessionsProvidersService());
+		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
+		const hostService = new StubHostService();
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ITunnelAgentHostService, tunnelService as unknown as ITunnelAgentHostService);
+		instantiationService.stub(IRemoteAgentHostService, remoteService as unknown as IRemoteAgentHostService);
+		instantiationService.stub(ISessionsProvidersService, providersService as unknown as ISessionsProvidersService);
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(INotificationService, { notify: () => ({ close() { } }) } as unknown as INotificationService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
+		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IHostService, hostService);
+		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
+		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
+		const tunnelId = 'tunnel-online';
+		const address = `${TUNNEL_ADDRESS_PREFIX}${tunnelId}`;
+		tunnelService.setCached([{ tunnelId, clusterId: 'use', name: 'Online Tunnel' }]);
+		tunnelService.setListed([{ tunnelId, clusterId: 'use', name: 'Online Tunnel', tags: [], protocolVersion: 5, hostConnectionCount: 1 }]);
+		const testable = contribution as unknown as {
+			_reconnectPaused: Set<string>;
+			_reconnectTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+			_silentStatusCheck(): Promise<void>;
+		};
+
+		testable._reconnectPaused.add(address);
+		await testable._silentStatusCheck();
+
+		assert.deepStrictEqual(
+			{ paused: testable._reconnectPaused.has(address), timers: [...testable._reconnectTimeouts.keys()] },
+			{ paused: false, timers: [address] },
+		);
+	});
+
+	test('clears the provider connection only after a connected transport disconnects', () => {
+		const tunnelService = store.add(new StubTunnelService());
+		const remoteService = store.add(new StubRemoteAgentHostService());
+		const providersService = store.add(new StubSessionsProvidersService());
+		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
+		const hostService = new StubHostService();
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ITunnelAgentHostService, tunnelService as unknown as ITunnelAgentHostService);
+		instantiationService.stub(IRemoteAgentHostService, remoteService as unknown as IRemoteAgentHostService);
+		instantiationService.stub(ISessionsProvidersService, providersService as unknown as ISessionsProvidersService);
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(INotificationService, { notify: () => ({ close() { } }) } as unknown as INotificationService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
+		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IHostService, hostService);
+		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
+		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
+		const tunnelId = 'tunnel-disconnect';
+		const address = `${TUNNEL_ADDRESS_PREFIX}${tunnelId}`;
+		tunnelService.setCached([{ tunnelId, clusterId: 'use', name: 'Disconnect Tunnel' }]);
+		remoteService.addConnection({ address, name: 'Disconnect Tunnel', clientId: 'client', status: RemoteAgentHostConnectionStatus.connected }, {} as IAgentConnection);
+		const provider = contribution.stubProviders.get(address)!;
+
+		remoteService.fireConnectionChange();
+		const whileConnected = provider.clearConnectionCalls.length;
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.connecting);
+		const whileConnecting = provider.clearConnectionCalls.length;
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.connected);
+		remoteService.setConnectionStatus(address, RemoteAgentHostConnectionStatus.disconnected);
+		const afterDisconnect = provider.clearConnectionCalls.length;
+		remoteService.fireConnectionChange();
+
+		assert.deepStrictEqual(
+			{ whileConnected, whileConnecting, afterDisconnect, afterRepeatDisconnect: provider.clearConnectionCalls.length },
+			{ whileConnected: 0, whileConnecting: 0, afterDisconnect: 1, afterRepeatDisconnect: 1 },
+		);
 	});
 });


### PR DESCRIPTION
Tunnel-backed agent host connections could drop overnight and never come back, forcing a full manual re-run of the connect workflow (connect command → select tunnel → select workspace).

### Auto-reconnect paused permanently on desktop

After `RECONNECT_MAX_ATTEMPTS` consecutive failures, `_pauseReconnect` cancels the retry timer and relies on something later calling `_resumeReconnects`. Its only triggers were an `online` event and `visibilitychange`, both registered behind `if (isWeb)`. On desktop the sole remaining caller was an added GitHub auth session.

The pause is terminal rather than merely delayed: `_reconnectPaused` isn't consulted as a hard gate, so it works by cancelling the timer and relying on nothing re-arming it. The re-arm normally comes from `_handleConnectionChanges` on an explicit Connected → Disconnected transition — but once paused you're already disconnected, so that transition never fires again. No timer, no transition, no resume trigger.

This routes `IHostService.onDidChangeFocus` into `_resumeReconnects` so both web and desktop recover on the next window focus, and drops the web-only visibility listener it subsumes. `_resumeReconnects` is still rate-limited by `RESUME_RATE_LIMIT_MS`, so focus churn can't hammer the relay.

A status check that confirms the host is online now resumes any paused address rather than only those parked with reason `hostOffline`, which makes `_hostOfflinePaused` redundant. The pause log message claimed recovery triggers that didn't exist on desktop; it now reports the real ones.

### Tunnel providers kept advertising dead connections

Only the SSH/configured-host contribution called `clearConnection()`, so a tunnel provider kept `_connection` pointing at a dead protocol client and went on advertising its sessions as openable. Opening one subscribed over the dead client, threw, and permanently poisoned that editor with "Couldn't open session" — the error is baked into the chat history at hydration time and never re-hydrates.

`_wireConnections` must run before `_handleConnectionChanges` for this, since it reads the previous status to detect the transition. The ordering is commented and covered by a test that fails if it's reverted.

### Notes

`clearConnection()` deliberately preserves the cached session list, so offline sessions stay visible; this is not `unpublishCachedSessions()`.

Already-open editors still can't self-heal after a reconnect — the stale `ChatModel` is retained by `ChatService._sessionModels` and `ChatEditorInput.modelRef`, so refreshing them needs `ChatService.loadRemoteSession` to make its contributed-session bindings replaceable. That's shared chat machinery and out of scope here; this PR reduces how often tabs get poisoned in the first place.

### Testing

Three new tests in `tunnelAgentHost.contribution.test.ts`: a max-attempts pause resuming on focus (with the rate limit still suppressing repeats), a confirmed-online status check resuming a max-attempts pause, and `clearConnection()` firing only on a connected → disconnected transition. Each was verified to fail without the corresponding fix.
