### PR TITLE
feat: auto API inference for custom endpoint BYOK

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -150,15 +150,23 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 
 	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>): Promise<OpenAIEndpoint> {
 		const modelConfiguration = model.configuration?.models?.find(m => m.id === model.id);
-		const apiTypeOverride = modelConfiguration?.apiType ?? model.configuration?.apiType;
-		const url = resolveCustomEndpointUrl(model.id, model.url, apiTypeOverride);
-		const apiType: CustomEndpointApiType = apiTypeOverride ?? inferApiTypeFromUrl(url);
+		let url = modelConfiguration?.url || model.url;
+		let apiType: CustomEndpointApiType;
+
+		if (hasExplicitApiPath(url)) {
+			apiType = inferApiTypeFromUrl(url);
+		} else {
+			const apiTypeOverride = modelConfiguration?.apiType ?? model.configuration?.apiType;
+			url = resolveCustomEndpointUrl(model.id, url, apiTypeOverride);
+			apiType = apiTypeOverride ?? inferApiTypeFromUrl(url);
+		}
+
 		const modelCapabilities = {
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
 			contextWindow: modelConfiguration?.contextWindow,
-			toolCalling: !!model.capabilities?.toolCalling || false,
-			vision: !!model.capabilities?.imageInput || false,
+			toolCalling: !!model.capabilities?.toolCalling,
+			vision: !!model.capabilities?.imageInput,
 			name: model.name,
 			url,
 			thinking: modelConfiguration?.thinking ?? false,


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/325237 (PR 3 of 4: Auto API inference)

### Description
This PR improves custom endpoint BYOK API type inference so that full URLs containing explicit API paths (`/chat/completions`, `/responses`, `/messages`) are automatically detected and used to infer the correct `apiType` without requiring manual configuration.

### Key Changes
- Updated `createOpenAIEndPoint` in `customEndpointProvider.ts` to automatically detect the `apiType` directly from the URL when an explicit API path is present, while still respecting explicit `apiType` overrides if provided.
