### PR TITLE
Read the Auto tier from settings.json and send it on POST /auto

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -5164,6 +5164,21 @@
               "onExp"
             ]
           },
+          "github.copilot.chat.autoMode.v2.tier": {
+            "type": "string",
+            "default": "",
+            "enum": [
+              "",
+              "eco",
+              "balanced",
+              "max",
+              "fast"
+            ],
+            "markdownDescription": "%github.copilot.config.chat.autoMode.v2.tier%",
+            "tags": [
+              "advanced"
+            ]
+          },
           "github.copilot.chat.agent.modelDetails.enabled": {
             "type": "boolean",
             "default": true,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -431,6 +431,7 @@
 	"github.copilot.config.cli.planExitMode.enabled": "Enable Plan Mode exit handling in Copilot CLI.",
 	"github.copilot.config.cli.autoModel.enabled": "Enable the Auto model option in Copilot CLI, which automatically selects the best model for each request. Requires VS Code reload.",
 	"github.copilot.config.chat.autoMode.v2.enabled": "Use the single-call Auto API to select the best model for each request. When disabled, model selection falls back to the previous two-call flow.",
+	"github.copilot.config.chat.autoMode.v2.tier": "Auto routing tier to request. A tier shifts how much cost, latency and quality matter when Auto picks a model; it never changes which models you are eligible for. Leave empty to let Auto choose as before.",
 	"github.copilot.config.chat.agent.modelDetails.enabled": "Show model details (model name and request multiplier) on agent chat responses when using Copilot CLI or Claude agent in VS Code. Requires VS Code reload to update already loaded sessions.",
 	"github.copilot.config.cli.planCommand.enabled": "Enable the /plan command in Copilot CLI to create implementation plans before coding.",
 	"github.copilot.config.cli.lazyLoadSessionItem.enabled": "Enable lazy loading of session items in Copilot CLI. Requires VS Code reload.",

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -632,6 +632,12 @@ export namespace ConfigKey {
 		 * Experiment-based so it can be remotely disabled; an explicit user setting still wins.
 		 */
 		export const AutoModeV2Enabled = defineSetting<boolean>('chat.autoMode.v2.enabled', ConfigType.ExperimentBased, true, undefined, undefined, { experimentName: 'copilotchat.autoModeV2Enabled' });
+		/**
+		 * Auto tier to request on `POST /auto`. Empty sends no tier, which routes exactly
+		 * as Auto did before tiers existed. Not experiment-based: this is a dogfooding
+		 * switch that is expected to be set by hand in settings.json.
+		 */
+		export const AutoModeV2Tier = defineSetting<'' | 'eco' | 'balanced' | 'max' | 'fast'>('chat.autoMode.v2.tier', ConfigType.Simple, '');
 		export const CLIModelDetailsEnabled = defineSetting<boolean>('chat.agent.modelDetails.enabled', ConfigType.Simple, true);
 		export const CLIPlanCommandEnabled = defineSetting<boolean>('chat.cli.planCommand.enabled', ConfigType.Simple, true);
 		export const CLIChatLazyLoadSessionItem = defineSetting<boolean>('chat.cli.lazyLoadSessionItem.enabled', ConfigType.Simple, true);

--- a/extensions/copilot/src/platform/endpoint/node/autoV2Fetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/autoV2Fetcher.ts
@@ -77,6 +77,8 @@ export class AutoV2Fetcher {
 			 * Keeps the placeholder prompt out of telemetry and the request log.
 			 */
 			isDiscountProbe?: boolean;
+			/** Auto tier to request. Omitted from the body when empty. */
+			tier?: string;
 		} = {},
 	): Promise<AutoV2Response> {
 		const startTime = Date.now();
@@ -86,6 +88,9 @@ export class AutoV2Fetcher {
 		}
 		if (options.multiTurn) {
 			requestBody.multi_turn = options.multiTurn;
+		}
+		if (options.tier) {
+			requestBody.tier = options.tier;
 		}
 
 		const copilotToken = (await this._authService.getCopilotToken()).token;

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -522,6 +522,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				hasImage: hasImage(chatRequest),
 				conversationId,
 				vscodeRequestId: chatRequest?.id,
+				tier: this._configurationService.getConfig(ConfigKey.Advanced.AutoModeV2Tier) || undefined,
 			});
 			this._setLastAutoV2Discounts(result.discounted_costs);
 


### PR DESCRIPTION
> [!NOTE]
> Draft / spike. Opening early for visibility on the client shape — happy to close if you'd rather this waited for the picker UX.

## What

Adds a `github.copilot.chat.autoMode.v2.tier` setting and forwards its value as `tier` on the single-call `POST /auto` request.

```jsonc
// settings.json
"github.copilot.chat.autoMode.v2.tier": "eco"   // "" | eco | balanced | max | fast
```

## Why

CAPI is adding a tier contract to `POST /auto`: a tier shifts the relative importance of the cost / latency / quality routing signals within the same eligible model pool. It never relaxes model policy, health, capacity or availability checks, and it cannot make an ineligible or unhealthy model selectable.

We'd like to dogfood that server side before designing any picker UX, and Insiders already calls `POST /auto`. A settings-only switch is the smallest way to exercise it.

## Safety

- Default is `""`, which sends no `tier` field at all — the request body is byte-identical to today unless someone opts in.
- The server ignores `tier` entirely unless the caller is enrolled in the tier contract, so this is inert for everyone else.
- An unrecognized value resolves server-side to untiered routing rather than erroring.

## Known limitation

`AutoV2CacheEntry` is keyed by `conversationId` and reused for the whole conversation, so changing the setting mid-chat has no effect until a new conversation (or the 24h session token renews). Acceptable for a dogfooding switch; a real implementation would key the cache on the tier and store it on the entry so it survives the early renewal.

## Deliberately not included

- The discount probe (`_probeAutoV2Discounts`) still sends no tier — it only reads `discounted_costs` for the picker.
- No tests, no picker UI, no telemetry changes.

## Testing

Set the setting, start a **new** chat, and confirm the `auto_tier` claim on the returned `session_token`.
