### PR TITLE
agentHost: Align deferred tool search result names

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1640,27 +1640,32 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	private _toToolSearchResult(clientResult: ToolResultObject, availableTools: readonly CurrentToolMetadata[] | undefined): ToolResultObject {
-		const deferred = new Set<string>();
+		const deferred = new Map<string, string>();
 		for (const tool of availableTools ?? []) {
 			if (tool.deferLoading) {
-				deferred.add(tool.name);
+				deferred.set(tool.name, tool.name);
 				if (tool.namespacedName) {
-					deferred.add(tool.namespacedName);
+					deferred.set(tool.namespacedName, tool.name);
 				}
 			}
 		}
-		const clientNames = this._parseToolSearchNames(clientResult.textResultForLlm);
-		const toolReferences = clientNames.filter(name => deferred.has(name));
+		const parsedClientNames = this._parseToolSearchNames(clientResult.textResultForLlm);
+		const clientNames = parsedClientNames ?? [];
+		const toolReferences = [...new Set(clientNames.map(name => deferred.get(name)).filter(isDefined))];
 		this._logService.info(`[Copilot:${this.sessionId}] tool_search override: availableTools=${availableTools?.length ?? 0}, deferred=${deferred.size}, clientMatched=[${clientNames.join(', ')}] -> toolReferences=[${toolReferences.join(', ')}]`);
-		return { ...clientResult, toolReferences };
+		return {
+			...clientResult,
+			...(clientResult.resultType === 'success' && parsedClientNames !== undefined ? { textResultForLlm: JSON.stringify(toolReferences) } : {}),
+			toolReferences,
+		};
 	}
 
-	private _parseToolSearchNames(text: string): string[] {
+	private _parseToolSearchNames(text: string): string[] | undefined {
 		try {
 			const parsed = JSON.parse(text);
-			return Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === 'string') : [];
+			return Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === 'string') : undefined;
 		} catch {
-			return [];
+			return undefined;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -95,7 +95,8 @@ non-core client tools behind the runtime's `tool_search_tool`:
   maps `tool_search_tool` back to `toolSearch` to execute the real VS Code tool.
 - **The prompt** (this folder): `toolSearchInstructionLines(toolSearchActive)`
   adds a `tool_instructions` line (`toolSearchToolInstructions`) telling the
-  model to load deferred tools via `tool_search_tool` first — gated on
+  model to load deferred tools via `tool_search_tool` first and not to interpret
+  one ranked miss as evidence that a tool or server is unavailable — gated on
   `context.toolSearchActive` because the `toolSearch` tool is *always* forwarded,
   so presence alone can't gate it. The runtime already emits its own
   deferred-tools reminder (`build_deferred_tools_user_message`) with the accurate

--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -87,7 +87,10 @@ non-core client tools behind the runtime's `tool_search_tool`:
   live deferred-tool metadata to the override handler; Agent Host carries that
   corpus as transient tool-call metadata and injects it only into the local
   `toolSearch` invocation, so embeddings rank the runtime/MCP tools rather than
-  the extension's registry. The corpus is never added to model-facing tool input.
+  the extension's registry. Client results are canonicalized against that live
+  metadata before Agent Host returns both the model-visible result and runtime
+  tool references; unmatched extension-registry names are omitted. The corpus is
+  never added to model-facing tool input.
   Every other client tool gets
   `defer: 'never'` if it is in `NON_DEFERRED_CLIENT_TOOL_NAMES`
   (`runTests`, `rename`, `usages`), else `defer: 'auto'`. Built-in runtime tools

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -69,7 +69,7 @@ const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstr
 /** Tool-search guidance mirrored from the Copilot extension prompt. */
 const toolSearchToolInstructions: ToolInstructionLine = hasTool =>
 	hasTool(CLIENT_TOOL_SEARCH_REFERENCE_NAME)
-		? `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`
+		? `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`
 		: undefined;
 
 export function toolSearchInstructionLines(toolSearchActive: boolean): readonly ToolInstructionLine[] {

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -268,7 +268,7 @@ suite('AgentHostPromptRegistry', () => {
 		// when `toolSearchActive` AND the client tool-search tool are both
 		// present; the composition/gating itself is covered in
 		// toolInstructions.test.ts.
-		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`;
 
 		test('layers the tool-search line onto the default config when active and the tool-search tool is present', () => {
 			const registry = new AgentHostPromptRegistry();

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -7058,7 +7058,108 @@ suite('CopilotAgentSession', () => {
 
 			const result = await handlerPromise;
 			assert.strictEqual(result.resultType, 'success');
-			assert.deepStrictEqual(result.toolReferences, ['everything-get-sum']);
+			assert.deepStrictEqual({
+				textResultForLlm: result.textResultForLlm,
+				toolReferences: result.toolReferences,
+			}, {
+				textResultForLlm: '["everything-get-sum"]',
+				toolReferences: ['everything-get-sum'],
+			});
+		});
+
+		test('tool-search override hides unvalidated client-registry names from the model', async () => {
+			const { session, runtime, mockSession } = await createToolSearchSession(false);
+			const [override] = runtime.createClientSdkTools();
+			const toolCallId = 'tc-tool-search-unvalidated';
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId,
+				toolName: 'tool_search_tool',
+				arguments: { query: 'create github pull request draft' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const handlerPromise = invokeClientToolHandler(override, toolCallId, { query: 'create github pull request draft' }, [
+				{ name: 'create_pull_request', description: 'Create a pull request', deferLoading: true },
+				{ name: 'doSearch', description: 'Search GitHub', deferLoading: true },
+				{ name: 'issue_fetch', description: 'Fetch an issue', deferLoading: true },
+				{ name: 'pullRequestInViewport', description: 'Get the pull request in the viewport', deferLoading: true },
+				{ name: 'pullRequestStatusChecks', description: 'Get pull request status checks', deferLoading: true },
+			]);
+			session.handleClientToolCallComplete(toolCallId, {
+				success: true,
+				pastTenseMessage: 'Searched tools',
+				content: [{
+					type: ToolResultContentType.Text,
+					text: '["github-pull-request_create_pull_request","github-pull-request_doSearch","github-pull-request_issue_fetch","github-pull-request_pullRequestInViewport","github-pull-request_pullRequestStatusChecks"]',
+				}],
+			});
+
+			const result = await handlerPromise;
+			assert.deepStrictEqual({
+				textResultForLlm: result.textResultForLlm,
+				toolReferences: result.toolReferences,
+			}, {
+				textResultForLlm: '[]',
+				toolReferences: [],
+			});
+		});
+
+		test('tool-search override canonicalizes namespaced aliases for the model and runtime', async () => {
+			const { session, runtime, mockSession } = await createToolSearchSession(false);
+			const [override] = runtime.createClientSdkTools();
+			const toolCallId = 'tc-tool-search-alias';
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId,
+				toolName: 'tool_search_tool',
+				arguments: { query: 'create pull request' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const handlerPromise = invokeClientToolHandler(override, toolCallId, { query: 'create pull request' }, [
+				{ name: 'create_pull_request', namespacedName: 'github-pull-request/create_pull_request', description: 'Create a pull request', deferLoading: true },
+			]);
+			session.handleClientToolCallComplete(toolCallId, {
+				success: true,
+				pastTenseMessage: 'Searched tools',
+				content: [{ type: ToolResultContentType.Text, text: '["github-pull-request/create_pull_request","create_pull_request"]' }],
+			});
+
+			const result = await handlerPromise;
+			assert.deepStrictEqual({
+				textResultForLlm: result.textResultForLlm,
+				toolReferences: result.toolReferences,
+			}, {
+				textResultForLlm: '["create_pull_request"]',
+				toolReferences: ['create_pull_request'],
+			});
+		});
+
+		test('tool-search override preserves non-list client result text', async () => {
+			const { session, runtime, mockSession } = await createToolSearchSession(false);
+			const [override] = runtime.createClientSdkTools();
+			const toolCallId = 'tc-tool-search-error-text';
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId,
+				toolName: 'tool_search_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const handlerPromise = invokeClientToolHandler(override, toolCallId);
+			session.handleClientToolCallComplete(toolCallId, {
+				success: true,
+				pastTenseMessage: 'Searched tools',
+				content: [{ type: ToolResultContentType.Text, text: 'Error: query parameter is required' }],
+			});
+
+			const result = await handlerPromise;
+			assert.deepStrictEqual({
+				textResultForLlm: result.textResultForLlm,
+				toolReferences: result.toolReferences,
+			}, {
+				textResultForLlm: 'Error: query parameter is required',
+				toolReferences: [],
+			});
 		});
 
 		test('auto-approved tool search defers its only ready until candidates are available', async () => {

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -89,7 +89,7 @@ suite('toolInstructions', () => {
 	// exposing the tool-search tool. These lock its content, gating, and
 	// composition so neither the instruction nor its gate can silently regress.
 	suite('toolSearchInstructionLines', () => {
-		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
+		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again. Search results are ranked and can omit available tools; if a listed tool is missing, retry once with its exact name and do not treat the miss as evidence that the tool or its server is unavailable.`;
 
 		test('active tool search contributes the tool-search line only when the client exposes the tool-search tool', () => {
 			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)), TOOL_SEARCH_LINE);


### PR DESCRIPTION
## Summary

- canonicalize client tool-search matches against the Agent Host runtime catalog
- return the same validated tool names to both the model and runtime activation
- omit extension-registry identifiers that are not callable in the runtime

## Why

Agent Host previously filtered client search results when building `toolReferences`, but left the original unfiltered JSON in `textResultForLlm`. The model could therefore see and call an identifier such as `github-pull-request_create_pull_request` even though the runtime had rejected it and exposed the callable tool as `create_pull_request`.

This change mirrors the direct `extensions/copilot` path: only names validated against the actual model tool catalog remain model-visible. Namespaced aliases are normalized to their canonical runtime names, while non-list client error text is preserved.

## Validation

- full `npm run compile`
- 328 focused Agent Host prompt and session tests
- targeted ESLint
- pre-commit hygiene
- regression proof that the leaked-name and alias tests fail without the production fix
