### PR TITLE
feat: global config for all models under custom endpoint BYOK

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2039,6 +2039,66 @@
               "title": "API Type",
               "markdownDescription": "Default request/response format for models in this group. Individual models can override this with their own `apiType` property; when both are unset the type is inferred from the URL path."
             },
+            "global": {
+              "type": "object",
+              "description": "Global default settings applied to all models under this endpoint provider.",
+              "title": "Global Model Settings",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "pattern": "^https?://.+",
+                  "patternErrorMessage": "URL must start with http:// or https://",
+                  "markdownDescription": "Default URL endpoint for models in this group."
+                },
+                "apiType": {
+                  "type": "string",
+                  "enum": [
+                    "chat-completions",
+                    "responses",
+                    "messages"
+                  ],
+                  "enumItemLabels": [
+                    "Chat Completions",
+                    "Responses",
+                    "Messages"
+                  ],
+                  "enumDescriptions": [
+                    "Chat Completions API",
+                    "Responses API",
+                    "Messages API"
+                  ],
+                  "title": "API Type"
+                },
+                "toolCalling": {
+                  "type": "boolean",
+                  "description": "Whether models support tool calling by default"
+                },
+                "vision": {
+                  "type": "boolean",
+                  "description": "Whether models support vision capabilities by default"
+                },
+                "maxInputTokens": {
+                  "type": "number",
+                  "description": "Default maximum number of input tokens"
+                },
+                "maxOutputTokens": {
+                  "type": "number",
+                  "description": "Default maximum number of output tokens"
+                },
+                "contextWindow": {
+                  "type": "number",
+                  "description": "Default context window in tokens"
+                },
+                "thinking": {
+                  "type": "boolean",
+                  "description": "Whether models support thinking by default"
+                },
+                "streaming": {
+                  "type": "boolean",
+                  "description": "Whether models support streaming by default"
+                }
+              }
+            },
             "models": {
               "type": "array",
               "defaultSnippets": [

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -83,6 +83,7 @@ function apiTypeToSupportedEndpoints(apiType: CustomEndpointApiType): ModelSuppo
 export interface CustomEndpointModelProviderConfig extends LanguageModelChatConfiguration {
 	url?: string;
 	apiType?: CustomEndpointApiType;
+	global?: Partial<CustomEndpointModelConfig>;
 	models?: CustomEndpointModelConfig[];
 }
 
@@ -137,11 +138,13 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			return super.getAllModels(silent, apiKey, configuration);
 		}
 		const models: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[] = [];
+		const globalConfig = configuration?.global || {};
 		if (Array.isArray(configuration?.models)) {
 			for (const modelConfig of configuration.models) {
+				const mergedConfig = { ...globalConfig, ...modelConfig } as CustomEndpointModelConfig;
 				models.push({
-					...byokKnownModelToAPIInfoWithEffort(this._name, modelConfig.id, modelConfig),
-					url: modelConfig.url
+					...byokKnownModelToAPIInfoWithEffort(this._name, mergedConfig.id, mergedConfig),
+					url: mergedConfig.url
 				});
 			}
 		}
@@ -149,25 +152,28 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 	}
 
 	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>): Promise<OpenAIEndpoint> {
-		const modelConfiguration = model.configuration?.models?.find(m => m.id === model.id);
-		const apiTypeOverride = modelConfiguration?.apiType ?? model.configuration?.apiType;
-		const url = resolveCustomEndpointUrl(model.id, model.url, apiTypeOverride);
+		const explicitConfig = model.configuration?.models?.find(m => m.id === model.id);
+		const globalConfig = model.configuration?.global || {};
+		const modelConfiguration = { ...globalConfig, ...explicitConfig } as Partial<CustomEndpointModelConfig>;
+
+		const apiTypeOverride = modelConfiguration.apiType ?? model.configuration?.apiType;
+		const url = resolveCustomEndpointUrl(model.id, modelConfiguration.url || model.url, apiTypeOverride);
 		const apiType: CustomEndpointApiType = apiTypeOverride ?? inferApiTypeFromUrl(url);
 		const modelCapabilities = {
-			maxInputTokens: model.maxInputTokens,
-			maxOutputTokens: model.maxOutputTokens,
-			contextWindow: modelConfiguration?.contextWindow,
-			toolCalling: !!model.capabilities?.toolCalling || false,
-			vision: !!model.capabilities?.imageInput || false,
-			name: model.name,
+			maxInputTokens: modelConfiguration.maxInputTokens ?? model.maxInputTokens,
+			maxOutputTokens: modelConfiguration.maxOutputTokens ?? model.maxOutputTokens,
+			contextWindow: modelConfiguration.contextWindow ?? modelConfiguration.contextWindow,
+			toolCalling: modelConfiguration.toolCalling ?? !!model.capabilities?.toolCalling,
+			vision: modelConfiguration.vision ?? !!model.capabilities?.imageInput,
+			name: modelConfiguration.name ?? model.name,
 			url,
-			thinking: modelConfiguration?.thinking ?? false,
-			streaming: modelConfiguration?.streaming,
-			requestHeaders: modelConfiguration?.requestHeaders,
-			modelOptions: modelConfiguration?.modelOptions,
-			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled,
-			supportsReasoningEffort: modelConfiguration?.supportsReasoningEffort,
-			reasoningEffortFormat: modelConfiguration?.reasoningEffortFormat
+			thinking: modelConfiguration.thinking ?? false,
+			streaming: modelConfiguration.streaming,
+			requestHeaders: modelConfiguration.requestHeaders,
+			modelOptions: modelConfiguration.modelOptions,
+			zeroDataRetentionEnabled: modelConfiguration.zeroDataRetentionEnabled,
+			supportsReasoningEffort: modelConfiguration.supportsReasoningEffort,
+			reasoningEffortFormat: modelConfiguration.reasoningEffortFormat
 		};
 		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
 		const supportedEndpoints = apiTypeToSupportedEndpoints(apiType);


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/325237 (PR 2 of 4: Global config for all models under an endpoint group)

### Description
This PR adds a `global` settings configuration block for custom endpoint BYOK providers, allowing users to define default configurations (such as URL, API type, token limits, and capabilities) once and have them automatically inherited across all models in that group.

### Key Changes
- **Configuration Schema**: Added `global` property to `customendpoint` provider configuration in `package.json`.
- **Model Merging**: Updated `getAllModels` and `createOpenAIEndPoint` in `customEndpointProvider.ts` to merge `global` defaults with per-model configurations.
