### PR TITLE
Only show tips to users with 2+ requests in agents window

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -51,7 +51,8 @@ import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTrac
 
 // #region --- New Chat Widget ---
 
-const MIN_REQUESTS_FOR_TIPS = 2;
+/** Minimum number of started sessions required before showing tips. */
+const MIN_SESSIONS_FOR_TIPS = 2;
 
 export class NewChatWidget extends Disposable {
 
@@ -474,8 +475,8 @@ export class NewChatWidget extends Disposable {
 	}
 
 	private isChatTipSuppressed(): boolean {
-		const requestsSent = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
-		return requestsSent < MIN_REQUESTS_FOR_TIPS || this.isInputOnboardingVisible() || this._isInputNotificationVisible;
+		const sessionCount = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
+		return sessionCount < MIN_SESSIONS_FOR_TIPS || this.isInputOnboardingVisible() || this._isInputNotificationVisible;
 	}
 
 	private updateChatTipVisibility(): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -46,8 +46,12 @@ import { IChatTipService } from '../../../../workbench/contrib/chat/browser/chat
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTracker.js';
 
 // #region --- New Chat Widget ---
+
+const MIN_REQUESTS_FOR_TIPS = 2;
 
 export class NewChatWidget extends Disposable {
 
@@ -121,6 +125,7 @@ export class NewChatWidget extends Disposable {
 		@IChatTipService private readonly chatTipService: IChatTipService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 		this._workspacePickerVisibleKey = SessionWorkspacePickerVisibleContext.bindTo(contextKeyService);
@@ -249,6 +254,7 @@ export class NewChatWidget extends Disposable {
 				this._clearChatTip();
 			}
 		}));
+		this._register(this.storageService.onDidChangeValue(StorageScope.APPLICATION, TOTAL_SESSIONS_KEY, this._store)(() => this.updateChatTipVisibility()));
 		const foregroundSessionCountContextKeys = new Set([ChatContextKeys.foregroundSessionCount.key]);
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (e.affectsSome(foregroundSessionCountContextKeys)) {
@@ -468,7 +474,8 @@ export class NewChatWidget extends Disposable {
 	}
 
 	private isChatTipSuppressed(): boolean {
-		return this.isInputOnboardingVisible() || this._isInputNotificationVisible;
+		const requestsSent = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
+		return requestsSent < MIN_REQUESTS_FOR_TIPS || this.isInputOnboardingVisible() || this._isInputNotificationVisible;
 	}
 
 	private updateChatTipVisibility(): void {

--- a/src/vs/sessions/contrib/chat/test/browser/newChatWidget.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newChatWidget.test.ts
@@ -50,6 +50,7 @@ const updateChatTipVisibility = Reflect.get(NewChatWidget.prototype, 'updateChat
 interface IChatTipVisibilityHarness {
 	_isInputOnboardingVisible: boolean;
 	_isInputNotificationVisible: boolean;
+	storageService: { getNumber(key: string, scope: unknown, defaultValue: number): number };
 	isInputOnboardingVisible(): boolean;
 	isChatTipSuppressed(): boolean;
 	updateChatTipVisibility(): void;
@@ -57,10 +58,13 @@ interface IChatTipVisibilityHarness {
 	_renderChatTip(): void;
 }
 
-function createChatTipVisibilityHarness(visibilityChanges: string[]): IChatTipVisibilityHarness {
+function createChatTipVisibilityHarness(visibilityChanges: string[], storageValues: Map<string, number> = new Map()): IChatTipVisibilityHarness {
 	const harness: IChatTipVisibilityHarness = {
 		_isInputOnboardingVisible: false,
 		_isInputNotificationVisible: false,
+		storageService: {
+			getNumber: (key: string, _scope: unknown, defaultValue: number) => storageValues.get(key) ?? defaultValue,
+		},
 		isInputOnboardingVisible: () => isInputOnboardingVisible.call(harness),
 		isChatTipSuppressed: () => isChatTipSuppressed.call(harness),
 		updateChatTipVisibility: () => updateChatTipVisibility.call(harness),
@@ -170,5 +174,27 @@ suite('NewChatWidget', () => {
 		setInputOnboardingVisible.call(harness, false);
 
 		assert.deepStrictEqual(visibilityChanges, ['visible', 'hidden', 'hidden', 'hidden', 'visible']);
+	});
+
+	test('hides tips for users below the session count threshold', () => {
+		const visibilityChanges = ['visible'];
+		const storageValues = new Map([['agentSessions.telemetry.totalSessions', 0]]);
+		const harness = createChatTipVisibilityHarness(visibilityChanges, storageValues);
+
+		// Tips should be hidden because session count is 0 (below the threshold of 2)
+		updateChatTipVisibility.call(harness);
+
+		assert.deepStrictEqual(visibilityChanges, ['visible', 'hidden']);
+	});
+
+	test('shows tips for users at or above the session count threshold', () => {
+		const visibilityChanges: string[] = [];
+		const storageValues = new Map([['agentSessions.telemetry.totalSessions', 2]]);
+		const harness = createChatTipVisibilityHarness(visibilityChanges, storageValues);
+
+		// Tips should be visible because session count is 2 (at the threshold)
+		updateChatTipVisibility.call(harness);
+
+		assert.deepStrictEqual(visibilityChanges, ['visible']);
 	});
 });

--- a/src/vs/sessions/contrib/chat/test/browser/newChatWidget.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newChatWidget.test.ts
@@ -166,7 +166,8 @@ suite('NewChatWidget', () => {
 
 	test('hides tips for notifications until all suppressors are inactive', () => {
 		const visibilityChanges = ['visible'];
-		const harness = createChatTipVisibilityHarness(visibilityChanges);
+		const storageValues = new Map([['agentSessions.telemetry.totalSessions', 2]]);
+		const harness = createChatTipVisibilityHarness(visibilityChanges, storageValues);
 
 		setInputNotificationVisible.call(harness, true);
 		setInputOnboardingVisible.call(harness, true);


### PR DESCRIPTION
When a user has sent fewer than 2 requests in the agents window, we now hide the tips section to focus on core chat functionality. This uses the existing request tracking in telemetry storage.