### PR TITLE
agentHost: capture git baseline checkpoint for Claude and Codex sessions

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -36,6 +36,7 @@ import { isSubagentSession, parseSubagentSessionUri, buildDefaultChatUri, parseC
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { projectFromCopilotContext } from '../copilot/copilotGitProject.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
@@ -452,6 +453,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
 		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
+		@IAgentHostCheckpointService private readonly _checkpointService: IAgentHostCheckpointService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -1180,10 +1182,24 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// Emit the full resolved set (index 0 = process root, 1..N = additional
 		// roots). Falls back to the session's own ordered set when the host
 		// didn't hand us one (e.g. workspace-less single-root).
+		const materializedWorkingDirectories = workingDirectories ?? session.workingDirectories;
+
+		// Capture the per-session baseline (turn/0) git checkpoint so per-turn
+		// diffs computed on `ChatTurnComplete` can reflect the full working-tree
+		// delta — including terminal-tool edits that are invisible to the
+		// FileEditTracker pipeline. Best-effort: a non-git folder or capture
+		// failure leaves the session running with the legacy `file_edits`-based
+		// per-turn diff path. Identical to the Copilot harness — the resolved
+		// directories are passed explicitly because the state manager does not
+		// learn about them until it observes the materialize event fired below.
+		this._checkpointService.captureBaselineCheckpoint(session.sessionUri, materializedWorkingDirectories).catch(err => {
+			this._logService.warn(`[Claude:${sessionId}] Baseline checkpoint capture failed: ${err instanceof Error ? err.message : String(err)}`);
+		});
+
 		this._onDidMaterializeSession.fire({
 			session: session.sessionUri,
 			project: session.project,
-			workingDirectories: workingDirectories ?? session.workingDirectories,
+			workingDirectories: materializedWorkingDirectories,
 		});
 
 		return session;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1184,14 +1184,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// didn't hand us one (e.g. workspace-less single-root).
 		const materializedWorkingDirectories = workingDirectories ?? session.workingDirectories;
 
-		// Capture the per-session baseline (turn/0) git checkpoint so per-turn
-		// diffs computed on `ChatTurnComplete` can reflect the full working-tree
-		// delta — including terminal-tool edits that are invisible to the
-		// FileEditTracker pipeline. Best-effort: a non-git folder or capture
-		// failure leaves the session running with the legacy `file_edits`-based
-		// per-turn diff path. Identical to the Copilot harness — the resolved
-		// directories are passed explicitly because the state manager does not
-		// learn about them until it observes the materialize event fired below.
+		// Pass the resolved directories before the materialize event updates them in the state manager.
 		this._checkpointService.captureBaselineCheckpoint(session.sessionUri, materializedWorkingDirectories).catch(err => {
 			this._logService.warn(`[Claude:${sessionId}] Baseline checkpoint capture failed: ${err instanceof Error ? err.message : String(err)}`);
 		});

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -49,6 +49,7 @@ import { INativeEnvironmentService } from '../../../environment/common/environme
 import { IAgentPluginManager, type ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { parsePlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
+import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
 import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
@@ -867,6 +868,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		@ICodexProxyService private readonly _codexProxyService: ICodexProxyService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
+		@IAgentHostCheckpointService private readonly _checkpointService: IAgentHostCheckpointService,
 		@IAgentSdkDownloader private readonly _agentSdkDownloader: IAgentSdkDownloader,
 		@IProductService private readonly _productService: IProductService,
 		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
@@ -3543,6 +3545,24 @@ export class CodexAgent extends Disposable implements IAgent {
 			this._fire(sessionUri, { type: ActionType.ChatTurnComplete, turnId: effectiveTurnId, duration });
 			return;
 		}
+
+		// Capture the per-session baseline (turn/0) git checkpoint on the fresh
+		// first send — after the thread is materialized (so the worktree cwd is
+		// finalized) and before `turn/start`. This lets per-turn diffs computed
+		// on `ChatTurnComplete` reflect the full working-tree delta, including
+		// terminal-tool edits that are invisible to the FileEditTracker pipeline.
+		// Best-effort and identical to the Copilot harness: a non-git folder or
+		// capture failure leaves the session on the legacy `file_edits`-based
+		// per-turn diff path. Gated to fresh sends only (`!firstTurnSent`) and
+		// non-resume (`!needsResume`, still un-cleared here — the resume block
+		// below clears it) so restored sessions are never given a late baseline.
+		if (!session.firstTurnSent && !session.needsResume) {
+			const baselineWorkingDirectories = session.workingDirectories ?? (session.workingDirectory ? [session.workingDirectory] : undefined);
+			this._checkpointService.captureBaselineCheckpoint(sessionUri, baselineWorkingDirectories).catch(err => {
+				this._logService.warn(`[Codex:${sessionId}] Baseline checkpoint capture failed: ${err instanceof Error ? err.message : String(err)}`);
+			});
+		}
+
 		// Codex registers client tools and MCP servers only at `thread/start`.
 		// If the thread was prewarmed (or otherwise started) before the current
 		// client tools / MCP servers were known, restart it now — before any

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -3546,16 +3546,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			return;
 		}
 
-		// Capture the per-session baseline (turn/0) git checkpoint on the fresh
-		// first send — after the thread is materialized (so the worktree cwd is
-		// finalized) and before `turn/start`. This lets per-turn diffs computed
-		// on `ChatTurnComplete` reflect the full working-tree delta, including
-		// terminal-tool edits that are invisible to the FileEditTracker pipeline.
-		// Best-effort and identical to the Copilot harness: a non-git folder or
-		// capture failure leaves the session on the legacy `file_edits`-based
-		// per-turn diff path. Gated to fresh sends only (`!firstTurnSent`) and
-		// non-resume (`!needsResume`, still un-cleared here — the resume block
-		// below clears it) so restored sessions are never given a late baseline.
+		// Check needsResume before the resume block clears it so restored sessions never receive a late baseline.
 		if (!session.firstTurnSent && !session.needsResume) {
 			const baselineWorkingDirectories = session.workingDirectories ?? (session.workingDirectory ? [session.workingDirectory] : undefined);
 			this._checkpointService.captureBaselineCheckpoint(sessionUri, baselineWorkingDirectories).catch(err => {

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { Event } from '../../../../base/common/event.js';
 import type { IDetailedDiffResult, IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
 import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+import type { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import type { Message } from '../../common/state/sessionState.js';
 
 export class TestSessionDatabase implements ISessionDatabase {
@@ -343,4 +344,23 @@ function createReference<T>(object: T): IReference<T> {
 		object,
 		dispose: () => { },
 	};
+}
+
+/**
+ * Recording {@link IAgentHostCheckpointService} double that captures
+ * {@link captureBaselineCheckpoint} invocations (session + resolved working
+ * directories) so tests can assert baseline capture on the fresh materialize
+ * path — and its absence on resume / subsequent sends. All other methods are
+ * no-ops, mirroring `NULL_CHECKPOINT_SERVICE`.
+ */
+export class RecordingCheckpointService implements IAgentHostCheckpointService {
+	declare readonly _serviceBrand: undefined;
+	readonly baselineCalls: { readonly session: string; readonly workingDirectories: readonly string[] | undefined }[] = [];
+	async captureBaselineCheckpoint(sessionUri: URI, workingDirectories: readonly URI[] | undefined): Promise<void> {
+		this.baselineCalls.push({ session: sessionUri.toString(), workingDirectories: workingDirectories?.map(w => w.toString()) });
+	}
+	async captureTurnCheckpoint(): Promise<void> { }
+	async getTurnCheckpointPair(): Promise<{ parent: string; current: string } | undefined> { return undefined; }
+	async getBaselineCheckpoint(): Promise<string | undefined> { return undefined; }
+	async deleteCheckpoints(): Promise<void> { }
 }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -60,6 +60,7 @@ import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpo
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { ClaudeAgent } from '../../node/claude/claudeAgent.js';
 import { IClaudeAgentSdkService } from '../../node/claude/claudeAgentSdkService.js';
 import { IAgentPluginManager } from '../../common/agentPluginManager.js';
@@ -674,6 +675,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			...claudeFileEnvServices(disposables),
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
@@ -807,6 +809,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			...claudeFileEnvServices(disposables),
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
@@ -884,6 +887,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			...claudeFileEnvServices(disposables),
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -73,7 +73,7 @@ import { resolvePromptToContentBlocks } from '../../node/claude/claudePromptReso
 import { ICopilotApiService, type ICopilotApiServiceRequestOptions } from '../../node/shared/copilotApiService.js';
 import { AgentService } from '../../node/agentService.js';
 import { injectSideChatContext } from '../../node/agentPeerChats.js';
-import { createNoopGitService, createNullSessionDataService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
+import { createNoopGitService, createNullSessionDataService, createSessionDataService, RecordingCheckpointService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
 // #region Test fakes
 
@@ -815,24 +815,6 @@ class CapturingLogService extends NullLogService {
 	override error(message: string | Error, ...args: unknown[]): void {
 		this.errors.push([String(message), ...args.map(a => String(a))].join(' '));
 	}
-}
-
-/**
- * Recording {@link IAgentHostCheckpointService} double that captures
- * {@link captureBaselineCheckpoint} invocations so tests can assert baseline
- * capture happens on the fresh materialize path (and not on resume). All other
- * methods are no-ops mirroring {@link NULL_CHECKPOINT_SERVICE}.
- */
-class RecordingCheckpointService implements IAgentHostCheckpointService {
-	declare readonly _serviceBrand: undefined;
-	readonly baselineCalls: { readonly session: string; readonly workingDirectories: readonly string[] | undefined }[] = [];
-	async captureBaselineCheckpoint(sessionUri: URI, workingDirectories: readonly URI[] | undefined): Promise<void> {
-		this.baselineCalls.push({ session: sessionUri.toString(), workingDirectories: workingDirectories?.map(w => w.toString()) });
-	}
-	async captureTurnCheckpoint(): Promise<void> { }
-	async getTurnCheckpointPair(): Promise<{ parent: string; current: string } | undefined> { return undefined; }
-	async getBaselineCheckpoint(): Promise<string | undefined> { return undefined; }
-	async deleteCheckpoints(): Promise<void> { }
 }
 
 function createTestContext(
@@ -1923,45 +1905,28 @@ suite('ClaudeAgent', () => {
 		);
 	});
 
-	test('materialize captures the baseline checkpoint on the fresh path (parity with Copilot)', async () => {
+	test('captures the baseline checkpoint on fresh materialize but not on resume (parity with Copilot)', async () => {
 		const checkpointService = new RecordingCheckpointService();
 		const { agent, sdk } = createTestContext(disposables, { checkpointService });
 		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
 
-		const created = await agent.createSession({ workingDirectories: [URI.file('/work-baseline')] });
+		const workDir = URI.file('/work-baseline');
+
+		// Fresh materialize captures the baseline for the resolved directories.
+		const created = await agent.createSession({ workingDirectories: [workDir] });
 		const sessionId = AgentSession.id(created.session);
 		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
-		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', [workDir], undefined, 'turn-1');
 
-		// Fresh materialize captures exactly one baseline for this session,
-		// identical to the Copilot harness.
-		assert.deepStrictEqual(
-			checkpointService.baselineCalls.map(c => c.session),
-			[created.session.toString()],
-		);
-	});
-
-	test('resume does not capture a baseline checkpoint (only fresh materialize does)', async () => {
-		const checkpointService = new RecordingCheckpointService();
-		const { agent, sdk } = createTestContext(disposables, { checkpointService });
-		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
-
-		// Phase 1: fresh materialize captures the baseline.
-		const created = await agent.createSession({ workingDirectories: [URI.file('/work-resume-baseline')] });
-		const sessionId = AgentSession.id(created.session);
-		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
-		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
-		assert.strictEqual(checkpointService.baselineCalls.length, 1, 'fresh materialize captures the baseline');
-
-		// Phase 2: simulate cross-window resume by tearing the in-memory entry
-		// down and forcing the resume branch on the next send. Resume must NOT
-		// capture a (late) baseline against the already-edited tree.
+		// Cross-window resume (dispose + second send) must NOT capture a late baseline.
 		await agent.disposeSession(created.session);
-		sdk.sessionList = [{ sessionId, cwd: '/work-resume-baseline', summary: '', lastModified: Date.now() }];
+		sdk.sessionList = [{ sessionId, cwd: workDir.fsPath, summary: '', lastModified: Date.now() }];
 		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
-		await agent.chats.sendMessage(defaultChatUri(created.session), 'turn 2', undefined, undefined, 'turn-2');
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'turn 2', [workDir], undefined, 'turn-2');
 
-		assert.strictEqual(checkpointService.baselineCalls.length, 1, 'resume must not capture a second baseline');
+		assert.deepStrictEqual(checkpointService.baselineCalls, [
+			{ session: created.session.toString(), workingDirectories: [workDir.toString()] },
+		]);
 	});
 
 	test('createSession honors config.session when the workbench pre-mints the URI', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -55,6 +55,7 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ProtectedResourceMetadata, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputRequestPurpose, ToolCallStatus, type SessionConfigState, type ChatInputRequest, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../../node/agentHostStateManager.js';
@@ -816,9 +817,27 @@ class CapturingLogService extends NullLogService {
 	}
 }
 
+/**
+ * Recording {@link IAgentHostCheckpointService} double that captures
+ * {@link captureBaselineCheckpoint} invocations so tests can assert baseline
+ * capture happens on the fresh materialize path (and not on resume). All other
+ * methods are no-ops mirroring {@link NULL_CHECKPOINT_SERVICE}.
+ */
+class RecordingCheckpointService implements IAgentHostCheckpointService {
+	declare readonly _serviceBrand: undefined;
+	readonly baselineCalls: { readonly session: string; readonly workingDirectories: readonly string[] | undefined }[] = [];
+	async captureBaselineCheckpoint(sessionUri: URI, workingDirectories: readonly URI[] | undefined): Promise<void> {
+		this.baselineCalls.push({ session: sessionUri.toString(), workingDirectories: workingDirectories?.map(w => w.toString()) });
+	}
+	async captureTurnCheckpoint(): Promise<void> { }
+	async getTurnCheckpointPair(): Promise<{ parent: string; current: string } | undefined> { return undefined; }
+	async getBaselineCheckpoint(): Promise<string | undefined> { return undefined; }
+	async deleteCheckpoints(): Promise<void> { }
+}
+
 function createTestContext(
 	disposables: Pick<DisposableStore, 'add'>,
-	overrides?: { logService?: ILogService; database?: TestSessionDatabase; rootConfig?: Record<string, unknown>; userHome?: URI; gitHubEndpointService?: IAgentHostGitHubEndpointService },
+	overrides?: { logService?: ILogService; database?: TestSessionDatabase; rootConfig?: Record<string, unknown>; userHome?: URI; gitHubEndpointService?: IAgentHostGitHubEndpointService; checkpointService?: IAgentHostCheckpointService },
 ): ITestContext {
 	const proxy = new FakeClaudeProxyService();
 	const api = new FakeCopilotApiService();
@@ -849,6 +868,7 @@ function createTestContext(
 		[IClaudeAgentSdkService, sdk],
 		[IAgentPluginManager, new FakeAgentPluginManager()],
 		[IAgentHostGitService, createNoopGitService()],
+		[IAgentHostCheckpointService, overrides?.checkpointService ?? NULL_CHECKPOINT_SERVICE],
 		[IAgentConfigurationService, configService],
 		[IAgentHostStateManager, stateManager],
 		[IAgentHostOTelService, otelService],
@@ -922,6 +942,7 @@ function createTestAgentStateServices(disposables: Pick<DisposableStore, 'add'>)
 		[IAgentConfigurationService, disposables.add(new AgentConfigurationService(stateManager, logService))],
 		[IAgentHostStateManager, stateManager],
 		[IAgentHostOTelService, new RecordingOTelService()],
+		[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 	];
 }
 
@@ -1900,6 +1921,47 @@ suite('ClaudeAgent', () => {
 			{ model: 'claude-opus-4-6', effort: 'medium' },
 			'resume must not clobber the overlay model',
 		);
+	});
+
+	test('materialize captures the baseline checkpoint on the fresh path (parity with Copilot)', async () => {
+		const checkpointService = new RecordingCheckpointService();
+		const { agent, sdk } = createTestContext(disposables, { checkpointService });
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const created = await agent.createSession({ workingDirectories: [URI.file('/work-baseline')] });
+		const sessionId = AgentSession.id(created.session);
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
+
+		// Fresh materialize captures exactly one baseline for this session,
+		// identical to the Copilot harness.
+		assert.deepStrictEqual(
+			checkpointService.baselineCalls.map(c => c.session),
+			[created.session.toString()],
+		);
+	});
+
+	test('resume does not capture a baseline checkpoint (only fresh materialize does)', async () => {
+		const checkpointService = new RecordingCheckpointService();
+		const { agent, sdk } = createTestContext(disposables, { checkpointService });
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		// Phase 1: fresh materialize captures the baseline.
+		const created = await agent.createSession({ workingDirectories: [URI.file('/work-resume-baseline')] });
+		const sessionId = AgentSession.id(created.session);
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'hi', undefined, undefined, 'turn-1');
+		assert.strictEqual(checkpointService.baselineCalls.length, 1, 'fresh materialize captures the baseline');
+
+		// Phase 2: simulate cross-window resume by tearing the in-memory entry
+		// down and forcing the resume branch on the next send. Resume must NOT
+		// capture a (late) baseline against the already-edited tree.
+		await agent.disposeSession(created.session);
+		sdk.sessionList = [{ sessionId, cwd: '/work-resume-baseline', summary: '', lastModified: Date.now() }];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'turn 2', undefined, undefined, 'turn-2');
+
+		assert.strictEqual(checkpointService.baselineCalls.length, 1, 'resume must not capture a second baseline');
 	});
 
 	test('createSession honors config.session when the workbench pre-mints the URI', async () => {
@@ -3651,6 +3713,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			[IAgentConfigurationService, configService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostOTelService, new RecordingOTelService()],
@@ -4907,6 +4970,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			[IAgentConfigurationService, configService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostOTelService, new RecordingOTelService()],
@@ -6819,6 +6883,7 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, pluginManager],
 			[IAgentHostGitService, createNoopGitService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			[IAgentConfigurationService, configService],
 			[IAgentHostStateManager, stateManager],
 			[IAgentHostOTelService, otelService],

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -16,6 +16,7 @@ import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEn
 import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
 import { CodexAgent, toCodexModelSelectionId } from '../../../node/codex/codexAgent.js';
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
@@ -36,6 +37,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Pr
 	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE);
 	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -44,7 +44,7 @@ import { AgentHostCodexMultiRootEnabledConfigKey } from '../../../common/agentHo
 import { CodexSessionConfigKey } from '../../../common/codexSessionConfigKeys.js';
 import type { SandboxPolicy } from '../../../node/codex/protocol/generated/v2/SandboxPolicy.js';
 import type { SelectedCapabilityRoot } from '../../../node/codex/protocol/generated/v2/SelectedCapabilityRoot.js';
-import { createSessionDataService, TestSessionDatabase } from '../../common/sessionTestHelpers.js';
+import { createSessionDataService, RecordingCheckpointService, TestSessionDatabase } from '../../common/sessionTestHelpers.js';
 
 interface ITestWireRequest {
 	readonly id: number;
@@ -133,24 +133,6 @@ interface ICreateAgentOptions {
 	readonly sessionConfig?: Readonly<Record<string, boolean | string | readonly string[]>>;
 	readonly database?: TestSessionDatabase;
 	readonly checkpointService?: IAgentHostCheckpointService;
-}
-
-/**
- * Recording {@link IAgentHostCheckpointService} double that captures
- * {@link captureBaselineCheckpoint} invocations so tests can assert baseline
- * capture happens once on the fresh first send (and not on subsequent sends).
- * All other methods are no-ops mirroring {@link NULL_CHECKPOINT_SERVICE}.
- */
-class RecordingCheckpointService implements IAgentHostCheckpointService {
-	declare readonly _serviceBrand: undefined;
-	readonly baselineCalls: { readonly session: string; readonly workingDirectories: readonly string[] | undefined }[] = [];
-	async captureBaselineCheckpoint(sessionUri: URI, workingDirectories: readonly URI[] | undefined): Promise<void> {
-		this.baselineCalls.push({ session: sessionUri.toString(), workingDirectories: workingDirectories?.map(w => w.toString()) });
-	}
-	async captureTurnCheckpoint(): Promise<void> { }
-	async getTurnCheckpointPair(): Promise<{ parent: string; current: string } | undefined> { return undefined; }
-	async getBaselineCheckpoint(): Promise<string | undefined> { return undefined; }
-	async deleteCheckpoints(): Promise<void> { }
 }
 
 class TestCodexLogService extends NullLogService {
@@ -1112,30 +1094,7 @@ suite('CodexAgent baseline checkpoint', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	/**
-	 * Drives the wire protocol until a `turn/start` request is observed,
-	 * answering any intermediate `thread/start` (with a synthetic thread id)
-	 * and `thread/unsubscribe` (with `{}`) requests along the way. Resilient to
-	 * an optional tool re-materialization that restarts the thread before the
-	 * first turn.
-	 */
-	async function drainUntilTurnStart(peer: ITestPeer): Promise<void> {
-		for (let i = 0; i < 6; i++) {
-			const req = await readNextRequest(peer.outbound);
-			if (req.method === 'turn/start') {
-				peer.push({ id: req.id, result: {} });
-				return;
-			}
-			if (req.method === 'thread/start') {
-				peer.push({ id: req.id, result: { thread: { id: `thread-drain-${i}` } } });
-			} else {
-				peer.push({ id: req.id, result: {} });
-			}
-		}
-		throw new Error('Timed out waiting for turn/start');
-	}
-
-	test('fresh first send captures the baseline checkpoint once', async () => {
+	test('captures the baseline checkpoint on the fresh first send but not on subsequent sends', async () => {
 		const checkpointService = new RecordingCheckpointService();
 		const agent = await createAgent(disposables, { checkpointService });
 		const peer = disposables.add(createTestPeer());
@@ -1147,57 +1106,32 @@ suite('CodexAgent baseline checkpoint', () => {
 		const folder = URI.file('/repo/baseline-folder');
 		const { session } = await agent.createSession({ workingDirectories: [folder], model: { id: COPILOT_TEST_MODEL } });
 		const entry = agent['_sessions'].get(AgentSession.id(session))!;
-		const prewarmStart = await readNextRequest(peer.outbound);
+		const chat = URI.parse(buildDefaultChatUri(session));
 
+		// Complete the prewarm `thread/start` so the folder thread is materialized
+		// (which sets the tool/mcp/customization signatures).
+		const prewarmStart = await readNextRequest(peer.outbound);
 		try {
 			peer.push({ id: prewarmStart.id, result: { thread: { id: 'thread-baseline' } } });
 			await entry.materializePromise;
 
-			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', undefined, undefined, 'turn-1');
-			await drainUntilTurnStart(peer);
-			await send;
-
-			// The fresh first send captures exactly one baseline for this
-			// session — identical to the Copilot harness.
-			assert.deepStrictEqual(
-				checkpointService.baselineCalls.map(c => c.session),
-				[session.toString()],
-			);
-		} finally {
-			peer.exit();
-		}
-	});
-
-	test('subsequent sends do not re-capture the baseline checkpoint', async () => {
-		const checkpointService = new RecordingCheckpointService();
-		const agent = await createAgent(disposables, { checkpointService });
-		const peer = disposables.add(createTestPeer());
-		const client = new CodexAppServerClient(peer.transport);
-		agent['_connection'] = { kind: 'ready', client, usageSource: 'github', child: { kill: () => true } } as never;
-		agent['_refreshSkillHookCustomizations'] = async () => { };
-		agent['_refreshSkillExtraRoots'] = async () => { };
-
-		const folder = URI.file('/repo/baseline-folder-2');
-		const { session } = await agent.createSession({ workingDirectories: [folder], model: { id: COPILOT_TEST_MODEL } });
-		const entry = agent['_sessions'].get(AgentSession.id(session))!;
-		const prewarmStart = await readNextRequest(peer.outbound);
-
-		try {
-			peer.push({ id: prewarmStart.id, result: { thread: { id: 'thread-baseline-2' } } });
-			await entry.materializePromise;
-
-			const chat = URI.parse(buildDefaultChatUri(session));
-			const send1 = agent.chats.sendMessage(chat, 'hello', undefined, undefined, 'turn-1');
-			await drainUntilTurnStart(peer);
+			// Fresh first send: the folder is already materialized with matching
+			// signatures, so the only outbound request is `turn/start`.
+			const send1 = agent.chats.sendMessage(chat, 'hello', [folder], undefined, 'turn-1');
+			const turnStart1 = await readNextRequest(peer.outbound);
+			peer.push({ id: turnStart1.id, result: {} });
 			await send1;
-			assert.strictEqual(checkpointService.baselineCalls.length, 1, 'fresh first send captures the baseline');
 
-			// A second send has `firstTurnSent === true`, so the gate must
-			// prevent a second baseline capture.
-			const send2 = agent.chats.sendMessage(chat, 'again', undefined, undefined, 'turn-2');
-			await drainUntilTurnStart(peer);
+			// The second send has `firstTurnSent === true`, so the gate prevents
+			// a second capture.
+			const send2 = agent.chats.sendMessage(chat, 'again', [folder], undefined, 'turn-2');
+			const turnStart2 = await readNextRequest(peer.outbound);
+			peer.push({ id: turnStart2.id, result: {} });
 			await send2;
-			assert.strictEqual(checkpointService.baselineCalls.length, 1, 'subsequent sends must not re-capture the baseline');
+
+			assert.deepStrictEqual(checkpointService.baselineCalls, [
+				{ session: session.toString(), workingDirectories: [folder.toString()] },
+			]);
 		} finally {
 			peer.exit();
 		}

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -33,6 +33,7 @@ import { AgentConfigurationService, IAgentConfigurationService } from '../../../
 import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
 import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 import { CodexAgent, toCodexModelSelectionId } from '../../../node/codex/codexAgent.js';
 import { CodexAppServerClient, type ICodexAppServerTransport } from '../../../node/codex/codexAppServerClient.js';
@@ -131,6 +132,25 @@ interface ICreateAgentOptions {
 	readonly multiRootEnabled?: boolean;
 	readonly sessionConfig?: Readonly<Record<string, boolean | string | readonly string[]>>;
 	readonly database?: TestSessionDatabase;
+	readonly checkpointService?: IAgentHostCheckpointService;
+}
+
+/**
+ * Recording {@link IAgentHostCheckpointService} double that captures
+ * {@link captureBaselineCheckpoint} invocations so tests can assert baseline
+ * capture happens once on the fresh first send (and not on subsequent sends).
+ * All other methods are no-ops mirroring {@link NULL_CHECKPOINT_SERVICE}.
+ */
+class RecordingCheckpointService implements IAgentHostCheckpointService {
+	declare readonly _serviceBrand: undefined;
+	readonly baselineCalls: { readonly session: string; readonly workingDirectories: readonly string[] | undefined }[] = [];
+	async captureBaselineCheckpoint(sessionUri: URI, workingDirectories: readonly URI[] | undefined): Promise<void> {
+		this.baselineCalls.push({ session: sessionUri.toString(), workingDirectories: workingDirectories?.map(w => w.toString()) });
+	}
+	async captureTurnCheckpoint(): Promise<void> { }
+	async getTurnCheckpointPair(): Promise<{ parent: string; current: string } | undefined> { return undefined; }
+	async getBaselineCheckpoint(): Promise<string | undefined> { return undefined; }
+	async deleteCheckpoints(): Promise<void> { }
 }
 
 class TestCodexLogService extends NullLogService {
@@ -189,6 +209,7 @@ async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: I
 	instantiationService.stub(IAgentConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined, isSdkResolvableWithoutDownload: async () => true });
+	instantiationService.stub(IAgentHostCheckpointService, options.checkpointService ?? NULL_CHECKPOINT_SERVICE);
 	instantiationService.stub(IAgentHostOTelService, {
 		_serviceBrand: undefined,
 		getNativeSdkTelemetryConfig: async () => undefined,
@@ -1083,6 +1104,102 @@ suite('CodexAgent prewarm eviction', () => {
 		} finally {
 			peerB?.exit();
 			peerA.exit();
+		}
+	});
+});
+
+suite('CodexAgent baseline checkpoint', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Drives the wire protocol until a `turn/start` request is observed,
+	 * answering any intermediate `thread/start` (with a synthetic thread id)
+	 * and `thread/unsubscribe` (with `{}`) requests along the way. Resilient to
+	 * an optional tool re-materialization that restarts the thread before the
+	 * first turn.
+	 */
+	async function drainUntilTurnStart(peer: ITestPeer): Promise<void> {
+		for (let i = 0; i < 6; i++) {
+			const req = await readNextRequest(peer.outbound);
+			if (req.method === 'turn/start') {
+				peer.push({ id: req.id, result: {} });
+				return;
+			}
+			if (req.method === 'thread/start') {
+				peer.push({ id: req.id, result: { thread: { id: `thread-drain-${i}` } } });
+			} else {
+				peer.push({ id: req.id, result: {} });
+			}
+		}
+		throw new Error('Timed out waiting for turn/start');
+	}
+
+	test('fresh first send captures the baseline checkpoint once', async () => {
+		const checkpointService = new RecordingCheckpointService();
+		const agent = await createAgent(disposables, { checkpointService });
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = { kind: 'ready', client, usageSource: 'github', child: { kill: () => true } } as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+
+		const folder = URI.file('/repo/baseline-folder');
+		const { session } = await agent.createSession({ workingDirectories: [folder], model: { id: COPILOT_TEST_MODEL } });
+		const entry = agent['_sessions'].get(AgentSession.id(session))!;
+		const prewarmStart = await readNextRequest(peer.outbound);
+
+		try {
+			peer.push({ id: prewarmStart.id, result: { thread: { id: 'thread-baseline' } } });
+			await entry.materializePromise;
+
+			const send = agent.chats.sendMessage(URI.parse(buildDefaultChatUri(session)), 'hello', undefined, undefined, 'turn-1');
+			await drainUntilTurnStart(peer);
+			await send;
+
+			// The fresh first send captures exactly one baseline for this
+			// session — identical to the Copilot harness.
+			assert.deepStrictEqual(
+				checkpointService.baselineCalls.map(c => c.session),
+				[session.toString()],
+			);
+		} finally {
+			peer.exit();
+		}
+	});
+
+	test('subsequent sends do not re-capture the baseline checkpoint', async () => {
+		const checkpointService = new RecordingCheckpointService();
+		const agent = await createAgent(disposables, { checkpointService });
+		const peer = disposables.add(createTestPeer());
+		const client = new CodexAppServerClient(peer.transport);
+		agent['_connection'] = { kind: 'ready', client, usageSource: 'github', child: { kill: () => true } } as never;
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+
+		const folder = URI.file('/repo/baseline-folder-2');
+		const { session } = await agent.createSession({ workingDirectories: [folder], model: { id: COPILOT_TEST_MODEL } });
+		const entry = agent['_sessions'].get(AgentSession.id(session))!;
+		const prewarmStart = await readNextRequest(peer.outbound);
+
+		try {
+			peer.push({ id: prewarmStart.id, result: { thread: { id: 'thread-baseline-2' } } });
+			await entry.materializePromise;
+
+			const chat = URI.parse(buildDefaultChatUri(session));
+			const send1 = agent.chats.sendMessage(chat, 'hello', undefined, undefined, 'turn-1');
+			await drainUntilTurnStart(peer);
+			await send1;
+			assert.strictEqual(checkpointService.baselineCalls.length, 1, 'fresh first send captures the baseline');
+
+			// A second send has `firstTurnSent === true`, so the gate must
+			// prevent a second baseline capture.
+			const send2 = agent.chats.sendMessage(chat, 'again', undefined, undefined, 'turn-2');
+			await drainUntilTurnStart(peer);
+			await send2;
+			assert.strictEqual(checkpointService.baselineCalls.length, 1, 'subsequent sends must not re-capture the baseline');
+		} finally {
+			peer.exit();
 		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -18,6 +18,7 @@ import { CodexAgent } from '../../../node/codex/codexAgent.js';
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
 import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
@@ -33,6 +34,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 		getRootValue: () => undefined,
 	});
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE);
 	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });


### PR DESCRIPTION
Fixes #329528

### Problem

Per-turn change lists for **Claude** and **Codex** sessions miss **terminal-tool edits**, but Copilot sessions show them.

The Agent Host computes per-turn changes two ways: an authoritative **git checkpoint diff** (includes terminal-tool edits) and a **DB `file_edits` fallback** (misses them). The git path only runs if a per-session **baseline checkpoint** (`turn/0`) was captured — and `captureBaselineCheckpoint` was only invoked from the Copilot harness. Claude and Codex never captured a baseline, so their per-turn changesets always fell back to the DB path.

### Fix

Mirror the Copilot harness — **identical in every way** — for Claude and Codex:

- Inject `IAgentHostCheckpointService` into each harness (same as Copilot).
- Call `captureBaselineCheckpoint(sessionUri, resolvedWorkingDirectories)` on each harness's **fresh** materialize path, **fire-and-forget** (`.catch`, not awaited).
  - **Claude:** in `_materializeProvisional`, before the materialize event fires.
  - **Codex:** on the fresh first send, after the thread is materialized and before `turn/start`, gated `!firstTurnSent && !needsResume` (placed before the resume block clears `needsResume`, so restored sessions are never given a late baseline).

Copilot is unchanged. **No AHP protocol changes.**

### Behavior (inherited from Copilot, no new decisions)

- **Fresh-only:** captured on first materialize, never on resume — restored/pre-existing sessions are not backfilled.
- **Best-effort:** non-git / workspace-less sessions stay on the DB fallback.
- **Idempotent + correctly ordered:** guaranteed by the shared checkpoint service (skips existing baselines; baseline and turn capture share a per-session sequencer).
- **Multi-root:** unchanged — same primary-folder-only read path Copilot has today (tracked separately).

### Tests

- **Claude** (`claudeAgent.test.ts`): baseline captured on fresh materialize; **not** on resume.
- **Codex** (`codexPrewarmEviction.test.ts`): baseline captured on fresh first send; **not** on subsequent sends.
- Existing Claude/Codex test collections wired with `NULL_CHECKPOINT_SERVICE`.

### Validation

- `npm run typecheck-client`: pass.
- Node unit suite: 13591 passing, 0 failing (no regressions); 4 new tests green.
