### PR TITLE
Fix stationary mouse menu selection issues

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -191,7 +191,7 @@ export class Menu extends ActionBar {
 			}
 		}));
 
-		this._register(addDisposableListener(this.actionsList, EventType.MOUSE_OVER, e => {
+		this._register(addDisposableListener(this.actionsList, EventType.MOUSE_MOVE, e => {
 			let target = e.target as HTMLElement;
 			if (!target || !isAncestor(target, this.actionsList) || target === this.actionsList) {
 				return;
@@ -203,6 +203,11 @@ export class Menu extends ActionBar {
 
 			if (target.classList.contains('action-item')) {
 				const lastFocusedItem = this.focusedItem;
+				// Moving within the focused item is the common case; skip the item lookup for it
+				if (lastFocusedItem !== undefined && this.actionsList.children[lastFocusedItem] === target) {
+					return;
+				}
+
 				this.setFocusedItem(target);
 
 				if (lastFocusedItem !== this.focusedItem) {
@@ -790,7 +795,7 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 			}
 		}));
 
-		this._register(addDisposableListener(this.element, EventType.MOUSE_OVER, e => {
+		this._register(addDisposableListener(this.element, EventType.MOUSE_MOVE, e => {
 			if (!this.mouseOver) {
 				this.mouseOver = true;
 

--- a/src/vs/base/test/browser/ui/menu/menu.test.ts
+++ b/src/vs/base/test/browser/ui/menu/menu.test.ts
@@ -4,13 +4,82 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { $, append, getWindow } from '../../../../browser/dom.js';
-import { getMenuWidgetCSS, unthemedMenuStyles } from '../../../../browser/ui/menu/menu.js';
+import sinon from 'sinon';
+import { $, append, EventType, getWindow } from '../../../../browser/dom.js';
+import { getMenuWidgetCSS, Menu, unthemedMenuStyles } from '../../../../browser/ui/menu/menu.js';
+import { Action, SubmenuAction } from '../../../../common/actions.js';
 import { toDisposable } from '../../../../common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
 
 suite('Menu', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	// A menu positioned under a resting pointer receives `mouseover` without any
+	// `mousemove`, so hover must react to `mousemove` to leave keyboard focus alone.
+	test('stationary mouse does not change focus (#110594, #148158)', () => {
+		const host = append(document.body, $('div'));
+		disposables.add(toDisposable(() => host.remove()));
+		const menu = disposables.add(new Menu(host, [
+			disposables.add(new Action('first', 'First')),
+			disposables.add(new Action('second', 'Second'))
+		], {}, unthemedMenuStyles));
+		const actionItems = Array.from(host.querySelectorAll<HTMLElement>('.action-item'));
+		const getFocusedActions = () => actionItems.map((_, index) => menu.isFocused(index));
+
+		menu.focus(true);
+		const focusStates = [getFocusedActions()];
+
+		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_OVER, { bubbles: true }));
+		focusStates.push(getFocusedActions());
+
+		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		focusStates.push(getFocusedActions());
+
+		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		focusStates.push(getFocusedActions());
+
+		actionItems[0].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		focusStates.push(getFocusedActions());
+
+		assert.deepStrictEqual(focusStates, [
+			[true, false],
+			[true, false],
+			[false, true],
+			[false, true],
+			[true, false]
+		]);
+	});
+
+	test('stationary mouse does not open submenu (#110594, #148158)', () => {
+		const clock = sinon.useFakeTimers();
+		const host = append(document.body, $('div'));
+		disposables.add(toDisposable(() => host.remove()));
+		const submenu = new SubmenuAction('submenu', 'Submenu', [
+			disposables.add(new Action('child', 'Child'))
+		]);
+		disposables.add(new Menu(host, [submenu], {}, unthemedMenuStyles));
+		const submenuAction = host.querySelector<HTMLElement>('.action-item')!;
+		const submenuItem = submenuAction.querySelector<HTMLElement>('.action-menu-item')!;
+
+		submenuAction.dispatchEvent(new MouseEvent(EventType.MOUSE_OVER, { bubbles: true }));
+		clock.tick(250);
+		const expandedAfterMouseOver = submenuItem.getAttribute('aria-expanded');
+
+		submenuAction.dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		clock.tick(250);
+
+		assert.deepStrictEqual({
+			expandedAfterMouseOver,
+			expandedAfterMouseMove: submenuItem.getAttribute('aria-expanded')
+		}, {
+			expandedAfterMouseOver: 'false',
+			expandedAfterMouseMove: 'true'
+		});
+	});
 
 	test('high contrast selection outline does not apply to nested submenu items (#327543)', () => {
 		const host = append(document.body, $('div'));


### PR DESCRIPTION
This pull request addresses issues #110594 and #148158, which involve the unexpected change in menu selection when the mouse pointer remains stationary. 

### Changes made:
- Updated `menu.ts` to ensure that menu focus and delayed submenu expansion respond only to actual `mousemove` events, rather than synthetic `mouseover` events generated when a menu appears under a stationary pointer.
- Enhanced `menu.test.ts` with regression tests to cover both the unchanged row focus behavior and the suppressed submenu expansion, while confirming that real mouse movements still function correctly.

### Validation:
- All relevant unit tests passed successfully.
- Code has been linted and checked for formatting issues. 

This fix improves the user experience by preventing unintended menu selections due to pointer behavior.