### PR TITLE
feat: model metadata and pricing support for BYOK models

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2069,6 +2069,36 @@
                     "type": "string",
                     "description": "Display name of the model"
                   },
+                  "description": {
+                    "type": "string",
+                    "description": "Detailed description or tooltip for the model"
+                  },
+                  "icon": {
+                    "type": "string",
+                    "description": "Theme icon or codicon id for the model"
+                  },
+                  "maxTokens": {
+                    "type": "number",
+                    "description": "Maximum token limit for the context window"
+                  },
+                  "credits": {
+                    "type": "object",
+                    "description": "Token pricing / credit cost configuration for this model",
+                    "properties": {
+                      "input": {
+                        "type": "number",
+                        "description": "Cost per input token"
+                      },
+                      "output": {
+                        "type": "number",
+                        "description": "Cost per output token"
+                      },
+                      "cacheRead": {
+                        "type": "number",
+                        "description": "Cost per cached input token read"
+                      }
+                    }
+                  },
                   "url": {
                     "type": "string",
                     "pattern": "^https?://.+",

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -47,6 +47,10 @@ export type BYOKModelConfig = BYOKGlobalKeyModelConfig | BYOKPerModelConfig | BY
 export interface BYOKModelCapabilities {
 	name: string;
 	url?: string;
+	description?: string;
+	icon?: string;
+	maxTokens?: number;
+	credits?: { input?: number; output?: number; cacheRead?: number };
 	/**
 	 * The maximum number of prompt (input) tokens. Optional when {@link contextWindow}
 	 * is supplied, in which case it is derived as `contextWindow - maxOutputTokens`.
@@ -107,7 +111,7 @@ export function isNoAuthConfig(config: BYOKModelConfig): config is BYOKNoAuthMod
 
 /**
  * Resolves a model's token limits from its BYOK capabilities, honoring an explicit
- * {@link BYOKModelCapabilities.contextWindow} when provided.
+ * {@link BYOKModelCapabilities.contextWindow} or {@link BYOKModelCapabilities.maxTokens} when provided.
  *
  * - When `contextWindow` is set it is the source of truth for the full window and, if
  *   `maxInputTokens` is omitted, the prompt budget is derived as
@@ -121,8 +125,11 @@ export function isNoAuthConfig(config: BYOKModelConfig): config is BYOKNoAuthMod
  * `maxOutputTokens > contextWindow`, or a `maxInputTokens` supplied alongside a smaller
  * `contextWindow` overflowing the window.
  */
-export function resolveModelTokenLimits(capabilities: Pick<BYOKModelCapabilities, 'maxInputTokens' | 'maxOutputTokens' | 'contextWindow'>): { contextWindow: number; maxInputTokens: number; maxOutputTokens: number } {
-	const contextWindow = capabilities.contextWindow ?? ((capabilities.maxInputTokens ?? 0) + capabilities.maxOutputTokens);
+export function resolveModelTokenLimits(capabilities: Pick<BYOKModelCapabilities, 'maxInputTokens' | 'maxOutputTokens' | 'contextWindow' | 'maxTokens'>): { contextWindow: number; maxInputTokens: number; maxOutputTokens: number } {
+	let contextWindow = capabilities.contextWindow ?? ((capabilities.maxInputTokens ?? 0) + capabilities.maxOutputTokens);
+	if (capabilities.maxTokens !== undefined) {
+		contextWindow = Math.min(contextWindow, capabilities.maxTokens);
+	}
 	// The output budget can never exceed the full window.
 	const maxOutputTokens = Math.min(capabilities.maxOutputTokens, contextWindow);
 	// The prompt budget is whatever remains after the output reservation; an explicitly
@@ -173,6 +180,15 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 		modelOptions: knownModelInfo?.modelOptions,
 		reasoningEffortFormat: knownModelInfo?.reasoningEffortFormat
 	};
+	if (knownModelInfo?.credits) {
+		modelInfo.billing = {
+			token_prices: {
+				input_tokens: knownModelInfo.credits.input,
+				output_tokens: knownModelInfo.credits.output,
+				cache_read_tokens: knownModelInfo.credits.cacheRead
+			}
+		};
+	}
 	if (knownModelInfo?.requestHeaders && Object.keys(knownModelInfo.requestHeaders).length > 0) {
 		modelInfo.requestHeaders = { ...knownModelInfo.requestHeaders };
 	}
@@ -200,7 +216,7 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		// vendor (e.g. multiple Ollama servers) are distinguishable in
 		// the model picker.
 		family: id,
-		tooltip: `${capabilities.name} is contributed via the ${providerName} provider.`,
+		tooltip: capabilities.description || `${capabilities.name} is contributed via the ${providerName} provider.`,
 		multiplierNumeric: undefined,
 		isUserSelectable: true,
 		capabilities: {

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -90,6 +90,10 @@ interface _CustomEndpointModelConfig {
 	name: string;
 	url: string;
 	apiType?: CustomEndpointApiType;
+	description?: string;
+	icon?: string;
+	maxTokens?: number;
+	credits?: { input?: number; output?: number; cacheRead?: number };
 	/** Optional when {@link contextWindow} is set; then derived as `contextWindow - maxOutputTokens`. */
 	maxInputTokens?: number;
 	maxOutputTokens: number;
@@ -156,11 +160,15 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 		const modelCapabilities = {
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
-			contextWindow: modelConfiguration?.contextWindow,
+			contextWindow: modelConfiguration?.contextWindow ?? modelConfiguration?.maxTokens,
 			toolCalling: !!model.capabilities?.toolCalling || false,
 			vision: !!model.capabilities?.imageInput || false,
 			name: model.name,
 			url,
+			description: modelConfiguration?.description,
+			icon: modelConfiguration?.icon,
+			credits: modelConfiguration?.credits,
+			maxTokens: modelConfiguration?.maxTokens,
 			thinking: modelConfiguration?.thinking ?? false,
 			streaming: modelConfiguration?.streaming,
 			requestHeaders: modelConfiguration?.requestHeaders,


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/325237 (PR 4 of 4: Adding model metadata & pricing)

### Description
This PR adds support for model metadata (`description`, `icon`, `maxTokens`, `credits`) for BYOK custom endpoints, allowing custom models to provide richer metadata and pricing details in the VS Code Copilot model picker.

### Key Changes
- **Configuration Schema**: Added `description`, `icon`, `maxTokens`, and `credits` (input, output, cacheRead) properties to `package.json` under custom endpoint models.
- **Provider Capabilities**: Updated `BYOKModelCapabilities`, `resolveModelTokenLimits`, and `resolveModelInfo` in `byokProvider.ts` to parse metadata and map pricing information to `IChatModelInformation.billing`.
- **Custom Endpoint Provider**: Forwarded metadata fields in `customEndpointProvider.ts`.
