### PR TITLE
sessions: fix revealing comments from peer chats

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -412,6 +412,13 @@ included in plan submission, so pre-existing or already-submitted session feedba
 is not resent or cleared. Ownership snapshots include hidden feedback states so a
 pre-existing comment cannot become plan-owned merely by transitioning to accepted.
 
+Agent-host feedback is session-scoped and shared by every peer chat. The feedback
+server tools normalize chat channels to the parent annotations channel, while the
+review-confirmation command bridge resolves the rendered `IChat.resource` through
+`ISessionsManagementService.getSessionForChatResource` before reading or mutating
+feedback. This keeps the unreviewed count, picker contents, and reveal selection on
+the same parent session even when the tool is invoked from an additional chat.
+
 Per-session view state (the last active chat, the set of closed chats, grid
 order, stickiness, and which slot was active) is held in `SessionsService`'s
 `_sessionStates` map and serialized to workspace-scoped machine storage. The

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
@@ -3,12 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { isEqual } from '../../../../base/common/resources.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { Range, type IRange } from '../../../../editor/common/core/range.js';
 import { localize } from '../../../../nls.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ICodeReviewService } from '../../codeReview/browser/codeReviewService.js';
 import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedbackService } from './agentFeedbackService.js';
 
@@ -34,16 +36,22 @@ function kindLabel(kind: AgentFeedbackKind): string | undefined {
 	}
 }
 
+function getOwningSessionResource(sessionsManagementService: ISessionsManagementService, resource: URI): URI {
+	return sessionsManagementService.getSessionForChatResource(resource)?.session.resource ?? resource;
+}
+
 /**
  * Registers the commands the chat `viewUnreviewedComments` confirmation
  * renderer (in `vs/workbench/contrib/chat`) uses to fetch unreviewed comments
  * and apply the user's selection. Keeping the logic here means the chat layer
  * never depends on the `vs/sessions` feedback model.
  */
-export function registerAgentFeedbackReviewCommands(): void {
-	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.GetComments, (accessor, sessionResource: UriComponents): IChatAgentFeedbackReviewComment[] => {
+export function registerAgentFeedbackReviewCommands(): IDisposable {
+	const registrations = new DisposableStore();
+
+	registrations.add(CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.GetComments, (accessor, sessionOrChatResource: UriComponents): IChatAgentFeedbackReviewComment[] => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
-		const resource = URI.revive(sessionResource);
+		const resource = getOwningSessionResource(accessor.get(ISessionsManagementService), URI.revive(sessionOrChatResource));
 		return feedbackService.getFeedback(resource)
 			.filter(item => item.state === AgentFeedbackState.Created && REVIEWABLE_KINDS.has(item.kind))
 			.map(item => ({
@@ -52,14 +60,15 @@ export function registerAgentFeedbackReviewCommands(): void {
 				text: item.text,
 				fileUri: item.resourceUri,
 			}));
-	});
+	}));
 
-	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Reveal, async (accessor, sessionResource: UriComponents, commentId: string): Promise<void> => {
+	registrations.add(CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Reveal, async (accessor, sessionOrChatResource: UriComponents, commentId: string): Promise<void> => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
-		await feedbackService.revealFeedback(URI.revive(sessionResource), commentId);
-	});
+		const resource = getOwningSessionResource(accessor.get(ISessionsManagementService), URI.revive(sessionOrChatResource));
+		await feedbackService.revealFeedback(resource, commentId);
+	}));
 
-	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.RevealAt, async (accessor, resourceUri: string, range: IRange): Promise<void> => {
+	registrations.add(CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.RevealAt, async (accessor, resourceUri: string, range: IRange): Promise<void> => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
 		const resource = URI.parse(resourceUri);
 		// A rendered `addComment` tool call links here without knowing the
@@ -82,12 +91,12 @@ export function registerAgentFeedbackReviewCommands(): void {
 		} else {
 			await feedbackService.revealSessionComment(sessionResource, '', resource, range);
 		}
-	});
+	}));
 
-	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Delete, (accessor, sessionResource: UriComponents, commentId: string): void => {
+	registrations.add(CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Delete, (accessor, sessionOrChatResource: UriComponents, commentId: string): void => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
 		const codeReviewService = accessor.get(ICodeReviewService);
-		const resource = URI.revive(sessionResource);
+		const resource = getOwningSessionResource(accessor.get(ISessionsManagementService), URI.revive(sessionOrChatResource));
 		// Suppress the originating PR comment first (before removing the mirror)
 		// so the PR-review seeder does not immediately re-create the mirror the
 		// user just deleted.
@@ -96,13 +105,15 @@ export function registerAgentFeedbackReviewCommands(): void {
 			codeReviewService.dismissPRReviewComment(resource, item.sourcePRReviewCommentId);
 		}
 		feedbackService.removeFeedback(resource, commentId);
-	});
+	}));
 
-	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Accept, (accessor, sessionResource: UriComponents, commentIds: readonly string[]): void => {
+	registrations.add(CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Accept, (accessor, sessionOrChatResource: UriComponents, commentIds: readonly string[]): void => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
-		const resource = URI.revive(sessionResource);
+		const resource = getOwningSessionResource(accessor.get(ISessionsManagementService), URI.revive(sessionOrChatResource));
 		for (const id of commentIds) {
 			feedbackService.acceptFeedback(resource, id, { revealToAgent: true });
 		}
-	});
+	}));
+
+	return registrations;
 }

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackReviewCommands.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackReviewCommands.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { AgentFeedbackReviewCommandId } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChat, ISession } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ICodeReviewService } from '../../../codeReview/browser/codeReviewService.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedback, IAgentFeedbackService } from '../../browser/agentFeedbackService.js';
+import { registerAgentFeedbackReviewCommands } from '../../browser/agentFeedbackReviewCommands.js';
+
+suite('AgentFeedbackReviewCommands', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('routes peer chat review commands to the owning session and preserves session resources', async () => {
+		const sessionResource = URI.parse('agent-host-copilotcli:/session-1');
+		const peerChatResource = sessionResource.with({ fragment: 'peer-chat-1' });
+		const fileResource = URI.file('/workspace/file.ts');
+		const session = new class extends mock<ISession>() {
+			override readonly resource = sessionResource;
+		}();
+		const chat = new class extends mock<IChat>() {
+			override readonly resource = peerChatResource;
+		}();
+		const feedback: IAgentFeedback = {
+			id: 'comment-1',
+			text: 'Review this',
+			resourceUri: fileResource,
+			range: new Range(3, 1, 3, 5),
+			sessionResource,
+			kind: AgentFeedbackKind.AgentReview,
+			state: AgentFeedbackState.Created,
+		};
+
+		const operations: string[] = [];
+		const feedbackService = new class extends mock<IAgentFeedbackService>() {
+			override getFeedback(resource: URI): readonly IAgentFeedback[] {
+				operations.push(`get:${resource.toString()}`);
+				return [feedback];
+			}
+
+			override async revealFeedback(resource: URI, feedbackId: string): Promise<void> {
+				operations.push(`reveal:${resource.toString()}:${feedbackId}`);
+			}
+
+			override removeFeedback(resource: URI, feedbackId: string): void {
+				operations.push(`remove:${resource.toString()}:${feedbackId}`);
+			}
+
+			override acceptFeedback(resource: URI, feedbackId: string, options?: { readonly revealToAgent?: boolean }): void {
+				operations.push(`accept:${resource.toString()}:${feedbackId}:${options?.revealToAgent === true}`);
+			}
+		}();
+		const sessionsManagementService = new class extends mock<ISessionsManagementService>() {
+			override getSessionForChatResource(resource: URI): { session: ISession; chat: IChat } | undefined {
+				return resource.toString() === peerChatResource.toString() ? { session, chat } : undefined;
+			}
+		}();
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IAgentFeedbackService, feedbackService);
+		instantiationService.stub(ISessionsManagementService, sessionsManagementService);
+		instantiationService.stub(ICodeReviewService, new class extends mock<ICodeReviewService>() { });
+		store.add(registerAgentFeedbackReviewCommands());
+
+		const getComments = CommandsRegistry.getCommand(AgentFeedbackReviewCommandId.GetComments)?.handler;
+		const reveal = CommandsRegistry.getCommand(AgentFeedbackReviewCommandId.Reveal)?.handler;
+		const remove = CommandsRegistry.getCommand(AgentFeedbackReviewCommandId.Delete)?.handler;
+		const accept = CommandsRegistry.getCommand(AgentFeedbackReviewCommandId.Accept)?.handler;
+		assert.ok(getComments && reveal && remove && accept);
+
+		const peerChatComments = getComments(instantiationService, peerChatResource);
+		const sessionComments = getComments(instantiationService, sessionResource);
+		await reveal(instantiationService, peerChatResource, feedback.id);
+		remove(instantiationService, peerChatResource, feedback.id);
+		accept(instantiationService, peerChatResource, [feedback.id]);
+
+		assert.deepStrictEqual({
+			peerChatComments,
+			sessionComments,
+			operations,
+		}, {
+			peerChatComments: [{
+				id: 'comment-1',
+				kindLabel: 'Agent Review',
+				text: 'Review this',
+				fileUri: fileResource,
+			}],
+			sessionComments: [{
+				id: 'comment-1',
+				kindLabel: 'Agent Review',
+				text: 'Review this',
+				fileUri: fileResource,
+			}],
+			operations: [
+				`get:${sessionResource.toString()}`,
+				`get:${sessionResource.toString()}`,
+				`reveal:${sessionResource.toString()}:comment-1`,
+				`get:${sessionResource.toString()}`,
+				`remove:${sessionResource.toString()}:comment-1`,
+				`accept:${sessionResource.toString()}:comment-1:true`,
+			],
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1293,21 +1293,22 @@ export interface IChatAgentFeedbackReviewComment {
  * Command ids the agent feedback review confirmation renderer (workbench/chat)
  * uses to fetch unreviewed comments and apply the user's selection. They are
  * implemented by the agent feedback feature in `vs/sessions`, keeping the chat
- * layer decoupled from the feedback model. Most take the owning session resource
- * (`UriComponents`) as their first argument; {@link AgentFeedbackReviewCommandId.RevealAt}
- * instead resolves the session from the file resource so a rendered tool call
- * can link to a comment without knowing the session URI.
+ * layer decoupled from the feedback model. Most take the rendered session or chat
+ * resource (`UriComponents`) as their first argument and resolve it to the owning
+ * session; {@link AgentFeedbackReviewCommandId.RevealAt} instead resolves the
+ * session from the file resource so a rendered tool call can link to a comment
+ * without knowing the session URI.
  */
 export const enum AgentFeedbackReviewCommandId {
-	/** `(sessionResource)` -> `IChatAgentFeedbackReviewComment[]` (the `created` reviewable comments). */
+	/** `(sessionOrChatResource)` -> `IChatAgentFeedbackReviewComment[]` (the `created` reviewable comments). */
 	GetComments = '_agentFeedbackReview.getComments',
-	/** `(sessionResource, commentId)` -> opens the file and reveals the comment. */
+	/** `(sessionOrChatResource, commentId)` -> opens the file and reveals the comment. */
 	Reveal = '_agentFeedbackReview.reveal',
 	/** `(resourceUri, range)` -> resolves the owning session and reveals the comment at that file range. */
 	RevealAt = '_agentFeedbackReview.revealAt',
-	/** `(sessionResource, commentId)` -> deletes the comment entirely. */
+	/** `(sessionOrChatResource, commentId)` -> deletes the comment entirely. */
 	Delete = '_agentFeedbackReview.delete',
-	/** `(sessionResource, commentIds)` -> accepts (reveals) the given comments. */
+	/** `(sessionOrChatResource, commentIds)` -> accepts (reveals) the given comments. */
 	Accept = '_agentFeedbackReview.accept',
 }
 


### PR DESCRIPTION
## What changed

- Resolve review-confirmation commands from the rendered chat resource to the owning session.
- Keep fetch, reveal, delete, and accept operations on the same annotations channel used by `listComments`.
- Add regression coverage for peer-chat routing and the existing raw-session fallback.
- Document the session-scoped feedback behavior.

## Why

`listComments` already normalized peer-chat channels to the parent session, but the Reveal unreviewed comments confirmation queried feedback using the peer chat resource. That selected the wrong feedback backend and displayed "No unreviewed comments" even when the server had counted pending review comments.

## Validation

- Focused unit test
- Client typecheck
- Layer validation
- Targeted ESLint