### PR TITLE
markdown: fix cut and paste in editing mode (#329313)

### DIFF
--- a/extensions/markdown-language-features/markdown-editor-src/editor.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/editor.ts
@@ -134,6 +134,7 @@ class Editor extends Disposable {
 			}
 		});
 
+		this.#setupClipboardHandlers();
 		this.#vscode.postMessage({ type: 'ready' });
 		this._register({
 			dispose: () => {
@@ -142,6 +143,105 @@ class Editor extends Disposable {
 				}
 				this.#codeBlockEditorRequests.clear();
 			},
+		});
+	}
+
+	#setupClipboardHandlers(): void {
+		const handlePaste = (clipboardData: DataTransfer | null) => {
+			if (this.model.readonlyMode.get()) {
+				return;
+			}
+			const selection = this.model.selection.get();
+			if (!selection) {
+				return;
+			}
+			const text = clipboardData?.getData('text/plain');
+			if (text) {
+				const range = selection.range;
+				this.model.applyEdit(
+					StringEdit.replace(range, text),
+					Selection.collapsed(range.start + text.length)
+				);
+			} else if (navigator.clipboard?.readText) {
+				navigator.clipboard.readText().then(textFromClipboard => {
+					if (textFromClipboard) {
+						const curSelection = this.model.selection.get();
+						if (!curSelection) { return; }
+						const range = curSelection.range;
+						this.model.applyEdit(
+							StringEdit.replace(range, textFromClipboard),
+							Selection.collapsed(range.start + textFromClipboard.length)
+						);
+					}
+				}).catch(() => {});
+			}
+		};
+
+		const handleCut = (clipboardData: DataTransfer | null) => {
+			if (this.model.readonlyMode.get()) {
+				return;
+			}
+			const selection = this.model.selection.get();
+			if (!selection || selection.isCollapsed) {
+				return;
+			}
+			const range = selection.range;
+			const selectedText = this.model.sourceText.get().value.slice(range.start, range.endExclusive);
+			if (!selectedText) {
+				return;
+			}
+			if (clipboardData) {
+				clipboardData.setData('text/plain', selectedText);
+			}
+			if (navigator.clipboard?.writeText) {
+				navigator.clipboard.writeText(selectedText).catch(() => {});
+			}
+			this.model.applyEdit(
+				StringEdit.replace(range, ''),
+				Selection.collapsed(range.start)
+			);
+		};
+
+		const onPaste = (e: ClipboardEvent) => {
+			if (this.model.readonlyMode.get()) { return; }
+			e.preventDefault();
+			e.stopPropagation();
+			handlePaste(e.clipboardData);
+		};
+
+		const onCut = (e: ClipboardEvent) => {
+			if (this.model.readonlyMode.get()) { return; }
+			e.preventDefault();
+			e.stopPropagation();
+			handleCut(e.clipboardData);
+		};
+
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (this.model.readonlyMode.get()) { return; }
+			const isMod = e.metaKey || e.ctrlKey;
+			if (!isMod || e.altKey) { return; }
+			const key = e.key.toLowerCase();
+			if (key === 'v') {
+				e.preventDefault();
+				e.stopPropagation();
+				handlePaste(null);
+			} else if (key === 'x') {
+				e.preventDefault();
+				e.stopPropagation();
+				handleCut(null);
+			}
+		};
+
+		window.addEventListener('paste', onPaste, true);
+		window.addEventListener('cut', onCut, true);
+		window.addEventListener('keydown', onKeyDown, true);
+
+		this._register({
+			dispose: () => {
+				window.removeEventListener('paste', onPaste, true);
+				window.removeEventListener('cut', onCut, true);
+				window.removeEventListener('keydown', onKeyDown, true);
+			}
 		});
 	}
 


### PR DESCRIPTION
Fixes #329313

### Cause
In VS Code Desktop, keydowns for `Cmd+X` / `Cmd+V` (and context menu actions) dispatch `execCommand('cut')` / `execCommand('paste')` to the webview iframe. Because the Hybrid Markdown editor (`vscode.markdown.editor`) uses a custom model and EditContext rather than standard contenteditable elements, native `execCommand` dispatches did not mutate the underlying `EditorModel`.

### Solution
Added explicit clipboard handlers (`#setupClipboardHandlers`) in `markdown-editor-src/editor.ts` to capture DOM `paste` / `cut` events and shortcut keydowns (`Cmd+V` / `Cmd+X`), applying `StringEdit.replace` edits to the `EditorModel` at the active selection.

### Setup & Reproduction Steps
1. Enable `workbench.editor.markdownDefaultEditorInAgentsWindow: true` in Settings.
2. Open any `.md` file with the Hybrid Markdown Editor (`vscode.markdown.editor`).
3. Switch the mode pill to **Editing** mode.
4. Try to Cut (`Cmd+X` / `Ctrl+X`) or Paste (`Cmd+V` / `Ctrl+V`).

### Verification Steps
- [x] **Paste**:
  - Verify plain text can be pasted at the caret position using `Cmd+V` (`Ctrl+V`).
  - Verify pasting over a selection correctly replaces the selected text and moves the caret after the pasted text.
  - Verify pasting via the right-click context menu ("Paste") works as expected.
  - Verify multi-line text preserves line breaks when pasted.

- [x] **Cut**:
  - Verify selected text is cut using `Cmd+X` (`Ctrl+X`) and placed into the system clipboard.
  - Verify cutting via the right-click context menu ("Cut") works as expected.
  - Verify the cut text can be pasted into another editor/document.
  - Verify pressing `Cmd+X` with no text selected produces no unexpected errors.

- [x] **Undo / Redo & Integration**:
  - Verify `Cmd+Z` (Undo) and `Cmd+Shift+Z` (Redo) correctly reverse and reapply cut/paste edits.
  - Verify cut and paste operations are blocked when the editor is in Readonly mode.
  - Verify the editor shows the dirty indicator (`●`) upon editing and saves correctly with `Cmd+S`.