### PR TITLE
agentHost: Forward selected client tool confirmation option

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3735,6 +3735,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					toolCallId,
 					approved: true,
 					confirmed: confirmedReasonToProtocol(state.confirmed),
+					...(state.confirmed.type === ToolConfirmKind.UserAction && state.confirmed.selectedButton
+						? { selectedOptionId: state.confirmed.selectedButton }
+						: {}),
 				});
 			} else if (state.type === IChatToolInvocation.StateKind.Cancelled) {
 				// Pre-execution cancellation (a denied confirmation). If the

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3729,16 +3729,26 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 			if (state.type === IChatToolInvocation.StateKind.Executing) {
 				confirmationDispatched = true;
-				this._resolveToolCall(opts.chatURI, opts.turnId, toolCallId, {
-					type: ActionType.ChatToolCallConfirmed,
-					turnId: opts.turnId,
-					toolCallId,
-					approved: true,
-					confirmed: confirmedReasonToProtocol(state.confirmed),
-					...(state.confirmed.type === ToolConfirmKind.UserAction && state.confirmed.selectedButton
-						? { selectedOptionId: state.confirmed.selectedButton }
-						: {}),
-				});
+				const selectedOptionId = state.confirmed.type === ToolConfirmKind.UserAction ? state.confirmed.selectedButton : undefined;
+				const approved = state.confirmed.type !== ToolConfirmKind.UserAction
+					|| state.confirmed.selectedButtonKind !== ConfirmationOptionKind.Deny;
+				this._resolveToolCall(opts.chatURI, opts.turnId, toolCallId, approved
+					? {
+						type: ActionType.ChatToolCallConfirmed,
+						turnId: opts.turnId,
+						toolCallId,
+						approved: true,
+						confirmed: confirmedReasonToProtocol(state.confirmed),
+						...(selectedOptionId ? { selectedOptionId } : {}),
+					}
+					: {
+						type: ActionType.ChatToolCallConfirmed,
+						turnId: opts.turnId,
+						toolCallId,
+						approved: false,
+						reason: ToolCallCancellationReason.Denied,
+						...(selectedOptionId ? { selectedOptionId } : {}),
+					});
 			} else if (state.type === IChatToolInvocation.StateKind.Cancelled) {
 				// Pre-execution cancellation (a denied confirmation). If the
 				// protocol call already reached a terminal state the server

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -25,7 +25,7 @@ import { buildChatUri, buildDefaultChatUri, buildSubagentChatUri, createChatStat
 import { chatReducer, sessionReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { ContentEncoding } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { McpAuthRequiredReason, SessionInputRequestKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ConfirmationOptionKind, McpAuthRequiredReason, SessionInputRequestKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { IChatProgress, IChatService, IChatToolInvocation, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatEditingService } from '../../../common/editing/chatEditingService.js';
@@ -1577,6 +1577,10 @@ suite('AgentHostClientTools', () => {
 				invocationMessage: 'Run Task',
 				toolInput: '{"task":"build"}',
 				confirmationTitle: 'Run Task',
+				options: [
+					{ id: 'allow-once', label: 'Allow Once', kind: ConfirmationOptionKind.Approve },
+					{ id: 'skip', label: 'Skip', kind: ConfirmationOptionKind.Deny },
+				],
 			} as ChatAction);
 
 			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -1681,6 +1685,37 @@ suite('AgentHostClientTools', () => {
 					{ type: ActionType.ChatToolCallConfirmed, approved: true, confirmed: ToolCallConfirmationReason.UserAction },
 					{ type: ActionType.ChatToolCallComplete, success: true },
 				],
+			});
+		});
+
+		test('renders and dispatches a pending protocol confirmation for an owned client tool', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool]);
+			await provideSessionWithPendingConfirmationClientTool(handler, connection);
+
+			const invocation = toolsService.begunToolCalls[0];
+			const state = invocation.state.get();
+			assert.strictEqual(state.type, IChatToolInvocation.StateKind.WaitingForConfirmation);
+			assert.strictEqual(toolsService.invokedToolCalls.length, 0);
+			if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+				return;
+			}
+			state.confirm({
+				type: ToolConfirmKind.UserAction,
+				selectedButton: 'allow-once',
+				selectedButtonKind: ConfirmationOptionKind.Approve,
+			});
+			await timeout(0);
+
+			const confirmation = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+				&& entry.action.type === ActionType.ChatToolCallConfirmed
+				&& entry.action.toolCallId === 'tool-call-1');
+			assert.deepStrictEqual(confirmation?.action, {
+				type: ActionType.ChatToolCallConfirmed,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				approved: true,
+				confirmed: ToolCallConfirmationReason.UserAction,
+				selectedOptionId: 'allow-once',
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -1688,35 +1688,50 @@ suite('AgentHostClientTools', () => {
 			});
 		});
 
-		test('renders and dispatches a pending protocol confirmation for an owned client tool', async () => {
-			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool]);
-			await provideSessionWithPendingConfirmationClientTool(handler, connection);
+		test('dispatches a selected protocol confirmation option with its approval kind', async () => {
+			for (const option of [
+				{ id: 'allow-once', kind: ConfirmationOptionKind.Approve },
+				{ id: 'skip', kind: ConfirmationOptionKind.Deny },
+			]) {
+				const local = disposables.add(new DisposableStore());
+				const { handler, connection, toolsService } = createHandlerWithMocks(local, [testRunTaskTool]);
+				await provideSessionWithPendingConfirmationClientTool(handler, connection);
 
-			const invocation = toolsService.begunToolCalls[0];
-			const state = invocation.state.get();
-			assert.strictEqual(state.type, IChatToolInvocation.StateKind.WaitingForConfirmation);
-			assert.strictEqual(toolsService.invokedToolCalls.length, 0);
-			if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
-				return;
+				const invocation = toolsService.begunToolCalls[0];
+				const state = invocation.state.get();
+				assert.strictEqual(state.type, IChatToolInvocation.StateKind.WaitingForConfirmation);
+				assert.strictEqual(toolsService.invokedToolCalls.length, 0);
+				if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+					return;
+				}
+				state.confirm({
+					type: ToolConfirmKind.UserAction,
+					selectedButton: option.id,
+					selectedButtonKind: option.kind,
+				});
+				await timeout(0);
+
+				const confirmation = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+					&& entry.action.type === ActionType.ChatToolCallConfirmed
+					&& entry.action.toolCallId === 'tool-call-1');
+				assert.deepStrictEqual(confirmation?.action, option.kind === ConfirmationOptionKind.Approve
+					? {
+						type: ActionType.ChatToolCallConfirmed,
+						turnId: 'turn-1',
+						toolCallId: 'tool-call-1',
+						approved: true,
+						confirmed: ToolCallConfirmationReason.UserAction,
+						selectedOptionId: option.id,
+					}
+					: {
+						type: ActionType.ChatToolCallConfirmed,
+						turnId: 'turn-1',
+						toolCallId: 'tool-call-1',
+						approved: false,
+						reason: ToolCallCancellationReason.Denied,
+						selectedOptionId: option.id,
+					});
 			}
-			state.confirm({
-				type: ToolConfirmKind.UserAction,
-				selectedButton: 'allow-once',
-				selectedButtonKind: ConfirmationOptionKind.Approve,
-			});
-			await timeout(0);
-
-			const confirmation = connection.dispatchedActions.find(entry => isChatAction(entry.action)
-				&& entry.action.type === ActionType.ChatToolCallConfirmed
-				&& entry.action.toolCallId === 'tool-call-1');
-			assert.deepStrictEqual(confirmation?.action, {
-				type: ActionType.ChatToolCallConfirmed,
-				turnId: 'turn-1',
-				toolCallId: 'tool-call-1',
-				approved: true,
-				confirmed: ToolCallConfirmationReason.UserAction,
-				selectedOptionId: 'allow-once',
-			});
 		});
 
 		test('preserves the client tool confirmation reason through execution', async () => {


### PR DESCRIPTION
> Created by GitHub Copilot.

## Why
#329288 restored the confirmation UI for owned Agent Host client tools. This follow-up fixes the remaining option-handling gap: every custom button was dispatched as approved, and its option ID was dropped. As a result, **Skip** could run the tool, while **Allow in Session** could not persist the permission.

## Repro
1. Start an Agent Host session with default permissions and no remembered browser-tool approval.
2. Ask Copilot: `Please open Wikipedia.`
3. Choose **Skip** when `openBrowserPage` requests confirmation.

**Before:** `ChatToolCallConfirmed` is sent with `approved: true`.  
**After:** the selected option ID is forwarded and approval is derived from the option kind.

## Tests
The regression test fails against #329288 (`Skip` is emitted as `approved: true` and the option ID is absent) and passes with this change on Chromium, WebKit, and Firefox.

Fixes #329422
