### PR TITLE
Harden chat import storage paths

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatImportExport.ts
@@ -15,7 +15,7 @@ import { ChatViewPaneTarget, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { isExportableSessionData } from '../../common/model/chatModel.js';
+import { extractExportableSessionData, isExportableSessionData } from '../../common/model/chatModel.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { revive } from '../../../../../base/common/marshalling.js';
@@ -117,13 +117,14 @@ export function registerChatExportActions() {
 				if (!isExportableSessionData(data)) {
 					throw new Error('Invalid chat session data');
 				}
+				const importedData = extractExportableSessionData(data);
 
 				let sessionResource: URI;
 				let resolvedTarget: typeof ChatViewPaneTarget | PreferredGroup;
 				let options: IChatEditorOptions;
 
 				if (opts?.target === 'chatViewPane') {
-					const modelRef = chatService.loadSessionFromData(data, 'ChatImportExport#importToChatView');
+					const modelRef = chatService.loadSessionFromData(importedData, 'ChatImportExport#importToChatView');
 					try {
 						sessionResource = modelRef.object.sessionResource;
 						resolvedTarget = ChatViewPaneTarget;
@@ -135,7 +136,7 @@ export function registerChatExportActions() {
 				} else {
 					sessionResource = ChatEditorInput.getNewEditorUri();
 					resolvedTarget = ACTIVE_GROUP;
-					options = { target: { data }, pinned: true };
+					options = { target: { data: importedData }, pinned: true };
 					await widgetService.openSession(sessionResource, resolvedTarget, options);
 				}
 			} catch (err) {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts
@@ -16,6 +16,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { Dto } from '../../../../services/extensions/common/proxyIdentifier.js';
 import { ISnapshotEntry, ModifiedFileEntryState, WorkingSetDisplayMetadata } from '../../common/editing/chatEditingService.js';
+import { getChatSessionStorageResource } from '../../common/model/chatUri.js';
 import { getKeyForChatSessionResource, IChatEditingTimelineState } from './chatEditingOperations.js';
 
 const STORAGE_CONTENTS_FOLDER = 'contents';
@@ -41,7 +42,8 @@ export class ChatEditingSessionStorage {
 
 	protected _getStorageLocation(): URI {
 		const workspaceId = this._workspaceContextService.getWorkspace().id;
-		return joinPath(this._environmentService.workspaceStorageHome, workspaceId, 'chatEditingSessions', this.storageKey);
+		const storageRoot = joinPath(this._environmentService.workspaceStorageHome, workspaceId, 'chatEditingSessions');
+		return getChatSessionStorageResource(storageRoot, this.storageKey);
 	}
 
 	public async restoreState(): Promise<StoredSessionState | undefined> {

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2198,6 +2198,14 @@ export function isExportableSessionData(obj: unknown): obj is IExportableChatDat
 		typeof (obj as IExportableChatData).responderUsername === 'string';
 }
 
+export function extractExportableSessionData(data: IExportableChatData): IExportableChatData {
+	return {
+		initialLocation: data.initialLocation,
+		requests: data.requests,
+		responderUsername: data.responderUsername,
+	};
+}
+
 export function isSerializableSessionData(obj: unknown): obj is ISerializableChatData {
 	const data = obj as ISerializableChatData;
 	return isExportableSessionData(obj) &&

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -31,7 +31,7 @@ import { ChatAgentLocation, ChatPermissionLevel } from '../constants.js';
 import { ModifiedFileEntryState } from '../editing/chatEditingService.js';
 import { ChatModel, ISerializableChatData, ISerializableChatDataIn, ISerializableChatModelInputState, ISerializableChatsData, ISerializedChatDataReference, normalizeSerializableChatData } from './chatModel.js';
 import { ChatSessionOperationLog } from './chatSessionOperationLog.js';
-import { LocalChatSessionUri } from './chatUri.js';
+import { getChatSessionStorageResource, LocalChatSessionUri } from './chatUri.js';
 import { stringifyEntryWithFallback } from './objectMutationLog.js';
 
 const maxPersistedSessions = 400;
@@ -697,7 +697,7 @@ export class ChatSessionStore extends Disposable {
 		let rawData: VSBuffer | undefined;
 
 		if (this.previousEmptyWindowStorageRoot) {
-			const storageLocation2 = joinPath(this.previousEmptyWindowStorageRoot, `${sessionId}.json`);
+			const storageLocation2 = getChatSessionStorageResource(this.previousEmptyWindowStorageRoot, sessionId, '.json');
 			try {
 				rawData = (await this.fileService.readFile(storageLocation2)).value;
 				this.logService.info(`ChatSessionStore: Read chat session ${sessionId} from previous location`);
@@ -717,15 +717,18 @@ export class ChatSessionStore extends Disposable {
 		log?: URI;
 	} {
 		return {
-			flat: joinPath(this.storageRoot, `${chatSessionId}.json`),
+			flat: getChatSessionStorageResource(this.storageRoot, chatSessionId, '.json'),
 			// todo@connor4312: remove after stabilizing
-			log: this.configurationService.getValue('chat.useLogSessionStorage') !== false ? joinPath(this.storageRoot, `${chatSessionId}.jsonl`) : undefined,
+			log: this.configurationService.getValue('chat.useLogSessionStorage') !== false ? getChatSessionStorageResource(this.storageRoot, chatSessionId, '.jsonl') : undefined,
 		};
 	}
 
 	private getTransferredSessionStorageLocation(sessionResource: URI): URI {
 		const sessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
-		return joinPath(this.transferredSessionStorageRoot, `${sessionId}.json`);
+		if (!sessionId) {
+			throw new Error(`Invalid local chat session resource: ${sessionResource.toString()}`);
+		}
+		return getChatSessionStorageResource(this.transferredSessionStorageRoot, sessionId, '.json');
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -458,7 +458,14 @@ export class ChatSessionStore extends Disposable {
 			return;
 		}
 
-		const storageLocation = this.getStorageLocation(sessionId);
+		let storageLocation: ReturnType<ChatSessionStore['getStorageLocation']>;
+		try {
+			storageLocation = this.getStorageLocation(sessionId);
+		} catch (e) {
+			this.reportError('invalidSessionId', `Removing invalid chat session from index: ${sessionId}`, e);
+			delete index.entries[sessionId];
+			return;
+		}
 		for (const uri of [storageLocation.flat, storageLocation.log]) {
 			try {
 				if (uri) {
@@ -627,7 +634,18 @@ export class ChatSessionStore extends Disposable {
 
 	public async readSession(sessionId: string): Promise<ISerializedChatDataReference | undefined> {
 		return await this.storeQueue.queue(async () => {
-			const storageLocation = this.getStorageLocation(sessionId);
+			let storageLocation: ReturnType<ChatSessionStore['getStorageLocation']>;
+			try {
+				storageLocation = this.getStorageLocation(sessionId);
+			} catch (e) {
+				this.reportError('invalidSessionId', `Ignoring invalid chat session from index: ${sessionId}`, e);
+				const index = this.internalGetIndex();
+				if (index.entries[sessionId]) {
+					delete index.entries[sessionId];
+					await this.flushIndex();
+				}
+				return undefined;
+			}
 			return this.readSessionFromLocation(storageLocation.flat, storageLocation.log, sessionId);
 		});
 	}

--- a/src/vs/workbench/contrib/chat/common/model/chatUri.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatUri.ts
@@ -5,6 +5,7 @@
 
 import { encodeBase64, VSBuffer, decodeBase64 } from '../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../base/common/network.js';
+import { extUri } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localChatSessionType } from '../chatSessionsService.js';
 
@@ -70,6 +71,17 @@ export function chatSessionResourceToId(resource: URI): string {
 	}
 
 	return resource.toString();
+}
+
+/**
+ * Resolves a session resource that must be an immediate child of its storage root.
+ */
+export function getChatSessionStorageResource(storageRoot: URI, sessionId: string, suffix: string = ''): URI {
+	const resource = extUri.joinPath(storageRoot, `${sessionId}${suffix}`);
+	if (!extUri.isEqual(extUri.dirname(resource), storageRoot)) {
+		throw new Error(`Invalid chat session ID: ${sessionId}`);
+	}
+	return resource;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/chatEditing/chatEditingSessionStorage.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatEditing/chatEditingSessionStorage.test.ts
@@ -12,10 +12,12 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { FileService } from '../../../../../../platform/files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { TestEnvironmentService } from '../../../../../test/browser/workbenchTestServices.js';
 import { ChatEditingSessionStorage, IChatEditingSessionStop, StoredSessionState } from '../../../browser/chatEditing/chatEditingSessionStorage.js';
 import { ChatEditingSnapshotTextModelContentProvider } from '../../../browser/chatEditing/chatEditingTextModelContentProviders.js';
 import { ISnapshotEntry, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
+import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 
 suite('ChatEditingSessionStorage', () => {
@@ -23,6 +25,7 @@ suite('ChatEditingSessionStorage', () => {
 	const sessionResource = URI.parse('chat://test-session');
 	let fs: FileService;
 	let storage: TestChatEditingSessionStorage;
+	let workspaceContextService: IWorkspaceContextService;
 
 	class TestChatEditingSessionStorage extends ChatEditingSessionStorage {
 		public get storageLocation() {
@@ -33,14 +36,15 @@ suite('ChatEditingSessionStorage', () => {
 	setup(() => {
 		fs = ds.add(new FileService(new NullLogService()));
 		ds.add(fs.registerProvider(TestEnvironmentService.workspaceStorageHome.scheme, ds.add(new InMemoryFileSystemProvider())));
+		// eslint-disable-next-line local/code-no-any-casts
+		workspaceContextService = { getWorkspace: () => ({ id: 'workspaceId' }) } as any;
 
 		storage = new TestChatEditingSessionStorage(
 			sessionResource,
 			fs,
 			TestEnvironmentService,
 			new NullLogService(),
-			// eslint-disable-next-line local/code-no-any-casts
-			{ getWorkspace: () => ({ id: 'workspaceId' }) } as any,
+			workspaceContextService,
 		);
 	});
 
@@ -69,6 +73,18 @@ suite('ChatEditingSessionStorage', () => {
 	test('state is empty initially', async () => {
 		const s = await storage.restoreState();
 		assert.strictEqual(s, undefined);
+	});
+
+	test('rejects session IDs that escape the storage root', () => {
+		const maliciousStorage = new TestChatEditingSessionStorage(
+			LocalChatSessionUri.forSession('../../../outside'),
+			fs,
+			TestEnvironmentService,
+			new NullLogService(),
+			workspaceContextService,
+		);
+
+		assert.throws(() => maliciousStorage.storageLocation, /Invalid chat session ID/);
 	});
 
 	test('round trips state', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -27,7 +27,7 @@ import { TestExtensionService, TestStorageService } from '../../../../../test/co
 import { CellUri } from '../../../../notebook/common/notebookCommon.js';
 import { IChatRequestImplicitVariableEntry, IChatRequestStringVariableEntry, IChatRequestFileEntry, StringChatContextValue } from '../../../common/attachments/chatVariableEntries.js';
 import { ChatAgentService, IChatAgentService } from '../../../common/participants/chatAgents.js';
-import { ChatModel, ChatRequestModel, ChatResponseResource, IChatRequestModeInfo, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, ISerializableChatModelInputState, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response, serializeSendOptions, toChatHistoryContent } from '../../../common/model/chatModel.js';
+import { ChatModel, ChatRequestModel, ChatResponseResource, extractExportableSessionData, IChatRequestModeInfo, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, ISerializableChatModelInputState, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response, serializeSendOptions, toChatHistoryContent } from '../../../common/model/chatModel.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { ChatRequestTextPart } from '../../../common/requestParser/chatParserTypes.js';
 import { ChatRequestQueueKind, IChatService, IChatTerminalToolInvocationData, IChatToolInvocation, ResponseModelState } from '../../../common/chatService/chatService.js';
@@ -1373,6 +1373,23 @@ suite('isExportableSessionData', () => {
 
 	test('invalid - undefined', () => {
 		assert.strictEqual(isExportableSessionData(undefined), false);
+	});
+
+	test('extracts only exportable session fields', () => {
+		const data = {
+			initialLocation: ChatAgentLocation.Chat,
+			requests: [],
+			responderUsername: 'assistant',
+			sessionId: '../../../outside',
+			creationDate: 1,
+			customTitle: 'Injected title',
+		};
+
+		assert.deepStrictEqual(extractExportableSessionData(data), {
+			initialLocation: ChatAgentLocation.Chat,
+			requests: [],
+			responderUsername: 'assistant',
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -9,7 +9,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IFileDeleteOptions, IFileService } from '../../../../../../platform/files/common/files.js';
 import { ServiceCollection } from '../../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -59,12 +59,21 @@ class MockWorkspaceEditingService extends Disposable implements Partial<IWorkspa
 	}
 }
 
+class TestChatSessionFileService extends InMemoryTestFileService {
+	readonly deleteOperations: URI[] = [];
+
+	override async del(resource: URI, options?: IFileDeleteOptions): Promise<void> {
+		this.deleteOperations.push(resource);
+		await super.del(resource, options);
+	}
+}
+
 suite('ChatSessionStore', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
 	let mockWorkspaceEditingService: MockWorkspaceEditingService;
-	let fileService: InMemoryTestFileService;
+	let fileService: TestChatSessionFileService;
 
 	function createChatSessionStore(isEmptyWindow: boolean = false): ChatSessionStore {
 		const workspace = isEmptyWindow ? new Workspace('empty-window-id', []) : TestWorkspace;
@@ -77,7 +86,7 @@ suite('ChatSessionStore', () => {
 		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
 		instantiationService.stub(ILogService, NullLogService);
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
-		fileService = testDisposables.add(new InMemoryTestFileService());
+		fileService = testDisposables.add(new TestChatSessionFileService());
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IEnvironmentService, { workspaceStorageHome: URI.file('/test/workspaceStorage') });
 		instantiationService.stub(ILifecycleService, testDisposables.add(new TestLifecycleService()));
@@ -185,6 +194,27 @@ suite('ChatSessionStore', () => {
 		assert.strictEqual((session.value as ISerializableChatData3).sessionId, 'session-1');
 	});
 
+	test('readSession ignores and removes a legacy invalid session ID', async () => {
+		const store = createChatSessionStore();
+		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
+		await store.storeSessions([model]);
+		const index = await store.getIndex();
+		index['../../../outside'] = { ...index['session-1'], sessionId: '../../../outside' };
+		delete index['session-1'];
+
+		const session = await store.readSession('../../../outside');
+
+		assert.deepStrictEqual({
+			session,
+			index: await store.getIndex(),
+			readOperations: fileService.readOperations,
+		}, {
+			session: undefined,
+			index: {},
+			readOperations: [],
+		});
+	});
+
 	test('deleteSession removes session from index', async () => {
 		const store = createChatSessionStore();
 		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
@@ -199,17 +229,37 @@ suite('ChatSessionStore', () => {
 		assert.strictEqual(index['session-1'], undefined);
 	});
 
-	test('clearAllSessions removes all sessions', async () => {
+	test('deleteSession removes a legacy invalid session ID without deleting files', async () => {
+		const store = createChatSessionStore();
+		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
+		await store.storeSessions([model]);
+		const index = await store.getIndex();
+		index['../../../outside'] = { ...index['session-1'], sessionId: '../../../outside' };
+		delete index['session-1'];
+
+		await store.deleteSession('../../../outside');
+
+		assert.deepStrictEqual({
+			index: await store.getIndex(),
+			deleteOperations: fileService.deleteOperations,
+		}, {
+			index: {},
+			deleteOperations: [],
+		});
+	});
+
+	test('clearAllSessions removes all sessions including legacy invalid session IDs', async () => {
 		const store = createChatSessionStore();
 		const model1 = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
 		const model2 = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-2')));
 
 		await store.storeSessions([model1, model2]);
-		assert.strictEqual(Object.keys(await store.getIndex()).length, 2);
+		const index = await store.getIndex();
+		index['../../../outside'] = { ...index['session-1'], sessionId: '../../../outside' };
+		assert.strictEqual(Object.keys(index).length, 3);
 
 		await store.clearAllSessions();
 
-		const index = await store.getIndex();
 		assert.deepStrictEqual(index, {});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -64,6 +64,7 @@ suite('ChatSessionStore', () => {
 
 	let instantiationService: TestInstantiationService;
 	let mockWorkspaceEditingService: MockWorkspaceEditingService;
+	let fileService: InMemoryTestFileService;
 
 	function createChatSessionStore(isEmptyWindow: boolean = false): ChatSessionStore {
 		const workspace = isEmptyWindow ? new Workspace('empty-window-id', []) : TestWorkspace;
@@ -76,7 +77,8 @@ suite('ChatSessionStore', () => {
 		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
 		instantiationService.stub(ILogService, NullLogService);
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
-		instantiationService.stub(IFileService, testDisposables.add(new InMemoryTestFileService()));
+		fileService = testDisposables.add(new InMemoryTestFileService());
+		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IEnvironmentService, { workspaceStorageHome: URI.file('/test/workspaceStorage') });
 		instantiationService.stub(ILifecycleService, testDisposables.add(new TestLifecycleService()));
 		instantiationService.stub(IUserDataProfilesService, { defaultProfile: toUserDataProfile('default', 'Default', URI.file('/test/userdata'), URI.file('/test/cache')) });
@@ -145,6 +147,21 @@ suite('ChatSessionStore', () => {
 		const index = await store.getIndex();
 		assert.ok(index['session-1']);
 		assert.strictEqual(index['session-1'].sessionId, 'session-1');
+	});
+
+	test('storeSessions rejects session IDs that escape the storage root', async () => {
+		const store = createChatSessionStore();
+		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('../../../outside')));
+
+		await store.storeSessions([model]);
+
+		assert.deepStrictEqual({
+			hasSessions: store.hasSessions(),
+			writtenResources: fileService.writeOperations.map(operation => operation.resource.toString()),
+		}, {
+			hasSessions: false,
+			writtenResources: [],
+		});
 	});
 
 	test('storeSessions persists custom title', async () => {


### PR DESCRIPTION
Discard imported persistence identity and validate session-derived storage locations remain within their expected roots.\n\n(Written by Copilot)\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
