### PR TITLE
editor: avoid telemetry creation after disposal

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -16,6 +16,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../browser/editorBrowser.js';
 import { observableCodeEditor } from '../../../../browser/observableCodeEditor.js';
+import product from '../../../../../platform/product/common/product.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { CursorColumns } from '../../../../common/core/cursorColumns.js';
 import { LineRange } from '../../../../common/core/ranges/lineRange.js';
@@ -124,7 +125,7 @@ export class InlineCompletionsModel extends Disposable {
 		@IDefaultAccountService defaultAccountService: IDefaultAccountService,
 	) {
 		super();
-		this._source = this._register(this._instantiationService.createInstance(InlineCompletionsSource, this.textModel, this._textModelVersionId, this._debounceValue, this.primaryPosition));
+		this._source = this._register(this._instantiationService.createInstance(InlineCompletionsSource, this.textModel, this._textModelVersionId, this._debounceValue, this.primaryPosition, product.defaultChatAgent?.completionsEnablementSetting));
 		this.lastTriggerKind = this._source.inlineCompletions.map(this, v => v?.request?.context.triggerKind);
 
 		this._editorObs = observableCodeEditor(this._editor);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -82,6 +82,7 @@ export class InlineCompletionsSource extends Disposable {
 	public readonly suggestWidgetInlineCompletions = this._state.map(this, v => v.suggestWidgetInlineCompletions);
 
 	private readonly _renameProcessor: RenameSymbolProcessor;
+	private readonly _dataChannelTelemetryService: DataChannelForwardingTelemetryService;
 
 	private _completionsEnabled: Record<string, boolean> | undefined = undefined;
 
@@ -98,6 +99,7 @@ export class InlineCompletionsSource extends Disposable {
 		@ITextModelService private readonly _textModelService: ITextModelService,
 	) {
 		super();
+		this._dataChannelTelemetryService = this._instantiationService.createInstance(DataChannelForwardingTelemetryService);
 		this._loggingEnabled = observableConfigValue('editor.inlineSuggest.logFetch', false, this._configurationService).recomputeInitiallyAndOnChange(this._store);
 		this._sendRequestData = observableConfigValue('editor.inlineSuggest.emptyResponseInformation', true, this._configurationService).recomputeInitiallyAndOnChange(this._store);
 		this._structuredFetchLogger = this._register(this._instantiationService.createInstance(StructuredLogger.cast<
@@ -550,8 +552,7 @@ export class InlineCompletionsSource extends Disposable {
 			editKind: undefined,
 		};
 
-		const dataChannel = this._instantiationService.createInstance(DataChannelForwardingTelemetryService);
-		sendInlineCompletionsEndOfLifeTelemetry(dataChannel, emptyEndOfLifeEvent);
+		sendInlineCompletionsEndOfLifeTelemetry(this._dataChannelTelemetryService, emptyEndOfLifeEvent);
 	}
 
 	public clearSuggestWidgetInlineCompletions(tx: ITransaction): void {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -20,7 +20,7 @@ import { DataChannelForwardingTelemetryService, forwardToChannelIf, isCopilotLik
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
-import product from '../../../../../platform/product/common/product.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { StringEdit } from '../../../../common/core/edits/stringEdit.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
@@ -97,6 +97,7 @@ export class InlineCompletionsSource extends Disposable {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
+		@IProductService productService: IProductService,
 	) {
 		super();
 		this._dataChannelTelemetryService = this._instantiationService.createInstance(DataChannelForwardingTelemetryService);
@@ -113,7 +114,7 @@ export class InlineCompletionsSource extends Disposable {
 
 		this.clearOperationOnTextModelChange.recomputeInitiallyAndOnChange(this._store);
 
-		const enablementSetting = product.defaultChatAgent?.completionsEnablementSetting ?? undefined;
+		const enablementSetting = productService.defaultChatAgent?.completionsEnablementSetting;
 		if (enablementSetting) {
 			this._updateCompletionsEnablement(enablementSetting);
 			this._register(this._configurationService.onDidChangeConfiguration(e => {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -20,7 +20,6 @@ import { DataChannelForwardingTelemetryService, forwardToChannelIf, isCopilotLik
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
-import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { StringEdit } from '../../../../common/core/edits/stringEdit.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
@@ -91,13 +90,13 @@ export class InlineCompletionsSource extends Disposable {
 		private readonly _versionId: IObservableWithChange<number | null, IModelContentChangedEvent | undefined>,
 		private readonly _debounceValue: IFeatureDebounceInformation,
 		private readonly _cursorPosition: IObservable<Position>,
+		completionsEnablementSetting: string | undefined,
 		@ILanguageConfigurationService private readonly _languageConfigurationService: ILanguageConfigurationService,
 		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
-		@IProductService productService: IProductService,
 	) {
 		super();
 		this._dataChannelTelemetryService = this._instantiationService.createInstance(DataChannelForwardingTelemetryService);
@@ -114,12 +113,11 @@ export class InlineCompletionsSource extends Disposable {
 
 		this.clearOperationOnTextModelChange.recomputeInitiallyAndOnChange(this._store);
 
-		const enablementSetting = productService.defaultChatAgent?.completionsEnablementSetting;
-		if (enablementSetting) {
-			this._updateCompletionsEnablement(enablementSetting);
+		if (completionsEnablementSetting) {
+			this._updateCompletionsEnablement(completionsEnablementSetting);
 			this._register(this._configurationService.onDidChangeConfiguration(e => {
-				if (e.affectsConfiguration(enablementSetting)) {
-					this._updateCompletionsEnablement(enablementSetting);
+				if (e.affectsConfiguration(completionsEnablementSetting)) {
+					this._updateCompletionsEnablement(completionsEnablementSetting);
 				}
 			}));
 		}

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
@@ -4,9 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { timeout } from '../../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { hasKey } from '../../../../../base/common/types.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IDataChannelService } from '../../../../../platform/dataChannel/common/dataChannel.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { Range } from '../../../../common/core/range.js';
+import { InlineCompletions, InlineCompletionsProvider, ProviderId } from '../../../../common/languages.js';
 import { InlineCompletionsModel } from '../../browser/model/inlineCompletionsModel.js';
 import { IWithAsyncTestCodeEditorAndInlineCompletionsModel, MockInlineCompletionsProvider, withAsyncTestCodeEditorAndInlineCompletionsModel } from './utils.js';
 import { ITestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
@@ -14,6 +21,49 @@ import { Selection } from '../../../../common/core/selection.js';
 
 suite('Inline Completions', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Emits empty response telemetry after instantiation service disposal', async function () {
+		const providerStarted = new DeferredPromise<void>();
+		const providerResponse = new DeferredPromise<InlineCompletions>();
+		const provider: InlineCompletionsProvider = {
+			providerId: ProviderId.fromExtensionId('GitHub.copilot'),
+			provideInlineCompletions: () => {
+				providerStarted.complete();
+				return providerResponse.p;
+			},
+			disposeInlineCompletions: () => { },
+		};
+		const sentEventNames: string[] = [];
+		const dataChannelService: IDataChannelService = {
+			_serviceBrand: undefined,
+			onDidSendData: Event.None,
+			getDataChannel: channelId => ({
+				sendData: data => {
+					if (channelId === 'editTelemetry' && hasKey(data, { eventName: true }) && typeof data.eventName === 'string') {
+						sentEventNames.push(data.eventName);
+					}
+				}
+			})
+		};
+		const serviceCollection = new ServiceCollection(
+			[IDataChannelService, dataChannelService],
+			[IConfigurationService, new TestConfigurationService({
+				'github.copilot.enable': { '*': true },
+			})],
+		);
+
+		await withAsyncTestCodeEditorAndInlineCompletionsModel('', { provider, serviceCollection },
+			async ({ model, instantiationService }) => {
+				const request = model.triggerExplicitly();
+				await providerStarted.p;
+				instantiationService.dispose();
+				await providerResponse.complete({ items: [] });
+				await request;
+			}
+		);
+
+		assert.deepStrictEqual(sentEventNames, ['inlineCompletion.endOfLife']);
+	});
 
 	test('Does not trigger automatically if disabled', async function () {
 		const provider = new MockInlineCompletionsProvider();

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
@@ -6,16 +6,17 @@
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
+import { observableValue } from '../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IDataChannelService } from '../../../../../platform/dataChannel/common/dataChannel.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import product from '../../../../../platform/product/common/product.js';
-import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { Range } from '../../../../common/core/range.js';
-import { InlineCompletions, InlineCompletionsProvider, ProviderId } from '../../../../common/languages.js';
+import { InlineCompletionTriggerKind, InlineCompletions, InlineCompletionsProvider, ProviderId } from '../../../../common/languages.js';
 import { InlineCompletionsModel } from '../../browser/model/inlineCompletionsModel.js';
+import { InlineCompletionEditorType } from '../../browser/model/provideInlineCompletions.js';
+import { InlineCompletionsSource } from '../../browser/model/inlineCompletionsSource.js';
 import { IWithAsyncTestCodeEditorAndInlineCompletionsModel, MockInlineCompletionsProvider, withAsyncTestCodeEditorAndInlineCompletionsModel } from './utils.js';
 import { ITestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { Selection } from '../../../../common/core/selection.js';
@@ -47,19 +48,35 @@ suite('Inline Completions', () => {
 			[IConfigurationService, new TestConfigurationService({
 				'github.copilot.enable': { '*': true },
 			})],
-			[IProductService, {
-				_serviceBrand: undefined,
-				...product,
-				defaultChatAgent: {
-					...product.defaultChatAgent,
-					completionsEnablementSetting: 'github.copilot.enable',
-				},
-			}],
 		);
 
 		await withAsyncTestCodeEditorAndInlineCompletionsModel('', { provider, serviceCollection },
-			async ({ model, instantiationService }) => {
-				const request = model.triggerExplicitly();
+			async ({ editor, model, store, instantiationService }) => {
+				const source = store.add(instantiationService.createInstance(
+					InlineCompletionsSource,
+					model.textModel,
+					model._textModelVersionId,
+					{ get: () => 0, update: () => 0, default: () => 0 },
+					observableValue('testCursorPosition', editor.getPosition()!),
+					'github.copilot.enable',
+				));
+				const request = source.fetch([provider], undefined, {
+					triggerKind: InlineCompletionTriggerKind.Explicit,
+					selectedSuggestionInfo: undefined,
+					earliestShownDateTime: 0,
+					includeInlineCompletions: true,
+					includeInlineEdits: false,
+					requestIssuedDateTime: Date.now(),
+				}, undefined, false, observableValue('userJumpedToActiveCompletion', false), {
+					startTime: Date.now(),
+					sku: undefined,
+					editorType: InlineCompletionEditorType.TextEditor,
+					languageId: 'plaintext',
+					availableProviders: [provider.providerId!],
+					reason: '',
+					typingInterval: 0,
+					typingIntervalCharacterCount: 0,
+				});
 				await providerStarted.p;
 				instantiationService.dispose();
 				await providerResponse.complete({ items: [] });

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
@@ -11,6 +11,8 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IDataChannelService } from '../../../../../platform/dataChannel/common/dataChannel.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import product from '../../../../../platform/product/common/product.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { Range } from '../../../../common/core/range.js';
 import { InlineCompletions, InlineCompletionsProvider, ProviderId } from '../../../../common/languages.js';
 import { InlineCompletionsModel } from '../../browser/model/inlineCompletionsModel.js';
@@ -45,6 +47,14 @@ suite('Inline Completions', () => {
 			[IConfigurationService, new TestConfigurationService({
 				'github.copilot.enable': { '*': true },
 			})],
+			[IProductService, {
+				_serviceBrand: undefined,
+				...product,
+				defaultChatAgent: {
+					...product.defaultChatAgent,
+					completionsEnablementSetting: 'github.copilot.enable',
+				},
+			}],
 		);
 
 		await withAsyncTestCodeEditorAndInlineCompletionsModel('', { provider, serviceCollection },

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts
@@ -6,7 +6,6 @@
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
-import { hasKey } from '../../../../../base/common/types.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IDataChannelService } from '../../../../../platform/dataChannel/common/dataChannel.js';
@@ -33,16 +32,12 @@ suite('Inline Completions', () => {
 			},
 			disposeInlineCompletions: () => { },
 		};
-		const sentEventNames: string[] = [];
+		const sentChannelIds: string[] = [];
 		const dataChannelService: IDataChannelService = {
 			_serviceBrand: undefined,
 			onDidSendData: Event.None,
 			getDataChannel: channelId => ({
-				sendData: data => {
-					if (channelId === 'editTelemetry' && hasKey(data, { eventName: true }) && typeof data.eventName === 'string') {
-						sentEventNames.push(data.eventName);
-					}
-				}
+				sendData: () => sentChannelIds.push(channelId)
 			})
 		};
 		const serviceCollection = new ServiceCollection(
@@ -62,7 +57,7 @@ suite('Inline Completions', () => {
 			}
 		);
 
-		assert.deepStrictEqual(sentEventNames, ['inlineCompletion.endOfLife']);
+		assert.deepStrictEqual(sentChannelIds, ['editTelemetry']);
 	});
 
 	test('Does not trigger automatically if disabled', async function () {

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
@@ -17,6 +17,7 @@ import { IAccessibilitySignalService } from '../../../../../platform/accessibili
 import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { CoreEditingCommands, CoreNavigationCommands } from '../../../../browser/coreCommands.js';
 import { IBulkEditService } from '../../../../browser/services/bulkEditService.js';
 import { IRenameSymbolTrackerService, NullRenameSymbolTrackerService } from '../../../../browser/services/renameSymbolTrackerService.js';
@@ -245,6 +246,7 @@ export interface IWithAsyncTestCodeEditorAndInlineCompletionsModel {
 	context: GhostTextContext;
 	store: DisposableStore;
 	logger: ITraceLogger;
+	instantiationService: TestInstantiationService;
 }
 
 export async function withAsyncTestCodeEditorAndInlineCompletionsModel<T>(
@@ -320,7 +322,7 @@ export async function withAsyncTestCodeEditorAndInlineCompletionsModel<T>(
 				const model = controller.model.get()!;
 				const context = new GhostTextContext(model, editor, logger);
 				try {
-					result = await callback({ editor, editorViewModel, model, context, store: disposableStore, logger });
+					result = await callback({ editor, editorViewModel, model, context, store: disposableStore, logger, instantiationService });
 				} finally {
 					context.dispose();
 					model.dispose();

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -53,8 +53,6 @@ import { INotificationService } from '../../../platform/notification/common/noti
 import { TestNotificationService } from '../../../platform/notification/test/common/testNotificationService.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { NullOpenerService } from '../../../platform/opener/test/common/nullOpenerService.js';
-import product from '../../../platform/product/common/product.js';
-import { IProductService } from '../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../platform/telemetry/common/telemetryUtils.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
@@ -241,7 +239,6 @@ export function createCodeEditorServices(disposables: Pick<DisposableStore, 'add
 	define(ITelemetryService, NullTelemetryServiceShape);
 	define(ILoggerService, NullLoggerService);
 	define(IDataChannelService, NullDataChannelService);
-	defineInstance(IProductService, { _serviceBrand: undefined, ...product });
 	define(IEnvironmentService, class extends mock<IEnvironmentService>() {
 		declare readonly _serviceBrand: undefined;
 		override isBuilt: boolean = true;

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -53,6 +53,8 @@ import { INotificationService } from '../../../platform/notification/common/noti
 import { TestNotificationService } from '../../../platform/notification/test/common/testNotificationService.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { NullOpenerService } from '../../../platform/opener/test/common/nullOpenerService.js';
+import product from '../../../platform/product/common/product.js';
+import { IProductService } from '../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../platform/telemetry/common/telemetryUtils.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
@@ -239,6 +241,7 @@ export function createCodeEditorServices(disposables: Pick<DisposableStore, 'add
 	define(ITelemetryService, NullTelemetryServiceShape);
 	define(ILoggerService, NullLoggerService);
 	define(IDataChannelService, NullDataChannelService);
+	defineInstance(IProductService, { _serviceBrand: undefined, ...product });
 	define(IEnvironmentService, class extends mock<IEnvironmentService>() {
 		declare readonly _serviceBrand: undefined;
 		override isBuilt: boolean = true;


### PR DESCRIPTION
## Why

A recent Code Insiders renderer log captured an inline-completions request settling after its editor-scoped instantiation service had already been disposed:

```text
2026-08-06 15:49:14.083 [error] InstantiationService has been disposed: Error: InstantiationService has been disposed
    at s._throwIfDisposed (.../sessions.desktop.main.js:1581:574)
    at s.createInstance (.../sessions.desktop.main.js:1581:1228)
    at gee._sendInlineCompletionsRequestTelemetry (.../sessions.desktop.main.js:983:26508)
    at .../sessions.desktop.main.js:983:23532
    at async RRe.trigger (.../sessions.desktop.main.js:983:51898)
```

Source-map resolution traced the failure to `InlineCompletionsSource._sendInlineCompletionsRequestTelemetry`. The request’s `finally` block sends end-of-life telemetry, but that method lazily created `DataChannelForwardingTelemetryService` through the editor-scoped `IInstantiationService`. If the editor was disposed while awaiting the provider, telemetry creation threw instead of completing cleanup.

## What changed

Create and retain the lightweight `DataChannelForwardingTelemetryService` when `InlineCompletionsSource` is constructed, while its DI scope is valid, and reuse it when asynchronous requests settle. This preserves the telemetry rather than adding a disposal guard that would silently drop it.

## Validation

- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/editor/contrib/inlineCompletions/test/browser/inlineCompletions.test.ts` — 28 passing
- `git diff --check`

(Written by Copilot)