### PR TITLE
agentHost: show multi-root sessions in empty and single-folder Editor windows

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListStore.ts
@@ -11,7 +11,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, type IIsArchivedChangedAction, type IIsReadChangedAction, type INotification, type SessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { readSessionMultiRootMetadata, SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
-import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, type IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 
 /**
  * Minimal agent-host connection surface needed by the session list store.
@@ -374,14 +374,25 @@ export class AgentHostSessionListStore extends Disposable {
 		const workingDirectories = entry.summary.workingDirectories?.map(directory => URI.parse(directory)) ?? [];
 		const workspace = this._workspaceContextService.getWorkspace();
 		const folders = workspace.folders;
+		const configuration = workspace.configuration;
 		const multiRoot = readSessionMultiRootMetadata(entry.summary._meta);
 		if (multiRoot) {
-			return URI.isUri(workspace.configuration)
-				&& extUriBiasedIgnorePathCase.isEqual(URI.parse(multiRoot.workspaceFile), workspace.configuration);
+			// A multi-root window matches strictly by workspace-file identity so two
+			// different `.code-workspace` files that share a folder don't cross over.
+			if (URI.isUri(configuration)) {
+				return extUriBiasedIgnorePathCase.isEqual(URI.parse(multiRoot.workspaceFile), configuration);
+			}
+			// An empty window shows every session; a single-folder (or other
+			// non-multi-root) window falls back to working-directory containment.
+			return folders.length === 0 || this._matchesAnyFolder(workingDirectories, folders);
 		}
 		if (folders.length === 0) {
 			return true;
 		}
+		return this._matchesAnyFolder(workingDirectories, folders);
+	}
+
+	private _matchesAnyFolder(workingDirectories: readonly URI[], folders: readonly IWorkspaceFolder[]): boolean {
 		return workingDirectories.some(directory =>
 			folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(directory, folder.uri))
 		);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3215,6 +3215,72 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('multi-root session is shown in an empty window', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.EMPTY,
+				getWorkspace: () => ({ id: 'empty', folders: [] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'multi-root'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Multi-root session',
+				workingDirectories: [URI.file('/workspace/a'), URI.file('/workspace/b')],
+				_meta: withSessionMultiRootMetadata(undefined, { workspaceFile: URI.file('/workspace/demo.code-workspace').toString() }),
+			});
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'metadata-less'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Metadata-less session',
+				workingDirectories: [URI.file('/elsewhere')],
+			});
+
+			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+			await listController.refresh(CancellationToken.None);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['Multi-root session', 'Metadata-less session']);
+		});
+
+		test('multi-root session is shown in a single-folder window that is one of its roots', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const folder = URI.file('/workspace/a');
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkbenchState: () => WorkbenchState.FOLDER,
+				getWorkspace: () => ({ id: 'folder', folders: [{ uri: folder, name: 'a', index: 0, toResource: () => folder }] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'contains-folder'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Contains folder',
+				workingDirectories: [URI.file('/workspace/a'), URI.file('/workspace/b')],
+				_meta: withSessionMultiRootMetadata(undefined, { workspaceFile: URI.file('/workspace/demo.code-workspace').toString() }),
+			});
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'other-roots'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Other roots',
+				workingDirectories: [URI.file('/workspace/c'), URI.file('/workspace/d')],
+				_meta: withSessionMultiRootMetadata(undefined, { workspaceFile: URI.file('/workspace/other.code-workspace').toString() }),
+			});
+
+			const listController = createSessionListController(disposables, instantiationService, agentHostService);
+			await listController.refresh(CancellationToken.None);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['Contains folder']);
+		});
+
 		test('sessionAdded notification filters out sessions outside the workspace', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
 


### PR DESCRIPTION
## Problem

In the **Editor window** (not the Agents window), a Copilot Agent Host session created in a **multi-root workspace** would not appear in the agent-session list when:

1. **An empty (no folder) Editor window is open** — the multi-root session does not show up, even though empty windows are meant to show all sessions.
2. **One of the constituent folders is opened** (e.g. just `copilot-sdk` or just `copilot-agent-runtime`) — the session does not show up.

The Agents window was unaffected because it does not apply this workspace filter.

## Root cause

`AgentHostSessionListStore._isSessionInWorkspace` treated the `_meta.multiRoot.workspaceFile` branch as an **exclusive early return**, matching strictly by `.code-workspace` identity against `workspace.configuration`:

```ts
if (multiRoot) {
    return URI.isUri(workspace.configuration)
        && extUriBiasedIgnorePathCase.isEqual(URI.parse(multiRoot.workspaceFile), workspace.configuration);
}
```

`workspace.configuration` is a URI **only** in a multi-root (`WORKSPACE`) window — it is `null` in both empty (`EMPTY`) and single-folder (`FOLDER`) windows. So for a multi-root session this branch always returned `false` in those windows and never fell through to the empty-window "show all" rule or the working-directory containment check.

## Fix

Restrict the strict workspace-file identity match to **actual multi-root windows** (`workspace.configuration` is a URI). In non-multi-root windows, fall back to the rules already used for metadata-less sessions:

- **Empty window** → show every session (Problem 1).
- **Single-folder / other non-multi-root window** → working-directory containment (Problem 2).

The strict identity gate is retained for real multi-root windows, so two different `.code-workspace` files that share a folder still don't cross over.

## Tests

- Added regression test: multi-root session is shown in an empty window.
- Added regression test: multi-root session is shown in a single-folder window that is one of its roots (and a non-matching multi-root session is excluded).
- Existing `multi-root workspace filtering uses workspace-file metadata` and the other session-list filtering tests still pass.

## Validation

- `npm run typecheck-client` — pass
- `npm run valid-layers-check` — pass
- `scripts/test.sh` (session-list filtering + multi-root tests) — pass