### PR TITLE
scm: Avoid quick diff after model disposal

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -256,6 +256,10 @@ export class QuickDiffModel extends Disposable {
 	private diff(): Promise<{ allChanges: QuickDiffChange[]; changes: QuickDiffChange[]; mapChanges: Map<string, number[]>; versionId: number } | null> {
 		const location = this.environmentService.isSessionsWindow ? ProgressLocation.Window : ProgressLocation.Scm;
 		return this.progressService.withProgress({ location, delay: 250 }, async () => {
+			if (this._disposed || this._model.isDisposed()) {
+				return null;
+			}
+
 			const versionId = this._model.textEditorModel.getVersionId();
 			const originalURIs = await this.getQuickDiffsPromise();
 			if (this._disposed || this._model.isDisposed() || (originalURIs.length === 0)) {


### PR DESCRIPTION
## Summary
- skip queued quick diff work when its text file model has already been disposed
- preserve the existing post-await disposal check for disposal during provider resolution

## Validation
- `npm run typecheck-client`
- `npm run eslint -- src/vs/workbench/contrib/scm/browser/quickDiffModel.ts`
- `git diff --check`

The issue was found in Insiders logs while deleting a worktree: a queued quick diff attempted to call `getVersionId()` before checking whether the text model had been disposed.

(Written by Copilot)