### PR TITLE
agents window: fix sessions list icon/animation

### DIFF
--- a/src/vs/base/browser/animationSync.ts
+++ b/src/vs/base/browser/animationSync.ts
@@ -89,6 +89,7 @@ let unregisterWindowListener: IDisposable | undefined;
 
 /**
  * Pauses CSS animations while their element is outside the viewport or its document is hidden.
+ * Tracking survives temporary DOM detachment; dispose it when the element is no longer reusable.
  */
 export function pauseCSSAnimationsWhenHidden(element: HTMLElement, options: IPauseCSSAnimationsWhenHiddenOptions): IDisposable {
 	const targetWindow = getWindow(element);
@@ -106,12 +107,6 @@ export function pauseCSSAnimationsWhenHidden(element: HTMLElement, options: IPau
 				const target = entry.target as HTMLElement;
 				const trackedAnimation = trackedAnimations.get(target);
 				if (!trackedAnimation) {
-					continue;
-				}
-				if (!target.isConnected) {
-					observer.unobserve(target);
-					trackedAnimations.delete(target);
-					intersectingElements.delete(target);
 					continue;
 				}
 				if (entry.isIntersecting) {
@@ -135,12 +130,6 @@ export function pauseCSSAnimationsWhenHidden(element: HTMLElement, options: IPau
 			const documentHidden = targetWindow.document.hidden;
 			const toResync: Array<[HTMLElement, IPauseCSSAnimationsWhenHiddenOptions]> = [];
 			for (const [target, trackedAnimation] of trackedAnimations) {
-				if (!target.isConnected) {
-					observer.unobserve(target);
-					trackedAnimations.delete(target);
-					intersectingElements.delete(target);
-					continue;
-				}
 				const paused = documentHidden || !intersectingElements.has(target);
 				target.classList.toggle(trackedAnimation.options.pausedClass, paused);
 				if (!paused) {

--- a/src/vs/base/test/browser/animationSync.test.ts
+++ b/src/vs/base/test/browser/animationSync.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { pauseCSSAnimationsWhenHidden } from '../../browser/animationSync.js';
+import { mainWindow } from '../../browser/window.js';
+import { toDisposable } from '../../common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+async function waitForAnimationFrames(count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await new Promise<void>(resolve => mainWindow.requestAnimationFrame(() => resolve()));
+	}
+}
+
+suite('Animation Sync', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('continues observing an element after temporary DOM detachment', async () => {
+		assert.strictEqual(typeof mainWindow.IntersectionObserver, 'function');
+
+		const host = mainWindow.document.createElement('div');
+		const element = mainWindow.document.createElement('div');
+		host.appendChild(element);
+		store.add(toDisposable(() => host.remove()));
+		store.add(pauseCSSAnimationsWhenHidden(element, { pausedClass: 'paused' }));
+
+		await waitForAnimationFrames(5);
+		const detached = element.classList.contains('paused');
+		mainWindow.document.body.appendChild(host);
+		await waitForAnimationFrames(5);
+		const attached = element.classList.contains('paused');
+
+		assert.deepStrictEqual({ detached, attached }, { detached: true, attached: false });
+	});
+});

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -27,7 +27,7 @@ The sessions list (`SessionsView` + `SessionsList`) displays every session known
 
 Each session row displays:
 
-- **Status icon** — animated indicator for InProgress / NeedsInput / Error / Completed / Unread; quick chats never show a PR glyph (they have no GitHub PR association) and no per-row chat icon is shown either (the Chats section header, Pinned section, or custom group already conveys their identity)
+- **Status icon** — animated indicator for InProgress / NeedsInput / Error / Completed / Unread; unread takes precedence over completed-state glyphs such as a pull request, while quick chats never show a PR glyph (they have no GitHub PR association) and no per-row chat icon is shown either (the Chats section header, Pinned section, or custom group already conveys their identity)
 - **Title** — the session's display title (observable)
 - **Type icon** (regular sessions only) — folder/worktree/cloud icon indicating the workspace kind; omitted for quick chats
 - **Workspace badge** — folder/worktree/cloud icon + label (hidden when redundant with section header)
@@ -37,7 +37,7 @@ Each session row displays:
 
 Quick-chat rows (`.session-item.quick-chat`, driven by the reactive `ISession.isQuickChat` observable) are single-line entries: the details (second) row is hidden entirely and its content is never built — smaller icon, one line of title only, tighter row height (see `SessionsTreeDelegate.ITEM_HEIGHT_QUICK_CHAT`). Regular sessions keep the standard two-line row (title + details row).
 
-Continuous row animations preserve their existing appearance while limiting rendering work: the title shimmer follows the same three-second path with at most 30 visual updates per second, then rests for three seconds before repeating. Both it and the shared pixel spinner pause outside the viewport and whenever their document is hidden. Status icons cross-fade only for state changes within the same session; when virtualization rebinds a row template to another session, the new icon renders immediately so stale status is never shown.
+Continuous row animations preserve their existing appearance while limiting rendering work: the title shimmer follows the same three-second path with at most 30 visual updates per second, then rests for three seconds before repeating. Both it and the shared pixel spinner pause outside the viewport and whenever their document is hidden, while their visibility tracking survives temporary row-template detachment. Status icons cross-fade only for state changes within the same session; when virtualization rebinds a row template to another session, the new icon renders immediately so stale status is never shown.
 
 `SessionsFlatList` reuses the same session row renderer for sectionless surfaces, including the approval row and dynamic row height updates. Consumers that size their own container listen for content-height changes and relayout the list. When embedded inside another hover, consumers disable row hovers so moving over the list does not replace the parent hover.
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -325,6 +325,7 @@ interface ISessionItemTemplate {
 	readonly ciButtonContainer: HTMLElement;
 	readonly contextKeyService: IContextKeyService;
 	readonly statusContext: IContextKey<SessionStatus>;
+	readonly isReadContext: IContextKey<boolean>;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
 }
@@ -386,7 +387,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	readonly onDidApproveSession: Event<IApprovedSession> = this._onDidApproveSession.event;
 
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; showHover: boolean; approvalRowMaxLines: number; toolbarMenuId: MenuId | undefined; handleToolbarAction?: (action: IAction, session: ISession) => boolean | Promise<boolean>; onDidRequestRename?: (session: ISession) => void },
+		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; showHover: boolean; approvalRowMaxLines: number; toolbarMenuId: MenuId | undefined; handleToolbarAction?: (action: IAction, session: ISession) => boolean | Promise<boolean>; onDidRequestRename?: (session: ISession) => void },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly ciFixModel: ISessionCIFixModel | undefined,
 		private readonly instantiationService: IInstantiationService,
@@ -463,6 +464,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const statusContext = SessionItemStatusContext.bindTo(contextKeyService);
+		const isReadContext = SessionIsReadContext.bindTo(contextKeyService);
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
 		let titleToolbar: MenuWorkbenchToolBar | undefined;
 		if (this.options.toolbarMenuId) {
@@ -473,7 +475,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}));
 		}
 
-		return { container, statusIcon, title, titleContainer, titleToolbar, pendingVoiceIndicator, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, ciRow, ciLabel, ciButtonContainer, contextKeyService, statusContext, disposables, elementDisposables };
+		return { container, statusIcon, title, titleContainer, titleToolbar, pendingVoiceIndicator, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, ciRow, ciLabel, ciButtonContainer, contextKeyService, statusContext, isReadContext, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -546,7 +548,6 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const isPinned = this.options.isPinned(element);
 		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
 		SessionIsArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
-		SessionIsReadContext.bindTo(template.contextKeyService).set(this.options.isRead(element));
 		SessionItemHasBranchNameContext.bindTo(template.contextKeyService).set(!!element.workspace.get()?.folders[0]?.gitRepository?.branchName?.trim());
 
 		// Pinned & archived styling — reactive
@@ -574,7 +575,8 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		template.elementDisposables.add(autorun(reader => {
 			const sessionStatus = element.status.read(reader);
 			template.statusContext.set(sessionStatus);
-			const isRead = this.options.isRead(element);
+			const isRead = element.isRead.read(reader);
+			template.isReadContext.set(isRead);
 			const isArchived = element.isArchived.read(reader);
 			const gitHubInfo = element.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
 			const isQuickChat = element.isQuickChat?.read(reader) ?? false;
@@ -1913,7 +1915,6 @@ export class SessionsList extends Disposable implements ISessionsList {
 			{
 				grouping: this.options.grouping,
 				isPinned: s => this.isSessionPinned(s),
-				isRead: s => s.isRead.get(),
 				visibleSessions: this._sessionsService.visibleSessions,
 				getMultiSelectedSessions: s => this.getMultiSelectedSessions(s),
 				showHover: true,
@@ -3643,7 +3644,6 @@ export class SessionsFlatList extends Disposable {
 			{
 				grouping: () => SessionsGrouping.Date,
 				isPinned: s => this._sessionsListModelService.isSessionPinned(s),
-				isRead: s => s.isRead.get(),
 				visibleSessions: this._sessionsService.visibleSessions,
 				getMultiSelectedSessions: s => [s],
 				showHover: this.options.showSessionHover ?? true,

--- a/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
@@ -244,11 +244,11 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 				if (isArchived) {
 					return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 				}
-				if (completedStateIcon) {
-					return completedStateIcon;
-				}
 				if (!isRead) {
 					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+				}
+				if (completedStateIcon) {
+					return completedStateIcon;
 				}
 				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 		}

--- a/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
@@ -63,6 +63,20 @@ suite('SessionsListModelService', () => {
 		service = disposables.add(instantiationService.createInstance(SessionsListModelService));
 	});
 
+	test('unread state takes precedence over the completed-state icon', () => {
+		const completedStateIcon = Codicon.gitPullRequest;
+		const unreadIcon = service.getStatusIcon(SessionStatus.Completed, false, false, completedStateIcon);
+		const readIcon = service.getStatusIcon(SessionStatus.Completed, true, false, completedStateIcon);
+
+		assert.deepStrictEqual({
+			unread: { id: unreadIcon.id, color: unreadIcon.color?.id },
+			read: { id: readIcon.id, color: readIcon.color?.id },
+		}, {
+			unread: { id: Codicon.circleFilled.id, color: 'textLink.foreground' },
+			read: { id: Codicon.gitPullRequest.id, color: undefined },
+		});
+	});
+
 	// -- Pinning --
 
 	test('pinSession marks session as pinned', () => {


### PR DESCRIPTION
Investigated and fixed the missing Sessions-list progress icon.

### Root cause
The shared animation observer removed a spinner from tracking whenever its virtualized row was temporarily detached. When that row was later reattached, the spinner remained paused at its initial all-transparent frame. Scrolling recycled the row and created a newly tracked spinner, explaining why the icon returned.

A live pre-fix probe reproduced `paused: true` with all 6 dots invisible after reattachment. The patched build now reports `paused: false` with visible animated dots.

### Changes
- Kept temporarily detached animations observed until their owner disposes them in `animationSync.ts`.
- Made session read state reactive in the row renderer in `sessionsList.ts`.
- Restored unread-dot priority over completed-state/PR glyphs in `sessionsListModelService.ts`.
- Added regressions in `animationSync.test.ts` and `sessionsListModelService.test.ts`.
- Updated the Sessions-list specification in `SESSIONS_LIST.md`.
