### PR TITLE
Fix quick picks closing from toolbar menus

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -379,6 +379,7 @@ export class ContextView extends Disposable {
 		if (!skipAnimation && closeAnimation && closeAnimation.duration > 0 && this.hasRequiredAncestorClasses(closeAnimation.requiredAncestorClasses)) {
 			this.view.style.setProperty(CONTEXT_VIEW_CLOSE_ANIMATION_DURATION_VARIABLE, `${closeAnimation.duration}ms`);
 			this.prepareMenuCloseAnimation();
+			this.view.inert = true;
 			this.view.classList.add(closeAnimation.className);
 			const timeout = setTimeout(() => this.completeHideAnimation(), closeAnimation.duration);
 			this.hidingContextView = {
@@ -411,6 +412,7 @@ export class ContextView extends Disposable {
 		this.view.style.removeProperty(CONTEXT_VIEW_MENU_MOTION_CLOSE_START_TRANSFORM_VARIABLE);
 		hidingContextView.toDispose.dispose();
 		DOM.hide(this.view);
+		this.view.inert = false;
 	}
 
 	private prepareMenuCloseAnimation(): void {

--- a/src/vs/base/test/browser/ui/contextview/contextview.test.ts
+++ b/src/vs/base/test/browser/ui/contextview/contextview.test.ts
@@ -72,11 +72,13 @@ suite('ContextView', () => {
 		assert.deepStrictEqual({
 			disposeCount,
 			hasClosingClass: contextView.getViewElement().classList.contains('closing'),
-			animationDuration: contextView.getViewElement().style.getPropertyValue(CONTEXT_VIEW_CLOSE_ANIMATION_DURATION_VARIABLE)
+			animationDuration: contextView.getViewElement().style.getPropertyValue(CONTEXT_VIEW_CLOSE_ANIMATION_DURATION_VARIABLE),
+			inert: contextView.getViewElement().inert
 		}, {
 			disposeCount: 0,
 			hasClosingClass: true,
-			animationDuration: '100ms'
+			animationDuration: '100ms',
+			inert: true
 		});
 
 		clock.tick(100);
@@ -84,11 +86,13 @@ suite('ContextView', () => {
 		assert.deepStrictEqual({
 			disposeCount,
 			hasClosingClass: contextView.getViewElement().classList.contains('closing'),
-			animationDuration: contextView.getViewElement().style.getPropertyValue(CONTEXT_VIEW_CLOSE_ANIMATION_DURATION_VARIABLE)
+			animationDuration: contextView.getViewElement().style.getPropertyValue(CONTEXT_VIEW_CLOSE_ANIMATION_DURATION_VARIABLE),
+			inert: contextView.getViewElement().inert
 		}, {
 			disposeCount: 1,
 			hasClosingClass: false,
-			animationDuration: ''
+			animationDuration: '',
+			inert: false
 		});
 
 		contextView.dispose();


### PR DESCRIPTION
Fixes #329326
Fixes #329137
Fixes #328190
Fixes #328836
Fixes #328893
Fixes #328859
Fixes #329110
Fixes #329315
Fixes #329309

Duplicates:
#328525
#328410
#328919

Animated context views delay disposal while their close animation runs. Toolbar menus therefore remained focusable after invoking an action, allowing existing menu mouse-out handling to reclaim focus from a newly opened quick pick. The quick pick then blurred and closed immediately.

This makes closing context views inert until their delayed disposal completes, preventing them from receiving or reclaiming focus while preserving the close animation.
