### PR TITLE
Style overrides: Adjust dirty tab border positioning and sizing

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -373,12 +373,12 @@
 	position: absolute;
 	z-index: 8;
 	top: 0;
-	left: 0;
-	width: 100% !important;
-	height: 2px !important;
+	left: var(--vscode-spacing-size20);
+	width: calc(100% - var(--vscode-spacing-size40));
+	height: 2px;
 	border: none;
 	border-radius: var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0 0;
-	background-color: var(--tab-dirty-border-top-color) !important;
+	background-color: var(--tab-dirty-border-top-color);
 	pointer-events: none;
 }
 


### PR DESCRIPTION
This pull request makes adjustments to the visual styling of the tabs in the workbench, specifically refining the appearance and positioning of the dirty border indicator at the top of tabs. The changes improve alignment with spacing variables and remove unnecessary overrides.

Styling improvements for tab dirty border:

* Updated the left position of the dirty border to use `var(--vscode-spacing-size20)` and adjusted the width to `calc(100% - var(--vscode-spacing-size40))` for better alignment with the tab's internal spacing.
* Removed `!important` from the width, height, and background-color properties to allow for better CSS specificity and maintainability.
* Set the height to a fixed `2px` (without `!important`) for consistency.