### PR TITLE
Add voice session awareness and actions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -1291,6 +1291,14 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	attach(uris: URI[]): void {
 		this._contextAttachments.addAttachments(...uris.map(uri => toFileVariableEntry(uri)));
 	}
+
+	getVoiceModels() {
+		return this._sessionModelSelectionModel.state.get().models;
+	}
+
+	selectVoiceModel(identifier: string): boolean {
+		return this._sessionModelSelectionModel.selectModel(identifier);
+	}
 }
 
 // #endregion

--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -27,6 +27,7 @@ import { IVoiceSessionController } from '../../../../workbench/contrib/chat/brow
 import { AgentsVoiceSettingId } from '../../../../workbench/contrib/agentsVoice/common/agentsVoice.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { VoiceModeActionViewItem } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceModeActionViewItem.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
 
@@ -56,6 +57,12 @@ export interface INewChatVoiceComposer {
 	prefillInput(text: string): void;
 	/** Focus the composer input. */
 	focus(): void;
+	/** Models currently offered by the composer. */
+	getVoiceModels(): readonly ILanguageModelChatMetadataAndIdentifier[];
+	/** Select a model by its exact frontend identifier. */
+	selectVoiceModel(identifier: string): boolean;
+	/** Attach files to this draft composer. */
+	attach(uris: URI[]): void;
 }
 
 export const INewChatVoiceTargetService = createDecorator<INewChatVoiceTargetService>('newChatVoiceTargetService');

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -6,13 +6,14 @@
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isEqual } from '../../../../base/common/resources.js';
+import { basename, isEqual } from '../../../../base/common/resources.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { combineVoiceInput } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceInputUtils.js';
+import { IVoiceAttachmentResult, IVoiceModelSelectionResult, resolveVoiceModel } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { INewChatVoiceComposer, INewChatVoiceTargetService, NEW_CHAT_VOICE_SENTINEL } from './newChatVoice.js';
@@ -96,6 +97,42 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 				return activeChat.toString();
 			}
 			return this.chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource?.toString();
+		}));
+
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.selectModel', (_accessor, requestedModel: string): IVoiceModelSelectionResult => {
+			const composer = this._activeComposerTarget();
+			const widget = composer ? undefined : this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
+			const models = composer?.getVoiceModels() ?? widget?.inputPart.availableLanguageModels;
+			if (!models) {
+				return { ok: false, reason: 'no_input' };
+			}
+			const resolved = resolveVoiceModel(models, requestedModel);
+			if (!resolved.ok || !resolved.identifier) {
+				return resolved;
+			}
+			const selected = composer
+				? composer.selectVoiceModel(resolved.identifier)
+				: widget!.inputPart.switchModelByIdentifier(resolved.identifier, true, true);
+			return selected ? resolved : { ok: false, reason: 'selection_failed', available_models: resolved.available_models };
+		}));
+
+		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.attachFiles', async (_accessor, resourceStrings: readonly string[]): Promise<IVoiceAttachmentResult> => {
+			const composer = this._activeComposerTarget();
+			const widget = composer ? undefined : this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
+			if (!composer && !widget) {
+				return { ok: false, reason: 'no_input' };
+			}
+			try {
+				const resources = resourceStrings.map(resource => URI.parse(resource));
+				if (composer) {
+					composer.attach(resources);
+				} else {
+					await Promise.all(resources.map(resource => widget!.attachmentModel.addFile(resource)));
+				}
+				return { ok: true, attached: resources.map(resource => basename(resource)) };
+			} catch {
+				return { ok: false, reason: 'attachment_failed' };
+			}
 		}));
 
 		// Reveal the session that owns the given chat resource.

--- a/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
@@ -26,6 +26,9 @@ suite('SessionsVoiceNewComposerContribution', () => {
 			sendQuery: () => { },
 			prefillInput: () => { },
 			focus: () => { },
+			getVoiceModels: () => [],
+			selectVoiceModel: () => false,
+			attach: () => { },
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/speechToText/dictationMicGlow.ts
@@ -12,6 +12,7 @@ import { autorun, IObservable } from '../../../../../base/common/observable.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IColorTheme, IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { isDark } from '../../../../../platform/theme/common/theme.js';
+import { inputBackground } from '../../../../../platform/theme/common/colors/inputColors.js';
 import { chatDictationActiveMicGlow } from '../../common/widget/chatColors.js';
 import { readVoiceGlowIntensity } from '../voiceClient/voiceGlow.js';
 import { createVoiceRimLight, IVoiceRimLight } from '../voiceClient/voiceGlowController.js';
@@ -126,10 +127,11 @@ export function setupDictationMicGlow(
 			return;
 		}
 		const kind = isDark(theme.type) ? 'dark' : 'light';
+		const background = theme.getColor(inputBackground);
 		if (rim.value) {
-			rim.value.refresh(accent, kind);
+			rim.value.refresh(accent, kind, background);
 		} else {
-			rim.value = createVoiceRimLight(target, accent, kind);
+			rim.value = createVoiceRimLight(target, accent, kind, 'cool', background);
 		}
 	};
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlow.ts
@@ -14,6 +14,7 @@
  */
 
 import { Color, HSLA } from '../../../../../base/common/color.js';
+import { inputBackground } from '../../../../../platform/theme/common/colors/inputColors.js';
 import { IColorTheme } from '../../../../../platform/theme/common/themeService.js';
 import { chatVoiceGlowBaseColor, chatVoiceListeningGlow, chatVoiceSpeakingGlow } from '../../common/widget/chatColors.js';
 
@@ -54,6 +55,7 @@ export function readVoiceGlowIntensity(analyser: AnalyserNode | null, dataArray:
 export interface IVoiceGlowColors {
 	readonly listening: Color;
 	readonly speaking: Color;
+	readonly background: Color;
 }
 
 /**
@@ -83,6 +85,7 @@ function shiftHue(base: Color, degrees: number, saturationMul: number = 1, light
 export const DEFAULT_VOICE_GLOW_COLORS: IVoiceGlowColors = {
 	listening: VOICE_GLOW_FALLBACK,
 	speaking: shiftHue(VOICE_GLOW_FALLBACK, VOICE_GLOW_SPEAKING_HUE_SHIFT),
+	background: Color.fromHex('#3C3C3C'),
 };
 
 /**
@@ -96,6 +99,7 @@ export function resolveVoiceGlowColors(theme: Pick<IColorTheme, 'getColor'>): IV
 	return {
 		listening: theme.getColor(chatVoiceListeningGlow) ?? base,
 		speaking: theme.getColor(chatVoiceSpeakingGlow) ?? shiftHue(base, VOICE_GLOW_SPEAKING_HUE_SHIFT),
+		background: theme.getColor(inputBackground) ?? DEFAULT_VOICE_GLOW_COLORS.background,
 	};
 }
 
@@ -145,12 +149,19 @@ const RIM_HUE_SHIFT = { cool: -10, warm: 7 } as const;
  * Shared with the dictation microphone glow, so an open microphone is the same
  * color whichever feature opened it.
  */
-export function resolveVoiceRimAccent(accent: Color, mood: VoiceRimMood, theme: GlowThemeKind): IVoiceRimAccent {
+export function resolveVoiceRimAccent(accent: Color, mood: VoiceRimMood, theme: GlowThemeKind, background?: Color): IVoiceRimAccent {
 	const { h, s } = accent.hsla;
+	const tuned = new Color(new HSLA(
+		(h + RIM_HUE_SHIFT[mood] + 360) % 360,
+		Math.min(RIM_SAT_MAX, Math.max(RIM_SAT_MIN, s * 100)) / 100,
+		RIM_LIGHTNESS[theme][mood] / 100,
+		1,
+	));
+	const contrasted = (background ?? (theme === 'light' ? Color.white : DEFAULT_VOICE_GLOW_COLORS.background)).ensureConstrast(tuned, 3);
 	return {
-		hue: (h + RIM_HUE_SHIFT[mood] + 360) % 360,
-		saturation: Math.round(Math.min(RIM_SAT_MAX, Math.max(RIM_SAT_MIN, s * 100))),
-		lightness: RIM_LIGHTNESS[theme][mood],
+		hue: contrasted.hsla.h,
+		saturation: Math.round(contrasted.hsla.s * 100),
+		lightness: Math.round(contrasted.hsla.l * 100),
 	};
 }
 
@@ -171,4 +182,3 @@ export function computeVoiceMicGlowBoxShadow(voiceState: VoiceGlowState, intensi
 	const shadowAlpha = 0.2 + intensity * 0.45;
 	return `0 0 ${shadowSpread}px rgba(${r},${g},${b},${shadowAlpha})`;
 }
-

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlowController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceGlowController.ts
@@ -249,7 +249,7 @@ export interface IVoiceRimLight extends IDisposable {
 	/** Pin to a representative still frame (reduced motion). */
 	driveStatic(level: number): void;
 	/** Re-mount with a freshly resolved accent / theme. */
-	refresh(accent: Color, theme: GlowThemeKind): void;
+	refresh(accent: Color, theme: GlowThemeKind, background?: Color): void;
 }
 
 /**
@@ -277,7 +277,7 @@ const RIM_SIZE_FLOOR = 0.35;
  * The rim lives in its own absolutely-positioned slot, so hosts that rebuild
  * their button contents don't tear it out.
  */
-export function createVoiceRimLight(target: HTMLElement, accent: Color, theme: GlowThemeKind, mood: VoiceRimMood = 'cool'): IVoiceRimLight {
+export function createVoiceRimLight(target: HTMLElement, accent: Color, theme: GlowThemeKind, mood: VoiceRimMood = 'cool', background?: Color): IVoiceRimLight {
 	const store = new DisposableStore();
 	const doc = target.ownerDocument;
 
@@ -292,8 +292,8 @@ export function createVoiceRimLight(target: HTMLElement, accent: Color, theme: G
 	const mount = store.add(new MutableDisposable<IMountedLayer>());
 	let level = 0.3;
 
-	const remount = (nextAccent: Color, nextTheme: GlowThemeKind) => {
-		const rim = resolveVoiceRimAccent(nextAccent, mood, nextTheme);
+	const remount = (nextAccent: Color, nextTheme: GlowThemeKind, nextBackground?: Color) => {
+		const rim = resolveVoiceRimAccent(nextAccent, mood, nextTheme, nextBackground);
 		// Measured lazily: hosts commonly build the button before it is attached,
 		// and a detached element has no box to measure.
 		const height = target.getBoundingClientRect().height;
@@ -314,7 +314,7 @@ export function createVoiceRimLight(target: HTMLElement, accent: Color, theme: G
 		});
 		mount.value.driveStatic(level);
 	};
-	remount(accent, theme);
+	remount(accent, theme, background);
 
 	return {
 		drive: (input: number) => {
@@ -417,7 +417,8 @@ class VoiceGlowController extends Disposable implements IVoiceGlowController {
 			this._target.classList.toggle('voice-listening', state === 'listening');
 			this._target.classList.toggle('voice-processing', state === 'processing');
 			this._target.classList.toggle('voice-speaking', state === 'speaking');
-			this._target.style.setProperty('--voice-accent', voiceGlowStateColor(state, this._colors).toString());
+			const accent = resolveVoiceRimAccent(voiceGlowStateColor(state, this._colors), mood, this._themeKind(), this._colors.background);
+			this._target.style.setProperty('--voice-accent', `hsl(${accent.hue} ${accent.saturation}% ${accent.lightness}%)`);
 		}
 
 		if (this._front && !reducedMotion) {
@@ -509,7 +510,7 @@ class VoiceGlowController extends Disposable implements IVoiceGlowController {
 
 	private _mount(host: HTMLElement, mood: RimMood): IMountedLayer {
 		const theme = this._themeKind();
-		const accent = resolveVoiceRimAccent(mood === 'warm' ? this._colors.speaking : this._colors.listening, mood, theme);
+		const accent = resolveVoiceRimAccent(mood === 'warm' ? this._colors.speaking : this._colors.listening, mood, theme, this._colors.background);
 		return mountRimLayers(host, {
 			theme,
 			mood,

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -26,7 +26,7 @@ import { IVoiceAudioResponse, IVoiceBargeIn, IVoiceCheckpointNarrationMetadata, 
 import { getVoiceConfirmationType, isPendingVoiceQuestionnaireInvocation, isVoiceQuestionnaireInvocation } from '../../common/voiceClient/voiceConfirmation.js';
 import { IMicCaptureService, IPttDiagnostic, isMicrophonePermissionDeniedError } from './micCaptureService.js';
 import { ITtsPlaybackService } from './ttsPlaybackService.js';
-import { IVoiceToolDispatchService, VoiceToolDispatchService } from './voiceToolDispatchService.js';
+import { IVoiceAttachmentResult, IVoiceModelSelectionResult, IVoiceToolDispatchService, VoiceToolDispatchService } from './voiceToolDispatchService.js';
 import { IVoicePlaybackService } from '../../common/voicePlaybackService.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { AgentSessionStatus } from '../agentSessions/agentSessionsModel.js';
@@ -36,6 +36,7 @@ import { getDisplayedQuestionText, getOptionsWithDefaultsFirst } from '../../com
 import { formatQuestionPrompt } from '../../common/voiceClient/voicePendingNarration.js';
 import { IChatWidget, IChatWidgetService } from '../chat.js';
 import { IChatModel, IChatProgressResponseContent, IChatResponseModel } from '../../common/model/chatModel.js';
+import { isExplicitFileOrImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -814,9 +815,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				const resourceStr = await this.commandService.executeCommand<string | undefined>('_chat.voice.getCurrentSession').catch(() => undefined);
 				return resourceStr ? URI.parse(resourceStr) : undefined;
 			},
-			switchToSession: (resource: URI): void => {
-				this.commandService.executeCommand('_chat.voice.switchToSession', resource.toString());
-			},
+			switchToSession: async (resource: URI): Promise<boolean> =>
+				await this.commandService.executeCommand<boolean>('_chat.voice.switchToSession', resource.toString()).catch(() => false) === true,
+			setTargetSession: (resource: URI): void => this.setTargetSession(resource),
+			getTargetSessionResource: (): URI | undefined => this._targetSession.get(),
+			selectModel: async (requestedModel: string): Promise<IVoiceModelSelectionResult> =>
+				(await this.commandService.executeCommand<IVoiceModelSelectionResult>('_chat.voice.selectModel', requestedModel)
+					.catch(() => undefined)) ?? { ok: false, reason: 'no_input' },
+			attachFiles: async (resources: readonly URI[]): Promise<IVoiceAttachmentResult> =>
+				(await this.commandService.executeCommand<IVoiceAttachmentResult>('_chat.voice.attachFiles', resources.map(resource => resource.toString()))
+					.catch(() => undefined)) ?? { ok: false, reason: 'no_input' },
 			getAutoApprovedSessions: (): Set<string> => {
 				return this._autoApprovedSessions;
 			},
@@ -5868,7 +5876,28 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		return { state: realState, hideConfirmationDetail: false };
 	}
 
-
+	private _getInputContext(model: IChatModel): Pick<IVoiceSessionContext['sessions'][number], 'selected_model' | 'attachment_names' | 'attachment_count'> {
+		const state = model.inputModel?.state?.get();
+		const selectedModel = state?.selectedModel
+			?? this.chatWidgetService.getWidgetBySessionResource(model.sessionResource)?.inputPart.selectedLanguageModel.get();
+		const attachmentNames = state?.attachments
+			.filter(isExplicitFileOrImageVariableEntry)
+			.map(attachment => attachment.name)
+			.filter(name => name.length > 0) ?? [];
+		return {
+			...(selectedModel ? {
+				selected_model: {
+					identifier: selectedModel.identifier,
+					name: selectedModel.metadata.name,
+					vendor: selectedModel.metadata.vendor,
+				},
+			} : {}),
+			...(attachmentNames.length > 0 ? {
+				attachment_names: attachmentNames.slice(0, 10),
+				attachment_count: attachmentNames.length,
+			} : {}),
+		};
+	}
 
 	private _buildSessionContext(): IVoiceSessionContext {
 		const oneHourAgo = Date.now() - 60 * 60 * 1000;
@@ -5889,7 +5918,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// which one to use.
 		const targetSessionId = this._getActiveSessionId();
 
-		const sessionList = sessions.map(s => {
+		const sessionList: IVoiceSessionContext['sessions'] = sessions.map(s => {
 			const model = this.chatService.getSession(s.resource);
 			const isActive = s.resource.toString() === targetSessionId;
 			if (!model) {
@@ -5922,6 +5951,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				return {
 					id: sessionIdStr,
 					...(s.label ? { label: s.label } : {}),
+					session_type: 'agent' as const,
 					is_active: isActive,
 					agent_state: scoped.state,
 					...(cachedSummary ? { last_response_summary: cachedSummary } : {}),
@@ -5948,12 +5978,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return {
 				id: s.resource.toString(),
 				...(s.label ? { label: s.label } : {}),
+				session_type: 'agent' as const,
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(!scoped.hideConfirmationDetail && stateInfo.confirmation_type ? { confirmation_type: stateInfo.confirmation_type } : {}),
 				...(shipSummary ? { last_response_summary: shipSummary } : {}),
 				...(pending ? { pending } : {}),
+				...this._getInputContext(model),
 			};
 		});
 
@@ -5976,12 +6008,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			sessionList.push({
 				id: key,
 				...(chatModel.title ? { label: chatModel.title } : {}),
+				session_type: 'chat',
 				is_active: isActive,
 				agent_state: scoped.state,
 				...(!scoped.hideConfirmationDetail && stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(!scoped.hideConfirmationDetail && stateInfo.confirmation_type ? { confirmation_type: stateInfo.confirmation_type } : {}),
 				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
 				...(pending ? { pending } : {}),
+				...this._getInputContext(chatModel),
 			});
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -5,6 +5,7 @@
 
 import { URI } from '../../../../../base/common/uri.js';
 import { constObservable } from '../../../../../base/common/observable.js';
+import { posix, win32 } from '../../../../../base/common/path.js';
 import { localize } from '../../../../../nls.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
@@ -79,7 +80,7 @@ function voiceModelReference(model: ILanguageModelChatMetadataAndIdentifier): IV
 }
 
 function normalizeModelName(value: string): string {
-	return value.toLocaleLowerCase().replace(/[^a-z0-9]/g, '');
+	return value.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 /** Resolve only exact identifiers or unique normalized names; never guess among similar models. */
@@ -363,33 +364,47 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 		{ ok: true; resources: readonly URI[] }
 		| { ok: false; reason: NonNullable<IVoiceAttachmentResult['reason']>; candidates?: readonly string[] }
 	> {
-		const rawValues = [args['uri'], args['path'], ...(Array.isArray(args['uris']) ? args['uris'] : []), ...(Array.isArray(args['paths']) ? args['paths'] : [])]
+		const uriValues = [args['uri'], ...(Array.isArray(args['uris']) ? args['uris'] : [])]
 			.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
-		if (rawValues.length === 0) {
+		const pathValues = [args['path'], ...(Array.isArray(args['paths']) ? args['paths'] : [])]
+			.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+		if (uriValues.length === 0 && pathValues.length === 0) {
 			const activeResource = EditorResourceAccessor.getCanonicalUri(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
 			return activeResource ? { ok: true, resources: [activeResource] } : { ok: false, reason: 'no_file' };
 		}
 
 		const resources: URI[] = [];
-		for (const rawValue of rawValues) {
+		for (const rawValue of uriValues) {
 			const value = rawValue.trim();
-			const parsed = URI.parse(value);
-			if (parsed.scheme) {
-				if (!await this.fileService.exists(parsed)) {
+			let resource: URI;
+			try {
+				resource = URI.parse(value, true);
+			} catch {
+				return { ok: false, reason: 'file_not_found', candidates: [value] };
+			}
+			if (!await this.fileService.exists(resource)) {
+				return { ok: false, reason: 'file_not_found', candidates: [value] };
+			}
+			resources.push(resource);
+		}
+
+		for (const rawValue of pathValues) {
+			const value = rawValue.trim();
+			const isWindowsPath = win32.isAbsolute(value);
+			if (isWindowsPath || posix.isAbsolute(value)) {
+				const resource = URI.file(isWindowsPath ? value.replaceAll('\\', '/') : value);
+				if (!await this.fileService.exists(resource)) {
 					return { ok: false, reason: 'file_not_found', candidates: [value] };
 				}
-				resources.push(parsed);
+				resources.push(resource);
 				continue;
 			}
 
-			const relativePath = value.replace(/^\.\//, '');
-			const matches: URI[] = [];
-			for (const folder of this.workspaceContextService.getWorkspace().folders) {
-				const candidate = URI.joinPath(folder.uri, relativePath);
-				if (await this.fileService.exists(candidate)) {
-					matches.push(candidate);
-				}
-			}
+			const relativePath = value.replace(/^\.[\\/]/, '').replaceAll('\\', '/');
+			const candidates = this.workspaceContextService.getWorkspace().folders
+				.map(folder => URI.joinPath(folder.uri, relativePath));
+			const exists = await Promise.all(candidates.map(candidate => this.fileService.exists(candidate)));
+			const matches = candidates.filter((_candidate, index) => exists[index]);
 			if (matches.length === 0) {
 				return { ok: false, reason: 'file_not_found', candidates: [value] };
 			}
@@ -673,21 +688,24 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 		});
 
 		for (const model of this.chatService.chatModels.get()) {
-			if (agentResources.has(model.sessionResource.toString()) || model.getRequests().length === 0) {
+			const sessionId = model.sessionResource.toString();
+			const isActive = activeResource?.toString() === sessionId;
+			if (agentResources.has(sessionId) || (model.getRequests().length === 0 && !isActive)) {
 				continue;
 			}
 			const needsInput = model.requestNeedsInput?.get();
 			const inProgress = model.hasActiveRequest?.get();
+			const lastActivity = model.lastMessageDate || 0;
 			sessionData.push({
-				id: model.sessionResource.toString(),
+				id: sessionId,
 				label: model.title || undefined,
 				session_type: 'chat',
 				state: needsInput ? 'waiting_for_input' : inProgress ? 'working' : 'idle',
-				is_active: activeResource?.toString() === model.sessionResource.toString(),
+				is_active: isActive,
 				insertions: 0,
 				deletions: 0,
-				last_activity: model.lastMessageDate,
-				last_activity_minutes_ago: Math.max(0, Math.round((Date.now() - model.lastMessageDate) / 60000)),
+				last_activity: lastActivity,
+				last_activity_minutes_ago: lastActivity ? Math.max(0, Math.round((Date.now() - lastActivity) / 60000)) : undefined,
 				last_response_summary: lastResponseSummary(model),
 				...inputDetails(model),
 			});

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -15,11 +15,17 @@ import { IBackendQuestionAnswer, resolveQuestionAnswers } from '../../common/voi
 import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { ChatPlanReviewData } from '../../common/model/chatProgressTypes/chatPlanReviewData.js';
 import { IChatModel } from '../../common/model/chatModel.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../common/languageModels.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
-import { IVoiceDispatchResult, IVoiceToolCall, peekPendingId } from '../../common/voiceClient/voiceClientService.js';
+import { IVoiceDispatchResult, IVoiceModelReference, IVoiceToolCall, peekPendingId } from '../../common/voiceClient/voiceClientService.js';
 import { getVoiceConfirmationType } from '../../common/voiceClient/voiceConfirmation.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/editor.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { isExplicitFileOrImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 
 /**
  * Callbacks that require access to the chat widget or view state.
@@ -31,7 +37,15 @@ export interface IVoiceToolDispatchDelegate {
 	/** Get the resource URI of the currently active session. */
 	getCurrentSessionResource(): Promise<URI | undefined>;
 	/** Switch the view to a different session by resource URI. */
-	switchToSession(resource: URI): void;
+	switchToSession(resource: URI): Promise<boolean>;
+	/** Set the session all subsequent voice turns and actions belong to. */
+	setTargetSession(resource: URI): void;
+	/** The explicit voice target, or the currently shown session when unpinned. */
+	getTargetSessionResource(): URI | undefined;
+	/** Select a model in the currently shown voice input. */
+	selectModel(requestedModel: string): Promise<IVoiceModelSelectionResult>;
+	/** Attach files to the currently shown voice input. */
+	attachFiles(resources: readonly URI[]): Promise<IVoiceAttachmentResult>;
 	/** Get the set of auto-approved session resource strings. */
 	getAutoApprovedSessions(): Set<string>;
 	/** Mark all current sessions as auto-approved. */
@@ -40,6 +54,62 @@ export interface IVoiceToolDispatchDelegate {
 	removeAutoApprovedSession(resource: string): void;
 	/** Trigger an auto-approve check cycle. */
 	triggerAutoApproveCheck(): void;
+}
+
+export interface IVoiceModelSelectionResult {
+	readonly ok: boolean;
+	readonly reason?: 'no_input' | 'model_not_found' | 'ambiguous_model' | 'selection_failed';
+	readonly selected_model?: IVoiceModelReference;
+	readonly available_models?: readonly IVoiceModelReference[];
+}
+
+export interface IVoiceAttachmentResult {
+	readonly ok: boolean;
+	readonly reason?: 'no_input' | 'no_file' | 'file_not_found' | 'ambiguous_file' | 'attachment_failed';
+	readonly attached?: readonly string[];
+	readonly candidates?: readonly string[];
+}
+
+function voiceModelReference(model: ILanguageModelChatMetadataAndIdentifier): IVoiceModelReference {
+	return {
+		identifier: model.identifier,
+		name: model.metadata.name,
+		vendor: model.metadata.vendor,
+	};
+}
+
+function normalizeModelName(value: string): string {
+	return value.toLocaleLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** Resolve only exact identifiers or unique normalized names; never guess among similar models. */
+export function resolveVoiceModel(models: readonly ILanguageModelChatMetadataAndIdentifier[], requestedModel: string): IVoiceModelSelectionResult & { readonly identifier?: string } {
+	const exactIdentifier = models.find(model => model.identifier === requestedModel);
+	if (exactIdentifier) {
+		return { ok: true, identifier: exactIdentifier.identifier, selected_model: voiceModelReference(exactIdentifier) };
+	}
+
+	const normalized = normalizeModelName(requestedModel);
+	const exactMatches = models.filter(model => [
+		model.metadata.name,
+		model.metadata.id,
+		model.metadata.family,
+		`${model.metadata.name} ${model.metadata.vendor}`,
+	].some(candidate => normalizeModelName(candidate) === normalized));
+	if (exactMatches.length === 1) {
+		return { ok: true, identifier: exactMatches[0].identifier, selected_model: voiceModelReference(exactMatches[0]) };
+	}
+	if (exactMatches.length > 1) {
+		return { ok: false, reason: 'ambiguous_model', available_models: exactMatches.map(voiceModelReference) };
+	}
+
+	const related = normalized ? models.filter(model => [model.metadata.name, model.metadata.id, model.metadata.family]
+		.some(candidate => normalizeModelName(candidate).includes(normalized) || normalized.includes(normalizeModelName(candidate)))) : [];
+	return {
+		ok: false,
+		reason: related.length > 1 ? 'ambiguous_model' : 'model_not_found',
+		available_models: (related.length > 0 ? related : models).slice(0, 10).map(voiceModelReference),
+	};
 }
 
 export interface IVoiceToolDispatchService {
@@ -78,6 +148,9 @@ const ACTION_LABELS: Record<string, string> = {
 	get_session_thread: localize('agentsVoice.action.getSessionThread', "Checking conversation..."),
 	respond_to_session: localize('agentsVoice.action.respond', "Responding..."),
 	focus_session: localize('agentsVoice.action.focusSession', "Focusing session..."),
+	set_model: localize('agentsVoice.action.setModel', "Changing model..."),
+	attach_file: localize('agentsVoice.action.attachFile', "Attaching file..."),
+	attach_files: localize('agentsVoice.action.attachFiles', "Attaching files..."),
 	auto_approve_session: localize('agentsVoice.action.autoApprove', "Auto-approving session..."),
 	revoke_auto_approve: localize('agentsVoice.action.revokeAutoApprove', "Revoking auto-approve..."),
 };
@@ -92,6 +165,9 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IChatService private readonly chatService: IChatService,
 		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
+		@IEditorService private readonly editorService: IEditorService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IFileService private readonly fileService: IFileService,
 	) { }
 
 	setDelegate(delegate: IVoiceToolDispatchDelegate): void {
@@ -170,35 +246,48 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 					}
 				}
 				if (firstResource) {
-					delegate.switchToSession(firstResource);
+					if (await delegate.switchToSession(firstResource)) {
+						delegate.setTargetSession(firstResource);
+					}
 				}
 				break;
 			}
 			case 'focus_session': {
 				const targetSessionId = argString('coding_session_id');
-				let targetResource: URI | undefined;
-				if (targetSessionId) {
-					// Try agent sessions first
-					const agentSession = this.agentSessionsService.model.sessions
-						.find(s => !s.isArchived() && s.resource.toString() === targetSessionId);
-					targetResource = agentSession?.resource;
-					// Fall back to regular chat sessions
-					if (!targetResource) {
-						for (const chatModel of this.chatService.chatModels.get()) {
-							if (chatModel.sessionResource.toString() === targetSessionId) {
-								targetResource = chatModel.sessionResource;
-								break;
-							}
-						}
-					}
-				}
+				const targetResource = this._findSessionResource(targetSessionId);
 				if (targetResource) {
 					const currentResource = await delegate.getCurrentSessionResource();
-					if (targetResource.toString() !== currentResource?.toString()) {
-						delegate.switchToSession(targetResource);
+					const switched = targetResource.toString() === currentResource?.toString()
+						|| await delegate.switchToSession(targetResource);
+					if (switched) {
+						delegate.setTargetSession(targetResource);
+						return JSON.stringify({ ok: true, session_id: targetResource.toString() });
 					}
 				}
-				break;
+				return JSON.stringify({ ok: false, reason: targetResource ? 'switch_failed' : 'session_not_found' });
+			}
+			case 'set_model': {
+				const requestedModel = argString('model_id') || argString('model');
+				if (!requestedModel) {
+					return JSON.stringify({ ok: false, reason: 'model_not_found' });
+				}
+				const target = await this._showActionTarget(argString('coding_session_id'));
+				if (!target.ok) {
+					return JSON.stringify(target);
+				}
+				return JSON.stringify(await delegate.selectModel(requestedModel));
+			}
+			case 'attach_file':
+			case 'attach_files': {
+				const target = await this._showActionTarget(argString('coding_session_id'));
+				if (!target.ok) {
+					return JSON.stringify(target);
+				}
+				const resolved = await this._resolveAttachmentResources(args);
+				if (!resolved.ok) {
+					return JSON.stringify(resolved);
+				}
+				return JSON.stringify(await delegate.attachFiles(resolved.resources));
 			}
 			case 'auto_approve_session': {
 				delegate.addAllAutoApprovedSessions();
@@ -230,6 +319,86 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 			}
 		}
 		return 'ok';
+	}
+
+	private _findSessionResource(sessionId: string): URI | undefined {
+		if (!sessionId) {
+			return undefined;
+		}
+		const agentSession = this.agentSessionsService.model.sessions
+			.find(session => !session.isArchived() && session.resource.toString() === sessionId);
+		if (agentSession) {
+			return agentSession.resource;
+		}
+		for (const model of this.chatService.chatModels.get()) {
+			if (model.sessionResource.toString() === sessionId) {
+				return model.sessionResource;
+			}
+		}
+		return undefined;
+	}
+
+	private async _showActionTarget(sessionId: string): Promise<{ ok: true; resource: URI } | { ok: false; reason: 'no_session' | 'session_not_found' | 'switch_failed' }> {
+		const delegate = this._delegate;
+		if (!delegate) {
+			return { ok: false, reason: 'no_session' };
+		}
+		const resource = sessionId
+			? this._findSessionResource(sessionId)
+			: delegate.getTargetSessionResource() ?? await delegate.getCurrentSessionResource();
+		if (!resource) {
+			return { ok: false, reason: sessionId ? 'session_not_found' : 'no_session' };
+		}
+		const current = await delegate.getCurrentSessionResource();
+		if (current?.toString() !== resource.toString() && !await delegate.switchToSession(resource)) {
+			return { ok: false, reason: 'switch_failed' };
+		}
+		if (sessionId) {
+			delegate.setTargetSession(resource);
+		}
+		return { ok: true, resource };
+	}
+
+	private async _resolveAttachmentResources(args: Record<string, unknown>): Promise<
+		{ ok: true; resources: readonly URI[] }
+		| { ok: false; reason: NonNullable<IVoiceAttachmentResult['reason']>; candidates?: readonly string[] }
+	> {
+		const rawValues = [args['uri'], args['path'], ...(Array.isArray(args['uris']) ? args['uris'] : []), ...(Array.isArray(args['paths']) ? args['paths'] : [])]
+			.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+		if (rawValues.length === 0) {
+			const activeResource = EditorResourceAccessor.getCanonicalUri(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+			return activeResource ? { ok: true, resources: [activeResource] } : { ok: false, reason: 'no_file' };
+		}
+
+		const resources: URI[] = [];
+		for (const rawValue of rawValues) {
+			const value = rawValue.trim();
+			const parsed = URI.parse(value);
+			if (parsed.scheme) {
+				if (!await this.fileService.exists(parsed)) {
+					return { ok: false, reason: 'file_not_found', candidates: [value] };
+				}
+				resources.push(parsed);
+				continue;
+			}
+
+			const relativePath = value.replace(/^\.\//, '');
+			const matches: URI[] = [];
+			for (const folder of this.workspaceContextService.getWorkspace().folders) {
+				const candidate = URI.joinPath(folder.uri, relativePath);
+				if (await this.fileService.exists(candidate)) {
+					matches.push(candidate);
+				}
+			}
+			if (matches.length === 0) {
+				return { ok: false, reason: 'file_not_found', candidates: [value] };
+			}
+			if (matches.length > 1) {
+				return { ok: false, reason: 'ambiguous_file', candidates: matches.map(match => match.toString()) };
+			}
+			resources.push(matches[0]);
+		}
+		return { ok: true, resources };
 	}
 
 	/**
@@ -455,71 +624,89 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 
 
 	private async _gatherSessionInfo(): Promise<string> {
-		const allSessions = this.agentSessionsService.model.sessions.filter(s => !s.isArchived());
-		const delegate = this._delegate;
-		const currentResource = await delegate?.getCurrentSessionResource();
-
-		// Per-session lastActivity (ms epoch). 0 means "no timing info" — treat as oldest.
-		const lastActivityOf = (s: typeof allSessions[number]): number =>
-			s.timing.lastRequestEnded ?? s.timing.lastRequestStarted ?? s.timing.created ?? 0;
-
-		// Calendar-day key (local time) for an epoch ms timestamp.
-		const dayKey = (ms: number): string => {
-			const d = new Date(ms);
-			return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+		const agentSessions = this.agentSessionsService.model.sessions.filter(session => !session.isArchived());
+		const currentResource = await this._delegate?.getCurrentSessionResource();
+		const activeResource = this._delegate?.getTargetSessionResource() ?? currentResource;
+		const agentResources = new Set(agentSessions.map(session => session.resource.toString()));
+		const inputDetails = (model: IChatModel | undefined) => {
+			const state = model?.inputModel?.state?.get();
+			const selected = state?.selectedModel;
+			const attachments = state?.attachments.filter(isExplicitFileOrImageVariableEntry) ?? [];
+			return {
+				...(selected ? { selected_model: voiceModelReference(selected) } : {}),
+				...(attachments.length ? {
+					attachment_names: attachments.map(attachment => attachment.name).slice(0, 10),
+					attachment_count: attachments.length,
+				} : {}),
+			};
+		};
+		const lastResponseSummary = (model: IChatModel | undefined): string | undefined => {
+			const summary = model?.getRequests().at(-1)?.response?.response.value
+				.filter(part => part.kind === 'markdownContent')
+				.map(part => (part as { content: { value: string } }).content.value)
+				.join(' ')
+				.slice(0, 500);
+			return summary || undefined;
 		};
 
-		// Filter to "active today, or if none today, the most-recent active day".
-		const todayKey = dayKey(Date.now());
-		const withTiming = allSessions
-			.map(s => ({ s, t: lastActivityOf(s) }))
-			.filter(x => x.t > 0); // drop sessions with no activity timestamp at all
-
-		let filtered: typeof allSessions;
-		const todays = withTiming.filter(x => dayKey(x.t) === todayKey);
-		if (todays.length > 0) {
-			filtered = todays.map(x => x.s);
-		} else if (withTiming.length > 0) {
-			// Fall back to the most recent active day.
-			const mostRecent = withTiming.reduce((a, b) => (a.t >= b.t ? a : b));
-			const mostRecentKey = dayKey(mostRecent.t);
-			filtered = withTiming.filter(x => dayKey(x.t) === mostRecentKey).map(x => x.s);
-		} else {
-			filtered = [];
-		}
-
-		const sessionData = filtered.map(session => {
+		const sessionData: Array<Record<string, unknown> & { state: string; is_active: boolean; last_activity: number }> = agentSessions.map(session => {
 			const model = this.chatService.getSession(session.resource);
 			const changes = getAgentChangesSummary(session.changes);
-			const lastReq = model?.getRequests().at(-1);
-			const lastResponseSummary = lastReq?.response?.response.value
-				.filter(p => p.kind === 'markdownContent')
-				.map(p => (p as { content: { value: string } }).content.value)
-				.join(' ')
-				.slice(0, 500) || '';
-
-			const statusLabel =
-				session.status === AgentSessionStatus.InProgress ? 'working'
-					: session.status === AgentSessionStatus.NeedsInput ? 'waiting_for_input'
-						: session.status === AgentSessionStatus.Completed ? 'idle'
-							: 'unknown';
-
-			const isActive = currentResource?.toString() === session.resource.toString();
-			const lastActivity = lastActivityOf(session);
-			const minutesAgo = lastActivity ? Math.round((Date.now() - lastActivity) / 60000) : undefined;
-
+			const state = session.status === AgentSessionStatus.InProgress ? 'working'
+				: session.status === AgentSessionStatus.NeedsInput ? 'waiting_for_input'
+					: session.status === AgentSessionStatus.Completed ? 'idle'
+						: 'unknown';
+			const lastActivity = session.timing.lastRequestEnded ?? session.timing.lastRequestStarted ?? session.timing.created ?? 0;
 			return {
 				id: session.resource.toString(),
-				state: statusLabel,
-				is_active: isActive,
+				label: session.label || undefined,
+				session_type: 'agent' as const,
+				state,
+				is_active: activeResource?.toString() === session.resource.toString(),
 				insertions: changes?.insertions ?? 0,
 				deletions: changes?.deletions ?? 0,
-				last_activity_minutes_ago: minutesAgo,
-				last_response_summary: lastResponseSummary,
+				last_activity: lastActivity,
+				last_activity_minutes_ago: lastActivity ? Math.max(0, Math.round((Date.now() - lastActivity) / 60000)) : undefined,
+				last_response_summary: lastResponseSummary(model),
+				...inputDetails(model),
 			};
 		});
 
-		return JSON.stringify({ sessions: sessionData });
+		for (const model of this.chatService.chatModels.get()) {
+			if (agentResources.has(model.sessionResource.toString()) || model.getRequests().length === 0) {
+				continue;
+			}
+			const needsInput = model.requestNeedsInput?.get();
+			const inProgress = model.hasActiveRequest?.get();
+			sessionData.push({
+				id: model.sessionResource.toString(),
+				label: model.title || undefined,
+				session_type: 'chat',
+				state: needsInput ? 'waiting_for_input' : inProgress ? 'working' : 'idle',
+				is_active: activeResource?.toString() === model.sessionResource.toString(),
+				insertions: 0,
+				deletions: 0,
+				last_activity: model.lastMessageDate,
+				last_activity_minutes_ago: Math.max(0, Math.round((Date.now() - model.lastMessageDate) / 60000)),
+				last_response_summary: lastResponseSummary(model),
+				...inputDetails(model),
+			});
+		}
+
+		sessionData.sort((a, b) => Number(b.is_active) - Number(a.is_active) || b.last_activity - a.last_activity);
+		const counts = sessionData.reduce((result, session) => {
+			if (session.state === 'working') { result.working++; }
+			else if (session.state === 'waiting_for_input') { result.waiting_for_input++; }
+			else if (session.state === 'idle') { result.idle++; }
+			return result;
+		}, { working: 0, waiting_for_input: 0, idle: 0 });
+		const visibleSessions = sessionData.slice(0, 20).map(({ last_activity, ...session }) => session);
+		return JSON.stringify({
+			total_sessions: sessionData.length,
+			counts,
+			sessions: visibleSessions,
+			truncated: visibleSessions.length < sessionData.length,
+		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -560,6 +560,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this._currentLanguageModel;
 	}
 
+	/** Models the current input can select, for frontend-owned voice actions. */
+	get availableLanguageModels(): readonly ILanguageModelChatMetadataAndIdentifier[] {
+		return this.getModels();
+	}
+
 	private _onDidChangeCurrentChatMode: Emitter<IChatModeChangeEvent> = this._register(new Emitter<IChatModeChangeEvent>());
 	readonly onDidChangeCurrentChatMode: Event<IChatModeChangeEvent> = this._onDidChangeCurrentChatMode.event;
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -15,7 +15,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { MutableDisposable, toDisposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { autorun, IObservable, IReader, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
+import { basename, isEqual } from '../../../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
@@ -81,6 +81,7 @@ import { IVoiceInputModeService, SimulatedVoiceState } from '../../voiceInputMod
 import { isGlowingVoiceState, readVoiceGlowIntensity, resolveVoiceGlowColors, VoiceGlowState } from '../../voiceClient/voiceGlow.js';
 import { createVoiceGlowController } from '../../voiceClient/voiceGlowController.js';
 import { combineVoiceInput } from '../../voiceClient/voiceInputUtils.js';
+import { IVoiceAttachmentResult, IVoiceModelSelectionResult, resolveVoiceModel } from '../../voiceClient/voiceToolDispatchService.js';
 import { IAgentTitleBarStatusService } from '../../agentSessions/experiments/agentTitleBarStatusService.js';
 import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
 import { VOICE_AGENT_PROGRESS_SETTING } from '../../../common/voiceClient/voiceClientService.js';
@@ -455,7 +456,38 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.getCurrentSession', (_accessor): string | undefined => {
 				return this._widget?.viewModel?.sessionResource?.toString();
 			}));
+			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.selectModel', (_accessor, requestedModel: string): IVoiceModelSelectionResult => {
+				const widget = this._getVoiceActionWidget();
+				if (!widget) {
+					return { ok: false, reason: 'no_input' };
+				}
+				const resolved = resolveVoiceModel(widget.inputPart.availableLanguageModels, requestedModel);
+				if (!resolved.ok || !resolved.identifier) {
+					return resolved;
+				}
+				return widget.inputPart.switchModelByIdentifier(resolved.identifier, true, true)
+					? resolved
+					: { ok: false, reason: 'selection_failed', available_models: resolved.available_models };
+			}));
+			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.attachFiles', async (_accessor, resourceStrings: readonly string[]): Promise<IVoiceAttachmentResult> => {
+				const widget = this._getVoiceActionWidget();
+				if (!widget) {
+					return { ok: false, reason: 'no_input' };
+				}
+				try {
+					const resources = resourceStrings.map(resource => URI.parse(resource));
+					await Promise.all(resources.map(resource => widget.attachmentModel.addFile(resource)));
+					return { ok: true, attached: resources.map(resource => basename(resource)) };
+				} catch {
+					return { ok: false, reason: 'attachment_failed' };
+				}
+			}));
 		}
+	}
+
+	private _getVoiceActionWidget() {
+		const target = this._currentVoiceInputResource();
+		return target ? this.chatWidgetService.getWidgetBySessionResource(target) : this._widget;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -100,14 +100,27 @@ export interface IVoiceSessionContext {
 		id: string;
 		/** Human-readable name, so the backend can tell two sessions apart. */
 		label?: string;
+		/** Which frontend session surface owns this conversation. */
+		session_type?: 'agent' | 'chat';
 		is_active: boolean;
 		agent_state: string;
 		agent_state_detail?: string;
 		confirmation_type?: VoiceConfirmationType;
+		/** The model currently selected for this session's next request. */
+		selected_model?: IVoiceModelReference;
+		/** Names only: file contents remain in the frontend until a request is sent. */
+		attachment_names?: string[];
+		attachment_count?: number;
 		last_response_summary?: string;
 		pending?: IVoiceSessionPending;
 	}[];
 	display_locale: string;
+}
+
+export interface IVoiceModelReference {
+	readonly identifier: string;
+	readonly name: string;
+	readonly vendor: string;
 }
 
 export type VoiceConfirmationType = 'questionnaire' | 'elicitation' | 'plan' | 'tool' | 'generic';

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceGlow.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Color } from '../../../../../../base/common/color.js';
+import { Color, HSLA } from '../../../../../../base/common/color.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ColorScheme } from '../../../../../../platform/theme/common/theme.js';
 import { IColorTheme } from '../../../../../../platform/theme/common/themeService.js';
@@ -78,9 +78,21 @@ suite('VoiceGlow', () => {
 			},
 			{
 				dark: { mic: '202.0 96% 56%', voiceMode: '202.0 96% 56%' },
-				light: { mic: '202.0 96% 72%', voiceMode: '202.0 96% 72%' },
+				light: { mic: '202.0 41% 52%', voiceMode: '202.0 41% 52%' },
 				washedOut: { mic: '197.0 70% 56%', voiceMode: '197.0 70% 56%' },
 			}
 		);
+	});
+
+	test('the active rim keeps non-text contrast against custom input backgrounds', () => {
+		const accent = Color.fromHex('#7A8B99');
+		for (const [kind, background] of [
+			['light', Color.fromHex('#FAFAFA')],
+			['dark', Color.fromHex('#242424')],
+		] as const) {
+			const rim = resolveVoiceRimAccent(accent, 'cool', kind, background);
+			const rimColor = new Color(new HSLA(rim.hue, rim.saturation / 100, rim.lightness / 100, 1));
+			assert.ok(background.getContrastRatio(rimColor) >= 3, `${kind} rim contrast was ${background.getContrastRatio(rimColor)}`);
+		}
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceSessionController.test.ts
@@ -424,6 +424,7 @@ class TestChatWidgetService extends mock<IChatWidgetService>() {
 	override readonly onDidChangeFocusedSession = Event.None;
 	override readonly onDidAddWidget = Event.None;
 	override getAllWidgets() { return []; }
+	override getWidgetBySessionResource(): undefined { return undefined; }
 }
 
 class TestCommandService extends mock<ICommandService>() {
@@ -1346,6 +1347,7 @@ suite('VoiceSessionController', () => {
 		assert.deepStrictEqual({
 			pendingContext: pendingContext ? {
 				id: pendingContext['id'],
+				session_type: pendingContext['session_type'],
 				is_active: pendingContext['is_active'],
 				agent_state: pendingContext['agent_state'],
 				agent_state_detail: pendingContext['agent_state_detail'],
@@ -1362,6 +1364,7 @@ suite('VoiceSessionController', () => {
 		}, {
 			pendingContext: {
 				id: sessionResource.toString(),
+				session_type: 'chat',
 				is_active: true,
 				agent_state: 'waiting_for_confirmation',
 				agent_state_detail: [
@@ -1388,6 +1391,7 @@ suite('VoiceSessionController', () => {
 			resolvedContext: {
 				id: sessionResource.toString(),
 				label: 'Chat',
+				session_type: 'chat',
 				is_active: true,
 				agent_state: 'idle',
 			},
@@ -3816,6 +3820,55 @@ suite('VoiceSessionController', () => {
 
 		assert.strictEqual(session.agent_state, 'waiting_for_confirmation');
 		assert.strictEqual(session.label, 'Auth fix');
+	});
+
+	test('grounds the active session with its selected model and attachment names', () => {
+		const chatService = new ControllableChatService();
+		const resource = URI.parse('vscode-chat://regular/session-aware');
+		const lastRequest = {
+			id: 'request-1',
+			response: {
+				isPendingConfirmation: observableValue('pending', undefined),
+				isIncomplete: observableValue('incomplete', false),
+				response: { value: [], getMarkdown: () => '' },
+			},
+		};
+		const model = {
+			sessionResource: resource,
+			title: 'Session awareness',
+			lastMessageDate: Date.now(),
+			getRequests: () => [lastRequest],
+			lastRequestObs: observableValue('lastRequest', lastRequest),
+			inputModel: {
+				state: observableValue('inputState', {
+					selectedModel: {
+						identifier: 'copilot/gpt-5',
+						metadata: { name: 'GPT-5', vendor: 'copilot' },
+					},
+					attachments: [{ kind: 'file', name: 'voiceSessionController.ts' }, { kind: 'file', name: 'README.md' }],
+				}),
+			},
+		} as unknown as IChatModel;
+		chatService.setModels([model]);
+		const controller = createController(new TestVoiceClientService(), undefined, undefined, undefined, undefined, undefined, chatService);
+		controller.setActiveSessionShown(resource);
+		const buildSessionContext = Reflect.get(controller, '_buildSessionContext') as () => IVoiceSessionContext;
+
+		const [session] = buildSessionContext.call(controller).sessions;
+
+		assert.deepStrictEqual({
+			session_type: session.session_type,
+			is_active: session.is_active,
+			selected_model: session.selected_model,
+			attachment_names: session.attachment_names,
+			attachment_count: session.attachment_count,
+		}, {
+			session_type: 'chat',
+			is_active: true,
+			selected_model: { identifier: 'copilot/gpt-5', name: 'GPT-5', vendor: 'copilot' },
+			attachment_names: ['voiceSessionController.ts', 'README.md'],
+			attachment_count: 2,
+		});
 	});
 
 	test('an older tool confirmation holds the turn ahead of a newer form', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
@@ -10,7 +10,7 @@ import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
-import { IVoiceToolDispatchDelegate, resolveVoiceModel, VoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
+import { IVoiceModelSelectionResult, IVoiceToolDispatchDelegate, resolveVoiceModel, VoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
 import { IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { ChatPlanReviewData } from '../../../common/model/chatProgressTypes/chatPlanReviewData.js';
@@ -59,40 +59,246 @@ suite('VoiceToolDispatchService - model selection', () => {
 suite('VoiceToolDispatchService - session actions', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('focusing a session also retargets subsequent voice turns', async () => {
-		const resource = URI.parse('agent-session://test/target');
+	interface IActionHarnessOptions {
+		readonly currentResource?: URI;
+		readonly targetResource?: URI;
+		readonly agentSessionResources?: readonly URI[];
+		readonly chatModels?: readonly IChatModel[];
+		readonly activeEditorResource?: URI;
+		readonly workspaceFolders?: readonly URI[];
+		readonly existingResources?: ReadonlySet<string>;
+		readonly selectModelResult?: IVoiceModelSelectionResult;
+		readonly switchSucceeds?: boolean;
+	}
+
+	function createActionHarness(options: IActionHarnessOptions = {}) {
+		const calls = {
+			switchedTo: [] as URI[],
+			targeted: [] as URI[],
+			selectedModels: [] as string[],
+			attachedResources: [] as Array<readonly URI[]>,
+		};
+		let currentResource = options.currentResource;
+		let targetResource = options.targetResource;
 		const agentSessionsService = new class extends mock<IAgentSessionsService>() {
 			override get model(): IAgentSessionsModel {
-				return { sessions: [{ isArchived: () => false, resource }] } as IAgentSessionsModel;
+				return {
+					sessions: (options.agentSessionResources ?? []).map(resource => ({ isArchived: () => false, resource })),
+				} as IAgentSessionsModel;
 			}
 		};
 		const chatService = new class extends mock<IChatService>() {
-			override readonly chatModels = observableValue<readonly IChatModel[]>('chatModels', []);
+			override readonly chatModels = observableValue<readonly IChatModel[]>('chatModels', options.chatModels ?? []);
+		};
+		const editorService = new class extends mock<IEditorService>() {
+			override get activeEditor(): IEditorService['activeEditor'] {
+				return options.activeEditorResource ? { resource: options.activeEditorResource } as IEditorService['activeEditor'] : undefined;
+			}
+		};
+		const workspaceContextService = new class extends mock<IWorkspaceContextService>() {
+			override getWorkspace(): ReturnType<IWorkspaceContextService['getWorkspace']> {
+				return {
+					folders: (options.workspaceFolders ?? []).map((uri, index) => ({ uri, index, name: `folder-${index}` })),
+				} as ReturnType<IWorkspaceContextService['getWorkspace']>;
+			}
+		};
+		const fileService = new class extends mock<IFileService>() {
+			override async exists(resource: URI): Promise<boolean> {
+				return options.existingResources?.has(resource.toString()) ?? false;
+			}
 		};
 		const service = new VoiceToolDispatchService(
 			agentSessionsService,
 			chatService,
 			new class extends mock<ILanguageModelToolsService>() { },
-			new class extends mock<IEditorService>() { },
-			new class extends mock<IWorkspaceContextService>() { },
-			new class extends mock<IFileService>() { },
+			editorService,
+			workspaceContextService,
+			fileService,
 		);
-		let switchedTo: URI | undefined;
-		let target: URI | undefined;
 		service.setDelegate(new class extends mock<IVoiceToolDispatchDelegate>() {
-			override async getCurrentSessionResource(): Promise<undefined> { return undefined; }
-			override async switchToSession(value: URI): Promise<boolean> { switchedTo = value; return true; }
-			override setTargetSession(value: URI): void { target = value; }
+			override async getCurrentSessionResource(): Promise<URI | undefined> { return currentResource; }
+			override async switchToSession(resource: URI): Promise<boolean> {
+				calls.switchedTo.push(resource);
+				if (options.switchSucceeds === false) {
+					return false;
+				}
+				currentResource = resource;
+				return true;
+			}
+			override setTargetSession(resource: URI): void {
+				targetResource = resource;
+				calls.targeted.push(resource);
+			}
+			override getTargetSessionResource(): URI | undefined { return targetResource; }
+			override async selectModel(requestedModel: string): Promise<IVoiceModelSelectionResult> {
+				calls.selectedModels.push(requestedModel);
+				return options.selectModelResult ?? {
+					ok: true,
+					selected_model: { identifier: requestedModel, name: requestedModel, vendor: 'test' },
+				};
+			}
+			override async attachFiles(resources: readonly URI[]) {
+				calls.attachedResources.push(resources);
+				return { ok: true, attached: resources.map(resource => resource.toString()) };
+			}
 		}());
+		return { service, calls };
+	}
 
-		const result = JSON.parse(await service.dispatchToolCall({
-			name: 'focus_session',
-			args: { coding_session_id: resource.toString() },
-		} as unknown as IVoiceToolCall));
+	async function dispatch(service: VoiceToolDispatchService, name: string, args: Record<string, unknown> = {}) {
+		return JSON.parse(await service.dispatchToolCall({ name, args } as IVoiceToolCall));
+	}
+
+	test('focusing a session also retargets subsequent voice turns', async () => {
+		const resource = URI.parse('agent-session://test/target');
+		const { service, calls } = createActionHarness({ agentSessionResources: [resource] });
+
+		const result = await dispatch(service, 'focus_session', { coding_session_id: resource.toString() });
 
 		assert.deepStrictEqual(result, { ok: true, session_id: resource.toString() });
-		assert.strictEqual(switchedTo?.toString(), resource.toString());
-		assert.strictEqual(target?.toString(), resource.toString());
+		assert.strictEqual(calls.switchedTo[0]?.toString(), resource.toString());
+		assert.strictEqual(calls.targeted[0]?.toString(), resource.toString());
+	});
+
+	test('sets a model on the current session without changing the voice target', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const { service, calls } = createActionHarness({ currentResource });
+
+		const result = await dispatch(service, 'set_model', { model: 'GPT-5' });
+
+		assert.deepStrictEqual(result, {
+			ok: true,
+			selected_model: { identifier: 'GPT-5', name: 'GPT-5', vendor: 'test' },
+		});
+		assert.deepStrictEqual(calls.selectedModels, ['GPT-5']);
+		assert.deepStrictEqual(calls.switchedTo, []);
+		assert.deepStrictEqual(calls.targeted, []);
+	});
+
+	test('targets a requested session and preserves a model selection failure', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const targetResource = URI.parse('vscode-chat://test/target');
+		const targetModel = { sessionResource: targetResource } as IChatModel;
+		const { service, calls } = createActionHarness({
+			currentResource,
+			chatModels: [targetModel],
+			selectModelResult: { ok: false, reason: 'selection_failed' },
+		});
+
+		const result = await dispatch(service, 'set_model', { model_id: 'copilot/gpt-5', coding_session_id: targetResource.toString() });
+
+		assert.deepStrictEqual(result, { ok: false, reason: 'selection_failed' });
+		assert.strictEqual(calls.switchedTo[0]?.toString(), targetResource.toString());
+		assert.strictEqual(calls.targeted[0]?.toString(), targetResource.toString());
+		assert.deepStrictEqual(calls.selectedModels, ['copilot/gpt-5']);
+	});
+
+	test('does not select a model when the requested session cannot be found or shown', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const targetResource = URI.parse('vscode-chat://test/target');
+		const targetModel = { sessionResource: targetResource } as IChatModel;
+		const missing = createActionHarness({ currentResource });
+		const unavailable = createActionHarness({ currentResource, chatModels: [targetModel], switchSucceeds: false });
+
+		assert.deepStrictEqual(
+			await dispatch(missing.service, 'set_model', { model: 'GPT-5', coding_session_id: targetResource.toString() }),
+			{ ok: false, reason: 'session_not_found' },
+		);
+		assert.deepStrictEqual(
+			await dispatch(unavailable.service, 'set_model', { model: 'GPT-5', coding_session_id: targetResource.toString() }),
+			{ ok: false, reason: 'switch_failed' },
+		);
+		assert.deepStrictEqual(missing.calls.selectedModels, []);
+		assert.deepStrictEqual(unavailable.calls.selectedModels, []);
+		assert.deepStrictEqual(unavailable.calls.targeted, []);
+	});
+
+	test('attaches the active editor when no file argument is supplied', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const activeEditorResource = URI.file('/workspace/active.ts');
+		const { service, calls } = createActionHarness({ currentResource, activeEditorResource });
+
+		const result = await dispatch(service, 'attach_file');
+
+		assert.deepStrictEqual(result, { ok: true, attached: [activeEditorResource.toString()] });
+		assert.strictEqual(calls.attachedResources[0]?.[0]?.toString(), activeEditorResource.toString());
+	});
+
+	test('reports no file when an argument and active editor are both absent', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const { service, calls } = createActionHarness({ currentResource });
+
+		const result = await dispatch(service, 'attach_file');
+
+		assert.deepStrictEqual(result, { ok: false, reason: 'no_file' });
+		assert.deepStrictEqual(calls.attachedResources, []);
+	});
+
+	test('reports a workspace-relative attachment that does not exist', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const { service } = createActionHarness({ currentResource, workspaceFolders: [URI.file('/workspace')] });
+
+		const result = await dispatch(service, 'attach_file', { path: 'src/missing.ts' });
+
+		assert.deepStrictEqual(result, { ok: false, reason: 'file_not_found', candidates: ['src/missing.ts'] });
+	});
+
+	test('reports all matching workspace roots for an ambiguous attachment', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const workspaceFolders = [URI.file('/workspace/one'), URI.file('/workspace/two')];
+		const matches = workspaceFolders.map(folder => URI.joinPath(folder, 'src/shared.ts'));
+		const { service } = createActionHarness({
+			currentResource,
+			workspaceFolders,
+			existingResources: new Set(matches.map(resource => resource.toString())),
+		});
+
+		const result = await dispatch(service, 'attach_file', { path: 'src/shared.ts' });
+
+		assert.deepStrictEqual(result, {
+			ok: false,
+			reason: 'ambiguous_file',
+			candidates: matches.map(resource => resource.toString()),
+		});
+	});
+
+	test('treats an absolute Windows path as a file instead of a URI scheme', async () => {
+		const currentResource = URI.parse('vscode-chat://test/current');
+		const file = URI.file('C:/repo/file.ts');
+		const { service, calls } = createActionHarness({
+			currentResource,
+			existingResources: new Set([file.toString()]),
+		});
+
+		const result = await dispatch(service, 'attach_file', { path: 'C:\\repo\\file.ts' });
+
+		assert.strictEqual(result.ok, true);
+		assert.strictEqual(calls.attachedResources[0]?.[0]?.toString(), file.toString());
+	});
+
+	test('includes an active regular chat before its first request', async () => {
+		const resource = URI.parse('vscode-chat://test/empty-active');
+		const model = {
+			sessionResource: resource,
+			title: 'New chat',
+			lastMessageDate: 0,
+			getRequests: () => [],
+		} as unknown as IChatModel;
+		const { service } = createActionHarness({ currentResource: resource, chatModels: [model] });
+
+		const result = await dispatch(service, 'get_session_info');
+
+		assert.strictEqual(result.total_sessions, 1);
+		assert.deepStrictEqual(result.counts, { working: 0, waiting_for_input: 0, idle: 1 });
+		assert.deepStrictEqual(result.sessions[0], {
+			id: resource.toString(),
+			label: 'New chat',
+			session_type: 'chat',
+			state: 'idle',
+			is_active: true,
+			insertions: 0,
+			deletions: 0,
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
@@ -10,7 +10,7 @@ import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAgentSessionsModel } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../browser/agentSessions/agentSessionsService.js';
-import { VoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
+import { IVoiceToolDispatchDelegate, resolveVoiceModel, VoiceToolDispatchService } from '../../../browser/voiceClient/voiceToolDispatchService.js';
 import { IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { ChatPlanReviewData } from '../../../common/model/chatProgressTypes/chatPlanReviewData.js';
@@ -18,6 +18,83 @@ import { ChatQuestionCarouselData } from '../../../common/model/chatProgressType
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { AskQuestionsToolId } from '../../../common/tools/builtinTools/askQuestionsTool.js';
 import { derivePendingId, IVoiceToolCall } from '../../../common/voiceClient/voiceClientService.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
+
+suite('VoiceToolDispatchService - model selection', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const model = (identifier: string, name: string, id = name): ILanguageModelChatMetadataAndIdentifier => ({
+		identifier,
+		metadata: { name, id, family: id, vendor: 'copilot' },
+	} as ILanguageModelChatMetadataAndIdentifier);
+
+	test('matches a unique normalized model name', () => {
+		const result = resolveVoiceModel([
+			model('copilot/gpt-5', 'GPT-5'),
+			model('copilot/claude', 'Claude Sonnet 4'),
+		], 'gpt 5');
+
+		assert.deepStrictEqual(result, {
+			ok: true,
+			identifier: 'copilot/gpt-5',
+			selected_model: { identifier: 'copilot/gpt-5', name: 'GPT-5', vendor: 'copilot' },
+		});
+	});
+
+	test('returns candidates instead of guessing between ambiguous names', () => {
+		const result = resolveVoiceModel([
+			model('copilot/gpt-5-fast', 'GPT-5'),
+			model('openai/gpt-5', 'GPT-5'),
+		], 'GPT-5');
+
+		assert.strictEqual(result.ok, false);
+		assert.strictEqual(result.reason, 'ambiguous_model');
+		assert.deepStrictEqual(result.available_models?.map(candidate => candidate.identifier), ['copilot/gpt-5-fast', 'openai/gpt-5']);
+	});
+});
+
+suite('VoiceToolDispatchService - session actions', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('focusing a session also retargets subsequent voice turns', async () => {
+		const resource = URI.parse('agent-session://test/target');
+		const agentSessionsService = new class extends mock<IAgentSessionsService>() {
+			override get model(): IAgentSessionsModel {
+				return { sessions: [{ isArchived: () => false, resource }] } as IAgentSessionsModel;
+			}
+		};
+		const chatService = new class extends mock<IChatService>() {
+			override readonly chatModels = observableValue<readonly IChatModel[]>('chatModels', []);
+		};
+		const service = new VoiceToolDispatchService(
+			agentSessionsService,
+			chatService,
+			new class extends mock<ILanguageModelToolsService>() { },
+			new class extends mock<IEditorService>() { },
+			new class extends mock<IWorkspaceContextService>() { },
+			new class extends mock<IFileService>() { },
+		);
+		let switchedTo: URI | undefined;
+		let target: URI | undefined;
+		service.setDelegate(new class extends mock<IVoiceToolDispatchDelegate>() {
+			override async getCurrentSessionResource(): Promise<undefined> { return undefined; }
+			override async switchToSession(value: URI): Promise<boolean> { switchedTo = value; return true; }
+			override setTargetSession(value: URI): void { target = value; }
+		}());
+
+		const result = JSON.parse(await service.dispatchToolCall({
+			name: 'focus_session',
+			args: { coding_session_id: resource.toString() },
+		} as unknown as IVoiceToolCall));
+
+		assert.deepStrictEqual(result, { ok: true, session_id: resource.toString() });
+		assert.strictEqual(switchedTo?.toString(), resource.toString());
+		assert.strictEqual(target?.toString(), resource.toString());
+	});
+});
 
 suite('VoiceToolDispatchService - respondToSession', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -46,6 +123,9 @@ suite('VoiceToolDispatchService - respondToSession', () => {
 			agentSessionsService,
 			chatService,
 			new class extends mock<ILanguageModelToolsService>() { },
+			new class extends mock<IEditorService>() { },
+			new class extends mock<IWorkspaceContextService>() { },
+			new class extends mock<IFileService>() { },
 		);
 	}
 


### PR DESCRIPTION
Part of #329488
Part of #329489
Part of #329490
Fixes #329491

## Summary

This adds the frontend foundation for session-aware Voice Mode:

- enriches the ongoing voice session context with session type, selected model, and attachment metadata
- expands `get_session_info` to include agent and regular chat sessions, aggregate state counts, target state, activity, and truncation metadata
- makes session focus/navigation retarget subsequent voice turns only after the requested surface is shown successfully
- adds frontend dispatch for voice-driven model selection and file attachment in workbench chat and the Agents/new-session composer
- strengthens the active listening indication against the actual themed input background with a 3:1 non-text contrast target

The branch is based directly on `main` and has no dependency on `megrogge/chat-input-window`.

## Frontend action contract

### Session context

Each `session_context.sessions[]` entry may now include:

- `session_type`: `agent` or `chat`
- `selected_model`: `{ identifier, name, vendor }`
- `attachment_names`: display names only; file contents remain frontend-owned until request submission
- `attachment_count`

`get_session_info` returns:

- `total_sessions`
- `counts`: `working`, `waiting_for_input`, and `idle`
- `sessions`: active target first, then most recently active, capped at 20
- `truncated`

The session list includes IDs, labels, types, state, active-target marker, activity age, response summary, model/attachment metadata, and agent change counts where available.

### Actions

- `focus_session({ coding_session_id })` reveals the session and makes it the target for later voice turns. It returns structured `ok`, `session_not_found`, or `switch_failed` results.
- `set_model({ model_id | model, coding_session_id? })` selects only an exact frontend identifier or unique normalized exact name. Ambiguous input returns candidates; the frontend does not guess.
- `attach_file` / `attach_files({ uri | path | uris | paths, coding_session_id? })` attach exact URIs or exact workspace-relative paths. With no file argument, the active editor is attached. Ambiguous workspace paths return candidates.
- Explicitly targeted model/attachment actions reveal and retarget the requested session before changing its input.

## Required voice-backend follow-up

No voice-backend code is available in this repository. The backend needs corresponding tool and routing changes before all user-facing flows are end to end:

1. Consume the added session context fields and use `get_session_info` for questions about the current session, session counts, running work, selected model, and attachments.
2. Register and emit `set_model` with `model_id` (preferred) or `model`, plus optional `coding_session_id`.
3. Register and emit `attach_file` / `attach_files` with `uri`, `path`, `uris`, or `paths`, plus optional `coding_session_id`. A call without file arguments means the active editor.
4. Treat `ambiguous_model` and `ambiguous_file` as clarification prompts. Do not claim that an action succeeded unless the frontend returned `ok: true`.
5. Treat "start a new session" as the existing `new_sessions` application action. Do not answer the utterance conversationally or submit it as prompt text to the current coding session.
6. After a successful `focus_session`, route subsequent turns to that returned session ID until the frontend target changes.

### Routing boundary

The voice backend should answer or act directly for application state/actions and lightweight questions that do not need workspace context or durable chat history. Examples include:

- "What session am I in?"
- "How many sessions are running?"
- "Is the agent still working?"
- "Which model am I using?"
- "Start a new session"
- "Change to GPT-5"
- "Attach this file"
- "What does polymorphism mean?"
- "While that request runs, what is the difference between TCP and UDP?"

It should submit a coding-agent chat request for work that requires workspace context, tools, repository inspection, project modification, or a durable answer in chat history. Examples include debugging a test, explaining a compiler error in the project, refactoring, searching the repository, reviewing a PR, creating a migration, or investigating a build.

Direct voice answers should not create a new coding request or pollute the active coding session while other work continues.

## Related fixes

#329441 and #329451 address the two previously reported persistence/playback bugs separately. Those changes look complementary to this work; this PR neither duplicates nor depends on them.

## Validation

- `npm run compile-client` — 0 errors
- targeted ESLint for all changed TypeScript files
- `./scripts/test.sh --grep 'VoiceGlow'` — 5 passing
- `./scripts/test.sh --grep 'VoiceToolDispatchService'` — 16 passing
- `./scripts/test.sh --grep 'VoiceSessionController'` — 114 passing
- `./scripts/test.sh --grep 'SessionsVoiceNewComposerContribution'` — 3 passing
- isolated Code OSS launch with simulated listening state; verified the active themed rim/input state
