### PR TITLE
chat-lib: remove recursive npm publish lifecycle

### DIFF
--- a/extensions/copilot/chat-lib/package.json
+++ b/extensions/copilot/chat-lib/package.json
@@ -65,7 +65,6 @@
 		"copy": "copyfiles src/package.json \"src/**/*.tiktoken\" dist",
 		"package": "npm pack",
 		"postinstall": "tsx script/postinstall.js",
-		"publish": "npm publish",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	}


### PR DESCRIPTION
## Summary

Remove the `publish` lifecycle script from `@vscode/chat-lib`. npm automatically runs this lifecycle after uploading a package, so defining it as `npm publish` recursively attempts to upload the same immutable version and fails the Azure Artifacts publish task.

Fixes #329365

## Validation

- `npm publish --dry-run --foreground-scripts --tag next --registry=https://registry.npmjs.org` from `extensions/copilot/chat-lib`
- Pre-commit hygiene hook


cc @chrmarti 