### PR TITLE
agentHost: support Codex conversation compaction

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -63,6 +63,7 @@ import { AgentHostFileCompletionProvider } from './agentHostFileCompletionProvid
 import { AgentHostRenameCompletionProvider } from './agentHostRenameCommand.js';
 import { AgentHostSkillCompletionProvider } from './agentHostSkillCompletionProvider.js';
 import { AgentHostWorkspaceFiles } from './agentHostWorkspaceFiles.js';
+import { CodexCompactCompletionProvider } from './codexCompactCommand.js';
 import { CopilotApiService, ICopilotApiService } from './shared/copilotApiService.js';
 import { INetworkDiagnosticsService } from './networkDiagnosticsService.js';
 import { parseMcpChannelUri } from './shared/mcpCustomizationController.js';
@@ -505,6 +506,11 @@ export class AgentService extends Disposable implements IAgentService {
 		// AgentSideEffects (redirected to a SessionTitleChanged action).
 		this._register(this._completions.registerProvider(
 			new AgentHostRenameCompletionProvider(
+				session => (this._stateManager.getSessionState(session)?.turns.length ?? 0) > 0,
+			),
+		));
+		this._register(this._completions.registerProvider(
+			new CodexCompactCompletionProvider(
 				session => (this._stateManager.getSessionState(session)?.turns.length ?? 0) > 0,
 			),
 		));

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -30,6 +30,7 @@ import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
+import { parseLeadingSlashCommand } from '../../common/agentHostSlashCommand.js';
 import type { ConfigSchema, ModelSelection, ProtectedResourceMetadata, ToolDefinition, AgentSelection } from '../../common/state/protocol/state.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
 import type { AuthRequiredParams } from '../../common/state/protocol/common/notifications.js';
@@ -120,6 +121,7 @@ import type { ThreadApproveGuardianDeniedActionResponse } from './protocol/gener
 import type { ConfigReadResponse } from './protocol/generated/v2/ConfigReadResponse.js';
 import type { ConfigWriteResponse } from './protocol/generated/v2/ConfigWriteResponse.js';
 import { formatGuardianDenialNotification, summarizeGuardianReviewAction, toGuardianAssessmentEventJson } from './codexGuardianReview.js';
+import { CODEX_COMPACT_SLASH_COMMAND } from '../codexCompactCommand.js';
 
 const CLIENT_INFO = {
 	name: 'vscode_agent_host',
@@ -2074,6 +2076,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			'thread/settings/updated', // VS Code owns session config; Codex settings echoes are not consumed yet.
 			'thread/goal/updated', // Goals are not surfaced in the Agent Host UI yet.
 			'thread/goal/cleared', // Goals are not surfaced in the Agent Host UI yet.
+			'thread/compacted', // Deprecated completion echo; the contextCompaction item owns UI progress.
 			'remoteControl/status/changed', // Remote-control state is not part of the VS Code integration.
 			'serverRequest/resolved', // We resolve requests through JSON-RPC responses, so this echo is informational.
 			'item/autoApprovalReview/started', // Informational; the completed notification drives the denied-action card.
@@ -3612,18 +3615,26 @@ export class CodexAgent extends Disposable implements IAgent {
 			}
 		}
 
-		const { input, cleanupPaths } = resolveCodexInput(prompt, attachments);
 		// Buffer the prompt text for `turn/started`'s userMessage fallback.
 		session.lastPromptText = prompt;
 		session.currentTurnId = effectiveTurnId;
 		this._startTurnStopWatch(session);
+		let cleanupPaths: readonly string[] = [];
+		const isCompactCommand = parseLeadingSlashCommand(prompt)?.command === CODEX_COMPACT_SLASH_COMMAND;
 		try {
+			if (isCompactCommand) {
+				await conn.client.request<'thread/compact/start'>('thread/compact/start', { threadId }, this._traceContext(session));
+				session.firstTurnSent = true;
+				return;
+			}
+			const resolvedInput = resolveCodexInput(prompt, attachments);
+			cleanupPaths = resolvedInput.cleanupPaths;
 			const model = await this._resolveModel(session);
 			const resolvedModel = parseCodexModelSelection(model);
 			const turnOptions = this._turnStartOptions(session, resolvedModel.modelId, customizationLaunch.developerInstructions);
 			await conn.client.request<'turn/start'>('turn/start', {
 				threadId,
-				input: input.slice(),
+				input: resolvedInput.input.slice(),
 				model: resolvedModel.modelId,
 				...turnOptions,
 			}, this._traceContext(session));
@@ -3638,13 +3649,14 @@ export class CodexAgent extends Disposable implements IAgent {
 				return;
 			}
 			const message = err instanceof Error ? err.message : String(err);
-			this._logService.error(`[Codex:${sessionId}] turn/start error: ${message}`);
+			const operation = isCompactCommand ? 'thread/compact/start' : 'turn/start';
+			this._logService.error(`[Codex:${sessionId}] ${operation} error: ${message}`);
 			const duration = this._clearTurnStopWatch(session);
 			this._fire(sessionUri, {
 				type: ActionType.ChatError,
 				turnId: effectiveTurnId,
 				duration,
-				error: { errorType: 'CodexTurnError', ...extractForwardedErrorInfo(message) },
+				error: { errorType: isCompactCommand ? 'CodexCompactionError' : 'CodexTurnError', ...extractForwardedErrorInfo(message) },
 			});
 			this._fire(sessionUri, { type: ActionType.ChatTurnComplete, turnId: effectiveTurnId, duration });
 		} finally {

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { localize } from '../../../../nls.js';
 import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { ActionType, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolResultContentType, TurnState } from '../../common/state/sessionState.js';
@@ -284,6 +285,14 @@ export function describeFileChange(changes: readonly FileUpdateChange[]): string
 
 export function fileChangeOutput(changes: readonly FileUpdateChange[]): string {
 	return changes.map(change => `${describeFileChange([change])}\n${change.diff}`.trim()).join('\n\n');
+}
+
+export function codexCompactionLabels(): { readonly displayName: string; readonly invocationMessage: string; readonly pastTenseMessage: string } {
+	return {
+		displayName: localize('codex.compaction.displayName', "Compact conversation"),
+		invocationMessage: localize('codex.compaction.inProgress', "Compacting conversation"),
+		pastTenseMessage: localize('codex.compaction.completed', "Compacted conversation"),
+	};
 }
 
 function jsonValueToText(value: JsonValue): string {
@@ -796,6 +805,32 @@ function mapItemStartedBody(
 			},
 		];
 	}
+	if (params.item.type === 'contextCompaction') {
+		const toolCallId = generateUuid();
+		const labels = codexCompactionLabels();
+		state.itemToToolCall.set(params.item.id, {
+			toolCallId,
+			turnId: params.turnId,
+			toolName: 'compact',
+			output: '',
+		});
+		return [
+			{
+				type: ActionType.ChatToolCallStart,
+				turnId: params.turnId,
+				toolCallId,
+				toolName: 'compact',
+				displayName: labels.displayName,
+			},
+			{
+				type: ActionType.ChatToolCallReady,
+				turnId: params.turnId,
+				toolCallId,
+				invocationMessage: labels.invocationMessage,
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			},
+		];
+	}
 	return [];
 }
 
@@ -922,6 +957,17 @@ export function mapItemCompleted(
 	}
 	state.itemToToolCall.delete(params.item.id);
 	const declined = state.declinedToolCalls.delete(entry.toolCallId);
+	if (params.item.type === 'contextCompaction') {
+		return [{
+			type: ActionType.ChatToolCallComplete,
+			turnId: entry.turnId,
+			toolCallId: entry.toolCallId,
+			result: {
+				success: true,
+				pastTenseMessage: codexCompactionLabels().pastTenseMessage,
+			},
+		}];
+	}
 	if (params.item.type === 'commandExecution') {
 		const success = params.item.status === 'completed' && (params.item.exitCode === 0 || params.item.exitCode === null);
 		const output = params.item.aggregatedOutput ?? entry.output;

--- a/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/codex/codexReplayMapper.ts
@@ -19,6 +19,7 @@ import {
 import {
 	describeFileChange,
 	describeWebSearch,
+	codexCompactionLabels,
 	fileChangeOutput,
 	turnStateFromStatus,
 } from './codexMapAppServerEvents.js';
@@ -41,6 +42,7 @@ import type { Turn as CodexTurn } from './protocol/generated/v2/Turn.js';
  *  - `commandExecution` → completed terminal `ToolCallResponsePart`
  *  - `webSearch`        → completed web-search `ToolCallResponsePart`
  *  - `fileChange`       → completed file-edit `ToolCallResponsePart`
+ *  - `contextCompaction` → completed compaction `ToolCallResponsePart`
  *  - everything else    → currently dropped (reasoning/plan/mcp/collab)
  *
  * Mirrors the live mapper's translation kernel — including the sandbox
@@ -129,6 +131,11 @@ function replayTurnToTurn(codexTurn: CodexTurn): Turn | undefined {
 			parts.push(webSearchToolCallPart(item));
 		} else if (item.type === 'fileChange') {
 			parts.push(fileChangeToolCallPart(item));
+		} else if (item.type === 'contextCompaction') {
+			if (!userText) {
+				userText = '/compact';
+			}
+			parts.push(compactionToolCallPart());
 		}
 		// Other item types (plan/reasoning/mcpToolCall/collabAgentToolCall/…)
 		// are not yet reconstructed in replay.
@@ -235,6 +242,23 @@ function fileChangeToolCallPart(item: Extract<ThreadItem, { type: 'fileChange' }
 			pastTenseMessage: success ? 'Applied file changes' : 'Failed to apply file changes',
 			content: textContent(output),
 			error: success ? undefined : { message: `Patch ${item.status}` },
+		},
+	};
+}
+
+function compactionToolCallPart(): ToolCallResponsePart {
+	const labels = codexCompactionLabels();
+	return {
+		kind: ResponsePartKind.ToolCall,
+		toolCall: {
+			status: ToolCallStatus.Completed,
+			toolCallId: generateUuid(),
+			toolName: 'compact',
+			displayName: labels.displayName,
+			invocationMessage: labels.invocationMessage,
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			success: true,
+			pastTenseMessage: labels.pastTenseMessage,
 		},
 	};
 }

--- a/src/vs/platform/agentHost/node/codexCompactCommand.ts
+++ b/src/vs/platform/agentHost/node/codexCompactCommand.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { localize } from '../../../nls.js';
+import { AgentSession, CODEX_AGENT_PROVIDER_ID } from '../common/agentService.js';
+import { toCommandCompletionAttachmentMeta } from '../common/meta/agentCompletionAttachmentMeta.js';
+import { CompletionItem, CompletionItemKind, CompletionsParams } from '../common/state/protocol/commands.js';
+import type { URI } from '../common/state/protocol/common/state.js';
+import { MessageAttachmentKind } from '../common/state/protocol/state.js';
+import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
+import { extractLeadingSlashToken, matchesSlashCompletion } from './agentHostSlashCompletion.js';
+
+export const CODEX_COMPACT_SLASH_COMMAND = 'compact';
+
+export class CodexCompactCompletionProvider implements IAgentHostCompletionItemProvider {
+	readonly kinds: ReadonlySet<CompletionItemKind> = new Set([CompletionItemKind.UserMessage]);
+	readonly triggerCharacters = [CompletionTriggerCharacter.Slash] as const;
+
+	constructor(private readonly _hasHistory: (session: URI) => boolean) { }
+
+	async provideCompletionItems(params: CompletionsParams, _token: CancellationToken): Promise<readonly CompletionItem[]> {
+		if (AgentSession.provider(params.channel) !== CODEX_AGENT_PROVIDER_ID || !this._hasHistory(params.channel)) {
+			return [];
+		}
+		const leading = extractLeadingSlashToken(params.text, params.offset);
+		if (!leading || !matchesSlashCompletion(leading.typed, CODEX_COMPACT_SLASH_COMMAND)) {
+			return [];
+		}
+		return [{
+			insertText: `/${CODEX_COMPACT_SLASH_COMMAND} `,
+			rangeStart: leading.rangeStart,
+			rangeEnd: leading.rangeEnd,
+			attachment: {
+				type: MessageAttachmentKind.Simple,
+				label: `/${CODEX_COMPACT_SLASH_COMMAND}`,
+				_meta: toCommandCompletionAttachmentMeta({
+					command: CODEX_COMPACT_SLASH_COMMAND,
+					description: localize('codex.compact.description', "Compact this conversation's context"),
+				}),
+			},
+		}];
+	}
+}

--- a/src/vs/platform/agentHost/test/node/codex/codexCompactCommand.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexCompactCommand.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CODEX_AGENT_PROVIDER_ID } from '../../../common/agentService.js';
+import { CompletionItemKind } from '../../../common/state/protocol/commands.js';
+import { MessageAttachmentKind } from '../../../common/state/protocol/state.js';
+import { CODEX_COMPACT_SLASH_COMMAND, CodexCompactCompletionProvider } from '../../../node/codexCompactCommand.js';
+
+suite('CodexCompactCompletionProvider', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const codexSession = `${CODEX_AGENT_PROVIDER_ID}:/abc`;
+
+	function run(text: string, channel = codexSession, hasHistory = true) {
+		const provider = new CodexCompactCompletionProvider(() => hasHistory);
+		return provider.provideCompletionItems({ kind: CompletionItemKind.UserMessage, channel, text, offset: text.length }, CancellationToken.None);
+	}
+
+	test('offers /compact with command metadata for Codex sessions with history', async () => {
+		const items = await run('/com');
+		assert.deepStrictEqual(items, [{
+			insertText: '/compact ',
+			rangeStart: 0,
+			rangeEnd: 4,
+			attachment: {
+				type: MessageAttachmentKind.Simple,
+				label: '/compact',
+				_meta: {
+					command: CODEX_COMPACT_SLASH_COMMAND,
+					description: 'Compact this conversation\'s context',
+				},
+			},
+		}]);
+	});
+
+	test('does not offer /compact for empty or non-Codex sessions', async () => {
+		assert.deepStrictEqual({
+			empty: await run('/', codexSession, false),
+			other: await run('/', 'copilotcli:/abc'),
+			unrelated: await run('/rename'),
+		}, { empty: [], other: [], unrelated: [] });
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -207,6 +207,33 @@ suite('codexMapAppServerEvents', () => {
 		}]);
 	});
 
+	test('contextCompaction item maps to visible running and completed progress', () => {
+		const state = createCodexSessionMapState();
+		const started = mapItemStarted(state, {
+			item: { type: 'contextCompaction', id: 'compact_1' },
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const toolCallId = state.itemToToolCall.get('compact_1')?.toolCallId;
+		const completed = mapItemCompleted(state, {
+			item: { type: 'contextCompaction', id: 'compact_1' },
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 1,
+		});
+
+		assert.deepStrictEqual({ started, completed, remaining: state.itemToToolCall.size }, {
+			started: [
+				{ type: ActionType.ChatToolCallStart, turnId: 'turn_a', toolCallId, toolName: 'compact', displayName: 'Compact conversation' },
+				{ type: ActionType.ChatToolCallReady, turnId: 'turn_a', toolCallId, invocationMessage: 'Compacting conversation', confirmed: ToolCallConfirmationReason.NotNeeded },
+			],
+			completed: [{
+				type: ActionType.ChatToolCallComplete,
+				turnId: 'turn_a',
+				toolCallId,
+				result: { success: true, pastTenseMessage: 'Compacted conversation' },
+			}],
+			remaining: 0,
+		});
+	});
+
 	test('item/completed for agentMessage clears the mapping', () => {
 		const state = createCodexSessionMapState();
 		mapItemStarted(state, {

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -349,6 +349,40 @@ suite('CodexAgent prewarm eviction', () => {
 		await assertPrewarmEvictedOnSend(disposables, false);
 	});
 
+	test('/compact invokes thread/compact/start instead of starting a prompt turn', async () => {
+		const agent = await createAgent(disposables);
+		agent['_schedulePrewarm'] = () => { };
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const peer = disposables.add(createTestPeer());
+		agent['_connection'] = {
+			kind: 'ready',
+			client: new CodexAppServerClient(peer.transport),
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+
+		const repo = URI.file('/repo');
+		const { session } = await agent.createSession({ workingDirectories: [repo], model: { id: COPILOT_TEST_MODEL } });
+		const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), '/compact', [repo], undefined, 'turn-compact');
+		const threadStart = await readNextRequest(peer.outbound);
+		peer.push({ id: threadStart.id, result: { thread: { id: 'thread-compact' } } });
+		const compactStart = await readNextRequest(peer.outbound);
+		peer.push({ id: compactStart.id, result: {} });
+		await send;
+
+		assert.deepStrictEqual({
+			threadStart: { method: threadStart.method, cwd: threadStart.params.cwd },
+			compactStart: { method: compactStart.method, threadId: compactStart.params.threadId },
+			firstTurnSent: agent['_sessions'].get(AgentSession.id(session))?.firstTurnSent,
+		}, {
+			threadStart: { method: 'thread/start', cwd: repo.fsPath },
+			compactStart: { method: 'thread/compact/start', threadId: 'thread-compact' },
+			firstTurnSent: true,
+		});
+		peer.exit();
+	});
+
 	test('thread start receives custom agents, instructions, skills, and MCP from client plugins', async () => {
 		const agent = await createAgent(disposables);
 		agent['_schedulePrewarm'] = () => { };

--- a/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexReplayMapper.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { replayThreadToTurns } from '../../../node/codex/codexReplayMapper.js';
-import { ResponsePartKind, TurnState } from '../../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ToolCallStatus, TurnState } from '../../../common/state/sessionState.js';
 
 suite('codexReplayMapper', () => {
 
@@ -201,6 +201,68 @@ suite('codexReplayMapper', () => {
 			success: true,
 			output: 'total 0',
 		});
+	});
+
+	test('contextCompaction is restored as a completed /compact turn', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_compact',
+				items: [{ type: 'contextCompaction', id: 'compact_1' }],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+		const part = turns[0].responseParts[0];
+
+		assert.deepStrictEqual({
+			message: turns[0].message,
+			kind: part.kind,
+			toolCall: part.kind === ResponsePartKind.ToolCall && part.toolCall.status === ToolCallStatus.Completed ? {
+				status: part.toolCall.status,
+				toolName: part.toolCall.toolName,
+				displayName: part.toolCall.displayName,
+				invocationMessage: part.toolCall.invocationMessage,
+				pastTenseMessage: part.toolCall.pastTenseMessage,
+				success: part.toolCall.success,
+			} : undefined,
+		}, {
+			message: { text: '/compact', origin: { kind: MessageKind.User } },
+			kind: ResponsePartKind.ToolCall,
+			toolCall: {
+				status: ToolCallStatus.Completed,
+				toolName: 'compact',
+				displayName: 'Compact conversation',
+				invocationMessage: 'Compacting conversation',
+				pastTenseMessage: 'Compacted conversation',
+				success: true,
+			},
+		});
+	});
+
+	test('automatic contextCompaction remains progress within its existing turn', () => {
+		const turns = replayThreadToTurns({
+			id: 'thr',
+			turns: [{
+				id: 'turn_auto_compact',
+				items: [
+					{ type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'continue', text_elements: [] }] },
+					{ type: 'contextCompaction', id: 'compact_1' },
+					{ type: 'agentMessage', id: 'a1', text: 'continued', phase: null, memoryCitation: null },
+				],
+				itemsView: { type: 'full' } as never,
+				status: 'completed' as never,
+				error: null, startedAt: null, completedAt: null, durationMs: null,
+			}],
+		} as never);
+
+		assert.strictEqual(turns.length, 1);
+		assert.strictEqual(turns[0].message.text, 'continue');
+		assert.deepStrictEqual(turns[0].responseParts.map(part => part.kind), [
+			ResponsePartKind.ToolCall,
+			ResponsePartKind.Markdown,
+		]);
 	});
 
 	test('commandExecution coalesces a sandbox pre-flight with its re-run into one box', () => {


### PR DESCRIPTION
## Summary

- add a Codex `/compact` completion for sessions with history and dispatch it through `thread/compact/start`
- map manual and automatic `contextCompaction` lifecycles to localized, accessible chat progress and dedicated errors
- preserve manual versus automatic compaction semantics when replaying Codex threads

## Testing

- focused ESLint
- `npm run transpile-client`
- 76 focused Agent Host tests
- `git diff --check`
- live Code OSS Agents-window verification using the launch workflow:
  - `/compact` appears in slash-command completions
  - in-progress UI shows “Compacting conversation”, Analyzing state, cancel affordance, and ARIA progress
  - completion UI shows and announces “Compacted conversation”, with context usage reset to 0%
