### PR TITLE
Guard Azure node_modules caches against missing native packages

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
@@ -129,6 +129,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         displayName: Mixin distro node modules
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -174,6 +174,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         displayName: Mixin distro node modules
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/common/checkNativeOptionalDeps.ts
+++ b/build/azure-pipelines/common/checkNativeOptionalDeps.ts
@@ -17,9 +17,9 @@ import path from 'path';
 //
 // `findMissingNativeOptionalDep` is the reusable primitive that detects this.
 // It is used from two places:
-//   - The CLI entry point below runs after `npm ci` in the node_modules
-//     cache-build jobs (.github/workflows/pr-node-modules.yml) and fails the
-//     job so a poisoned cache is never saved.
+//   - The CLI entry point below runs after restoring or installing the root
+//     node_modules in CI and fails the job so a poisoned cache is neither used
+//     nor saved.
 //   - The agent-SDK producer (build/agent-sdk/package.ts) runs it after its
 //     scratch `npm ci` so a binary-less tarball is never built and uploaded to
 //     the CDN.
@@ -54,11 +54,11 @@ export function findMissingNativeOptionalDep(nodeModulesDir: string, basePackage
 
 // #region CLI entry point
 //
-// Runs after the root `npm ci` in the node_modules cache-build jobs (see
-// .github/workflows/pr-node-modules.yml), before the cache is saved. Verifies
-// the repo-root node_modules has the per-platform package for the current host
-// so a poisoned cache (base package present, native package silently skipped)
-// is never persisted.
+// Runs after the root node_modules is restored or installed in CI. Verifies
+// the repo-root node_modules has the per-platform package for the target so a
+// poisoned cache (base package present, native package silently skipped) is
+// neither used nor persisted. The optional CLI arguments override the current
+// platform and architecture for cross-architecture builds.
 
 // Base packages whose per-platform package (`<base>-<platform>-<arch>`) is
 // required whenever the base package itself is installed.
@@ -79,7 +79,8 @@ function isCliInvocation(): boolean {
 }
 
 function main(): void {
-	const { platform, arch } = process;
+	const platform = process.argv[2] ?? process.platform;
+	const arch = process.argv[3] ?? process.arch;
 	if (!SUPPORTED_PLATFORMS.has(platform) || !SUPPORTED_ARCHS.has(arch)) {
 		console.log(`Skipping native optional-dependency check on unsupported ${platform}-${arch}.`);
 		return;
@@ -96,11 +97,11 @@ function main(): void {
 	}
 
 	if (errors.length > 0) {
-		console.error('\x1b[1;31m*** Missing native optional-dependency packages — refusing to save a poisoned node_modules cache ***\x1b[0m');
+		console.error('\x1b[1;31m*** Missing native optional-dependency packages in node_modules ***\x1b[0m');
 		for (const err of errors) {
 			console.error(`  - ${err}`);
 		}
-		console.error('\nnpm does not fail when an optional dependency cannot be installed, so this tree would poison the shared node_modules cache. Re-run a fresh `npm ci` (e.g. after bumping build/.cachesalt) to restore the package before the cache is saved.');
+		console.error('\nnpm does not fail when an optional dependency cannot be installed, so a fresh install or restored cache can be incomplete. Re-run a fresh `npm ci` (e.g. after bumping build/.cachesalt) to restore the missing package.');
 		process.exit(1);
 	}
 

--- a/build/azure-pipelines/copilot/setup-steps.yml
+++ b/build/azure-pipelines/copilot/setup-steps.yml
@@ -83,6 +83,10 @@ steps:
     displayName: Install vscode-capi dependencies
     condition: and(succeeded(), ne(variables.BUILD_CACHE_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+    workingDirectory: $(Build.SourcesDirectory)
+    displayName: Verify native optional dependency binaries
+
   - script: |
       set -e
       mkdir -p .build

--- a/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
@@ -102,6 +102,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts darwin $(VSCODE_ARCH)
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -112,6 +112,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts darwin $(VSCODE_ARCH)
+    displayName: Verify native optional dependency binaries
+
   - script: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules

--- a/build/azure-pipelines/linux/product-build-linux-node-modules.yml
+++ b/build/azure-pipelines/linux/product-build-linux-node-modules.yml
@@ -142,6 +142,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -159,6 +159,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+    displayName: Verify native optional dependency binaries
+
   - script: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -104,6 +104,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/web/product-build-web-node-modules.yml
+++ b/build/azure-pipelines/web/product-build-web-node-modules.yml
@@ -79,6 +79,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -93,6 +93,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/win32/product-build-win32-node-modules.yml
+++ b/build/azure-pipelines/win32/product-build-win32-node-modules.yml
@@ -85,6 +85,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts win32 $(VSCODE_ARCH)
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - powershell: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -100,6 +100,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts win32 $(VSCODE_ARCH)
+    displayName: Verify native optional dependency binaries
+
   - powershell: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules


### PR DESCRIPTION
## Summary

- verify Codex and Claude native optional-dependency packages after Azure node_modules restoration or installation
- cover product compile, cache-builder, quality, web, Alpine, and Copilot cache paths
- support explicit target platform and architecture arguments for cross-architecture cache builds

## Root cause

Build 461711 restored an Azure Pipelines `Cache@2` node_modules archive and skipped `npm ci`. The existing root-cache guard was wired into the separate GitHub Actions cache workflow, while #324255 protected Agent SDK scratch installs. As a result, the Azure product-build cache path never invoked the check.

The poisoned cache was subsequently invalidated by #329299. These changes prevent another incomplete cache from being consumed or saved.

## Validation

- `npm run typecheck --prefix build`
- `npm test --prefix build` (261 tests)
- `node --experimental-strip-types build/hygiene.ts <changed files>`
- parsed all changed Azure YAML files
- simulated a missing `@openai/codex-win32-x64` optional package