### PR TITLE
Make agentStatusIndicator.background inherit from commandCenter.background

### DIFF
--- a/src/vs/workbench/contrib/chat/common/widget/chatColors.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/chatColors.ts
@@ -8,13 +8,15 @@ import { localize } from '../../../../../nls.js';
 import { badgeBackground, badgeForeground, contrastBorder, editorBackground, editorSelectionBackground, editorWidgetBackground, focusBorder, foreground, registerColor, transparent } from '../../../../../platform/theme/common/colorRegistry.js';
 import { buttonBackground } from '../../../../../platform/theme/common/colors/inputColors.js';
 import { darken, lighten } from '../../../../../platform/theme/common/colorUtils.js';
+import { COMMAND_CENTER_BACKGROUND } from '../../../../common/theme.js';
 
-// This color intentionally matches commandCenter.background but is separate so that it
-// doesn't get overridden when debugging (the debug toolbar overrides commandCenter.background).
-// This allows themes to customize it while maintaining independence from debug mode changes.
+// This color inherits its default value from commandCenter.background but is registered
+// separately so that it doesn't get overridden when debugging (the debug toolbar overrides
+// commandCenter.background). This allows themes to customize it while maintaining
+// independence from debug mode changes.
 export const agentStatusIndicatorBackground = registerColor(
 	'agentStatusIndicator.background',
-	{ dark: Color.white.transparent(0.05), light: Color.black.transparent(0.05), hcDark: null, hcLight: null },
+	COMMAND_CENTER_BACKGROUND,
 	localize('agentStatusIndicator.background', 'Background color of the agent status indicator in the titlebar.')
 );
 


### PR DESCRIPTION
## Summary

gentStatusIndicator.background previously duplicated the hardcoded default color values of commandCenter.background (\Color.white.transparent(0.05)\ / \Color.black.transparent(0.05)\). This change makes it reference \COMMAND_CENTER_BACKGROUND\ directly as its default so it inherits the command center's background color automatically, while remaining a distinct registered color (so it isn't affected by the debug toolbar's runtime CSS override of \--vscode-commandCenter-background\).

Themes can still override \gentStatusIndicator.background\ independently if desired.

## Changes
- \src/vs/workbench/contrib/chat/common/widget/chatColors.ts\: pass \COMMAND_CENTER_BACKGROUND\ as the \defaults\ argument to \egisterColor\ instead of duplicating literal color values.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>