### PR TITLE
sessions: Preserve side pane with multiple sessions

### DIFF
--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -324,7 +324,10 @@ does, causing the aux bar to fall back to the default-visible logic (§3.2) on t
   submitted (§3.3). A created session with no explicit "visible" choice stays closed until the user
   opens it.
 - **In single-pane, editor/detail visibility is shared by lifecycle type** — New Sessions and Existing
-  Sessions restore independent profiles; quick chats only suppress the pane temporarily.
+  Sessions restore independent profiles; quick chats only suppress the pane temporarily while a single
+  session is visible. With multiple visible sessions, the focused session may reveal parts from its
+  matching profile, but it never automatically hides parts it does not use. This restores an existing
+  session's open side pane without letting a quick chat hide a pane used by another session.
 - **In the classic desktop layout, the sessions sidebar is auto-managed on a small window ([D7])** — when the main container is
   1800px wide or narrower and both the editor and auxiliary bar are open, the sidebar is hidden; it is shown
   again once either closes or the window widens, unless the user closed it themselves. Suspended while

--- a/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
+++ b/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
@@ -160,6 +160,12 @@ No side pane at all — the detail panel and managed tabs are not shown; the cha
 full-width. This is a temporary effective hide: the matching New/Existing profile is
 restored when returning to a workspace session.
 
+### Multiple visible sessions
+Visibility restoration is reveal-only while multiple sessions are visible. Focusing a workspace
+session reveals the parts enabled by its matching profile, while focusing a quick chat or another
+session without side-pane content does not hide parts used by another session. Collapsing back to
+one session restores that session type's complete shared profile.
+
 ---
 
 ## 7. Transition matrix (single-session, not maximized)

--- a/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
+++ b/src/vs/sessions/SINGLE_PANE_SCENARIOS.md
@@ -165,6 +165,8 @@ Visibility restoration is reveal-only while multiple sessions are visible. Focus
 session reveals the parts enabled by its matching profile, while focusing a quick chat or another
 session without side-pane content does not hide parts used by another session. Collapsing back to
 one session restores that session type's complete shared profile.
+Reveal-only preservation applies only to panel synchronization: active Changes/Files editors still
+publish their docked-details capability so **Toggle Details** remains available.
 
 ---
 

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDetailPanelStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDetailPanelStrategy.ts
@@ -81,8 +81,9 @@ export class SinglePaneDetailPanelStrategy extends SinglePaneLayoutStrategy {
 			const hasDockedDetails = target === DetailPanelTarget.Changes || target === DetailPanelTarget.ChangesForced || target === DetailPanelTarget.Files || target === DetailPanelTarget.FilesForced;
 			this._hasDockedDetailsContext!.set(hasDockedDetails);
 			auxBarVisibleObs.read(reader);
+			const syncTarget = this._ctx.multipleSessionsVisibleObs.read(reader) ? DetailPanelTarget.Preserve : target;
 			const generation = ++this._detailGeneration;
-			void this._detailSequencer.queue(() => this._syncDetailTarget(target, generation)).catch(onUnexpectedError);
+			void this._detailSequencer.queue(() => this._syncDetailTarget(syncTarget, generation)).catch(onUnexpectedError);
 		}));
 
 		// The empty Files placeholder's content (the Files tree) lives in the detail; keyed on active-editor so the inactive auto-ensured tab never reveals it.
@@ -97,9 +98,6 @@ export class SinglePaneDetailPanelStrategy extends SinglePaneLayoutStrategy {
 	}
 
 	private _computeDetailTarget(reader: IReader, activeEditor: EditorInput | undefined, mainPartEmptyObs: IObservable<boolean>, editorMaximizedObs: IObservable<boolean>, editorPartVisibleObs: IObservable<boolean>): DetailPanelTarget {
-		if (this._ctx.multipleSessionsVisibleObs.read(reader)) {
-			return DetailPanelTarget.Preserve;
-		}
 		const activeSession = this._sessionsService.activeSession.read(reader);
 		if (!activeSession) {
 			return DetailPanelTarget.Preserve;

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDetailPanelStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDetailPanelStrategy.ts
@@ -97,6 +97,9 @@ export class SinglePaneDetailPanelStrategy extends SinglePaneLayoutStrategy {
 	}
 
 	private _computeDetailTarget(reader: IReader, activeEditor: EditorInput | undefined, mainPartEmptyObs: IObservable<boolean>, editorMaximizedObs: IObservable<boolean>, editorPartVisibleObs: IObservable<boolean>): DetailPanelTarget {
+		if (this._ctx.multipleSessionsVisibleObs.read(reader)) {
+			return DetailPanelTarget.Preserve;
+		}
 		const activeSession = this._sessionsService.activeSession.read(reader);
 		if (!activeSession) {
 			return DetailPanelTarget.Preserve;

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneSidePaneVisibilityStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneSidePaneVisibilityStrategy.ts
@@ -49,7 +49,7 @@ const DEFAULT_EXISTING_SESSION_VISIBILITY_STATE: ISidePaneVisibilityState = {
 
 /**
  * Keeps separate shared editor/detail compositions for new and existing sessions.
- * Quick chats temporarily suppress the pane without changing either profile.
+ * Quick chats temporarily suppress the pane while a single session is visible.
  */
 export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrategy {
 
@@ -79,9 +79,28 @@ export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrate
 		let activeProfile: SessionVisibilityProfile | undefined;
 		let quickChatActive = false;
 		let initialized = false;
+		let multipleSessionsWereVisible = false;
 		let previousIsCreated: boolean | undefined;
 		let previousSession: IActiveSession | undefined;
 		this._register(autorun(reader => {
+			const multipleSessionsVisible = this._ctx.multipleSessionsVisibleObs.read(reader);
+			if (multipleSessionsVisible) {
+				this._pendingAuxiliaryBarRestore = undefined;
+				multipleSessionsWereVisible = true;
+				const activeSession = this._sessionsService.activeSession.read(reader);
+				const isQuickChat = activeSession?.isQuickChat?.read(reader) ?? false;
+				const workspace = activeSession?.workspace.read(reader);
+				if (activeSession && !isQuickChat && workspace) {
+					const profile = activeSession.isCreated.read(reader)
+						? SessionVisibilityProfile.Existing
+						: SessionVisibilityProfile.New;
+					this._ctx.withSessionLayoutRestore(() => this._revealState(this._getProfile(profile)));
+				}
+				return;
+			}
+
+			const restoreAfterMultipleSessions = multipleSessionsWereVisible;
+			multipleSessionsWereVisible = false;
 			const activeSession = this._sessionsService.activeSession.read(reader);
 			if (!activeSession) {
 				return;
@@ -111,7 +130,7 @@ export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrate
 				this._captureProfile(SessionVisibilityProfile.New);
 				this._captureProfile(SessionVisibilityProfile.Existing);
 			}
-			if (!isSubmit && (!initialized || quickChatActive || activeProfile !== nextProfile || sessionChanged)) {
+			if (!isSubmit && (!initialized || restoreAfterMultipleSessions || quickChatActive || activeProfile !== nextProfile || sessionChanged)) {
 				const profile = this._getProfile(nextProfile);
 				this._pendingAuxiliaryBarRestore = profile.auxiliaryBarVisible
 					? (mainPartEmpty ? PendingAuxiliaryBarRestore.WaitingForContent : PendingAuxiliaryBarRestore.WaitingForEmptyGroup)
@@ -139,6 +158,10 @@ export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrate
 			if (this._applyingProfile || this._pendingAuxiliaryBarRestore !== PendingAuxiliaryBarRestore.WaitingForEmptyGroup) {
 				return;
 			}
+			if (this._ctx.multipleSessionsVisibleObs.get()) {
+				this._pendingAuxiliaryBarRestore = undefined;
+				return;
+			}
 			const activeSession = this._sessionsService.activeSession.get();
 			if (!activeSession || activeSession.isQuickChat?.get()) {
 				this._pendingAuxiliaryBarRestore = undefined;
@@ -156,6 +179,9 @@ export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrate
 				return;
 			}
 			if (this._ctx.isRestoringSessionLayout) {
+				return;
+			}
+			if (this._ctx.multipleSessionsVisibleObs.get()) {
 				return;
 			}
 			const activeSession = this._sessionsService.activeSession.get();
@@ -215,6 +241,20 @@ export class SinglePaneSidePaneVisibilityStrategy extends SinglePaneLayoutStrate
 			if (!state.auxiliaryBarVisible && this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
 				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 			}
+			if (state.auxiliaryBarVisible && !this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+				this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+			}
+			if (state.editorVisible && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+				this._layoutService.setPartHidden(false, Parts.EDITOR_PART);
+			}
+		} finally {
+			suppression.dispose();
+		}
+	}
+
+	private _revealState(state: ISidePaneVisibilityState): void {
+		const suppression = this._layoutService.suppressEditorPartAutoVisibility();
+		try {
 			if (state.auxiliaryBarVisible && !this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
 				this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
 			}

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -1712,6 +1712,72 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
+	test('[single-pane] keeps the side pane visible when a quick chat is active among multiple sessions', async () => {
+		createSinglePaneController({ singlePaneLayoutEnabled: true, activateAux: true });
+		const workspaceSession = makeSession(URI.parse('session:workspace'));
+		const quickChat = makeSession(URI.parse('session:quick'), { isQuickChat: true });
+
+		harness.activeSessionObs.set(workspaceSession, undefined);
+		await timeout(0);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.setPartHiddenCalls = [];
+
+		transaction(tx => {
+			harness.visibleSessionsObs.set([workspaceSession, quickChat], tx);
+			harness.activeSessionObs.set(quickChat, tx);
+		});
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			editorVisible: harness.partVisibility.get(Parts.EDITOR_PART),
+			auxiliaryBarVisible: harness.partVisibility.get(Parts.AUXILIARYBAR_PART),
+			hideCalls: harness.setPartHiddenCalls.filter(call => call.hidden),
+		}, {
+			editorVisible: true,
+			auxiliaryBarVisible: true,
+			hideCalls: [],
+		});
+	});
+
+	test('[single-pane] restores open side-pane parts when an existing session is opened to the side', async () => {
+		createSinglePaneController({
+			singlePaneLayoutEnabled: true,
+			activateAux: true,
+			sidePaneVisibilityState: {
+				newSession: { editorVisible: false, auxiliaryBarVisible: true },
+				existingSession: { editorVisible: true, auxiliaryBarVisible: true },
+			},
+		});
+		const quickChat = makeSession(URI.parse('session:quick'), { isQuickChat: true });
+		const existingSession = makeSession(URI.parse('session:existing'));
+
+		harness.activeSessionObs.set(quickChat, undefined);
+		await timeout(0);
+		harness.partVisibility.set(Parts.EDITOR_PART, false);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.setPartHiddenCalls = [];
+
+		transaction(tx => {
+			harness.visibleSessionsObs.set([quickChat, existingSession], tx);
+			harness.activeSessionObs.set(existingSession, tx);
+		});
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			editorVisible: harness.partVisibility.get(Parts.EDITOR_PART),
+			auxiliaryBarVisible: harness.partVisibility.get(Parts.AUXILIARYBAR_PART),
+			revealCalls: harness.setPartHiddenCalls.filter(call => !call.hidden),
+		}, {
+			editorVisible: true,
+			auxiliaryBarVisible: true,
+			revealCalls: [
+				{ part: Parts.AUXILIARYBAR_PART, hidden: false },
+				{ part: Parts.EDITOR_PART, hidden: false },
+			],
+		});
+	});
+
 	test('[single-pane] hides Editor before Details when switching to Quick Chat before the outgoing group clears', async () => {
 		createSinglePaneController({ singlePaneLayoutEnabled: true, activateAux: true });
 		await timeout(0);

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -1763,14 +1763,19 @@ suite('LayoutController (desktop)', () => {
 			harness.activeSessionObs.set(existingSession, tx);
 		});
 		await timeout(0);
+		harness.activeEditorInput = makeFileEditor();
+		harness.onDidActiveEditorChange.fire();
+		await timeout(0);
 
 		assert.deepStrictEqual({
 			editorVisible: harness.partVisibility.get(Parts.EDITOR_PART),
 			auxiliaryBarVisible: harness.partVisibility.get(Parts.AUXILIARYBAR_PART),
+			hasDockedDetails: harness.contextKeyService.getContextKeyValue(HasDockedDetailsContext.key),
 			revealCalls: harness.setPartHiddenCalls.filter(call => !call.hidden),
 		}, {
 			editorVisible: true,
 			auxiliaryBarVisible: true,
+			hasDockedDetails: true,
 			revealCalls: [
 				{ part: Parts.AUXILIARYBAR_PART, hidden: false },
 				{ part: Parts.EDITOR_PART, hidden: false },


### PR DESCRIPTION
## Summary

- keep the single-pane side pane visible when focusing a session without side-pane content while multiple sessions are open
- restore remembered open side-pane parts when an existing workspace session is opened to the side
- add focused regression coverage and document reveal-only multi-session restoration

## Validation

- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts --grep "\[single-pane\]"` (28 passing)