### PR TITLE
test: skip flaky Codex structured file reads

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -394,6 +394,20 @@ Use the affected provider command with `--grep "<exact test title>"` and tempora
 
   Temporarily clear `shellToolReplayUnstableOnLinux`.
 
+### Codex structured file-read result text
+
+- Tests:
+  - `reads a file from a nested directory`
+  - `reads a value from JSON`
+- Scope: Codex.
+- Expected: successful file-read tool completions include the file contents in their result text.
+- Observed: the turn response contains the expected value, but the successful tool completion can have an empty `text` field.
+- Gate: these two tests remain enabled for other providers and are skipped for Codex.
+- Tracking issue: [#329512](https://github.com/microsoft/vscode/issues/329512).
+- Failing runs:
+  - [PR #329485](https://github.com/microsoft/vscode/actions/runs/31132506547/job/92724492870?pr=329485)
+  - [PR #329492](https://github.com/microsoft/vscode/actions/runs/31130785836/job/92718953820?pr=329492)
+
 ### Claude subagent replay on Windows
 
 - Test: `reopening a session keeps sub-agent messages out of the parent transcript (replay path)`.

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -47,14 +47,16 @@ function fileOperationPrompt(
 	return `Run exactly this shell command, with no modifications: \`${shellCommand}\`. ${shellFollowup}`;
 }
 
-function fileOperationTest(context: IAgentHostE2ETestContext, title: string, run: Mocha.AsyncFunc): void {
-	const enabled = context.config.fileOperationStrategy === 'fileTools' || context.portableShellToolReplayEnabled;
+function fileOperationTest(context: IAgentHostE2ETestContext, title: string, run: Mocha.AsyncFunc, providerEnabled = true): void {
+	const enabled = providerEnabled && (context.config.fileOperationStrategy === 'fileTools' || context.portableShellToolReplayEnabled);
 	(enabled ? test : test.skip)(title, run);
 }
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
 	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, isWindows } = context;
 	const shellOutputOracleAvailable = !(isWindows && config.provider === 'copilotcli');
+	// Codex intermittently reports successful structured reads with empty result text: https://github.com/microsoft/vscode/issues/329512
+	const structuredReadResultTextAvailable = config.provider !== 'codex';
 	const BEHAVIOR_SNAPSHOT = {
 		profile: 'behavior',
 		// Codex occasionally omits command completion; direct filesystem and response assertions are the success oracle.
@@ -114,7 +116,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	});
+	}, structuredReadResultTextAvailable);
 
 	(portableShellToolReplayEnabled && shellOutputOracleAvailable ? test : test.skip)('lists workspace entries', async function () {
 		this.timeout(180_000);
@@ -217,7 +219,7 @@ Use your file creation tool; do not run a shell command. Then reply exactly "don
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	});
+	}, structuredReadResultTextAvailable);
 
 	fileOperationTest(context, 'counts lines in a file', async function () {
 		this.timeout(180_000);


### PR DESCRIPTION
## Summary

- skip the two structured file-read E2E cases for Codex while successful tool completions can omit result text
- keep both cases enabled for every other provider
- document the temporary gate and investigation

Refs #329512

## Failing runs

- https://github.com/microsoft/vscode/actions/runs/31132506547/job/92724492870?pr=329485
- https://github.com/microsoft/vscode/actions/runs/31130785836/job/92718953820?pr=329492

## Validation

- targeted TypeScript source transform
- `git diff --check`