### PR TITLE
Add lightweight chat session history reads

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -925,6 +925,11 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		}
 
 		this._contributions.set(contribution.type, { contribution, extension: undefined });
+		if (contribution.alternativeIds) {
+			for (const alternativeId of contribution.alternativeIds) {
+				this._alternativeIdMap.set(alternativeId, contribution.type);
+			}
+		}
 		// Programmatically-registered contributions are always considered
 		// available; mark them as such so the autorun in the constructor
 		// registers the in-place "New {0} Session" action for them. Without
@@ -944,6 +949,13 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 		return toDisposable(() => {
 			this._contributions.delete(contribution.type);
+			if (contribution.alternativeIds) {
+				for (const alternativeId of contribution.alternativeIds) {
+					if (this._alternativeIdMap.get(alternativeId) === contribution.type) {
+						this._alternativeIdMap.delete(alternativeId);
+					}
+				}
+			}
 			this._contributionDisposables.deleteAndDispose(contribution.type);
 			this._updateHasCanDelegateProvidersContextKey();
 			this._onDidChangeAvailability.fire();
@@ -1299,19 +1311,23 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	}
 
 	public async getChatSessionHistory(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]> {
-		const existing = this._sessions.get(sessionResource);
+		const existing = this._sessions.get(this._resolveResource(sessionResource));
 		if (existing) {
 			return [...existing.session.history];
 		}
 
-		const sessionType = getChatSessionType(sessionResource);
-		if (!(await raceCancellationError(this.canResolveChatSession(sessionType), token))) {
-			throw Error(`Cannot find provider '${sessionType}'`);
-		}
-		const resolvedType = this._resolveToPrimaryType(sessionType) || sessionType;
-		const provider = this._contentProviders.get(resolvedType);
-		if (!provider || isUntitledChatSession(sessionResource)) {
+		if (isUntitledChatSession(sessionResource)) {
 			return [];
+		}
+
+		const sessionType = getChatSessionType(sessionResource);
+		const resolvedType = this._resolveToPrimaryType(sessionType) || sessionType;
+		if (!(await raceCancellationError(this.canResolveChatSession(resolvedType), token))) {
+			throw Error(`Cannot find provider '${resolvedType}'`);
+		}
+		const provider = this._contentProviders.get(resolvedType);
+		if (!provider) {
+			throw Error(`Cannot find provider '${resolvedType}'`);
 		}
 
 		const session = await raceCancellationError(provider.provideChatSessionContent(sessionResource, token), token);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -32,7 +32,7 @@ import { ExtensionsRegistry } from '../../../../services/extensions/common/exten
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 import { IChatAgentAttachmentCapabilities, IChatAgentData, IChatAgentService } from '../../common/participants/chatAgents.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { ChatSessionOptionsMap, ChatSessionStatus, ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatNewSessionRequest, IChatSession, IChatSessionCommitEvent, IChatSessionContentProvider, IChatSessionCustomizationItemGroup, IChatSessionCustomizationsProvider, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionOptionsChangeEvent, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionRequestHistoryItem, IChatSessionsExtensionPoint, IChatSessionsService, IChatInputCompletionsParams, IChatInputCompletionsResult, isSessionInProgressStatus, localChatSessionType, ReadonlyChatSessionOptionsMap, ResolvedChatSessionsExtensionPoint, SessionType } from '../../common/chatSessionsService.js';
+import { ChatSessionOptionsMap, ChatSessionStatus, ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatNewSessionRequest, IChatSession, IChatSessionCommitEvent, IChatSessionContentProvider, IChatSessionCustomizationItemGroup, IChatSessionCustomizationsProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionOptionsChangeEvent, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionRequestHistoryItem, IChatSessionsExtensionPoint, IChatSessionsService, IChatInputCompletionsParams, IChatInputCompletionsResult, isSessionInProgressStatus, localChatSessionType, ReadonlyChatSessionOptionsMap, ResolvedChatSessionsExtensionPoint, SessionType } from '../../common/chatSessionsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
@@ -1296,6 +1296,30 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		}
 
 		return session;
+	}
+
+	public async getChatSessionHistory(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]> {
+		const existing = this._sessions.get(sessionResource);
+		if (existing) {
+			return [...existing.session.history];
+		}
+
+		const sessionType = getChatSessionType(sessionResource);
+		if (!(await raceCancellationError(this.canResolveChatSession(sessionType), token))) {
+			throw Error(`Cannot find provider '${sessionType}'`);
+		}
+		const resolvedType = this._resolveToPrimaryType(sessionType) || sessionType;
+		const provider = this._contentProviders.get(resolvedType);
+		if (!provider || isUntitledChatSession(sessionResource)) {
+			return [];
+		}
+
+		const session = await raceCancellationError(provider.provideChatSessionContent(sessionResource, token), token);
+		try {
+			return [...session.history];
+		} finally {
+			session.dispose();
+		}
 	}
 
 	public hasAnySessionOptions(sessionResource: URI): boolean {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -772,6 +772,11 @@ export interface IChatSessionsService {
 
 	getChatSessionContribution(chatSessionType: string): ResolvedChatSessionsExtensionPoint | undefined;
 	getAllChatSessionContributions(): ResolvedChatSessionsExtensionPoint[];
+	/**
+	 * Reads a session's history without retaining a contributed session in the
+	 * global session cache. Intended for lightweight ranking and previews.
+	 */
+	getChatSessionHistory?(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]>;
 
 	/**
 	 * Programmatically register a chat session contribution (for internal session types

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -776,7 +776,7 @@ export interface IChatSessionsService {
 	 * Reads a session's history without retaining a contributed session in the
 	 * global session cache. Intended for lightweight ranking and previews.
 	 */
-	getChatSessionHistory?(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]>;
+	getChatSessionHistory(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]>;
 
 	/**
 	 * Programmatically register a chat session contribution (for internal session types

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -12,7 +12,7 @@ import { ContextKeyExpr, IContextKey, RawContextKey } from '../../../../../../pl
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { applyCodexAgentHostPreference, ChatSessionsService } from '../../../browser/chatSessions/chatSessions.contribution.js';
-import { ChatSessionOptionsMap, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsExtensionPoint, ReadonlyChatSessionOptionsMap, SessionType } from '../../../common/chatSessionsService.js';
+import { ChatSessionOptionsMap, IChatSessionHistoryItem, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsExtensionPoint, ReadonlyChatSessionOptionsMap, SessionType } from '../../../common/chatSessionsService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { AGENT_HOST_ENABLED_CONTEXT_KEY } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { AgentHostCodexAgentEnabledSettingId, CodexPreferAgentHostEditorSettingId, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, protectedResourcesRequireGitHubCopilotSignIn } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -538,6 +538,66 @@ suite('ChatSessionsService - untitled↔real session aliases', () => {
 		// option to the untitled entry.
 		service.clearMaterializedSessionResource(untitled);
 		assert.strictEqual(service.getSessionOption(real, 'model'), 'sonnet');
+	});
+});
+
+suite('ChatSessionsService - lightweight history reads', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: ChatSessionsService;
+
+	setup(() => {
+		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
+		service = store.add(instantiationService.createInstance(ChatSessionsService));
+	});
+
+	function registerHistoryProvider(type: string, history: readonly IChatSessionHistoryItem[], counters: { provided: number; disposed: number }): void {
+		store.add(service.registerChatSessionContribution({ type, name: type, displayName: type, description: '' }));
+		store.add(service.registerChatSessionContentProvider(type, {
+			provideChatSessionContent: async resource => {
+				counters.provided++;
+				return {
+					sessionResource: resource,
+					history,
+					onWillDispose: Event.None,
+					dispose: () => counters.disposed++,
+				};
+			},
+		}));
+	}
+
+	test('loads and disposes uncached sessions without retaining them', async () => {
+		const type = 'history-preview';
+		const resource = URI.from({ scheme: type, path: '/session-1' });
+		const history: readonly IChatSessionHistoryItem[] = [{ type: 'request', prompt: 'Summarize the changes', participant: 'test' }];
+		const counters = { provided: 0, disposed: 0 };
+		registerHistoryProvider(type, history, counters);
+
+		const first = await service.getChatSessionHistory(resource, CancellationToken.None);
+		const second = await service.getChatSessionHistory(resource, CancellationToken.None);
+
+		assert.deepStrictEqual({ first, second, counters }, {
+			first: history,
+			second: history,
+			counters: { provided: 2, disposed: 2 },
+		});
+	});
+
+	test('reads an already retained session without resolving it again', async () => {
+		const type = 'history-cached';
+		const resource = URI.from({ scheme: type, path: '/session-1' });
+		const history: readonly IChatSessionHistoryItem[] = [{ type: 'request', prompt: 'Continue the review', participant: 'test' }];
+		const counters = { provided: 0, disposed: 0 };
+		registerHistoryProvider(type, history, counters);
+
+		await service.getOrCreateChatSession(resource, CancellationToken.None);
+		const result = await service.getChatSessionHistory(resource, CancellationToken.None);
+
+		assert.deepStrictEqual({ result, counters }, {
+			result: history,
+			counters: { provided: 1, disposed: 0 },
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -599,6 +599,65 @@ suite('ChatSessionsService - lightweight history reads', () => {
 			counters: { provided: 1, disposed: 0 },
 		});
 	});
+
+	test('reads an aliased retained session without resolving it again', async () => {
+		const type = 'history-cached-alias';
+		const resource = URI.from({ scheme: type, path: '/session-1' });
+		const alias = URI.from({ scheme: type, path: '/session-1-materialized' });
+		const history: readonly IChatSessionHistoryItem[] = [{ type: 'request', prompt: 'Continue the aliased session', participant: 'test' }];
+		const counters = { provided: 0, disposed: 0 };
+		registerHistoryProvider(type, history, counters);
+
+		await service.getOrCreateChatSession(resource, CancellationToken.None);
+		service.registerSessionResourceAlias(resource, alias);
+		const result = await service.getChatSessionHistory(alias, CancellationToken.None);
+
+		assert.deepStrictEqual({ result, counters }, {
+			result: history,
+			counters: { provided: 1, disposed: 0 },
+		});
+	});
+
+	test('resolves alternative session types through their primary provider', async () => {
+		const type = 'history-primary';
+		const alternativeType = 'history-alternative';
+		const resource = URI.from({ scheme: alternativeType, path: '/session-1' });
+		const history: readonly IChatSessionHistoryItem[] = [{ type: 'request', prompt: 'Read through the primary provider', participant: 'test' }];
+		const counters = { provided: 0, disposed: 0 };
+		store.add(service.registerChatSessionContribution({ type, name: type, displayName: type, description: '', alternativeIds: [alternativeType] }));
+		store.add(service.registerChatSessionContentProvider(type, {
+			provideChatSessionContent: async sessionResource => {
+				counters.provided++;
+				return {
+					sessionResource,
+					history,
+					onWillDispose: Event.None,
+					dispose: () => counters.disposed++,
+				};
+			},
+		}));
+
+		const result = await service.getChatSessionHistory(resource, CancellationToken.None);
+
+		assert.deepStrictEqual({ result, counters }, {
+			result: history,
+			counters: { provided: 1, disposed: 1 },
+		});
+	});
+
+	test('returns empty history for an unretained untitled session', async () => {
+		const resource = URI.from({ scheme: 'history-untitled', path: '/untitled-session-1' });
+
+		assert.deepStrictEqual(await service.getChatSessionHistory(resource, CancellationToken.None), []);
+	});
+
+	test('throws when a retained-session provider cannot be resolved', async () => {
+		const type = 'history-unresolvable';
+		const resource = URI.from({ scheme: type, path: '/session-1' });
+		store.add(service.registerChatSessionContribution({ type, name: type, displayName: type, description: '' }));
+
+		await assert.rejects(service.getChatSessionHistory(resource, CancellationToken.None), new Error(`Cannot find provider '${type}'`));
+	});
 });
 
 suite('ChatSessionOptionsMap', () => {

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -9,7 +9,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { ReadonlyChatSessionOptionsMap, IChatNewSessionRequest, IChatSession, IChatSessionCommitEvent, IChatSessionContentProvider, IChatSessionCustomizationItemGroup, IChatSessionCustomizationsProvider, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionOptionsChangeEvent, IChatSessionProviderOptionGroup, IChatSessionRequestHistoryItem, IChatSessionsExtensionPoint, IChatSessionsService, ResolvedChatSessionsExtensionPoint, ChatSessionOptionsMap, IChatInputCompletionsParams, IChatInputCompletionsResult } from '../../common/chatSessionsService.js';
+import { ReadonlyChatSessionOptionsMap, IChatNewSessionRequest, IChatSession, IChatSessionCommitEvent, IChatSessionContentProvider, IChatSessionCustomizationItemGroup, IChatSessionCustomizationsProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionOptionsChangeEvent, IChatSessionProviderOptionGroup, IChatSessionRequestHistoryItem, IChatSessionsExtensionPoint, IChatSessionsService, ResolvedChatSessionsExtensionPoint, ChatSessionOptionsMap, IChatInputCompletionsParams, IChatInputCompletionsResult } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IChatAgentAttachmentCapabilities } from '../../common/participants/chatAgents.js';
 import { Target } from '../../common/promptSyntax/promptTypes.js';
@@ -185,6 +185,15 @@ export class MockChatSessionsService implements IChatSessionsService {
 			throw new Error(`No content provider for ${sessionType}`);
 		}
 		return provider.provideChatSessionContent(sessionResource, token);
+	}
+
+	async getChatSessionHistory(sessionResource: URI, token: CancellationToken): Promise<readonly IChatSessionHistoryItem[]> {
+		const session = await this.getOrCreateChatSession(sessionResource, token);
+		try {
+			return [...session.history];
+		} finally {
+			session.dispose();
+		}
 	}
 
 	async canResolveChatSession(sessionType: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

- add a lightweight API for reading contributed chat-session history
- reuse an already-retained session when available
- otherwise resolve the session only for the duration of the read and dispose it immediately

This is an independent routing prerequisite extracted from #326698. It avoids populating the global session cache when routing or preview code only needs recent conversation content.

## Developer impact

Callers can enrich session rankings and previews without changing session ownership or retaining every inspected session.

## Validation

- `npm run typecheck-client`
- targeted ESLint for all three changed files
- focused Electron unit tests for cached and uncached history reads — 2 passing
