### PR TITLE
sessions: Add Copy Pull Request URL action and dedicated PR menu group

### DIFF
--- a/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
@@ -17,6 +17,7 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { Action2, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -75,7 +76,7 @@ class OpenPullRequestAction extends Action2 {
 				when: SessionHasPullRequestContext
 			}, {
 				id: Menus.SessionItemContextMenu,
-				group: 'navigation',
+				group: '2_pullRequest',
 				order: 0,
 				when: SessionHasPullRequestContext
 			}],
@@ -87,19 +88,53 @@ class OpenPullRequestAction extends Action2 {
 		const sessionsService = accessor.get(ISessionsService);
 
 		const targetSession = (Array.isArray(session) ? session[0] : session) ?? sessionsService.activeSession.get();
-		const pullRequestUri = this._getPullRequestUri(targetSession);
+		const pullRequestUri = getSessionPullRequestUri(targetSession);
 		if (!pullRequestUri) {
 			return;
 		}
 
 		await openerService.open(pullRequestUri, { openExternal: true });
 	}
-
-	private _getPullRequestUri(session: ISession | undefined): URI | undefined {
-		return session?.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest?.uri;
-	}
 }
 registerAction2(OpenPullRequestAction);
+
+// --- Copy Pull Request URL action
+
+function getSessionPullRequestUri(session: ISession | undefined): URI | undefined {
+	return session?.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest?.uri;
+}
+
+class CopyPullRequestUrlAction extends Action2 {
+	static readonly ID = 'workbench.agentSessions.action.copyPullRequestUrl';
+
+	constructor() {
+		super({
+			id: CopyPullRequestUrlAction.ID,
+			title: localize2('agentSessions.copyPullRequestUrl', 'Copy Pull Request URL'),
+			f1: false,
+			menu: [{
+				id: Menus.SessionItemContextMenu,
+				group: '2_pullRequest',
+				order: 1,
+				when: SessionHasPullRequestContext
+			}],
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, session?: IActiveSession | ISession | ISession[]): Promise<void> {
+		const clipboardService = accessor.get(IClipboardService);
+		const sessionsService = accessor.get(ISessionsService);
+
+		const targetSession = (Array.isArray(session) ? session[0] : session) ?? sessionsService.activeSession.get();
+		const pullRequestUri = getSessionPullRequestUri(targetSession);
+		if (!pullRequestUri) {
+			return;
+		}
+
+		await clipboardService.writeText(pullRequestUri.toString(true));
+	}
+}
+registerAction2(CopyPullRequestUrlAction);
 
 // --- Open Pull Request action view item (session header pull request pill)
 

--- a/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestActions.ts
@@ -63,7 +63,7 @@ class OpenPullRequestAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenPullRequestAction.ID,
-			title: localize2('agentSessions.openPullRequest', 'Open Pull Request'),
+			title: localize2('agentSessions.openPullRequest', "Open Pull Request"),
 			icon: Codicon.gitPullRequest,
 			f1: false,
 			// Pull request pill shown in the session header meta row
@@ -110,7 +110,7 @@ class CopyPullRequestUrlAction extends Action2 {
 	constructor() {
 		super({
 			id: CopyPullRequestUrlAction.ID,
-			title: localize2('agentSessions.copyPullRequestUrl', 'Copy Pull Request URL'),
+			title: localize2('agentSessions.copyPullRequestUrl', "Copy Pull Request URL"),
 			f1: false,
 			menu: [{
 				id: Menus.SessionItemContextMenu,

--- a/src/vs/sessions/contrib/github/test/browser/pullRequestActions.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/pullRequestActions.test.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { isIMenuItem, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { Menus } from '../../../../browser/menus.js';
+import { SessionHasPullRequestContext } from '../../../../common/contextkeys.js';
+import { ISession, ISessionWorkspace } from '../../../../services/sessions/common/session.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import '../../browser/pullRequestActions.js';
+
+function createSessionWithPullRequest(pullRequestUri: URI | undefined): ISession {
+	const workspaceUri = URI.from({ scheme: 'test', path: '/workspace' });
+	const workspace: ISessionWorkspace = {
+		uri: workspaceUri,
+		label: 'workspace',
+		icon: Codicon.folder,
+		folders: [{
+			root: workspaceUri,
+			workingDirectory: workspaceUri,
+			name: 'workspace',
+			description: undefined,
+			gitRepository: pullRequestUri ? {
+				uri: workspaceUri,
+				workTreeUri: undefined,
+				baseBranchName: undefined,
+				gitHubInfo: constObservable({
+					owner: 'owner',
+					repo: 'repo',
+					pullRequest: { number: 1, uri: pullRequestUri },
+				}),
+			} : undefined,
+		}],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: false,
+	};
+	return new class extends mock<ISession>() {
+		override readonly workspace = constObservable<ISessionWorkspace | undefined>(workspace);
+	};
+}
+
+suite('Pull Request Actions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Open Pull Request and Copy Pull Request URL are contributed to a dedicated context menu group', () => {
+		const items = MenuRegistry.getMenuItems(Menus.SessionItemContextMenu)
+			.filter(isIMenuItem)
+			.filter(item => item.command.id === 'workbench.agentSessions.action.openPullRequest' || item.command.id === 'workbench.agentSessions.action.copyPullRequestUrl');
+
+		assert.deepStrictEqual(items.map(item => ({
+			id: item.command.id,
+			group: item.group,
+			order: item.order,
+			hasPullRequestGate: (item.when?.serialize() ?? '').includes(SessionHasPullRequestContext.key),
+		})).sort((a, b) => (a.order ?? 0) - (b.order ?? 0)), [
+			{ id: 'workbench.agentSessions.action.openPullRequest', group: '2_pullRequest', order: 0, hasPullRequestGate: true },
+			{ id: 'workbench.agentSessions.action.copyPullRequestUrl', group: '2_pullRequest', order: 1, hasPullRequestGate: true },
+		]);
+	});
+
+	test('Copy Pull Request URL writes the pull request URL to the clipboard', async () => {
+		const pullRequestUri = URI.parse('https://github.com/owner/repo/pull/1');
+		const session = createSessionWithPullRequest(pullRequestUri);
+
+		const instantiationService = new TestInstantiationService();
+		const clipboardService = new class extends mock<IClipboardService>() {
+			readonly writes: string[] = [];
+			override async writeText(text: string): Promise<void> {
+				this.writes.push(text);
+			}
+		};
+		instantiationService.stub(IClipboardService, clipboardService);
+		instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
+			override readonly activeSession = constObservable(undefined);
+		});
+
+		await instantiationService.invokeFunction(accessor => CommandsRegistry.getCommand('workbench.agentSessions.action.copyPullRequestUrl')!.handler(accessor, session));
+
+		assert.deepStrictEqual(clipboardService.writes, [pullRequestUri.toString(true)]);
+	});
+
+	test('Copy Pull Request URL is a no-op when the session has no pull request', async () => {
+		const session = createSessionWithPullRequest(undefined);
+
+		const instantiationService = new TestInstantiationService();
+		const clipboardService = new class extends mock<IClipboardService>() {
+			readonly writes: string[] = [];
+			override async writeText(text: string): Promise<void> {
+				this.writes.push(text);
+			}
+		};
+		instantiationService.stub(IClipboardService, clipboardService);
+		instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
+			override readonly activeSession = constObservable(undefined);
+		});
+
+		await instantiationService.invokeFunction(accessor => CommandsRegistry.getCommand('workbench.agentSessions.action.copyPullRequestUrl')!.handler(accessor, session));
+
+		assert.deepStrictEqual(clipboardService.writes, []);
+	});
+
+	test('Open Pull Request opens the pull request URL externally', async () => {
+		const pullRequestUri = URI.parse('https://github.com/owner/repo/pull/1');
+		const session = createSessionWithPullRequest(pullRequestUri);
+
+		const instantiationService = new TestInstantiationService();
+		const openerService = new class extends mock<IOpenerService>() {
+			readonly opened: { readonly resource: URI; readonly openExternal: boolean | undefined }[] = [];
+			override async open(resource: URI, options?: { readonly openExternal?: boolean }): Promise<boolean> {
+				this.opened.push({ resource, openExternal: options?.openExternal });
+				return true;
+			}
+		};
+		instantiationService.stub(IOpenerService, openerService);
+		instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
+			override readonly activeSession = constObservable(undefined);
+		});
+
+		await instantiationService.invokeFunction(accessor => CommandsRegistry.getCommand('workbench.agentSessions.action.openPullRequest')!.handler(accessor, session));
+
+		assert.deepStrictEqual(openerService.opened, [{ resource: pullRequestUri, openExternal: true }]);
+	});
+});


### PR DESCRIPTION
## What changed

- Added a **Copy Pull Request URL** action to the session list context menu, available whenever a session has an associated GitHub pull request.
- Moved **Open Pull Request** and **Copy Pull Request URL** into a new, dedicated `2_pullRequest` context-menu group so they're visually grouped together and separated from the other context menu groups.

## Why

Agents Window idea #12 requested an easy way to copy a session's pull request URL directly from the session list, without needing to open the PR pill / picker first. Grouping the two PR-related actions together also makes the context menu easier to scan.

## Details

- `CopyPullRequestUrlAction` reuses the existing PR URL resolution logic (now factored into a shared `getSessionPullRequestUri` helper) and the existing `IClipboardService` abstraction, consistent with other "copy" actions in the sessions codebase (e.g. `CopySessionBranchNameAction`).
- Both actions are gated on the existing `SessionHasPullRequestContext` context key, so they're hidden when a session has no PR, and update automatically as PR metadata loads/changes (no new context keys needed).
- Only the `SessionItemContextMenu` group assignment changed. The session header pull-request pill (`Menus.SessionHeaderMeta`) is untouched, so behavior outside the session list context menu is unaffected.

## Testing

- Added `pullRequestActions.test.ts` covering: menu group/order/gating for both actions, clipboard write behavior (including the no-PR no-op case), and the existing Open Pull Request open-external behavior.
- `./scripts/test.sh --runGlob "**/sessions/contrib/github/test/**/*.test.js"` - 94 passing.
- `./scripts/test.sh --runGlob "**/sessions/contrib/sessions/test/**/*.test.js"` - 116 passing.
- `npm run compile` and `npm run hygiene` - both clean.

Fixes #329364
