### PR TITLE
sessions: Preserve single-pane resize proportions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -72,15 +72,17 @@ Editor-content overlays must use the editor pane container rather than the edito
 
 The workbench grid is built with `proportionalLayout: false` (see `createWorkbenchLayout()` in [browser/workbench.ts](src/vs/sessions/browser/workbench.ts)). In this mode the split views do **not** distribute resize deltas proportionally — instead each delta (window resize, or a part being shown/hidden) is absorbed by the highest-`LayoutPriority` view, while the others keep their established sizes. Each part therefore declares an explicit `priority`:
 
-The single-pane layout preserves the established Sessions/Editor ratio when the outer container dimensions change, after the non-proportional grid has laid out its fixed Sidebar and panel. This keeps the two primary horizontal surfaces balanced without allowing the Sidebar or docked Details width to drift; minimum-width constraints still take precedence when the available width is insufficient.
+The single-pane layout preserves the established Sessions/Editor ratio when the outer container dimensions change and the actual Editor area is visible, after the non-proportional grid has laid out its fixed Sidebar and panel. This keeps the two primary horizontal surfaces balanced without allowing the Sidebar or docked Details width to drift; minimum-width constraints still take precedence when the available width is insufficient.
+
+The shared editor grid node is also visible in Details-only layouts because it hosts the docked Auxiliary Bar. Grid-node visibility must not be treated as Editor visibility when deciding whether to preserve the Sessions/Editor ratio, or a container resize will incorrectly resize the user's Details width.
 
 Sidebar visibility is intentionally excluded from that proportional adjustment. The Sessions Part is the high-priority view, so collapsing the Sessions list gives all freed width to the Sessions Part while the Editor and docked Details retain their user-set widths; showing the list takes that width back from Sessions.
 
 | Part | `LayoutPriority` | Width behaviour |
 |------|------------------|-----------------|
 | Sidebar | `Low` | Fixed user-set width; never absorbs deltas. `minimumWidth` 170 (270 web), `maximumWidth` ∞, snaps closed below the minimum. |
-| Sessions Part | **`High`** | The single flexible view — grows/shrinks to absorb every horizontal delta. `minimumWidth` 300, `maximumWidth` ∞. |
-| Editor | `Normal` | Keeps its user-set width (`600` default); only resized via its own sash. |
+| Sessions Part | **`High`** | Absorbs horizontal deltas in the non-proportional grid. In single-pane, an outer-container resize is post-adjusted to preserve its ratio with a visible Editor. `minimumWidth` 300, `maximumWidth` ∞. |
+| Editor | `Normal` | Normally keeps its user-set width (`600` default) and responds to its sash. In single-pane, an outer-container resize also adjusts it proportionally while the actual Editor area is visible. |
 | Auxiliary Bar | `Low` | Keeps its user-set width (`340` default); only resized via its own sash. |
 | Custom View Grid | **`High`** | Claims the whole row. Never visible at the same time as the Sessions Part, so the "exactly one `High` view" invariant below still holds. |
 

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -72,6 +72,10 @@ Editor-content overlays must use the editor pane container rather than the edito
 
 The workbench grid is built with `proportionalLayout: false` (see `createWorkbenchLayout()` in [browser/workbench.ts](src/vs/sessions/browser/workbench.ts)). In this mode the split views do **not** distribute resize deltas proportionally — instead each delta (window resize, or a part being shown/hidden) is absorbed by the highest-`LayoutPriority` view, while the others keep their established sizes. Each part therefore declares an explicit `priority`:
 
+The single-pane layout preserves the established Sessions/Editor ratio when the outer container dimensions change, after the non-proportional grid has laid out its fixed Sidebar and panel. This keeps the two primary horizontal surfaces balanced without allowing the Sidebar or docked Details width to drift; minimum-width constraints still take precedence when the available width is insufficient.
+
+Sidebar visibility is intentionally excluded from that proportional adjustment. The Sessions Part is the high-priority view, so collapsing the Sessions list gives all freed width to the Sessions Part while the Editor and docked Details retain their user-set widths; showing the list takes that width back from Sessions.
+
 | Part | `LayoutPriority` | Width behaviour |
 |------|------------------|-----------------|
 | Sidebar | `Low` | Fixed user-set width; never absorbs deltas. `minimumWidth` 170 (270 web), `maximumWidth` ∞, snaps closed below the minimum. |

--- a/src/vs/sessions/browser/singlePaneWorkbench.ts
+++ b/src/vs/sessions/browser/singlePaneWorkbench.ts
@@ -12,31 +12,14 @@ import { DockedEditorInput } from '../common/dockedEditorInput.js';
 import { DockedAuxiliaryBarController } from './dockedAuxiliaryBarController.js';
 import { SinglePaneMainEditorPart } from './parts/singlePaneEditorPart.js';
 import { EDITOR_PART_MINIMUM_WIDTH } from './parts/editorPartSizing.js';
-import { ISideBarResizeContext, Workbench } from './workbench.js';
-
-interface IDockedSideBarResizeContext extends ISideBarResizeContext {
-	readonly freedSideBarWidth: number;
-	readonly editorSizeBeforeSideBarHide: IViewSize | undefined;
-	readonly detailWidthBeforeSideBarHide: number | undefined;
-}
+import { Workbench } from './workbench.js';
 
 /**
- * Remembers editor/detail widths captured around visibility and sidebar-collapse
- * transitions so the docked side pane restores the user's chosen sizes.
+ * Remembers the editor width captured around visibility transitions.
  */
 export class DockedEditorSizeMemento {
 	/** Editor node size captured when "Hide Editor" is used with the detail still visible. */
 	dockedEditorSizeBeforeHide: IViewSize | undefined;
-	/** Editor node size grown while the sidebar is collapsed (editor content visible). */
-	editorSizeGrownForSidebarHide: IViewSize | undefined;
-	/** Detail-panel width grown while the sidebar is collapsed (editor content hidden). */
-	detailWidthGrownForSidebarHide: number | undefined;
-
-	/** Drop the sidebar-collapse snapshots, e.g. once the node returns to the detail width. */
-	clearSidebarGrowSnapshots(): void {
-		this.editorSizeGrownForSidebarHide = undefined;
-		this.detailWidthGrownForSidebarHide = undefined;
-	}
 }
 
 /**
@@ -166,7 +149,7 @@ export class SinglePaneWorkbench extends Workbench {
 		// The docked auxiliary bar is not a grid view (it lives inside the editor
 		// node), so its width comes from the docked layout state, not the grid.
 		if (view === this.auxiliaryBarPartView) {
-			return this._memento.detailWidthGrownForSidebarHide ?? this._dockedAuxiliaryBarWidth;
+			return this._dockedAuxiliaryBarWidth;
 		}
 		return super._persistedGridViewSize(view, dimension, visible);
 	}
@@ -202,6 +185,50 @@ export class SinglePaneWorkbench extends Workbench {
 
 	protected override _layoutSidePane(): void {
 		this._layoutDockedAuxBar();
+	}
+
+	protected override _layoutGrid(): void {
+		const sessionsSize = this.workbenchGrid.getViewSize(this.sessionsPartView);
+		const editorSize = this.workbenchGrid.getViewSize(this.editorPartView);
+		const preserveRatio = this.workbenchGrid.isViewVisible(this.sessionsPartView)
+			&& this.workbenchGrid.isViewVisible(this.editorPartView)
+			&& sessionsSize.width > 0
+			&& editorSize.width > 0;
+
+		super._layoutGrid();
+
+		if (preserveRatio) {
+			this._preserveSessionsEditorRatio(sessionsSize.width, editorSize.width);
+		}
+	}
+
+	private _preserveSessionsEditorRatio(previousSessionsWidth: number, previousEditorWidth: number): void {
+		const sessionsSize = this.workbenchGrid.getViewSize(this.sessionsPartView);
+		const editorSize = this.workbenchGrid.getViewSize(this.editorPartView);
+		const previousTotalWidth = previousSessionsWidth + previousEditorWidth;
+		const totalWidth = sessionsSize.width + editorSize.width;
+		if (totalWidth === previousTotalWidth) {
+			return;
+		}
+
+		const minimumEditorWidth = this._minimumPartWidthForActivation(this.editorPartView);
+		const maximumEditorWidth = totalWidth - this._minimumPartWidthForActivation(this.sessionsPartView);
+		if (maximumEditorWidth < minimumEditorWidth) {
+			return;
+		}
+
+		const proportionalEditorWidth = Math.round(totalWidth * previousEditorWidth / previousTotalWidth);
+		const targetEditorWidth = Math.min(maximumEditorWidth, Math.max(minimumEditorWidth, proportionalEditorWidth));
+		if (targetEditorWidth === editorSize.width) {
+			return;
+		}
+
+		this._runWithEditorResizeSyncSuspended(() => {
+			this.workbenchGrid.resizeView(this.editorPartView, {
+				width: targetEditorWidth,
+				height: editorSize.height
+			});
+		});
 	}
 
 	protected override _applyEditorAreaVisibility(): void {
@@ -265,7 +292,6 @@ export class SinglePaneWorkbench extends Workbench {
 				this.partVisibility.editor = false;
 				this._setMainEditorAreaHidden(true);
 				this._editorRevealedExplicitly = false;
-				this._memento.clearSidebarGrowSnapshots();
 				this._layoutDockedAuxBar();
 				this._fireDidChangePartVisibility(Parts.EDITOR_PART, false);
 				this._savePartVisibility();
@@ -324,10 +350,8 @@ export class SinglePaneWorkbench extends Workbench {
 					width: this._dockedAuxiliaryBarWidth,
 					height: this._memento.dockedEditorSizeBeforeHide.height
 				});
-				this._memento.clearSidebarGrowSnapshots();
 			} else {
 				this._memento.dockedEditorSizeBeforeHide = undefined;
-				this._memento.clearSidebarGrowSnapshots();
 			}
 		} else if (dockedEditorSizeBeforeHide) {
 			this.workbenchGrid.resizeView(this.editorPartView, dockedEditorSizeBeforeHide);
@@ -426,62 +450,4 @@ export class SinglePaneWorkbench extends Workbench {
 		}
 	}
 
-	protected override _prepareSideBarResize(hidden: boolean): ISideBarResizeContext {
-		const shouldResize = this.partVisibility.editor || this.partVisibility.auxiliaryBar;
-		// Grow the editor node when the editor is visible, else the detail (keeps node == detail width so reveal-sync can't misfire).
-		const growEditorNode = shouldResize && this.partVisibility.editor;
-		const growDetailPanel = shouldResize && !this.partVisibility.editor;
-		return {
-			freedSideBarWidth: hidden && shouldResize ? this.workbenchGrid.getViewSize(this.sideBarPartView).width : 0,
-			editorSizeBeforeSideBarHide: hidden && growEditorNode ? this.workbenchGrid.getViewSize(this.editorPartView) : undefined,
-			detailWidthBeforeSideBarHide: hidden && growDetailPanel ? this._dockedAuxiliaryBarWidth : undefined,
-		} satisfies IDockedSideBarResizeContext;
-	}
-
-	protected override _applySideBarResize(hidden: boolean, context: ISideBarResizeContext): void {
-		const { freedSideBarWidth, editorSizeBeforeSideBarHide, detailWidthBeforeSideBarHide } = context as IDockedSideBarResizeContext;
-
-		if (editorSizeBeforeSideBarHide) {
-			this._memento.editorSizeGrownForSidebarHide = editorSizeBeforeSideBarHide;
-			this._resizeEditorAfterSidebarChange({
-				width: editorSizeBeforeSideBarHide.width + freedSideBarWidth,
-				height: editorSizeBeforeSideBarHide.height
-			});
-		} else if (detailWidthBeforeSideBarHide !== undefined) {
-			this._memento.detailWidthGrownForSidebarHide = detailWidthBeforeSideBarHide;
-			this._growDetailAfterSidebarChange(detailWidthBeforeSideBarHide + freedSideBarWidth);
-		} else if (!hidden && this._memento.editorSizeGrownForSidebarHide) {
-			this._resizeEditorAfterSidebarChange(this._memento.editorSizeGrownForSidebarHide);
-			this._memento.editorSizeGrownForSidebarHide = undefined;
-		} else if (!hidden && this._memento.detailWidthGrownForSidebarHide !== undefined) {
-			this._growDetailAfterSidebarChange(this._memento.detailWidthGrownForSidebarHide);
-			this._memento.detailWidthGrownForSidebarHide = undefined;
-		} else if (!hidden) {
-			this._memento.clearSidebarGrowSnapshots();
-		}
-	}
-
-	private _resizeEditorAfterSidebarChange(size: IViewSize): void {
-		this._syncingEditorVisibility = true;
-		try {
-			this.workbenchGrid.resizeView(this.editorPartView, size);
-		} finally {
-			this._syncingEditorVisibility = false;
-		}
-		this._layoutDockedAuxBar();
-	}
-
-	private _growDetailAfterSidebarChange(width: number): void {
-		this._dockedAuxiliaryBarWidth = Math.max(DockedAuxiliaryBarController.MIN_WIDTH, width);
-		this._syncingEditorVisibility = true;
-		try {
-			this.workbenchGrid.resizeView(this.editorPartView, {
-				width: this._dockedAuxiliaryBarWidth,
-				height: this.workbenchGrid.getViewSize(this.editorPartView).height
-			});
-		} finally {
-			this._syncingEditorVisibility = false;
-		}
-		this._layoutDockedAuxBar();
-	}
 }

--- a/src/vs/sessions/browser/singlePaneWorkbench.ts
+++ b/src/vs/sessions/browser/singlePaneWorkbench.ts
@@ -190,7 +190,8 @@ export class SinglePaneWorkbench extends Workbench {
 	protected override _layoutGrid(): void {
 		const sessionsSize = this.workbenchGrid.getViewSize(this.sessionsPartView);
 		const editorSize = this.workbenchGrid.getViewSize(this.editorPartView);
-		const preserveRatio = this.workbenchGrid.isViewVisible(this.sessionsPartView)
+		const preserveRatio = this.partVisibility.editor
+			&& this.workbenchGrid.isViewVisible(this.sessionsPartView)
 			&& this.workbenchGrid.isViewVisible(this.editorPartView)
 			&& sessionsSize.width > 0
 			&& editorSize.width > 0;

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -1872,7 +1872,7 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		this.handleContainerDidLayout(this.mainContainer, this._mainContainerDimension);
 	}
 
-	private _layoutGrid(): void {
+	protected _layoutGrid(): void {
 		const mobileTopBarHeight = this.mobileTopBarElement?.offsetHeight ?? 0;
 		// Keep in sync with the desktop grid margin in workbench.css.
 		const isPhone = this.layoutPolicy.viewportClass.get() === 'phone';

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -61,6 +61,7 @@ suite('Sessions - Workbench', () => {
 	const toggleSecondarySideBar = Workbench.prototype.toggleSecondarySideBar as (this: ITestWorkbench) => void;
 	const restoreSessionsPartOnActivation = Reflect.get(Workbench.prototype, '_restoreSessionsPartOnActivation') as (this: ITestWorkbench) => void;
 	const restoreEditorPartOnActivation = Reflect.get(Workbench.prototype, '_restoreEditorPartOnActivation') as (this: ITestWorkbench) => void;
+	const layoutSinglePaneGrid = Reflect.get(SinglePaneWorkbench.prototype, '_layoutGrid') as (this: IContainerResizeTestHarness) => void;
 	const preserveSessionsEditorRatio = Reflect.get(SinglePaneWorkbench.prototype, '_preserveSessionsEditorRatio') as (this: IProportionalResizeTestHarness, previousSessionsWidth: number, previousEditorWidth: number) => void;
 
 	// --- Harness ------------------------------------------------------------
@@ -122,6 +123,17 @@ suite('Sessions - Workbench', () => {
 			resizeView(view: object, size: IViewSize): void;
 		};
 		_runWithEditorResizeSyncSuspended(fn: () => void): void;
+	}
+
+	interface IContainerResizeTestHarness extends IProportionalResizeTestHarness {
+		partVisibility: { sidebar: boolean; editor: boolean; auxiliaryBar: boolean };
+		mobileTopBarElement: undefined;
+		layoutPolicy: { viewportClass: { get(): string } };
+		_mainContainerDimension: IViewSize;
+		workbenchGrid: IProportionalResizeTestHarness['workbenchGrid'] & {
+			isViewVisible(view: object): boolean;
+			layout(width: number, height: number): void;
+		};
 	}
 
 	interface ISavePartSizesTestHarness {
@@ -595,6 +607,44 @@ suite('Sessions - Workbench', () => {
 			sessions: { width: 750, height: 700 },
 			editor: { width: 750, height: 700 },
 			resizes: [{ width: 750, height: 700 }],
+		});
+	});
+
+	test('single-pane detail-only container resize preserves the detail width', () => {
+		const sessionsPartView = { minimumWidth: 300 };
+		const editorPartView = { minimumWidth: 300 };
+		const sizes = new Map<object, IViewSize>([
+			[sessionsPartView, { width: 900, height: 700 }],
+			[editorPartView, { width: 300, height: 700 }],
+		]);
+		const resizes: IViewSize[] = [];
+		const host: IContainerResizeTestHarness = {
+			partVisibility: { sidebar: true, editor: false, auxiliaryBar: true },
+			mobileTopBarElement: undefined,
+			layoutPolicy: { viewportClass: { get: () => 'desktop' } },
+			_mainContainerDimension: { width: 1800, height: 800 },
+			sessionsPartView,
+			editorPartView,
+			workbenchGrid: {
+				getViewSize: view => sizes.get(view)!,
+				isViewVisible: () => true,
+				layout: () => sizes.set(sessionsPartView, { width: 1200, height: 700 }),
+				resizeView: (_view, size) => resizes.push(size),
+			},
+			_runWithEditorResizeSyncSuspended: fn => fn(),
+		};
+		Object.setPrototypeOf(host, SinglePaneWorkbench.prototype);
+
+		layoutSinglePaneGrid.call(host);
+
+		assert.deepStrictEqual({
+			sessions: sizes.get(sessionsPartView),
+			detail: sizes.get(editorPartView),
+			resizes,
+		}, {
+			sessions: { width: 1200, height: 700 },
+			detail: { width: 300, height: 700 },
+			resizes: [],
 		});
 	});
 

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -39,7 +39,6 @@ suite('Sessions - Workbench', () => {
 	const onEditorNodeResized = Reflect.get(SinglePaneWorkbench.prototype, '_onEditorNodeResized') as (this: ITestWorkbench, nodeWidth: number) => void;
 	const onGridDidChange = Reflect.get(SinglePaneWorkbench.prototype, '_onGridDidChange') as (this: ITestWorkbench) => void;
 	const onEditorPartGridVisibilityChange = Reflect.get(SinglePaneWorkbench.prototype, '_onEditorPartGridVisibilityChange') as (this: ITestWorkbench, visible: boolean) => void;
-	const persistedAuxiliaryBarWidth = Reflect.get(SinglePaneWorkbench.prototype, '_persistedGridViewSize') as (this: ITestWorkbench, view: object, dimension: 'width' | 'height', visible: boolean) => number | undefined;
 	const persistedEditorWidth = Reflect.get(SinglePaneWorkbench.prototype, '_persistedEditorWidth') as (this: ITestWorkbench, editorGridWidth: number | undefined) => number | undefined;
 	const rememberAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'rememberAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
 	const restoreAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'restoreAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
@@ -62,6 +61,7 @@ suite('Sessions - Workbench', () => {
 	const toggleSecondarySideBar = Workbench.prototype.toggleSecondarySideBar as (this: ITestWorkbench) => void;
 	const restoreSessionsPartOnActivation = Reflect.get(Workbench.prototype, '_restoreSessionsPartOnActivation') as (this: ITestWorkbench) => void;
 	const restoreEditorPartOnActivation = Reflect.get(Workbench.prototype, '_restoreEditorPartOnActivation') as (this: ITestWorkbench) => void;
+	const preserveSessionsEditorRatio = Reflect.get(SinglePaneWorkbench.prototype, '_preserveSessionsEditorRatio') as (this: IProportionalResizeTestHarness, previousSessionsWidth: number, previousEditorWidth: number) => void;
 
 	// --- Harness ------------------------------------------------------------
 
@@ -95,6 +95,10 @@ suite('Sessions - Workbench', () => {
 		panelPartView: object;
 		customViewGridPartView: object;
 		editorPartView: object;
+		workbenchGrid: {
+			getViewSize(view: object): IViewSize;
+			isViewVisible(view: object): boolean;
+		};
 		setEditorHidden(hidden: boolean, explicit?: boolean): void;
 		setAuxiliaryBarHidden(hidden: boolean): void;
 		setEditorMaximized(maximized: boolean): void;
@@ -107,6 +111,17 @@ suite('Sessions - Workbench', () => {
 			viewportClass: { get(): string };
 		};
 		titleBarPartView: { minimumHeight: number };
+	}
+
+	interface IProportionalResizeTestHarness {
+		partVisibility: { auxiliaryBar: boolean };
+		sessionsPartView: { minimumWidth: number };
+		editorPartView: { minimumWidth: number };
+		workbenchGrid: {
+			getViewSize(view: object): IViewSize;
+			resizeView(view: object, size: IViewSize): void;
+		};
+		_runWithEditorResizeSyncSuspended(fn: () => void): void;
 	}
 
 	interface ISavePartSizesTestHarness {
@@ -170,6 +185,7 @@ suite('Sessions - Workbench', () => {
 		const sidePaneToggleEvents: ('will' | { did: ISidePaneToggleEvent })[] = [];
 		const notifyPartVisibility = (view: object, visible: boolean) => notifyPartVisibilityOn(host as unknown as ITestWorkbench, view, visible);
 		let editorNodeVisible = (options.partVisibility?.editor ?? false) || (options.partVisibility?.auxiliaryBar ?? true);
+		let sideBarNodeVisible = options.partVisibility?.sidebar ?? true;
 		const viewSizes = new Map<object, IViewSize>([
 			[editorPartView, { width: options.editorWidth ?? 0, height: 800 }],
 			[sessionsPartView, { width: options.sessionsWidth ?? 1000, height: 800 }],
@@ -198,6 +214,14 @@ suite('Sessions - Workbench', () => {
 				setViewVisible: (view: object, visible: boolean, sizing?: { type: string }) => {
 					if (view === editorPartView) {
 						editorNodeVisible = visible;
+					} else if (view === sideBarPartView && sideBarNodeVisible !== visible) {
+						const sideBarWidth = viewSizes.get(sideBarPartView)!.width;
+						const sessionsSize = viewSizes.get(sessionsPartView)!;
+						viewSizes.set(sessionsPartView, {
+							width: sessionsSize.width + (visible ? -sideBarWidth : sideBarWidth),
+							height: sessionsSize.height,
+						});
+						sideBarNodeVisible = visible;
 					}
 					gridVisibility.set(view, visible);
 					visibilityChanges.push(visible);
@@ -452,27 +476,32 @@ suite('Sessions - Workbench', () => {
 		});
 	});
 
-	test('docked sidebar hide grows the editor by the freed sidebar width and show restores it', () => {
+	test('single-pane sidebar visibility leaves the editor width unchanged', () => {
 		const host = createHost({ single: true, sideBarWidth: 280, editorWidth: 620, partVisibility: { sidebar: true, editor: true, auxiliaryBar: true } });
 
 		setSideBarHidden.call(host, true);
+		const widthsAfterHide = {
+			sessions: host.workbenchGrid.getViewSize(host.sessionsPartView).width,
+			editor: host.workbenchGrid.getViewSize(host.editorPartView).width,
+		};
 		setSideBarHidden.call(host, false);
 
 		assert.deepStrictEqual({
 			sidebarVisible: host.partVisibility.sidebar,
 			visibilityChanges: host.visibilityChanges,
+			widthsAfterHide,
+			sessionsWidth: host.workbenchGrid.getViewSize(host.sessionsPartView).width,
+			editorWidth: host.workbenchGrid.getViewSize(host.editorPartView).width,
 			resizes: host.resizes,
 			layoutCount: host.counts.layout,
-			snapshot: host._memento.editorSizeGrownForSidebarHide,
 		}, {
 			sidebarVisible: true,
 			visibilityChanges: [false, true],
-			resizes: [
-				{ width: 900, height: 800 },
-				{ width: 620, height: 800 },
-			],
-			layoutCount: 2,
-			snapshot: undefined,
+			widthsAfterHide: { sessions: 1280, editor: 620 },
+			sessionsWidth: 1000,
+			editorWidth: 620,
+			resizes: [],
+			layoutCount: 0,
 		});
 	});
 
@@ -492,43 +521,22 @@ suite('Sessions - Workbench', () => {
 		});
 	});
 
-	test('docked sidebar hide grows the detail panel (not the editor node) when the editor is hidden and show restores it', () => {
+	test('single-pane sidebar visibility leaves a detail-only pane width unchanged', () => {
 		const host = createHost({ single: true, sideBarWidth: 280, editorWidth: 620, dockedWidth: 300, partVisibility: { sidebar: true, editor: false, auxiliaryBar: true } });
 
 		setSideBarHidden.call(host, true);
-		const afterHide = {
-			editorVisible: host.partVisibility.editor,
-			detailWidth: host._dockedAuxiliaryBarWidth,
-			resizes: [...host.resizes],
-			detailSnapshot: host._memento.detailWidthGrownForSidebarHide,
-			editorSnapshot: host._memento.editorSizeGrownForSidebarHide,
-		};
-
 		setSideBarHidden.call(host, false);
 
 		assert.deepStrictEqual({
-			afterHide,
 			editorVisible: host.partVisibility.editor,
 			detailWidth: host._dockedAuxiliaryBarWidth,
 			resizes: host.resizes,
-			detailSnapshot: host._memento.detailWidthGrownForSidebarHide,
 			layoutCount: host.counts.layout,
 		}, {
-			afterHide: {
-				editorVisible: false,
-				detailWidth: 580,
-				resizes: [{ width: 580, height: 800 }],
-				detailSnapshot: 300,
-				editorSnapshot: undefined,
-			},
 			editorVisible: false,
 			detailWidth: 300,
-			resizes: [
-				{ width: 580, height: 800 },
-				{ width: 300, height: 800 },
-			],
-			detailSnapshot: undefined,
-			layoutCount: 2,
+			resizes: [],
+			layoutCount: 0,
 		});
 	});
 
@@ -547,6 +555,47 @@ suite('Sessions - Workbench', () => {
 		const editorNode = topRightSection.data[1] as { size: number; visible: boolean };
 
 		assert.deepStrictEqual({ size: editorNode.size, visible: editorNode.visible }, { size: 300, visible: true });
+	});
+
+	test('single-pane container resize preserves the sessions/editor ratio', () => {
+		const sessionsPartView = { minimumWidth: 300 };
+		const editorPartView = { minimumWidth: 300 };
+		const sizes = new Map<object, IViewSize>([
+			[sessionsPartView, { width: 900, height: 700 }],
+			[editorPartView, { width: 600, height: 700 }],
+		]);
+		const resizes: IViewSize[] = [];
+		const host: IProportionalResizeTestHarness = {
+			partVisibility: { auxiliaryBar: false },
+			sessionsPartView,
+			editorPartView,
+			workbenchGrid: {
+				getViewSize: view => sizes.get(view)!,
+				resizeView: (view, size) => {
+					const previousEditorWidth = sizes.get(view)!.width;
+					resizes.push(size);
+					sizes.set(view, size);
+					sizes.set(sessionsPartView, {
+						width: sizes.get(sessionsPartView)!.width - (size.width - previousEditorWidth),
+						height: size.height,
+					});
+				},
+			},
+			_runWithEditorResizeSyncSuspended: fn => fn(),
+		};
+		Object.setPrototypeOf(host, SinglePaneWorkbench.prototype);
+
+		preserveSessionsEditorRatio.call(host, 600, 600);
+
+		assert.deepStrictEqual({
+			sessions: sizes.get(sessionsPartView),
+			editor: sizes.get(editorPartView),
+			resizes,
+		}, {
+			sessions: { width: 750, height: 700 },
+			editor: { width: 750, height: 700 },
+			resizes: [{ width: 750, height: 700 }],
+		});
 	});
 
 	test('single-pane descriptor retains a persisted detail-only width below the default', () => {
@@ -752,13 +801,6 @@ suite('Sessions - Workbench', () => {
 		});
 	});
 
-	test('persists the user detail width instead of a temporary sidebar-collapse grow width', () => {
-		const host = createHost({ single: true, dockedWidth: 580 });
-		host._memento.detailWidthGrownForSidebarHide = 300;
-
-		assert.strictEqual(persistedAuxiliaryBarWidth.call(host, host.auxiliaryBarPartView, 'width', false), 300);
-	});
-
 	test('persisted editor width excludes the detail only when the detail is visible', () => {
 		// Editor + detail visible: the node includes the detail, so it is excluded
 		// to store the pure editor-content width (reconstructed by adding it back).
@@ -921,27 +963,6 @@ suite('Sessions - Workbench', () => {
 		setEditorHidden.call(host, true);
 
 		assert.deepStrictEqual(host.resizes, [{ width: 220, height: 800 }]);
-	});
-
-	test('clears stale sidebar-grow snapshots when hiding the editor with the detail visible', () => {
-		const host = createHost({ single: true, sessionsWidth: 1000, hasAppliedInitialEditorSplit: true, dockedWidth: 320, editorWidth: 900, partVisibility: { editor: true, auxiliaryBar: true } });
-		// Captured while the editor was visible and the sessions list was hidden.
-		host._memento.editorSizeGrownForSidebarHide = { width: 900, height: 800 };
-		host._memento.detailWidthGrownForSidebarHide = 500;
-
-		setEditorHidden.call(host, true);
-
-		assert.deepStrictEqual({
-			editorVisible: host.partVisibility.editor,
-			resizes: host.resizes,
-			editorSizeGrownForSidebarHide: host._memento.editorSizeGrownForSidebarHide,
-			detailWidthGrownForSidebarHide: host._memento.detailWidthGrownForSidebarHide,
-		}, {
-			editorVisible: false,
-			resizes: [{ width: 320, height: 800 }],
-			editorSizeGrownForSidebarHide: undefined,
-			detailWidthGrownForSidebarHide: undefined,
-		});
 	});
 
 	// --- [Scenario 5] editor auto-reveal on open ---------------------------
@@ -1242,21 +1263,12 @@ suite('Sessions - Workbench', () => {
 		});
 	});
 
-	test('reopening the whole side pane while the sidebar is collapsed even-splits instead of restoring a cramped width', () => {
-		// Simulates toggle-close order (auxiliary bar already hidden, editor about
-		// to hide) while the sidebar is collapsed: the editor grid node collapses to
-		// a tiny width and a stale sidebar-grow snapshot is present. Closing must not
-		// capture the collapsed width, and must clear the stale snapshots so the
-		// reopen applies a comfortable even split of the wide main area.
+	test('reopening the whole side pane even-splits instead of restoring a cramped width', () => {
 		const host = createHost({ single: true, sessionsWidth: 1360, windowWidth: 1360, hasAppliedInitialEditorSplit: true, dockedWidth: 300, editorWidth: 40, partVisibility: { editor: true, auxiliaryBar: false } });
-		host._memento.editorSizeGrownForSidebarHide = { width: 620, height: 800 };
-		host._memento.detailWidthGrownForSidebarHide = 300;
 
 		setEditorHidden.call(host, true);
 		const afterClose = {
 			snapshot: host._memento.dockedEditorSizeBeforeHide,
-			grownEditor: host._memento.editorSizeGrownForSidebarHide,
-			grownDetail: host._memento.detailWidthGrownForSidebarHide,
 			resizes: [...host.resizes],
 		};
 
@@ -1270,8 +1282,6 @@ suite('Sessions - Workbench', () => {
 		}, {
 			afterClose: {
 				snapshot: undefined,
-				grownEditor: undefined,
-				grownDetail: undefined,
 				resizes: [],
 			},
 			editorVisible: true,
@@ -1488,8 +1498,6 @@ suite('Sessions - Workbench', () => {
 
 	test('keeps editor resize state when the outer sash hides details before collapsing the editor', () => {
 		const host = createHost({ single: true, sessionsWidth: 1000, dockedWidth: 300, editorWidth: 600, partVisibility: { editor: true, auxiliaryBar: true } });
-		host._memento.editorSizeGrownForSidebarHide = { width: 800, height: 600 };
-		host._memento.detailWidthGrownForSidebarHide = 400;
 		host._editorRevealedExplicitly = true;
 
 		onEditorNodeResized.call(host, 300);
@@ -1497,14 +1505,10 @@ suite('Sessions - Workbench', () => {
 		assert.deepStrictEqual({
 			editorVisible: host.partVisibility.editor,
 			detailVisible: host.partVisibility.auxiliaryBar,
-			editorSizeGrownForSidebarHide: host._memento.editorSizeGrownForSidebarHide,
-			detailWidthGrownForSidebarHide: host._memento.detailWidthGrownForSidebarHide,
 			editorRevealedExplicitly: host._editorRevealedExplicitly,
 		}, {
 			editorVisible: true,
 			detailVisible: false,
-			editorSizeGrownForSidebarHide: { width: 800, height: 600 },
-			detailWidthGrownForSidebarHide: 400,
 			editorRevealedExplicitly: true,
 		});
 	});


### PR DESCRIPTION
## Summary

- preserve the Sessions/Editor width ratio when the single-pane window is resized
- keep the Editor and docked Details widths stable when the Sessions list sidebar is collapsed
- remove obsolete sidebar-collapse editor/detail growth bookkeeping
- add focused layout regression coverage and update the layout specification

## Validation

- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/sessions/test/browser/workbench.test.ts` (86 passing)