### PR TITLE
agentHost: Clarify deferred tool search misses

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -95,7 +95,8 @@ non-core client tools behind the runtime's `tool_search_tool`:
   maps `tool_search_tool` back to `toolSearch` to execute the real VS Code tool.
 - **The prompt** (this folder): `toolSearchInstructionLines(toolSearchActive)`
   adds a `tool_instructions` line (`toolSearchToolInstructions`) telling the
-  model to load deferred tools via `tool_search_tool` first — gated on
+  model to load deferred tools via `tool_search_tool` first and not to interpret
+  one ranked miss as evidence that a tool or server is unavailable — gated on
   `context.toolSearchActive` because the `toolSearch` tool is *always* forwarded,
   so presence alone can't gate it. The runtime already emits its own
   deferred-tools reminder (`build_deferred_tools_user_message`) with the accurate

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -69,7 +69,7 @@ const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstr
 /** Tool-search guidance mirrored from the Copilot extension prompt. */
 const toolSearchToolInstructions: ToolInstructionLine = hasTool =>
 	hasTool(CLIENT_TOOL_SEARCH_REFERENCE_NAME)
-		? `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`
+		? `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`
 		: undefined;
 
 export function toolSearchInstructionLines(toolSearchActive: boolean): readonly ToolInstructionLine[] {

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -268,7 +268,7 @@ suite('AgentHostPromptRegistry', () => {
 		// when `toolSearchActive` AND the client tool-search tool are both
 		// present; the composition/gating itself is covered in
 		// toolInstructions.test.ts.
-		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`;
 
 		test('layers the tool-search line onto the default config when active and the tool-search tool is present', () => {
 			const registry = new AgentHostPromptRegistry();

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -89,7 +89,7 @@ suite('toolInstructions', () => {
 	// exposing the tool-search tool. These lock its content, gating, and
 	// composition so neither the instruction nor its gate can silently regress.
 	suite('toolSearchInstructionLines', () => {
-		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`;
 
 		test('active tool search contributes the tool-search line only when the client exposes the tool-search tool', () => {
 			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)), TOOL_SEARCH_LINE);


### PR DESCRIPTION
## Summary

Clarify the agent host's deferred-tool guidance so models understand that ranked tool-search results can omit available tools and should retry once using the exact tool name before concluding that a tool or server is unavailable.

## Changes

- update the tool-search prompt guidance
- keep the prompt documentation aligned
- update the prompt registry and tool-instruction tests