### PR TITLE
Style override: Remove redundant CSS rule for status bar item

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
@@ -102,7 +102,6 @@
 	padding: 0 var(--vscode-spacing-size60);
 }
 
-.style-override .part.statusbar > .items-container > .statusbar-item.left.first-visible-item,
 .style-override .part.statusbar > .items-container > .statusbar-item.left.first-visible-item > .statusbar-item-label {
 	padding-right: var(--vscode-spacing-size40);
 }


### PR DESCRIPTION
Eliminate an unnecessary CSS rule for the first visible status bar item to streamline styling. This resolves an issue where there is a 4px gap in status bar items containing left & right controls.

