### PR TITLE
Style overrides: Add border to modified side-by-side diff editor

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
@@ -46,3 +46,7 @@
 .style-override.monaco-workbench:not(.hc-black):not(.hc-light) .terminal-resize-overlay {
 	box-shadow: var(--vscode-shadow-lg);
 }
+
+.style-override.monaco-workbench .monaco-diff-editor.side-by-side .editor.modified {
+	border-left: 1px solid var(--vscode-surface-border);
+}


### PR DESCRIPTION
Enhance the visual distinction of modified lines in the side-by-side diff editor by adding a left border. This change improves readability and helps users quickly identify modifications.

