### PR TITLE
mcp: add setting to exclude user-level MCP servers from a workspace

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagement.ts
+++ b/src/vs/platform/mcp/common/mcpManagement.ts
@@ -282,6 +282,7 @@ export const mcpGalleryServiceUrlConfig = 'chat.mcp.gallery.serviceUrl';
 export const mcpGalleryServiceEnablementConfig = 'chat.mcp.gallery.enabled';
 export const mcpAutoStartConfig = 'chat.mcp.autostart';
 export const mcpAppsEnabledConfig = 'chat.mcp.apps.enabled';
+export const mcpUserServersEnabledConfig = 'chat.mcp.userServersEnabled';
 
 export interface IMcpGalleryConfig {
 	readonly serviceUrl?: string;

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1019,7 +1019,7 @@ configurationRegistry.registerConfiguration({
 		[mcpUserServersEnabledConfig]: {
 			type: 'boolean',
 			title: nls.localize('chat.mcp.userServersEnabled.title', "Use User-Level MCP Servers"),
-			markdownDescription: nls.localize('chat.mcp.userServersEnabled.description', "Controls whether Model Context Protocol servers configured at the user level (for example, in your user `mcp.json`) are available in this workspace. Set to `false` in workspace settings to restrict the agent to only workspace-defined MCP servers, so personal MCP configuration cannot affect this project and the same set of servers is available to every contributor."),
+			markdownDescription: nls.localize('chat.mcp.userServersEnabled.description', "Controls whether Model Context Protocol servers configured at the user level (for example, in your user `mcp.json`) are available in this workspace. Disable this in workspace settings to restrict the agent to only workspace-defined MCP servers, so personal MCP configuration cannot affect this project and the same set of servers is available to every contributor."),
 			default: true,
 			tags: ['mcp'],
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -31,7 +31,7 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { McpAccessValue, McpAutoStartValue, mcpAccessConfig, mcpAllowedServersConfig, mcpAutoStartConfig, mcpDeniedServersConfig, mcpGalleryServiceEnablementConfig, mcpGalleryServiceUrlConfig, mcpAppsEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
+import { McpAccessValue, McpAutoStartValue, mcpAccessConfig, mcpAllowedServersConfig, mcpAutoStartConfig, mcpDeniedServersConfig, mcpGalleryServiceEnablementConfig, mcpGalleryServiceUrlConfig, mcpAppsEnabledConfig, mcpUserServersEnabledConfig } from '../../../../platform/mcp/common/mcpManagement.js';
 import product from '../../../../platform/product/common/product.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
@@ -1015,6 +1015,13 @@ configurationRegistry.registerConfiguration({
 					]
 				},
 			}
+		},
+		[mcpUserServersEnabledConfig]: {
+			type: 'boolean',
+			title: nls.localize('chat.mcp.userServersEnabled.title', "Use User-Level MCP Servers"),
+			markdownDescription: nls.localize('chat.mcp.userServersEnabled.description', "Controls whether Model Context Protocol servers configured at the user level (for example, in your user `mcp.json`) are available in this workspace. Set to `false` in workspace settings to restrict the agent to only workspace-defined MCP servers, so personal MCP configuration cannot affect this project and the same set of servers is available to every contributor."),
+			default: true,
+			tags: ['mcp'],
 		},
 		[mcpAllowedServersConfig]: {
 			type: ['array', 'null'],

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -19,7 +19,7 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IGalleryMcpServer, IMcpGalleryService, IQueryOptions, IInstallableMcpServer, IGalleryMcpServerConfiguration, mcpAccessConfig, McpAccessValue, IAllowedMcpServersService, IMcpGalleryServerResolveResult, McpGalleryResolveStatus } from '../../../../platform/mcp/common/mcpManagement.js';
+import { IGalleryMcpServer, IMcpGalleryService, IQueryOptions, IInstallableMcpServer, IGalleryMcpServerConfiguration, mcpAccessConfig, mcpUserServersEnabledConfig, McpAccessValue, IAllowedMcpServersService, IMcpGalleryServerResolveResult, McpGalleryResolveStatus } from '../../../../platform/mcp/common/mcpManagement.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IMcpServerConfiguration, IMcpServerVariable, IMcpStdioServerConfiguration, McpServerType } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -219,7 +219,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		});
 		urlService.registerHandler(this);
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(mcpAccessConfig)) {
+			if (e.affectsConfiguration(mcpAccessConfig) || e.affectsConfiguration(mcpUserServersEnabledConfig)) {
 				this._onChange.fire(undefined);
 			}
 		}));
@@ -484,6 +484,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 	}
 
 	getEnabledLocalMcpServers(): IWorkbenchLocalMcpServer[] {
+		const userServersEnabled = this.configurationService.getValue<boolean>(mcpUserServersEnabledConfig) !== false;
 		const result = new Map<string, IWorkbenchLocalMcpServer>();
 		const userRemote: IWorkbenchLocalMcpServer[] = [];
 		const workspace: IWorkbenchLocalMcpServer[] = [];
@@ -495,9 +496,13 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			}
 
 			if (server.local?.scope === LocalMcpServerScope.User) {
-				result.set(server.name, server.local);
+				if (userServersEnabled) {
+					result.set(server.name, server.local);
+				}
 			} else if (server.local?.scope === LocalMcpServerScope.RemoteUser) {
-				userRemote.push(server.local);
+				if (userServersEnabled) {
+					userRemote.push(server.local);
+				}
 			} else if (server.local?.scope === LocalMcpServerScope.Workspace) {
 				workspace.push(server.local);
 			}

--- a/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
@@ -11,7 +11,7 @@ import { constObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -19,7 +19,7 @@ import { ServiceCollection } from '../../../../../platform/instantiation/common/
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
-import { GalleryMcpServerStatus, IAllowedMcpServersService, IGalleryMcpServer, IMcpGalleryServerResolveResult, IMcpGalleryService, IInstallableMcpServer, InstallOptions, McpAccessValue, McpGalleryResolveStatus, mcpAccessConfig, TransportType } from '../../../../../platform/mcp/common/mcpManagement.js';
+import { GalleryMcpServerStatus, IAllowedMcpServersService, IGalleryMcpServer, IMcpGalleryServerResolveResult, IMcpGalleryService, IInstallableMcpServer, InstallOptions, McpAccessValue, McpGalleryResolveStatus, mcpAccessConfig, mcpUserServersEnabledConfig, TransportType } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { IMcpGalleryManifest, IMcpGalleryManifestService, McpGalleryManifestStatus } from '../../../../../platform/mcp/common/mcpGalleryManifest.js';
 import { IMcpServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -672,5 +672,87 @@ suite('McpWorkbenchService - registry-only enforcement', () => {
 		]));
 
 		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name), ['allowed']);
+	});
+});
+
+suite('McpWorkbenchService - user-scoped server exclusion', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function createFixture(installed: IWorkbenchLocalMcpServer[], configuration: Record<string, unknown> = {}) {
+		const galleryService = new TestMcpGalleryService(store);
+		const manifestService = new TestMcpGalleryManifestService(store);
+		const managementService = new TestWorkbenchMcpManagementService(store);
+		managementService.installed = [...installed];
+		const configurationService = new TestConfigurationService({ [mcpAccessConfig]: McpAccessValue.All, ...configuration });
+		const services = new ServiceCollection(
+			[IMcpGalleryManifestService, manifestService],
+			[IMcpGalleryService, galleryService],
+			[IWorkbenchMcpManagementService, managementService],
+			[IEditorService, upcastPartial<IEditorService>({})],
+			[IUserDataProfilesService, upcastPartial<IUserDataProfilesService>({ profiles: [] })],
+			[IUriIdentityService, upcastPartial<IUriIdentityService>({})],
+			[IWorkspaceContextService, upcastPartial<IWorkspaceContextService>({})],
+			[IWorkbenchEnvironmentService, upcastPartial<IWorkbenchEnvironmentService>({})],
+			[ILabelService, upcastPartial<ILabelService>({})],
+			[IProductService, TestProductService],
+			[IRemoteAgentService, upcastPartial<IRemoteAgentService>({})],
+			[IConfigurationService, configurationService],
+			[ITelemetryService, NullTelemetryService],
+			[ILogService, store.add(new NullLogService())],
+			[IExtensionsWorkbenchService, upcastPartial<IExtensionsWorkbenchService>({})],
+			[IAllowedMcpServersService, upcastPartial<IAllowedMcpServersService>({ onDidChangeAllowedMcpServers: Event.None })],
+			[IMcpService, upcastPartial<IMcpService>({ servers: constObservable([]) })],
+			[IURLService, upcastPartial<IURLService>({ registerHandler: () => Disposable.None })],
+			[IFileService, upcastPartial<IFileService>({})],
+		);
+		const instantiationService = store.add(new TestInstantiationService(services));
+		const service = store.add(instantiationService.createInstance(McpWorkbenchService));
+		await Event.toPromise(service.onChange);
+		return { service, configurationService };
+	}
+
+	test('includes user and remote-user scoped servers by default', async () => {
+		const user = createLocal('user-server', LocalMcpServerScope.User);
+		const remoteUser = createLocal('remote-user-server', LocalMcpServerScope.RemoteUser);
+		const workspace = createLocal('workspace-server', LocalMcpServerScope.Workspace);
+		const { service } = await createFixture([user, remoteUser, workspace]);
+
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name).sort(), ['remote-user-server', 'user-server', 'workspace-server']);
+	});
+
+	test('excludes user and remote-user scoped servers when disabled, keeping workspace-scoped servers', async () => {
+		const user = createLocal('user-server', LocalMcpServerScope.User);
+		const remoteUser = createLocal('remote-user-server', LocalMcpServerScope.RemoteUser);
+		const workspace = createLocal('workspace-server', LocalMcpServerScope.Workspace);
+		const { service } = await createFixture([user, remoteUser, workspace], { [mcpUserServersEnabledConfig]: false });
+
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name), ['workspace-server']);
+	});
+
+	test('a workspace-scoped server is not shadowed by an excluded user-scoped server of the same name', async () => {
+		const user = createLocal('shared-name', LocalMcpServerScope.User);
+		const workspace = createLocal('shared-name', LocalMcpServerScope.Workspace);
+		const { service } = await createFixture([user, workspace], { [mcpUserServersEnabledConfig]: false });
+
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.mcpResource.toString()), [workspace.mcpResource.toString()]);
+	});
+
+	test('re-evaluates enabled servers when the setting changes', async () => {
+		const user = createLocal('user-server', LocalMcpServerScope.User);
+		const { service, configurationService } = await createFixture([user]);
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name), ['user-server']);
+
+		const changePromise = Event.toPromise(service.onChange);
+		configurationService.setUserConfiguration(mcpUserServersEnabledConfig, false);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === mcpUserServersEnabledConfig,
+			affectedKeys: new Set([mcpUserServersEnabledConfig]),
+			change: { keys: [mcpUserServersEnabledConfig], overrides: [] },
+			source: ConfigurationTarget.WORKSPACE,
+		});
+		await changePromise;
+
+		assert.deepStrictEqual(service.getEnabledLocalMcpServers().map(server => server.name), []);
 	});
 });

--- a/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/browser/mcpWorkbenchService.test.ts
@@ -749,7 +749,7 @@ suite('McpWorkbenchService - user-scoped server exclusion', () => {
 			affectsConfiguration: (key: string) => key === mcpUserServersEnabledConfig,
 			affectedKeys: new Set([mcpUserServersEnabledConfig]),
 			change: { keys: [mcpUserServersEnabledConfig], overrides: [] },
-			source: ConfigurationTarget.WORKSPACE,
+			source: ConfigurationTarget.USER,
 		});
 		await changePromise;
 


### PR DESCRIPTION
## Summary

Adds `chat.mcp.userServersEnabled` (boolean, default `true`). When set to `false` in workspace settings, MCP servers configured at user or remote-user scope are excluded from resolution — only workspace-defined MCP servers (e.g. `.vscode/mcp.json`) remain available to the agent for that workspace.

This closes the gap described in #329475: VS Code already lets a workspace opt out of user-level configuration for agents (`chat.agentFilesLocations`), skills (`chat.agentSkillsLocations`), instructions (`chat.instructionsFilesLocations`), and hooks (`chat.hookFilesLocations`), but had no equivalent for MCP servers. Personal MCP configuration outside the workspace could still change what tools an agent has access to inside a project, which breaks reproducibility for teams that check in an MCP-based agent harness.

## Implementation notes

- The merge point for local MCP servers by scope is `McpWorkbenchService.getEnabledLocalMcpServers()` (`src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts`), which is the single consumer feeding `InstalledMcpServersDiscovery`. Filtering there means the setting affects exactly what tools get registered/resolved, without touching how servers are listed/managed in the MCP Servers UI.
- `LocalMcpServerScope.User` and `LocalMcpServerScope.RemoteUser` are both excluded when the setting is `false`; `LocalMcpServerScope.Workspace` is always kept, so a workspace-defined server is never shadowed by an excluded user-scoped server of the same name.
- The setting is registered next to the existing `chat.mcp.access` toggle in `chat.shared.contribution.ts`, with no explicit `scope`, matching the sibling MCP settings (window-scope by default, settable in workspace settings).
- `chat.mcp.allowedServers` / `chat.mcp.deniedServers` were considered but don't fit: they're `ConfigurationScope.APPLICATION`-only, policy-delivered, hidden from the Settings UI, and match by server identity (name/URL/command) rather than scope — they can't express "keep workspace servers, drop everything from the user profile."

## Test plan

- [x] `npm run typecheck-client`
- [x] `npx eslint` on all changed files
- [x] Added unit tests in `mcpWorkbenchService.test.ts` covering: default (user servers included), exclusion when disabled (workspace servers kept), no shadowing of a workspace server by a same-named excluded user server, and re-evaluation on config change
- [x] Ran the full `src/vs/workbench/contrib/mcp` test suite (`./scripts/test.sh --glob "**/mcp/**/*.test.js"`) — 242 passing, no regressions

Opening this now to get the shape of the setting in front of the team for feedback — happy to adjust naming/scope/placement based on direction from whoever owns MCP settings.