### PR TITLE
Add chat pet component fixtures

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatPetWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatPetWidget.ts
@@ -8,14 +8,15 @@ import * as dom from '../../../../../base/browser/dom.js';
 import { GlobalPointerMoveMonitor } from '../../../../../base/browser/globalPointerMoveMonitor.js';
 import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { StandardMouseEvent } from '../../../../../base/browser/mouseEvent.js';
-import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { status } from '../../../../../base/browser/ui/aria/aria.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { Action, IAction, Separator } from '../../../../../base/common/actions.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { FileAccess } from '../../../../../base/common/network.js';
-import { autorun, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { AppResourcePath, FileAccess } from '../../../../../base/common/network.js';
+import { autorun, constObservable, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { localize } from '../../../../../nls.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
@@ -23,6 +24,7 @@ import { IChatModel } from '../../common/model/chatModel.js';
 import { ChatPetVariant, IChatPetService } from '../chatPetService.js';
 
 export type ChatPetState = 'idle' | 'sleep' | 'waking' | 'typing' | 'rendering' | 'complete' | 'love' | 'clapping' | 'jump' | 'cool' | 'yapping' | 'yappingMouthOpen' | 'onTheRun' | 'searching' | 'searchingDown';
+export type ChatPetAnimationDurationSource = 'sprite' | 'css' | 'all';
 export type ChatPetClickInteraction = Extract<ChatPetState, 'love' | 'jump' | 'cool' | 'yapping'>;
 
 export const CHAT_PET_IDLE_SLEEP_DELAY = 20_000;
@@ -34,6 +36,391 @@ const WAKE_STATE_DURATION = 880;
 const SEARCH_INTERVAL = 10_000;
 const DRAG_THRESHOLD = 2;
 const KEYBOARD_MOVE_DISTANCE = 8;
+
+export function getChatPetBaseState(hasActiveRequest: boolean, needsInput: boolean, hasInput: boolean, idleExpired: boolean): ChatPetState {
+	if (needsInput) {
+		return 'clapping';
+	}
+	if (hasActiveRequest) {
+		return 'rendering';
+	}
+	if (idleExpired) {
+		return 'sleep';
+	}
+	if (hasInput) {
+		return 'typing';
+	}
+	return 'idle';
+}
+
+export function isChatPetVisible(enabled: boolean, isLatestFocusedWidget: boolean): boolean {
+	return enabled && isLatestFocusedWidget;
+}
+
+export function getChatPetRenderedState(baseState: ChatPetState, transientState: ChatPetState | undefined, isDragging: boolean): ChatPetState {
+	return isDragging ? 'idle' : transientState ?? baseState;
+}
+
+function getTransientStateDuration(state: ChatPetState): number {
+	switch (state) {
+		case 'complete':
+			return COMPLETE_STATE_DURATION;
+		case 'love':
+			return LOVE_STATE_DURATION;
+		case 'cool':
+			return COOL_STATE_DURATION;
+		case 'waking':
+			return WAKE_STATE_DURATION;
+		default:
+			return TRANSIENT_STATE_DURATION;
+	}
+}
+
+export function getChatPetClickInteraction(random: number, previousInteraction?: ChatPetClickInteraction): ChatPetClickInteraction {
+	const interactions: readonly ChatPetClickInteraction[] = ['love', 'jump', 'cool', 'yapping'];
+	const availableInteractions = interactions.filter(interaction => interaction !== previousInteraction);
+	return availableInteractions[Math.min(Math.floor(random * availableInteractions.length), availableInteractions.length - 1)];
+}
+
+export class ChatPetWidget extends Disposable {
+
+	private readonly _view: ChatPetView;
+	private readonly _dragMonitor = this._register(new GlobalPointerMoveMonitor());
+	private readonly _idleExpired = observableValue(this, false);
+	private readonly _transientState = observableValue<ChatPetState | undefined>(this, undefined);
+	private readonly _isDragging = observableValue(this, false);
+	private readonly _idleScheduler = this._register(new RunOnceScheduler(() => this._idleExpired.set(true, undefined), CHAT_PET_IDLE_SLEEP_DELAY));
+	private readonly _transientScheduler = this._register(new RunOnceScheduler(() => this._transientState.set(undefined, undefined), TRANSIENT_STATE_DURATION));
+	private readonly _searchScheduler: RunOnceScheduler;
+	private readonly _clickSuppressionScheduler = this._register(new RunOnceScheduler(() => this._suppressNextPointerClick = false, 0));
+	private readonly _contextMenuActions = this._register(new MutableDisposable<DisposableStore>());
+	private _motionReduced = false;
+	private _enabled = false;
+	private _busy = false;
+	private _enablementInitialized = false;
+	private _suppressNextPointerClick = false;
+	private _lastClickInteraction: ChatPetClickInteraction | undefined;
+	private _variant: ChatPetVariant;
+
+	constructor(
+		parent: HTMLElement,
+		dragBounds: HTMLElement,
+		model: IObservable<IChatModel | undefined>,
+		hasInput: IObservable<boolean>,
+		isLatestFocusedWidget: IObservable<boolean>,
+		inputChanged: (listener: () => void) => IDisposable,
+		@IChatPetService private readonly chatPetService: IChatPetService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+	) {
+		super();
+
+		this._variant = this.chatPetService.variant.get();
+		this._searchScheduler = this._register(new RunOnceScheduler(() => this._trySearch(), SEARCH_INTERVAL));
+		this._view = this._register(new ChatPetView(parent, dragBounds, {
+			ariaLabel: localize('chatPet.interact', "Interact with the VS Code pet. Use the context menu to put it on the run."),
+			onDidCompleteAnimation: state => this._onAnimationComplete(state),
+		}));
+		this._register(dom.addDisposableListener(this._view.element, dom.EventType.POINTER_DOWN, event => this._startDrag(event)));
+		this._register(dom.addDisposableListener(this._view.element, dom.EventType.KEY_DOWN, event => this._onKeyDown(event)));
+		this._register(dom.addDisposableListener(this._view.element, dom.EventType.CONTEXT_MENU, event => {
+			if (!this._enabled) {
+				return;
+			}
+			dom.EventHelper.stop(event, true);
+			this._showContextMenu(event);
+		}));
+		this._register(inputChanged(() => {
+			if (this._enabled && !this.chatPetService.onTheRun.get()) {
+				this._wake();
+			}
+		}));
+		this._register(this._view.onDidClick(e => {
+			dom.EventHelper.stop(e, true);
+			if (this._suppressNextPointerClick && e.type !== dom.EventType.KEY_DOWN) {
+				this._suppressNextPointerClick = false;
+				this._clickSuppressionScheduler.cancel();
+				return;
+			}
+			if (this.chatPetService.onTheRun.get()) {
+				this._transientState.set(undefined, undefined);
+				this.chatPetService.setOnTheRun(false);
+				return;
+			}
+			const wasSleeping = this._idleExpired.get() || this._view.renderedState === 'sleep';
+			if (wasSleeping) {
+				this._wake();
+			}
+			if (wasSleeping || this._transientState.get() === 'waking') {
+				status(localize('chatPet.wokeUp', "The VS Code pet woke up"));
+				return;
+			}
+			const interaction = getChatPetClickInteraction(Math.random(), this._lastClickInteraction);
+			this._lastClickInteraction = interaction;
+			this._showTransientState(interaction);
+			switch (interaction) {
+				case 'love':
+					status(localize('chatPet.loved', "The VS Code pet feels loved"));
+					break;
+				case 'jump':
+					status(localize('chatPet.jumped', "The VS Code pet jumped"));
+					break;
+				case 'cool':
+					status(localize('chatPet.cool', "The VS Code pet put on sunglasses"));
+					break;
+				case 'yapping':
+					status(localize('chatPet.yapping', "The VS Code pet is yapping"));
+					break;
+			}
+		}));
+
+		const motionReduced = observableFromEvent(this, this.accessibilityService.onDidChangeReducedMotion, () => this.accessibilityService.isMotionReduced());
+		this._register(autorun(reader => {
+			this._motionReduced = motionReduced.read(reader);
+			const enabled = isChatPetVisible(this.chatPetService.enabled.read(reader), isLatestFocusedWidget.read(reader));
+			const variant = this.chatPetService.variant.read(reader);
+			const variantChanged = variant !== this._variant;
+			this._variant = variant;
+			const onTheRun = this.chatPetService.onTheRun.read(reader);
+			this._view.setOnTheRun(onTheRun);
+			this._view.setAriaLabel(onTheRun
+				? localize('chatPet.restore', "Bring back the VS Code pet")
+				: localize('chatPet.interact', "Interact with the VS Code pet. Use the context menu to put it on the run."));
+			const chatModel = model.read(reader);
+			const request = chatModel?.lastRequestObs.read(reader);
+			const needsInput = !!request?.response?.isPendingConfirmation.read(reader);
+			const hasActiveRequest = chatModel?.hasActiveRequest.read(reader) ?? false;
+			const inputHasContent = hasInput.read(reader);
+			this._busy = hasActiveRequest || needsInput;
+			let idleExpired = this._idleExpired.read(reader);
+			let transientState = this._transientState.read(reader);
+			const isDragging = this._isDragging.read(reader);
+
+			if (!this._enablementInitialized || enabled !== this._enabled) {
+				const wasInitialized = this._enablementInitialized;
+				this._enablementInitialized = true;
+				this._enabled = enabled;
+				if (enabled) {
+					this._view.show(this._motionReduced);
+				} else {
+					this._view.hide(!wasInitialized || this._motionReduced);
+				}
+			}
+
+			if (!enabled) {
+				this._idleScheduler.cancel();
+				this._searchScheduler.cancel();
+				this._transientScheduler.cancel();
+				if (transientState !== undefined) {
+					this._transientState.set(undefined, undefined);
+				}
+				if (this._motionReduced) {
+					this._view.hide(true);
+				}
+				return;
+			}
+
+			if (onTheRun) {
+				this._idleScheduler.cancel();
+				if (!this._searchScheduler.isScheduled()) {
+					this._searchScheduler.schedule();
+				}
+				const state = transientState === 'searching' || transientState === 'searchingDown' ? transientState : 'onTheRun';
+				this._renderState(state, variantChanged);
+				return;
+			}
+			this._searchScheduler.cancel();
+
+			if (this._busy) {
+				this._idleScheduler.cancel();
+				if (idleExpired) {
+					idleExpired = false;
+					this._idleExpired.set(false, undefined);
+					transientState = this._beginWakeAnimation() ?? transientState;
+				}
+			} else if (!idleExpired && !this._idleScheduler.isScheduled()) {
+				this._idleScheduler.schedule();
+			}
+
+			const baseState = getChatPetBaseState(hasActiveRequest, needsInput, inputHasContent, idleExpired);
+			this._renderState(getChatPetRenderedState(baseState, transientState, isDragging), variantChanged, isDragging);
+		}));
+
+		this._register(autorun(reader => {
+			const chatModel = model.read(reader);
+			const response = chatModel?.lastRequestObs.read(reader)?.response;
+			if (!response) {
+				return;
+			}
+			reader.store.add(response.onDidChange(e => {
+				if (e.reason === 'completedRequest' && !response.isCanceled) {
+					this._showTransientState('complete');
+				}
+			}));
+		}));
+	}
+
+	private _startDrag(event: PointerEvent): void {
+		if (!this._enabled || this.chatPetService.onTheRun.get() || event.button !== 0) {
+			return;
+		}
+
+		this._wake();
+		dom.EventHelper.stop(event);
+		this._view.focus();
+		const startX = event.clientX;
+		const startLeft = this._view.currentLeft;
+		let didDrag = false;
+
+		this._dragMonitor.startMonitoring(this._view.element, event.pointerId, event.buttons, moveEvent => {
+			const delta = moveEvent.clientX - startX;
+			if (!didDrag && Math.abs(delta) < DRAG_THRESHOLD) {
+				return;
+			}
+
+			if (!didDrag) {
+				didDrag = true;
+				this._view.setDragging(true);
+				this._isDragging.set(true, undefined);
+			}
+			dom.EventHelper.stop(moveEvent, true);
+			this._view.setResisting(this._view.setHorizontalPosition(startLeft + delta));
+		}, () => {
+			this._view.setDragging(false);
+			this._view.setResisting(false);
+			this._isDragging.set(false, undefined);
+			if (didDrag) {
+				this._suppressNextPointerClick = true;
+				this._clickSuppressionScheduler.schedule();
+			}
+		});
+	}
+
+	private _showContextMenu(event: MouseEvent): void {
+		const onTheRun = this.chatPetService.onTheRun.get();
+		const actions = new DisposableStore();
+		this._contextMenuActions.value = actions;
+		const stable = actions.add(new Action('chat.pet.variant.stable', localize('chatPet.variant.stable.action', "Stable Colors"), undefined, true, () => this.chatPetService.setVariant('stable')));
+		stable.checked = this.chatPetService.variant.get() === 'stable';
+		const insiders = actions.add(new Action('chat.pet.variant.insiders', localize('chatPet.variant.insiders.action', "Insiders Colors"), undefined, true, () => this.chatPetService.setVariant('insiders')));
+		insiders.checked = this.chatPetService.variant.get() === 'insiders';
+		const onTheRunAction = actions.add(new Action(
+			'chat.pet.onTheRun',
+			onTheRun ? localize('chatPet.comeBack.action', "Come Back") : localize('chatPet.goOnTheRun.action', "Go on the Run"),
+			undefined,
+			true,
+			() => {
+				this._transientState.set(undefined, undefined);
+				this.chatPetService.setOnTheRun(!onTheRun);
+			}
+		));
+		const separator = new Separator();
+		this.contextMenuService.showContextMenu({
+			getAnchor: () => new StandardMouseEvent(dom.getWindow(this._view.element), event),
+			getActions: (): IAction[] => [
+				onTheRunAction,
+				separator,
+				stable,
+				insiders,
+			],
+			onHide: () => {
+				if (this._contextMenuActions.value === actions) {
+					this._contextMenuActions.clear();
+				}
+			},
+		});
+	}
+
+	private _onKeyDown(event: KeyboardEvent): void {
+		const keyboardEvent = new StandardKeyboardEvent(event);
+		let delta: number;
+		let announcement: string;
+		if (keyboardEvent.equals(KeyCode.LeftArrow)) {
+			delta = -KEYBOARD_MOVE_DISTANCE;
+			announcement = localize('chatPet.movedLeft', "VS Code pet moved left");
+		} else if (keyboardEvent.equals(KeyCode.RightArrow)) {
+			delta = KEYBOARD_MOVE_DISTANCE;
+			announcement = localize('chatPet.movedRight', "VS Code pet moved right");
+		} else {
+			return;
+		}
+
+		this._wake();
+		keyboardEvent.preventDefault();
+		keyboardEvent.stopPropagation();
+		this._view.setHorizontalPosition(this._view.currentLeft + delta);
+		status(announcement);
+	}
+
+	private _showTransientState(state: ChatPetState): void {
+		if (!this.chatPetService.enabled.get()) {
+			return;
+		}
+
+		this._wake();
+		const renderedState = state === 'yapping' && this._motionReduced ? 'yappingMouthOpen' : state;
+		this._transientState.set(renderedState, undefined);
+		if (renderedState === 'yappingMouthOpen' || renderedState === 'yapping') {
+			this._transientScheduler.cancel();
+		} else {
+			this._transientScheduler.schedule(getTransientStateDuration(renderedState));
+		}
+		if (!this._isDragging.get()) {
+			this._renderState(renderedState, true);
+		}
+	}
+
+	private _trySearch(): void {
+		if (!this._enabled || !this.chatPetService.onTheRun.get()) {
+			return;
+		}
+		if (this._motionReduced) {
+			this._searchScheduler.schedule();
+			return;
+		}
+		this._transientState.set('searching', undefined);
+		this._renderState('searching', true);
+		this._searchScheduler.schedule();
+	}
+
+	private _wake(): void {
+		const wasSleeping = this._idleExpired.get() || this._view.renderedState === 'sleep';
+		this._idleExpired.set(false, undefined);
+		if (this._busy) {
+			this._idleScheduler.cancel();
+		} else {
+			this._idleScheduler.schedule();
+		}
+		if (wasSleeping) {
+			this._beginWakeAnimation();
+		}
+	}
+
+	private _beginWakeAnimation(): ChatPetState | undefined {
+		if (this._motionReduced) {
+			return undefined;
+		}
+
+		this._transientState.set('waking', undefined);
+		this._transientScheduler.schedule(WAKE_STATE_DURATION);
+		return 'waking';
+	}
+
+	private _renderState(state: ChatPetState, restart = false, useStaticSprite = false): void {
+		this._view.renderState(state, this._variant, this._motionReduced, restart, useStaticSprite);
+	}
+
+	private _onAnimationComplete(state: ChatPetState): void {
+		if (state === 'searching' && this.chatPetService.onTheRun.get()) {
+			this._transientState.set('searchingDown', undefined);
+		} else if (state === 'searchingDown') {
+			this._transientState.set(undefined, undefined);
+		} else if (state === 'yapping' && !this._isDragging.get() && this._view.renderedState === 'yapping') {
+			this._transientState.set('yappingMouthOpen', undefined);
+		}
+	}
+}
+
 const CHAT_PET_SOURCE_SIZE = 96;
 const CHAT_PET_MAX_VERTICAL_OFFSET = 10;
 const CHAT_PET_SPEECH_BUBBLE_RIGHT_OVERHANG = 20;
@@ -66,12 +453,28 @@ interface ChatPetSpriteElement {
 	readonly canvas: HTMLCanvasElement;
 }
 
+interface ActiveChatPetSpriteAnimation {
+	readonly source: ChatPetSpriteSource;
+	readonly sprite: ChatPetSpriteElement;
+	readonly onComplete: (() => void) | undefined;
+	completionReported: boolean;
+}
+
+export interface IChatPetViewOptions {
+	readonly ariaLabel: string;
+	readonly animationTime?: IObservable<number | undefined>;
+	readonly onDidCompleteAnimation?: (state: ChatPetState) => void;
+	readonly resourceBaseUrl?: string;
+	readonly loopAnimations?: boolean;
+	readonly trackDocumentCursor?: boolean;
+}
+
+const spriteSources = new Map<string, Record<ChatPetState, ChatPetSpriteSources>>();
+const speechSpriteSources = new Map<string, ChatPetSpriteSources>();
+
 export function getChatPetBuddyName(quality: string | undefined): 'buddy-idle-stable' | 'buddy-idle-insiders' {
 	return quality === 'stable' ? 'buddy-idle-stable' : 'buddy-idle-insiders';
 }
-
-const spriteSources = new Map<ChatPetVariant, Record<ChatPetState, ChatPetSpriteSources>>();
-const speechSpriteSources = new Map<ChatPetVariant, ChatPetSpriteSources>();
 
 export function doesChatPetStateTrackCursor(state: ChatPetState | undefined): boolean {
 	return state !== undefined && state !== 'sleep' && state !== 'waking' && state !== 'typing' && state !== 'complete' && state !== 'love' && state !== 'cool' && state !== 'yappingMouthOpen' && state !== 'onTheRun' && state !== 'searching' && state !== 'searchingDown';
@@ -135,18 +538,21 @@ export function getChatPetFrameDurations(state: ChatPetState): readonly number[]
 	}
 }
 
-function createSpriteSources(name: string, state: ChatPetState, tracksCursor = true): ChatPetSpriteSources {
-	const root = 'vs/workbench/contrib/chat/browser/widget/media/chatPet';
+function resolveChatPetResource(resource: AppResourcePath, resourceBaseUrl: string | undefined): string {
+	return resourceBaseUrl === undefined ? FileAccess.asBrowserUri(resource).toString(true) : `${resourceBaseUrl}/${resource}`;
+}
+
+function createSpriteSources(name: string, state: ChatPetState, tracksCursor: boolean, resourceBaseUrl: string | undefined): ChatPetSpriteSources {
 	const suffix = tracksCursor ? '-tracking-96' : '-96';
 	const frameDurations = getChatPetFrameDurations(state);
 	const staticSource = {
-		url: FileAccess.asBrowserUri(`${root}/${name}${suffix}.png`).toString(true),
+		url: resolveChatPetResource(`vs/workbench/contrib/chat/browser/widget/media/chatPet/${name}${suffix}.png`, resourceBaseUrl),
 		frameDurations: [],
 		iterations: 1,
 	};
 	return {
 		animated: frameDurations.length === 0 ? staticSource : {
-			url: FileAccess.asBrowserUri(`${root}/${name}${suffix}.spritesheet.png`).toString(true),
+			url: resolveChatPetResource(`vs/workbench/contrib/chat/browser/widget/media/chatPet/${name}${suffix}.spritesheet.png`, resourceBaseUrl),
 			frameDurations,
 			iterations: state === 'waking' || state === 'cool' || state === 'searching' ? 1 : Infinity,
 		},
@@ -158,10 +564,11 @@ export function getChatPetSpeechFrameDurations(): readonly number[] {
 	return SPEECH_FRAME_DURATIONS;
 }
 
-function getSpriteSources(variant: ChatPetVariant): Record<ChatPetState, ChatPetSpriteSources> {
-	let sources = spriteSources.get(variant);
+function getSpriteSources(variant: ChatPetVariant, resourceBaseUrl: string | undefined): Record<ChatPetState, ChatPetSpriteSources> {
+	const key = `${resourceBaseUrl ?? ''}:${variant}`;
+	let sources = spriteSources.get(key);
 	if (!sources) {
-		const createStateSpriteSources = (state: ChatPetState) => createSpriteSources(getChatPetSpriteName(state, variant), state, doesChatPetStateTrackCursor(state));
+		const createStateSpriteSources = (state: ChatPetState) => createSpriteSources(getChatPetSpriteName(state, variant), state, doesChatPetStateTrackCursor(state), resourceBaseUrl);
 		sources = {
 			idle: createStateSpriteSources('idle'),
 			sleep: createStateSpriteSources('sleep'),
@@ -179,30 +586,30 @@ function getSpriteSources(variant: ChatPetVariant): Record<ChatPetState, ChatPet
 			searching: createStateSpriteSources('searching'),
 			searchingDown: createStateSpriteSources('searchingDown'),
 		};
-		spriteSources.set(variant, sources);
+		spriteSources.set(key, sources);
 	}
 
 	return sources;
 }
 
-function getSpeechSpriteSources(variant: ChatPetVariant): ChatPetSpriteSources {
-	let sources = speechSpriteSources.get(variant);
+function getSpeechSpriteSources(variant: ChatPetVariant, resourceBaseUrl: string | undefined): ChatPetSpriteSources {
+	const key = `${resourceBaseUrl ?? ''}:${variant}`;
+	let sources = speechSpriteSources.get(key);
 	if (!sources) {
-		const root = 'vs/workbench/contrib/chat/browser/widget/media/chatPet';
 		const name = `buddy-speech-${variant}-96`;
 		sources = {
 			animated: {
-				url: FileAccess.asBrowserUri(`${root}/${name}.spritesheet.png`).toString(true),
+				url: resolveChatPetResource(`vs/workbench/contrib/chat/browser/widget/media/chatPet/${name}.spritesheet.png`, resourceBaseUrl),
 				frameDurations: SPEECH_FRAME_DURATIONS,
 				iterations: Infinity,
 			},
 			reducedMotion: {
-				url: FileAccess.asBrowserUri(`${root}/${name}.png`).toString(true),
+				url: resolveChatPetResource(`vs/workbench/contrib/chat/browser/widget/media/chatPet/${name}.png`, resourceBaseUrl),
 				frameDurations: [],
 				iterations: 1,
 			},
 		};
-		speechSpriteSources.set(variant, sources);
+		speechSpriteSources.set(key, sources);
 	}
 	return sources;
 }
@@ -213,30 +620,6 @@ function doesChatPetStateSpeak(state: ChatPetState | undefined): boolean {
 
 export function isChatPetImageSource(image: Pick<HTMLImageElement, 'getAttribute'>, source: string): boolean {
 	return image.getAttribute('src') === source;
-}
-
-export function getChatPetBaseState(hasActiveRequest: boolean, needsInput: boolean, hasInput: boolean, idleExpired: boolean): ChatPetState {
-	if (needsInput) {
-		return 'clapping';
-	}
-	if (hasActiveRequest) {
-		return 'rendering';
-	}
-	if (idleExpired) {
-		return 'sleep';
-	}
-	if (hasInput) {
-		return 'typing';
-	}
-	return 'idle';
-}
-
-export function isChatPetVisible(enabled: boolean, isLatestFocusedWidget: boolean): boolean {
-	return enabled && isLatestFocusedWidget;
-}
-
-export function getChatPetRenderedState(baseState: ChatPetState, transientState: ChatPetState | undefined, isDragging: boolean): ChatPetState {
-	return isDragging ? 'idle' : transientState ?? baseState;
 }
 
 type ChatPetAnimationFrame = { frameIndex: number; complete: true } | { frameIndex: number; complete: false; nextFrameDelay: number };
@@ -259,27 +642,6 @@ export function getChatPetAnimationFrame(frameDurations: readonly number[], elap
 		}
 	}
 	return { frameIndex: frameDurations.length - 1, complete: false, nextFrameDelay: totalDuration };
-}
-
-function getTransientStateDuration(state: ChatPetState): number {
-	switch (state) {
-		case 'complete':
-			return COMPLETE_STATE_DURATION;
-		case 'love':
-			return LOVE_STATE_DURATION;
-		case 'cool':
-			return COOL_STATE_DURATION;
-		case 'waking':
-			return WAKE_STATE_DURATION;
-		default:
-			return TRANSIENT_STATE_DURATION;
-	}
-}
-
-export function getChatPetClickInteraction(random: number, previousInteraction?: ChatPetClickInteraction): ChatPetClickInteraction {
-	const interactions: readonly ChatPetClickInteraction[] = ['love', 'jump', 'cool', 'yapping'];
-	const availableInteractions = interactions.filter(interaction => interaction !== previousInteraction);
-	return availableInteractions[Math.min(Math.floor(random * availableInteractions.length), availableInteractions.length - 1)];
 }
 
 export function getChatPetGazeDirection(cursorX: number, cursorY: number, petCenterX: number, petCenterY: number): readonly [number, number] {
@@ -308,7 +670,7 @@ export function shouldPlaceChatPetSpeechBubbleLeft(state: ChatPetState | undefin
 	return state === 'rendering' && buttonRight + CHAT_PET_SPEECH_BUBBLE_RIGHT_OVERHANG > inputRight;
 }
 
-export class ChatPetWidget extends Disposable {
+export class ChatPetView extends Disposable {
 
 	private readonly _overlay: HTMLElement;
 	private readonly _button: Button;
@@ -317,64 +679,48 @@ export class ChatPetWidget extends Disposable {
 	private readonly _eyes: HTMLElement;
 	private readonly _pupils: HTMLElement[] = [];
 	private readonly _gazeScheduler: dom.AnimationFrameScheduler;
-	private readonly _dragMonitor = this._register(new GlobalPointerMoveMonitor());
-	private readonly _idleExpired = observableValue(this, false);
-	private readonly _transientState = observableValue<ChatPetState | undefined>(this, undefined);
-	private readonly _isDragging = observableValue(this, false);
-	private readonly _idleScheduler = this._register(new RunOnceScheduler(() => this._idleExpired.set(true, undefined), CHAT_PET_IDLE_SLEEP_DELAY));
-	private readonly _transientScheduler = this._register(new RunOnceScheduler(() => this._transientState.set(undefined, undefined), TRANSIENT_STATE_DURATION));
-	private readonly _searchScheduler: RunOnceScheduler;
-	private readonly _clickSuppressionScheduler = this._register(new RunOnceScheduler(() => this._suppressNextPointerClick = false, 0));
 	private readonly _spriteAnimation = this._register(new MutableDisposable());
 	private readonly _speechAnimation = this._register(new MutableDisposable());
-	private readonly _contextMenuActions = this._register(new MutableDisposable<DisposableStore>());
+	private readonly _animationTime: IObservable<number | undefined>;
+	private readonly _onDidRender = this._register(new Emitter<void>());
 	private _cursorPosition: readonly [number, number] | undefined;
 	private _activeSprite: ChatPetSpriteElement | undefined;
 	private _pendingSprite: ChatPetSpriteElement | undefined;
 	private _pendingSource: ChatPetSpriteSource | undefined;
 	private _pendingState: ChatPetState | undefined;
+	private _activeSpriteAnimation: ActiveChatPetSpriteAnimation | undefined;
+	private _activeSpeechAnimation: ActiveChatPetSpriteAnimation | undefined;
 	private _renderedState: ChatPetState | undefined;
 	private _motionReduced = false;
-	private _enabled = false;
-	private _busy = false;
-	private _enablementInitialized = false;
+	private _variant: ChatPetVariant = 'stable';
 	private _hasCustomPosition = false;
-	private _suppressNextPointerClick = false;
-	private _lastClickInteraction: ChatPetClickInteraction | undefined;
-	private _variant: ChatPetVariant;
+	private _visibleRequested = false;
+	private _renderError: Error | undefined;
+	private _animationControlled = false;
 
 	constructor(
-		private readonly parent: HTMLElement,
-		private readonly dragBounds: HTMLElement,
-		model: IObservable<IChatModel | undefined>,
-		hasInput: IObservable<boolean>,
-		isLatestFocusedWidget: IObservable<boolean>,
-		inputChanged: (listener: () => void) => IDisposable,
-		@IChatPetService private readonly chatPetService: IChatPetService,
-		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
-		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+		private readonly _parent: HTMLElement,
+		private readonly _dragBounds: HTMLElement,
+		private readonly _options: IChatPetViewOptions,
 	) {
 		super();
 
-		this._variant = this.chatPetService.variant.get();
-		this._searchScheduler = this._register(new RunOnceScheduler(() => this._trySearch(), SEARCH_INTERVAL));
-		this.parent.classList.add('chat-pet-host');
+		this._animationTime = _options.animationTime ?? constObservable(undefined);
+		this._parent.classList.add('chat-pet-host');
 		this._overlay = dom.$('.chat-pet-overlay');
-		this.parent.prepend(this._overlay);
+		this._parent.prepend(this._overlay);
 		this._register(toDisposable(() => this._overlay.remove()));
-		this._button = this._register(new Button(this._overlay, {
-			ariaLabel: localize('chatPet.interact', "Interact with the VS Code pet. Use the context menu to put it on the run."),
-		}));
+		this._button = this._register(new Button(this._overlay, { ariaLabel: _options.ariaLabel }));
 		this._button.element.classList.add('chat-pet-button');
-		const resizeObserver = this._register(new dom.DisposableResizeObserver('ChatPetWidget.dragBounds', () => {
+		const resizeObserver = this._register(new dom.DisposableResizeObserver('ChatPetView.dragBounds', () => {
 			this._updateVerticalPosition();
 			this._updateSpeechBubblePosition();
 			if (this._hasCustomPosition) {
-				this._setHorizontalPosition(this._getCurrentLeft());
+				this.setHorizontalPosition(this.currentLeft);
 			}
 		}, dom.getWindow(this._button.element)));
-		this._register(resizeObserver.observe(this.dragBounds));
-		this._register(resizeObserver.observe(this.parent));
+		this._register(resizeObserver.observe(this._dragBounds));
+		this._register(resizeObserver.observe(this._parent));
 		this._updateVerticalPosition();
 		this._updateSpeechBubblePosition();
 		this._sprites = [0, 1].map(() => {
@@ -388,6 +734,7 @@ export class ChatPetWidget extends Disposable {
 			image.setAttribute('aria-hidden', 'true');
 			const sprite = { container, image, canvas };
 			this._register(dom.addDisposableListener(image, 'load', () => this._onImageLoad(sprite)));
+			this._register(dom.addDisposableListener(image, 'error', () => this._onImageError(image)));
 			return sprite;
 		});
 		this._eyes = dom.append(this._button.element, dom.$('.chat-pet-eyes'));
@@ -405,269 +752,183 @@ export class ChatPetWidget extends Disposable {
 		speechBubbleImage.alt = '';
 		speechBubbleImage.setAttribute('aria-hidden', 'true');
 		this._speechBubble = { container: speechBubbleContainer, image: speechBubbleImage, canvas: speechBubbleCanvas };
-		this._register(dom.addDisposableListener(speechBubbleImage, 'load', () => this._updateSpeechBubble(this._renderedState, true)));
-		this._gazeScheduler = this._register(new dom.AnimationFrameScheduler(this._button.element, () => this._updateGaze()));
-		this._register(dom.addDisposableListener(dom.getWindow(this._button.element).document, dom.EventType.POINTER_MOVE, (event: PointerEvent) => {
-			this._cursorPosition = [event.clientX, event.clientY];
-			if (this._enabled && doesChatPetStateTrackCursor(this._renderedState)) {
-				this._gazeScheduler.schedule();
-			}
+		this._register(dom.addDisposableListener(speechBubbleImage, 'load', () => {
+			this._updateSpeechBubble(this._renderedState, true);
+			this._onDidRender.fire();
 		}));
+		this._register(dom.addDisposableListener(speechBubbleImage, 'error', () => this._onImageError(speechBubbleImage)));
+		this._gazeScheduler = this._register(new dom.AnimationFrameScheduler(this._button.element, () => this._updateGaze()));
+		if (this._options.trackDocumentCursor ?? true) {
+			this._register(dom.addDisposableListener(dom.getWindow(this._button.element).document, dom.EventType.POINTER_MOVE, (event: PointerEvent) => {
+				this.setCursorPosition(event.clientX, event.clientY);
+			}));
+		}
 		const onAnimationComplete = (event: AnimationEvent) => {
 			if (event.animationName === 'chat-pet-enter') {
 				this._button.element.classList.remove('entering');
-			} else if (event.animationName === 'chat-pet-exit' && !this._enabled) {
-				this._finishDisable();
-			} else if (event.animationName === 'chat-pet-yapping-fall' && !this._isDragging.get() && event.target === this._activeSprite?.container && this._button.element.dataset.state === 'yapping') {
-				this._transientState.set('yappingMouthOpen', undefined);
+			} else if (event.animationName === 'chat-pet-exit' && !this._visibleRequested) {
+				this._finishHide();
+			} else if (event.animationName === 'chat-pet-yapping-fall' && event.target === this._activeSprite?.container && this._button.element.dataset.state === 'yapping') {
+				this._options.onDidCompleteAnimation?.('yapping');
 			} else if (event.animationName === 'chat-pet-search-down' && this._button.element.dataset.state === 'searchingDown') {
-				this._transientState.set(undefined, undefined);
+				this._options.onDidCompleteAnimation?.('searchingDown');
 			}
 		};
 		this._register(dom.addDisposableListener(this._button.element, dom.EventType.ANIMATION_END, onAnimationComplete));
 		this._register(dom.addDisposableListener(this._button.element, 'animationcancel', onAnimationComplete));
-		this._register(dom.addDisposableListener(this._button.element, dom.EventType.POINTER_DOWN, event => this._startDrag(event)));
-		this._register(dom.addDisposableListener(this._button.element, dom.EventType.KEY_DOWN, event => this._onKeyDown(event)));
-		this._register(dom.addDisposableListener(this._button.element, dom.EventType.CONTEXT_MENU, event => {
-			if (!this._enabled) {
-				return;
-			}
-			dom.EventHelper.stop(event, true);
-			this._showContextMenu(event);
-		}));
-		this._register(inputChanged(() => {
-			if (this._enabled && !this.chatPetService.onTheRun.get()) {
-				this._wake();
-			}
-		}));
-
-		this._register(this._button.onDidClick(e => {
-			dom.EventHelper.stop(e, true);
-			if (this._suppressNextPointerClick && e.type !== dom.EventType.KEY_DOWN) {
-				this._suppressNextPointerClick = false;
-				this._clickSuppressionScheduler.cancel();
-				return;
-			}
-			if (this.chatPetService.onTheRun.get()) {
-				this._transientState.set(undefined, undefined);
-				this.chatPetService.setOnTheRun(false);
-				return;
-			}
-			const wasSleeping = this._idleExpired.get() || this._renderedState === 'sleep';
-			if (wasSleeping) {
-				this._wake();
-			}
-			if (wasSleeping || this._transientState.get() === 'waking') {
-				status(localize('chatPet.wokeUp', "The VS Code pet woke up"));
-				return;
-			}
-			const interaction = getChatPetClickInteraction(Math.random(), this._lastClickInteraction);
-			this._lastClickInteraction = interaction;
-			this._showTransientState(interaction);
-			switch (interaction) {
-				case 'love':
-					status(localize('chatPet.loved', "The VS Code pet feels loved"));
-					break;
-				case 'jump':
-					status(localize('chatPet.jumped', "The VS Code pet jumped"));
-					break;
-				case 'cool':
-					status(localize('chatPet.cool', "The VS Code pet put on sunglasses"));
-					break;
-				case 'yapping':
-					status(localize('chatPet.yapping', "The VS Code pet is yapping"));
-					break;
-			}
-		}));
-
-		const motionReduced = observableFromEvent(this, this.accessibilityService.onDidChangeReducedMotion, () => this.accessibilityService.isMotionReduced());
 		this._register(autorun(reader => {
-			this._motionReduced = motionReduced.read(reader);
-			const enabled = isChatPetVisible(this.chatPetService.enabled.read(reader), isLatestFocusedWidget.read(reader));
-			const variant = this.chatPetService.variant.read(reader);
-			const variantChanged = variant !== this._variant;
-			this._variant = variant;
-			const onTheRun = this.chatPetService.onTheRun.read(reader);
-			this._button.element.classList.toggle('on-the-run', onTheRun);
-			this._button.setAriaLabel(onTheRun
-				? localize('chatPet.restore', "Bring back the VS Code pet")
-				: localize('chatPet.interact', "Interact with the VS Code pet. Use the context menu to put it on the run."));
-			const chatModel = model.read(reader);
-			const request = chatModel?.lastRequestObs.read(reader);
-			const needsInput = !!request?.response?.isPendingConfirmation.read(reader);
-			const hasActiveRequest = chatModel?.hasActiveRequest.read(reader) ?? false;
-			const inputHasContent = hasInput.read(reader);
-			this._busy = hasActiveRequest || needsInput;
-			let idleExpired = this._idleExpired.read(reader);
-			let transientState = this._transientState.read(reader);
-			const isDragging = this._isDragging.read(reader);
-
-			if (!this._enablementInitialized || enabled !== this._enabled) {
-				const wasInitialized = this._enablementInitialized;
-				this._enablementInitialized = true;
-				this._enabled = enabled;
-				if (enabled) {
-					this._startEnableAnimation();
-				} else if (wasInitialized) {
-					this._startDisableAnimation();
-				} else {
-					this._finishDisable();
-				}
-			}
-
-			if (!enabled) {
-				this._idleScheduler.cancel();
-				this._searchScheduler.cancel();
-				this._transientScheduler.cancel();
-				if (transientState !== undefined) {
-					this._transientState.set(undefined, undefined);
-				}
-				if (this._motionReduced) {
-					this._finishDisable();
+			const animationTime = this._animationTime.read(reader);
+			if (animationTime === undefined) {
+				if (this._animationControlled) {
+					this._animationControlled = false;
+					this._resumeAnimations();
 				}
 				return;
 			}
-
-			if (onTheRun) {
-				this._idleScheduler.cancel();
-				if (!this._searchScheduler.isScheduled()) {
-					this._searchScheduler.schedule();
-				}
-				const state = transientState === 'searching' || transientState === 'searchingDown' ? transientState : 'onTheRun';
-				this._renderState(state, variantChanged);
-				return;
-			}
-			this._searchScheduler.cancel();
-
-			if (this._busy) {
-				this._idleScheduler.cancel();
-				if (idleExpired) {
-					idleExpired = false;
-					this._idleExpired.set(false, undefined);
-					transientState = this._beginWakeAnimation() ?? transientState;
-				}
-			} else if (!idleExpired && !this._idleScheduler.isScheduled()) {
-				this._idleScheduler.schedule();
-			}
-
-			const baseState = getChatPetBaseState(hasActiveRequest, needsInput, inputHasContent, idleExpired);
-			this._renderState(getChatPetRenderedState(baseState, transientState, isDragging), variantChanged, isDragging);
-		}));
-
-		this._register(autorun(reader => {
-			const chatModel = model.read(reader);
-			const response = chatModel?.lastRequestObs.read(reader)?.response;
-			if (!response) {
-				return;
-			}
-			reader.store.add(response.onDidChange(e => {
-				if (e.reason === 'completedRequest' && !response.isCanceled) {
-					this._showTransientState('complete');
-				}
-			}));
+			this._animationControlled = true;
+			this._spriteAnimation.clear();
+			this._speechAnimation.clear();
+			this._renderControlledAnimation(this._activeSpriteAnimation, animationTime);
+			this._renderControlledAnimation(this._activeSpeechAnimation, animationTime);
+			this._updateCssAnimationTime(animationTime);
 		}));
 	}
 
-	private _startDrag(event: PointerEvent): void {
-		if (!this._enabled || this.chatPetService.onTheRun.get() || event.button !== 0) {
-			return;
-		}
-
-		this._wake();
-		dom.EventHelper.stop(event);
-		this._button.element.focus();
-		const startX = event.clientX;
-		const startLeft = this._getCurrentLeft();
-		let didDrag = false;
-
-		this._dragMonitor.startMonitoring(this._button.element, event.pointerId, event.buttons, moveEvent => {
-			const delta = moveEvent.clientX - startX;
-			if (!didDrag && Math.abs(delta) < DRAG_THRESHOLD) {
-				return;
-			}
-
-			if (!didDrag) {
-				didDrag = true;
-				this._button.element.classList.remove('entering');
-				this._button.element.classList.add('dragging');
-				this._spriteAnimation.clear();
-				this._isDragging.set(true, undefined);
-			}
-			dom.EventHelper.stop(moveEvent, true);
-			this._button.element.classList.toggle('resisting', this._setHorizontalPosition(startLeft + delta));
-		}, () => {
-			this._button.element.classList.remove('dragging', 'resisting');
-			this._isDragging.set(false, undefined);
-			if (didDrag) {
-				this._suppressNextPointerClick = true;
-				this._clickSuppressionScheduler.schedule();
-			}
-		});
+	get element(): HTMLElement {
+		return this._button.element;
 	}
 
-	private _showContextMenu(event: MouseEvent): void {
-		const onTheRun = this.chatPetService.onTheRun.get();
-		const actions = new DisposableStore();
-		this._contextMenuActions.value = actions;
-		const stable = actions.add(new Action('chat.pet.variant.stable', localize('chatPet.variant.stable.action', "Stable Colors"), undefined, true, () => this.chatPetService.setVariant('stable')));
-		stable.checked = this.chatPetService.variant.get() === 'stable';
-		const insiders = actions.add(new Action('chat.pet.variant.insiders', localize('chatPet.variant.insiders.action', "Insiders Colors"), undefined, true, () => this.chatPetService.setVariant('insiders')));
-		insiders.checked = this.chatPetService.variant.get() === 'insiders';
-		const onTheRunAction = actions.add(new Action(
-			'chat.pet.onTheRun',
-			onTheRun ? localize('chatPet.comeBack.action', "Come Back") : localize('chatPet.goOnTheRun.action', "Go on the Run"),
-			undefined,
-			true,
-			() => {
-				this._transientState.set(undefined, undefined);
-				this.chatPetService.setOnTheRun(!onTheRun);
-			}
-		));
-		const separator = new Separator();
-		this.contextMenuService.showContextMenu({
-			getAnchor: () => new StandardMouseEvent(dom.getWindow(this._button.element), event),
-			getActions: (): IAction[] => [
-				onTheRunAction,
-				separator,
-				stable,
-				insiders,
-			],
-			onHide: () => {
-				if (this._contextMenuActions.value === actions) {
-					this._contextMenuActions.clear();
-				}
-			},
-		});
+	get onDidClick() {
+		return this._button.onDidClick;
 	}
 
-	private _onKeyDown(event: KeyboardEvent): void {
-		const keyboardEvent = new StandardKeyboardEvent(event);
-		let delta: number;
-		let announcement: string;
-		if (keyboardEvent.equals(KeyCode.LeftArrow)) {
-			delta = -KEYBOARD_MOVE_DISTANCE;
-			announcement = localize('chatPet.movedLeft', "VS Code pet moved left");
-		} else if (keyboardEvent.equals(KeyCode.RightArrow)) {
-			delta = KEYBOARD_MOVE_DISTANCE;
-			announcement = localize('chatPet.movedRight', "VS Code pet moved right");
-		} else {
-			return;
-		}
-
-		this._wake();
-		keyboardEvent.preventDefault();
-		keyboardEvent.stopPropagation();
-		this._setHorizontalPosition(this._getCurrentLeft() + delta);
-		status(announcement);
+	get renderedState(): ChatPetState | undefined {
+		return this._renderedState;
 	}
 
-	private _getCurrentLeft(): number {
+	get currentLeft(): number {
 		return this._button.element.offsetLeft;
 	}
 
-	private _setHorizontalPosition(left: number): boolean {
+	setAriaLabel(label: string): void {
+		this._button.setAriaLabel(label);
+	}
+
+	setCursorPosition(clientX: number, clientY: number): void {
+		this._cursorPosition = [clientX, clientY];
+		if (this._visibleRequested && doesChatPetStateTrackCursor(this._renderedState)) {
+			this._gazeScheduler.schedule();
+		}
+	}
+
+	setOnTheRun(onTheRun: boolean): void {
+		this._button.element.classList.toggle('on-the-run', onTheRun);
+	}
+
+	setDragging(dragging: boolean): void {
+		this._button.element.classList.toggle('dragging', dragging);
+		if (dragging) {
+			this._button.element.classList.remove('entering');
+			this._spriteAnimation.clear();
+			this._activeSpriteAnimation = undefined;
+		}
+	}
+
+	setResisting(resisting: boolean): void {
+		this._button.element.classList.toggle('resisting', resisting);
+	}
+
+	focus(): void {
+		this._button.element.focus();
+	}
+
+	show(reducedMotion: boolean): void {
+		this._visibleRequested = true;
+		this._button.element.classList.remove('hidden', 'exiting', 'entering');
+		this._button.element.tabIndex = 0;
+		this._button.element.getBoundingClientRect();
+		this._gazeScheduler.schedule();
+		if (!reducedMotion) {
+			this._button.element.classList.add('entering');
+			this._updateCssAnimationTime(this._animationTime.get());
+		}
+	}
+
+	hide(reducedMotion: boolean): void {
+		this._visibleRequested = false;
+		this._button.element.tabIndex = -1;
+		this._button.element.classList.remove('entering');
+		if (reducedMotion || this._button.element.classList.contains('hidden')) {
+			this._finishHide();
+			return;
+		}
+		this._button.element.classList.add('exiting');
+		this._updateCssAnimationTime(this._animationTime.get());
+	}
+
+	renderState(state: ChatPetState, variant: ChatPetVariant, reducedMotion: boolean, restart = false, useStaticSprite = false): void {
+		this._renderError = undefined;
+		this._variant = variant;
+		this._motionReduced = reducedMotion;
+		const sources = getSpriteSources(variant, this._options.resourceBaseUrl)[state];
+		const source = reducedMotion || useStaticSprite ? sources.reducedMotion : sources.animated;
+		if (!restart && this._activeSprite && isChatPetImageSource(this._activeSprite.image, source.url)) {
+			this._pendingSprite = undefined;
+			this._pendingSource = undefined;
+			this._pendingState = undefined;
+			this._button.element.dataset.state = state;
+			this._renderedState = state;
+			this._eyes.classList.toggle('tracking', doesChatPetStateTrackCursor(state));
+			this._updateSpeechBubble(state, restart);
+			this._updateCssAnimationTime(this._animationTime.get());
+			this._onDidRender.fire();
+			return;
+		}
+
+		const sprite = this._sprites.find(candidate => candidate !== this._activeSprite);
+		if (!sprite) {
+			return;
+		}
+
+		this._pendingSprite = sprite;
+		this._pendingSource = source;
+		this._pendingState = state;
+		sprite.image.removeAttribute('src');
+		sprite.image.src = source.url;
+	}
+
+	async whenReady(): Promise<void> {
+		while (!this._isReady()) {
+			await Event.toPromise(this._onDidRender.event);
+		}
+	}
+
+	getAnimationDuration(source: ChatPetAnimationDurationSource = 'all'): number {
+		const durations: number[] = [];
+		if (source !== 'css') {
+			for (const animation of [this._activeSpriteAnimation, this._activeSpeechAnimation]) {
+				if (animation) {
+					durations.push(animation.source.frameDurations.reduce((total, duration) => total + duration, 0));
+				}
+			}
+		}
+		if (source !== 'sprite') {
+			for (const animation of this._button.element.getAnimations({ subtree: true })) {
+				if (animation instanceof CSSAnimation && (animation.animationName === 'chat-pet-eye-bob' || animation.animationName === 'chat-pet-eye-blink')) {
+					continue;
+				}
+				const duration = animation.effect?.getTiming().duration;
+				if (typeof duration === 'number') {
+					durations.push(duration);
+				}
+			}
+		}
+		return Math.max(0, ...durations);
+	}
+
+	setHorizontalPosition(left: number): boolean {
 		const parentBounds = this._overlay.getBoundingClientRect();
-		const bounds = this.dragBounds.getBoundingClientRect();
+		const bounds = this._dragBounds.getBoundingClientRect();
 		const minimumLeft = bounds.left - parentBounds.left;
 		const maximumLeft = bounds.right - parentBounds.left - this._button.element.offsetWidth;
 		const clampedLeft = getChatPetHorizontalPosition(left, minimumLeft, maximumLeft);
@@ -678,16 +939,24 @@ export class ChatPetWidget extends Disposable {
 		return clampedLeft !== left;
 	}
 
-	private _updateVerticalPosition(): void {
-		const hostTop = this._overlay.getBoundingClientRect().top;
-		const inputTop = this.dragBounds.getBoundingClientRect().top;
-		this._button.element.style.bottom = `calc(100% - ${getChatPetVerticalOffset(hostTop, inputTop)}px)`;
-	}
-
-	private _updateSpeechBubblePosition(): void {
-		const buttonRight = this._button.element.getBoundingClientRect().right;
-		const inputRight = this.dragBounds.getBoundingClientRect().right;
-		this._button.element.classList.toggle('speech-bubble-left', shouldPlaceChatPetSpeechBubbleLeft(this._renderedState, buttonRight, inputRight));
+	private _finishHide(): void {
+		this._button.element.classList.remove('entering', 'exiting');
+		this._button.element.classList.add('hidden');
+		this._spriteAnimation.clear();
+		this._speechAnimation.clear();
+		this._activeSpriteAnimation = undefined;
+		this._activeSpeechAnimation = undefined;
+		this._speechBubble.container.classList.add('hidden');
+		this._speechBubble.image.removeAttribute('src');
+		this._pendingSprite = undefined;
+		this._pendingSource = undefined;
+		this._pendingState = undefined;
+		this._activeSprite = undefined;
+		this._renderedState = undefined;
+		for (const sprite of this._sprites) {
+			sprite.container.classList.add('hidden');
+			sprite.image.removeAttribute('src');
+		}
 	}
 
 	private _updateGaze(): void {
@@ -707,122 +976,16 @@ export class ChatPetWidget extends Disposable {
 		}
 	}
 
-	private _startEnableAnimation(): void {
-		this._button.element.classList.remove('hidden', 'exiting', 'entering');
-		this._button.element.tabIndex = 0;
-		this._button.element.getBoundingClientRect();
-		this._gazeScheduler.schedule();
-		if (!this._motionReduced) {
-			this._button.element.classList.add('entering');
-		}
+	private _updateVerticalPosition(): void {
+		const hostTop = this._overlay.getBoundingClientRect().top;
+		const inputTop = this._dragBounds.getBoundingClientRect().top;
+		this._button.element.style.bottom = `calc(100% - ${getChatPetVerticalOffset(hostTop, inputTop)}px)`;
 	}
 
-	private _startDisableAnimation(): void {
-		this._button.element.tabIndex = -1;
-		this._button.element.classList.remove('entering');
-		if (this._motionReduced || this._button.element.classList.contains('hidden')) {
-			this._finishDisable();
-			return;
-		}
-		this._button.element.classList.add('exiting');
-	}
-
-	private _finishDisable(): void {
-		this._button.element.classList.remove('entering', 'exiting');
-		this._button.element.classList.add('hidden');
-		this._spriteAnimation.clear();
-		this._speechAnimation.clear();
-		this._speechBubble.container.classList.add('hidden');
-		this._speechBubble.image.removeAttribute('src');
-		this._pendingSprite = undefined;
-		this._pendingSource = undefined;
-		this._pendingState = undefined;
-		this._activeSprite = undefined;
-		this._renderedState = undefined;
-		for (const sprite of this._sprites) {
-			sprite.container.classList.add('hidden');
-			sprite.image.removeAttribute('src');
-		}
-	}
-
-	private _showTransientState(state: ChatPetState): void {
-		if (!this.chatPetService.enabled.get()) {
-			return;
-		}
-
-		this._wake();
-		const renderedState = state === 'yapping' && this._motionReduced ? 'yappingMouthOpen' : state;
-		this._transientState.set(renderedState, undefined);
-		if (renderedState === 'yappingMouthOpen' || renderedState === 'yapping') {
-			this._transientScheduler.cancel();
-		} else {
-			this._transientScheduler.schedule(getTransientStateDuration(renderedState));
-		}
-		if (!this._isDragging.get()) {
-			this._renderState(renderedState, true);
-		}
-	}
-
-	private _trySearch(): void {
-		if (!this._enabled || !this.chatPetService.onTheRun.get()) {
-			return;
-		}
-		if (this._motionReduced) {
-			this._searchScheduler.schedule();
-			return;
-		}
-		this._transientState.set('searching', undefined);
-		this._renderState('searching', true);
-		this._searchScheduler.schedule();
-	}
-
-	private _wake(): void {
-		const wasSleeping = this._idleExpired.get() || this._renderedState === 'sleep';
-		this._idleExpired.set(false, undefined);
-		if (this._busy) {
-			this._idleScheduler.cancel();
-		} else {
-			this._idleScheduler.schedule();
-		}
-		if (wasSleeping) {
-			this._beginWakeAnimation();
-		}
-	}
-
-	private _beginWakeAnimation(): ChatPetState | undefined {
-		if (this._motionReduced) {
-			return undefined;
-		}
-
-		this._transientState.set('waking', undefined);
-		this._transientScheduler.schedule(WAKE_STATE_DURATION);
-		return 'waking';
-	}
-
-	private _renderState(state: ChatPetState, restart = false, useStaticSprite = false): void {
-		const sources = getSpriteSources(this._variant)[state];
-		const source = this._motionReduced || useStaticSprite ? sources.reducedMotion : sources.animated;
-		if (!restart && this._activeSprite && isChatPetImageSource(this._activeSprite.image, source.url)) {
-			this._pendingSprite = undefined;
-			this._pendingSource = undefined;
-			this._pendingState = undefined;
-			this._button.element.dataset.state = state;
-			this._renderedState = state;
-			this._eyes.classList.toggle('tracking', doesChatPetStateTrackCursor(state));
-			this._updateSpeechBubble(state, restart);
-			return;
-		}
-
-		const sprite = this._sprites.find(candidate => candidate !== this._activeSprite);
-		if (!sprite) {
-			return;
-		}
-
-		this._pendingSprite = sprite;
-		this._pendingSource = source;
-		this._pendingState = state;
-		sprite.image.removeAttribute('src');
-		sprite.image.src = source.url;
+	private _updateSpeechBubblePosition(): void {
+		const buttonRight = this._button.element.getBoundingClientRect().right;
+		const inputRight = this._dragBounds.getBoundingClientRect().right;
+		this._button.element.classList.toggle('speech-bubble-left', shouldPlaceChatPetSpeechBubbleLeft(this._renderedState, buttonRight, inputRight));
 	}
 
 	private _onImageLoad(sprite: ChatPetSpriteElement): void {
@@ -835,7 +998,7 @@ export class ChatPetWidget extends Disposable {
 		sprite.container.classList.remove('hidden');
 		this._activeSprite = sprite;
 		const state = this._pendingState;
-		this._startSpriteAnimation(this._pendingSource, sprite, this._spriteAnimation, () => this._onSpriteAnimationComplete(sprite, state));
+		this._startSpriteAnimation(this._pendingSource, sprite, this._spriteAnimation, () => this._options.onDidCompleteAnimation?.(state));
 		this._button.element.dataset.state = state;
 		this._renderedState = state;
 		this._eyes.classList.toggle('tracking', doesChatPetStateTrackCursor(state));
@@ -844,50 +1007,48 @@ export class ChatPetWidget extends Disposable {
 		this._pendingSource = undefined;
 		this._pendingState = undefined;
 		this._restartEyeAnimation();
+		this._updateCssAnimationTime(this._animationTime.get());
 		if (doesChatPetStateTrackCursor(this._renderedState)) {
 			this._gazeScheduler.schedule();
 		}
+		this._onDidRender.fire();
 	}
 
-	private _onSpriteAnimationComplete(sprite: ChatPetSpriteElement, state: ChatPetState): void {
-		if (state !== 'searching' || sprite !== this._activeSprite || !this.chatPetService.onTheRun.get()) {
-			return;
+	private _onImageError(image: HTMLImageElement): void {
+		this._renderError = new Error(`Failed to load chat pet resource: ${image.src}`);
+		this._onDidRender.fire();
+	}
+
+	private _isReady(): boolean {
+		if (this._renderError) {
+			throw this._renderError;
 		}
-		this._transientState.set('searchingDown', undefined);
-		this._button.element.dataset.state = 'searchingDown';
-		this._renderedState = 'searchingDown';
+		if (this._pendingState !== undefined || this._activeSprite === undefined || this._renderedState === undefined) {
+			return false;
+		}
+		return !doesChatPetStateSpeak(this._renderedState) || this._activeSpeechAnimation !== undefined;
 	}
 
 	private _startSpriteAnimation(source: ChatPetSpriteSource, sprite: ChatPetSpriteElement, animationDisposable: MutableDisposable<IDisposable>, onComplete?: () => void): void {
-		const { frameDurations } = source;
-		const { image, canvas } = sprite;
-		const context = canvas.getContext('2d');
-		if (!context) {
+		const activeAnimation: ActiveChatPetSpriteAnimation = { source, sprite, onComplete, completionReported: false };
+		if (sprite === this._speechBubble) {
+			this._activeSpeechAnimation = activeAnimation;
+		} else {
+			this._activeSpriteAnimation = activeAnimation;
+		}
+
+		const animationTime = this._animationTime.get();
+		if (animationTime !== undefined) {
+			this._renderControlledAnimation(activeAnimation, animationTime);
 			return;
 		}
-		context.imageSmoothingEnabled = false;
-		const drawFrame = (frameIndex: number) => {
-			context.clearRect(0, 0, CHAT_PET_SOURCE_SIZE, CHAT_PET_SOURCE_SIZE);
-			context.drawImage(
-				image,
-				frameIndex * CHAT_PET_SOURCE_SIZE,
-				0,
-				CHAT_PET_SOURCE_SIZE,
-				CHAT_PET_SOURCE_SIZE,
-				0,
-				0,
-				CHAT_PET_SOURCE_SIZE,
-				CHAT_PET_SOURCE_SIZE
-			);
-		};
-		drawFrame(0);
-		if (frameDurations.length < 2) {
+		if (source.frameDurations.length < 2) {
+			this._drawAnimationFrame(source, sprite, 0);
 			return;
 		}
 
-		const targetWindow = dom.getWindow(canvas);
+		const targetWindow = dom.getWindow(sprite.canvas);
 		const startTime = targetWindow.performance.now();
-		let currentFrame = 0;
 		let frameTimer: number | undefined;
 		const animationDisposables = new DisposableStore();
 		const clearFrameTimer = () => {
@@ -904,19 +1065,15 @@ export class ChatPetWidget extends Disposable {
 		};
 		const updateFrame = () => {
 			frameTimer = undefined;
-			const frame = getChatPetAnimationFrame(frameDurations, targetWindow.performance.now() - startTime, source.iterations);
+			const frame = this._drawAnimationFrame(source, sprite, targetWindow.performance.now() - startTime);
 			if (frame.complete) {
-				drawFrame(frame.frameIndex);
 				animationDisposables.dispose();
 				onComplete?.();
 				return;
 			}
-			if (frame.frameIndex !== currentFrame) {
-				currentFrame = frame.frameIndex;
-				drawFrame(frame.frameIndex);
-			}
 			scheduleFrame(frame.nextFrameDelay);
 		};
+		updateFrame();
 		animationDisposables.add(dom.addDisposableListener(targetWindow.document, 'visibilitychange', () => {
 			clearFrameTimer();
 			if (!targetWindow.document.hidden) {
@@ -924,8 +1081,62 @@ export class ChatPetWidget extends Disposable {
 			}
 		}));
 		animationDisposables.add(toDisposable(clearFrameTimer));
-		scheduleFrame(frameDurations[0]);
 		animationDisposable.value = animationDisposables;
+	}
+
+	private _renderControlledAnimation(animation: ActiveChatPetSpriteAnimation | undefined, animationTime: number): void {
+		if (!animation) {
+			return;
+		}
+		const frame = this._drawAnimationFrame(animation.source, animation.sprite, animationTime);
+		if (animation.source.frameDurations.length >= 2 && frame.complete && !animation.completionReported) {
+			animation.completionReported = true;
+			animation.onComplete?.();
+		} else if (!frame.complete) {
+			animation.completionReported = false;
+		}
+	}
+
+	private _resumeAnimations(): void {
+		const spriteAnimation = this._activeSpriteAnimation;
+		const speechAnimation = this._activeSpeechAnimation;
+		this._spriteAnimation.clear();
+		this._speechAnimation.clear();
+		if (spriteAnimation) {
+			this._startSpriteAnimation(spriteAnimation.source, spriteAnimation.sprite, this._spriteAnimation, spriteAnimation.onComplete);
+		}
+		if (speechAnimation) {
+			this._startSpriteAnimation(speechAnimation.source, speechAnimation.sprite, this._speechAnimation, speechAnimation.onComplete);
+		}
+		for (const animation of this._button.element.getAnimations({ subtree: true })) {
+			if (this._options.loopAnimations) {
+				animation.effect?.updateTiming({ iterations: Infinity });
+			}
+			animation.currentTime = 0;
+			animation.play();
+		}
+	}
+
+	private _drawAnimationFrame(source: ChatPetSpriteSource, sprite: ChatPetSpriteElement, elapsed: number): ChatPetAnimationFrame {
+		const context = sprite.canvas.getContext('2d');
+		const frame = getChatPetAnimationFrame(source.frameDurations, elapsed, this._options.loopAnimations ? Infinity : source.iterations);
+		if (!context) {
+			return frame;
+		}
+		context.imageSmoothingEnabled = false;
+		context.clearRect(0, 0, CHAT_PET_SOURCE_SIZE, CHAT_PET_SOURCE_SIZE);
+		context.drawImage(
+			sprite.image,
+			frame.frameIndex * CHAT_PET_SOURCE_SIZE,
+			0,
+			CHAT_PET_SOURCE_SIZE,
+			CHAT_PET_SOURCE_SIZE,
+			0,
+			0,
+			CHAT_PET_SOURCE_SIZE,
+			CHAT_PET_SOURCE_SIZE
+		);
+		return frame;
 	}
 
 	private _updateSpeechBubble(state: ChatPetState | undefined, restart = false): void {
@@ -934,10 +1145,11 @@ export class ChatPetWidget extends Disposable {
 		this._speechBubble.container.classList.toggle('hidden', !visible);
 		if (!visible) {
 			this._speechAnimation.clear();
+			this._activeSpeechAnimation = undefined;
 			return;
 		}
 
-		const sources = getSpeechSpriteSources(this._variant);
+		const sources = getSpeechSpriteSources(this._variant, this._options.resourceBaseUrl);
 		const source = this._motionReduced ? sources.reducedMotion : sources.animated;
 		if (!isChatPetImageSource(this._speechBubble.image, source.url)) {
 			this._speechAnimation.clear();
@@ -956,6 +1168,17 @@ export class ChatPetWidget extends Disposable {
 		this._eyes.getBoundingClientRect();
 		if (!this._motionReduced) {
 			this._eyes.classList.add('animated');
+		}
+	}
+
+	private _updateCssAnimationTime(animationTime: number | undefined): void {
+		if (animationTime === undefined) {
+			return;
+		}
+		this._button.element.getBoundingClientRect();
+		for (const animation of this._button.element.getAnimations({ subtree: true })) {
+			animation.pause();
+			animation.currentTime = animationTime;
 		}
 	}
 }

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatPet.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatPet.fixture.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../base/browser/dom.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { autorun, observableValue } from '../../../../../base/common/observable.js';
+import { VirtualClock } from '../../../../../base/test/common/virtualScheduling/index.js';
+import { localize } from '../../../../../nls.js';
+import { ChatPetVariant } from '../../../../contrib/chat/browser/chatPetService.js';
+import { ChatPetAnimationDurationSource, ChatPetState, ChatPetView, doesChatPetStateTrackCursor } from '../../../../contrib/chat/browser/widget/chatPetWidget.js';
+import { ComponentFixtureContext, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
+
+interface ChatPetFixtureOptions {
+	readonly state: ChatPetState;
+	readonly defaultProgress: number;
+	readonly durationSource?: ChatPetAnimationDurationSource;
+	readonly variant?: ChatPetVariant;
+	readonly presentation?: 'entering' | 'exiting' | 'dragging';
+	readonly position?: 'left' | 'right';
+}
+
+class ChatPetFixtureTimeline extends Disposable {
+
+	readonly time = observableValue(this, 0);
+	readonly duration = observableValue(this, 0);
+	private _clock = new VirtualClock();
+
+	configure(duration: number, defaultProgress: number): void {
+		this.duration.set(duration, undefined);
+		this.setTime(Math.round(duration * defaultProgress));
+	}
+
+	setTime(time: number): void {
+		const clampedTime = Math.max(0, Math.min(time, this.duration.get()));
+		if (clampedTime < this._clock.now) {
+			this._clock = new VirtualClock();
+		}
+		if (clampedTime > this._clock.now) {
+			this._clock.schedule({
+				time: clampedTime,
+				run() { },
+				source: { toString: () => 'Chat pet timeline slider' },
+			});
+			this._clock.runNext();
+		}
+		this.time.set(this._clock.now, undefined);
+	}
+}
+
+function formatAnimationTime(time: number, duration: number): string {
+	return `${time} ms / ${duration} ms`;
+}
+
+class ChatPetFixtureGazeTarget extends Disposable {
+
+	private readonly _element: HTMLButtonElement;
+	private _x = 0;
+	private _y = 0;
+	private _dragOffset: readonly [number, number] | undefined;
+
+	constructor(
+		private readonly _container: HTMLElement,
+		private readonly _view: ChatPetView,
+	) {
+		super();
+
+		this._element = dom.append(_container, dom.$('button.chat-pet-fixture-cursor')) as HTMLButtonElement;
+		this._element.type = 'button';
+		this._element.ariaLabel = localize('chatPet.fixture.gazeTarget', "Pet gaze target");
+		this._element.style.position = 'absolute';
+		this._element.style.width = '16px';
+		this._element.style.height = '16px';
+		this._element.style.padding = '0';
+		this._element.style.border = 'var(--vscode-strokeThickness) solid var(--vscode-focusBorder)';
+		this._element.style.borderRadius = 'var(--vscode-cornerRadius-circle)';
+		this._element.style.backgroundColor = 'var(--vscode-editor-background)';
+		this._element.style.cursor = 'grab';
+		this._element.style.touchAction = 'none';
+		this._element.style.transform = 'translate(-50%, -50%)';
+
+		const bounds = _container.getBoundingClientRect();
+		this._setPosition(bounds.width * 0.75, bounds.height * 0.25);
+		this._register(dom.addDisposableListener(this._element, dom.EventType.POINTER_DOWN, (event: PointerEvent) => this._startDrag(event)));
+		this._register(dom.addDisposableListener(this._element, dom.EventType.POINTER_MOVE, (event: PointerEvent) => this._drag(event)));
+		this._register(dom.addDisposableListener(this._element, dom.EventType.POINTER_UP, (event: PointerEvent) => this._stopDrag(event)));
+		this._register(dom.addDisposableListener(this._element, 'pointercancel', (event: PointerEvent) => this._stopDrag(event)));
+		this._register(dom.addDisposableListener(this._element, dom.EventType.KEY_DOWN, (event: KeyboardEvent) => this._moveWithKeyboard(event)));
+	}
+
+	private _startDrag(event: PointerEvent): void {
+		const bounds = this._container.getBoundingClientRect();
+		this._dragOffset = [event.clientX - bounds.left - this._x, event.clientY - bounds.top - this._y];
+		this._element.setPointerCapture(event.pointerId);
+		this._element.style.cursor = 'grabbing';
+		event.preventDefault();
+	}
+
+	private _drag(event: PointerEvent): void {
+		if (!this._dragOffset || !this._element.hasPointerCapture(event.pointerId)) {
+			return;
+		}
+		const bounds = this._container.getBoundingClientRect();
+		this._setPosition(event.clientX - bounds.left - this._dragOffset[0], event.clientY - bounds.top - this._dragOffset[1]);
+	}
+
+	private _stopDrag(event: PointerEvent): void {
+		this._dragOffset = undefined;
+		if (this._element.hasPointerCapture(event.pointerId)) {
+			this._element.releasePointerCapture(event.pointerId);
+		}
+		this._element.style.cursor = 'grab';
+	}
+
+	private _moveWithKeyboard(event: KeyboardEvent): void {
+		const distance = event.shiftKey ? 10 : 1;
+		switch (event.key) {
+			case 'ArrowLeft':
+				this._setPosition(this._x - distance, this._y);
+				break;
+			case 'ArrowRight':
+				this._setPosition(this._x + distance, this._y);
+				break;
+			case 'ArrowUp':
+				this._setPosition(this._x, this._y - distance);
+				break;
+			case 'ArrowDown':
+				this._setPosition(this._x, this._y + distance);
+				break;
+			default:
+				return;
+		}
+		event.preventDefault();
+	}
+
+	private _setPosition(x: number, y: number): void {
+		const bounds = this._container.getBoundingClientRect();
+		this._x = Math.max(0, Math.min(bounds.width, x));
+		this._y = Math.max(0, Math.min(bounds.height, y));
+		this._element.style.left = `${this._x}px`;
+		this._element.style.top = `${this._y}px`;
+		this._view.setCursorPosition(bounds.left + this._x, bounds.top + this._y);
+	}
+}
+
+function defineChatPetFixture(options: ChatPetFixtureOptions) {
+	return defineComponentFixture({
+		labels: { kind: 'animated' },
+		virtualTime: { enabled: false },
+		enableAnimationsByDefault: true,
+		disableAnimationsWithCss: false,
+		render: context => renderChatPet(context, options),
+	});
+}
+
+async function renderChatPet(context: ComponentFixtureContext, options: ChatPetFixtureOptions): Promise<void> {
+	const { animationsEnabled, container, disposableStore } = context;
+	container.style.width = '480px';
+	container.style.height = '240px';
+	container.style.position = 'relative';
+	container.style.backgroundColor = 'var(--vscode-sideBar-background, var(--vscode-editor-background))';
+
+	const host = dom.append(container, dom.$('.chat-pet-fixture-host'));
+	host.style.position = 'absolute';
+	host.style.left = 'var(--vscode-spacing-size400)';
+	host.style.right = 'var(--vscode-spacing-size400)';
+	host.style.bottom = 'calc(var(--vscode-spacing-size400) + var(--vscode-spacing-size320))';
+	host.style.height = '48px';
+	host.style.backgroundColor = 'var(--vscode-input-background)';
+	host.style.border = 'var(--vscode-strokeThickness) solid var(--vscode-input-border, transparent)';
+	host.style.borderRadius = 'var(--vscode-cornerRadius-small)';
+
+	const timelineControls = dom.append(container, dom.$('.chat-pet-fixture-timeline'));
+	timelineControls.style.position = 'absolute';
+	timelineControls.style.left = 'var(--vscode-spacing-size400)';
+	timelineControls.style.right = 'var(--vscode-spacing-size400)';
+	timelineControls.style.bottom = 'var(--vscode-spacing-size120)';
+	timelineControls.style.display = 'grid';
+	timelineControls.style.gridTemplateColumns = 'auto 1fr auto';
+	timelineControls.style.alignItems = 'center';
+	timelineControls.style.gap = 'var(--vscode-spacing-size80)';
+
+	const animationTimeLabel = localize('chatPet.fixture.animationTime', "Animation time");
+	const timelineLabel = dom.append(timelineControls, dom.$('span'));
+	timelineLabel.textContent = animationTimeLabel;
+	const timelineSlider = dom.append(timelineControls, dom.$('input')) as HTMLInputElement;
+	timelineSlider.type = 'range';
+	timelineSlider.min = '0';
+	timelineSlider.step = '10';
+	timelineSlider.setAttribute('aria-label', animationTimeLabel);
+	const timelineValue = dom.append(timelineControls, dom.$('output'));
+	timelineValue.style.fontVariantNumeric = 'tabular-nums';
+	timelineValue.style.textAlign = 'right';
+
+	const timeline = disposableStore.add(new ChatPetFixtureTimeline());
+	const animationTime = observableValue<number | undefined>('chatPetFixtureAnimationTime', 0);
+	const view = disposableStore.add(new ChatPetView(host, host, {
+		ariaLabel: localize('chatPet.interact', "Interact with the VS Code pet. Use the context menu to put it on the run."),
+		animationTime,
+		loopAnimations: true,
+		resourceBaseUrl: '/out',
+		trackDocumentCursor: false,
+	}));
+	view.renderState(options.state, options.variant ?? 'stable', false, true);
+	view.show(true);
+
+	switch (options.presentation) {
+		case 'entering':
+			view.show(false);
+			break;
+		case 'exiting':
+			view.hide(false);
+			break;
+		case 'dragging':
+			view.setDragging(true);
+			view.setResisting(true);
+			break;
+	}
+	if (options.position === 'left') {
+		view.setHorizontalPosition(0);
+	}
+
+	await view.whenReady();
+	if (doesChatPetStateTrackCursor(options.state)) {
+		disposableStore.add(new ChatPetFixtureGazeTarget(container, view));
+	}
+	const duration = view.getAnimationDuration(options.durationSource ?? 'sprite');
+	if (duration <= 0) {
+		throw new Error(`Chat pet fixture state '${options.state}' has no ${options.durationSource ?? 'sprite'} animation`);
+	}
+	timeline.configure(duration, options.defaultProgress);
+	timelineControls.style.gridTemplateColumns = `auto minmax(0, 1fr) ${formatAnimationTime(duration, duration).length}ch`;
+
+	disposableStore.add(dom.addDisposableListener(timelineSlider, dom.EventType.INPUT, () => {
+		timeline.setTime(timelineSlider.valueAsNumber);
+	}));
+	disposableStore.add(autorun(reader => {
+		const enabled = animationsEnabled.read(reader);
+		timelineControls.style.display = enabled ? 'none' : 'grid';
+		animationTime.set(enabled ? undefined : timeline.time.read(reader), undefined);
+	}));
+	disposableStore.add(autorun(reader => {
+		const time = timeline.time.read(reader);
+		const duration = timeline.duration.read(reader);
+		timelineSlider.max = String(duration);
+		timelineSlider.value = String(time);
+		timelineValue.textContent = formatAnimationTime(time, duration);
+	}));
+}
+
+export default defineThemedFixtureGroup({ path: 'chat/pet/' }, {
+	Idle: defineChatPetFixture({ state: 'idle', defaultProgress: 0.25 }),
+	Sleeping: defineChatPetFixture({ state: 'sleep', defaultProgress: 0.5 }),
+	Waking: defineChatPetFixture({ state: 'waking', defaultProgress: 0.5 }),
+	Typing: defineChatPetFixture({ state: 'typing', defaultProgress: 0.5 }),
+	Rendering: defineChatPetFixture({ state: 'rendering', defaultProgress: 0.5 }),
+	Complete: defineChatPetFixture({ state: 'complete', defaultProgress: 0.5, durationSource: 'css' }),
+	Love: defineChatPetFixture({ state: 'love', defaultProgress: 0.4 }),
+	Clapping: defineChatPetFixture({ state: 'clapping', defaultProgress: 0.5 }),
+	Jump: defineChatPetFixture({ state: 'jump', defaultProgress: 0.5, durationSource: 'css' }),
+	Cool: defineChatPetFixture({ state: 'cool', defaultProgress: 0.6 }),
+	YappingFall: defineChatPetFixture({ state: 'yapping', defaultProgress: 0.75, durationSource: 'css' }),
+	YappingMouthOpen: defineChatPetFixture({ state: 'yappingMouthOpen', defaultProgress: 0.5 }),
+	Searching: defineChatPetFixture({ state: 'searching', defaultProgress: 0.5 }),
+	SearchingDown: defineChatPetFixture({ state: 'searchingDown', defaultProgress: 0.5, durationSource: 'css' }),
+	Entering: defineChatPetFixture({ state: 'idle', defaultProgress: 0.65, durationSource: 'css', presentation: 'entering' }),
+	Exiting: defineChatPetFixture({ state: 'idle', defaultProgress: 0.65, durationSource: 'css', presentation: 'exiting' }),
+	DraggingResistance: defineChatPetFixture({ state: 'idle', defaultProgress: 0.5, durationSource: 'css', presentation: 'dragging' }),
+	InsidersColors: defineChatPetFixture({ state: 'idle', defaultProgress: 0.25, variant: 'insiders' }),
+	RenderingSpeechBubbleLeft: defineChatPetFixture({ state: 'rendering', defaultProgress: 0.5, position: 'left' }),
+});

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -9,6 +9,7 @@ import { defineFixture, defineFixtureGroup, defineFixtureVariants } from '@vscod
 // eslint-disable-next-line local/code-import-patterns, local/code-amd-node-module
 import { z } from 'zod';
 import { DisposableStore, DisposableTracker, IDisposable, IReference, MutableDisposable, setDisposableTracker, toDisposable } from '../../../../base/common/lifecycle.js';
+import { constObservable, IObservable, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 // eslint-disable-next-line local/code-import-patterns
@@ -105,8 +106,6 @@ import { ISessionsManagementService } from '../../../../sessions/services/sessio
 import { ISessionsService } from '../../../../sessions/services/sessions/browser/sessionsService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { ICodeReviewService, PRReviewStateKind } from '../../../../sessions/contrib/codeReview/browser/codeReviewService.js';
-import { constObservable } from '../../../../base/common/observable.js';
-
 // Editor
 import { ITextModel } from '../../../../editor/common/model.js';
 
@@ -380,17 +379,18 @@ function getReverseStylesheetsOption(input: unknown): ReverseStylesheetsOption {
 	return parsedInput.reverseStylesheetsRange ?? parsedInput.reverseStylesheets;
 }
 
-/** Inputs exposed as Component Explorer controls. */
-const fixtureInputSchema = z.object({
-	reverseStylesheets: z.boolean().default(false).describe('Reverse the order of the bundled CSS documents to surface cascade-order dependencies.'),
-	reverseStylesheetsRange: z.object({
-		fromIndex: z.number(),
-		toIndex: z.number(),
-	}).optional().describe('Reverse the bundled CSS documents in this half-open index range.'),
-	enableAnimations: z.boolean().default(false).describe('Enable CSS animations and transitions.'),
-	outputTimeTrace: z.boolean().default(false).describe('Return the render\'s virtual-time trace as its output.'),
-	outputStylesheetFiles: z.boolean().default(false).describe('Return the bundled stylesheet files as the render output.'),
-});
+function createFixtureInputSchema(enableAnimationsByDefault: boolean) {
+	return z.object({
+		reverseStylesheets: z.boolean().default(false).describe('Reverse the order of the bundled CSS documents to surface cascade-order dependencies.'),
+		reverseStylesheetsRange: z.object({
+			fromIndex: z.number(),
+			toIndex: z.number(),
+		}).optional().describe('Reverse the bundled CSS documents in this half-open index range.'),
+		enableAnimations: z.boolean().default(enableAnimationsByDefault).describe('Enable CSS animations and transitions.'),
+		outputTimeTrace: z.boolean().default(false).describe('Return the render\'s virtual-time trace as its output.'),
+		outputStylesheetFiles: z.boolean().default(false).describe('Return the bundled stylesheet files as the render output.'),
+	});
+}
 
 function getPlatformClass(): string {
 	const alwaysUseMac = true;
@@ -860,6 +860,7 @@ export interface ComponentFixtureContext {
 	disposableStore: DisposableStore;
 	disposableStackStore: DisposableStackStore;
 	theme: ColorThemeData;
+	animationsEnabled: IObservable<boolean>;
 }
 
 export interface ComponentFixtureOptions {
@@ -867,6 +868,8 @@ export interface ComponentFixtureOptions {
 	labels?: ThemedFixtureGroupLabels;
 	virtualTime?: { enabled?: boolean; durationMs?: number; teardownDrainMs?: number };
 	additionalThemes?: readonly ComponentFixtureAdditionalTheme[];
+	enableAnimationsByDefault?: boolean;
+	disableAnimationsWithCss?: boolean;
 }
 
 type ThemedFixtures = ReturnType<typeof defineFixtureVariants>;
@@ -898,7 +901,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 		isolation: 'none',
 		displayMode: { type: 'component' },
 		background: themeVariant.background,
-		inputSchema: fixtureInputSchema,
+		inputSchema: createFixtureInputSchema(options.enableAnimationsByDefault ?? false),
 		inputControls: {
 			reverseStylesheets: { placement: 'toolbar', label: 'Reverse Stylesheets' },
 			enableAnimations: { placement: 'toolbar', label: 'Enable Animations' },
@@ -906,6 +909,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 		render: async (container: HTMLElement, context) => {
 			const disposableStore = new DisposableStore();
 			const input = parseFixtureInput(context.input);
+			const animationsEnabled = observableValue('componentFixtureAnimationsEnabled', input.enableAnimations);
 			const { label: themeLabel, theme, scopeThemingParticipants } = themeVariant;
 
 			// Replace Math.random with a seeded PRNG so fixtures render deterministically.
@@ -1016,7 +1020,8 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 				context.watchInput('reverseStylesheets', (_value, input) => updateStylesheetOrder(input));
 				context.watchInput('reverseStylesheetsRange', (_value, input) => updateStylesheetOrder(input));
 				context.watchInput('enableAnimations', value => {
-					container.classList.toggle('disable-animations', !value);
+					container.classList.toggle('disable-animations', (options.disableAnimationsWithCss ?? true) && !value);
+					animationsEnabled.set(value, undefined);
 				});
 
 				let renderTimeApi: IDisposable | undefined;
@@ -1046,7 +1051,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 
 				try {
 					const disposableStackStore = disposableStore.add(new DisposableStackStore());
-					const result = options.render({ container, disposableStore, disposableStackStore, theme });
+					const result = options.render({ container, disposableStore, disposableStackStore, theme, animationsEnabled });
 
 					const p2 = virtualTimeEnabled
 						? p.run({


### PR DESCRIPTION
## Summary

- separate chat pet behavior from rendering while keeping both classes in `chatPetWidget.ts`
- add themed component fixtures for the pet animation states with deterministic timeline controls
- loop enabled animations and provide a draggable gaze target for cursor-aware states
- expose fixture animation enablement so pet fixtures can pause and scrub canvas and CSS animations

## Testing

- `npm run typecheck-client`
- targeted ESLint for the changed files
- `npm run transpile-client`
- `.\scripts\test.bat --run src\vs\workbench\contrib\chat\test\browser\widget\chatPetWidget.test.ts` (19 passing)

<img width="1092" height="407" alt="chrome_GCMoFIZhw6" src="https://github.com/user-attachments/assets/afdba88f-da12-4efc-9ae6-9fb4a0e748d5" />
