### PR TITLE
Check native optional deps against the host, not the build target

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
@@ -129,7 +129,7 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Verify native optional dependency binaries
 

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -174,7 +174,7 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
         displayName: Verify native optional dependency binaries
 
       - script: node build/azure-pipelines/distro/mixin-npm.ts

--- a/build/azure-pipelines/common/checkNativeOptionalDeps.ts
+++ b/build/azure-pipelines/common/checkNativeOptionalDeps.ts
@@ -55,10 +55,19 @@ export function findMissingNativeOptionalDep(nodeModulesDir: string, basePackage
 // #region CLI entry point
 //
 // Runs after the root node_modules is restored or installed in CI. Verifies
-// the repo-root node_modules has the per-platform package for the target so a
-// poisoned cache (base package present, native package silently skipped) is
-// neither used nor persisted. The optional CLI arguments override the current
-// platform and architecture for cross-architecture builds.
+// the repo-root node_modules has the per-platform package for the machine
+// running the install, so a silently incomplete install (base package present,
+// native package skipped) is neither used nor persisted in the cache.
+//
+// This deliberately checks the HOST platform/arch, never the build target. The
+// pipelines set `npm_config_arch`, but that only steers node-gyp/prebuild
+// downloads — it does NOT drive npm's `os`/`cpu` optional-dependency
+// filtering. On a cross-architecture job (e.g. Windows arm64 built on an x64
+// agent) npm therefore installs the HOST's per-platform package, and asserting
+// on the target's would fail every such job. The per-target binaries that
+// actually ship are produced separately by `build/agent-sdk/package.ts`, which
+// installs into a scratch dir with `npm_config_os`/`npm_config_cpu` set and
+// validates the result via `findMissingNativeOptionalDep` below.
 
 // Base packages whose per-platform package (`<base>-<platform>-<arch>`) is
 // required whenever the base package itself is installed.
@@ -79,8 +88,8 @@ function isCliInvocation(): boolean {
 }
 
 function main(): void {
-	const platform = process.argv[2] ?? process.platform;
-	const arch = process.argv[3] ?? process.arch;
+	const platform = process.platform;
+	const arch = process.arch;
 	if (!SUPPORTED_PLATFORMS.has(platform) || !SUPPORTED_ARCHS.has(arch)) {
 		console.log(`Skipping native optional-dependency check on unsupported ${platform}-${arch}.`);
 		return;

--- a/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
@@ -102,7 +102,7 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts darwin $(VSCODE_ARCH)
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Verify native optional dependency binaries
 

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -112,7 +112,7 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts darwin $(VSCODE_ARCH)
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
     displayName: Verify native optional dependency binaries
 
   - script: node build/azure-pipelines/distro/mixin-npm.ts

--- a/build/azure-pipelines/linux/product-build-linux-node-modules.yml
+++ b/build/azure-pipelines/linux/product-build-linux-node-modules.yml
@@ -142,7 +142,7 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Verify native optional dependency binaries
 

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -159,7 +159,7 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts linux $(NPM_ARCH)
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
     displayName: Verify native optional dependency binaries
 
   - script: node build/azure-pipelines/distro/mixin-npm.ts

--- a/build/azure-pipelines/win32/product-build-win32-node-modules.yml
+++ b/build/azure-pipelines/win32/product-build-win32-node-modules.yml
@@ -85,7 +85,7 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-      - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts win32 $(VSCODE_ARCH)
+      - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Verify native optional dependency binaries
 

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -100,7 +100,7 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-  - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts win32 $(VSCODE_ARCH)
+  - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
     displayName: Verify native optional dependency binaries
 
   - powershell: node build/azure-pipelines/distro/mixin-npm.ts


### PR DESCRIPTION
Fixes the `node_modules` stage failures on `main` (red continuously since build [20260806.29](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462044) at 10:51 UTC).

### What's wrong

The native optional-dependency guard added in #329346 asserts that the **target** architecture's per-platform package is present in the **host's** root `node_modules`:

```yaml
- script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts darwin $(VSCODE_ARCH)
```

The pipelines set `npm_config_arch`, but that only steers node-gyp/prebuild downloads — it does **not** drive npm's `os`/`cpu` optional-dependency filtering (that needs `--cpu`/`--os`). On a cross-architecture job npm therefore installs the *host's* per-platform package, so the assertion can never hold:

```
@openai/codex: required per-platform package '@openai/codex-darwin-x64' is missing from node_modules
@anthropic-ai/claude-agent-sdk: required per-platform package '@anthropic-ai/claude-agent-sdk-darwin-x64' is missing
```

The correlation is exact — every cross-arch job fails, every native job passes:

| Job | Host | Target | Result |
|---|---|---|---|
| macOS (X64) | arm64 | x64 | ✗ |
| Windows (ARM64) | x64 | arm64 | ✗ |
| Linux (ARM64) | x64 | arm64 | ✗ |
| Linux Alpine (ARM64) | x64 | arm64 | ✗ |
| Linux Alpine (X64), Web | x64 | x64 | ✓ |
| Linux (ARMHF) | x64 | armhf | ✓ (skipped, unsupported arch) |
| all compile stages | native | native | ✓ |

### Why it surfaced late, and why it's sticky

The step is gated on `ne(NODE_MODULES_RESTORED, 'true')`, so it only runs on a **cache miss**. It stayed invisible until `b017b98` changed `package-lock.json` and produced a fresh cache key. Because the job now fails *before* `Create node_modules archive`, the cache for that key is **never saved** — so every subsequent build re-misses and re-fails, even commits that don't touch `package-lock.json`. Retrying cannot clear it.

### The fix

Check the host platform/arch, and drop the `argv` override so no call site can reintroduce the target-arch assertion. This preserves the original intent (catching the silent optional-dependency gap from #323881) — that failure mode is about the *host's* install being incomplete.

The per-target binaries that actually ship are unaffected: they're produced separately by `build/agent-sdk/package.ts`, which installs into a scratch dir with `npm_config_os`/`npm_config_cpu` set and validates via the same exported `findMissingNativeOptionalDep` helper (untouched here).

### Validation

- `npm run typecheck` in `build/` — clean
- Guard passes on host: `Verified native optional-dependency packages for darwin-arm64.`
- A stale `... win32 arm64` invocation now correctly ignores the args instead of failing
- Detection still fires: synthetic base-package-without-native-package returns the missing name; an uninstalled base package correctly returns `OK`
- All 8 YAML edits are trailing-token removals with byte-identical indentation

### Follow-up (not in this PR)

Because the guard is gated to cache misses, it never inspects a *restored* cache — so it can't catch the poisoned-cache scenario its own comments describe. Worth addressing separately; this PR just unwedges `main`.