### PR TITLE
Verify SSH host keys for remote agent host connections

### DIFF
--- a/src/vs/platform/agentHost/browser/sshHostKeyTrustService.ts
+++ b/src/vs/platform/agentHost/browser/sshHostKeyTrustService.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
+import {
+	computeHostKeyStoreKey,
+	ISSHHostKeyTrustService,
+	type ISSHTrustedHost,
+	type ISSHTrustedHostKey,
+} from '../common/sshHostKeyTrust.js';
+
+/** Storage key for the JSON map of trusted SSH host keys. */
+export const SSH_HOST_KEY_TRUST_STORAGE_KEY = 'sshRemoteAgentHost.trustedHostKeys';
+
+/**
+ * Parse one persisted host key entry, returning `undefined` when any field is
+ * missing or the wrong shape. Trust data must never be reconstructed from
+ * partial input — a half-read entry could otherwise match a key it shouldn't.
+ */
+function parseTrustedHostKey(value: unknown): ISSHTrustedHostKey | undefined {
+	if (typeof value !== 'object' || value === null) {
+		return undefined;
+	}
+	const { keyType, fingerprint, addedAt, alias } = value as Record<string, unknown>;
+	if (typeof keyType !== 'string' || !keyType
+		|| typeof fingerprint !== 'string' || !fingerprint
+		|| typeof addedAt !== 'number' || !Number.isFinite(addedAt)) {
+		return undefined;
+	}
+	return {
+		keyType,
+		fingerprint,
+		addedAt,
+		...(typeof alias === 'string' && alias ? { alias } : undefined),
+	};
+}
+
+/**
+ * Parse the persisted trust map. A malformed entry is dropped rather than
+ * discarding the whole map, so one bad record never forces the user to
+ * re-accept every host they have ever trusted.
+ */
+export function parseTrustedHostKeys(raw: string | undefined): Map<string, ISSHTrustedHostKey[]> {
+	const hosts = new Map<string, ISSHTrustedHostKey[]>();
+	if (!raw) {
+		return hosts;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return hosts;
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		return hosts;
+	}
+
+	for (const [storeKey, value] of Object.entries(parsed as Record<string, unknown>)) {
+		if (!storeKey || !Array.isArray(value)) {
+			continue;
+		}
+		const keys: ISSHTrustedHostKey[] = [];
+		for (const entry of value) {
+			const key = parseTrustedHostKey(entry);
+			if (key) {
+				keys.push(key);
+			}
+		}
+		if (keys.length) {
+			hosts.set(storeKey, keys);
+		}
+	}
+	return hosts;
+}
+
+/**
+ * Split a `hostname:port` store key back into its parts. Returns `undefined`
+ * for anything that doesn't round-trip, so a corrupt key is skipped rather
+ * than surfacing a host with a bogus port in the "forget" picker.
+ */
+function parseStoreKey(storeKey: string): { host: string; port: number } | undefined {
+	const separator = storeKey.lastIndexOf(':');
+	if (separator <= 0) {
+		return undefined;
+	}
+	const host = storeKey.substring(0, separator);
+	const port = Number(storeKey.substring(separator + 1));
+	if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) {
+		return undefined;
+	}
+	return { host, port };
+}
+
+/**
+ * Storage-backed {@link ISSHHostKeyTrustService}. Persists at application
+ * scope with {@link StorageTarget.MACHINE} because host key trust is a
+ * property of this machine's view of the network and must not sync to other
+ * devices, where the same alias could resolve somewhere else entirely.
+ */
+export class SSHHostKeyTrustService extends Disposable implements ISSHHostKeyTrustService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeTrustedHosts = this._register(new Emitter<string>());
+	readonly onDidChangeTrustedHosts: Event<string> = this._onDidChangeTrustedHosts.event;
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		super();
+	}
+
+	getTrustedKeys(host: string, port: number): readonly ISSHTrustedHostKey[] {
+		return this._read().get(computeHostKeyStoreKey(host, port)) ?? [];
+	}
+
+	trustHostKey(host: string, port: number, key: ISSHTrustedHostKey): void {
+		const storeKey = computeHostKeyStoreKey(host, port);
+		const hosts = this._read();
+		const existing = hosts.get(storeKey) ?? [];
+		// One trusted key per algorithm: a rotated key supersedes the old one
+		// rather than leaving the superseded key permanently trusted.
+		const keys = existing.filter(k => k.keyType !== key.keyType);
+		keys.push(key);
+		hosts.set(storeKey, keys);
+		this._write(hosts);
+		this._onDidChangeTrustedHosts.fire(storeKey);
+	}
+
+	forgetHost(host: string, port: number): void {
+		const storeKey = computeHostKeyStoreKey(host, port);
+		const hosts = this._read();
+		if (!hosts.delete(storeKey)) {
+			return;
+		}
+		this._write(hosts);
+		this._onDidChangeTrustedHosts.fire(storeKey);
+	}
+
+	listTrustedHosts(): readonly ISSHTrustedHost[] {
+		const result: ISSHTrustedHost[] = [];
+		for (const [storeKey, keys] of this._read()) {
+			const parsed = parseStoreKey(storeKey);
+			if (parsed) {
+				result.push({ host: parsed.host, port: parsed.port, keys });
+			}
+		}
+		return result;
+	}
+
+	private _read(): Map<string, ISSHTrustedHostKey[]> {
+		return parseTrustedHostKeys(this._storageService.get(SSH_HOST_KEY_TRUST_STORAGE_KEY, StorageScope.APPLICATION));
+	}
+
+	private _write(hosts: Map<string, ISSHTrustedHostKey[]>): void {
+		if (hosts.size === 0) {
+			this._storageService.remove(SSH_HOST_KEY_TRUST_STORAGE_KEY, StorageScope.APPLICATION);
+			return;
+		}
+		this._storageService.store(
+			SSH_HOST_KEY_TRUST_STORAGE_KEY,
+			JSON.stringify(Object.fromEntries(hosts)),
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE,
+		);
+	}
+}

--- a/src/vs/platform/agentHost/common/sshConfigParsing.ts
+++ b/src/vs/platform/agentHost/common/sshConfigParsing.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ISSHResolvedConfig } from './sshRemoteAgentHost.js';
+import { isSSHStrictHostKeyChecking, type ISSHResolvedConfig } from './sshRemoteAgentHost.js';
 
 /** Strip inline comments from an SSH config value. */
 export function stripSSHComment(s: string): string {
@@ -35,6 +35,24 @@ export function parseSSHConfigHostEntries(content: string): string[] {
 }
 
 /**
+ * Split a space-separated `ssh -G` path list, honoring double quotes so paths
+ * containing spaces survive. `ssh -G` emits `userknownhostsfile` and
+ * `globalknownhostsfile` as one line holding several paths.
+ */
+function parseSSHPathList(value: string): string[] {
+	const paths: string[] = [];
+	const pattern = /"([^"]*)"|(\S+)/g;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(value)) !== null) {
+		const path = match[1] ?? match[2];
+		if (path) {
+			paths.push(path);
+		}
+	}
+	return paths;
+}
+
+/**
  * Parse `ssh -G` output into a resolved config object.
  */
 export function parseSSHGOutput(stdout: string): ISSHResolvedConfig {
@@ -54,6 +72,8 @@ export function parseSSHGOutput(stdout: string): ISSHResolvedConfig {
 		}
 	}
 
+	const strictHostKeyChecking = map.get('stricthostkeychecking')?.toLowerCase();
+
 	return {
 		hostname: map.get('hostname') ?? '',
 		user: map.get('user') || undefined,
@@ -61,5 +81,10 @@ export function parseSSHGOutput(stdout: string): ISSHResolvedConfig {
 		identityFile: identityFiles,
 		identityAgent: map.get('identityagent') || undefined,
 		forwardAgent: map.get('forwardagent') === 'yes',
+		userKnownHostsFiles: parseSSHPathList(map.get('userknownhostsfile') ?? ''),
+		globalKnownHostsFiles: parseSSHPathList(map.get('globalknownhostsfile') ?? ''),
+		strictHostKeyChecking: strictHostKeyChecking && isSSHStrictHostKeyChecking(strictHostKeyChecking)
+			? strictHostKeyChecking
+			: undefined,
 	};
 }

--- a/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
+++ b/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
@@ -42,12 +42,18 @@ export function decideHostKeyTrust(
 ): SSHHostKeyDecision {
 	const strict = request.strictHostKeyChecking;
 
-	if (strict === 'no' || strict === 'off') {
-		return { kind: 'trust', persist: false, reason: 'strict-disabled' };
-	}
-
+	// Revocation is checked before everything, including the
+	// `StrictHostKeyChecking` opt-out. Verified against OpenSSH 9.9: with
+	// `StrictHostKeyChecking=no` it still reports "REVOKED HOST KEY DETECTED"
+	// and disables password auth, keyboard-interactive auth and agent
+	// forwarding. Disabling host key checking means "I accept unknown keys",
+	// never "I accept keys I have explicitly revoked".
 	if (request.knownHostsMatch === 'revoked') {
 		return { kind: 'deny', reason: 'revoked' };
+	}
+
+	if (strict === 'no' || strict === 'off') {
+		return { kind: 'trust', persist: false, reason: 'strict-disabled' };
 	}
 
 	const storedForKeyType = trustedKeys.find(key => key.keyType === request.keyType);

--- a/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
+++ b/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ISSHHostKeyVerificationRequest } from './sshRemoteAgentHost.js';
+import type { ISSHTrustedHostKey } from './sshHostKeyTrust.js';
+
+/**
+ * What should happen with a presented host key, once the trust store and the
+ * user's `known_hosts` files have both been consulted.
+ */
+export type SSHHostKeyDecision =
+	/** Trust silently. No UI. */
+	| { readonly kind: 'trust'; readonly persist: boolean; readonly reason: 'stored' | 'known-hosts' | 'strict-accept-new' | 'strict-disabled' }
+	/**
+	 * Refuse without offering a way through. Used for a changed or revoked
+	 * key: an explicit "forget this host" step is required to recover, so a
+	 * possible impersonation can never be waved away with one reflexive click.
+	 */
+	| { readonly kind: 'deny'; readonly reason: 'mismatch' | 'revoked' | 'strict-yes' | 'not-user-initiated' }
+	/** Ask the user, then persist if they accept. */
+	| { readonly kind: 'prompt'; readonly reason: 'unknown' | 'ca-only' };
+
+/**
+ * Apply the host key trust policy.
+ *
+ * Pure so the whole matrix can be tested directly; the caller owns the UI and
+ * the storage writes. Ordering matters and is deliberate:
+ *
+ * 1. `StrictHostKeyChecking no`/`off` short-circuits everything, because the
+ *    user has explicitly opted out of verification in their SSH config. We
+ *    honor that but never persist, so turning it back on restores prompting.
+ * 2. Revocation beats every other signal, including a stored trust entry.
+ * 3. A key that disagrees with one we already trust is a mismatch even if
+ *    `known_hosts` happens to agree with the server, since our store is the
+ *    authority for hosts we have connected to before.
+ */
+export function decideHostKeyTrust(
+	request: ISSHHostKeyVerificationRequest,
+	trustedKeys: readonly ISSHTrustedHostKey[],
+): SSHHostKeyDecision {
+	const strict = request.strictHostKeyChecking;
+
+	if (strict === 'no' || strict === 'off') {
+		return { kind: 'trust', persist: false, reason: 'strict-disabled' };
+	}
+
+	if (request.knownHostsMatch === 'revoked') {
+		return { kind: 'deny', reason: 'revoked' };
+	}
+
+	const storedForKeyType = trustedKeys.find(key => key.keyType === request.keyType);
+	if (storedForKeyType) {
+		return storedForKeyType.fingerprint === request.fingerprint
+			? { kind: 'trust', persist: false, reason: 'stored' }
+			: { kind: 'deny', reason: 'mismatch' };
+	}
+
+	if (request.knownHostsMatch === 'mismatch') {
+		return { kind: 'deny', reason: 'mismatch' };
+	}
+
+	if (request.knownHostsMatch === 'match') {
+		// Copy into our own store so subsequent decisions do not depend on
+		// re-reading the user's files.
+		return { kind: 'trust', persist: true, reason: 'known-hosts' };
+	}
+
+	// Unknown (or CA-only, which we cannot validate — see below).
+	if (strict === 'yes') {
+		return { kind: 'deny', reason: 'strict-yes' };
+	}
+	if (strict === 'accept-new') {
+		return { kind: 'trust', persist: true, reason: 'strict-accept-new' };
+	}
+	if (!request.userInitiated) {
+		// A background reconnect must never raise a modal the user did not ask
+		// for, and silently trusting an unknown key would defeat the point.
+		return { kind: 'deny', reason: 'not-user-initiated' };
+	}
+	return { kind: 'prompt', reason: request.knownHostsMatch === 'ca-only' ? 'ca-only' : 'unknown' };
+}

--- a/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
+++ b/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
@@ -28,10 +28,11 @@ export type SSHHostKeyDecision =
  * Pure so the whole matrix can be tested directly; the caller owns the UI and
  * the storage writes. Ordering matters and is deliberate:
  *
- * 1. `StrictHostKeyChecking no`/`off` short-circuits everything, because the
+ * 1. Revocation beats every other signal, including a stored trust entry and
+ *    the `StrictHostKeyChecking` opt-out.
+ * 2. `StrictHostKeyChecking no`/`off` then short-circuits the rest, because the
  *    user has explicitly opted out of verification in their SSH config. We
  *    honor that but never persist, so turning it back on restores prompting.
- * 2. Revocation beats every other signal, including a stored trust entry.
  * 3. A key that disagrees with one we already trust is a mismatch even if
  *    `known_hosts` happens to agree with the server, since our store is the
  *    authority for hosts we have connected to before.

--- a/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
+++ b/src/vs/platform/agentHost/common/sshHostKeyPolicy.ts
@@ -7,18 +7,26 @@ import type { ISSHHostKeyVerificationRequest } from './sshRemoteAgentHost.js';
 import type { ISSHTrustedHostKey } from './sshHostKeyTrust.js';
 
 /**
+ * Refuse without offering a way through. Used for a changed or revoked key: an
+ * explicit "forget this host" step is required to recover, so a possible
+ * impersonation can never be waved away with one reflexive click.
+ *
+ * For a mismatch, `source` records where the disagreement came from, because
+ * it decides whether forgetting our stored key can actually unblock the user —
+ * a `known_hosts` verdict is not ours to clear.
+ */
+export type SSHHostKeyDenial =
+	| { readonly kind: 'deny'; readonly reason: 'mismatch'; readonly source: 'stored' | 'known-hosts' }
+	| { readonly kind: 'deny'; readonly reason: 'revoked' | 'strict-yes' | 'not-user-initiated' };
+
+/**
  * What should happen with a presented host key, once the trust store and the
  * user's `known_hosts` files have both been consulted.
  */
 export type SSHHostKeyDecision =
 	/** Trust silently. No UI. */
 	| { readonly kind: 'trust'; readonly persist: boolean; readonly reason: 'stored' | 'known-hosts' | 'strict-accept-new' | 'strict-disabled' }
-	/**
-	 * Refuse without offering a way through. Used for a changed or revoked
-	 * key: an explicit "forget this host" step is required to recover, so a
-	 * possible impersonation can never be waved away with one reflexive click.
-	 */
-	| { readonly kind: 'deny'; readonly reason: 'mismatch' | 'revoked' | 'strict-yes' | 'not-user-initiated' }
+	| SSHHostKeyDenial
 	/** Ask the user, then persist if they accept. */
 	| { readonly kind: 'prompt'; readonly reason: 'unknown' | 'ca-only' };
 
@@ -30,9 +38,11 @@ export type SSHHostKeyDecision =
  *
  * 1. Revocation beats every other signal, including a stored trust entry and
  *    the `StrictHostKeyChecking` opt-out.
- * 2. `StrictHostKeyChecking no`/`off` then short-circuits the rest, because the
+ * 2. `StrictHostKeyChecking no`/`off` then accepts *unknown* keys, because the
  *    user has explicitly opted out of verification in their SSH config. We
  *    honor that but never persist, so turning it back on restores prompting.
+ *    It does not extend to a key that contradicts one we already trust — see
+ *    the note on that branch.
  * 3. A key that disagrees with one we already trust is a mismatch even if
  *    `known_hosts` happens to agree with the server, since our store is the
  *    authority for hosts we have connected to before.
@@ -54,6 +64,26 @@ export function decideHostKeyTrust(
 	}
 
 	if (strict === 'no' || strict === 'off') {
+		// The opt-out covers *unknown* keys, not a key that disagrees with one
+		// we already trust. Verified against OpenSSH 9.9: with
+		// `StrictHostKeyChecking=no` and a changed host key it still prints
+		// "REMOTE HOST IDENTIFICATION HAS CHANGED!" and then disables password
+		// authentication, keyboard-interactive authentication and agent
+		// forwarding — precisely the paths that would hand credentials or agent
+		// access to a possible impostor.
+		//
+		// We refuse outright instead of connecting under those restrictions.
+		// That is stricter than OpenSSH, which still permits a signature-based
+		// (public key) login, but it matches the hard-fail contract a changed
+		// key gets everywhere else here, and recovery is the same explicit
+		// "forget this host" step.
+		const storedUnderOptOut = trustedKeys.find(key => key.keyType === request.keyType);
+		if (storedUnderOptOut && storedUnderOptOut.fingerprint !== request.fingerprint) {
+			return { kind: 'deny', reason: 'mismatch', source: 'stored' };
+		}
+		if (request.knownHostsMatch === 'mismatch') {
+			return { kind: 'deny', reason: 'mismatch', source: 'known-hosts' };
+		}
 		return { kind: 'trust', persist: false, reason: 'strict-disabled' };
 	}
 
@@ -61,11 +91,11 @@ export function decideHostKeyTrust(
 	if (storedForKeyType) {
 		return storedForKeyType.fingerprint === request.fingerprint
 			? { kind: 'trust', persist: false, reason: 'stored' }
-			: { kind: 'deny', reason: 'mismatch' };
+			: { kind: 'deny', reason: 'mismatch', source: 'stored' };
 	}
 
 	if (request.knownHostsMatch === 'mismatch') {
-		return { kind: 'deny', reason: 'mismatch' };
+		return { kind: 'deny', reason: 'mismatch', source: 'known-hosts' };
 	}
 
 	if (request.knownHostsMatch === 'match') {

--- a/src/vs/platform/agentHost/common/sshHostKeyTrust.ts
+++ b/src/vs/platform/agentHost/common/sshHostKeyTrust.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../base/common/event.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+/**
+ * One host key the user has accepted for a remote, identified by its
+ * OpenSSH-style `SHA256:` fingerprint.
+ */
+export interface ISSHTrustedHostKey {
+	/** Host key algorithm, e.g. `ssh-ed25519`. */
+	readonly keyType: string;
+	/** `SHA256:...` fingerprint, matching `ssh-keygen -lf`. */
+	readonly fingerprint: string;
+	/** When this key was first trusted, as epoch milliseconds. */
+	readonly addedAt: number;
+	/** SSH config alias this host was reached through, for display. */
+	readonly alias?: string;
+}
+
+/** All trusted keys for a single host, keyed by `hostname:port`. */
+export interface ISSHTrustedHost {
+	readonly host: string;
+	readonly port: number;
+	readonly keys: readonly ISSHTrustedHostKey[];
+}
+
+/**
+ * Build the stable trust-store key for a host. Uses the resolved hostname and
+ * port rather than an SSH config alias, since several aliases can point at one
+ * machine and the host key belongs to the machine.
+ */
+export function computeHostKeyStoreKey(host: string, port: number): string {
+	return `${host.toLowerCase()}:${port}`;
+}
+
+export const ISSHHostKeyTrustService = createDecorator<ISSHHostKeyTrustService>('sshHostKeyTrustService');
+
+/**
+ * Stores the SSH host keys the user has accepted for remote agent hosts.
+ *
+ * This is deliberately *our own* store rather than `~/.ssh/known_hosts`: we
+ * read the user's `known_hosts` files as an additional trust source (so anyone
+ * who already reached a machine from a terminal is not prompted again), but we
+ * never write to them. Nothing here should ever modify the user's SSH setup.
+ */
+export interface ISSHHostKeyTrustService {
+	readonly _serviceBrand: undefined;
+
+	/** Fires with the `hostname:port` key whose trusted set changed. */
+	readonly onDidChangeTrustedHosts: Event<string>;
+
+	/** Trusted keys for a host, or an empty array when none are stored. */
+	getTrustedKeys(host: string, port: number): readonly ISSHTrustedHostKey[];
+
+	/**
+	 * Record a host key as trusted. Replaces any existing entry for the same
+	 * key type, so a key learned through rotation supersedes its predecessor
+	 * rather than accumulating alongside it.
+	 */
+	trustHostKey(host: string, port: number, key: ISSHTrustedHostKey): void;
+
+	/** Drop all trusted keys for a host. */
+	forgetHost(host: string, port: number): void;
+
+	/** Every host with at least one trusted key, for the "forget" picker. */
+	listTrustedHosts(): readonly ISSHTrustedHost[];
+}

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -384,12 +384,41 @@ export type SSHKnownHostsMatch = 'match' | 'mismatch' | 'revoked' | 'ca-only' | 
  * fingerprint); the renderer owns the actual policy, since it holds the trust
  * store and the UI. The renderer must answer via
  * {@link ISSHRemoteAgentHostMainService.respondHostKeyVerification} with the
- * same `requestId`, otherwise the connection stalls until `readyTimeout`.
+ * same `requestId`, otherwise the connection stalls until the deadline.
  *
  * (`ISSHRemoteAgentHostMainService` is a misnomer inherited from its siblings:
  * it and the WSL/tunnel equivalents are all registered in `sharedProcessMain`,
  * so they run in the shared process, not the main process.)
  */
+/**
+ * Error name for a connect attempt refused because the server's host key was
+ * not trusted. Matching on the name (rather than `instanceof`) is deliberate:
+ * the error is raised in the shared process and inspected in the renderer, and
+ * only `name`/`message` survive IPC serialization.
+ */
+export const SSH_HOST_KEY_DENIED_ERROR_NAME = 'SSHHostKeyDenied';
+
+/**
+ * Raised when host key verification refused the connection.
+ *
+ * The host key UI owns the conversation about *why* — either the user
+ * declined the prompt themselves, or a specific, actionable notification
+ * (with a "Forget Saved Host Key" action) is already on screen. Callers should
+ * therefore not add a generic "failed to connect" error on top; see
+ * {@link isSSHHostKeyDeniedError}.
+ */
+export class SSHHostKeyDeniedError extends Error {
+	constructor(displayHost: string) {
+		super(`Host key verification failed for ${displayHost}`);
+		this.name = SSH_HOST_KEY_DENIED_ERROR_NAME;
+	}
+}
+
+/** Whether `error` is an {@link SSHHostKeyDeniedError}, including across IPC. */
+export function isSSHHostKeyDeniedError(error: unknown): boolean {
+	return error instanceof Error && error.name === SSH_HOST_KEY_DENIED_ERROR_NAME;
+}
+
 export interface ISSHHostKeyVerificationRequest {
 	readonly requestId: string;
 	readonly connectionKey: string;
@@ -458,7 +487,7 @@ export interface ISSHRemoteAgentHostMainService {
 	 * Fires when the SSH server requests keyboard-interactive auth (typically
 	 * a password prompt). The renderer must answer via {@link respondKeyboardInteractive}
 	 * with the same `requestId`, otherwise the auth attempt will hang until the
-	 * SSH `readyTimeout` elapses.
+	 * SSH handshake deadline elapses.
 	 */
 	readonly onDidRequestKeyboardInteractive: Event<ISSHKeyboardInteractiveRequest>;
 

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -375,16 +375,20 @@ export type ISSHEndpointSelection =
 export type SSHKnownHostsMatch = 'match' | 'mismatch' | 'revoked' | 'ca-only' | 'unknown';
 
 /**
- * Request from the main process for the renderer to decide whether a server's
- * host key should be trusted. Fired from ssh2's `hostVerifier` during key
- * exchange — that is, *before* authentication — so declining guarantees no
+ * Request from the shared process for the renderer to decide whether a
+ * server's host key should be trusted. Fired from ssh2's `hostVerifier` during
+ * key exchange — that is, *before* authentication — so declining guarantees no
  * password or SSH agent access is ever exposed to an unverified server.
  *
- * The main process only gathers evidence ({@link knownHostsMatch} and the
+ * The shared process only gathers evidence ({@link knownHostsMatch} and the
  * fingerprint); the renderer owns the actual policy, since it holds the trust
  * store and the UI. The renderer must answer via
  * {@link ISSHRemoteAgentHostMainService.respondHostKeyVerification} with the
  * same `requestId`, otherwise the connection stalls until `readyTimeout`.
+ *
+ * (`ISSHRemoteAgentHostMainService` is a misnomer inherited from its siblings:
+ * it and the WSL/tunnel equivalents are all registered in `sharedProcessMain`,
+ * so they run in the shared process, not the main process.)
  */
 export interface ISSHHostKeyVerificationRequest {
 	readonly requestId: string;

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -375,22 +375,6 @@ export type ISSHEndpointSelection =
 export type SSHKnownHostsMatch = 'match' | 'mismatch' | 'revoked' | 'ca-only' | 'unknown';
 
 /**
- * Request from the shared process for the renderer to decide whether a
- * server's host key should be trusted. Fired from ssh2's `hostVerifier` during
- * key exchange — that is, *before* authentication — so declining guarantees no
- * password or SSH agent access is ever exposed to an unverified server.
- *
- * The shared process only gathers evidence ({@link knownHostsMatch} and the
- * fingerprint); the renderer owns the actual policy, since it holds the trust
- * store and the UI. The renderer must answer via
- * {@link ISSHRemoteAgentHostMainService.respondHostKeyVerification} with the
- * same `requestId`, otherwise the connection stalls until the deadline.
- *
- * (`ISSHRemoteAgentHostMainService` is a misnomer inherited from its siblings:
- * it and the WSL/tunnel equivalents are all registered in `sharedProcessMain`,
- * so they run in the shared process, not the main process.)
- */
-/**
  * Error name for a connect attempt refused because the server's host key was
  * not trusted. Matching on the name (rather than `instanceof`) is deliberate:
  * the error is raised in the shared process and inspected in the renderer, and
@@ -419,6 +403,22 @@ export function isSSHHostKeyDeniedError(error: unknown): boolean {
 	return error instanceof Error && error.name === SSH_HOST_KEY_DENIED_ERROR_NAME;
 }
 
+/**
+ * Request from the shared process for the renderer to decide whether a
+ * server's host key should be trusted. Fired from ssh2's `hostVerifier` during
+ * key exchange — that is, *before* authentication — so declining guarantees no
+ * password or SSH agent access is ever exposed to an unverified server.
+ *
+ * The shared process only gathers evidence ({@link knownHostsMatch} and the
+ * fingerprint); the renderer owns the actual policy, since it holds the trust
+ * store and the UI. The renderer must answer via
+ * {@link ISSHRemoteAgentHostMainService.respondHostKeyVerification} with the
+ * same `requestId`, otherwise the connection stalls until the deadline.
+ *
+ * (`ISSHRemoteAgentHostMainService` is a misnomer inherited from its siblings:
+ * it and the WSL/tunnel equivalents are all registered in `sharedProcessMain`,
+ * so they run in the shared process, not the main process.)
+ */
 export interface ISSHHostKeyVerificationRequest {
 	readonly requestId: string;
 	readonly connectionKey: string;

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -255,6 +255,19 @@ export interface ISSHConnectResult {
 }
 
 /**
+ * How OpenSSH should react to an unknown or changed host key, as reported by
+ * `ssh -G` (`stricthostkeychecking`). We honor the user's real SSH config here
+ * rather than introducing a parallel VS Code setting, so the escape hatch for
+ * users who genuinely cannot use verification stays where they expect it.
+ */
+export type SSHStrictHostKeyChecking = 'ask' | 'accept-new' | 'yes' | 'no' | 'off';
+
+/** Narrow an arbitrary `ssh -G` value to a {@link SSHStrictHostKeyChecking}. */
+export function isSSHStrictHostKeyChecking(value: string): value is SSHStrictHostKeyChecking {
+	return value === 'ask' || value === 'accept-new' || value === 'yes' || value === 'no' || value === 'off';
+}
+
+/**
  * Resolved SSH configuration for a host, obtained from `ssh -G`.
  */
 export interface ISSHResolvedConfig {
@@ -264,6 +277,16 @@ export interface ISSHResolvedConfig {
 	readonly identityFile: string[];
 	readonly identityAgent: string | undefined;
 	readonly forwardAgent: boolean;
+	/**
+	 * `UserKnownHostsFile` paths, in priority order. `ssh -G` emits these as a
+	 * single space-separated list, so this is already split. Typically
+	 * `~/.ssh/known_hosts` and `~/.ssh/known_hosts2`.
+	 */
+	readonly userKnownHostsFiles: string[];
+	/** `GlobalKnownHostsFile` paths, e.g. `/etc/ssh/ssh_known_hosts`. */
+	readonly globalKnownHostsFiles: string[];
+	/** Resolved `StrictHostKeyChecking`, when it is a value we recognize. */
+	readonly strictHostKeyChecking: SSHStrictHostKeyChecking | undefined;
 }
 
 export interface ISSHConnectProgress {
@@ -345,6 +368,64 @@ export type ISSHEndpointSelection =
 	| { readonly kind: 'spawn' };
 
 /**
+ * What the user's `known_hosts` files say about a presented host key. Mirrors
+ * `KnownHostsMatch` in `../node/sshKnownHosts.js`, redeclared here because
+ * this common-layer module cannot import from `node`.
+ */
+export type SSHKnownHostsMatch = 'match' | 'mismatch' | 'revoked' | 'ca-only' | 'unknown';
+
+/**
+ * Request from the main process for the renderer to decide whether a server's
+ * host key should be trusted. Fired from ssh2's `hostVerifier` during key
+ * exchange — that is, *before* authentication — so declining guarantees no
+ * password or SSH agent access is ever exposed to an unverified server.
+ *
+ * The main process only gathers evidence ({@link knownHostsMatch} and the
+ * fingerprint); the renderer owns the actual policy, since it holds the trust
+ * store and the UI. The renderer must answer via
+ * {@link ISSHRemoteAgentHostMainService.respondHostKeyVerification} with the
+ * same `requestId`, otherwise the connection stalls until `readyTimeout`.
+ */
+export interface ISSHHostKeyVerificationRequest {
+	readonly requestId: string;
+	readonly connectionKey: string;
+	/** Display-friendly host (e.g. SSH config alias or `user@host`). */
+	readonly displayHost: string;
+	/** Resolved hostname the key was presented for. */
+	readonly host: string;
+	readonly port: number;
+	/** Host key algorithm, e.g. `ssh-ed25519`. */
+	readonly keyType: string;
+	/** OpenSSH-style `SHA256:...` fingerprint, matching `ssh-keygen -lf`. */
+	readonly fingerprint: string;
+	/** What the user's `known_hosts` files say about this key. */
+	readonly knownHostsMatch: SSHKnownHostsMatch;
+	/** Resolved `StrictHostKeyChecking` from `ssh -G`, when recognized. */
+	readonly strictHostKeyChecking?: SSHStrictHostKeyChecking;
+	/**
+	 * Whether the owning connect attempt was directly requested by the user.
+	 * Background reconnects must never open a modal, so an unknown host key on
+	 * a silent reconnect is declined rather than prompted for.
+	 */
+	readonly userInitiated: boolean;
+}
+
+/**
+ * A host key proven to belong to an already-authenticated server, delivered
+ * via OpenSSH's `UpdateHostKeys` extension (`hostkeys-00@openssh.com`). ssh2
+ * completes the `hostkeys-prove-00@openssh.com` challenge and verifies the
+ * signatures before surfacing these, so they can be trusted without prompting
+ * — this is what lets a legitimate server key rotation be picked up silently
+ * instead of surfacing as a scary mismatch.
+ */
+export interface ISSHHostKeysAnnouncement {
+	readonly connectionKey: string;
+	readonly host: string;
+	readonly port: number;
+	readonly keys: readonly { readonly keyType: string; readonly fingerprint: string }[];
+}
+
+/**
  * Main-process service that performs the actual SSH work.
  * The renderer calls this over IPC and handles registration
  * with {@link IRemoteAgentHostService} locally.
@@ -412,6 +493,36 @@ export interface ISSHRemoteAgentHostMainService {
 	 * aborts the owning connect attempt with a cancellation error.
 	 */
 	respondEndpointSelection(requestId: string, selection: ISSHEndpointSelection | undefined): Promise<void>;
+
+	/**
+	 * Fires when a server presents a host key during key exchange and the
+	 * renderer must decide whether to trust it. Answering is mandatory: until
+	 * {@link respondHostKeyVerification} is called with the same `requestId`,
+	 * the SSH handshake is suspended.
+	 */
+	readonly onDidRequestHostKeyVerification: Event<ISSHHostKeyVerificationRequest>;
+
+	/**
+	 * Fires when a previously requested host key verification is no longer
+	 * needed (e.g. the owning connect attempt failed or was aborted). The
+	 * renderer should dismiss any UI it opened for `requestId`.
+	 */
+	readonly onDidCancelHostKeyVerification: Event<string /* requestId */>;
+
+	/**
+	 * Provide the user's trust decision for a previously fired host key
+	 * verification request. Passing `false` fails the key exchange, which
+	 * tears the connection down before any authentication is attempted.
+	 */
+	respondHostKeyVerification(requestId: string, trusted: boolean): Promise<void>;
+
+	/**
+	 * Fires when a server announces its full set of host keys over an
+	 * already-authenticated connection. See {@link ISSHHostKeysAnnouncement} —
+	 * these keys are cryptographically proven, so consumers can persist them
+	 * without prompting.
+	 */
+	readonly onDidAnnounceHostKeys: Event<ISSHHostKeysAnnouncement>;
 
 	/**
 	 * Bootstrap a remote agent host over SSH. Returns serializable

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../base/common/event.js';
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
+import { Codicon } from '../../../base/common/codicons.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
@@ -603,12 +604,11 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	 * wording so it is recognizable to anyone who has used `ssh` directly.
 	 * Cancel is the default so the safe answer is the one you get by dismissing.
 	 *
-	 * `IDialogService.confirm` accepts no {@link CancellationToken} and offers
-	 * no programmatic dismissal, so unlike the keyboard-interactive quick input
-	 * this modal cannot be torn down if the connection dies while it is open.
-	 * The stale dialog is cosmetic: the caller re-checks cancellation before
-	 * acting on the answer, so a late "Connect" can neither persist trust nor
-	 * revive a dead connect attempt.
+	 * Uses a custom dialog so the prompt can be dismissed programmatically when
+	 * the connection dies underneath it — a native dialog cannot be, and would
+	 * strand the user with a question about a connection that no longer exists.
+	 * Answering a stale prompt was always safe (the caller re-checks
+	 * cancellation before acting), but leaving it on screen is confusing.
 	 */
 	private async _promptForHostKey(request: ISSHHostKeyVerificationRequest, reason: 'unknown' | 'ca-only', token: CancellationToken): Promise<boolean> {
 		if (token.isCancellationRequested) {
@@ -631,6 +631,10 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			detail,
 			primaryButton: localize('sshHostKeyConnect', "&&Connect"),
 			cancelButton: localize('sshHostKeyCancel', "Cancel"),
+			custom: { icon: Codicon.shield },
+			// Cancellation resolves the dialog as if Cancel was pressed, which
+			// is also the answer we want for a connection that is already gone.
+			token,
 		});
 		return confirmed;
 	}

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -122,6 +122,14 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	 */
 	private readonly _lastConnectedServerTypeByAddress = new Map<string, AgentHostServerType>();
 
+	/**
+	 * The host key that authenticated the most recent session for a given
+	 * connection key. Used to decide whether an `UpdateHostKeys` announcement
+	 * may be trusted (see {@link _handleAnnouncedHostKeys}). Bounded by the
+	 * number of distinct SSH hosts, and each entry is overwritten on reconnect.
+	 */
+	private readonly _sessionHostKeys = new Map<string, { keyType: string; fingerprint: string }>();
+
 	constructor(
 		@ISharedProcessService sharedProcessService: ISharedProcessService,
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
@@ -564,6 +572,9 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			if (cts.token.isCancellationRequested) {
 				return;
 			}
+			// Remember which host key actually authenticated this session, so
+			// a later UpdateHostKeys announcement can be checked against it.
+			this._sessionHostKeys.set(request.connectionKey, { keyType: request.keyType, fingerprint: request.fingerprint });
 			await this._mainService.respondHostKeyVerification(request.requestId, trusted);
 		} catch (err) {
 			this._logService.error('[SSHRemoteAgentHost] Failed handling host key verification', err);
@@ -657,10 +668,23 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	}
 
 	/**
-	 * Persist host keys the server proved it owns. ssh2 verifies these before
-	 * surfacing them, so trusting them without a prompt is safe and is what
-	 * makes a legitimate server key rotation invisible to the user instead of
-	 * a hard failure on the next connect.
+	 * Persist host keys the server proved it owns, so a legitimate key
+	 * rotation is invisible to the user instead of a hard failure on the next
+	 * connect.
+	 *
+	 * ssh2 verifies the `hostkeys-prove` signatures before surfacing these,
+	 * but that only proves the keys belong to *whoever we are currently
+	 * talking to* — it says nothing about whether that party is the real host.
+	 * So we additionally require that the host key which authenticated this
+	 * very session is itself currently trusted. This mirrors OpenSSH, whose
+	 * `UpdateHostKeys` documentation states additional host keys are accepted
+	 * only "if the key used to authenticate the host was already trusted or
+	 * explicitly accepted by the user".
+	 *
+	 * Without that check, a session accepted through
+	 * `StrictHostKeyChecking=no` — where we deliberately did not verify
+	 * anything — could announce keys that overwrite the user's genuine stored
+	 * key, leaving an impostor's key trusted once strict checking is restored.
 	 */
 	private _handleAnnouncedHostKeys(announcement: ISSHHostKeysAnnouncement): void {
 		const existing = this._hostKeyTrustService.getTrustedKeys(announcement.host, announcement.port);
@@ -670,6 +694,13 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			// establish trust without any verification at all.
 			return;
 		}
+
+		const sessionKey = this._sessionHostKeys.get(announcement.connectionKey);
+		if (!sessionKey || !existing.some(e => e.keyType === sessionKey.keyType && e.fingerprint === sessionKey.fingerprint)) {
+			this._logService.warn(`[SSHRemoteAgentHost] Ignoring announced host keys for ${announcement.host}: the key that authenticated this session is not itself trusted`);
+			return;
+		}
+
 		for (const key of announcement.keys) {
 			if (!existing.some(e => e.keyType === key.keyType && e.fingerprint === key.fingerprint)) {
 				this._logService.info(`[SSHRemoteAgentHost] Learned rotated ${key.keyType} host key for ${announcement.host}: ${key.fingerprint}`);

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -602,6 +602,13 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	 * Ask the user whether to trust an unrecognized host key, echoing OpenSSH's
 	 * wording so it is recognizable to anyone who has used `ssh` directly.
 	 * Cancel is the default so the safe answer is the one you get by dismissing.
+	 *
+	 * `IDialogService.confirm` accepts no {@link CancellationToken} and offers
+	 * no programmatic dismissal, so unlike the keyboard-interactive quick input
+	 * this modal cannot be torn down if the connection dies while it is open.
+	 * The stale dialog is cosmetic: the caller re-checks cancellation before
+	 * acting on the answer, so a late "Connect" can neither persist trust nor
+	 * revive a dead connect attempt.
 	 */
 	private async _promptForHostKey(request: ISSHHostKeyVerificationRequest, reason: 'unknown' | 'ca-only', token: CancellationToken): Promise<boolean> {
 		if (token.isCancellationRequested) {

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -12,7 +12,8 @@ import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IDialogService } from '../../dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { INotificationService } from '../../notification/common/notification.js';
+import { INotificationService, Severity } from '../../notification/common/notification.js';
+import { toAction } from '../../../base/common/actions.js';
 import { IProductService } from '../../product/common/productService.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
 import { ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
@@ -38,11 +39,33 @@ import {
 	type ISSHEndpointCandidate,
 	type ISSHEndpointSelection,
 	type ISSHEndpointSelectionRequest,
+	type ISSHHostKeyVerificationRequest,
+	type ISSHHostKeysAnnouncement,
 	type ISSHKeyboardInteractiveRequest,
 	type ISSHRemoteAgentHostMainService,
 	type ISSHResolvedConfig,
 	type ISSHConnectProgress,
 } from '../common/sshRemoteAgentHost.js';
+import { ISSHHostKeyTrustService } from '../common/sshHostKeyTrust.js';
+import { decideHostKeyTrust } from '../common/sshHostKeyPolicy.js';
+
+/**
+ * Human-readable name for a host key algorithm, matching how OpenSSH labels
+ * them in its own prompts (e.g. "ED25519 key fingerprint is ...").
+ */
+export function describeHostKeyType(keyType: string): string {
+	switch (keyType) {
+		case 'ssh-ed25519': return 'ED25519';
+		case 'ssh-rsa':
+		case 'rsa-sha2-256':
+		case 'rsa-sha2-512': return 'RSA';
+		case 'ssh-dss': return 'DSA';
+		case 'ecdsa-sha2-nistp256':
+		case 'ecdsa-sha2-nistp384':
+		case 'ecdsa-sha2-nistp521': return 'ECDSA';
+		default: return keyType;
+	}
+}
 
 export const ISSHRelayClientFactory = createDecorator<ISSHRelayClientFactory>('sshRelayClientFactory');
 
@@ -110,6 +133,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		@IRemoteAgentHostLocationPreferenceService private readonly _locationPreferenceService: IRemoteAgentHostLocationPreferenceService,
 		@IDialogService private readonly _dialogService: IDialogService,
 		@IProductService private readonly _productService: IProductService,
+		@ISSHHostKeyTrustService private readonly _hostKeyTrustService: ISSHHostKeyTrustService,
 	) {
 		super();
 
@@ -161,6 +185,20 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		// no preference is stored and an editor-owned endpoint is live.
 		this._register(this._mainService.onDidRequestEndpointSelection(request => {
 			this._handleEndpointSelectionRequest(request);
+		}));
+
+		// Verify server host keys. Without this the shared process would accept
+		// any key from any server, so this is what actually makes SSH agent
+		// host connections resistant to impersonation.
+		this._register(this._mainService.onDidRequestHostKeyVerification(request => {
+			this._handleHostKeyVerificationRequest(request);
+		}));
+
+		// Learn host keys a server proves it owns over an already-authenticated
+		// connection (OpenSSH's UpdateHostKeys), so a legitimate key rotation
+		// is picked up silently rather than becoming a hard failure later.
+		this._register(this._mainService.onDidAnnounceHostKeys(announcement => {
+			this._handleAnnouncedHostKeys(announcement);
 		}));
 	}
 
@@ -475,6 +513,172 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		} finally {
 			cancelListener.dispose();
 			cts.dispose();
+		}
+	}
+
+	/**
+	 * Decide whether to trust a server's host key, and tell the shared process.
+	 *
+	 * Policy lives in {@link decideHostKeyTrust}; this method owns the UI and
+	 * the storage writes. Every path must respond exactly once — the SSH
+	 * handshake is suspended until it hears back.
+	 */
+	private async _handleHostKeyVerificationRequest(request: ISSHHostKeyVerificationRequest): Promise<void> {
+		this._logService.info(`[SSHRemoteAgentHost] Host key verification for ${request.displayHost}: ${request.keyType} ${request.fingerprint} (known_hosts: ${request.knownHostsMatch})`);
+
+		const cts = new CancellationTokenSource();
+		const cancelListener = this._mainService.onDidCancelHostKeyVerification(requestId => {
+			if (requestId === request.requestId) {
+				cts.cancel();
+			}
+		});
+
+		try {
+			const decision = decideHostKeyTrust(request, this._hostKeyTrustService.getTrustedKeys(request.host, request.port));
+			this._logService.info(`[SSHRemoteAgentHost] Host key decision for ${request.displayHost}: ${decision.kind} (${decision.reason})`);
+
+			let trusted: boolean;
+			switch (decision.kind) {
+				case 'trust':
+					if (decision.persist) {
+						this._trustHostKey(request);
+					}
+					trusted = true;
+					break;
+				case 'deny':
+					this._reportHostKeyDenied(request, decision.reason);
+					trusted = false;
+					break;
+				case 'prompt': {
+					trusted = await this._promptForHostKey(request, decision.reason, cts.token);
+					if (cts.token.isCancellationRequested) {
+						return;
+					}
+					if (trusted) {
+						this._trustHostKey(request);
+					}
+					break;
+				}
+			}
+
+			if (cts.token.isCancellationRequested) {
+				return;
+			}
+			await this._mainService.respondHostKeyVerification(request.requestId, trusted);
+		} catch (err) {
+			this._logService.error('[SSHRemoteAgentHost] Failed handling host key verification', err);
+			// Fail closed: an error here must never become a way to connect to
+			// an unverified server.
+			try {
+				await this._mainService.respondHostKeyVerification(request.requestId, false);
+			} catch { /* swallow */ }
+		} finally {
+			cancelListener.dispose();
+			cts.dispose();
+		}
+	}
+
+	private _trustHostKey(request: ISSHHostKeyVerificationRequest): void {
+		this._hostKeyTrustService.trustHostKey(request.host, request.port, {
+			keyType: request.keyType,
+			fingerprint: request.fingerprint,
+			addedAt: Date.now(),
+			...(request.displayHost !== request.host ? { alias: request.displayHost } : undefined),
+		});
+	}
+
+	/**
+	 * Ask the user whether to trust an unrecognized host key, echoing OpenSSH's
+	 * wording so it is recognizable to anyone who has used `ssh` directly.
+	 * Cancel is the default so the safe answer is the one you get by dismissing.
+	 */
+	private async _promptForHostKey(request: ISSHHostKeyVerificationRequest, reason: 'unknown' | 'ca-only', token: CancellationToken): Promise<boolean> {
+		if (token.isCancellationRequested) {
+			return false;
+		}
+
+		const detail = reason === 'ca-only'
+			? localize(
+				'sshHostKeyCaOnlyDetail',
+				"{0} key fingerprint is {1}.\n\nThis host is configured to use a certificate authority, but certificate-based host keys cannot be verified here, so this key cannot be checked against it.",
+				describeHostKeyType(request.keyType), request.fingerprint)
+			: localize(
+				'sshHostKeyUnknownDetail',
+				"{0} key fingerprint is {1}.\n\nVerify this fingerprint matches the host before continuing.",
+				describeHostKeyType(request.keyType), request.fingerprint);
+
+		const { confirmed } = await this._dialogService.confirm({
+			type: 'warning',
+			message: localize('sshHostKeyUnknownMessage', "The authenticity of host '{0}' can't be established.", request.displayHost),
+			detail,
+			primaryButton: localize('sshHostKeyConnect', "&&Connect"),
+			cancelButton: localize('sshHostKeyCancel', "Cancel"),
+		});
+		return confirmed;
+	}
+
+	/**
+	 * Explain a refusal. A changed or revoked key gets an error notification
+	 * with no "trust anyway" affordance — recovering requires explicitly
+	 * forgetting the host, so a possible impersonation cannot be dismissed
+	 * with a single reflexive click.
+	 */
+	private _reportHostKeyDenied(request: ISSHHostKeyVerificationRequest, reason: 'mismatch' | 'revoked' | 'strict-yes' | 'not-user-initiated'): void {
+		if (reason === 'not-user-initiated') {
+			// A background reconnect: log it, but do not interrupt with UI the
+			// user did not ask for. Connecting manually surfaces the prompt.
+			this._logService.warn(`[SSHRemoteAgentHost] Declining unknown host key for ${request.displayHost} during a background reconnect; connect manually to review it.`);
+			return;
+		}
+
+		if (reason === 'strict-yes') {
+			this._notificationService.error(localize(
+				'sshHostKeyStrictUnknown',
+				"Can't connect to '{0}': its host key is not known, and StrictHostKeyChecking is set to \"yes\" in your SSH configuration.",
+				request.displayHost));
+			return;
+		}
+
+		const message = reason === 'revoked'
+			? localize('sshHostKeyRevoked', "Host key verification failed for '{0}'. This host's {1} key has been marked as revoked in your known_hosts file.", request.displayHost, describeHostKeyType(request.keyType))
+			: localize('sshHostKeyChanged', "Host key verification failed for '{0}'. Its {1} host key has changed, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}.", request.displayHost, describeHostKeyType(request.keyType), request.fingerprint);
+
+		this._notificationService.notify({
+			severity: Severity.Error,
+			message,
+			actions: {
+				primary: [toAction({
+					id: 'sshHostKey.forget',
+					label: localize('sshHostKeyForgetAction', "Forget Saved Host Key"),
+					run: () => this._hostKeyTrustService.forgetHost(request.host, request.port),
+				})],
+			},
+		});
+	}
+
+	/**
+	 * Persist host keys the server proved it owns. ssh2 verifies these before
+	 * surfacing them, so trusting them without a prompt is safe and is what
+	 * makes a legitimate server key rotation invisible to the user instead of
+	 * a hard failure on the next connect.
+	 */
+	private _handleAnnouncedHostKeys(announcement: ISSHHostKeysAnnouncement): void {
+		const existing = this._hostKeyTrustService.getTrustedKeys(announcement.host, announcement.port);
+		if (!existing.length) {
+			// Only extend trust we already have. Recording keys for a host the
+			// user has never accepted would turn an announcement into a way to
+			// establish trust without any verification at all.
+			return;
+		}
+		for (const key of announcement.keys) {
+			if (!existing.some(e => e.keyType === key.keyType && e.fingerprint === key.fingerprint)) {
+				this._logService.info(`[SSHRemoteAgentHost] Learned rotated ${key.keyType} host key for ${announcement.host}: ${key.fingerprint}`);
+				this._hostKeyTrustService.trustHostKey(announcement.host, announcement.port, {
+					keyType: key.keyType,
+					fingerprint: key.fingerprint,
+					addedAt: Date.now(),
+				});
+			}
 		}
 	}
 

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -48,7 +48,7 @@ import {
 	type ISSHConnectProgress,
 } from '../common/sshRemoteAgentHost.js';
 import { ISSHHostKeyTrustService } from '../common/sshHostKeyTrust.js';
-import { decideHostKeyTrust } from '../common/sshHostKeyPolicy.js';
+import { decideHostKeyTrust, type SSHHostKeyDenial } from '../common/sshHostKeyPolicy.js';
 
 /**
  * Human-readable name for a host key algorithm, matching how OpenSSH labels
@@ -200,7 +200,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		// any key from any server, so this is what actually makes SSH agent
 		// host connections resistant to impersonation.
 		this._register(this._mainService.onDidRequestHostKeyVerification(request => {
-			this._handleHostKeyVerificationRequest(request);
+			this._trackHostKeyVerification(this._handleHostKeyVerificationRequest(request));
 		}));
 
 		// Learn host keys a server proves it owns over an already-authenticated
@@ -532,6 +532,16 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	 * the storage writes. Every path must respond exactly once — the SSH
 	 * handshake is suspended until it hears back.
 	 */
+	/**
+	 * Hook for observing when a host key verification has fully settled.
+	 * Overridden by tests so they can await the real operation instead of
+	 * sleeping for a fixed interval, which is load-dependent and flaky —
+	 * particularly for the cases that assert *nothing* happened.
+	 */
+	protected _trackHostKeyVerification(handled: Promise<void>): void {
+		void handled;
+	}
+
 	private async _handleHostKeyVerificationRequest(request: ISSHHostKeyVerificationRequest): Promise<void> {
 		this._logService.info(`[SSHRemoteAgentHost] Host key verification for ${request.displayHost}: ${request.keyType} ${request.fingerprint} (known_hosts: ${request.knownHostsMatch})`);
 
@@ -555,7 +565,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 					trusted = true;
 					break;
 				case 'deny':
-					this._reportHostKeyDenied(request, decision.reason);
+					this._reportHostKeyDenied(request, decision);
 					trusted = false;
 					break;
 				case 'prompt': {
@@ -645,15 +655,15 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	 * forgetting the host, so a possible impersonation cannot be dismissed
 	 * with a single reflexive click.
 	 */
-	private _reportHostKeyDenied(request: ISSHHostKeyVerificationRequest, reason: 'mismatch' | 'revoked' | 'strict-yes' | 'not-user-initiated'): void {
-		if (reason === 'not-user-initiated') {
+	private _reportHostKeyDenied(request: ISSHHostKeyVerificationRequest, denial: SSHHostKeyDenial): void {
+		if (denial.reason === 'not-user-initiated') {
 			// A background reconnect: log it, but do not interrupt with UI the
 			// user did not ask for. Connecting manually surfaces the prompt.
 			this._logService.warn(`[SSHRemoteAgentHost] Declining unknown host key for ${request.displayHost} during a background reconnect; connect manually to review it.`);
 			return;
 		}
 
-		if (reason === 'strict-yes') {
+		if (denial.reason === 'strict-yes') {
 			this._notificationService.error(localize(
 				'sshHostKeyStrictUnknown',
 				"Can't connect to '{0}': its host key is not known, and StrictHostKeyChecking is set to \"yes\" in your SSH configuration.",
@@ -661,13 +671,32 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			return;
 		}
 
-		const message = reason === 'revoked'
-			? localize('sshHostKeyRevoked', "Host key verification failed for '{0}'. This host's {1} key has been marked as revoked in your known_hosts file.", request.displayHost, describeHostKeyType(request.keyType))
-			: localize('sshHostKeyChanged', "Host key verification failed for '{0}'. Its {1} host key has changed, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}.", request.displayHost, describeHostKeyType(request.keyType), request.fingerprint);
+		// Forgetting our stored key only helps when our store is what
+		// disagreed. A revoked marker, or a conflicting `known_hosts` entry,
+		// lives in the user's own files and would keep winning afterwards — so
+		// offering the action there would send them in circles.
+		if (denial.reason !== 'mismatch') { // 'revoked'
+			this._notificationService.error(localize(
+				'sshHostKeyRevoked',
+				"Host key verification failed for '{0}'. This host's {1} key has been marked as revoked in your known_hosts file. Remove the @revoked line from known_hosts if this key should be trusted again.",
+				request.displayHost, describeHostKeyType(request.keyType)));
+			return;
+		}
+
+		if (denial.source === 'known-hosts') {
+			this._notificationService.error(localize(
+				'sshHostKeyChangedKnownHosts',
+				"Host key verification failed for '{0}'. Its {1} host key does not match the entry in your known_hosts file, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}. Update or remove the known_hosts entry if this change was expected.",
+				request.displayHost, describeHostKeyType(request.keyType), request.fingerprint));
+			return;
+		}
 
 		this._notificationService.notify({
 			severity: Severity.Error,
-			message,
+			message: localize(
+				'sshHostKeyChanged',
+				"Host key verification failed for '{0}'. Its {1} host key has changed, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}.",
+				request.displayHost, describeHostKeyType(request.keyType), request.fingerprint),
 			actions: {
 				primary: [toAction({
 					id: 'sshHostKey.forget',

--- a/src/vs/platform/agentHost/node/sshKnownHosts.ts
+++ b/src/vs/platform/agentHost/node/sshKnownHosts.ts
@@ -1,0 +1,274 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createHash, createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Result of matching a presented host key against the entries in the user's
+ * `known_hosts` files.
+ *
+ * `mismatch` is deliberately scoped to entries of the *same* key type: a host
+ * that has an `ssh-rsa` entry on file but presents an `ssh-ed25519` key is
+ * `unknown` (we simply have never seen that key type for it), not evidence of
+ * an attack. Treating that as a mismatch would fire a false alarm for every
+ * user with an RSA-only entry, since ssh2 negotiates ed25519 first.
+ */
+export type KnownHostsMatch =
+	/** An entry for this host and key type matches the presented key exactly. */
+	| 'match'
+	/** An entry for this host and key type exists but holds a *different* key. */
+	| 'mismatch'
+	/** The presented key is explicitly marked `@revoked`. */
+	| 'revoked'
+	/**
+	 * The only entries for this host are `@cert-authority` lines. ssh2 cannot
+	 * validate host certificates (it advertises no `*-cert-v01@openssh.com`
+	 * host key algorithms), so we can neither trust nor reject on this basis.
+	 * Surfaced distinctly so the UI can say so plainly rather than showing an
+	 * ordinary trust-on-first-use prompt for a host that deliberately set up a
+	 * CA precisely to avoid one.
+	 */
+	| 'ca-only'
+	/** No entry for this host and key type. */
+	| 'unknown';
+
+/**
+ * A single parsed `known_hosts` entry.
+ */
+export interface IKnownHostsEntry {
+	/** `@revoked` / `@cert-authority` marker, when present. */
+	readonly marker?: 'revoked' | 'cert-authority';
+	/**
+	 * Comma-separated host patterns, already split. Empty when {@link hashedHost}
+	 * is set, since hashed entries encode exactly one host per line.
+	 */
+	readonly patterns: readonly string[];
+	/** Salt and hash for a `|1|<salt>|<hash>` hashed entry. */
+	readonly hashedHost?: { readonly salt: Buffer; readonly hash: Buffer };
+	/** Key algorithm name, e.g. `ssh-ed25519`. */
+	readonly keyType: string;
+	/** The raw key blob (base64-decoded). */
+	readonly key: Buffer;
+}
+
+/**
+ * Compute the OpenSSH-style `SHA256:` fingerprint of a raw SSH wire-format
+ * public key blob. Matches `ssh-keygen -lf` byte for byte, including the
+ * stripped base64 padding, so the value can be compared by eye (or by copy
+ * and paste) against what the `ssh` command line displays.
+ */
+export function computeHostKeyFingerprint(keyBlob: Buffer): string {
+	const digest = createHash('sha256').update(keyBlob).digest('base64');
+	return `SHA256:${digest.replace(/=+$/, '')}`;
+}
+
+/**
+ * Read the algorithm name from the head of an SSH wire-format key blob. Every
+ * such blob begins with a length-prefixed algorithm string, so this identifies
+ * the key type without needing to parse the key material itself.
+ *
+ * Returns `undefined` when the buffer is too short or the embedded length is
+ * not self-consistent, so a malformed blob is rejected rather than producing a
+ * garbage type that could be matched against.
+ */
+export function readHostKeyType(keyBlob: Buffer): string | undefined {
+	if (keyBlob.length < 4) {
+		return undefined;
+	}
+	const length = keyBlob.readUInt32BE(0);
+	if (length === 0 || length > 64 || 4 + length > keyBlob.length) {
+		return undefined;
+	}
+	return keyBlob.subarray(4, 4 + length).toString('ascii');
+}
+
+/**
+ * Parse a single line from a `known_hosts` file. Returns `undefined` for blank
+ * lines, comments, and anything malformed — a corrupt line should be skipped
+ * rather than aborting the whole file, matching OpenSSH's own tolerance.
+ */
+export function parseKnownHostsLine(line: string): IKnownHostsEntry | undefined {
+	const trimmed = line.trim();
+	if (!trimmed || trimmed.startsWith('#')) {
+		return undefined;
+	}
+
+	const fields = trimmed.split(/\s+/);
+	let index = 0;
+
+	let marker: 'revoked' | 'cert-authority' | undefined;
+	if (fields[index]?.startsWith('@')) {
+		const raw = fields[index].substring(1);
+		if (raw !== 'revoked' && raw !== 'cert-authority') {
+			// An unrecognized marker means we cannot reason about this line at
+			// all, so skip it rather than silently treating it as unmarked.
+			return undefined;
+		}
+		marker = raw;
+		index++;
+	}
+
+	const hostField = fields[index++];
+	const keyType = fields[index++];
+	const keyBase64 = fields[index++];
+	if (!hostField || !keyType || !keyBase64) {
+		return undefined;
+	}
+
+	let key: Buffer;
+	try {
+		key = Buffer.from(keyBase64, 'base64');
+	} catch {
+		return undefined;
+	}
+	// Guard against base64 that decodes to nothing, and against a blob whose
+	// embedded algorithm name disagrees with the line's key type field.
+	if (key.length === 0 || readHostKeyType(key) !== keyType) {
+		return undefined;
+	}
+
+	if (hostField.startsWith('|1|')) {
+		const parts = hostField.split('|');
+		// Shape is ['', '1', '<salt>', '<hash>'].
+		if (parts.length !== 4) {
+			return undefined;
+		}
+		const salt = Buffer.from(parts[2], 'base64');
+		const hash = Buffer.from(parts[3], 'base64');
+		// HMAC-SHA1 digests are always 20 bytes; anything else is corrupt.
+		if (salt.length === 0 || hash.length !== 20) {
+			return undefined;
+		}
+		return { marker, patterns: [], hashedHost: { salt, hash }, keyType, key };
+	}
+
+	return { marker, patterns: hostField.split(','), keyType, key };
+}
+
+/** Parse the full contents of a `known_hosts` file, skipping malformed lines. */
+export function parseKnownHosts(contents: string): IKnownHostsEntry[] {
+	const entries: IKnownHostsEntry[] = [];
+	for (const line of contents.split('\n')) {
+		const entry = parseKnownHostsLine(line);
+		if (entry) {
+			entries.push(entry);
+		}
+	}
+	return entries;
+}
+
+/**
+ * Build the host identifiers OpenSSH would look for. A host on the default
+ * port is stored bare (`example.com`); any other port uses the bracketed form
+ * (`[example.com]:2222`).
+ */
+function hostCandidates(host: string, port: number): string[] {
+	const lower = host.toLowerCase();
+	return port === 22 ? [lower] : [`[${lower}]:${port}`];
+}
+
+/**
+ * Match a host pattern from a `known_hosts` line. Patterns support `*` (any
+ * run of characters) and `?` (a single character); everything else is literal.
+ */
+function matchesPattern(pattern: string, candidate: string): boolean {
+	const escaped = pattern.toLowerCase().replace(/[.+^${}()|[\]\\]/g, '\\$&');
+	const regex = new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`);
+	return regex.test(candidate);
+}
+
+/**
+ * Whether a non-hashed entry applies to `candidate`. A leading `!` negates a
+ * pattern, and a single negation vetoes the whole entry even if another
+ * pattern on the same line matches — this mirrors OpenSSH, and getting it
+ * backwards would let an explicitly excluded host be silently trusted.
+ */
+function entryAppliesToCandidate(patterns: readonly string[], candidate: string): boolean {
+	let matched = false;
+	for (const pattern of patterns) {
+		if (pattern.startsWith('!')) {
+			if (matchesPattern(pattern.substring(1), candidate)) {
+				return false;
+			}
+		} else if (matchesPattern(pattern, candidate)) {
+			matched = true;
+		}
+	}
+	return matched;
+}
+
+/**
+ * Whether a hashed entry (`|1|<salt>|<hash>`) applies to `candidate`. OpenSSH
+ * hashes the host with HMAC-SHA1 keyed by the per-entry salt.
+ */
+function hashedEntryAppliesToCandidate(hashedHost: { salt: Buffer; hash: Buffer }, candidate: string): boolean {
+	const computed = createHmac('sha1', hashedHost.salt).update(candidate).digest();
+	return computed.length === hashedHost.hash.length && timingSafeEqual(computed, hashedHost.hash);
+}
+
+/** Whether an entry applies to any of the candidate host identifiers. */
+function entryApplies(entry: IKnownHostsEntry, candidates: readonly string[]): boolean {
+	return candidates.some(candidate => entry.hashedHost
+		? hashedEntryAppliesToCandidate(entry.hashedHost, candidate)
+		: entryAppliesToCandidate(entry.patterns, candidate));
+}
+
+/**
+ * Decide what the user's `known_hosts` entries say about a presented host key.
+ *
+ * Precedence is deliberate and mirrors OpenSSH:
+ * 1. `@revoked` wins outright — an explicitly revoked key must never be
+ *    trusted, even if an ordinary entry elsewhere also matches it.
+ * 2. An exact match on host + key type + key bytes is a `match`.
+ * 3. An entry for the same host and key type holding different bytes is a
+ *    `mismatch` (the classic host-key-changed warning).
+ * 4. Otherwise, if the only applicable entries are `@cert-authority` lines,
+ *    report `ca-only` so the caller can explain why it cannot verify.
+ */
+export function matchKnownHosts(
+	entries: readonly IKnownHostsEntry[],
+	host: string,
+	port: number,
+	keyType: string,
+	keyBlob: Buffer,
+): KnownHostsMatch {
+	const candidates = hostCandidates(host, port);
+	const applicable = entries.filter(entry => entryApplies(entry, candidates));
+
+	// Revocation is resolved in its own pass, before anything can return a
+	// positive result. Folding it into the main loop would make the outcome
+	// depend on line order — a revoked key listed after a stale trusted entry
+	// for the same host would be accepted.
+	if (applicable.some(entry => entry.marker === 'revoked' && entry.key.equals(keyBlob))) {
+		return 'revoked';
+	}
+
+	let sawSameTypeEntry = false;
+	let sawCertAuthority = false;
+
+	for (const entry of applicable) {
+		if (entry.marker === 'revoked') {
+			continue;
+		}
+
+		if (entry.marker === 'cert-authority') {
+			sawCertAuthority = true;
+			continue;
+		}
+
+		if (entry.keyType !== keyType) {
+			continue;
+		}
+		if (entry.key.equals(keyBlob)) {
+			return 'match';
+		}
+		sawSameTypeEntry = true;
+	}
+
+	if (sawSameTypeEntry) {
+		return 'mismatch';
+	}
+	return sawCertAuthority ? 'ca-only' : 'unknown';
+}

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -121,6 +121,27 @@ const LOG_PREFIX = '[SSHRemoteAgentHost]';
 const RECONNECT_RELAY_TIMEOUT_MS = 60_000;
 
 /**
+ * Handshake timeout for a connect that can never show UI (a background
+ * reconnect). Nothing blocks on a human, so a server that accepts TCP but
+ * stalls the handshake should be abandoned promptly.
+ */
+const HANDSHAKE_TIMEOUT_MS = 30_000;
+
+/**
+ * Handshake timeout for a user-initiated connect, which may suspend the
+ * handshake on a host key confirmation or a password prompt.
+ *
+ * ssh2's `readyTimeout` covers the whole handshake and keeps running while
+ * `hostVerifier` awaits a verdict, so the 30s used elsewhere would kill the
+ * connection out from under a user who is doing exactly what the host key
+ * dialog asks — going to check a fingerprint against another source. Waiting
+ * longer is safe here precisely because these prompts only happen *after* the
+ * server has proven it is responsive (we are holding its host key), so this
+ * window is not what protects us from an unreachable host.
+ */
+const INTERACTIVE_HANDSHAKE_TIMEOUT_MS = 300_000;
+
+/**
  * One entry in the queue of authentication attempts handed to ssh2's
  * `authHandler`. Each attempt corresponds to one of the auth method shapes
  * documented at https://www.npmjs.com/package/ssh2#client-methods.
@@ -1305,11 +1326,15 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		connectionKey?: string,
 	): Promise<SSHClient> {
 		const port = config.port ?? 22;
+		// A background reconnect never prompts (the host key policy declines
+		// unknown keys outright rather than raising UI), so only a
+		// user-initiated connect needs the interaction-sized window.
+		const canPrompt = config.userInitiated ?? true;
 		const connectConfig: ConnectConfig = {
 			host: config.host,
 			port,
 			username: config.username,
-			readyTimeout: 30_000,
+			readyTimeout: canPrompt ? INTERACTIVE_HANDSHAKE_TIMEOUT_MS : HANDSHAKE_TIMEOUT_MS,
 			keepaliveInterval: 15_000,
 		};
 

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -28,11 +28,21 @@ import {
 	type ISSHEndpointCandidate,
 	type ISSHEndpointSelection,
 	type ISSHEndpointSelectionRequest,
+	type ISSHHostKeyVerificationRequest,
+	type ISSHHostKeysAnnouncement,
 	type ISSHKeyboardInteractivePrompt,
 	type ISSHKeyboardInteractiveRequest,
 	type ISSHResolvedConfig,
 	type SSHAgentHostLifecycle,
+	type SSHStrictHostKeyChecking,
 } from '../common/sshRemoteAgentHost.js';
+import {
+	computeHostKeyFingerprint,
+	matchKnownHosts,
+	parseKnownHosts,
+	readHostKeyType,
+	type IKnownHostsEntry,
+} from './sshKnownHosts.js';
 import type { RemoteAgentHostLocationPreference } from '../common/remoteAgentHostLocationPreference.js';
 import type { IRelayMessage } from '../common/relayTransport.js';
 import {
@@ -78,6 +88,12 @@ interface SSHClient {
 	on(event: 'ready', listener: () => void): SSHClient;
 	on(event: 'error', listener: (err: Error) => void): SSHClient;
 	on(event: 'close', listener: () => void): SSHClient;
+	/**
+	 * OpenSSH's `UpdateHostKeys` announcement. ssh2 verifies the
+	 * `hostkeys-prove-00@openssh.com` signatures before emitting, so these keys
+	 * are proven to belong to the connected server.
+	 */
+	on(event: 'hostkeys', listener: (keys: readonly { getPublicSSH(): Buffer; type: string }[]) => void): SSHClient;
 	removeListener(event: 'close', listener: () => void): SSHClient;
 	removeListener(event: 'error', listener: (err: Error) => void): SSHClient;
 	connect(config: ConnectConfig): void;
@@ -676,6 +692,15 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	private readonly _onDidCancelEndpointSelection = this._register(new Emitter<string>());
 	readonly onDidCancelEndpointSelection: Event<string> = this._onDidCancelEndpointSelection.event;
 
+	private readonly _onDidRequestHostKeyVerification = this._register(new Emitter<ISSHHostKeyVerificationRequest>());
+	readonly onDidRequestHostKeyVerification: Event<ISSHHostKeyVerificationRequest> = this._onDidRequestHostKeyVerification.event;
+
+	private readonly _onDidCancelHostKeyVerification = this._register(new Emitter<string>());
+	readonly onDidCancelHostKeyVerification: Event<string> = this._onDidCancelHostKeyVerification.event;
+
+	private readonly _onDidAnnounceHostKeys = this._register(new Emitter<ISSHHostKeysAnnouncement>());
+	readonly onDidAnnounceHostKeys: Event<ISSHHostKeysAnnouncement> = this._onDidAnnounceHostKeys.event;
+
 	/**
 	 * Pending keyboard-interactive prompts awaiting a response from the renderer.
 	 * Keyed by `requestId`. Each entry can either finish the ssh2 prompt with
@@ -691,6 +716,14 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	 */
 	private readonly _pendingEndpointSelections = new Map<string, (selection: ISSHEndpointSelection | undefined) => void>();
 	private _endpointSelectionCounter = 0;
+
+	/**
+	 * Pending host key verifications awaiting a verdict from the renderer,
+	 * keyed by `requestId`. Every entry must eventually be settled — leaving
+	 * one unanswered suspends the SSH handshake until `readyTimeout`.
+	 */
+	private readonly _pendingHostKeyRequests = new Map<string, { verify: (trusted: boolean) => void }>();
+	private _hostKeyRequestCounter = 0;
 
 	private readonly _connections = this._register(new DisposableMap<string, SSHConnection>());
 
@@ -1271,9 +1304,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		config: ISSHAgentHostConfig,
 		connectionKey?: string,
 	): Promise<SSHClient> {
+		const port = config.port ?? 22;
 		const connectConfig: ConnectConfig = {
 			host: config.host,
-			port: config.port ?? 22,
+			port,
 			username: config.username,
 			readyTimeout: 30_000,
 			keepaliveInterval: 15_000,
@@ -1342,6 +1376,40 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			}
 		}
 
+		// Verify the server's host key during key exchange. Without this, ssh2
+		// accepts any key from any server ("Host accepted by default"), which
+		// would let an on-path attacker impersonate the remote and collect the
+		// password typed into our own keyboard-interactive prompt. hostVerifier
+		// runs before authentication, so declining guarantees no credential or
+		// forwarded agent access ever reaches an unverified server.
+		//
+		// Note we deliberately do not set `hostHash`: that would make ssh2
+		// pre-hash the key and hand us a hex digest, discarding the raw blob we
+		// need to compare against `known_hosts` entries.
+		const liveHostKeyRequests = new Set<string>();
+		const cancelLiveHostKeyRequests = () => {
+			for (const requestId of liveHostKeyRequests) {
+				const pending = this._pendingHostKeyRequests.get(requestId);
+				this._pendingHostKeyRequests.delete(requestId);
+				this._onDidCancelHostKeyVerification.fire(requestId);
+				// Fail closed: an aborted connect must never leave ssh2 waiting
+				// on a verdict until `readyTimeout` elapses.
+				pending?.verify(false);
+			}
+			liveHostKeyRequests.clear();
+		};
+		connectConfig.hostVerifier = (key: Buffer, verify: (permitted: boolean) => void) => {
+			void this._verifyHostKey(
+				connectionKey ?? displayHost,
+				displayHost,
+				config,
+				port,
+				key,
+				verify,
+				requestId => liveHostKeyRequests.add(requestId),
+			);
+		};
+
 		const client = await this._createSSHClient();
 		return new Promise<SSHClient>((resolve, reject) => {
 			let settled = false;
@@ -1353,6 +1421,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				settled = true;
 				this._logService.info(`${LOG_PREFIX} SSH connection established to ${config.host}`);
 				cancelLiveKbiRequests();
+				cancelLiveHostKeyRequests();
 				resolve(client);
 			};
 
@@ -1362,6 +1431,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				}
 				settled = true;
 				cancelLiveKbiRequests();
+				cancelLiveHostKeyRequests();
 				if (endClient) {
 					client.end();
 				}
@@ -1380,6 +1450,16 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			client.on('error', (err: Error) => {
 				this._logService.error(`${LOG_PREFIX} SSH connection error: ${err.message}`);
 				rejectConnect(err, false);
+			});
+
+			// A server may announce its full host key set over the
+			// already-authenticated channel (OpenSSH's UpdateHostKeys). ssh2
+			// completes the `hostkeys-prove` challenge and verifies the
+			// signatures before emitting, so these are safe to persist without
+			// prompting — this is what lets a legitimate key rotation be
+			// learned silently instead of surfacing as a scary mismatch later.
+			client.on('hostkeys', (keys: readonly { getPublicSSH(): Buffer; type: string }[]) => {
+				this._handleAnnouncedHostKeys(connectionKey ?? displayHost, config.host, port, keys);
 			});
 
 			client.connect(connectConfig);
@@ -1565,6 +1645,154 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			return;
 		}
 		pending.finish(responses);
+	}
+
+	/**
+	 * Read every `known_hosts` file that applies to `host` and return the
+	 * parsed entries. Overridable so tests can supply entries without touching
+	 * the developer's real SSH setup.
+	 *
+	 * Resolution deliberately goes through `ssh -G` rather than assuming
+	 * `~/.ssh/known_hosts`, so a user who has redirected `UserKnownHostsFile`
+	 * gets the files they actually configured. A failure here is not fatal: we
+	 * fall back to no entries, which downgrades to a trust prompt rather than
+	 * silently accepting an unverified key.
+	 */
+	protected async _readKnownHostsEntries(host: string): Promise<{ entries: IKnownHostsEntry[]; strictHostKeyChecking: SSHStrictHostKeyChecking | undefined }> {
+		let resolved: ISSHResolvedConfig | undefined;
+		try {
+			resolved = await this.resolveSSHConfig(host);
+		} catch (err) {
+			this._logService.warn(`${LOG_PREFIX} Could not resolve SSH config for known_hosts lookup of ${host}: ${err}`);
+		}
+
+		const paths = [
+			...(resolved?.userKnownHostsFiles ?? ['~/.ssh/known_hosts']),
+			...(resolved?.globalKnownHostsFiles ?? []),
+		];
+
+		const entries: IKnownHostsEntry[] = [];
+		for (const path of paths) {
+			const expanded = path.replace(/^~/, os.homedir());
+			try {
+				entries.push(...parseKnownHosts(await fsp.readFile(expanded, 'utf-8')));
+			} catch {
+				// Missing or unreadable known_hosts files are normal (most
+				// systems have no known_hosts2 and no global file).
+			}
+		}
+		return { entries, strictHostKeyChecking: resolved?.strictHostKeyChecking };
+	}
+
+	/**
+	 * Decide whether a presented host key should be trusted, by gathering the
+	 * evidence the renderer needs and asking it to apply policy.
+	 *
+	 * This process only collects facts — the fingerprint and what the user's
+	 * `known_hosts` files say. The renderer owns the decision because it holds
+	 * the trust store and the UI.
+	 */
+	private async _verifyHostKey(
+		connectionKey: string,
+		displayHost: string,
+		config: ISSHAgentHostConfig,
+		port: number,
+		key: Buffer,
+		verify: (permitted: boolean) => void,
+		onRequest: (requestId: string) => void,
+	): Promise<void> {
+		let settled = false;
+		const verifyOnce = (permitted: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			verify(permitted);
+		};
+
+		try {
+			const keyType = readHostKeyType(key);
+			if (!keyType) {
+				// A blob whose self-declared algorithm we cannot read is not
+				// something we can meaningfully show the user or compare, so
+				// refuse rather than prompting about an unidentifiable key.
+				this._logService.error(`${LOG_PREFIX} Rejecting malformed host key from ${displayHost}`);
+				verifyOnce(false);
+				return;
+			}
+
+			const fingerprint = computeHostKeyFingerprint(key);
+			const { entries, strictHostKeyChecking } = await this._readKnownHostsEntries(config.sshConfigHost ?? config.host);
+			const knownHostsMatch = matchKnownHosts(entries, config.host, port, keyType, key);
+			this._logService.info(`${LOG_PREFIX} Host key for ${displayHost}: ${keyType} ${fingerprint} (known_hosts: ${knownHostsMatch})`);
+
+			const requestId = `hostkey-${++this._hostKeyRequestCounter}`;
+			onRequest(requestId);
+			this._pendingHostKeyRequests.set(requestId, { verify: verifyOnce });
+			this._onDidRequestHostKeyVerification.fire({
+				requestId,
+				connectionKey,
+				displayHost,
+				host: config.host,
+				port,
+				keyType,
+				fingerprint,
+				knownHostsMatch,
+				...(strictHostKeyChecking ? { strictHostKeyChecking } : undefined),
+				userInitiated: config.userInitiated ?? true,
+			});
+		} catch (err) {
+			// Fail closed. Anything unexpected while gathering evidence must
+			// deny rather than accept, or a transient error becomes a way to
+			// bypass verification entirely.
+			this._logService.error(`${LOG_PREFIX} Host key verification failed for ${displayHost}`, err);
+			verifyOnce(false);
+		}
+	}
+
+	async respondHostKeyVerification(requestId: string, trusted: boolean): Promise<void> {
+		const pending = this._pendingHostKeyRequests.get(requestId);
+		if (!pending) {
+			this._logService.warn(`${LOG_PREFIX} respondHostKeyVerification: no pending request for ${requestId}`);
+			return;
+		}
+		this._pendingHostKeyRequests.delete(requestId);
+		this._logService.info(`${LOG_PREFIX} Host key ${trusted ? 'accepted' : 'rejected'} for request ${requestId}`);
+		pending.verify(trusted);
+	}
+
+	/**
+	 * Surface host keys announced over an authenticated connection. ssh2 has
+	 * already proven each key belongs to this server (it runs the
+	 * `hostkeys-prove-00@openssh.com` challenge and verifies the signatures
+	 * before emitting), so consumers may persist them without prompting.
+	 */
+	private _handleAnnouncedHostKeys(
+		connectionKey: string,
+		host: string,
+		port: number,
+		keys: readonly { getPublicSSH(): Buffer; type: string }[],
+	): void {
+		const announced: { keyType: string; fingerprint: string }[] = [];
+		for (const key of keys) {
+			try {
+				const blob = key.getPublicSSH();
+				const keyType = readHostKeyType(blob);
+				// Skip anything whose blob disagrees with its declared type
+				// (notably certificates, which ssh2 misparses) rather than
+				// persisting trust in a key we did not correctly understand.
+				if (keyType && keyType === key.type) {
+					announced.push({ keyType, fingerprint: computeHostKeyFingerprint(blob) });
+				}
+			} catch (err) {
+				this._logService.warn(`${LOG_PREFIX} Skipping unreadable announced host key for ${host}: ${err}`);
+			}
+		}
+		if (!announced.length) {
+			return;
+		}
+		this._logService.info(`${LOG_PREFIX} Server ${host} announced ${announced.length} proven host key(s)`);
+		this._onDidAnnounceHostKeys.fire({ connectionKey, host, port, keys: announced });
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -120,26 +120,30 @@ const LOG_PREFIX = '[SSHRemoteAgentHost]';
  */
 const RECONNECT_RELAY_TIMEOUT_MS = 60_000;
 
+/** Opaque handle for the handshake deadline timer; see `_armHandshakeDeadline`. */
+type IHandshakeDeadlineHandle = ReturnType<typeof setTimeout>;
+
 /**
- * Handshake timeout for a connect that can never show UI (a background
- * reconnect). Nothing blocks on a human, so a server that accepts TCP but
- * stalls the handshake should be abandoned promptly.
+ * Deadline for the parts of the handshake that involve no human: TCP connect,
+ * key exchange, and authentication. Kept short so an unreachable or stalled
+ * server fails promptly.
  */
 const HANDSHAKE_TIMEOUT_MS = 30_000;
 
 /**
- * Handshake timeout for a user-initiated connect, which may suspend the
- * handshake on a host key confirmation or a password prompt.
+ * Deadline that applies only while we are waiting on a person — a host key
+ * confirmation or a keyboard-interactive prompt.
  *
- * ssh2's `readyTimeout` covers the whole handshake and keeps running while
- * `hostVerifier` awaits a verdict, so the 30s used elsewhere would kill the
- * connection out from under a user who is doing exactly what the host key
- * dialog asks — going to check a fingerprint against another source. Waiting
- * longer is safe here precisely because these prompts only happen *after* the
- * server has proven it is responsive (we are holding its host key), so this
- * window is not what protects us from an unreachable host.
+ * We manage the handshake deadline ourselves (ssh2's `readyTimeout` is
+ * disabled) because ssh2's timer covers the whole handshake and keeps running
+ * while `hostVerifier` awaits a verdict. Leaving it armed would abort the
+ * connection out from under a user doing exactly what the host key dialog asks
+ * — going to compare a fingerprint against another source — while simply
+ * raising it for the whole handshake would make an unreachable host take
+ * minutes to fail. So the deadline is short by default and only stretched for
+ * the interval a prompt is actually outstanding.
  */
-const INTERACTIVE_HANDSHAKE_TIMEOUT_MS = 300_000;
+const INTERACTIVE_TIMEOUT_MS = 300_000;
 
 /**
  * One entry in the queue of authentication attempts handed to ssh2's
@@ -1326,15 +1330,13 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		connectionKey?: string,
 	): Promise<SSHClient> {
 		const port = config.port ?? 22;
-		// A background reconnect never prompts (the host key policy declines
-		// unknown keys outright rather than raising UI), so only a
-		// user-initiated connect needs the interaction-sized window.
-		const canPrompt = config.userInitiated ?? true;
 		const connectConfig: ConnectConfig = {
 			host: config.host,
 			port,
 			username: config.username,
-			readyTimeout: canPrompt ? INTERACTIVE_HANDSHAKE_TIMEOUT_MS : HANDSHAKE_TIMEOUT_MS,
+			// We enforce the handshake deadline ourselves so it can be stretched
+			// while a prompt is outstanding; see INTERACTIVE_TIMEOUT_MS.
+			readyTimeout: 0,
 			keepaliveInterval: 15_000,
 		};
 
@@ -1412,13 +1414,21 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		// pre-hash the key and hand us a hex digest, discarding the raw blob we
 		// need to compare against `known_hosts` entries.
 		const liveHostKeyRequests = new Set<string>();
+		// Set once the connect attempt settles, so a verification that is still
+		// gathering evidence at that moment can bail out instead of registering
+		// itself after cancellation has already swept the set.
+		let hostKeyVerificationAborted = false;
+		// Forward references into the connect promise below, following the same
+		// pattern the keyboard-interactive path already uses.
+		let armDeadline: ((ms: number) => void) | undefined;
 		const cancelLiveHostKeyRequests = () => {
+			hostKeyVerificationAborted = true;
 			for (const requestId of liveHostKeyRequests) {
 				const pending = this._pendingHostKeyRequests.get(requestId);
 				this._pendingHostKeyRequests.delete(requestId);
 				this._onDidCancelHostKeyVerification.fire(requestId);
 				// Fail closed: an aborted connect must never leave ssh2 waiting
-				// on a verdict until `readyTimeout` elapses.
+				// on a verdict until the deadline elapses.
 				pending?.verify(false);
 			}
 			liveHostKeyRequests.clear();
@@ -1431,19 +1441,45 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				port,
 				key,
 				verify,
-				requestId => liveHostKeyRequests.add(requestId),
+				requestId => {
+					liveHostKeyRequests.add(requestId);
+					// A human is now in the loop; stop holding them to the
+					// network-sized deadline.
+					armDeadline?.(INTERACTIVE_TIMEOUT_MS);
+				},
+				() => hostKeyVerificationAborted,
+				() => armDeadline?.(HANDSHAKE_TIMEOUT_MS),
 			);
 		};
 
 		const client = await this._createSSHClient();
 		return new Promise<SSHClient>((resolve, reject) => {
 			let settled = false;
+			let deadlineTimer: IHandshakeDeadlineHandle | undefined;
+
+			const clearDeadline = () => {
+				this._clearHandshakeDeadline(deadlineTimer);
+				deadlineTimer = undefined;
+			};
+
+			// Replaces ssh2's `readyTimeout` (disabled above) so the window can
+			// be widened only for the interval a prompt is actually outstanding.
+			armDeadline = (ms: number) => {
+				if (settled) {
+					return;
+				}
+				clearDeadline();
+				deadlineTimer = this._armHandshakeDeadline(ms, () => {
+					rejectConnect(new Error(`SSH handshake to ${config.host} timed out`), true);
+				});
+			};
 
 			const resolveConnect = () => {
 				if (settled) {
 					return;
 				}
 				settled = true;
+				clearDeadline();
 				this._logService.info(`${LOG_PREFIX} SSH connection established to ${config.host}`);
 				cancelLiveKbiRequests();
 				cancelLiveHostKeyRequests();
@@ -1455,6 +1491,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 					return;
 				}
 				settled = true;
+				clearDeadline();
 				cancelLiveKbiRequests();
 				cancelLiveHostKeyRequests();
 				if (endClient) {
@@ -1477,6 +1514,15 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				rejectConnect(err, false);
 			});
 
+			// A server can drop the connection cleanly mid-handshake (for
+			// example sshd refusing a session under MaxStartups), in which case
+			// ssh2 emits only 'end'/'close' with no 'error'. Without this the
+			// connect promise would never settle and any outstanding host key
+			// prompt would be left on screen forever.
+			client.on('close', () => {
+				rejectConnect(new Error(`SSH connection to ${config.host} closed before the handshake completed`), false);
+			});
+
 			// A server may announce its full host key set over the
 			// already-authenticated channel (OpenSSH's UpdateHostKeys). ssh2
 			// completes the `hostkeys-prove` challenge and verifies the
@@ -1487,8 +1533,23 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				this._handleAnnouncedHostKeys(connectionKey ?? displayHost, config.host, port, keys);
 			});
 
+			armDeadline(HANDSHAKE_TIMEOUT_MS);
 			client.connect(connectConfig);
 		});
+	}
+
+	/**
+	 * Arm the handshake deadline. Overridable so tests can observe how the
+	 * window changes as prompts come and go without waiting on real timers.
+	 */
+	protected _armHandshakeDeadline(ms: number, onExpired: () => void): IHandshakeDeadlineHandle {
+		return setTimeout(onExpired, ms);
+	}
+
+	protected _clearHandshakeDeadline(timer: IHandshakeDeadlineHandle | undefined): void {
+		if (timer) {
+			clearTimeout(timer);
+		}
 	}
 
 	protected async _createSSHClient(): Promise<SSHClient> {
@@ -1725,13 +1786,21 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		key: Buffer,
 		verify: (permitted: boolean) => void,
 		onRequest: (requestId: string) => void,
+		isAborted: () => boolean,
+		onPromptSettled: () => void,
 	): Promise<void> {
 		let settled = false;
+		let prompted = false;
 		const verifyOnce = (permitted: boolean) => {
 			if (settled) {
 				return;
 			}
 			settled = true;
+			if (prompted) {
+				// The human is out of the loop; restore the network deadline so
+				// the rest of the handshake is not held to the long window.
+				onPromptSettled();
+			}
 			verify(permitted);
 		};
 
@@ -1748,10 +1817,22 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 			const fingerprint = computeHostKeyFingerprint(key);
 			const { entries, strictHostKeyChecking } = await this._readKnownHostsEntries(config.sshConfigHost ?? config.host);
+
+			// Gathering evidence is asynchronous, so the connect attempt may
+			// have failed while we were reading known_hosts. Registering now
+			// would leak a pending entry that nothing will ever settle, and
+			// would prompt the user about a connection that is already gone.
+			if (isAborted()) {
+				this._logService.info(`${LOG_PREFIX} Abandoning host key verification for ${displayHost}: connect attempt already settled`);
+				verifyOnce(false);
+				return;
+			}
+
 			const knownHostsMatch = matchKnownHosts(entries, config.host, port, keyType, key);
 			this._logService.info(`${LOG_PREFIX} Host key for ${displayHost}: ${keyType} ${fingerprint} (known_hosts: ${knownHostsMatch})`);
 
 			const requestId = `hostkey-${++this._hostKeyRequestCounter}`;
+			prompted = true;
 			onRequest(requestId);
 			this._pendingHostKeyRequests.set(requestId, { verify: verifyOnce });
 			this._onDidRequestHostKeyVerification.fire({

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -35,6 +35,7 @@ import {
 	type ISSHResolvedConfig,
 	type SSHAgentHostLifecycle,
 	type SSHStrictHostKeyChecking,
+	SSHHostKeyDeniedError,
 } from '../common/sshRemoteAgentHost.js';
 import {
 	computeHostKeyFingerprint,
@@ -746,8 +747,12 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	 * Pending host key verifications awaiting a verdict from the renderer,
 	 * keyed by `requestId`. Every entry must eventually be settled — leaving
 	 * one unanswered suspends the SSH handshake until the deadline elapses.
+	 *
+	 * `onUserDenied` lets the owning connect attempt distinguish "the renderer
+	 * refused this key" from any other handshake failure, so it can surface a
+	 * clean error instead of ssh2's internal wording.
 	 */
-	private readonly _pendingHostKeyRequests = new Map<string, { verify: (trusted: boolean) => void }>();
+	private readonly _pendingHostKeyRequests = new Map<string, { verify: (trusted: boolean) => void; onUserDenied?: () => void }>();
 	private _hostKeyRequestCounter = 0;
 
 	private readonly _connections = this._register(new DisposableMap<string, SSHConnection>());
@@ -1418,6 +1423,9 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		// gathering evidence at that moment can bail out instead of registering
 		// itself after cancellation has already swept the set.
 		let hostKeyVerificationAborted = false;
+		// Set when the renderer refuses a host key for this attempt, so the
+		// resulting handshake failure can be reported as what it actually is.
+		let hostKeyDenied = false;
 		// Forward references into the connect promise below, following the same
 		// pattern the keyboard-interactive path already uses.
 		let armDeadline: ((ms: number) => void) | undefined;
@@ -1446,6 +1454,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 					// A human is now in the loop; stop holding them to the
 					// network-sized deadline.
 					armDeadline?.(INTERACTIVE_TIMEOUT_MS);
+					return () => { hostKeyDenied = true; };
 				},
 				() => hostKeyVerificationAborted,
 				() => armDeadline?.(HANDSHAKE_TIMEOUT_MS),
@@ -1511,7 +1520,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 			client.on('error', (err: Error) => {
 				this._logService.error(`${LOG_PREFIX} SSH connection error: ${err.message}`);
-				rejectConnect(err, false);
+				// ssh2 reports a refused host key as "Host denied (verification
+				// failed)", which is both jargon and redundant — the host key
+				// UI has already told the user what happened.
+				rejectConnect(hostKeyDenied ? new SSHHostKeyDeniedError(displayHost) : err, false);
 			});
 
 			// A server can drop the connection cleanly mid-handshake (for
@@ -1520,7 +1532,11 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			// connect promise would never settle and any outstanding host key
 			// prompt would be left on screen forever.
 			client.on('close', () => {
-				rejectConnect(new Error(`SSH connection to ${config.host} closed before the handshake completed`), false);
+				rejectConnect(
+					hostKeyDenied
+						? new SSHHostKeyDeniedError(displayHost)
+						: new Error(`SSH connection to ${config.host} closed before the handshake completed`),
+					false);
 			});
 
 			// A server may announce its full host key set over the
@@ -1785,7 +1801,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		port: number,
 		key: Buffer,
 		verify: (permitted: boolean) => void,
-		onRequest: (requestId: string) => void,
+		onRequest: (requestId: string) => (() => void) | void,
 		isAborted: () => boolean,
 		onPromptSettled: () => void,
 	): Promise<void> {
@@ -1833,8 +1849,8 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 			const requestId = `hostkey-${++this._hostKeyRequestCounter}`;
 			prompted = true;
-			onRequest(requestId);
-			this._pendingHostKeyRequests.set(requestId, { verify: verifyOnce });
+			const onUserDenied = onRequest(requestId) ?? undefined;
+			this._pendingHostKeyRequests.set(requestId, { verify: verifyOnce, onUserDenied });
 			this._onDidRequestHostKeyVerification.fire({
 				requestId,
 				connectionKey,
@@ -1864,6 +1880,11 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		}
 		this._pendingHostKeyRequests.delete(requestId);
 		this._logService.info(`${LOG_PREFIX} Host key ${trusted ? 'accepted' : 'rejected'} for request ${requestId}`);
+		if (!trusted) {
+			// Let the connect attempt report this as a host key refusal rather
+			// than surfacing ssh2's "Host denied (verification failed)".
+			pending.onUserDenied?.();
+		}
 		pending.verify(trusted);
 	}
 

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -1353,14 +1353,28 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		// the connect attempt fails or completes.
 		const liveKbiRequests = new Set<string>();
 		let cancelConnectFromKbi: (() => void) | undefined;
+		// Forward reference into the connect promise below. Declared up here so
+		// every human-facing prompt can widen the handshake deadline while it
+		// is outstanding.
+		let armDeadline: ((ms: number) => void) | undefined;
+		// Once the user has answered, the human is out of the loop again, so
+		// the rest of the handshake goes back to the network-sized deadline.
+		const wrapPromptFinish = <T>(finish: (value: T) => void) => (value: T) => {
+			armDeadline?.(HANDSHAKE_TIMEOUT_MS);
+			finish(value);
+		};
 		const kbiHandler: SSHKeyboardInteractivePromptHandler | undefined = attempts.some(a => a.type === 'keyboard-interactive')
 			? (name, instructions, prompts, finish) => {
-				const requestId = this._handleKeyboardInteractive(connectionKey ?? displayHost, displayHost, config.username, name, instructions, prompts, finish, () => cancelConnectFromKbi?.());
+				// A human is now in the loop; don't hold them to the
+				// network-sized deadline while they find their password.
+				armDeadline?.(INTERACTIVE_TIMEOUT_MS);
+				const requestId = this._handleKeyboardInteractive(connectionKey ?? displayHost, displayHost, config.username, name, instructions, prompts, wrapPromptFinish(finish), () => cancelConnectFromKbi?.());
 				liveKbiRequests.add(requestId);
 			}
 			: undefined;
 		const keyPassphraseHandler: SSHKeyPassphrasePromptHandler | undefined = attempts.some(a => a.type === 'publickey' && a.encrypted)
 			? (keyPath, finish) => {
+				armDeadline?.(INTERACTIVE_TIMEOUT_MS);
 				const requestId = this._handleKeyboardInteractive(
 					connectionKey ?? displayHost,
 					displayHost,
@@ -1368,7 +1382,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 					localize('sshKeyPassphraseName', "SSH Key Passphrase"),
 					'',
 					[{ prompt: localize('sshKeyPassphrasePrompt', "Enter passphrase for SSH key {0}.", keyPath), echo: false }],
-					responses => finish(responses[0]),
+					wrapPromptFinish((responses: readonly string[]) => finish(responses[0])),
 					() => cancelConnectFromKbi?.(),
 				);
 				liveKbiRequests.add(requestId);
@@ -1426,9 +1440,6 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		// Set when the renderer refuses a host key for this attempt, so the
 		// resulting handshake failure can be reported as what it actually is.
 		let hostKeyDenied = false;
-		// Forward references into the connect promise below, following the same
-		// pattern the keyboard-interactive path already uses.
-		let armDeadline: ((ms: number) => void) | undefined;
 		const cancelLiveHostKeyRequests = () => {
 			hostKeyVerificationAborted = true;
 			for (const requestId of liveHostKeyRequests) {

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -745,7 +745,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	/**
 	 * Pending host key verifications awaiting a verdict from the renderer,
 	 * keyed by `requestId`. Every entry must eventually be settled — leaving
-	 * one unanswered suspends the SSH handshake until `readyTimeout`.
+	 * one unanswered suspends the SSH handshake until the deadline elapses.
 	 */
 	private readonly _pendingHostKeyRequests = new Map<string, { verify: (trusted: boolean) => void }>();
 	private _hostKeyRequestCounter = 0;
@@ -1378,9 +1378,9 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			for (const requestId of liveKbiRequests) {
 				// Pull the pending finish callback (if any) and invoke it with
 				// empty responses so ssh2 stops waiting on this attempt — without
-				// this, ssh2 hangs until `readyTimeout` elapses when a connect
-				// attempt is aborted mid-prompt. The renderer also gets notified
-				// so it can dismiss any open quick-input UI.
+				// this, ssh2 hangs until the handshake deadline elapses when a
+				// connect attempt is aborted mid-prompt. The renderer also gets
+				// notified so it can dismiss any open quick-input UI.
 				const pending = this._pendingKbiRequests.get(requestId);
 				this._pendingKbiRequests.delete(requestId);
 				this._onDidCancelKeyboardInteractive.fire(requestId);

--- a/src/vs/platform/agentHost/test/browser/sshHostKeyTrustService.test.ts
+++ b/src/vs/platform/agentHost/test/browser/sshHostKeyTrustService.test.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { InMemoryStorageService, StorageScope } from '../../../storage/common/storage.js';
+import {
+	parseTrustedHostKeys,
+	SSHHostKeyTrustService,
+	SSH_HOST_KEY_TRUST_STORAGE_KEY,
+} from '../../browser/sshHostKeyTrustService.js';
+
+suite('SSHHostKeyTrustService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(store: Pick<DisposableStore, 'add'>) {
+		const storageService = store.add(new InMemoryStorageService());
+		const service = store.add(new SSHHostKeyTrustService(storageService));
+		return { service, storageService };
+	}
+
+	test('stores, reads back and forgets host keys', () => {
+		const { service } = createService(disposables);
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1 });
+
+		const afterTrust = service.getTrustedKeys('example.com', 22);
+		// Host keys belong to a machine, so lookup must be case-insensitive in
+		// the same way hostnames are.
+		const mixedCase = service.getTrustedKeys('ExAmPlE.CoM', 22);
+		service.forgetHost('example.com', 22);
+
+		assert.deepStrictEqual(
+			{
+				afterTrust: afterTrust.map(k => `${k.keyType} ${k.fingerprint}`),
+				mixedCase: mixedCase.map(k => k.fingerprint),
+				afterForget: service.getTrustedKeys('example.com', 22).length,
+			},
+			{
+				afterTrust: ['ssh-ed25519 SHA256:aaa'],
+				mixedCase: ['SHA256:aaa'],
+				afterForget: 0,
+			});
+	});
+
+	test('keys hosts by port', () => {
+		const { service } = createService(disposables);
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1 });
+		service.trustHostKey('example.com', 2222, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:bbb', addedAt: 1 });
+
+		assert.deepStrictEqual(
+			{
+				default: service.getTrustedKeys('example.com', 22).map(k => k.fingerprint),
+				custom: service.getTrustedKeys('example.com', 2222).map(k => k.fingerprint),
+				listed: service.listTrustedHosts().map(h => `${h.host}:${h.port}`).sort(),
+			},
+			{
+				default: ['SHA256:aaa'],
+				custom: ['SHA256:bbb'],
+				listed: ['example.com:22', 'example.com:2222'],
+			});
+	});
+
+	test('a rotated key replaces its predecessor for the same algorithm', () => {
+		const { service } = createService(disposables);
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:old', addedAt: 1 });
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-rsa', fingerprint: 'SHA256:rsa', addedAt: 1 });
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:new', addedAt: 2 });
+
+		// The superseded ed25519 key must not remain trusted, or a rotation
+		// would leave the old key valid forever.
+		assert.deepStrictEqual(
+			service.getTrustedKeys('example.com', 22).map(k => `${k.keyType} ${k.fingerprint}`).sort(),
+			['ssh-ed25519 SHA256:new', 'ssh-rsa SHA256:rsa']);
+	});
+
+	test('persists across service instances at application scope', () => {
+		const store = new DisposableStore();
+		const storageService = store.add(new InMemoryStorageService());
+		const first = store.add(new SSHHostKeyTrustService(storageService));
+		first.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1, alias: 'myhost' });
+
+		const second = store.add(new SSHHostKeyTrustService(storageService));
+		assert.deepStrictEqual(
+			second.getTrustedKeys('example.com', 22).map(k => ({ keyType: k.keyType, fingerprint: k.fingerprint, alias: k.alias })),
+			[{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', alias: 'myhost' }]);
+		store.dispose();
+	});
+
+	test('clears storage entirely when the last host is forgotten', () => {
+		const { service, storageService } = createService(disposables);
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1 });
+		service.forgetHost('example.com', 22);
+		assert.strictEqual(storageService.get(SSH_HOST_KEY_TRUST_STORAGE_KEY, StorageScope.APPLICATION), undefined);
+	});
+
+	test('fires a change event for the affected host', () => {
+		const { service } = createService(disposables);
+		const fired: string[] = [];
+		disposables.add(service.onDidChangeTrustedHosts(key => fired.push(key)));
+
+		service.trustHostKey('example.com', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1 });
+		service.forgetHost('example.com', 22);
+		// Forgetting an unknown host is a no-op and must not fire.
+		service.forgetHost('other.com', 22);
+
+		assert.deepStrictEqual(fired, ['example.com:22', 'example.com:22']);
+	});
+
+	suite('parseTrustedHostKeys', () => {
+		test('drops malformed entries without discarding the rest', () => {
+			const raw = JSON.stringify({
+				'good.com:22': [{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:aaa', addedAt: 1 }],
+				'partial.com:22': [
+					{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:bbb', addedAt: 2 },
+					// Each of these is missing or has the wrong type for a
+					// required field. Trust must never be reconstructed from a
+					// partial record.
+					{ keyType: 'ssh-rsa', fingerprint: 'SHA256:ccc' },
+					{ keyType: '', fingerprint: 'SHA256:ddd', addedAt: 3 },
+					{ keyType: 'ssh-rsa', addedAt: 4 },
+					'not-an-object',
+				],
+				'empty.com:22': [],
+				'wrong-shape.com:22': 'not-an-array',
+			});
+
+			const parsed = parseTrustedHostKeys(raw);
+			assert.deepStrictEqual(
+				{
+					hosts: [...parsed.keys()].sort(),
+					partial: parsed.get('partial.com:22')?.map(k => k.fingerprint),
+				},
+				{ hosts: ['good.com:22', 'partial.com:22'], partial: ['SHA256:bbb'] });
+		});
+
+		test('returns empty for absent or invalid JSON', () => {
+			assert.deepStrictEqual(
+				{
+					undefinedRaw: parseTrustedHostKeys(undefined).size,
+					invalidJson: parseTrustedHostKeys('{not json').size,
+					array: parseTrustedHostKeys('[]').size,
+					nullValue: parseTrustedHostKeys('null').size,
+				},
+				{ undefinedRaw: 0, invalidJson: 0, array: 0, nullValue: 0 });
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
@@ -139,6 +139,9 @@ suite('SSH Config Parsing', () => {
 				identityFile: ['~/.ssh/id_rsa', '~/.ssh/id_ed25519'],
 				identityAgent: undefined,
 				forwardAgent: false,
+				userKnownHostsFiles: [],
+				globalKnownHostsFiles: [],
+				strictHostKeyChecking: undefined,
 			});
 		});
 
@@ -226,7 +229,61 @@ suite('SSH Config Parsing', () => {
 				identityFile: [],
 				identityAgent: undefined,
 				forwardAgent: false,
+				userKnownHostsFiles: [],
+				globalKnownHostsFiles: [],
+				strictHostKeyChecking: undefined,
 			});
+		});
+
+		test('splits the known_hosts path lists', () => {
+			// `ssh -G` emits these as one space-separated line, so treating the
+			// value as a single path would silently look in a bogus location.
+			const output = [
+				'userknownhostsfile /home/u/.ssh/known_hosts /home/u/.ssh/known_hosts2',
+				'globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2',
+			].join('\n');
+
+			const result = parseSSHGOutput(output);
+			assert.deepStrictEqual(
+				{ user: result.userKnownHostsFiles, global: result.globalKnownHostsFiles },
+				{
+					user: ['/home/u/.ssh/known_hosts', '/home/u/.ssh/known_hosts2'],
+					global: ['/etc/ssh/ssh_known_hosts', '/etc/ssh/ssh_known_hosts2'],
+				});
+		});
+
+		test('honors quoting in known_hosts path lists', () => {
+			const output = 'userknownhostsfile "/home/my user/.ssh/known_hosts" /home/u/other';
+			assert.deepStrictEqual(
+				parseSSHGOutput(output).userKnownHostsFiles,
+				['/home/my user/.ssh/known_hosts', '/home/u/other']);
+		});
+
+		test('parses recognized StrictHostKeyChecking values and ignores others', () => {
+			const parse = (value: string) => parseSSHGOutput(`stricthostkeychecking ${value}`).strictHostKeyChecking;
+			assert.deepStrictEqual(
+				{
+					ask: parse('ask'),
+					acceptNew: parse('accept-new'),
+					yes: parse('yes'),
+					no: parse('no'),
+					off: parse('off'),
+					uppercase: parse('ASK'),
+					// An unrecognized value must not be passed through as if it
+					// were a policy we understand.
+					bogus: parse('maybe'),
+					absent: parseSSHGOutput('').strictHostKeyChecking,
+				},
+				{
+					ask: 'ask',
+					acceptNew: 'accept-new',
+					yes: 'yes',
+					no: 'no',
+					off: 'off',
+					uppercase: 'ask',
+					bogus: undefined,
+					absent: undefined,
+				});
 		});
 
 		test('handles values with spaces', () => {

--- a/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
@@ -90,6 +90,20 @@ suite('sshHostKeyPolicy', () => {
 			'deny(revoked)');
 	});
 
+	test('revocation overrides even a StrictHostKeyChecking opt-out', () => {
+		// Verified against OpenSSH 9.9: with StrictHostKeyChecking=no it still
+		// reports "REVOKED HOST KEY DETECTED" and disables password auth,
+		// keyboard-interactive auth and agent forwarding. Disabling host key
+		// checking means "I accept unknown keys", never "I accept keys I have
+		// explicitly revoked".
+		assert.deepStrictEqual(
+			{
+				no: summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch: 'revoked', strictHostKeyChecking: 'no' }), [])),
+				off: summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch: 'revoked', strictHostKeyChecking: 'off' }), [])),
+			},
+			{ no: 'deny(revoked)', off: 'deny(revoked)' });
+	});
+
 	test('a stored key wins over a disagreeing known_hosts file', () => {
 		// Our store is authoritative for hosts already connected to, so a
 		// known_hosts entry that agrees with the server must not silently

--- a/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
@@ -123,9 +123,16 @@ suite('sshHostKeyPolicy', () => {
 				yesUnknown: decide('yes'),
 				no: decide('no'),
 				off: decide('off'),
-				// Disabling verification is an explicit opt-out, so it applies
-				// even to a changed key - but it must never persist trust.
+				// The opt-out covers *unknown* keys only. Verified against
+				// OpenSSH 9.9: with StrictHostKeyChecking=no and a changed key
+				// it warns and disables password auth, keyboard-interactive
+				// auth and agent forwarding. We refuse outright instead.
 				noWithMismatch: decide('no', 'mismatch'),
+				offWithMismatch: decide('off', 'mismatch'),
+				// A stored key that disagrees is refused under the opt-out too.
+				noWithStoredMismatch: summarize(decideHostKeyTrust(
+					makeRequest({ strictHostKeyChecking: 'no', knownHostsMatch: 'unknown' }),
+					trusted(OTHER_FINGERPRINT))),
 				// accept-new only relaxes *unknown* hosts; a changed key still
 				// hard-fails, matching OpenSSH.
 				acceptNewMismatch: decide('accept-new', 'mismatch'),
@@ -137,7 +144,9 @@ suite('sshHostKeyPolicy', () => {
 				yesUnknown: 'deny(strict-yes)',
 				no: 'trust(strict-disabled)',
 				off: 'trust(strict-disabled)',
-				noWithMismatch: 'trust(strict-disabled)',
+				noWithMismatch: 'deny(mismatch)',
+				offWithMismatch: 'deny(mismatch)',
+				noWithStoredMismatch: 'deny(mismatch)',
 				acceptNewMismatch: 'deny(mismatch)',
 				acceptNewRevoked: 'deny(revoked)',
 			});

--- a/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshHostKeyPolicy.test.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { decideHostKeyTrust, type SSHHostKeyDecision } from '../../common/sshHostKeyPolicy.js';
+import type { ISSHTrustedHostKey } from '../../common/sshHostKeyTrust.js';
+import type { ISSHHostKeyVerificationRequest, SSHKnownHostsMatch, SSHStrictHostKeyChecking } from '../../common/sshRemoteAgentHost.js';
+
+const FINGERPRINT = 'SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const OTHER_FINGERPRINT = 'SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function makeRequest(overrides: {
+	knownHostsMatch?: SSHKnownHostsMatch;
+	strictHostKeyChecking?: SSHStrictHostKeyChecking;
+	userInitiated?: boolean;
+} = {}): ISSHHostKeyVerificationRequest {
+	return {
+		requestId: 'hostkey-1',
+		connectionKey: 'ssh:testhost',
+		displayHost: 'testhost',
+		host: 'test.example.com',
+		port: 22,
+		keyType: 'ssh-ed25519',
+		fingerprint: FINGERPRINT,
+		knownHostsMatch: overrides.knownHostsMatch ?? 'unknown',
+		...(overrides.strictHostKeyChecking ? { strictHostKeyChecking: overrides.strictHostKeyChecking } : undefined),
+		userInitiated: overrides.userInitiated ?? true,
+	};
+}
+
+function trusted(fingerprint: string, keyType = 'ssh-ed25519'): ISSHTrustedHostKey[] {
+	return [{ keyType, fingerprint, addedAt: 1 }];
+}
+
+/** Reduce a decision to a compact string so whole tables can be asserted at once. */
+function summarize(decision: SSHHostKeyDecision): string {
+	return decision.kind === 'trust'
+		? `trust(${decision.reason}${decision.persist ? ',persist' : ''})`
+		: `${decision.kind}(${decision.reason})`;
+}
+
+suite('sshHostKeyPolicy', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('decides from the trust store first', () => {
+		assert.deepStrictEqual(
+			{
+				storedMatch: summarize(decideHostKeyTrust(makeRequest(), trusted(FINGERPRINT))),
+				storedDiffers: summarize(decideHostKeyTrust(makeRequest(), trusted(OTHER_FINGERPRINT))),
+				// A stored entry for a *different* algorithm says nothing about
+				// this key, so it must not suppress the prompt.
+				storedOtherKeyType: summarize(decideHostKeyTrust(makeRequest(), trusted(OTHER_FINGERPRINT, 'ssh-rsa'))),
+			},
+			{
+				storedMatch: 'trust(stored)',
+				storedDiffers: 'deny(mismatch)',
+				storedOtherKeyType: 'prompt(unknown)',
+			});
+	});
+
+	test('falls back to known_hosts when nothing is stored', () => {
+		const decide = (knownHostsMatch: SSHKnownHostsMatch) =>
+			summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch }), []));
+		assert.deepStrictEqual(
+			{
+				match: decide('match'),
+				mismatch: decide('mismatch'),
+				revoked: decide('revoked'),
+				caOnly: decide('ca-only'),
+				unknown: decide('unknown'),
+			},
+			{
+				// A known_hosts hit is copied into our store so later decisions
+				// no longer depend on re-reading the user's files.
+				match: 'trust(known-hosts,persist)',
+				mismatch: 'deny(mismatch)',
+				revoked: 'deny(revoked)',
+				caOnly: 'prompt(ca-only)',
+				unknown: 'prompt(unknown)',
+			});
+	});
+
+	test('revocation overrides a stored trust entry', () => {
+		assert.strictEqual(
+			summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch: 'revoked' }), trusted(FINGERPRINT))),
+			'deny(revoked)');
+	});
+
+	test('a stored key wins over a disagreeing known_hosts file', () => {
+		// Our store is authoritative for hosts already connected to, so a
+		// known_hosts entry that agrees with the server must not silently
+		// override a key the user previously accepted.
+		assert.strictEqual(
+			summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch: 'match' }), trusted(OTHER_FINGERPRINT))),
+			'deny(mismatch)');
+	});
+
+	test('honors StrictHostKeyChecking', () => {
+		const decide = (strictHostKeyChecking: SSHStrictHostKeyChecking, knownHostsMatch: SSHKnownHostsMatch = 'unknown') =>
+			summarize(decideHostKeyTrust(makeRequest({ strictHostKeyChecking, knownHostsMatch }), []));
+		assert.deepStrictEqual(
+			{
+				ask: decide('ask'),
+				acceptNewUnknown: decide('accept-new'),
+				yesUnknown: decide('yes'),
+				no: decide('no'),
+				off: decide('off'),
+				// Disabling verification is an explicit opt-out, so it applies
+				// even to a changed key - but it must never persist trust.
+				noWithMismatch: decide('no', 'mismatch'),
+				// accept-new only relaxes *unknown* hosts; a changed key still
+				// hard-fails, matching OpenSSH.
+				acceptNewMismatch: decide('accept-new', 'mismatch'),
+				acceptNewRevoked: decide('accept-new', 'revoked'),
+			},
+			{
+				ask: 'prompt(unknown)',
+				acceptNewUnknown: 'trust(strict-accept-new,persist)',
+				yesUnknown: 'deny(strict-yes)',
+				no: 'trust(strict-disabled)',
+				off: 'trust(strict-disabled)',
+				noWithMismatch: 'trust(strict-disabled)',
+				acceptNewMismatch: 'deny(mismatch)',
+				acceptNewRevoked: 'deny(revoked)',
+			});
+	});
+
+	test('never prompts during a background reconnect', () => {
+		const decide = (knownHostsMatch: SSHKnownHostsMatch, keys: ISSHTrustedHostKey[] = []) =>
+			summarize(decideHostKeyTrust(makeRequest({ knownHostsMatch, userInitiated: false }), keys));
+		assert.deepStrictEqual(
+			{
+				// An unknown key on a silent reconnect is declined rather than
+				// raising a modal the user never asked for.
+				unknown: decide('unknown'),
+				caOnly: decide('ca-only'),
+				// Already-trusted hosts still reconnect without interaction.
+				stored: decide('unknown', trusted(FINGERPRINT)),
+				knownHosts: decide('match'),
+			},
+			{
+				unknown: 'deny(not-user-initiated)',
+				caOnly: 'deny(not-user-initiated)',
+				stored: 'trust(stored)',
+				knownHosts: 'trust(known-hosts,persist)',
+			});
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -15,7 +15,7 @@ import { TestInstantiationService } from '../../../instantiation/test/common/ins
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
 import { IDialogService } from '../../../dialogs/common/dialogs.js';
-import { INotificationService, type INotificationHandle } from '../../../notification/common/notification.js';
+import { INotificationService, Severity, type INotification, type INotificationHandle } from '../../../notification/common/notification.js';
 import { TestNotificationService } from '../../../notification/test/common/testNotificationService.js';
 import { IProductService } from '../../../product/common/productService.js';
 
@@ -25,12 +25,17 @@ import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHo
 import type { IAgentConnection } from '../../common/agentService.js';
 import { AHP_UNSUPPORTED_PROTOCOL_VERSION, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { IRemoteAgentHostLocationPreferenceService, type RemoteAgentHostLocationPreference } from '../../common/remoteAgentHostLocationPreference.js';
+import { ISSHHostKeyTrustService } from '../../common/sshHostKeyTrust.js';
+import { SSHHostKeyTrustService } from '../../browser/sshHostKeyTrustService.js';
+import { InMemoryStorageService } from '../../../storage/common/storage.js';
 import type {
 	ISSHAgentHostConfig,
 	ISSHConnectResult,
 	ISSHEndpointCandidate,
 	ISSHEndpointSelection,
 	ISSHEndpointSelectionRequest,
+	ISSHHostKeyVerificationRequest,
+	ISSHHostKeysAnnouncement,
 	ISSHKeyboardInteractiveRequest,
 	ISSHResolvedConfig,
 	ISSHRemoteAgentHostMainService,
@@ -78,6 +83,40 @@ class MockSSHMainService {
 
 	private readonly _onDidCancelEndpointSelection = new Emitter<string>();
 	readonly onDidCancelEndpointSelection = this._onDidCancelEndpointSelection.event;
+
+	private readonly _onDidRequestHostKeyVerification = new Emitter<ISSHHostKeyVerificationRequest>();
+	readonly onDidRequestHostKeyVerification = this._onDidRequestHostKeyVerification.event;
+
+	private readonly _onDidCancelHostKeyVerification = new Emitter<string>();
+	readonly onDidCancelHostKeyVerification = this._onDidCancelHostKeyVerification.event;
+
+	private readonly _onDidAnnounceHostKeys = new Emitter<ISSHHostKeysAnnouncement>();
+	readonly onDidAnnounceHostKeys = this._onDidAnnounceHostKeys.event;
+
+	readonly hostKeyResponses: Array<{ requestId: string; trusted: boolean }> = [];
+	private readonly _hostKeyResponseWaiters: DeferredPromise<void>[] = [];
+
+	async respondHostKeyVerification(requestId: string, trusted: boolean): Promise<void> {
+		this.hostKeyResponses.push({ requestId, trusted });
+		this._hostKeyResponseWaiters.splice(0).forEach(waiter => waiter.complete());
+	}
+
+	/** Test helper: fire a host key verification request as the main process would. */
+	fireHostKeyVerificationRequest(request: ISSHHostKeyVerificationRequest): void {
+		this._onDidRequestHostKeyVerification.fire(request);
+	}
+
+	/** Test helper: fire a host key announcement as the main process would. */
+	fireHostKeysAnnouncement(announcement: ISSHHostKeysAnnouncement): void {
+		this._onDidAnnounceHostKeys.fire(announcement);
+	}
+
+	/** Test helper: resolves once {@link respondHostKeyVerification} is next called. */
+	waitForHostKeyResponse(): Promise<void> {
+		const deferred = new DeferredPromise<void>();
+		this._hostKeyResponseWaiters.push(deferred);
+		return deferred.p;
+	}
 
 	readonly endpointSelectionResponses: Array<{ requestId: string; selection: ISSHEndpointSelection | undefined }> = [];
 	private readonly _endpointSelectionResponseWaiters: DeferredPromise<void>[] = [];
@@ -148,7 +187,7 @@ class MockSSHMainService {
 	async ensureUserSSHConfig(): Promise<URI> { return URI.file('/tmp/ssh-config'); }
 	async listSSHConfigFiles(): Promise<URI[]> { return [URI.file('/tmp/ssh-config')]; }
 	async resolveSSHConfig(_host: string): Promise<ISSHResolvedConfig> {
-		return { hostname: '', user: undefined, port: 22, identityFile: [], identityAgent: undefined, forwardAgent: false };
+		return { hostname: '', user: undefined, port: 22, identityFile: [], identityAgent: undefined, forwardAgent: false, userKnownHostsFiles: [], globalKnownHostsFiles: [], strictHostKeyChecking: undefined };
 	}
 
 	dispose(): void {
@@ -161,6 +200,9 @@ class MockSSHMainService {
 		this._onDidCancelKeyboardInteractive.dispose();
 		this._onDidRequestEndpointSelection.dispose();
 		this._onDidCancelEndpointSelection.dispose();
+		this._onDidRequestHostKeyVerification.dispose();
+		this._onDidCancelHostKeyVerification.dispose();
+		this._onDidAnnounceHostKeys.dispose();
 	}
 }
 
@@ -270,9 +312,16 @@ class TestConfigurationService {
 /** Captures every message passed to `info()` so tests can assert on the SSH failover notification. */
 class CapturingNotificationService extends TestNotificationService {
 	readonly infoMessages: string[] = [];
+	readonly notifications: INotification[] = [];
+
 	override info(message: string): INotificationHandle {
 		this.infoMessages.push(message);
 		return super.info(message);
+	}
+
+	override notify(notification: INotification): INotificationHandle {
+		this.notifications.push(notification);
+		return super.notify(notification);
 	}
 }
 
@@ -311,6 +360,7 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 	let service: SSHRemoteAgentHostService;
 	let quickInputServiceStub: Partial<IQuickInputService>;
 	let locationPreferenceService: TestRemoteAgentHostLocationPreferenceService;
+	let hostKeyTrustService: SSHHostKeyTrustService;
 
 	setup(() => {
 		mainService = new MockSSHMainService();
@@ -338,6 +388,8 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 			prompt: (() => { throw new Error('unexpected dialogService.prompt call'); }) as unknown as IDialogService['prompt'],
 		} as Partial<IDialogService>);
 		instantiationService.stub(IProductService, { _serviceBrand: undefined, nameShort: 'Test Product' } as IProductService);
+		hostKeyTrustService = disposables.add(new SSHHostKeyTrustService(disposables.add(new InMemoryStorageService())));
+		instantiationService.stub(ISSHHostKeyTrustService, hostKeyTrustService as Partial<ISSHHostKeyTrustService>);
 
 		const clientWaiters: DeferredPromise<MockProtocolClient>[] = [];
 		waitForClient = (index: number): Promise<MockProtocolClient> => {
@@ -754,6 +806,7 @@ suite('SSHRemoteAgentHostService endpoint selection preference (renderer)', () =
 
 		locationPreferenceService = disposables.add(new TestRemoteAgentHostLocationPreferenceService());
 		instantiationService.stub(IRemoteAgentHostLocationPreferenceService, locationPreferenceService as Partial<IRemoteAgentHostLocationPreferenceService>);
+		instantiationService.stub(ISSHHostKeyTrustService, disposables.add(new SSHHostKeyTrustService(disposables.add(new InMemoryStorageService()))) as Partial<ISSHHostKeyTrustService>);
 
 		// Default to throwing so any test that doesn't expect the modal to
 		// appear fails loudly if the implementation shows it unexpectedly.
@@ -988,5 +1041,219 @@ suite('SSHRemoteAgentHostService endpoint selection preference (renderer)', () =
 		]);
 		assert.strictEqual(locationPreferenceService.getPreference(connectionKey), 'editor');
 		assert.strictEqual(locationPreferenceService.getPreference('ssh:other.example'), 'dedicated');
+	});
+});
+
+suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
+
+	const disposables = new DisposableStore();
+	let mainService: MockSSHMainService;
+	let hostKeyTrustService: SSHHostKeyTrustService;
+	let notificationService: CapturingNotificationService;
+	let confirmResult: boolean;
+	let confirmCalls: number;
+
+	setup(() => {
+		mainService = disposables.add(new MockSSHMainService());
+		const sharedProcessService: Partial<ISharedProcessService> = {
+			getChannel: () => asChannel(mainService),
+		};
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService() as Partial<IConfigurationService>);
+		instantiationService.stub(IQuickInputService, {} as Partial<IQuickInputService>);
+		instantiationService.stub(ISharedProcessService, sharedProcessService as ISharedProcessService);
+		instantiationService.stub(IRemoteAgentHostService, disposables.add(new MockRemoteAgentHostService()) as Partial<IRemoteAgentHostService>);
+		notificationService = new CapturingNotificationService();
+		instantiationService.stub(INotificationService, notificationService as Partial<INotificationService>);
+		instantiationService.stub(ISSHRelayClientFactory, {
+			createClient: () => disposables.add(new MockProtocolClient()) as unknown as RemoteAgentHostProtocolClient,
+		});
+		instantiationService.stub(IRemoteAgentHostLocationPreferenceService, disposables.add(new TestRemoteAgentHostLocationPreferenceService()) as Partial<IRemoteAgentHostLocationPreferenceService>);
+		instantiationService.stub(IProductService, { _serviceBrand: undefined, nameShort: 'Test Product' } as IProductService);
+
+		confirmResult = false;
+		confirmCalls = 0;
+		instantiationService.stub(IDialogService, {
+			confirm: (async () => {
+				confirmCalls++;
+				return { confirmed: confirmResult };
+			}) as unknown as IDialogService['confirm'],
+		} as Partial<IDialogService>);
+
+		hostKeyTrustService = disposables.add(new SSHHostKeyTrustService(disposables.add(new InMemoryStorageService())));
+		instantiationService.stub(ISSHHostKeyTrustService, hostKeyTrustService as Partial<ISSHHostKeyTrustService>);
+
+		disposables.add(instantiationService.createInstance(SSHRemoteAgentHostService));
+	});
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const FINGERPRINT = 'SHA256:testfingerprintaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+	function makeHostKeyRequest(overrides: Partial<ISSHHostKeyVerificationRequest> = {}): ISSHHostKeyVerificationRequest {
+		return {
+			requestId: 'hostkey-1',
+			connectionKey: 'ssh:remote.example',
+			displayHost: 'remote.example',
+			host: 'remote.example',
+			port: 22,
+			keyType: 'ssh-ed25519',
+			fingerprint: FINGERPRINT,
+			knownHostsMatch: 'unknown',
+			userInitiated: true,
+			...overrides,
+		};
+	}
+
+	async function fireAndWait(request: ISSHHostKeyVerificationRequest): Promise<void> {
+		const responded = mainService.waitForHostKeyResponse();
+		mainService.fireHostKeyVerificationRequest(request);
+		await responded;
+	}
+
+	test('prompts for an unknown host and persists on accept', async () => {
+		confirmResult = true;
+		await fireAndWait(makeHostKeyRequest());
+
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				confirmCalls,
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => `${k.keyType} ${k.fingerprint}`),
+			},
+			{
+				responses: [{ requestId: 'hostkey-1', trusted: true }],
+				confirmCalls: 1,
+				stored: ['ssh-ed25519 SHA256:testfingerprintaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+			});
+	});
+
+	test('declining the prompt refuses the key and stores nothing', async () => {
+		confirmResult = false;
+		await fireAndWait(makeHostKeyRequest());
+
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).length,
+			},
+			{ responses: [{ requestId: 'hostkey-1', trusted: false }], stored: 0 });
+	});
+
+	test('an already-trusted key connects silently', async () => {
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
+		await fireAndWait(makeHostKeyRequest());
+
+		assert.deepStrictEqual(
+			{ responses: mainService.hostKeyResponses, confirmCalls },
+			{ responses: [{ requestId: 'hostkey-1', trusted: true }], confirmCalls: 0 });
+	});
+
+	test('a changed key is refused with no way to click through', async () => {
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:theoldkey', addedAt: 1 });
+		await fireAndWait(makeHostKeyRequest());
+
+		const notified = notificationService.notifications.at(-1);
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				// No dialog at all: recovering requires explicitly forgetting
+				// the host, so a possible impersonation can't be waved away.
+				confirmCalls,
+				severity: notified?.severity,
+				hasForgetAction: !!notified?.actions?.primary?.length,
+				// The old key must remain stored until the user forgets it.
+				stillStored: hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => k.fingerprint),
+			},
+			{
+				responses: [{ requestId: 'hostkey-1', trusted: false }],
+				confirmCalls: 0,
+				severity: Severity.Error,
+				hasForgetAction: true,
+				stillStored: ['SHA256:theoldkey'],
+			});
+	});
+
+	test('the forget action clears the stored key so the next connect can re-verify', async () => {
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:theoldkey', addedAt: 1 });
+		await fireAndWait(makeHostKeyRequest());
+
+		await notificationService.notifications.at(-1)?.actions?.primary?.[0].run();
+		assert.strictEqual(hostKeyTrustService.getTrustedKeys('remote.example', 22).length, 0);
+	});
+
+	test('a known_hosts match is trusted silently and copied into the store', async () => {
+		await fireAndWait(makeHostKeyRequest({ knownHostsMatch: 'match' }));
+
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				confirmCalls,
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => k.fingerprint),
+			},
+			{
+				responses: [{ requestId: 'hostkey-1', trusted: true }],
+				confirmCalls: 0,
+				stored: [FINGERPRINT],
+			});
+	});
+
+	test('a revoked key is refused', async () => {
+		await fireAndWait(makeHostKeyRequest({ knownHostsMatch: 'revoked' }));
+		assert.deepStrictEqual(
+			{ responses: mainService.hostKeyResponses, confirmCalls },
+			{ responses: [{ requestId: 'hostkey-1', trusted: false }], confirmCalls: 0 });
+	});
+
+	test('a background reconnect never opens a dialog', async () => {
+		await fireAndWait(makeHostKeyRequest({ userInitiated: false }));
+		assert.deepStrictEqual(
+			{ responses: mainService.hostKeyResponses, confirmCalls },
+			{ responses: [{ requestId: 'hostkey-1', trusted: false }], confirmCalls: 0 });
+	});
+
+	test('StrictHostKeyChecking accept-new trusts unknown hosts without prompting', async () => {
+		await fireAndWait(makeHostKeyRequest({ strictHostKeyChecking: 'accept-new' }));
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				confirmCalls,
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).length,
+			},
+			{ responses: [{ requestId: 'hostkey-1', trusted: true }], confirmCalls: 0, stored: 1 });
+	});
+
+	test('learns a rotated key announced over an authenticated connection', async () => {
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
+
+		mainService.fireHostKeysAnnouncement({
+			connectionKey: 'ssh:remote.example',
+			host: 'remote.example',
+			port: 22,
+			keys: [
+				{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:rotated' },
+				{ keyType: 'ssh-rsa', fingerprint: 'SHA256:rsakey' },
+			],
+		});
+
+		assert.deepStrictEqual(
+			hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => `${k.keyType} ${k.fingerprint}`).sort(),
+			['ssh-ed25519 SHA256:rotated', 'ssh-rsa SHA256:rsakey']);
+	});
+
+	test('ignores announcements for hosts that were never trusted', async () => {
+		// Otherwise an announcement would become a way to establish trust
+		// without any verification at all.
+		mainService.fireHostKeysAnnouncement({
+			connectionKey: 'ssh:remote.example',
+			host: 'remote.example',
+			port: 22,
+			keys: [{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:rotated' }],
+		});
+
+		assert.strictEqual(hostKeyTrustService.getTrustedKeys('remote.example', 22).length, 0);
 	});
 });

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -1059,6 +1059,7 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 	let confirmCalls: number;
 	/** When set, the confirm dialog blocks on this until the test releases it. */
 	let confirmGate: (() => Promise<void>) | undefined;
+	let inFlightVerifications: Promise<void>[];
 	/** The options the last confirm dialog was opened with. */
 	let lastConfirmOptions: IConfirmation | undefined;
 
@@ -1086,6 +1087,7 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 		confirmCalls = 0;
 		confirmGate = undefined;
 		lastConfirmOptions = undefined;
+		inFlightVerifications = [];
 		instantiationService.stub(IDialogService, {
 			confirm: (async (confirmation: IConfirmation) => {
 				confirmCalls++;
@@ -1100,11 +1102,25 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 		hostKeyTrustService = disposables.add(new SSHHostKeyTrustService(disposables.add(new InMemoryStorageService())));
 		instantiationService.stub(ISSHHostKeyTrustService, hostKeyTrustService as Partial<ISSHHostKeyTrustService>);
 
-		disposables.add(instantiationService.createInstance(SSHRemoteAgentHostService));
+		// Subclassed so tests can await the real handler settling rather than
+		// sleeping for a fixed interval, which is load-dependent and flaky.
+		class TestableService extends SSHRemoteAgentHostService {
+			protected override _trackHostKeyVerification(handled: Promise<void>): void {
+				inFlightVerifications.push(handled);
+			}
+		}
+		disposables.add(instantiationService.createInstance(TestableService));
 	});
 
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/** Settles once every verification the test has triggered has finished. */
+	async function settleVerifications(): Promise<void> {
+		while (inFlightVerifications.length) {
+			await Promise.all(inFlightVerifications.splice(0));
+		}
+	}
 
 	const FINGERPRINT = 'SHA256:testfingerprintaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -1192,6 +1208,37 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 			});
 	});
 
+	test('a known_hosts mismatch or revocation offers no forget action', async () => {
+		// "Forget Saved Host Key" only clears *our* store. When the conflict
+		// lives in the user's own known_hosts file, forgetting would change
+		// nothing and the very same error would reappear on the next connect,
+		// so the message points at the file that actually decides instead.
+		await fireAndWait(makeHostKeyRequest({ knownHostsMatch: 'mismatch' }));
+		const fromKnownHosts = notificationService.notifications.at(-1);
+
+		await fireAndWait(makeHostKeyRequest({ requestId: 'hostkey-2', knownHostsMatch: 'revoked' }));
+		const fromRevoked = notificationService.notifications.at(-1);
+
+		assert.deepStrictEqual(
+			{
+				knownHostsHasForget: !!fromKnownHosts?.actions?.primary?.length,
+				knownHostsMentionsFile: !!fromKnownHosts?.message.toString().includes('known_hosts'),
+				revokedHasForget: !!fromRevoked?.actions?.primary?.length,
+				revokedMentionsFile: !!fromRevoked?.message.toString().includes('known_hosts'),
+				responses: mainService.hostKeyResponses,
+			},
+			{
+				knownHostsHasForget: false,
+				knownHostsMentionsFile: true,
+				revokedHasForget: false,
+				revokedMentionsFile: true,
+				responses: [
+					{ requestId: 'hostkey-1', trusted: false },
+					{ requestId: 'hostkey-2', trusted: false },
+				],
+			});
+	});
+
 	test('the forget action clears the stored key so the next connect can re-verify', async () => {
 		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: 'SHA256:theoldkey', addedAt: 1 });
 		await fireAndWait(makeHostKeyRequest());
@@ -1263,7 +1310,7 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 		mainService.fireHostKeyVerificationCancel('hostkey-1');
 		const dismissedAfterCancel = dialogToken?.isCancellationRequested;
 		releaseDialog();
-		await new Promise(resolve => setTimeout(resolve, 10));
+		await settleVerifications();
 
 		assert.deepStrictEqual(
 			{
@@ -1299,15 +1346,48 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 			['ssh-ed25519 SHA256:rotated', 'ssh-rsa SHA256:rsakey']);
 	});
 
-	test('an unverified session cannot poison stored trust via announcements', async () => {
-		// StrictHostKeyChecking=no accepts whatever key is presented without
-		// verifying it. ssh2 still proves announced keys belong to whoever we
-		// are talking to — but under `no` that could be an impostor, so the
-		// announcement must not be allowed to overwrite the real stored key.
-		// Mirrors OpenSSH, which only accepts additional host keys when the
-		// key that authenticated the host was already trusted.
+	test('a changed key is refused even when StrictHostKeyChecking is disabled', async () => {
+		// The opt-out means "I accept unknown keys", not "I accept a key that
+		// contradicts one I already trust". OpenSSH 9.9 keeps protecting this
+		// case too: it warns and disables password auth, keyboard-interactive
+		// auth and agent forwarding. We refuse outright, so no credential and
+		// no agent access ever reaches a possible impostor — and the
+		// announcement path is moot because the session never authenticates.
 		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
 		await fireAndWait(makeHostKeyRequest({ fingerprint: 'SHA256:impostorkey', strictHostKeyChecking: 'no' }));
+
+		mainService.fireHostKeysAnnouncement({
+			connectionKey: 'ssh:remote.example',
+			host: 'remote.example',
+			port: 22,
+			keys: [{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:attackerkey' }],
+		});
+
+		assert.deepStrictEqual(
+			{
+				// Refused outright, before authentication.
+				connected: mainService.hostKeyResponses,
+				// And the genuine stored key is untouched.
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => k.fingerprint),
+			},
+			{
+				connected: [{ requestId: 'hostkey-1', trusted: false }],
+				stored: [FINGERPRINT],
+			});
+	});
+
+	test('an unverified session cannot poison stored trust via announcements', async () => {
+		// A session accepted under StrictHostKeyChecking=no is unverified: the
+		// key was simply not checked. ssh2 still proves announced keys belong
+		// to whoever we are talking to — but that could be an impostor, so the
+		// announcement must not overwrite the real stored key. Mirrors
+		// OpenSSH, which only accepts additional host keys when the key that
+		// authenticated the host was already trusted.
+		//
+		// Uses an *unknown* key (a different algorithm), since a key that
+		// contradicts the stored one is now refused outright by the test above.
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
+		await fireAndWait(makeHostKeyRequest({ keyType: 'ssh-rsa', fingerprint: 'SHA256:impostorkey', strictHostKeyChecking: 'no' }));
 
 		mainService.fireHostKeysAnnouncement({
 			connectionKey: 'ssh:remote.example',

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -101,12 +101,12 @@ class MockSSHMainService {
 		this._hostKeyResponseWaiters.splice(0).forEach(waiter => waiter.complete());
 	}
 
-	/** Test helper: fire a host key verification request as the main process would. */
+	/** Test helper: fire a host key verification request as the shared process would. */
 	fireHostKeyVerificationRequest(request: ISSHHostKeyVerificationRequest): void {
 		this._onDidRequestHostKeyVerification.fire(request);
 	}
 
-	/** Test helper: fire a host key announcement as the main process would. */
+	/** Test helper: fire a host key announcement as the shared process would. */
 	fireHostKeysAnnouncement(announcement: ISSHHostKeysAnnouncement): void {
 		this._onDidAnnounceHostKeys.fire(announcement);
 	}
@@ -1228,6 +1228,9 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 
 	test('learns a rotated key announced over an authenticated connection', async () => {
 		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
+		// Establish a session whose host key is itself trusted — that is what
+		// entitles the server to tell us about its other keys.
+		await fireAndWait(makeHostKeyRequest());
 
 		mainService.fireHostKeysAnnouncement({
 			connectionKey: 'ssh:remote.example',
@@ -1242,6 +1245,36 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 		assert.deepStrictEqual(
 			hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => `${k.keyType} ${k.fingerprint}`).sort(),
 			['ssh-ed25519 SHA256:rotated', 'ssh-rsa SHA256:rsakey']);
+	});
+
+	test('an unverified session cannot poison stored trust via announcements', async () => {
+		// StrictHostKeyChecking=no accepts whatever key is presented without
+		// verifying it. ssh2 still proves announced keys belong to whoever we
+		// are talking to — but under `no` that could be an impostor, so the
+		// announcement must not be allowed to overwrite the real stored key.
+		// Mirrors OpenSSH, which only accepts additional host keys when the
+		// key that authenticated the host was already trusted.
+		hostKeyTrustService.trustHostKey('remote.example', 22, { keyType: 'ssh-ed25519', fingerprint: FINGERPRINT, addedAt: 1 });
+		await fireAndWait(makeHostKeyRequest({ fingerprint: 'SHA256:impostorkey', strictHostKeyChecking: 'no' }));
+
+		mainService.fireHostKeysAnnouncement({
+			connectionKey: 'ssh:remote.example',
+			host: 'remote.example',
+			port: 22,
+			keys: [{ keyType: 'ssh-ed25519', fingerprint: 'SHA256:attackerkey' }],
+		});
+
+		assert.deepStrictEqual(
+			{
+				// The unverified session was allowed to connect...
+				connected: mainService.hostKeyResponses,
+				// ...but the genuine stored key is untouched.
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).map(k => k.fingerprint),
+			},
+			{
+				connected: [{ requestId: 'hostkey-1', trusted: true }],
+				stored: [FINGERPRINT],
+			});
 	});
 
 	test('ignores announcements for hosts that were never trusted', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -14,7 +14,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
-import { IDialogService } from '../../../dialogs/common/dialogs.js';
+import { IConfirmation, IDialogService } from '../../../dialogs/common/dialogs.js';
 import { INotificationService, Severity, type INotification, type INotificationHandle } from '../../../notification/common/notification.js';
 import { TestNotificationService } from '../../../notification/test/common/testNotificationService.js';
 import { IProductService } from '../../../product/common/productService.js';
@@ -1059,6 +1059,8 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 	let confirmCalls: number;
 	/** When set, the confirm dialog blocks on this until the test releases it. */
 	let confirmGate: (() => Promise<void>) | undefined;
+	/** The options the last confirm dialog was opened with. */
+	let lastConfirmOptions: IConfirmation | undefined;
 
 	setup(() => {
 		mainService = disposables.add(new MockSSHMainService());
@@ -1083,9 +1085,11 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 		confirmResult = false;
 		confirmCalls = 0;
 		confirmGate = undefined;
+		lastConfirmOptions = undefined;
 		instantiationService.stub(IDialogService, {
-			confirm: (async () => {
+			confirm: (async (confirmation: IConfirmation) => {
 				confirmCalls++;
+				lastConfirmOptions = confirmation;
 				if (confirmGate) {
 					await confirmGate();
 				}
@@ -1237,11 +1241,11 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 			{ responses: [{ requestId: 'hostkey-1', trusted: true }], confirmCalls: 0, stored: 1 });
 	});
 
-	test('a late answer to a cancelled prompt cannot grant trust', async () => {
-		// IDialogService.confirm has no cancellation support, so a modal opened
-		// for a connection that then dies stays on screen. Answering "Connect"
-		// afterwards must be inert: no trust stored, no response sent to a
-		// connect attempt that is already gone.
+	test('a prompt for a connection that dies is dismissed, and a late answer grants nothing', async () => {
+		// The dialog is opened with a cancellation token so it tears itself
+		// down when the connection drops, rather than stranding the user with
+		// a question about a connection that no longer exists. Answering it
+		// late must also be inert.
 		let releaseDialog = () => { };
 		const dialogShown = new Promise<void>(resolveShown => {
 			confirmGate = () => {
@@ -1253,17 +1257,25 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 
 		mainService.fireHostKeyVerificationRequest(makeHostKeyRequest());
 		await dialogShown;
+		const dialogToken = lastConfirmOptions?.token;
+		const dismissedBeforeCancel = dialogToken?.isCancellationRequested;
 		// The connection drops while the user is still looking at the dialog.
 		mainService.fireHostKeyVerificationCancel('hostkey-1');
+		const dismissedAfterCancel = dialogToken?.isCancellationRequested;
 		releaseDialog();
 		await new Promise(resolve => setTimeout(resolve, 10));
 
 		assert.deepStrictEqual(
 			{
+				// The dialog is handed a live token that is cancelled when the
+				// connection dies, which is what dismisses it.
+				dismissedBeforeCancel,
+				dismissedAfterCancel,
+				// And a late "Connect" still grants nothing.
 				responses: mainService.hostKeyResponses,
 				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).length,
 			},
-			{ responses: [], stored: 0 });
+			{ dismissedBeforeCancel: false, dismissedAfterCancel: true, responses: [], stored: 0 });
 	});
 
 	test('learns a rotated key announced over an authenticated connection', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -106,6 +106,11 @@ class MockSSHMainService {
 		this._onDidRequestHostKeyVerification.fire(request);
 	}
 
+	/** Test helper: cancel a host key verification as the shared process would. */
+	fireHostKeyVerificationCancel(requestId: string): void {
+		this._onDidCancelHostKeyVerification.fire(requestId);
+	}
+
 	/** Test helper: fire a host key announcement as the shared process would. */
 	fireHostKeysAnnouncement(announcement: ISSHHostKeysAnnouncement): void {
 		this._onDidAnnounceHostKeys.fire(announcement);
@@ -1052,6 +1057,8 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 	let notificationService: CapturingNotificationService;
 	let confirmResult: boolean;
 	let confirmCalls: number;
+	/** When set, the confirm dialog blocks on this until the test releases it. */
+	let confirmGate: (() => Promise<void>) | undefined;
 
 	setup(() => {
 		mainService = disposables.add(new MockSSHMainService());
@@ -1075,9 +1082,13 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 
 		confirmResult = false;
 		confirmCalls = 0;
+		confirmGate = undefined;
 		instantiationService.stub(IDialogService, {
 			confirm: (async () => {
 				confirmCalls++;
+				if (confirmGate) {
+					await confirmGate();
+				}
 				return { confirmed: confirmResult };
 			}) as unknown as IDialogService['confirm'],
 		} as Partial<IDialogService>);
@@ -1224,6 +1235,35 @@ suite('SSHRemoteAgentHostService host key verification (renderer)', () => {
 				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).length,
 			},
 			{ responses: [{ requestId: 'hostkey-1', trusted: true }], confirmCalls: 0, stored: 1 });
+	});
+
+	test('a late answer to a cancelled prompt cannot grant trust', async () => {
+		// IDialogService.confirm has no cancellation support, so a modal opened
+		// for a connection that then dies stays on screen. Answering "Connect"
+		// afterwards must be inert: no trust stored, no response sent to a
+		// connect attempt that is already gone.
+		let releaseDialog = () => { };
+		const dialogShown = new Promise<void>(resolveShown => {
+			confirmGate = () => {
+				resolveShown();
+				return new Promise<void>(resolve => { releaseDialog = resolve; });
+			};
+		});
+		confirmResult = true;
+
+		mainService.fireHostKeyVerificationRequest(makeHostKeyRequest());
+		await dialogShown;
+		// The connection drops while the user is still looking at the dialog.
+		mainService.fireHostKeyVerificationCancel('hostkey-1');
+		releaseDialog();
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		assert.deepStrictEqual(
+			{
+				responses: mainService.hostKeyResponses,
+				stored: hostKeyTrustService.getTrustedKeys('remote.example', 22).length,
+			},
+			{ responses: [], stored: 0 });
 	});
 
 	test('learns a rotated key announced over an authenticated connection', async () => {

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -9,7 +9,7 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHHostKeyVerificationRequest } from '../../common/sshRemoteAgentHost.js';
+import { isSSHHostKeyDeniedError, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHHostKeyVerificationRequest } from '../../common/sshRemoteAgentHost.js';
 import { SSHRemoteAgentHostMainService, type SSHAuthAttempt } from '../../node/sshRemoteAgentHostService.js';
 import { computeHostKeyFingerprint, parseKnownHosts, type IKnownHostsEntry } from '../../node/sshKnownHosts.js';
 
@@ -189,8 +189,12 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 			void service.respondHostKeyVerification(request.requestId, trusted);
 		}));
 		try {
-			const result = await service.connectSSHForTest(config).then(() => 'resolved', err => `rejected: ${err.message}`);
-			return { requests, result };
+			let error: unknown;
+			const result = await service.connectSSHForTest(config).then(() => 'resolved', err => {
+				error = err;
+				return `rejected: ${err.message}`;
+			});
+			return { requests, result, error };
 		} finally {
 			store.dispose();
 		}
@@ -225,13 +229,24 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 			});
 	});
 
-	test('declining fails the connection before authentication', async () => {
+	test('declining fails the connection with a clean host key error', async () => {
+		// ssh2 reports this as "Host denied (verification failed)". That is
+		// jargon, and the host key UI has already explained what happened, so
+		// the connect attempt surfaces a recognizable error instead.
 		const service = createService();
-		const { result } = await connectAnswering(service, false);
+		const { result, error } = await connectAnswering(service, false);
 
 		assert.deepStrictEqual(
-			{ verdict: service.client.verdict, result },
-			{ verdict: false, result: 'rejected: Host denied (verification failed)' });
+			{
+				verdict: service.client.verdict,
+				result,
+				denied: isSSHHostKeyDeniedError(error),
+			},
+			{
+				verdict: false,
+				result: 'rejected: Host key verification failed for test-host',
+				denied: true,
+			});
 	});
 
 	test('reports the known_hosts verdict for a matching entry', async () => {

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -328,7 +328,7 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 			}));
 		});
 
-		void service.connectSSHForTest(makeConfig());
+		const connectPromise = service.connectSSHForTest(makeConfig());
 		await service.client.verifierEntered;
 		// Drive ssh2's auth flow the way the real client would: ask for the
 		// next method, then invoke that method's `prompt` callback.
@@ -338,6 +338,12 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 		});
 		await prompted;
 		const afterAnswering = service.currentDeadlineMs;
+
+		// Settle the connect so its deadline timer is cleared. Leaving it armed
+		// would fire ~30s later, long after this test finished, and surface as
+		// an unexpected error in whichever suite happened to be running.
+		service.client.fireError(new Error('Connection lost'));
+		await connectPromise.catch(() => undefined);
 		store.dispose();
 
 		assert.deepStrictEqual(

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -69,8 +69,12 @@ class HostKeyMockSSHClient {
 		return this;
 	}
 
+	/** ssh2's auth callback, so tests can drive the interactive prompt paths. */
+	authHandler: ((methodsLeft: string[] | null, partialSuccess: boolean, cb: (next: unknown) => void) => void) | undefined;
+
 	connect(config: ConnectConfig): void {
 		this.readyTimeout = config.readyTimeout;
+		this.authHandler = config.authHandler as unknown as typeof this.authHandler;
 		const hostVerifier = config.hostVerifier as ((key: Buffer, verify: (permitted: boolean) => void) => void) | undefined;
 		assert.ok(hostVerifier, 'hostVerifier must be installed — without it ssh2 accepts any host key');
 		this._verifierEntered();
@@ -116,8 +120,11 @@ class HostKeyTestService extends SSHRemoteAgentHostMainService {
 		return this.client as never;
 	}
 
+	/** Auth attempts to offer; set to exercise the interactive prompt paths. */
+	authAttempts: SSHAuthAttempt[] = [];
+
 	protected override async _buildAuthAttempts(_config: ISSHAgentHostConfig): Promise<SSHAuthAttempt[]> {
-		return [];
+		return this.authAttempts;
 	}
 
 	protected override async _readKnownHostsEntries(_host: string): Promise<{ entries: IKnownHostsEntry[]; strictHostKeyChecking: undefined }> {
@@ -296,6 +303,46 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 				afterSettle: service.currentDeadlineMs,
 			},
 			{ ssh2TimerDisabled: 0, armedBeforeConnect: 30_000, whilePrompting: 300_000, afterSettle: undefined });
+	});
+
+	test('widens the deadline for the password prompt too, not just the host key dialog', async () => {
+		// The interactive window must bracket *every* human prompt. A user
+		// typing a password is no faster than one comparing a fingerprint, and
+		// holding them to the 30s network deadline would abort the connection
+		// out from under them.
+		const service = createService();
+		service.authAttempts = [{ type: 'keyboard-interactive', username: 'test' }];
+		service.client.deferVerification = true;
+
+		const store = new DisposableStore();
+		store.add(service.onDidRequestHostKeyVerification(request => {
+			void service.respondHostKeyVerification(request.requestId, true);
+		}));
+
+		let whilePrompting: number | undefined;
+		const prompted = new Promise<void>(resolve => {
+			store.add(service.onDidRequestKeyboardInteractive(request => {
+				whilePrompting = service.currentDeadlineMs;
+				void service.respondKeyboardInteractive(request.requestId, ['hunter2']);
+				resolve();
+			}));
+		});
+
+		void service.connectSSHForTest(makeConfig());
+		await service.client.verifierEntered;
+		// Drive ssh2's auth flow the way the real client would: ask for the
+		// next method, then invoke that method's `prompt` callback.
+		service.client.authHandler?.(['keyboard-interactive'], false, next => {
+			const method = next as { prompt: (name: string, instructions: string, lang: string, prompts: readonly { prompt: string; echo?: boolean }[], finish: (responses: string[]) => void) => void };
+			method.prompt('', '', '', [{ prompt: 'Password:', echo: false }], () => { });
+		});
+		await prompted;
+		const afterAnswering = service.currentDeadlineMs;
+		store.dispose();
+
+		assert.deepStrictEqual(
+			{ whilePrompting, afterAnswering },
+			{ whilePrompting: 300_000, afterAnswering: 30_000 });
 	});
 
 	test('a connection that dies during evidence gathering leaves nothing pending', async () => {

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -42,9 +42,17 @@ class HostKeyMockSSHClient {
 	 */
 	deferVerification = false;
 
+	/** Resolves once ssh2 has entered `hostVerifier` for this connection. */
+	readonly verifierEntered: Promise<void>;
+	private _verifierEntered!: () => void;
+
 	private readonly _errorListeners: Array<(err: Error) => void> = [];
 	private readonly _readyListeners: Array<() => void> = [];
 	private readonly _hostKeysListeners: Array<(keys: readonly { getPublicSSH(): Buffer; type: string }[]) => void> = [];
+
+	constructor() {
+		this.verifierEntered = new Promise<void>(resolve => { this._verifierEntered = resolve; });
+	}
 
 	on(event: string, listener: (...args: never[]) => void): this {
 		if (event === 'error') {
@@ -65,6 +73,7 @@ class HostKeyMockSSHClient {
 		this.readyTimeout = config.readyTimeout;
 		const hostVerifier = config.hostVerifier as ((key: Buffer, verify: (permitted: boolean) => void) => void) | undefined;
 		assert.ok(hostVerifier, 'hostVerifier must be installed — without it ssh2 accepts any host key');
+		this._verifierEntered();
 		hostVerifier(HOST_KEY, permitted => {
 			this.verdictCount++;
 			this.verdict = permitted;
@@ -97,6 +106,11 @@ class HostKeyTestService extends SSHRemoteAgentHostMainService {
 	knownHostsContents = '';
 	/** Set to make the known_hosts read throw, exercising the fail-closed path. */
 	knownHostsError: Error | undefined;
+	/**
+	 * When set, the known_hosts read blocks on this promise, so a test can
+	 * make the connection die while evidence gathering is still in flight.
+	 */
+	knownHostsGate: Promise<void> | undefined;
 
 	protected override async _createSSHClient() {
 		return this.client as never;
@@ -107,10 +121,34 @@ class HostKeyTestService extends SSHRemoteAgentHostMainService {
 	}
 
 	protected override async _readKnownHostsEntries(_host: string): Promise<{ entries: IKnownHostsEntry[]; strictHostKeyChecking: undefined }> {
+		if (this.knownHostsGate) {
+			await this.knownHostsGate;
+		}
 		if (this.knownHostsError) {
 			throw this.knownHostsError;
 		}
 		return { entries: parseKnownHosts(this.knownHostsContents), strictHostKeyChecking: undefined };
+	}
+
+	/** Expose the pending-request map so tests can assert nothing is leaked. */
+	get pendingHostKeyRequestCount(): number {
+		return this['_pendingHostKeyRequests'].size;
+	}
+
+	/** Every deadline armed during the connect, in order. */
+	readonly deadlineHistory: number[] = [];
+	/** The currently armed deadline, or undefined when no timer is running. */
+	currentDeadlineMs: number | undefined;
+
+	protected override _armHandshakeDeadline(ms: number, onExpired: () => void): ReturnType<typeof setTimeout> {
+		this.deadlineHistory.push(ms);
+		this.currentDeadlineMs = ms;
+		return super._armHandshakeDeadline(ms, onExpired);
+	}
+
+	protected override _clearHandshakeDeadline(timer: ReturnType<typeof setTimeout> | undefined): void {
+		this.currentDeadlineMs = undefined;
+		super._clearHandshakeDeadline(timer);
 	}
 
 	connectSSHForTest(config: ISSHAgentHostConfig) {
@@ -217,25 +255,68 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 		assert.strictEqual(requests[0]?.userInitiated, false);
 	});
 
-	test('allows time for a human to answer, but only when a prompt is possible', async () => {
-		// ssh2's readyTimeout keeps running while hostVerifier awaits a
-		// verdict, so a short window would kill the connection out from under
-		// a user who is doing exactly what the dialog asks — going to check
-		// the fingerprint somewhere else.
-		const interactive = createService();
-		await connectAnswering(interactive, true, makeConfig({ userInitiated: true }));
-
-		const background = createService();
-		await connectAnswering(background, true, makeConfig({ userInitiated: false }));
+	test('bounds the handshake, and only widens it while a prompt is outstanding', async () => {
+		// ssh2's own readyTimeout is disabled because it keeps running while
+		// hostVerifier waits on a human. We arm the short network deadline up
+		// front, widen it only for the interval a prompt is actually
+		// outstanding, and restore it once the verdict arrives — so a user
+		// gets time to compare a fingerprint without an unreachable host
+		// taking minutes to fail.
+		const service = createService();
+		const observed: number[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidRequestHostKeyVerification(request => {
+			observed.push(service.currentDeadlineMs!);
+			void service.respondHostKeyVerification(request.requestId, true);
+		}));
+		await service.connectSSHForTest(makeConfig());
+		store.dispose();
 
 		assert.deepStrictEqual(
 			{
-				interactive: interactive.client.readyTimeout,
-				// A background reconnect never prompts, so it keeps the short
-				// window and abandons a stalled handshake promptly.
-				background: background.client.readyTimeout,
+				ssh2TimerDisabled: service.client.readyTimeout,
+				armedBeforeConnect: service.deadlineHistory[0],
+				whilePrompting: observed[0],
+				// Cleared once the connect settles — no timer left running.
+				afterSettle: service.currentDeadlineMs,
 			},
-			{ interactive: 300_000, background: 30_000 });
+			{ ssh2TimerDisabled: 0, armedBeforeConnect: 30_000, whilePrompting: 300_000, afterSettle: undefined });
+	});
+
+	test('a connection that dies during evidence gathering leaves nothing pending', async () => {
+		// `_verifyHostKey` awaits the known_hosts read, so the connection can
+		// die before the request is ever registered for cancellation. If that
+		// window isn't handled, we leak a pending entry forever and pop a
+		// dialog for a connection that is already gone.
+		const service = createService();
+		let openGate = () => { };
+		service.knownHostsGate = new Promise<void>(resolve => { openGate = resolve; });
+
+		const requests: ISSHHostKeyVerificationRequest[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidRequestHostKeyVerification(request => requests.push(request)));
+
+		const connectPromise = service.connectSSHForTest(makeConfig());
+		// Wait until ssh2 has actually entered hostVerifier and blocked inside
+		// the known_hosts read, then kill the connection underneath it.
+		await service.client.verifierEntered;
+		service.client.fireError(new Error('Connection lost'));
+		const result = await connectPromise.then(() => 'resolved', err => `rejected: ${err.message}`);
+
+		// Now release the read: verification resumes on a dead connection.
+		openGate();
+		await new Promise(resolve => setTimeout(resolve, 10));
+		store.dispose();
+
+		assert.deepStrictEqual(
+			{
+				result,
+				// No orphaned prompt, and no leaked map entry.
+				requestCount: requests.length,
+				pending: service.pendingHostKeyRequestCount,
+				verdict: service.client.verdict,
+			},
+			{ result: 'rejected: Connection lost', requestCount: 0, pending: 0, verdict: false });
 	});
 
 	test('fails closed when gathering evidence throws', async () => {

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -34,6 +34,8 @@ class HostKeyMockSSHClient {
 	/** The verdict `hostVerifier` produced, once it settles. */
 	verdict: boolean | undefined;
 	verdictCount = 0;
+	/** The `readyTimeout` ssh2 was configured with for this attempt. */
+	readyTimeout: number | undefined;
 	/**
 	 * When set, the connection is not driven to ready/error by the verdict, so
 	 * a test can control what happens while verification is still pending.
@@ -60,6 +62,7 @@ class HostKeyMockSSHClient {
 	}
 
 	connect(config: ConnectConfig): void {
+		this.readyTimeout = config.readyTimeout;
 		const hostVerifier = config.hostVerifier as ((key: Buffer, verify: (permitted: boolean) => void) => void) | undefined;
 		assert.ok(hostVerifier, 'hostVerifier must be installed — without it ssh2 accepts any host key');
 		hostVerifier(HOST_KEY, permitted => {
@@ -212,6 +215,27 @@ suite('SSHRemoteAgentHostMainService - host key verification', () => {
 		const service = createService();
 		const { requests } = await connectAnswering(service, false, makeConfig({ userInitiated: false }));
 		assert.strictEqual(requests[0]?.userInitiated, false);
+	});
+
+	test('allows time for a human to answer, but only when a prompt is possible', async () => {
+		// ssh2's readyTimeout keeps running while hostVerifier awaits a
+		// verdict, so a short window would kill the connection out from under
+		// a user who is doing exactly what the dialog asks — going to check
+		// the fingerprint somewhere else.
+		const interactive = createService();
+		await connectAnswering(interactive, true, makeConfig({ userInitiated: true }));
+
+		const background = createService();
+		await connectAnswering(background, true, makeConfig({ userInitiated: false }));
+
+		assert.deepStrictEqual(
+			{
+				interactive: interactive.client.readyTimeout,
+				// A background reconnect never prompts, so it keeps the short
+				// window and abandons a stalled handshake promptly.
+				background: background.client.readyTimeout,
+			},
+			{ interactive: 300_000, background: 30_000 });
 	});
 
 	test('fails closed when gathering evidence throws', async () => {

--- a/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshHostKeyVerification.test.ts
@@ -1,0 +1,285 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type { ConnectConfig } from 'ssh2';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { IProductService } from '../../../product/common/productService.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHHostKeyVerificationRequest } from '../../common/sshRemoteAgentHost.js';
+import { SSHRemoteAgentHostMainService, type SSHAuthAttempt } from '../../node/sshRemoteAgentHostService.js';
+import { computeHostKeyFingerprint, parseKnownHosts, type IKnownHostsEntry } from '../../node/sshKnownHosts.js';
+
+/** Build a syntactically valid SSH wire-format public key blob. */
+function makeKeyBlob(keyType: string, material: Buffer): Buffer {
+	const type = Buffer.from(keyType, 'ascii');
+	const header = Buffer.alloc(4);
+	header.writeUInt32BE(type.length, 0);
+	const body = Buffer.alloc(4);
+	body.writeUInt32BE(material.length, 0);
+	return Buffer.concat([header, type, body, material]);
+}
+
+const HOST_KEY = makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xaa));
+
+/**
+ * Mock client that drives only the host key verification path: on `connect` it
+ * invokes `hostVerifier` and records the verdict, without attempting auth.
+ */
+class HostKeyMockSSHClient {
+	ended = false;
+	/** The verdict `hostVerifier` produced, once it settles. */
+	verdict: boolean | undefined;
+	verdictCount = 0;
+	/**
+	 * When set, the connection is not driven to ready/error by the verdict, so
+	 * a test can control what happens while verification is still pending.
+	 */
+	deferVerification = false;
+
+	private readonly _errorListeners: Array<(err: Error) => void> = [];
+	private readonly _readyListeners: Array<() => void> = [];
+	private readonly _hostKeysListeners: Array<(keys: readonly { getPublicSSH(): Buffer; type: string }[]) => void> = [];
+
+	on(event: string, listener: (...args: never[]) => void): this {
+		if (event === 'error') {
+			this._errorListeners.push(listener as (err: Error) => void);
+		} else if (event === 'ready') {
+			this._readyListeners.push(listener as () => void);
+		} else if (event === 'hostkeys') {
+			this._hostKeysListeners.push(listener as (keys: readonly { getPublicSSH(): Buffer; type: string }[]) => void);
+		}
+		return this;
+	}
+
+	removeListener(_event: string, _listener: (...args: never[]) => void): this {
+		return this;
+	}
+
+	connect(config: ConnectConfig): void {
+		const hostVerifier = config.hostVerifier as ((key: Buffer, verify: (permitted: boolean) => void) => void) | undefined;
+		assert.ok(hostVerifier, 'hostVerifier must be installed — without it ssh2 accepts any host key');
+		hostVerifier(HOST_KEY, permitted => {
+			this.verdictCount++;
+			this.verdict = permitted;
+			if (this.deferVerification) {
+				return;
+			}
+			if (permitted) {
+				this._readyListeners.forEach(l => l());
+			} else {
+				this.fireError(new Error('Host denied (verification failed)'));
+			}
+		});
+	}
+
+	announceHostKeys(keys: readonly { getPublicSSH(): Buffer; type: string }[]): void {
+		this._hostKeysListeners.forEach(l => l(keys));
+	}
+
+	fireError(err: Error): void {
+		this._errorListeners.forEach(l => l(err));
+	}
+
+	end(): void {
+		this.ended = true;
+	}
+}
+
+class HostKeyTestService extends SSHRemoteAgentHostMainService {
+	readonly client = new HostKeyMockSSHClient();
+	knownHostsContents = '';
+	/** Set to make the known_hosts read throw, exercising the fail-closed path. */
+	knownHostsError: Error | undefined;
+
+	protected override async _createSSHClient() {
+		return this.client as never;
+	}
+
+	protected override async _buildAuthAttempts(_config: ISSHAgentHostConfig): Promise<SSHAuthAttempt[]> {
+		return [];
+	}
+
+	protected override async _readKnownHostsEntries(_host: string): Promise<{ entries: IKnownHostsEntry[]; strictHostKeyChecking: undefined }> {
+		if (this.knownHostsError) {
+			throw this.knownHostsError;
+		}
+		return { entries: parseKnownHosts(this.knownHostsContents), strictHostKeyChecking: undefined };
+	}
+
+	connectSSHForTest(config: ISSHAgentHostConfig) {
+		return this._connectSSH(config, 'ssh:test-host');
+	}
+}
+
+function makeConfig(overrides?: Partial<ISSHAgentHostConfig>): ISSHAgentHostConfig {
+	return {
+		host: 'test.example.com',
+		username: 'testuser',
+		authMethod: SSHAuthMethod.Agent,
+		name: 'Test Host',
+		sshConfigHost: 'test-host',
+		...overrides,
+	};
+}
+
+suite('SSHRemoteAgentHostMainService - host key verification', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(): HostKeyTestService {
+		const productService: Pick<IProductService, '_serviceBrand' | 'quality' | 'dataFolderName'> = {
+			_serviceBrand: undefined,
+			quality: 'stable',
+			dataFolderName: '.vscode-oss',
+		};
+		return disposables.add(new HostKeyTestService(new NullLogService(), productService as IProductService));
+	}
+
+	/** Run a connect attempt, answering the verification request with `trusted`. */
+	async function connectAnswering(service: HostKeyTestService, trusted: boolean, config = makeConfig()) {
+		const requests: ISSHHostKeyVerificationRequest[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidRequestHostKeyVerification(request => {
+			requests.push(request);
+			void service.respondHostKeyVerification(request.requestId, trusted);
+		}));
+		try {
+			const result = await service.connectSSHForTest(config).then(() => 'resolved', err => `rejected: ${err.message}`);
+			return { requests, result };
+		} finally {
+			store.dispose();
+		}
+	}
+
+	test('installs hostVerifier and reports the key to the renderer', async () => {
+		const service = createService();
+		const { requests, result } = await connectAnswering(service, true);
+
+		assert.deepStrictEqual(
+			{
+				requestCount: requests.length,
+				keyType: requests[0]?.keyType,
+				fingerprint: requests[0]?.fingerprint,
+				host: requests[0]?.host,
+				port: requests[0]?.port,
+				knownHostsMatch: requests[0]?.knownHostsMatch,
+				userInitiated: requests[0]?.userInitiated,
+				verdict: service.client.verdict,
+				result,
+			},
+			{
+				requestCount: 1,
+				keyType: 'ssh-ed25519',
+				fingerprint: computeHostKeyFingerprint(HOST_KEY),
+				host: 'test.example.com',
+				port: 22,
+				knownHostsMatch: 'unknown',
+				userInitiated: true,
+				verdict: true,
+				result: 'resolved',
+			});
+	});
+
+	test('declining fails the connection before authentication', async () => {
+		const service = createService();
+		const { result } = await connectAnswering(service, false);
+
+		assert.deepStrictEqual(
+			{ verdict: service.client.verdict, result },
+			{ verdict: false, result: 'rejected: Host denied (verification failed)' });
+	});
+
+	test('reports the known_hosts verdict for a matching entry', async () => {
+		const service = createService();
+		service.knownHostsContents = `test.example.com ssh-ed25519 ${HOST_KEY.toString('base64')}`;
+		const { requests } = await connectAnswering(service, true);
+		assert.strictEqual(requests[0]?.knownHostsMatch, 'match');
+	});
+
+	test('reports a mismatch when known_hosts holds a different key', async () => {
+		const service = createService();
+		const other = makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xbb));
+		service.knownHostsContents = `test.example.com ssh-ed25519 ${other.toString('base64')}`;
+		const { requests } = await connectAnswering(service, false);
+		assert.strictEqual(requests[0]?.knownHostsMatch, 'mismatch');
+	});
+
+	test('forwards userInitiated so background reconnects can be declined', async () => {
+		const service = createService();
+		const { requests } = await connectAnswering(service, false, makeConfig({ userInitiated: false }));
+		assert.strictEqual(requests[0]?.userInitiated, false);
+	});
+
+	test('fails closed when gathering evidence throws', async () => {
+		// A transient error must never become a way to reach a server without
+		// verification, so no request is raised and the key is refused.
+		const service = createService();
+		service.knownHostsError = new Error('boom');
+		const requests: ISSHHostKeyVerificationRequest[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidRequestHostKeyVerification(request => requests.push(request)));
+		const result = await service.connectSSHForTest(makeConfig()).then(() => 'resolved', err => `rejected: ${err.message}`);
+		store.dispose();
+
+		assert.deepStrictEqual(
+			{ requestCount: requests.length, verdict: service.client.verdict, result },
+			{ requestCount: 0, verdict: false, result: 'rejected: Host denied (verification failed)' });
+	});
+
+	test('cancelling an in-flight verification denies rather than hanging', async () => {
+		// If the connection drops while we're still waiting on a verdict, ssh2
+		// must still be told "no" — otherwise the handshake stalls until
+		// readyTimeout elapses, and the renderer's prompt is left orphaned.
+		const service = createService();
+		service.client.deferVerification = true;
+
+		const cancelled: string[] = [];
+		const requests: ISSHHostKeyVerificationRequest[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidCancelHostKeyVerification(requestId => cancelled.push(requestId)));
+		store.add(service.onDidRequestHostKeyVerification(request => {
+			requests.push(request);
+			// Simulate the connection dying while the user is still deciding.
+			service.client.fireError(new Error('Connection lost'));
+		}));
+
+		const result = await service.connectSSHForTest(makeConfig()).then(() => 'resolved', err => `rejected: ${err.message}`);
+		store.dispose();
+
+		assert.deepStrictEqual(
+			{
+				result,
+				cancelled: cancelled.length === 1 && cancelled[0] === requests[0]?.requestId,
+				verdict: service.client.verdict,
+				verdictCount: service.client.verdictCount,
+			},
+			{ result: 'rejected: Connection lost', cancelled: true, verdict: false, verdictCount: 1 });
+	});
+
+	test('surfaces proven announced host keys', async () => {
+		const service = createService();
+		const announcements: { host: string; keys: readonly { keyType: string; fingerprint: string }[] }[] = [];
+		const store = new DisposableStore();
+		store.add(service.onDidAnnounceHostKeys(a => announcements.push({ host: a.host, keys: a.keys })));
+		await connectAnswering(service, true);
+
+		const rotated = makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xcc));
+		service.client.announceHostKeys([
+			{ getPublicSSH: () => rotated, type: 'ssh-ed25519' },
+			// A certificate: ssh2 misparses these (it returns the cert's nonce
+			// as the key material), so the blob's embedded type disagrees with
+			// the declared type and it must be skipped rather than trusted.
+			{ getPublicSSH: () => makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xdd)), type: 'ssh-ed25519-cert-v01@openssh.com' },
+		]);
+		store.dispose();
+
+		assert.deepStrictEqual(announcements, [{
+			host: 'test.example.com',
+			keys: [{ keyType: 'ssh-ed25519', fingerprint: computeHostKeyFingerprint(rotated) }],
+		}]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/sshKnownHosts.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshKnownHosts.test.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { createHmac, randomBytes } from 'crypto';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	computeHostKeyFingerprint,
+	matchKnownHosts,
+	parseKnownHosts,
+	parseKnownHostsLine,
+	readHostKeyType,
+} from '../../node/sshKnownHosts.js';
+
+/** Build a syntactically valid SSH wire-format public key blob. */
+function makeKeyBlob(keyType: string, material: Buffer): Buffer {
+	const type = Buffer.from(keyType, 'ascii');
+	const header = Buffer.alloc(4);
+	header.writeUInt32BE(type.length, 0);
+	const body = Buffer.alloc(4);
+	body.writeUInt32BE(material.length, 0);
+	return Buffer.concat([header, type, body, material]);
+}
+
+const ED25519_A = makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xaa));
+const ED25519_B = makeKeyBlob('ssh-ed25519', Buffer.alloc(32, 0xbb));
+const RSA_A = makeKeyBlob('ssh-rsa', Buffer.alloc(64, 0xcc));
+
+function line(host: string, blob: Buffer, marker?: string): string {
+	const type = readHostKeyType(blob)!;
+	return `${marker ? `${marker} ` : ''}${host} ${type} ${blob.toString('base64')}`;
+}
+
+/** Build a hashed (`|1|salt|hash`) host field the way `ssh-keygen -H` does. */
+function hashedHostField(host: string, salt: Buffer): string {
+	const hash = createHmac('sha1', salt).update(host).digest();
+	return `|1|${salt.toString('base64')}|${hash.toString('base64')}`;
+}
+
+suite('sshKnownHosts', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('computeHostKeyFingerprint', () => {
+		test('matches the ssh-keygen -lf format for a known key', () => {
+			// Golden value: this exact blob and fingerprint pair was verified
+			// against `ssh-keygen -lf` so a change in encoding is caught here
+			// rather than only showing up against a live server.
+			const blob = Buffer.from(
+				'AAAAC3NzaC1lZDI1NTE5AAAAIJ5SStkj9JLI/lWstJ2hIit3/xB+2xVeUesa/GlxqHFz',
+				'base64');
+			assert.deepStrictEqual(
+				{
+					fingerprint: computeHostKeyFingerprint(blob),
+					keyType: readHostKeyType(blob),
+				},
+				{
+					fingerprint: 'SHA256:yvH+SxFjYRQ8Vcgn8CFkUoghmVAaLoQjp+kmo5k7y/8',
+					keyType: 'ssh-ed25519',
+				});
+		});
+
+		test('strips base64 padding', () => {
+			assert.ok(!computeHostKeyFingerprint(ED25519_A).includes('='));
+		});
+	});
+
+	suite('readHostKeyType', () => {
+		test('reads the algorithm and rejects malformed blobs', () => {
+			const lying = Buffer.alloc(8);
+			lying.writeUInt32BE(0xffff, 0);
+			assert.deepStrictEqual(
+				{
+					ed25519: readHostKeyType(ED25519_A),
+					rsa: readHostKeyType(RSA_A),
+					empty: readHostKeyType(Buffer.alloc(0)),
+					truncated: readHostKeyType(Buffer.alloc(2)),
+					lengthPastEnd: readHostKeyType(lying),
+				},
+				{
+					ed25519: 'ssh-ed25519',
+					rsa: 'ssh-rsa',
+					empty: undefined,
+					truncated: undefined,
+					lengthPastEnd: undefined,
+				});
+		});
+	});
+
+	suite('parseKnownHostsLine', () => {
+		test('parses a plain entry', () => {
+			const entry = parseKnownHostsLine(line('example.com', ED25519_A));
+			assert.deepStrictEqual(
+				{
+					patterns: entry?.patterns,
+					keyType: entry?.keyType,
+					marker: entry?.marker,
+					keyMatches: entry?.key.equals(ED25519_A),
+				},
+				{ patterns: ['example.com'], keyType: 'ssh-ed25519', marker: undefined, keyMatches: true });
+		});
+
+		test('parses comma-separated patterns and markers', () => {
+			const multi = parseKnownHostsLine(line('a.example.com,b.example.com,1.2.3.4', ED25519_A));
+			const revoked = parseKnownHostsLine(line('example.com', ED25519_A, '@revoked'));
+			const ca = parseKnownHostsLine(line('*.example.com', ED25519_A, '@cert-authority'));
+			assert.deepStrictEqual(
+				{
+					patterns: multi?.patterns,
+					revokedMarker: revoked?.marker,
+					caMarker: ca?.marker,
+				},
+				{
+					patterns: ['a.example.com', 'b.example.com', '1.2.3.4'],
+					revokedMarker: 'revoked',
+					caMarker: 'cert-authority',
+				});
+		});
+
+		test('parses a hashed entry', () => {
+			const salt = randomBytes(20);
+			const entry = parseKnownHostsLine(`${hashedHostField('example.com', salt)} ssh-ed25519 ${ED25519_A.toString('base64')}`);
+			assert.deepStrictEqual(
+				{
+					saltMatches: entry?.hashedHost?.salt.equals(salt),
+					hashLength: entry?.hashedHost?.hash.length,
+					patterns: entry?.patterns,
+				},
+				{ saltMatches: true, hashLength: 20, patterns: [] });
+		});
+
+		test('skips blanks, comments and malformed lines', () => {
+			const typeMismatch = `example.com ssh-rsa ${ED25519_A.toString('base64')}`;
+			assert.deepStrictEqual(
+				{
+					blank: parseKnownHostsLine('   '),
+					comment: parseKnownHostsLine('# a comment'),
+					tooFewFields: parseKnownHostsLine('example.com ssh-ed25519'),
+					unknownMarker: parseKnownHostsLine(line('example.com', ED25519_A, '@bogus')),
+					// The line claims ssh-rsa but the blob says ssh-ed25519.
+					// Trusting the label would let a mislabeled entry match a
+					// key type it does not actually hold.
+					typeDisagreesWithBlob: parseKnownHostsLine(typeMismatch),
+					shortHashedHash: parseKnownHostsLine(`|1|${randomBytes(20).toString('base64')}|${randomBytes(4).toString('base64')} ssh-ed25519 ${ED25519_A.toString('base64')}`),
+				},
+				{
+					blank: undefined,
+					comment: undefined,
+					tooFewFields: undefined,
+					unknownMarker: undefined,
+					typeDisagreesWithBlob: undefined,
+					shortHashedHash: undefined,
+				});
+		});
+	});
+
+	suite('matchKnownHosts', () => {
+		const match = (contents: string, host: string, port: number, blob: Buffer) =>
+			matchKnownHosts(parseKnownHosts(contents), host, port, readHostKeyType(blob)!, blob);
+
+		test('matches, mismatches and reports unknown hosts', () => {
+			const known = line('example.com', ED25519_A);
+			assert.deepStrictEqual(
+				{
+					exact: match(known, 'example.com', 22, ED25519_A),
+					caseInsensitive: match(known, 'EXAMPLE.COM', 22, ED25519_A),
+					changedKey: match(known, 'example.com', 22, ED25519_B),
+					otherHost: match(known, 'other.com', 22, ED25519_A),
+					empty: match('', 'example.com', 22, ED25519_A),
+				},
+				{
+					exact: 'match',
+					caseInsensitive: 'match',
+					changedKey: 'mismatch',
+					otherHost: 'unknown',
+					empty: 'unknown',
+				});
+		});
+
+		test('scopes mismatch to the same key type', () => {
+			// A host with only an RSA entry that presents an ed25519 key is
+			// unknown, not evidence of an attack. Reporting `mismatch` here
+			// would fire a false alarm for every RSA-only user, since ssh2
+			// negotiates ed25519 first.
+			const rsaOnly = line('example.com', RSA_A);
+			assert.deepStrictEqual(
+				{
+					differentType: match(rsaOnly, 'example.com', 22, ED25519_A),
+					sameType: match(rsaOnly, 'example.com', 22, RSA_A),
+				},
+				{ differentType: 'unknown', sameType: 'match' });
+		});
+
+		test('handles non-default ports via the bracket form', () => {
+			const bracketed = line('[example.com]:2222', ED25519_A);
+			const bare = line('example.com', ED25519_A);
+			assert.deepStrictEqual(
+				{
+					bracketedOnCustomPort: match(bracketed, 'example.com', 2222, ED25519_A),
+					bracketedOnDefaultPort: match(bracketed, 'example.com', 22, ED25519_A),
+					bareOnCustomPort: match(bare, 'example.com', 2222, ED25519_A),
+				},
+				{
+					bracketedOnCustomPort: 'match',
+					bracketedOnDefaultPort: 'unknown',
+					bareOnCustomPort: 'unknown',
+				});
+		});
+
+		test('supports glob patterns and negation', () => {
+			const glob = line('*.example.com', ED25519_A);
+			const negated = line('*.example.com,!secret.example.com', ED25519_A);
+			assert.deepStrictEqual(
+				{
+					globMatches: match(glob, 'host.example.com', 22, ED25519_A),
+					globMissesOtherDomain: match(glob, 'host.other.com', 22, ED25519_A),
+					singleChar: match(line('host?.example.com', ED25519_A), 'host1.example.com', 22, ED25519_A),
+					// A negation must veto the whole entry even though the
+					// wildcard on the same line also matches.
+					negatedHost: match(negated, 'secret.example.com', 22, ED25519_A),
+					nonNegatedHost: match(negated, 'public.example.com', 22, ED25519_A),
+				},
+				{
+					globMatches: 'match',
+					globMissesOtherDomain: 'unknown',
+					singleChar: 'match',
+					negatedHost: 'unknown',
+					nonNegatedHost: 'match',
+				});
+		});
+
+		test('matches hashed entries', () => {
+			const salt = randomBytes(20);
+			const hashed = `${hashedHostField('example.com', salt)} ssh-ed25519 ${ED25519_A.toString('base64')}`;
+			assert.deepStrictEqual(
+				{
+					sameKey: match(hashed, 'example.com', 22, ED25519_A),
+					changedKey: match(hashed, 'example.com', 22, ED25519_B),
+					otherHost: match(hashed, 'other.com', 22, ED25519_A),
+				},
+				{ sameKey: 'match', changedKey: 'mismatch', otherHost: 'unknown' });
+		});
+
+		test('revocation overrides an otherwise matching entry', () => {
+			// The revoked key is also listed as trusted; revocation must win,
+			// or an explicitly revoked key could still be accepted.
+			const contents = [
+				line('example.com', ED25519_A),
+				line('example.com', ED25519_A, '@revoked'),
+			].join('\n');
+			assert.deepStrictEqual(
+				{
+					revokedKey: match(contents, 'example.com', 22, ED25519_A),
+					otherKey: match(contents, 'example.com', 22, ED25519_B),
+				},
+				{ revokedKey: 'revoked', otherKey: 'mismatch' });
+		});
+
+		test('reports ca-only when the host is covered solely by a cert authority', () => {
+			const ca = line('*.example.com', ED25519_A, '@cert-authority');
+			assert.deepStrictEqual(
+				{
+					caOnly: match(ca, 'host.example.com', 22, ED25519_B),
+					// A normal entry alongside the CA line still decides.
+					caPlusNormal: match([ca, line('host.example.com', ED25519_B)].join('\n'), 'host.example.com', 22, ED25519_B),
+				},
+				{ caOnly: 'ca-only', caPlusNormal: 'match' });
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -339,6 +339,9 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 			identityFile: [],
 			identityAgent: undefined,
 			forwardAgent: false,
+			userKnownHostsFiles: [],
+			globalKnownHostsFiles: [],
+			strictHostKeyChecking: undefined,
 		};
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -22,7 +22,7 @@ import { IEditorService } from '../../../../../workbench/services/editor/common/
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
+import { ISSHRemoteAgentHostService, isSSHHostKeyDeniedError, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IWSLRemoteAgentHostService, WSL_INSTALL_DOCS_URL, type IWSLDistro } from '../../../../../platform/agentHost/common/wslRemoteAgentHost.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -560,7 +560,10 @@ async function connectWithProgress(
 		return connection;
 	} catch (err) {
 		handle.close();
-		if (isCancellationError(err)) {
+		if (isCancellationError(err) || isSSHHostKeyDeniedError(err)) {
+			// A refused host key needs no generic error on top: either the user
+			// declined the prompt themselves, or the host key UI has already
+			// shown a specific notification with a way to recover.
 			return undefined;
 		}
 		notificationService.error(localize('sshConnectFailed', "Failed to connect via SSH to {0}: {1}", displayHost, String(err)));

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/forgetSSHHostKeyCommand.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/forgetSSHHostKeyCommand.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { ISSHHostKeyTrustService, type ISSHTrustedHost } from '../../../../../platform/agentHost/common/sshHostKeyTrust.js';
+import { CHAT_CATEGORY } from '../../../../../workbench/contrib/chat/browser/actions/chatActions.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+
+export const ForgetSSHHostKeyCommandId = 'workbench.action.chat.forgetSSHHostKey';
+
+interface ITrustedHostPickItem extends IQuickPickItem {
+	readonly trustedHost: ISSHTrustedHost;
+}
+
+/**
+ * Build the quick pick entries for the stored hosts. The description carries
+ * the key types and fingerprints so the user can confirm they are forgetting
+ * the host they meant to — the whole point of this command is recovering from
+ * a key change, and doing that blindly would defeat the verification it exists
+ * to support.
+ */
+export function toTrustedHostPickItems(hosts: readonly ISSHTrustedHost[]): ITrustedHostPickItem[] {
+	return hosts
+		.slice()
+		.sort((a, b) => a.host.localeCompare(b.host) || a.port - b.port)
+		.map(trustedHost => {
+			const alias = trustedHost.keys.find(key => key.alias)?.alias;
+			const label = trustedHost.port === 22 ? trustedHost.host : `${trustedHost.host}:${trustedHost.port}`;
+			return {
+				label: alias && alias !== trustedHost.host ? `${alias} (${label})` : label,
+				description: trustedHost.keys.map(key => `${key.keyType} ${key.fingerprint}`).join(', '),
+				trustedHost,
+			};
+		});
+}
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: ForgetSSHHostKeyCommandId,
+			title: localize2('forgetSSHHostKey', "Forget SSH Host Key"),
+			category: CHAT_CATEGORY,
+			f1: true,
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+			),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const hostKeyTrustService = accessor.get(ISSHHostKeyTrustService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		const hosts = hostKeyTrustService.listTrustedHosts();
+		if (hosts.length === 0) {
+			notificationService.info(localize('forgetSSHHostKey.none', "No SSH host keys have been saved yet."));
+			return;
+		}
+
+		const picked = await quickInputService.pick<ITrustedHostPickItem>(
+			toTrustedHostPickItems(hosts),
+			{
+				placeHolder: localize('forgetSSHHostKey.placeholder', "Select the hosts whose saved SSH host keys should be forgotten"),
+				canPickMany: true,
+			},
+		);
+		if (!picked?.length) {
+			return;
+		}
+
+		for (const item of picked) {
+			hostKeyTrustService.forgetHost(item.trustedHost.host, item.trustedHost.port);
+		}
+
+		notificationService.info(picked.length === 1
+			? localize('forgetSSHHostKey.forgotOne', "Forgot the saved SSH host key for '{0}'. You'll be asked to verify it the next time you connect.", picked[0].trustedHost.host)
+			: localize('forgetSSHHostKey.forgotMany', "Forgot saved SSH host keys for {0} hosts. You'll be asked to verify them the next time you connect.", picked.length));
+	}
+});

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -106,6 +106,8 @@ import { IRemoteAgentHostService } from '../platform/agentHost/common/remoteAgen
 import { AgentsWindowRemoteAgentHostService } from '../platform/agentHost/browser/remoteAgentHostServiceImpl.js';
 import { IRemoteAgentHostLocationPreferenceService } from '../platform/agentHost/common/remoteAgentHostLocationPreference.js';
 import { RemoteAgentHostLocationPreferenceService } from '../platform/agentHost/browser/remoteAgentHostLocationPreferenceService.js';
+import { ISSHHostKeyTrustService } from '../platform/agentHost/common/sshHostKeyTrust.js';
+import { SSHHostKeyTrustService } from '../platform/agentHost/browser/sshHostKeyTrustService.js';
 import { registerSharedProcessRemoteService } from '../platform/ipc/electron-browser/services.js';
 import { IPluginGitService } from '../workbench/contrib/chat/common/plugins/pluginGitService.js';
 import { NativePluginGitCommandService } from '../workbench/contrib/chat/electron-browser/pluginGitCommandService.js';
@@ -119,6 +121,7 @@ registerSingleton(IUserDataInitializationService, new SyncDescriptor(UserDataIni
 registerSingleton(IPluginGitService, NativePluginGitCommandService, InstantiationType.Delayed);
 registerSingleton(IRemoteAgentHostService, AgentsWindowRemoteAgentHostService, InstantiationType.Delayed);
 registerSingleton(IRemoteAgentHostLocationPreferenceService, RemoteAgentHostLocationPreferenceService, InstantiationType.Delayed);
+registerSingleton(ISSHHostKeyTrustService, SSHHostKeyTrustService, InstantiationType.Delayed);
 registerSharedProcessRemoteService(ILocalGitService, 'localGit');
 
 
@@ -233,6 +236,7 @@ import './contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution
 import './contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.js';
 // Change Preferred Remote Agent Location (Chat: ... command)
 import './contrib/providers/remoteAgentHost/electron-browser/remoteAgentHostLocationPreferenceCommand.js';
+import './contrib/providers/remoteAgentHost/electron-browser/forgetSSHHostKeyCommand.js';
 // Copilot cloud sandbox connections (copilot-developer-cli) over a Web PubSub AHP relay
 import './contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHost.contribution.js';
 // Chat


### PR DESCRIPTION
Adds SSH host key verification to the remote agent host SSH feature.

## Why

We passed no `hostVerifier` to `ssh2`, so it took the documented "no verification" path and accepted **any** host key from any server. Every remote agent host SSH connection was trivially MITM-able.

The sequencing made it worse than it sounds: our keyboard-interactive password prompt ran *after* an unverified key exchange, so an impersonating server already had the user's password before any warning could have appeared. Agent forwarding was similarly exposed when enabled.

## What this does

`hostVerifier` suspends the handshake until a verdict is returned, so verification happens **before** authentication. Evidence is gathered in the shared process; policy and UI live in the renderer.

- **Trust store** — our own, at application scope / `StorageTarget.MACHINE` (host key trust is a property of this machine's view of the network and must not sync). We read `known_hosts` to consult and seed, but **never write to it**.
- **`known_hosts` support** — plain and hashed (`|1|`) entries, `!` negation, wildcards, non-default `[host]:port`, `@revoked`, `@cert-authority`. Files resolved via `ssh -G` so a redirected `UserKnownHostsFile` is honored.
- **`StrictHostKeyChecking`** — `yes` / `accept-new` / `no` / `off` / `ask`, matching OpenSSH. Revocation deliberately outranks the `no`/`off` opt-out.
- **Changed or revoked key: hard fail.** No click-through. Recovery requires the explicit **"Forget SSH Host Key"** command, so a possible impersonation can't be waved away with one reflexive click.
- **`UpdateHostKeys`** (`hostkeys-00@openssh.com`) — legitimate server key rotations are learned silently, which is what makes the hard-fail tolerable. Gated on the session's own key already being trusted, per the `ssh_config` documented rule.
- **Background reconnects never prompt** — an unknown key is declined instead of raising a modal the user didn't ask for.

## Verification

Verified live against **OpenSSH 9.9p2** (a throwaway sshd in a temp dir, plus `localhost`) rather than only against mocks:

- Our `SHA256:` fingerprints match `ssh-keygen -lf` exactly, including 16/16 keys in a real `known_hosts` — so what we show is copy-pasteable against what `ssh` shows.
- Denial occurs with `authenticated=false`, confirming the pre-auth ordering that motivates the change.
- Matching agrees with `ssh-keygen -F` and with what real `ssh` writes.
- A different ed25519 key reads as `mismatch`; a different *key type* reads as `unknown`, not a false alarm.
- `UpdateHostKeys` surfaced both server keys with signatures verified.

**323 unit tests**, typecheck and layers clean.

## Notes for reviewers

The security-critical invariant is that **`hostVerifier` must be answered exactly once on every path**. Fail-open is the catastrophic mode: it silently restores accept-anything behavior while every test still passes. Worth the most scrutiny.

Two rounds of review shaped this. A unit test caught a revocation-ordering bug in my own first implementation (a `@revoked` line after a stale trusted entry was unreachable). A GPT-5.6 review raised six findings, all real and all fixed — the two security-relevant ones (revoked keys accepted under `StrictHostKeyChecking=no`; an unverified session poisoning the trust store via announcements) were each re-confirmed against OpenSSH 9.9's actual behavior rather than taken on faith.

Also of note: ssh2's `readyTimeout` keeps running while a verdict is pending, so the original 30s would have aborted the connection out from under a user doing exactly what the dialog asks — comparing a fingerprint against another source. We now disable ssh2's timer and own the deadline: 30s for network phases, widened to 5 minutes only while a prompt is actually outstanding.

## Known limitation (pre-existing, not addressed here)

`ssh2` never negotiates certificate host key types. Since `HostCertificate` must match an existing `HostKey`, such servers offer both forms and we still connect on the plain key — verified live. The cost is a trust-on-first-use prompt on a host whose purpose was to eliminate TOFU, so a CA-only `known_hosts` yields a distinct `ca-only` message that says plainly we can't validate against the CA, rather than training users to click through the one dialog that matters.

A separate, higher-impact `ssh2` gap (agent-held client certificates failing with no diagnostic) is filed internally as follow-up.

(Written by Copilot)
