### PR TITLE
sessions: hide changes action for new sessions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -114,7 +114,7 @@ The titlebar is a standalone implementation (`TitlebarPart`) — not extending `
 |---------|---------|---------|
 | Left | `Menus.TitleBarLeftLayout` | Toggle sidebar, new session (when sidebar hidden, A/B experiment), agent host filter |
 | Center | `Menus.CommandCenter` | Session picker widget |
-| Right | `Menus.TitleBarSessionMenu`, `Menus.TitleBarRightLayout`, `Menus.TitleBarUpdate` | Active-session actions (including Create Pull Request), remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget, and the rightmost Update indicator |
+| Right | `Menus.TitleBarSessionMenu`, `Menus.TitleBarRightLayout`, `Menus.TitleBarUpdate` | Active-session actions (including Create Pull Request for created sessions with changes), remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget, and the rightmost Update indicator |
 
 No menubar or `WindowTitle` dependency. Editor-specific actions remain in the editor header, while session-level actions are placed on the right of the title bar.
 

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -24,7 +24,7 @@ import { IChangesViewService } from '../common/changesViewService.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionChangesEditor } from './sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from './changesView.js';
-import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
+import { SessionHasChangesContext, SessionIsCreatedContext, SinglePaneLayoutEnabledContext } from '../../../common/contextkeys.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { TOGGLE_DIFF_SIDE_BY_SIDE } from '../../../../workbench/browser/parts/editor/diffEditorCommands.js';
 import { logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
@@ -155,6 +155,7 @@ class ChangesHeaderActionsAction extends Action2 {
 					IsSessionsWindowContext,
 					IsAuxiliaryWindowContext.toNegated(),
 					SinglePaneLayoutEnabledContext,
+					SessionIsCreatedContext,
 					SessionHasChangesContext
 				)
 			},

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -13,7 +13,7 @@ import { EditorContextKeys } from '../../../../../editor/common/editorContextKey
 import { ActiveEditorContext, AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, MainEditorAreaVisibleContext } from '../../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../../browser/menus.js';
 import { ChangesContextKeys } from '../../common/changes.js';
-import { SessionHasChangesContext, SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
+import { SessionHasChangesContext, SessionIsCreatedContext, SinglePaneLayoutEnabledContext } from '../../../../common/contextkeys.js';
 import { SessionChangesEditor } from '../../browser/sessionChangesEditor.js';
 import { CHANGES_HEADER_ACTIONS_ID } from '../../browser/changesView.js';
 import '../../browser/changesViewActions.js';
@@ -210,7 +210,7 @@ suite('Changes View Actions', () => {
 		}]);
 	});
 
-	test('Create Pull Request anchor is contributed to the right-side title bar menu', () => {
+	test('Create Pull Request anchor is contributed to the right-side title bar menu for created sessions', () => {
 		const item = MenuRegistry.getMenuItems(Menus.TitleBarSessionMenu)
 			.filter(isIMenuItem)
 			.find(item => item.command.id === CHANGES_HEADER_ACTIONS_ID);
@@ -227,6 +227,7 @@ suite('Changes View Actions', () => {
 			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
 			hasAuxiliaryWindowGate: when.includes(IsAuxiliaryWindowContext.key),
 			hasSinglePaneLayoutGate: when.includes(SinglePaneLayoutEnabledContext.key),
+			hasCreatedSessionGate: when.includes(SessionIsCreatedContext.key),
 			hasChangesGate: when.includes(SessionHasChangesContext.key),
 		}, {
 			editorTitleItem: undefined,
@@ -235,6 +236,7 @@ suite('Changes View Actions', () => {
 			hasSessionsWindowGate: true,
 			hasAuxiliaryWindowGate: true,
 			hasSinglePaneLayoutGate: true,
+			hasCreatedSessionGate: true,
 			hasChangesGate: true,
 		});
 	});


### PR DESCRIPTION
## Summary

- hide the title-bar Changes action while the New Session composer is active
- require a created session in addition to pending changes before contributing the action
- update the layout specification and menu-registration test

## Validation

- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts --grep "Create Pull Request anchor"`