### PR TITLE
agentHost: return every Codex session from thread/list

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -64,6 +64,7 @@ import { buildUserInputRequest, emptyUserInputResponse, userInputResponseFromAns
 import { replayThreadToTurns } from './codexReplayMapper.js';
 import { CodexSessionMetadataStore } from './codexSessionMetadataStore.js';
 import { buildCodexLaunchConfig, buildCodexResumeParams } from './codexLaunchConfig.js';
+import { THREAD_LIST_MAX_PAGES, collectThreadListPages } from './codexThreadList.js';
 import { codexAccountRateLimitFromResponse, codexAccountStateFromResponse, type ICodexAccountState } from './codexAccountState.js';
 import { CodexSessionConfigKey, CODEX_DEFAULT_PERMISSIONS_PRESET, CODEX_PERMISSIONS_PRESETS, collaborationModeKind, migrateCodexPermissionValues, narrowAdditionalDirectories, narrowBoolean, narrowPersonality, narrowReasoningEffort, narrowReasoningSummary, narrowWebSearchMode, resolveCodexPermissions, type CodexApprovalPolicy, type CodexPermissionsPreset, type ICodexResolvedPermissions } from './codexSessionConfigKeys.js';
 import type { ReasoningEffort } from './protocol/generated/ReasoningEffort.js';
@@ -4053,11 +4054,6 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
-		// Reject rather than reporting an empty list while the GitHub token is
-		// still landing: the workbench treats a successful listing as the
-		// authoritative session set and would evict — and permanently unpin and
-		// ungroup — every Codex session. A rejection instead leaves the cached
-		// list intact and self-heals through the caller's backoff retry.
 		// Don't connect (and trigger a cold SDK download) just to list threads
 		// at startup. When the SDK isn't local yet, surface an empty list; the
 		// download fires (with host-level progress) once the user starts a
@@ -4069,9 +4065,10 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		try {
 			const conn = await this._ensureConnection();
-			const response = await conn.client.request<'thread/list', ThreadListResponse>('thread/list', {
-				limit: 200,
-			});
+			const threads = await collectThreadListPages<Thread>(
+				request => conn.client.request<'thread/list', ThreadListResponse>('thread/list', request),
+				collected => this._logService.warn(`[Codex] thread/list hit the ${THREAD_LIST_MAX_PAGES}-page cap after ${collected} threads; some sessions may be missing`),
+			);
 			// Map persisted threads back to the URI the workbench already
 			// knows them by. After `_materializeIfNeeded` runs, the codex
 			// thread is persisted to disk under its thread id but the
@@ -4086,12 +4083,18 @@ export class CodexAgent extends Disposable implements IAgent {
 					liveUriByThreadId.set(s.threadId, s.sessionUri);
 				}
 			}
-			return response.data.map(thread => {
+			return threads.map(thread => {
 				const sessionUri = liveUriByThreadId.get(thread.id) ?? AgentSession.uri(this.id, thread.id);
 				const liveWorkingDirectories = this._sessions.get(AgentSession.id(sessionUri))?.workingDirectories;
 				return this._withWorkingDirectories(this._threadToMetadata(thread, sessionUri), liveWorkingDirectories);
 			});
 		} catch (err) {
+			// `AgentService.listSessions` fans out across all providers via
+			// `Promise.all`, so a rejection here takes the sibling Copilot and
+			// Claude listings down with it. Returning empty is a workaround for
+			// that aggregation, not a correct signal — an empty list is
+			// indistinguishable from "this agent has no sessions" and the
+			// workbench may reconcile against it.
 			this._logService.warn(`[Codex] thread/list failed: ${err instanceof Error ? err.message : String(err)}`);
 			return [];
 		}

--- a/src/vs/platform/agentHost/node/codex/codexThreadList.ts
+++ b/src/vs/platform/agentHost/node/codex/codexThreadList.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure paging helper for the Codex `thread/list` path, extracted so it can be
+ * unit-tested without standing up the whole {@link CodexAgent} (mirrors the
+ * `codexForkPlan.ts` extraction). No protocol or service imports.
+ */
+
+/** Server-side `thread/list` page cap; a larger `limit` is silently clamped. */
+export const THREAD_LIST_PAGE_SIZE = 100;
+
+/** Safety stop for `thread/list` paging so a misbehaving server cannot hang startup. */
+export const THREAD_LIST_MAX_PAGES = 50;
+
+export interface IThreadListPageRequest {
+	readonly limit: number;
+	/**
+	 * Explicitly empty: codex reads an omitted filter as "only the currently
+	 * configured provider", which hides every thread recorded under a different
+	 * one. An empty array is its documented "all providers" request.
+	 */
+	readonly modelProviders: string[];
+	readonly cursor?: string;
+}
+
+export interface IThreadListPage<T> {
+	readonly data: readonly T[];
+	readonly nextCursor?: string | null;
+}
+
+export function buildThreadListPageRequest(cursor: string | undefined): IThreadListPageRequest {
+	return {
+		limit: THREAD_LIST_PAGE_SIZE,
+		modelProviders: [],
+		...(cursor !== undefined ? { cursor } : {}),
+	};
+}
+
+/**
+ * Page through `thread/list` until the server stops handing back a cursor.
+ * `onTruncated` reports that the page cap was hit with more results pending.
+ */
+export async function collectThreadListPages<T>(
+	fetchPage: (request: IThreadListPageRequest) => Promise<IThreadListPage<T>>,
+	onTruncated?: (collected: number) => void,
+): Promise<T[]> {
+	const items: T[] = [];
+	const seenCursors = new Set<string>();
+	let cursor: string | undefined;
+	for (let page = 0; page < THREAD_LIST_MAX_PAGES; page++) {
+		const response = await fetchPage(buildThreadListPageRequest(cursor));
+		items.push(...response.data);
+		const nextCursor = response.nextCursor ?? undefined;
+		// A server that keeps handing back the same cursor would loop forever.
+		if (nextCursor === undefined || seenCursors.has(nextCursor)) {
+			return items;
+		}
+		seenCursors.add(nextCursor);
+		cursor = nextCursor;
+	}
+	onTruncated?.(items.length);
+	return items;
+}

--- a/src/vs/platform/agentHost/test/node/codex/codexThreadList.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexThreadList.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IThreadListPage, IThreadListPageRequest, THREAD_LIST_MAX_PAGES, THREAD_LIST_PAGE_SIZE, buildThreadListPageRequest, collectThreadListPages } from '../../../node/codex/codexThreadList.js';
+
+suite('codexThreadList', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('buildThreadListPageRequest', () => {
+
+		test('always asks for all providers and omits the cursor on the first page', () => {
+			assert.deepStrictEqual({
+				first: buildThreadListPageRequest(undefined),
+				next: buildThreadListPageRequest('cursor-1'),
+			}, {
+				first: { limit: THREAD_LIST_PAGE_SIZE, modelProviders: [] },
+				next: { limit: THREAD_LIST_PAGE_SIZE, modelProviders: [], cursor: 'cursor-1' },
+			});
+		});
+	});
+
+	suite('collectThreadListPages', () => {
+
+		/** Serve `pages` in order, recording the request each page was fetched with. */
+		function pagedSource(pages: readonly IThreadListPage<string>[]) {
+			const requests: IThreadListPageRequest[] = [];
+			let index = 0;
+			const fetchPage = async (request: IThreadListPageRequest): Promise<IThreadListPage<string>> => {
+				requests.push(request);
+				return pages[index++] ?? { data: [] };
+			};
+			return { requests, fetchPage };
+		}
+
+		test('follows the cursor across pages and concatenates them in order', async () => {
+			const { requests, fetchPage } = pagedSource([
+				{ data: ['a', 'b'], nextCursor: 'c1' },
+				{ data: ['c'], nextCursor: 'c2' },
+				{ data: ['d'], nextCursor: null },
+			]);
+
+			assert.deepStrictEqual({
+				threads: await collectThreadListPages(fetchPage),
+				cursors: requests.map(r => r.cursor),
+			}, {
+				threads: ['a', 'b', 'c', 'd'],
+				cursors: [undefined, 'c1', 'c2'],
+			});
+		});
+
+		test('stops on a missing cursor without fetching another page', async () => {
+			const { requests, fetchPage } = pagedSource([{ data: ['only'] }]);
+
+			assert.deepStrictEqual({
+				threads: await collectThreadListPages(fetchPage),
+				pagesFetched: requests.length,
+			}, {
+				threads: ['only'],
+				pagesFetched: 1,
+			});
+		});
+
+		test('stops when the server repeats a cursor instead of looping forever', async () => {
+			let calls = 0;
+			const fetchPage = async (): Promise<IThreadListPage<string>> => {
+				calls++;
+				return { data: ['x'], nextCursor: 'same' };
+			};
+
+			assert.deepStrictEqual({
+				threads: await collectThreadListPages(fetchPage),
+				calls,
+			}, {
+				threads: ['x', 'x'],
+				calls: 2,
+			});
+		});
+
+		test('gives up at the page cap and reports the truncation', async () => {
+			let calls = 0;
+			const fetchPage = async (): Promise<IThreadListPage<string>> => {
+				calls++;
+				return { data: ['x'], nextCursor: `cursor-${calls}` };
+			};
+			const truncatedAt: number[] = [];
+
+			const threads = await collectThreadListPages(fetchPage, collected => truncatedAt.push(collected));
+
+			assert.deepStrictEqual({
+				calls,
+				threadCount: threads.length,
+				truncatedAt,
+			}, {
+				calls: THREAD_LIST_MAX_PAGES,
+				threadCount: THREAD_LIST_MAX_PAGES,
+				truncatedAt: [THREAD_LIST_MAX_PAGES],
+			});
+		});
+
+		test('does not report truncation when paging completes normally', async () => {
+			const { fetchPage } = pagedSource([{ data: ['a'], nextCursor: 'c1' }, { data: ['b'] }]);
+			const truncatedAt: number[] = [];
+
+			await collectThreadListPages(fetchPage, collected => truncatedAt.push(collected));
+
+			assert.deepStrictEqual(truncatedAt, []);
+		});
+	});
+});


### PR DESCRIPTION
Codex sessions disappeared from the Agents window. A session pinned the day before was gone from the list and could not be found by search, while `codex resume <id>` still opened it fine. `thread/list` was returning **10 of 768** non-archived threads.

## Root cause

Two independent bugs, both in how we call `thread/list`. I verified each against the **same** codex 0.146 binary and the **same** thread store, varying only the request:

| Request | Threads returned |
|---|---|
| As shipped today | **10** |
| + `-c model_provider="vscode-proxy"` (what we used to pass) | **100** |
| + `modelProviders: []` in the request | **100** |

**1. An omitted `modelProviders` filter means "only the active provider".**

```rust
// codex-rs/app-server/src/request_processors/thread_processor.rs
let model_provider_filter = match model_providers {
    Some(providers) => if providers.is_empty() { None } else { Some(providers) },
    None if relation_filter.is_some() => None,
    None => Some(vec![self.config.model_provider_id.clone()]),  // ← omitted ⇒ filter to active provider
};
```

`buildCodexLaunchConfig` stopped passing `model_provider="vscode-proxy"` when Codex gained OpenAI subscription support (#327290) — it now registers `model_providers.vscode-proxy.*` *additively*. So `config.model_provider_id` falls back to the built-in `openai`, and every thread recorded under a different provider is hidden. In the reporter's store:

```
vscode-proxy          645   ← hidden (including the pinned session)
codex_vscode_copilot   16   ← hidden
openai                 10   ← exactly what codex returned
```

The generated protocol type already documents the fix: *"Optional provider filter; when set, only sessions recorded under these providers are returned. **When present but empty, includes all providers.**"*

**2. `limit: 200` is silently clamped to 100, and the cursor was ignored.**

`THREAD_LIST_MAX_LIMIT` is 100, so a single un-paged request can never return more than 100 sessions regardless of the limit asked for. Even with bug 1 fixed, only 100 of 671 sessions would surface.

## Changes

- Pass `modelProviders: []` so the listing is provider-agnostic.
- Page through `thread/list` with `nextCursor` instead of one oversized request.

The paging loop is extracted into `codexThreadList.ts` as a pure helper so it can be unit-tested without standing up the whole `CodexAgent`, mirroring the existing `codexForkPlan.ts` extraction. It stops if the server ever repeats a cursor, and gives up after a bounded number of pages (logging a warning) so a misbehaving server cannot hang startup.

## Verification

Ran a dev build against the reporter's real thread store, reading the AHP protocol log:

```
10:12:18  total=135  {'copilotcli': 10, 'claude': 125}                  ← before codex connected
10:12:21  total=807  {'copilotcli': 10, 'claude': 125, 'codex': 672}    ← after
```

**672 codex sessions**, up from 10, including the specific pinned session that went missing. 672 matches the store's non-archived `vscode-proxy` count exactly, and exceeding 100 confirms the cursor paging works.

- `npm run typecheck-client` — 0 errors
- `./scripts/test.sh --grep "codexThreadList|LocalAgentHostSessionsProvider"` — 178 passing, 0 failing (6 new tests for the paging helper)
- `npm run hygiene`, `npm run valid-layers-check`, eslint — clean

## Follow-ups (deliberately not in this PR)

- **`IAgent.listSessions` has no failure contract.** Both `CodexAgent` and `ClaudeAgent` `return []` when they *cannot* answer (SDK not downloaded, backend unreachable), which is indistinguishable from "this agent has no sessions". Both files document why: `AgentService.listSessions` aggregates with `Promise.all`, so one rejection wipes out every sibling provider's listing. The interface should state that a resolved value is authoritative and failures must reject, and the aggregation should isolate failures (e.g. `Promise.allSettled`) so agents can do so safely.
