### PR TITLE
chat: protect package manager configuration edits

### DIFF
--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -67,6 +67,7 @@ const DEFAULT_EDIT_AUTO_APPROVE_PATTERNS: Readonly<Record<string, boolean>> = {
 	'**/.vscode/*.json': false,
 	'**/.git/**': false,
 	'**/{package.json,server.xml,build.rs,web.config,.gitattributes,.env}': false,
+	'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs}': false,
 	'**/*.{code-workspace,csproj,fsproj,vbproj,vcxproj,proj,targets,props}': false,
 	'**/*.lock': false,
 	'**/*-lock.{yaml,json}': false,

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -67,7 +67,7 @@ const DEFAULT_EDIT_AUTO_APPROVE_PATTERNS: Readonly<Record<string, boolean>> = {
 	'**/.vscode/*.json': false,
 	'**/.git/**': false,
 	'**/{package.json,server.xml,build.rs,web.config,.gitattributes,.env}': false,
-	'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs}': false,
+	'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs,.pnpmfile.mjs,pnpm-workspace.yaml}': false,
 	'**/*.{code-workspace,csproj,fsproj,vbproj,vcxproj,proj,targets,props}': false,
 	'**/*.lock': false,
 	'**/*-lock.{yaml,json}': false,

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -130,6 +130,22 @@ suite('SessionPermissionManager', () => {
 		assert.deepStrictEqual(results, files.map(() => undefined));
 	});
 
+	test('requires confirmation for package manager configuration files', async () => {
+		const files = [
+			'.npmrc',
+			'.yarnrc',
+			'.yarnrc.yml',
+			'.pnpmfile.js',
+			'.pnpmfile.cjs',
+			join('packages', 'nested', '.npmrc'),
+		];
+		const results: (ToolCallConfirmationReason | undefined)[] = [];
+		for (const file of files) {
+			results.push(await permissions.getAutoApproval(writeEvent(join(workDir, file)), sessionUri));
+		}
+		assert.deepStrictEqual(results, files.map(() => undefined));
+	});
+
 	test('requires confirmation for paths containing null bytes', async () => {
 		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'a\u0000b.txt')), sessionUri);
 		assert.strictEqual(result, undefined);

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -137,6 +137,8 @@ suite('SessionPermissionManager', () => {
 			'.yarnrc.yml',
 			'.pnpmfile.js',
 			'.pnpmfile.cjs',
+			'.pnpmfile.mjs',
+			'pnpm-workspace.yaml',
 			join('packages', 'nested', '.npmrc'),
 		];
 		const results: (ToolCallConfirmationReason | undefined)[] = [];

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -709,6 +709,7 @@ configurationRegistry.registerConfiguration({
 				'**/.vscode/*.json': false,
 				'**/.git/**': false,
 				'**/{package.json,server.xml,build.rs,web.config,.gitattributes,.env,Cargo.toml}': false,
+				'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs}': false,
 				'**/*.{code-workspace,csproj,fsproj,vbproj,vcxproj,proj,targets,props,gradle,gradle.kts}': false,
 				'**/gradle.properties': false,
 				'**/ruby_lsp/*/addon': false, // Auto-included Ruby addons

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -709,7 +709,7 @@ configurationRegistry.registerConfiguration({
 				'**/.vscode/*.json': false,
 				'**/.git/**': false,
 				'**/{package.json,server.xml,build.rs,web.config,.gitattributes,.env,Cargo.toml}': false,
-				'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs}': false,
+				'**/{.npmrc,.yarnrc,.yarnrc.yml,.pnpmfile.js,.pnpmfile.cjs,.pnpmfile.mjs,pnpm-workspace.yaml}': false,
 				'**/*.{code-workspace,csproj,fsproj,vbproj,vcxproj,proj,targets,props,gradle,gradle.kts}': false,
 				'**/gradle.properties': false,
 				'**/ruby_lsp/*/addon': false, // Auto-included Ruby addons


### PR DESCRIPTION
## Summary

- require confirmation before agents edit npm, Yarn, and pnpm configuration files
- apply the protection to both Agent Host and standard chat edit defaults
- add Agent Host regression coverage, including nested configuration files

## Validation

- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/sessionPermissions.test.ts`
- `npm run hygiene`

(Written by Copilot)