### PR TITLE
Add activeBackground color to activityBar in 2026 themes

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -72,6 +72,7 @@
 		"activityBar.background": "#191A1B",
 		"activityBar.foreground": "#bfbfbf",
 		"activityBar.inactiveForeground": "#8C8C8C",
+		"activityBar.activeBackground": "#313233",
 		"activityBar.border": "#2A2B2CFF",
 		"activityBar.activeBorder": "#bfbfbf",
 		"activityBar.activeFocusBorder": "#3994BCB3",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -81,6 +81,7 @@
 		"activityBar.background": "#FAFAFD",
 		"activityBar.foreground": "#202020",
 		"activityBar.inactiveForeground": "#606060",
+		"activityBar.activeBackground": "#D6D6D6",
 		"activityBar.border": "#F0F1F2FF",
 		"activityBar.activeBorder": "#000000",
 		"activityBar.activeFocusBorder": "#0069CCFF",


### PR DESCRIPTION
Introduce an `activeBackground` color for the activity bar in both the 2026 dark and light themes to enhance visual distinction and usability.

