### PR TITLE
agentHost: Attribute edits in focus windows

### DIFF
--- a/src/vs/editor/common/textModelEditSource.ts
+++ b/src/vs/editor/common/textModelEditSource.ts
@@ -108,18 +108,41 @@ export const EditSources = {
 		mode: string | undefined;
 		extensionId: VersionedExtensionId | undefined;
 		codeBlockSuggestionId: EditSuggestionId | undefined;
+		origin?: 'agentHost';
+		harness?: string;
 	}) {
 		return createEditSource({
 			source: 'Chat.applyEdits',
 			$modelId: avoidPathRedaction(data.modelId),
 			$extensionId: data.extensionId?.extensionId,
 			$extensionVersion: data.extensionId?.version,
+			$harness: data.harness,
+			$origin: data.origin,
 			$$languageId: data.languageId,
 			$$sessionId: data.sessionId,
 			$$requestId: data.requestId,
 			$$mode: data.mode,
 			$$codeBlockSuggestionId: data.codeBlockSuggestionId,
 		} as const);
+	},
+
+	agentHostChatApplyEdits(data: {
+		modelId: string | undefined;
+		sessionId: string;
+		requestId: string;
+		harness: string;
+	}) {
+		return EditSources.chatApplyEdits({
+			modelId: data.modelId,
+			sessionId: data.sessionId,
+			requestId: data.requestId,
+			languageId: '',
+			mode: undefined,
+			extensionId: undefined,
+			codeBlockSuggestionId: undefined,
+			origin: 'agentHost',
+			harness: data.harness,
+		});
 	},
 
 	chatUndoEdits: () => createEditSource({ source: 'Chat.undoEdits' } as const),

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -21,10 +21,18 @@ interface IFileEditAttributionMarkerBase {
 	readonly sequence: number;
 }
 
+export interface IFileEditAttributionSource {
+	readonly modelId?: string;
+	readonly conversationId: string;
+	readonly requestId: string;
+	readonly harness: string;
+}
+
 export interface ITrackedFileEditAttributionMarker extends IFileEditAttributionMarkerBase {
 	readonly status?: 'tracked';
 	readonly beforeDigest: string;
 	readonly afterDigest: string;
+	readonly source?: IFileEditAttributionSource;
 }
 
 export interface ISkippedFileEditAttributionMarker extends IFileEditAttributionMarkerBase {
@@ -144,7 +152,16 @@ export function getFileEditAttributionMarker(content: ToolResultFileEditContent)
 	if (marker.status !== undefined && marker.status !== 'tracked') {
 		return undefined;
 	}
-	return typeof marker.beforeDigest === 'string' && typeof marker.afterDigest === 'string' ? marker : undefined;
+	return typeof marker.beforeDigest === 'string' &&
+		typeof marker.afterDigest === 'string' &&
+		(marker.source === undefined || (
+			(marker.source.modelId === undefined || typeof marker.source.modelId === 'string') &&
+			typeof marker.source.conversationId === 'string' &&
+			typeof marker.source.requestId === 'string' &&
+			typeof marker.source.harness === 'string'
+		))
+		? marker
+		: undefined;
 }
 
 export function createFileEditContentDigest(content: string): string {

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -152,19 +152,25 @@ export function getFileEditAttributionMarker(content: ToolResultFileEditContent)
 	if (marker.status !== undefined && marker.status !== 'tracked') {
 		return undefined;
 	}
-	return typeof marker.beforeDigest === 'string' &&
-		typeof marker.afterDigest === 'string' &&
-		(marker.source === undefined || (
-			typeof marker.source === 'object' &&
-			marker.source !== null &&
-			!Array.isArray(marker.source) &&
-			(marker.source.modelId === undefined || typeof marker.source.modelId === 'string') &&
-			typeof marker.source.conversationId === 'string' &&
-			typeof marker.source.requestId === 'string' &&
-			typeof marker.source.harness === 'string'
-		))
-		? marker
-		: undefined;
+	if (
+		typeof marker.beforeDigest !== 'string' ||
+		typeof marker.afterDigest !== 'string' ||
+		(marker.source !== undefined && !isFileEditAttributionSource(marker.source))
+	) {
+		return undefined;
+	}
+	return marker;
+}
+
+function isFileEditAttributionSource(source: unknown): source is IFileEditAttributionSource {
+	if (typeof source !== 'object' || source === null || Array.isArray(source)) {
+		return false;
+	}
+	const candidate = source as Partial<IFileEditAttributionSource>;
+	return (candidate.modelId === undefined || typeof candidate.modelId === 'string') &&
+		typeof candidate.conversationId === 'string' &&
+		typeof candidate.requestId === 'string' &&
+		typeof candidate.harness === 'string';
 }
 
 export function createFileEditContentDigest(content: string): string {

--- a/src/vs/platform/agentHost/common/fileEditAttribution.ts
+++ b/src/vs/platform/agentHost/common/fileEditAttribution.ts
@@ -155,6 +155,9 @@ export function getFileEditAttributionMarker(content: ToolResultFileEditContent)
 	return typeof marker.beforeDigest === 'string' &&
 		typeof marker.afterDigest === 'string' &&
 		(marker.source === undefined || (
+			typeof marker.source === 'object' &&
+			marker.source !== null &&
+			!Array.isArray(marker.source) &&
 			(marker.source.modelId === undefined || typeof marker.source.modelId === 'string') &&
 			typeof marker.source.conversationId === 'string' &&
 			typeof marker.source.requestId === 'string' &&

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -324,6 +324,12 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			sequence: ++this._sequence,
 			beforeDigest: createFileEditContentDigest(edit.beforeText),
 			afterDigest: createFileEditContentDigest(edit.afterText),
+			source: {
+				modelId: source.modelId,
+				conversationId: source.conversationId,
+				requestId: source.requestId,
+				harness: source.harness,
+			},
 		};
 		resource.lastSequence = marker.sequence;
 		if (resource.intervals.length > MAX_INTERVALS_PER_RESOURCE) {

--- a/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentEditAttributionService.ts
@@ -325,10 +325,10 @@ export class AgentEditAttributionService extends Disposable implements IAgentEdi
 			beforeDigest: createFileEditContentDigest(edit.beforeText),
 			afterDigest: createFileEditContentDigest(edit.afterText),
 			source: {
-				modelId: source.modelId,
-				conversationId: source.conversationId,
-				requestId: source.requestId,
-				harness: source.harness,
+				modelId: edit.modelId,
+				conversationId: AgentSession.id(edit.sessionUri),
+				requestId: edit.turnId,
+				harness: provider,
 			},
 		};
 		resource.lastSequence = marker.sequence;

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -164,6 +164,51 @@ suite('Agent Edit Attribution Service', () => {
 		});
 	});
 
+	test('uses the current edit metadata for each marker', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));
+		const resource = URI.file('/workspace/file.ts');
+		await fileService.writeFile(resource, VSBuffer.fromString('abc'));
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(IDiffComputeService, new TestDiffComputeService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, { telemetryLevel: TelemetryLevel.USAGE, publicLog2() { } });
+		const service = disposables.add(instantiationService.createInstance(AgentEditAttributionService, async () => undefined, undefined));
+
+		const first = await service.recordEdit({
+			sessionUri: 'copilotcli:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+			filePath: resource.fsPath,
+			beforeText: 'a',
+			afterText: 'ab',
+			changes: [{ startOffset: 1, endOffsetExclusive: 1, newText: 'b' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+		const second = await service.recordEdit({
+			sessionUri: 'copilotcli:/session-1',
+			turnId: 'turn-2',
+			toolCallId: 'tool-2',
+			filePath: resource.fsPath,
+			beforeText: 'ab',
+			afterText: 'abc',
+			changes: [{ startOffset: 2, endOffsetExclusive: 2, newText: 'c' }],
+			modelId: 'model',
+			toolName: 'edit',
+		});
+
+		assert.deepStrictEqual([
+			first?.status !== 'skipped' ? first?.source : undefined,
+			second?.status !== 'skipped' ? second?.source : undefined,
+		], [
+			{ modelId: 'model', conversationId: 'session-1', requestId: 'turn-1', harness: 'copilotcli' },
+			{ modelId: 'model', conversationId: 'session-1', requestId: 'turn-2', harness: 'copilotcli' },
+		]);
+	});
+
 	test('normalizes ahp chat harness without coalescing chat resources', async () => {
 		const fileService = disposables.add(new FileService(new NullLogService()));
 		disposables.add(fileService.registerProvider('file', disposables.add(new InMemoryFileSystemProvider())));

--- a/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEditAttributionService.test.ts
@@ -83,6 +83,7 @@ suite('Agent Edit Attribution Service', () => {
 				editIdLength: marker.editId.length,
 				beforeDigest: marker.beforeDigest,
 				afterDigest: marker.afterDigest,
+				source: marker.source,
 			} : marker,
 			events: events.map(event => ({
 				eventName: event.eventName,
@@ -112,6 +113,12 @@ suite('Agent Edit Attribution Service', () => {
 				editIdLength: 36,
 				beforeDigest: createFileEditContentDigest('abcdef'),
 				afterDigest: createFileEditContentDigest('aBcdeF'),
+				source: {
+					modelId: 'model',
+					conversationId: 'session-1',
+					requestId: 'turn-1',
+					harness: 'copilotcli',
+				},
 			},
 			events: [{
 				eventName: 'editTelemetry.editSources.details',

--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/documentWithAnnotatedEdits.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/documentWithAnnotatedEdits.ts
@@ -121,7 +121,9 @@ export abstract class EditSourceBase {
 				return this._cache.get(new UnknownEditSource());
 
 			case 'Chat.applyEdits':
-				return this._cache.get(new ChatEditSource('sidebar'));
+				return '$origin' in data && data.$origin === 'agentHost'
+					? this._cache.get(new AgentHostEditSource())
+					: this._cache.get(new ChatEditSource('sidebar'));
 			case 'inlineChat.applyEdits':
 				return this._cache.get(new ChatEditSource('inline'));
 			case 'cursor':
@@ -134,7 +136,7 @@ export abstract class EditSourceBase {
 	public abstract getColor(): string;
 }
 
-export type EditSource = InlineSuggestEditSource | ChatEditSource | IdeEditSource | UserEditSource | UnknownEditSource | ExternalEditSource;
+export type EditSource = InlineSuggestEditSource | ChatEditSource | AgentHostEditSource | IdeEditSource | UserEditSource | UnknownEditSource | ExternalEditSource;
 
 export class InlineSuggestEditSource extends EditSourceBase {
 	public readonly category = 'ai';
@@ -159,6 +161,15 @@ class ChatEditSource extends EditSourceBase {
 	) { super(); }
 
 	override toString() { return `${this.category}/${this.feature}/${this.kind}`; }
+
+	public getColor(): string { return '#00ff0066'; }
+}
+
+class AgentHostEditSource extends EditSourceBase {
+	public readonly category = 'agentHost';
+	public readonly feature = 'chat';
+
+	override toString() { return `${this.category}/${this.feature}`; }
 
 	public getColor(): string { return '#00ff0066'; }
 }

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
@@ -17,6 +17,7 @@ import { buildCancelEditAttributionResource, buildCommitEditAttributionResource,
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
 import { EditTelemetryTrigger } from '../../../../../platform/telemetry/common/editTelemetry.js';
+import { EditSources, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 
 const MARKER_TTL = 5 * 60 * 1000;
 const ROUTE_TTL = 10 * 60 * 60 * 1000;
@@ -48,8 +49,8 @@ interface IExternalObservation {
 	readonly id: string;
 	readonly beforeDigest: string;
 	readonly afterDigest: string;
-	readonly timestamp: number;
-	suppressed: boolean;
+	referenceCount: number;
+	resolution?: IExternalEditCorrelationResolution;
 }
 
 interface IAgentHostResourceRoute {
@@ -88,10 +89,18 @@ export interface IAgentHostEditMarkerService {
 
 export interface IExternalEditCorrelation {
 	readonly onDidSuppress: Event<string>;
+	readonly onDidResolve?: Event<IExternalEditCorrelationResolution>;
 	readonly onDidInvalidate: Event<string>;
 	register(before: string, after: string): string;
 	isSuppressed(id: string): boolean;
+	getResolution?(id: string): IExternalEditCorrelationResolution | undefined;
+	waitForResolution?(ids: readonly string[], timeoutMs: number): Promise<void>;
 	release(id: string): void;
+}
+
+export interface IExternalEditCorrelationResolution {
+	readonly id: string;
+	readonly source?: TextModelEditSource;
 }
 
 export class AgentHostEditMarkerService extends Disposable implements IAgentHostEditMarkerService {
@@ -102,6 +111,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 	private readonly _acknowledgedCoverageGapIds = new Map<string, number>();
 	private readonly _pendingCoverageGapAcknowledgements = new Map<string, { readonly acknowledgements: readonly IEditAttributionCoverageGapAcknowledgement[]; readonly timestamp: number }>();
 	private readonly _onDidSuppress = this._register(new Emitter<string>());
+	private readonly _onDidResolve = this._register(new Emitter<IExternalEditCorrelationResolution>());
 	private readonly _onDidInvalidate = this._register(new Emitter<string>());
 	private readonly _onDidReceiveMarker = this._register(new Emitter<{ readonly resourceKey: string; readonly connection: IAgentConnection; readonly sequence: number }>());
 	private readonly _connectionListeners = this._register(new DisposableStore());
@@ -117,11 +127,31 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 
 	createCorrelation(resource: URI): IExternalEditCorrelation {
 		const resourceKey = this._key(resource);
+		let currentRegistration: { readonly before: string; readonly after: string; readonly id: string } | undefined;
+		let clearRegistrationScheduled = false;
 		return {
 			onDidSuppress: this._onDidSuppress.event,
+			onDidResolve: this._onDidResolve.event,
 			onDidInvalidate: this._onDidInvalidate.event,
-			register: (before, after) => this._registerObservation(resourceKey, before, after),
-			isSuppressed: id => this._observations.get(resourceKey)?.some(observation => observation.id === id && observation.suppressed) ?? false,
+			register: (before, after) => {
+				if (currentRegistration?.before === before && currentRegistration.after === after) {
+					this._retainObservation(resourceKey, currentRegistration.id);
+					return currentRegistration.id;
+				}
+				const id = this._registerObservation(resourceKey, before, after);
+				currentRegistration = { before, after, id };
+				if (!clearRegistrationScheduled) {
+					clearRegistrationScheduled = true;
+					queueMicrotask(() => {
+						currentRegistration = undefined;
+						clearRegistrationScheduled = false;
+					});
+				}
+				return id;
+			},
+			isSuppressed: id => this._getObservation(resourceKey, id)?.resolution !== undefined,
+			getResolution: id => this._getObservation(resourceKey, id)?.resolution,
+			waitForResolution: (ids, timeoutMs) => this._waitForResolution(resourceKey, ids, timeoutMs),
 			release: id => this._releaseObservation(resourceKey, id),
 		};
 	}
@@ -480,19 +510,15 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			id: generateUuid(),
 			beforeDigest: createFileEditContentDigest(before),
 			afterDigest: createFileEditContentDigest(after),
-			timestamp: Date.now(),
-			suppressed: false,
+			referenceCount: 1,
 		};
 		const observations = this._observations.get(resourceKey) ?? [];
-		observations.push(observation);
-		while (observations.length > MAX_OBSERVATIONS_PER_RESOURCE) {
-			const removed = observations.shift();
-			if (removed?.suppressed) {
-				this._onDidInvalidate.fire(removed.id);
-			}
+		if (observations.length >= MAX_OBSERVATIONS_PER_RESOURCE) {
+			return observation.id;
 		}
+		observations.push(observation);
 		this._observations.set(resourceKey, observations);
-		this._trySuppress(resourceKey, observation);
+		this._tryResolve(resourceKey, observation);
 		return observation.id;
 	}
 
@@ -509,12 +535,12 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			this._markers.set(resourceKey, markers);
 		}
 		for (const observation of this._observations.get(resourceKey) ?? []) {
-			this._trySuppress(resourceKey, observation);
+			this._tryResolve(resourceKey, observation);
 		}
 	}
 
-	private _trySuppress(resourceKey: string, observation: IExternalObservation): void {
-		if (observation.suppressed) {
+	private _tryResolve(resourceKey: string, observation: IExternalObservation): void {
+		if (observation.resolution) {
 			return;
 		}
 		const markers = this._markers.get(resourceKey);
@@ -546,7 +572,19 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			if (afterDigest !== observation.afterDigest) {
 				continue;
 			}
-			observation.suppressed = true;
+			const sources = consumed.map(index => markers[index].source);
+			const firstSource = sources[0];
+			const source = firstSource && sources.every(candidate =>
+				candidate !== undefined &&
+				candidate.modelId === firstSource.modelId &&
+				candidate.harness === firstSource.harness
+			) ? EditSources.agentHostChatApplyEdits({
+				modelId: firstSource.modelId,
+				sessionId: firstSource.conversationId,
+				requestId: firstSource.requestId,
+				harness: firstSource.harness,
+			}) : undefined;
+			observation.resolution = { id: observation.id, source };
 			for (const index of consumed.toSorted((a, b) => b - a)) {
 				markers.splice(index, 1);
 			}
@@ -554,7 +592,15 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 				this._markers.delete(resourceKey);
 			}
 			this._onDidSuppress.fire(observation.id);
+			this._onDidResolve.fire(observation.resolution);
 			return;
+		}
+	}
+
+	private _retainObservation(resourceKey: string, id: string): void {
+		const observation = this._getObservation(resourceKey, id);
+		if (observation) {
+			observation.referenceCount++;
 		}
 	}
 
@@ -565,7 +611,11 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 		}
 		const index = observations.findIndex(observation => observation.id === id);
 		if (index >= 0) {
-			observations.splice(index, 1);
+			const observation = observations[index];
+			observation.referenceCount--;
+			if (observation.referenceCount <= 0) {
+				observations.splice(index, 1);
+			}
 		}
 		if (observations.length === 0) {
 			this._observations.delete(resourceKey);
@@ -587,7 +637,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			return;
 		}
 		for (const observation of observations) {
-			if (observation.suppressed) {
+			if (observation.resolution) {
 				this._onDidInvalidate.fire(observation.id);
 			}
 		}
@@ -603,7 +653,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 		} else {
 			this._markers.delete(resourceKey);
 		}
-		const observations = this._observations.get(resourceKey)?.filter(observation => observation.suppressed || observation.timestamp >= minimumTimestamp);
+		const observations = this._observations.get(resourceKey)?.filter(observation => observation.referenceCount > 0);
 		if (observations?.length) {
 			this._observations.set(resourceKey, observations);
 		} else {
@@ -631,6 +681,35 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			? URI.from({ scheme: Schemas.file, path: resource.path })
 			: resource;
 		return this._uriIdentityService.extUri.getComparisonKey(this._uriIdentityService.asCanonicalUri(normalizedResource));
+	}
+
+	private _getObservation(resourceKey: string, id: string): IExternalObservation | undefined {
+		return this._observations.get(resourceKey)?.find(observation => observation.id === id);
+	}
+
+	private async _waitForResolution(resourceKey: string, ids: readonly string[], timeoutMs: number): Promise<void> {
+		const unresolved = new Set(ids.filter(id => {
+			const observation = this._getObservation(resourceKey, id);
+			return observation !== undefined && observation.resolution === undefined;
+		}));
+		if (unresolved.size === 0) {
+			return;
+		}
+		const store = new DisposableStore();
+		try {
+			await raceTimeout(new Promise<void>(resolve => {
+				const complete = (id: string) => {
+					unresolved.delete(id);
+					if (unresolved.size === 0) {
+						resolve();
+					}
+				};
+				store.add(this._onDidResolve.event(resolution => complete(resolution.id)));
+				store.add(this._onDidInvalidate.event(complete));
+			}), timeoutMs);
+		} finally {
+			store.dispose();
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/agentHostEditMarkerService.ts
@@ -49,6 +49,7 @@ interface IExternalObservation {
 	readonly id: string;
 	readonly beforeDigest: string;
 	readonly afterDigest: string;
+	readonly timestamp: number;
 	referenceCount: number;
 	resolution?: IExternalEditCorrelationResolution;
 }
@@ -510,6 +511,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 			id: generateUuid(),
 			beforeDigest: createFileEditContentDigest(before),
 			afterDigest: createFileEditContentDigest(after),
+			timestamp: Date.now(),
 			referenceCount: 1,
 		};
 		const observations = this._observations.get(resourceKey) ?? [];
@@ -653,7 +655,7 @@ export class AgentHostEditMarkerService extends Disposable implements IAgentHost
 		} else {
 			this._markers.delete(resourceKey);
 		}
-		const observations = this._observations.get(resourceKey)?.filter(observation => observation.referenceCount > 0);
+		const observations = this._observations.get(resourceKey)?.filter(observation => observation.resolution !== undefined || observation.timestamp >= minimumTimestamp);
 		if (observations?.length) {
 			this._observations.set(resourceKey, observations);
 		} else {

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editSourceTrackingImpl.ts
@@ -23,7 +23,9 @@ import { IScmRepoAdapter, ScmAdapter } from './scmAdapter.js';
 import { IRandomService } from '../randomService.js';
 import { AgentHostEditAttributionDeferredError, AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService, IPreparedAgentHostEditAttributionFlush } from './agentHostEditMarkerService.js';
 
-export type EditTelemetryCategory = 'nes' | 'inlineCompletionsCopilot' | 'inlineCompletionsNES' | 'inlineCompletionsOther' | 'otherAI' | 'user' | 'ide' | 'external' | 'unknown';
+const FOCUS_CORRELATION_DRAIN_TIMEOUT = 1_000;
+
+export type EditTelemetryCategory = 'nes' | 'inlineCompletionsCopilot' | 'inlineCompletionsNES' | 'inlineCompletionsOther' | 'otherAI' | 'agentHost' | 'user' | 'ide' | 'external' | 'unknown';
 
 export function getEditTelemetryCategory(source: EditSource): EditTelemetryCategory {
 	if (source.category === 'ai' && source.kind === 'nes') { return 'nes'; }
@@ -34,6 +36,7 @@ export function getEditTelemetryCategory(source: EditSource): EditTelemetryCateg
 	if (source.category === 'ai' && source.kind === 'completion') { return 'inlineCompletionsOther'; }
 
 	if (source.category === 'ai') { return 'otherAI'; }
+	if (source.category === 'agentHost') { return 'agentHost'; }
 	if (source.category === 'user') { return 'user'; }
 	if (source.category === 'ide') { return 'ide'; }
 	if (source.category === 'external') { return 'external'; }
@@ -95,13 +98,13 @@ class TrackedDocumentInfo extends Disposable {
 			if (!this._statsEnabled.read(reader)) { return undefined; }
 			longtermResetSignal.read(reader);
 
-			const t = reader.store.add(new DocumentEditSourceTracker(docWithJustReason, undefined, externalEditCorrelation));
+			const t = new DocumentEditSourceTracker(docWithJustReason, undefined, externalEditCorrelation);
 			const startFocusTime = this._userAttentionService.totalFocusTimeMs;
 			const startTime = Date.now();
 			reader.store.add(toDisposable(() => {
 				// send long term document telemetry
+				t.stopTracking();
 				this._sendTelemetryAndLog('longterm', longtermReason, t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
-				t.dispose();
 			}));
 			return t;
 		}).recomputeInitiallyAndOnChange(this._store);
@@ -150,13 +153,13 @@ class TrackedDocumentInfo extends Disposable {
 				resetSignal.trigger(undefined);
 			}));
 
-			const t = reader.store.add(new DocumentEditSourceTracker(docWithJustReason, undefined));
+			const t = new DocumentEditSourceTracker(docWithJustReason, undefined, externalEditCorrelation, 'reattribute');
 			const startFocusTime = this._userAttentionService.totalFocusTimeMs;
 			const startTime = Date.now();
-			reader.store.add(toDisposable(async () => {
+			reader.store.add(toDisposable(() => {
 				// send windowed document telemetry
+				t.stopTracking();
 				this._sendTelemetryAndLog('10minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
-				t.dispose();
 			}));
 
 			return t;
@@ -178,13 +181,13 @@ class TrackedDocumentInfo extends Disposable {
 				focusResetSignal.trigger(undefined);
 			}));
 
-			const t = reader.store.add(new DocumentEditSourceTracker(docWithJustReason, undefined));
+			const t = new DocumentEditSourceTracker(docWithJustReason, undefined, externalEditCorrelation, 'reattribute');
 			const startFocusTime = this._userAttentionService.totalFocusTimeMs;
 			const startTime = Date.now();
-			reader.store.add(toDisposable(async () => {
+			reader.store.add(toDisposable(() => {
 				// send focus-windowed document telemetry
+				t.stopTracking();
 				this._sendTelemetryAndLog('20minFocusWindow', 'time', t, this._userAttentionService.totalFocusTimeMs - startFocusTime, Date.now() - startTime);
-				t.dispose();
 			}));
 
 			return t;
@@ -197,10 +200,14 @@ class TrackedDocumentInfo extends Disposable {
 			this._logService.error(`[EditSourceTrackingImpl] Failed to send ${mode} edit telemetry: ${error}`);
 		}).finally(() => {
 			tracker.releaseExternalEditCorrelations();
+			tracker.dispose();
 		});
 	}
 
 	async sendTelemetry(mode: EditTelemetryMode, trigger: EditTelemetryTrigger, t: DocumentEditSourceTracker, focusTime: number, actualTime: number) {
+		if (mode !== 'longterm') {
+			await t.waitForExternalEditCorrelations(FOCUS_CORRELATION_DRAIN_TIMEOUT);
+		}
 		t.applyPendingExternalEdits();
 		let ranges = t.getTrackedRanges();
 		let internalKeys = t.getAllKeys();
@@ -247,11 +254,11 @@ class TrackedDocumentInfo extends Disposable {
 		const coverageGap = mode === 'longterm' && !isDirty && !deferSuppressedExternal && !preparedAgentFlush?.deferCoverageGap
 			? this._agentHostEditMarkerService?.takeCoverageGap?.(this._doc.document.uri, preparedAgentFlush?.coverageGapThroughSequence ?? preparedAgentFlush?.lastSequence)
 			: undefined;
-		const agentModifiedCount = preparedAgentFlush?.agentModifiedCount ?? 0;
+		const agentModifiedCount = mode === 'longterm' ? preparedAgentFlush?.agentModifiedCount ?? 0 : data.agentHostModifiedCount;
 		if (internalKeys.length === 0 && agentModifiedCount === 0 && !coverageGap) {
 			return;
 		}
-		const totalModifiedCount = data.totalModifiedCharactersInFinalState + agentModifiedCount;
+		const totalModifiedCount = data.totalModifiedCharactersInFinalState + (preparedAgentFlush?.agentModifiedCount ?? 0);
 
 		const telemetryKeys = new Map<string, {
 			readonly representative: TextModelEditSource;
@@ -299,8 +306,8 @@ class TrackedDocumentInfo extends Disposable {
 				statsUuid: statsUuid,
 				conversationId: repr.props.$$sessionId,
 				requestId: repr.props.$$requestId,
-				origin: undefined,
-				harness: undefined,
+				origin: repr.props.$origin,
+				harness: repr.props.$harness,
 				modifiedCount: value,
 				deltaModifiedCount: deltaModifiedCount,
 				totalModifiedCount,
@@ -345,6 +352,7 @@ class TrackedDocumentInfo extends Disposable {
 			inlineCompletionsCopilotModifiedCount: sums.inlineCompletionsCopilot ?? 0,
 			inlineCompletionsNESModifiedCount: sums.inlineCompletionsNES ?? 0,
 			otherAIModifiedCount: sums.otherAI ?? 0,
+			agentHostModifiedCount: sums.agentHost ?? 0,
 			userModifiedCount: sums.user ?? 0,
 			ideModifiedCount: sums.ide ?? 0,
 			unknownModifiedCount: sums.unknown ?? 0,

--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/editTracker.ts
@@ -4,15 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { observableSignal, runOnChange, IReader } from '../../../../../base/common/observable.js';
 import { AnnotatedStringEdit } from '../../../../../editor/common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
-import { IDocumentWithAnnotatedEdits, EditKeySourceData, EditSource } from '../helpers/documentWithAnnotatedEdits.js';
-import { IExternalEditCorrelation } from './agentHostEditMarkerService.js';
+import { IDocumentWithAnnotatedEdits, EditKeySourceData, EditSource, EditSourceBase } from '../helpers/documentWithAnnotatedEdits.js';
+import { IExternalEditCorrelation, IExternalEditCorrelationResolution } from './agentHostEditMarkerService.js';
 
 const EXTERNAL_OBSERVATION_KEY_PREFIX = 'external-observation:';
+export type ExternalEditCorrelationPolicy = 'suppress' | 'reattribute';
 
 /**
  * Tracks a single document.
@@ -22,21 +23,24 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 	private _pendingExternalEdits: AnnotatedStringEdit<EditKeySourceData> = AnnotatedStringEdit.empty;
 
 	private readonly _update = observableSignal(this);
+	private readonly _documentStore = this._register(new DisposableStore());
 	private readonly _representativePerKey: Map<string, TextModelEditSource> = new Map();
 	private readonly _sumAddedCharactersPerKey: Map</* key */string, number> = new Map();
 	private readonly _externalObservationIds = new Set<string>();
 	private readonly _ignoredInitialExternalObservationIds = new Set<string>();
 	private readonly _suppressedExternalObservationIds = new Set<string>();
 	private readonly _invalidatedExternalObservationIds = new Set<string>();
+	private readonly _reattributedExternalObservations = new Map<string, TextModelEditSource>();
 
 	constructor(
 		private readonly _doc: IDocumentWithAnnotatedEdits,
 		public readonly data: T,
 		private readonly _externalEditCorrelation?: IExternalEditCorrelation,
+		private readonly _externalEditCorrelationPolicy: ExternalEditCorrelationPolicy = 'suppress',
 	) {
 		super();
 
-		this._register(runOnChange(this._doc.value, (_val, _prevVal, edits) => {
+		this._documentStore.add(runOnChange(this._doc.value, (_val, _prevVal, edits) => {
 			let eComposed = AnnotatedStringEdit.compose(edits.map(e => e.edit));
 			if (eComposed.replacements.every(e => e.data.source.category === 'external')) {
 				if (this._edits.isEmpty() && !this._externalEditCorrelation) {
@@ -45,11 +49,14 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 					if (this._externalEditCorrelation) {
 						const observationId = this._externalEditCorrelation.register(_prevVal.value, _val.value);
 						this._externalObservationIds.add(observationId);
-						if (this._externalEditCorrelation.isSuppressed(observationId)) {
-							this._suppressedExternalObservationIds.add(observationId);
-						}
 						if (this._edits.isEmpty()) {
 							this._ignoredInitialExternalObservationIds.add(observationId);
+						}
+						const resolution = this._externalEditCorrelation.getResolution?.(observationId);
+						if (resolution) {
+							this._resolveExternalObservation(resolution);
+						} else if (this._externalEditCorrelationPolicy === 'suppress' && this._externalEditCorrelation.isSuppressed(observationId)) {
+							this._suppressedExternalObservationIds.add(observationId);
 						}
 						const key = `${EXTERNAL_OBSERVATION_KEY_PREFIX}${observationId}`;
 						eComposed = eComposed.mapData(replacement => new EditKeySourceData(key, replacement.data.source, replacement.data.representative));
@@ -68,15 +75,20 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 			this._update.trigger(undefined);
 		}));
 		if (this._externalEditCorrelation) {
-			this._register(this._externalEditCorrelation.onDidSuppress(observationId => {
-				if (this._externalObservationIds.has(observationId)) {
-					this._suppressedExternalObservationIds.add(observationId);
-					this._update.trigger(undefined);
-				}
-			}));
+			if (this._externalEditCorrelation.onDidResolve) {
+				this._register(this._externalEditCorrelation.onDidResolve(resolution => this._resolveExternalObservation(resolution)));
+			} else {
+				this._register(this._externalEditCorrelation.onDidSuppress(observationId => {
+					if (this._externalObservationIds.has(observationId) && this._externalEditCorrelationPolicy === 'suppress') {
+						this._suppressedExternalObservationIds.add(observationId);
+						this._update.trigger(undefined);
+					}
+				}));
+			}
 			this._register(this._externalEditCorrelation.onDidInvalidate(observationId => {
 				if (this._externalObservationIds.has(observationId)) {
 					this._suppressedExternalObservationIds.delete(observationId);
+					this._reattributedExternalObservations.delete(observationId);
 					this._invalidatedExternalObservationIds.add(observationId);
 					this._update.trigger(undefined);
 				}
@@ -89,6 +101,14 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 			this._externalEditCorrelation?.release(observationId);
 		}
 		this._externalObservationIds.clear();
+	}
+
+	public stopTracking(): void {
+		this._documentStore.clear();
+	}
+
+	public async waitForExternalEditCorrelations(timeoutMs: number): Promise<void> {
+		await this._externalEditCorrelation?.waitForResolution?.(Array.from(this._externalObservationIds), timeoutMs);
 	}
 
 	private _applyEdit(e: AnnotatedStringEdit<EditKeySourceData>): void {
@@ -122,6 +142,10 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 	}
 
 	public getRepresentative(key: string): TextModelEditSource | undefined {
+		const observationId = getExternalObservationId(key);
+		if (observationId) {
+			return this._reattributedExternalObservations.get(observationId) ?? this._representativePerKey.get(key);
+		}
 		return this._representativePerKey.get(key);
 	}
 
@@ -139,7 +163,9 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 		const ranges = this._edits.getNewRanges();
 		return ranges.map((r, idx) => {
 			const e = this._edits.replacements[idx];
-			const te = new TrackedEdit(e.replaceRange, r, e.data.key, e.data.source, e.data.representative);
+			const representative = this.getRepresentative(e.data.key) ?? e.data.representative;
+			const source = representative === e.data.representative ? e.data.source : EditSourceBase.create(representative);
+			const te = new TrackedEdit(e.replaceRange, r, e.data.key, source, representative);
 			return te;
 		}).filter(edit => this._shouldIncludeKey(edit.sourceKey, includeSuppressed));
 	}
@@ -149,18 +175,37 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 	}
 
 	private _shouldIncludeKey(key: string, includeSuppressed: boolean): boolean {
-		if (!key.startsWith(EXTERNAL_OBSERVATION_KEY_PREFIX)) {
+		const observationId = getExternalObservationId(key);
+		if (!observationId) {
 			return true;
 		}
-		const observationId = key.substring(EXTERNAL_OBSERVATION_KEY_PREFIX.length);
+		if (this._reattributedExternalObservations.has(observationId)) {
+			return true;
+		}
 		if (this._invalidatedExternalObservationIds.has(observationId)) {
 			return true;
 		}
 		const isSuppressed = this._suppressedExternalObservationIds.has(observationId);
 		if (this._ignoredInitialExternalObservationIds.has(observationId)) {
+			if (this._externalEditCorrelationPolicy === 'reattribute') {
+				return true;
+			}
 			return includeSuppressed && isSuppressed;
 		}
 		return includeSuppressed || !isSuppressed;
+	}
+
+	private _resolveExternalObservation(resolution: IExternalEditCorrelationResolution): void {
+		if (!this._externalObservationIds.has(resolution.id)) {
+			return;
+		}
+		this._invalidatedExternalObservationIds.delete(resolution.id);
+		if (this._externalEditCorrelationPolicy === 'suppress') {
+			this._suppressedExternalObservationIds.add(resolution.id);
+		} else if (resolution.source) {
+			this._reattributedExternalObservations.set(resolution.id, resolution.source);
+		}
+		this._update.trigger(undefined);
 	}
 
 	public _getDebugVisualization() {
@@ -178,6 +223,10 @@ export class DocumentEditSourceTracker<T = void> extends Disposable {
 			})
 		};
 	}
+}
+
+function getExternalObservationId(key: string): string | undefined {
+	return key.startsWith(EXTERNAL_OBSERVATION_KEY_PREFIX) ? key.substring(EXTERNAL_OBSERVATION_KEY_PREFIX.length) : undefined;
 }
 
 export class TrackedEdit {

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
@@ -14,11 +14,11 @@ import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelSc
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostConnectionsService } from '../../../../../platform/agentHost/common/agentHostConnectionsService.js';
 import { toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
-import { AttributedToolResultFileEditContent, createFileEditContentDigest, EditAttributionFlushOutcome, FILE_EDIT_ATTRIBUTION_PROPERTY, IEditAttributionCoverageGapAcknowledgement, IFileEditAttributionMarker, parseEditAttributionResource } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
+import { createFileEditContentDigest, EditAttributionFlushOutcome, FILE_EDIT_ATTRIBUTION_PROPERTY, IEditAttributionCoverageGapAcknowledgement, IFileEditAttributionMarker, parseEditAttributionResource } from '../../../../../platform/agentHost/common/fileEditAttribution.js';
 import { ActionType } from '../../../../../platform/agentHost/common/state/protocol/common/actions.js';
 import { ContentEncoding } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ActionEnvelope } from '../../../../../platform/agentHost/common/state/sessionActions.js';
-import { ToolResultContentType } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { ToolResultContentType, ToolResultFileEditContent } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { AgentHostEditAttributionDeferredError, AgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
@@ -102,6 +102,24 @@ suite('Agent Host Edit Marker Service', () => {
 		});
 	});
 
+	test('rejects null marker source metadata without disrupting action processing', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		const observation = correlation.register('a', 'ab');
+
+		const malformedMarker = {
+			version: 1,
+			editId: 'edit-null-source',
+			sequence: 1,
+			beforeDigest: createFileEditContentDigest('a'),
+			afterDigest: createFileEditContentDigest('ab'),
+			source: null,
+		};
+		context.fireRawMarker(malformedMarker);
+
+		assert.strictEqual(correlation.isSuppressed(observation), false);
+	});
+
 	test('does not evict active observations when the cap is reached', () => {
 		const context = createContext();
 		const correlation = context.service.createCorrelation(context.resource);
@@ -120,6 +138,31 @@ suite('Agent Host Edit Marker Service', () => {
 			suppressedIds: [first],
 		});
 	});
+
+	test('does not match an observation after its marker TTL expires', () => runWithFakedTimers({}, async () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		const observation = correlation.register('a', 'ab');
+		await timeout(5 * 60 * 1000 + 1);
+
+		context.fireMarker(marker(1, 'a', 'ab'));
+
+		assert.strictEqual(correlation.isSuppressed(observation), false);
+	}));
+
+	test('recovers observation capacity after unresolved observations expire', () => runWithFakedTimers({}, async () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		for (let index = 0; index < 128; index++) {
+			correlation.register(`before-${index}`, `after-${index}`);
+		}
+		await timeout(5 * 60 * 1000 + 1);
+
+		const observation = correlation.register('current-before', 'current-after');
+		context.fireMarker(marker(1, 'current-before', 'current-after'));
+
+		assert.strictEqual(correlation.isSuppressed(observation), true);
+	}));
 
 	test('does not report expired coverage gaps', () => runWithFakedTimers({}, async () => {
 		const context = createContext();
@@ -693,7 +736,10 @@ suite('Agent Host Edit Marker Service', () => {
 			invalidatedIds,
 			resourceReads,
 			fireMarker(attribution: IFileEditAttributionMarker) {
-				const content: AttributedToolResultFileEditContent = {
+				this.fireRawMarker(attribution);
+			},
+			fireRawMarker(attribution: object & { readonly sequence: number }) {
+				const content: ToolResultFileEditContent = {
 					type: ToolResultContentType.FileEdit,
 					before: {
 						uri: resource.toString(),
@@ -703,8 +749,8 @@ suite('Agent Host Edit Marker Service', () => {
 						uri: resource.toString(),
 						content: { uri: 'session-db:/after' },
 					},
-					[FILE_EDIT_ATTRIBUTION_PROPERTY]: attribution,
 				};
+				Object.assign(content, { [FILE_EDIT_ATTRIBUTION_PROPERTY]: attribution });
 				actionEmitter.fire({
 					channel: 'ahp-chat:copilot%3A%2Fsession',
 					serverSeq: attribution.sequence,

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/agentHostEditMarkerService.test.ts
@@ -46,6 +46,36 @@ suite('Agent Host Edit Marker Service', () => {
 		});
 	});
 
+	test('shares one resolved attribution with all active consumers', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		const first = correlation.register('a', 'ab');
+		const second = correlation.register('a', 'ab');
+		correlation.release(first);
+
+		context.fireMarker(marker(1, 'a', 'ab', {
+			modelId: 'gpt-5',
+			conversationId: 'session-1',
+			requestId: 'turn-1',
+			harness: 'copilotcli',
+		}));
+
+		const resolution = correlation.getResolution?.(second);
+		assert.deepStrictEqual({
+			sharedObservation: first === second,
+			suppressed: correlation.isSuppressed(second),
+			sourceKey: resolution?.source?.toKey(1),
+			sessionId: resolution?.source?.props.$$sessionId,
+			requestId: resolution?.source?.props.$$requestId,
+		}, {
+			sharedObservation: true,
+			suppressed: true,
+			sourceKey: 'source:Chat.applyEdits-$modelId:gpt-5-$harness:copilotcli-$origin:agentHost',
+			sessionId: 'session-1',
+			requestId: 'turn-1',
+		});
+	});
+
 	test('records oversized Agent edits as coverage gaps without suppressing reloads', () => {
 		const context = createContext();
 		const correlation = context.service.createCorrelation(context.resource);
@@ -69,6 +99,25 @@ suite('Agent Host Edit Marker Service', () => {
 				editCount: 1,
 				insertedCount: 42,
 			},
+		});
+	});
+
+	test('does not evict active observations when the cap is reached', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		const first = correlation.register('before-0', 'after-0');
+		for (let index = 1; index <= 128; index++) {
+			correlation.register(`before-${index}`, `after-${index}`);
+		}
+
+		context.fireMarker(marker(1, 'before-0', 'after-0'));
+
+		assert.deepStrictEqual({
+			firstSuppressed: correlation.isSuppressed(first),
+			suppressedIds: context.suppressedIds,
+		}, {
+			firstSuppressed: true,
+			suppressedIds: [first],
 		});
 	});
 
@@ -226,6 +275,42 @@ suite('Agent Host Edit Marker Service', () => {
 		}, {
 			suppressed: false,
 			suppressedIds: [],
+		});
+	});
+
+	test('uses metadata from the matching repeated digest cycle', () => {
+		const context = createContext();
+		const correlation = context.service.createCorrelation(context.resource);
+		context.fireMarker(marker(1, 'a', 'ab', {
+			modelId: 'old-model',
+			conversationId: 'old-session',
+			requestId: 'old-turn',
+			harness: 'copilotcli',
+		}));
+		context.fireMarker(marker(2, 'ab', 'a', {
+			modelId: 'old-model',
+			conversationId: 'old-session',
+			requestId: 'old-turn',
+			harness: 'copilotcli',
+		}));
+		context.fireMarker(marker(3, 'a', 'ab', {
+			modelId: 'new-model',
+			conversationId: 'new-session',
+			requestId: 'new-turn',
+			harness: 'claude',
+		}));
+
+		const observation = correlation.register('a', 'ab');
+		const resolution = correlation.getResolution?.(observation);
+
+		assert.deepStrictEqual({
+			sourceKey: resolution?.source?.toKey(1),
+			sessionId: resolution?.source?.props.$$sessionId,
+			requestId: resolution?.source?.props.$$requestId,
+		}, {
+			sourceKey: 'source:Chat.applyEdits-$modelId:new-model-$harness:claude-$origin:agentHost',
+			sessionId: 'new-session',
+			requestId: 'new-turn',
 		});
 	});
 
@@ -640,12 +725,18 @@ suite('Agent Host Edit Marker Service', () => {
 	}
 });
 
-function marker(sequence: number, before: string, after: string): IFileEditAttributionMarker {
+function marker(sequence: number, before: string, after: string, source?: {
+	readonly modelId?: string;
+	readonly conversationId: string;
+	readonly requestId: string;
+	readonly harness: string;
+}): IFileEditAttributionMarker {
 	return {
 		version: 1,
 		editId: `edit-${sequence}`,
 		sequence,
 		beforeDigest: createFileEditContentDigest(before),
 		afterDigest: createFileEditContentDigest(after),
+		source,
 	};
 }

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editSourceTrackingImpl.test.ts
@@ -13,7 +13,7 @@ import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelSc
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { computeStringDiff } from '../../../../../editor/common/services/editorWebWorker.js';
-import { EditSources, EditSuggestionId } from '../../../../../editor/common/textModelEditSource.js';
+import { EditSources, EditSuggestionId, TextModelEditSource } from '../../../../../editor/common/textModelEditSource.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
@@ -25,7 +25,7 @@ import { DiffService } from '../../browser/helpers/documentWithAnnotatedEdits.js
 import { StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
 import { IAiEditTelemetryService } from '../../browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { EditSourceTrackingImpl } from '../../browser/telemetry/editSourceTrackingImpl.js';
-import { AgentHostEditAttributionDeferredError, AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService } from '../../browser/telemetry/agentHostEditMarkerService.js';
+import { AgentHostEditAttributionDeferredError, AgentHostEditAttributionUnknownOutcomeError, IAgentHostEditMarkerService, IExternalEditCorrelation, IExternalEditCorrelationResolution } from '../../browser/telemetry/agentHostEditMarkerService.js';
 import { IScmRepoAdapter, ScmAdapter } from '../../browser/telemetry/scmAdapter.js';
 import { IRandomService } from '../../browser/randomService.js';
 import { MutableObservableWorkspace } from './editTelemetry.test.js';
@@ -160,6 +160,187 @@ suite('Edit Source Tracking Windows', () => {
 		}
 		assert.ok(visibleAgainState.windowedTracker.get());
 		assert.notStrictEqual(visibleAgainState.windowedTracker.get(), firstWindowedTracker);
+
+		context.disposables.dispose();
+	}));
+
+	test('fans out Agent Host reload attribution to both focus windows', () => runWithFakedTimers({}, async () => {
+		const visible = observableValue('visible', true);
+		const correlation = new TestExternalEditCorrelation();
+		let prepareCount = 0;
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => correlation,
+			prepareFlush: async () => {
+				prepareCount++;
+				return undefined;
+			},
+		};
+		const context = setup(visible, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		correlation.resolve(EditSources.agentHostChatApplyEdits({
+			modelId: 'gpt-5',
+			sessionId: 'session-1',
+			requestId: 'turn-1',
+			harness: 'copilotcli',
+		}));
+		visible.set(false, undefined);
+		await timeout(10);
+
+		const focusDetails = context.allDetails.filter(event => event.mode !== 'longterm');
+		const focusStats = context.allStats.filter(event => event.mode !== 'longterm');
+		assert.deepStrictEqual({
+			details: focusDetails.map(event => ({
+				mode: event.mode,
+				sourceKey: event.sourceKey,
+				sourceKeyCleaned: event.sourceKeyCleaned,
+				origin: event.origin,
+				harness: event.harness,
+				modelId: event.modelId,
+				conversationId: event.conversationId,
+				requestId: event.requestId,
+				modifiedCount: event.modifiedCount,
+				deltaModifiedCount: event.deltaModifiedCount,
+				totalModifiedCount: event.totalModifiedCount,
+			})).sort((a, b) => a.mode.localeCompare(b.mode)),
+			stats: focusStats.map(event => ({
+				mode: event.mode,
+				otherAIModifiedCount: event.otherAIModifiedCount,
+				agentHostModifiedCount: event.agentHostModifiedCount,
+				externalModifiedCount: event.externalModifiedCount,
+				totalModifiedCharacters: event.totalModifiedCharacters,
+			})).sort((a, b) => a.mode.localeCompare(b.mode)),
+			statsUuids: new Set(focusDetails.map(event => event.statsUuid)).size,
+			prepareCount,
+		}, {
+			details: [
+				{
+					mode: '10minFocusWindow',
+					sourceKey: 'source:Chat.applyEdits-$modelId:gpt-5-$harness:copilotcli-$origin:agentHost',
+					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+					origin: 'agentHost',
+					harness: 'copilotcli',
+					modelId: 'gpt-5',
+					conversationId: 'session-1',
+					requestId: 'turn-1',
+					modifiedCount: 8,
+					deltaModifiedCount: 8,
+					totalModifiedCount: 8,
+				},
+				{
+					mode: '20minFocusWindow',
+					sourceKey: 'source:Chat.applyEdits-$modelId:gpt-5-$harness:copilotcli-$origin:agentHost',
+					sourceKeyCleaned: 'source:Chat.applyEdits-$harness:copilotcli-$origin:agentHost',
+					origin: 'agentHost',
+					harness: 'copilotcli',
+					modelId: 'gpt-5',
+					conversationId: 'session-1',
+					requestId: 'turn-1',
+					modifiedCount: 8,
+					deltaModifiedCount: 8,
+					totalModifiedCount: 8,
+				},
+			],
+			stats: [
+				{
+					mode: '10minFocusWindow',
+					otherAIModifiedCount: 0,
+					agentHostModifiedCount: 8,
+					externalModifiedCount: 0,
+					totalModifiedCharacters: 8,
+				},
+				{
+					mode: '20minFocusWindow',
+					otherAIModifiedCount: 0,
+					agentHostModifiedCount: 8,
+					externalModifiedCount: 0,
+					totalModifiedCharacters: 8,
+				},
+			],
+			statsUuids: 2,
+			prepareCount: 0,
+		});
+
+		context.disposables.dispose();
+	}));
+
+	test('drains a late Agent Host marker before focus-window emission', () => runWithFakedTimers({}, async () => {
+		const visible = observableValue('visible', true);
+		const correlation = new TestExternalEditCorrelation(true);
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => correlation,
+			prepareFlush: async () => undefined,
+		};
+		const context = setup(visible, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		visible.set(false, undefined);
+		await timeout(10);
+		assert.strictEqual(context.allDetails.length, 0);
+
+		correlation.resolve(EditSources.agentHostChatApplyEdits({
+			modelId: undefined,
+			sessionId: 'session-1',
+			requestId: 'turn-late',
+			harness: 'claude',
+		}));
+		correlation.completeDrain();
+		await timeout(10);
+
+		assert.deepStrictEqual(context.allDetails.map(event => ({
+			mode: event.mode,
+			harness: event.harness,
+			requestId: event.requestId,
+		})).sort((a, b) => a.mode.localeCompare(b.mode)), [
+			{ mode: '10minFocusWindow', harness: 'claude', requestId: 'turn-late' },
+			{ mode: '20minFocusWindow', harness: 'claude', requestId: 'turn-late' },
+		]);
+
+		context.disposables.dispose();
+	}));
+
+	test('falls back to external attribution after the focus correlation drain times out', () => runWithFakedTimers({}, async () => {
+		const visible = observableValue('visible', true);
+		const correlation = new TestExternalEditCorrelation(true);
+		const markerService: IAgentHostEditMarkerService = {
+			createCorrelation: () => correlation,
+			prepareFlush: async () => undefined,
+		};
+		const context = setup(visible, markerService);
+		await timeout(10);
+
+		context.document.applyEdit(StringEditWithReason.replace(context.document.findRange('hello'), 'external', EditSources.reloadFromDisk()));
+		await timeout(1500);
+		visible.set(false, undefined);
+		await timeout(1_001);
+
+		assert.deepStrictEqual({
+			details: context.allDetails.map(event => ({
+				mode: event.mode,
+				sourceKey: event.sourceKey,
+				modifiedCount: event.modifiedCount,
+				totalModifiedCount: event.totalModifiedCount,
+			})).sort((a, b) => a.mode.localeCompare(b.mode)),
+			stats: context.allStats.map(event => ({
+				mode: event.mode,
+				agentHostModifiedCount: event.agentHostModifiedCount,
+				externalModifiedCount: event.externalModifiedCount,
+				totalModifiedCharacters: event.totalModifiedCharacters,
+			})).sort((a, b) => a.mode.localeCompare(b.mode)),
+		}, {
+			details: [
+				{ mode: '10minFocusWindow', sourceKey: 'source:reloadFromDisk', modifiedCount: 8, totalModifiedCount: 8 },
+				{ mode: '20minFocusWindow', sourceKey: 'source:reloadFromDisk', modifiedCount: 8, totalModifiedCount: 8 },
+			],
+			stats: [
+				{ mode: '10minFocusWindow', agentHostModifiedCount: 0, externalModifiedCount: 8, totalModifiedCharacters: 8 },
+				{ mode: '20minFocusWindow', agentHostModifiedCount: 0, externalModifiedCount: 8, totalModifiedCharacters: 8 },
+			],
+		});
 
 		context.disposables.dispose();
 	}));
@@ -677,6 +858,20 @@ function setup(
 		isIgnored: async () => false,
 	} satisfies IScmRepoAdapter;
 	const details: Array<{ sourceKey: string; trigger: string; requestId: string | undefined; statsUuid: string; modifiedCount: number; deltaModifiedCount: number; totalModifiedCount: number }> = [];
+	const allDetails: Array<{
+		mode: string;
+		sourceKey: string;
+		sourceKeyCleaned: string;
+		origin: string | undefined;
+		harness: string | undefined;
+		modelId: string | undefined;
+		conversationId: string | undefined;
+		requestId: string | undefined;
+		statsUuid: string;
+		modifiedCount: number;
+		deltaModifiedCount: number;
+		totalModifiedCount: number;
+	}> = [];
 	const stats: Array<{
 		statsUuid: string;
 		otherAIModifiedCount: number;
@@ -687,15 +882,22 @@ function setup(
 		agentHostUntrackedEditCount?: number;
 		agentHostUntrackedInsertedCount?: number;
 	}> = [];
+	const allStats: Array<typeof stats[number] & { mode: string }> = [];
 	let uuid = 0;
 	const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(), false, undefined, true));
 	instantiationService.stub(ITelemetryService, {
 		publicLog2(eventName, data) {
 			const eventData = data as { mode?: string } | undefined;
-			if (eventName === 'editTelemetry.editSources.details' && eventData?.mode === 'longterm') {
-				details.push(data as typeof details[number]);
-			} else if (eventName === 'editTelemetry.editSources.stats' && eventData?.mode === 'longterm') {
-				stats.push(data as typeof stats[number]);
+			if (eventName === 'editTelemetry.editSources.details') {
+				allDetails.push(data as typeof allDetails[number]);
+				if (eventData?.mode === 'longterm') {
+					details.push(data as typeof details[number]);
+				}
+			} else if (eventName === 'editTelemetry.editSources.stats') {
+				allStats.push(data as typeof allStats[number]);
+				if (eventData?.mode === 'longterm') {
+					stats.push(data as typeof stats[number]);
+				}
 			}
 		},
 	});
@@ -733,7 +935,7 @@ function setup(
 		languageId: 'typescript',
 	}));
 
-	return { disposables, document, details, stats, headHash, branch, impl };
+	return { disposables, document, details, stats, allDetails, allStats, headHash, branch, impl };
 }
 
 function chatEdit(requestId: string) {
@@ -746,4 +948,47 @@ function chatEdit(requestId: string) {
 		extensionId: undefined,
 		codeBlockSuggestionId: undefined,
 	});
+}
+
+class TestExternalEditCorrelation implements IExternalEditCorrelation {
+	private readonly _onDidSuppress = new Emitter<string>();
+	readonly onDidSuppress = this._onDidSuppress.event;
+	private readonly _onDidResolve = new Emitter<IExternalEditCorrelationResolution>();
+	readonly onDidResolve = this._onDidResolve.event;
+	private readonly _onDidInvalidate = new Emitter<string>();
+	readonly onDidInvalidate = this._onDidInvalidate.event;
+	private readonly _drain = new DeferredPromise<void>();
+	private resolution: IExternalEditCorrelationResolution | undefined;
+
+	constructor(private readonly waitForDrain = false) { }
+
+	register(): string {
+		return 'observation';
+	}
+
+	isSuppressed(): boolean {
+		return this.resolution !== undefined;
+	}
+
+	getResolution(): IExternalEditCorrelationResolution | undefined {
+		return this.resolution;
+	}
+
+	async waitForResolution(_ids: readonly string[], timeoutMs: number): Promise<void> {
+		if (this.waitForDrain) {
+			await Promise.race([this._drain.p, timeout(timeoutMs)]);
+		}
+	}
+
+	release(): void { }
+
+	resolve(source: TextModelEditSource): void {
+		this.resolution = { id: 'observation', source };
+		this._onDidSuppress.fire('observation');
+		this._onDidResolve.fire(this.resolution);
+	}
+
+	completeDrain(): void {
+		this._drain.complete();
+	}
 }

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/editTracker.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/editTracker.test.ts
@@ -14,7 +14,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { EditKeySourceData, EditSourceData, IDocumentWithAnnotatedEdits } from '../../browser/helpers/documentWithAnnotatedEdits.js';
 import { DocumentEditSourceTracker } from '../../browser/telemetry/editTracker.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { IExternalEditCorrelation } from '../../browser/telemetry/agentHostEditMarkerService.js';
+import { IExternalEditCorrelation, IExternalEditCorrelationResolution } from '../../browser/telemetry/agentHostEditMarkerService.js';
 
 suite('DocumentEditSourceTracker', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -176,6 +176,49 @@ suite('DocumentEditSourceTracker', () => {
 			},
 		]);
 	});
+
+	test('reattributes an initial external edit and preserves retention composition', () => {
+		const document = disposables.add(new TestAnnotatedDocument('initial'));
+		const correlation = new TestExternalEditCorrelation();
+		const tracker = disposables.add(new DocumentEditSourceTracker(document, undefined, correlation, 'reattribute'));
+		const agentHost = agentHostEditSource('gpt-5', 'turn-1', 'copilotcli');
+
+		document.apply(StringEdit.replace(OffsetRange.ofLength(7), 'external'), EditSources.reloadFromDisk());
+		tracker.applyPendingExternalEdits();
+		correlation.resolve(correlation.lastObservationId!, agentHost);
+		document.apply(StringEdit.replace(new OffsetRange(0, 3), 'X'), EditSources.cursor({ kind: 'type' }));
+
+		const externalKey = tracker.getAllKeys().find(key => key.startsWith('external-observation:'))!;
+		assert.deepStrictEqual({
+			sourceKey: tracker.getRepresentative(externalKey)?.toKey(1),
+			delta: tracker.getTotalInsertedCharactersCount(externalKey),
+			retained: tracker.getTrackedRanges().filter(range => range.sourceKey === externalKey).reduce((sum, range) => sum + range.range.length, 0),
+			category: tracker.getTrackedRanges().find(range => range.sourceKey === externalKey)?.source.category,
+		}, {
+			sourceKey: 'source:Chat.applyEdits-$modelId:gpt-5-$harness:copilotcli-$origin:agentHost',
+			delta: 8,
+			retained: 5,
+			category: 'agentHost',
+		});
+	});
+
+	test('restores external attribution when reattribution is invalidated', () => {
+		const document = disposables.add(new TestAnnotatedDocument('initial'));
+		const correlation = new TestExternalEditCorrelation();
+		const tracker = disposables.add(new DocumentEditSourceTracker(document, undefined, correlation, 'reattribute'));
+
+		document.apply(StringEdit.replace(OffsetRange.ofLength(7), 'external'), EditSources.reloadFromDisk());
+		tracker.applyPendingExternalEdits();
+		correlation.resolve(correlation.lastObservationId!, agentHostEditSource('gpt-5', 'turn-1', 'copilotcli'));
+		correlation.invalidate(correlation.lastObservationId!);
+
+		assert.deepStrictEqual(snapshot(tracker), [{
+			key: 'external-observation:observation-1',
+			delta: 8,
+			retained: 8,
+			requestId: undefined,
+		}]);
+	});
 });
 
 class TestAnnotatedDocument extends Disposable implements IDocumentWithAnnotatedEdits<EditKeySourceData> {
@@ -209,6 +252,15 @@ function chatEditSource(modelId: string, requestId: string): TextModelEditSource
 	});
 }
 
+function agentHostEditSource(modelId: string, requestId: string, harness: string): TextModelEditSource {
+	return EditSources.agentHostChatApplyEdits({
+		modelId,
+		sessionId: 'session-1',
+		requestId,
+		harness,
+	});
+}
+
 function snapshot(tracker: DocumentEditSourceTracker, includeSuppressed = false): Array<{ key: string; delta: number; retained: number; requestId: string | undefined }> {
 	const retained = new Map<string, number>();
 	for (const range of tracker.getTrackedRanges(undefined, includeSuppressed)) {
@@ -225,9 +277,11 @@ function snapshot(tracker: DocumentEditSourceTracker, includeSuppressed = false)
 class TestExternalEditCorrelation implements IExternalEditCorrelation {
 	private readonly _onDidSuppress = new Emitter<string>();
 	readonly onDidSuppress: Event<string> = this._onDidSuppress.event;
+	private readonly _onDidResolve = new Emitter<IExternalEditCorrelationResolution>();
+	readonly onDidResolve: Event<IExternalEditCorrelationResolution> = this._onDidResolve.event;
 	private readonly _onDidInvalidate = new Emitter<string>();
 	readonly onDidInvalidate: Event<string> = this._onDidInvalidate.event;
-	private readonly _suppressed = new Set<string>();
+	private readonly _resolutions = new Map<string, IExternalEditCorrelationResolution>();
 	private _sequence = 0;
 	lastObservationId: string | undefined;
 
@@ -236,20 +290,37 @@ class TestExternalEditCorrelation implements IExternalEditCorrelation {
 	}
 
 	isSuppressed(id: string): boolean {
-		return this._suppressed.has(id);
+		return this._resolutions.has(id);
+	}
+
+	getResolution(id: string): IExternalEditCorrelationResolution | undefined {
+		return this._resolutions.get(id);
+	}
+
+	waitForResolution(): Promise<void> {
+		return Promise.resolve();
 	}
 
 	release(id: string): void {
-		this._suppressed.delete(id);
+		this._resolutions.delete(id);
 	}
 
 	suppress(id: string): void {
-		this._suppressed.add(id);
+		const resolution = { id };
+		this._resolutions.set(id, resolution);
 		this._onDidSuppress.fire(id);
+		this._onDidResolve.fire(resolution);
+	}
+
+	resolve(id: string, source: TextModelEditSource): void {
+		const resolution = { id, source };
+		this._resolutions.set(id, resolution);
+		this._onDidSuppress.fire(id);
+		this._onDidResolve.fire(resolution);
 	}
 
 	invalidate(id: string): void {
-		this._suppressed.delete(id);
+		this._resolutions.delete(id);
 		this._onDidInvalidate.fire(id);
 	}
 }


### PR DESCRIPTION
## Overview

### What

Attribute model-observed Agent Host file edits in `editTelemetry.editSources.details` for the `10minFocusWindow` and `20minFocusWindow` modes. The existing focus-window lifecycle is unchanged: trackers exist only for documents visible in an editor group, use accumulated workbench attention time, reset independently, and emit partial windows when a tab is hidden or closed.

Agent Host edit markers now carry the normalized provider plus current model, session, and turn metadata. Workbench reload correlation produces one shared result that the long-term tracker uses to suppress its external copy and both active focus trackers use to reclassify the same reload as `Chat.applyEdits`. Focus windows do not call the Agent Host `prepareFlush` / `commitFlush` protocol and do not add a second retained-character count.

Unresolved focus correlations drain asynchronously for up to one second before emission, then remain external. Unresolved observations expire after the existing marker TTL, while resolved results remain available to active consumers. Unopened and headless-only resources continue to receive Agent Host long-term / standalone attribution only.

### Why

Focus windows previously observed Agent Host disk reloads as external edits, or ignored them when the reload was the first edit in a fresh window. This lost the Agent Host source identity for files that were open in the workbench even though the model transition was already represented in the focus tracker.

This preserves the existing focus-window query surface and totals while moving matched retained characters from external attribution to the Agent Host source that produced them. Long-term ownership, standalone Agent Host attribution, visibility semantics, attention-time semantics, and telemetry volume limits remain unchanged.

---

## Property-by-property parity

Legend: ✅ = same source identity / semantics, ≈ = intentionally window-scoped, ⊗ = unavailable.

| Field | Agent Host long-term source | Focus-window source | Parity |
|---|---|---|---|
| `sourceKey` | `Chat.applyEdits` with model, normalized harness, and `origin=agentHost` | Same identity constructed from the matched marker | ✅ |
| `sourceKeyCleaned` | Model-independent Agent Host source key | Same cleaned identity | ✅ |
| `modelId` | Model from the Agent Host edit | Current matched edit marker | ✅ |
| `conversationId` | Parent Agent Host session identity | Current matched edit marker | ✅ |
| `requestId` | Agent Host turn id | Current matched edit marker | ✅ |
| `origin` | `agentHost` | `agentHost` | ✅ |
| `harness` | Provider normalized from the parent session | Same normalized provider carried by the marker | ✅ |
| `mode` | `longterm` | `10minFocusWindow` or `20minFocusWindow` | ≈ Deliberately scoped to the existing focus lifecycle |
| `statsUuid` | Coordinated long-term flush id | Independent id for each focus tracker | ≈ Existing window ownership is preserved |
| `trigger` | Long-term lifecycle trigger | `time` | ≈ Existing focus-window trigger is preserved |
| `extensionId`, `extensionVersion` | — | — | ⊗ Not applicable to Agent Host sources |

## Measurement-by-measurement parity

| Metric | Previous focus behavior | New focus behavior | Parity |
|---|---|---|---|
| `modifiedCount` | Matched reload retained as external or omitted when initially ignored | Retained range is relabeled as Agent Host and composes with later edits | ✅ Same workbench edit geometry |
| `deltaModifiedCount` | Reload insertion count assigned to external attribution | Same insertion count assigned to Agent Host attribution | ✅ Relabeled, not added |
| `totalModifiedCount` | Included the model-observed reload once | Still includes the reload once | ✅ No Agent Host count is added |
| `agentHostModifiedCount` | `0` for focus windows | Retained characters from reattributed Agent Host ranges | ✅ Mutually exclusive category |
| `externalModifiedCount` | Included matched Agent Host reload ranges | Excludes successfully matched ranges | ✅ Moves the same retained characters |
| Other source counts | User, IDE, completion, and chat ranges | Unchanged | ✅ |

---

## Row-count and dashboard implications

- **Newly attributed rows:** visible/open documents can emit Agent Host `Chat.applyEdits` detail rows in both focus modes.
- **No synthetic rows:** unopened and headless-only resources do not gain focus-window telemetry.
- **No duplicate totals:** each correlated model transition remains one workbench edit per focus window.
- **Long-term rows:** Agent Host remains the owner of long-term source rows and coordinated totals.
- **Stats impact:** matched retained characters move from `externalModifiedCount` to `agentHostModifiedCount`; `totalModifiedCharacters` is unchanged.
- **Volume:** Agent Host sources participate in the existing top-10 focus detail limit.
- **Fallback:** malformed, expired, oversized, heterogeneous, or unresolved correlations remain external rather than claiming Agent Host attribution.
- **Query discriminator:** focus Agent Host rows have `origin == 'agentHost'` and a normalized `harness`; `ahp-chat` is never emitted as the harness.

## Semantic-shift ledger

| Signal | Shift | Impact |
|---|---|---|
| Focus edit source | Matched reloads move from external to Agent Host `Chat.applyEdits` | Source/category distributions become accurate; totals do not change |
| Initial external edit | A matched first reload is retained and attributed instead of ignored | Fresh focus windows can represent the Agent Host edit that opened or refreshed the model |
| Focus emission timing | An unresolved correlation may delay telemetry emission by up to one second | Reduces marker-ordering races without blocking tracker recreation or UI interaction |
| Correlation lifetime | Unresolved observations expire at the marker TTL; resolved results live until active consumers release them | Prevents stale matches and cap exhaustion while preserving fan-out |