### PR TITLE
sessions: Fix GitHub hover description clamp

### DIFF
--- a/src/vs/sessions/contrib/github/browser/issueHover.ts
+++ b/src/vs/sessions/contrib/github/browser/issueHover.ts
@@ -47,7 +47,8 @@ export function createIssueHoverElement(data: IIssueHoverData): HTMLElement {
 	append(hoverElement, $('.sessions-issue-hover-title', undefined, data.issue?.title || localize('agentSessions.issueHover.titleFallback', "Issue #{0}", data.number)));
 
 	const body = data.issue?.body.trim() || localize('agentSessions.issueHover.bodyFallback', "No description provided.");
-	append(hoverElement, $('.sessions-issue-hover-description', undefined, body));
+	const description = append(hoverElement, $('.sessions-issue-hover-description'));
+	append(description, $('.sessions-issue-hover-description-content', undefined, body));
 
 	return hoverElement;
 }

--- a/src/vs/sessions/contrib/github/browser/media/issueHover.css
+++ b/src/vs/sessions/contrib/github/browser/media/issueHover.css
@@ -43,15 +43,17 @@
 }
 
 .sessions-issue-hover-description {
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
-	-webkit-line-clamp: 3;
-	line-clamp: 3;
-	overflow: hidden;
 	padding: var(--vscode-spacing-size120) var(--vscode-spacing-size160);
 	border-top: var(--vscode-strokeThickness) solid var(--vscode-editorHoverWidget-border);
 	font-size: var(--vscode-agents-fontSize-body1);
 	line-height: 1.4;
 	color: var(--vscode-descriptionForeground);
 	overflow-wrap: anywhere;
+}
+
+.sessions-issue-hover-description-content {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
 }

--- a/src/vs/sessions/contrib/github/browser/media/pullRequestHover.css
+++ b/src/vs/sessions/contrib/github/browser/media/pullRequestHover.css
@@ -43,17 +43,19 @@
 }
 
 .sessions-pr-hover-description {
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
-	-webkit-line-clamp: 3;
-	line-clamp: 3;
-	overflow: hidden;
 	padding: var(--vscode-spacing-size120) var(--vscode-spacing-size160) 0 var(--vscode-spacing-size160);
 	border-top: var(--vscode-strokeThickness) solid var(--vscode-editorHoverWidget-border);
 	font-size: var(--vscode-agents-fontSize-body1);
 	line-height: 1.4;
 	color: var(--vscode-descriptionForeground);
 	overflow-wrap: anywhere;
+}
+
+.sessions-pr-hover-description-content {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
 }
 
 .sessions-pr-hover-branches {

--- a/src/vs/sessions/contrib/github/browser/pullRequestHover.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestHover.ts
@@ -47,7 +47,8 @@ export function createPullRequestHoverElement(data: IPullRequestHoverData): HTML
 	append(hoverElement, $('.sessions-pr-hover-title', undefined, data.pullRequest?.title || localize('agentSessions.pullRequestHover.titleFallback', "Pull Request #{0}", data.number)));
 
 	const body = data.pullRequest?.body.trim() || localize('agentSessions.pullRequestHover.bodyFallback', "No description provided.");
-	append(hoverElement, $('.sessions-pr-hover-description', undefined, body));
+	const description = append(hoverElement, $('.sessions-pr-hover-description'));
+	append(description, $('.sessions-pr-hover-description-content', undefined, body));
 
 	const branchRow = append(hoverElement, $('.sessions-pr-hover-branches'));
 	appendBranchPill(branchRow, data.pullRequest?.baseRef || localize('agentSessions.pullRequestHover.baseFallback', "target"));

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/openIssue.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/openIssue.fixture.ts
@@ -180,6 +180,16 @@ const openIssue: IGitHubIssue = {
 	closedAt: undefined,
 };
 
+const shortDescriptionIssue: IGitHubIssue = {
+	...openIssue,
+	body: 'The terminal stops streaming output.',
+};
+
+const longDescriptionIssue: IGitHubIssue = {
+	...openIssue,
+	body: 'Steps to reproduce: open a session on a worktree, start a long-running build, and switch to another session while output is still streaming. Return to the original session and observe that the terminal no longer updates even though the task is still running. The task also never reports completion, so it is unclear whether the build finished, failed, or remains active in the background. This description is intentionally long enough to exceed three lines and verify that the issue hover clamps the text without revealing any part of a fourth line.',
+};
+
 const completedIssue: IGitHubIssue = {
 	number: 678,
 	title: 'Session header pill should show the referenced issue',
@@ -223,7 +233,11 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 	}),
 
 	OpenIssue_Hover: defineComponentFixture({
-		render: (ctx) => renderIssueHover(ctx, openIssue),
+		render: (ctx) => renderIssueHover(ctx, shortDescriptionIssue),
+	}),
+
+	OpenIssue_Hover_LongDescription: defineComponentFixture({
+		render: (ctx) => renderIssueHover(ctx, longDescriptionIssue),
 	}),
 
 	OpenIssue_List: defineComponentFixture({

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/openPullRequest.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/openPullRequest.fixture.ts
@@ -193,6 +193,16 @@ const openPullRequestDetails: IGitHubPullRequest = {
 	mergeableState: 'clean',
 };
 
+const shortDescriptionPullRequest: IGitHubPullRequest = {
+	...openPullRequestDetails,
+	body: 'Suppresses the expected EPIPE error on graceful disconnect.',
+};
+
+const longDescriptionPullRequest: IGitHubPullRequest = {
+	...openPullRequestDetails,
+	body: 'Every graceful client disconnect currently logs an unexpected EPIPE error. This makes a routine shutdown look like a server failure and adds noise for anyone scanning logs while investigating connection issues. The change recognizes the expected disconnect path and avoids reporting it as an error while preserving diagnostics for unexpected failures. This description is intentionally long enough to exceed three lines and verify that the pull request hover clamps the text without revealing any part of a fourth line.',
+};
+
 const draftPullRequestDetails: IGitHubPullRequest = {
 	...openPullRequestDetails,
 	number: draftPr.number,
@@ -233,7 +243,11 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 	}),
 
 	OpenPullRequest_Hover: defineComponentFixture({
-		render: (ctx) => renderPullRequestHover(ctx, openPullRequestDetails),
+		render: (ctx) => renderPullRequestHover(ctx, shortDescriptionPullRequest),
+	}),
+
+	OpenPullRequest_Hover_LongDescription: defineComponentFixture({
+		render: (ctx) => renderPullRequestHover(ctx, longDescriptionPullRequest),
 	}),
 
 	OpenPullRequest_List: defineComponentFixture({


### PR DESCRIPTION
## Summary

- clamp issue and pull request hover descriptions on an unpadded inner element so no portion of a fourth line is visible
- remove the unsupported unprefixed `line-clamp` declaration
- add component fixtures covering short and overflowing descriptions for both hover types

## Validation

- pre-commit checks passed
- browser geometry check confirmed three visible line heights and zero visible height from the fourth line
- `npm run compile-client` reached unrelated `extensions/ipynb` type errors for missing `markdown-it` declarations
- `npm run hygiene` is blocked on Windows by an existing `C:\C:\...\remote\package.json` path-resolution error