### PR TITLE
agentHost: inherit model and permissions in session tools

### DIFF
--- a/.github/instructions/agentHostTesting.instructions.md
+++ b/.github/instructions/agentHostTesting.instructions.md
@@ -25,3 +25,7 @@ See the agent host protocol documentation for more details.
 You can run `node ./scripts/code-agent-host.js` to start an agent host. If you pass `--enable-mock-agent`, then the `ScriptedMockAgent` will be used.
 
 By default this will listen on `ws://127.0.0.1:8081`. You can then use the `ahp-websocket` client, when available, to connect to and communicate with it.
+
+## Learnings
+
+- Provider-owned session configuration inheritance must be selected by the owning `IAgent`; `AgentService` only orchestrates transfer and must not encode provider-specific configuration keys.

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1652,6 +1652,9 @@ export interface IAgent {
 	/** Resolve provider-owned session configuration; host-owned worktree fields are omitted. */
 	resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult>;
 
+	/** Select provider-owned configuration that a newly created session should inherit. */
+	getInheritedSessionConfig?(config: Readonly<Record<string, unknown>>): Record<string, unknown> | undefined;
+
 	/** Return dynamic completions for a provider-owned session configuration property. */
 	sessionConfigCompletions(params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult>;
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -49,7 +49,7 @@ import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
-import { type IChatContextSnapshot, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
+import { type IChatContextSnapshot, type ISessionCreationDefaults, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 
 import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
@@ -840,9 +840,10 @@ export class AgentService extends Disposable implements IAgentService {
 				}
 				return models;
 			},
+			getCreationDefaults: source => this._getServerToolCreationDefaults(source),
 			startPrompt: (session, chat, prompt) => this._startSessionPrompt(session, chat, prompt),
 			createChat: (session, chat, options) => this.createChat(session, chat, (options?.title !== undefined || options?.model !== undefined)
-				? { ...(options.title !== undefined ? { title: options.title } : {}), ...(options.model !== undefined ? { model: { id: options.model.id } } : {}) }
+				? { ...(options.title !== undefined ? { title: options.title } : {}), ...(options.model !== undefined ? { model: options.model } : {}) }
 				: undefined),
 			deleteSession: session => this.disposeSession(session),
 			getChatContext: (session, chatId) => this._getChatContext(session, chatId),
@@ -853,6 +854,21 @@ export class AgentService extends Disposable implements IAgentService {
 				type: ActionType.SessionMetaChanged,
 				_meta: withSessionSpawnDepth(this._stateManager.getSessionSummary(session.toString())?._meta, depth),
 			}),
+		};
+	}
+
+	private _getServerToolCreationDefaults(source: URI): ISessionCreationDefaults | undefined {
+		const session = this._stateManager.getSessionState(source.toString());
+		if (!session) {
+			return undefined;
+		}
+
+		const model = session.activeTurn?.message.model ?? session.draft?.model ?? session.turns.at(-1)?.message.model;
+		const config = this._providers.get(session.provider)?.getInheritedSessionConfig?.(session.config?.values ?? {});
+		return {
+			provider: session.provider,
+			...(model !== undefined ? { model } : {}),
+			...(config !== undefined ? { config } : {}),
 		};
 	}
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -863,7 +863,11 @@ export class AgentService extends Disposable implements IAgentService {
 			return undefined;
 		}
 
-		const model = session.activeTurn?.message.model ?? session.draft?.model ?? session.turns.at(-1)?.message.model;
+		const model = session.activeTurn
+			? session.activeTurn.message.model
+			: session.draft
+				? session.draft.model
+				: session.turns.at(-1)?.message.model;
 		const config = this._providers.get(session.provider)?.getInheritedSessionConfig?.(session.config?.values ?? {});
 		return {
 			provider: session.provider,

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -2031,6 +2031,16 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		});
 	}
 
+	getInheritedSessionConfig(config: Readonly<Record<string, unknown>>): Record<string, unknown> | undefined {
+		const inherited: Record<string, unknown> = {};
+		for (const key of [ClaudeSessionConfigKey.PermissionMode, SessionConfigKey.Permissions]) {
+			if (config[key] !== undefined) {
+				inherited[key] = config[key];
+			}
+		}
+		return Object.keys(inherited).length > 0 ? inherited : undefined;
+	}
+
 	sessionConfigCompletions(_params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult> {
 		// Plan section 3.3.5: Claude's only schema property is the
 		// `permissionMode` static enum, so dynamic completion is

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -4713,6 +4713,17 @@ export class CodexAgent extends Disposable implements IAgent {
 		return Promise.resolve({ values: resolvedValues, schema });
 	}
 
+	getInheritedSessionConfig(config: Readonly<Record<string, unknown>>): Record<string, unknown> | undefined {
+		const inherited: Record<string, unknown> = migrateCodexPermissionValues(config, {
+			approvalPolicy: codexSessionConfigDefaults[CodexSessionConfigKey.ApprovalPolicy],
+			sandboxMode: codexSessionConfigDefaults[CodexSessionConfigKey.SandboxMode],
+		});
+		if (config[SessionConfigKey.Permissions] !== undefined) {
+			inherited[SessionConfigKey.Permissions] = config[SessionConfigKey.Permissions];
+		}
+		return Object.keys(inherited).length > 0 ? inherited : undefined;
+	}
+
 	async sessionConfigCompletions(params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult> {
 		if (params.property !== CodexSessionConfigKey.AdditionalDirectories) {
 			return { items: [] };

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -2573,6 +2573,16 @@ export class CopilotAgent extends Disposable implements IAgent {
 		};
 	}
 
+	getInheritedSessionConfig(config: Readonly<Record<string, unknown>>): Record<string, unknown> | undefined {
+		const inherited: Record<string, unknown> = {};
+		for (const key of [SessionConfigKey.AutoApprove, SessionConfigKey.Permissions]) {
+			if (config[key] !== undefined) {
+				inherited[key] = config[key];
+			}
+		}
+		return Object.keys(inherited).length > 0 ? inherited : undefined;
+	}
+
 	async sessionConfigCompletions(_params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult> {
 		// Branch completions (the only dynamic Copilot property) are owned by the
 		// host now; no provider-specific completions remain.

--- a/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
@@ -6,9 +6,9 @@
 import { URI } from '../../../../base/common/uri.js';
 import type { Mutable } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
-import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
+import { AgentSession, type AgentProvider, type IAgentCreateSessionConfig, type IAgentModelInfo, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, getInlineToolInput, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionGitState, readSessionGitHubState, ResponsePartKind, ToolCallStatus, TurnState, type Message, type ResponsePart, type ToolCallState, type ToolDefinition, type StringOrMarkdown, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, getInlineToolInput, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionGitState, readSessionGitHubState, ResponsePartKind, ToolCallStatus, TurnState, type Message, type ModelSelection, type ResponsePart, type ToolCallState, type ToolDefinition, type StringOrMarkdown, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { buildOpenSessionLinkUri, parseOpenSessionLinkChatId, parseOpenSessionLinkUri } from '../../common/openSessionLink.js';
 import { SessionServerToolName } from '../../common/serverToolNames.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -64,7 +64,7 @@ const createSessionInputSchema: ToolDefinition['inputSchema'] = {
 	properties: {
 		workspace: { type: 'string', description: 'Absolute folder path, workspace URI, or a working directory from an existing session.' },
 		prompt: { type: 'string', description: 'Initial prompt to send to the new session.' },
-		model: { type: 'string', description: 'Optional model ID or display name.' },
+		model: { type: 'string', description: 'Optional model ID or display name. Defaults to the current chat\'s model.' },
 	},
 	required: ['workspace', 'prompt'],
 };
@@ -80,7 +80,7 @@ const createChatInputSchema: ToolDefinition['inputSchema'] = {
 		session: { type: 'string', description: 'Optional session to add the chat to: a session URI from `list_sessions` or an `agent-host-session://` link. Defaults to the current session when omitted.' },
 		prompt: { type: 'string', description: 'Initial prompt to send to the new chat.' },
 		title: { type: 'string', description: 'Optional title for the new chat.' },
-		model: { type: 'string', description: 'Optional model ID or display name. Defaults to the session\'s model.' },
+		model: { type: 'string', description: 'Optional model ID or display name. Defaults to the current chat\'s model.' },
 	},
 	required: ['prompt'],
 };
@@ -144,7 +144,7 @@ export const sessionServerToolDefinitions: ToolDefinition[] = [
 	{
 		name: SessionServerToolName.CreateChat,
 		title: 'Create Chat',
-		description: 'Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session\'s model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.',
+		description: 'Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat\'s model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.',
 		inputSchema: createChatInputSchema,
 		annotations: { readOnlyHint: false },
 	},
@@ -194,8 +194,9 @@ export interface ISessionServerToolAccessor {
 	readonly listSessions: () => Promise<readonly IAgentSessionMetadata[]>;
 	readonly createSession: (config: IAgentCreateSessionConfig) => Promise<URI>;
 	readonly getModels: () => readonly IAgentModelInfo[];
+	readonly getCreationDefaults: (source: URI) => ISessionCreationDefaults | undefined;
 	readonly startPrompt: (session: URI, chat: URI, prompt: string) => Promise<void>;
-	readonly createChat: (session: URI, chat: URI, options?: { title?: string; model?: IAgentModelInfo }) => Promise<void>;
+	readonly createChat: (session: URI, chat: URI, options?: { title?: string; model?: ModelSelection }) => Promise<void>;
 	readonly deleteSession: (session: URI) => Promise<void>;
 	/** Reads a point-in-time snapshot of a session's chat conversation (default chat, or a specific chat by id). */
 	readonly getChatContext: (session: URI, chatId?: string) => Promise<IChatContextSnapshot | undefined>;
@@ -203,6 +204,12 @@ export interface ISessionServerToolAccessor {
 	readonly getSessionSpawnDepth: (session: URI) => number;
 	/** Records the spawn depth of a freshly-created session so its own `create_session` calls can enforce the recursion limit. */
 	readonly setSessionSpawnDepth: (session: URI, depth: number) => void;
+}
+
+export interface ISessionCreationDefaults {
+	readonly provider?: AgentProvider;
+	readonly model?: ModelSelection;
+	readonly config?: Record<string, unknown>;
 }
 
 /** Point-in-time snapshot of a chat's conversation, read from the host state. */
@@ -582,16 +589,22 @@ export interface ICreateSessionResult {
  * {@link currentSession} (the session the tool runs in) and stamps the new
  * session one level deeper so its own `create_session` calls are bounded too.
  */
-export async function applyCreateSessionTool(accessor: ISessionServerToolAccessor, rawArgs: unknown, currentSession?: URI): Promise<ICreateSessionResult> {
+export async function applyCreateSessionTool(accessor: ISessionServerToolAccessor, rawArgs: unknown, source?: URI): Promise<ICreateSessionResult> {
+	const currentSession = source ? currentSessionUri(source.toString()) : undefined;
 	const parentDepth = currentSession ? accessor.getSessionSpawnDepth(currentSession) : 0;
 	if (parentDepth >= maxSessionSpawnDepth) {
 		throw new Error(`Refusing to create a session: recursion limit reached (max spawn depth ${maxSessionSpawnDepth}). This session was itself created ${parentDepth} level(s) deep.`);
 	}
 	const sessions = await accessor.listSessions();
 	const args = getCreateSessionArgs(rawArgs, sessions, accessor.getModels());
+	const defaults = source ? accessor.getCreationDefaults(source) : undefined;
+	const provider = args.model?.provider ?? defaults?.provider;
+	const inheritsSourceProvider = provider !== undefined && provider === defaults?.provider;
 	const config: IAgentCreateSessionConfig = {
 		workingDirectories: args.workspace ? [args.workspace] : undefined,
-		...(args.model !== undefined ? { provider: args.model.provider, model: { id: args.model.id } } : {}),
+		...(provider !== undefined ? { provider } : {}),
+		...(args.model !== undefined ? { model: { id: args.model.id } } : defaults?.model !== undefined ? { model: defaults.model } : {}),
+		...(inheritsSourceProvider && defaults?.config !== undefined ? { config: defaults.config } : {}),
 	};
 	const session = await accessor.createSession(config);
 	accessor.setSessionSpawnDepth(session, parentDepth + 1);
@@ -667,12 +680,16 @@ export function getCreateChatArgs(rawArgs: unknown, sessions: readonly IAgentSes
 }
 
 /** Adds a chat to a session, sends its initial prompt, and returns the created channels. */
-export async function applyCreateChatTool(accessor: ISessionServerToolAccessor, rawArgs: unknown, currentSession?: URI): Promise<ICreateChatResult> {
+export async function applyCreateChatTool(accessor: ISessionServerToolAccessor, rawArgs: unknown, source?: URI): Promise<ICreateChatResult> {
 	const sessions = await accessor.listSessions();
+	const currentSession = source ? currentSessionUri(source.toString()) : undefined;
 	const args = getCreateChatArgs(rawArgs, sessions, accessor.getModels(), currentSession);
+	const defaults = source ? accessor.getCreationDefaults(source) : undefined;
+	const targetProvider = AgentSession.provider(args.session);
+	const model = args.model !== undefined ? { id: args.model.id } : targetProvider === defaults?.provider ? defaults?.model : undefined;
 	const chatId = generateUuid();
 	const chat = URI.parse(buildChatUri(args.session.toString(), chatId));
-	await accessor.createChat(args.session, chat, { title: args.title, model: args.model });
+	await accessor.createChat(args.session, chat, { title: args.title, model });
 	await accessor.startPrompt(args.session, chat, args.prompt);
 	return { session: args.session.toString(), chat: chat.toString(), openLink: buildOpenSessionLinkUri(args.session, chatId) };
 }
@@ -1061,7 +1078,7 @@ export function createSessionServerToolGroup(accessor?: ISessionServerToolAccess
 					if (createdSessionCount >= maxCreatedSessions) {
 						throw new Error(`Refusing to create more than ${maxCreatedSessions} sessions from server tools in this process.`);
 					}
-					const result = await applyCreateSessionTool(accessor, rawArgs, currentSessionUri(sessionUri));
+					const result = await applyCreateSessionTool(accessor, rawArgs, URI.parse(sessionUri));
 					createdSessionCount++;
 					return formatCreateSessionResult(result);
 				}
@@ -1069,7 +1086,7 @@ export function createSessionServerToolGroup(accessor?: ISessionServerToolAccess
 					if (createdChatCount >= maxCreatedChats) {
 						throw new Error(`Refusing to create more than ${maxCreatedChats} chats from server tools in this process.`);
 					}
-					const result = await applyCreateChatTool(accessor, rawArgs, currentSessionUri(sessionUri));
+					const result = await applyCreateChatTool(accessor, rawArgs, URI.parse(sessionUri));
 					createdChatCount++;
 					return formatCreateChatResult(result);
 				}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -24,6 +24,8 @@ import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IConnectionTrackerService, IRestoredSubagentSession, SubagentChatSignal, type IAgent, type IAgentChatDataChange, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentDescriptor, type IAgentLegacyChat, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
+import { ClaudeSessionConfigKey } from '../../common/claudeSessionConfigKeys.js';
+import { CodexSessionConfigKey } from '../../common/codexSessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
@@ -4906,6 +4908,93 @@ suite('AgentService (node dispatcher)', () => {
 				beforeContext: undefined,
 				materializeCalls: 1,
 				transcript: [{ turn: 1, state: 'complete', user: 'Remember this', assistant: 'Remembered' }],
+			});
+		});
+
+		test('session creation tools inherit the calling chat model and session permissions', async () => {
+			class ServerToolAgent extends MockAgent {
+				readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
+				readonly createChatOptions: (IAgentCreateChatOptions | undefined)[] = [];
+				serverToolHost: IAgentServerToolHost | undefined;
+
+				setServerToolHost(host: IAgentServerToolHost): void {
+					this.serverToolHost = host;
+				}
+
+				override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+					this.createSessionConfigs.push(config);
+					return super.createSession(config);
+				}
+
+				override async createChat(_session: URI, _chat: URI, options?: IAgentCreateChatOptions): Promise<void> {
+					this.createChatOptions.push(options);
+				}
+
+				getInheritedSessionConfig(config: Readonly<Record<string, unknown>>): Record<string, unknown> | undefined {
+					const inherited: Record<string, unknown> = {};
+					for (const key of [SessionConfigKey.AutoApprove, SessionConfigKey.Permissions, ClaudeSessionConfigKey.PermissionMode, CodexSessionConfigKey.PermissionsPreset]) {
+						if (config[key] !== undefined) {
+							inherited[key] = config[key];
+						}
+					}
+					return inherited;
+				}
+			}
+
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(new TestSessionDatabase()), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = disposables.add(new ServerToolAgent('copilot'));
+			localService.registerProvider(agent);
+			const sourceSession = await localService.createSession({ provider: 'copilot' });
+			const sourceChat = URI.parse(buildChatUri(sourceSession, 'source-chat'));
+			await localService.createChat(sourceSession, sourceChat);
+			localService.stateManager.setSessionConfig(sourceSession.toString(), {
+				schema: { type: 'object', properties: {} },
+				values: {
+					[SessionConfigKey.AutoApprove]: 'autoApprove',
+					[SessionConfigKey.Permissions]: { allow: ['shell'], deny: ['write'] },
+					[ClaudeSessionConfigKey.PermissionMode]: 'bypassPermissions',
+					[CodexSessionConfigKey.PermissionsPreset]: 'full-access',
+					[SessionConfigKey.Mode]: 'plan',
+				},
+			});
+			localService.dispatchAction(sourceChat.toString(), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'source-turn',
+				startedAt: new Date().toISOString(),
+				message: { text: 'Create more work', origin: { kind: MessageKind.User }, model: { id: 'source-model' } },
+			}, 'test-client', 1);
+			const sourceModelBeforeCreation = localService.stateManager.getSessionState(sourceChat.toString())?.activeTurn?.message.model;
+
+			await agent.serverToolHost!.executeTool(sourceChat.toString(), SessionServerToolName.CreateSession, {
+				workspace: URI.file('/workspace').toString(),
+				prompt: 'new session',
+			});
+			await agent.serverToolHost!.executeTool(sourceChat.toString(), SessionServerToolName.CreateChat, {
+				prompt: 'new chat',
+			});
+
+			assert.deepStrictEqual({
+				sourceModelBeforeCreation,
+				sessionConfig: {
+					...agent.createSessionConfigs.at(-1),
+					workingDirectories: agent.createSessionConfigs.at(-1)?.workingDirectories?.map(uri => uri.toString()),
+				},
+				chatOptions: agent.createChatOptions.at(-1),
+			}, {
+				sourceModelBeforeCreation: { id: 'source-model' },
+				sessionConfig: {
+					_meta: undefined,
+					provider: 'copilot',
+					model: { id: 'source-model' },
+					workingDirectories: [URI.file('/workspace').toString()],
+					config: {
+						[SessionConfigKey.AutoApprove]: 'autoApprove',
+						[SessionConfigKey.Permissions]: { allow: ['shell'], deny: ['write'] },
+						[ClaudeSessionConfigKey.PermissionMode]: 'bypassPermissions',
+						[CodexSessionConfigKey.PermissionsPreset]: 'full-access',
+					},
+				},
+				chatOptions: { model: { id: 'source-model' } },
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -4998,6 +4998,58 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('session creation tools preserve the provider default model on the active turn', async () => {
+			class ServerToolAgent extends MockAgent {
+				readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
+				serverToolHost: IAgentServerToolHost | undefined;
+
+				setServerToolHost(host: IAgentServerToolHost): void {
+					this.serverToolHost = host;
+				}
+
+				override async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+					this.createSessionConfigs.push(config);
+					return super.createSession(config);
+				}
+			}
+
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(new TestSessionDatabase()), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = disposables.add(new ServerToolAgent('copilot'));
+			localService.registerProvider(agent);
+			const sourceSession = await localService.createSession({ provider: 'copilot' });
+			const sourceChat = buildDefaultChatUri(sourceSession);
+			localService.stateManager.dispatchServerAction(sourceChat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'previous-turn',
+				startedAt: new Date().toISOString(),
+				message: { text: 'previous', origin: { kind: MessageKind.User }, model: { id: 'previous-model' } },
+			});
+			localService.stateManager.dispatchServerAction(sourceChat, {
+				type: ActionType.ChatTurnComplete,
+				turnId: 'previous-turn',
+				duration: 1,
+			});
+			localService.dispatchAction(sourceChat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'active-turn',
+				startedAt: new Date().toISOString(),
+				message: { text: 'use provider default', origin: { kind: MessageKind.User } },
+			}, 'test-client', 1);
+
+			await agent.serverToolHost!.executeTool(sourceChat, SessionServerToolName.CreateSession, {
+				workspace: URI.file('/workspace').toString(),
+				prompt: 'new session',
+			});
+
+			assert.deepStrictEqual({
+				provider: agent.createSessionConfigs.at(-1)?.provider,
+				model: agent.createSessionConfigs.at(-1)?.model,
+			}, {
+				provider: 'copilot',
+				model: undefined,
+			});
+		});
+
 		test('createChat resolves a restored peer fork source before creating the fork', async () => {
 			let materializeCalls = 0;
 			let providerForkTurnId: string | undefined;

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-haiku-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-haiku-4_5.prompt.md
@@ -1216,7 +1216,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1227,7 +1227,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1246,7 +1246,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_5.prompt.md
@@ -1216,7 +1216,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1227,7 +1227,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1246,7 +1246,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_6.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_6.prompt.md
@@ -1216,7 +1216,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1227,7 +1227,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1246,7 +1246,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_7.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_7.prompt.md
@@ -1222,7 +1222,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1233,7 +1233,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1252,7 +1252,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_8.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_8.prompt.md
@@ -1226,7 +1226,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1237,7 +1237,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1256,7 +1256,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-5.prompt.md
@@ -1226,7 +1226,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1237,7 +1237,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1256,7 +1256,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_5.prompt.md
@@ -1216,7 +1216,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1227,7 +1227,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1246,7 +1246,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_6.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_6.prompt.md
@@ -1216,7 +1216,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1227,7 +1227,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1246,7 +1246,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-5.prompt.md
@@ -1225,7 +1225,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1236,7 +1236,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1255,7 +1255,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gemini-2_0-flash.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gemini-2_0-flash.prompt.md
@@ -1261,7 +1261,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1272,7 +1272,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1291,7 +1291,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-codex.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-codex.prompt.md
@@ -1170,7 +1170,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1181,7 +1181,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1200,7 +1200,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-mini.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-mini.prompt.md
@@ -1208,7 +1208,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1219,7 +1219,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1238,7 +1238,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5.prompt.md
@@ -1222,7 +1222,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1233,7 +1233,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1252,7 +1252,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex-mini.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex-mini.prompt.md
@@ -1170,7 +1170,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1181,7 +1181,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1200,7 +1200,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex.prompt.md
@@ -1170,7 +1170,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1181,7 +1181,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1200,7 +1200,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1.prompt.md
@@ -1222,7 +1222,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1233,7 +1233,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1252,7 +1252,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-luna.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-luna.prompt.md
@@ -1184,7 +1184,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1195,7 +1195,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1214,7 +1214,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-sol.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-sol.prompt.md
@@ -1184,7 +1184,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1195,7 +1195,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1214,7 +1214,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-terra.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-terra.prompt.md
@@ -1184,7 +1184,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [
@@ -1195,7 +1195,7 @@ Create a session in a workspace and start it with an initial prompt. The UI show
 ```
 
 #### create_chat
-Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the session's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
+Add a new chat to an existing session and start it with an initial prompt. Omit `session` to add the chat to the current session; otherwise pass a session URI from `list_sessions`. Optionally pass a `model` to use for the chat (defaults to the current chat's model). The UI shows a "Chat Created" confirmation with a button to open the session, so reply with a single short sentence and do NOT print the session URL or tell the user to click a button.
 ```json
 {
   "type": "object",
@@ -1214,7 +1214,7 @@ Add a new chat to an existing session and start it with an initial prompt. Omit 
     },
     "model": {
       "type": "string",
-      "description": "Optional model ID or display name. Defaults to the session's model."
+      "description": "Optional model ID or display name. Defaults to the current chat's model."
     }
   },
   "required": [

--- a/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
@@ -10,11 +10,12 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import type { IAgentCreateSessionConfig, IAgentModelInfo, IAgentSessionMetadata } from '../../common/agentService.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, withSessionGitState, withSessionGitHubState, type ResponsePart, type ToolCallState, type Turn } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, withSessionGitState, withSessionGitHubState, type ModelSelection, type ResponsePart, type ToolCallState, type Turn } from '../../common/state/sessionState.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { SessionServerToolName } from '../../common/serverToolNames.js';
 import {
 	applyCreateChatTool,
+	applyCreateSessionTool,
 	applyDeleteSessionTool,
 	applySendMessageTool,
 	createSessionServerToolGroup,
@@ -45,12 +46,13 @@ suite('SessionServerTools', () => {
 		return { session: URI.parse(`copilot:/${id}`), startTime: 0, modifiedTime: 0, status: status | SessionStatus.IsRead, workingDirectories: dir ? [dir] : undefined, summary: `title-${id}` };
 	}
 
-	function createAccessor(overrides?: Partial<ISessionServerToolAccessor> & { onCreate?: (config: IAgentCreateSessionConfig) => void; onPrompt?: (session: URI, chat: URI, prompt: string) => void; onCreateChat?: (session: URI, chat: URI, options?: { title?: string; model?: IAgentModelInfo }) => void; onDelete?: (session: URI) => void; depths?: Map<string, number> }): ISessionServerToolAccessor {
+	function createAccessor(overrides?: Partial<ISessionServerToolAccessor> & { onCreate?: (config: IAgentCreateSessionConfig) => void; onPrompt?: (session: URI, chat: URI, prompt: string) => void; onCreateChat?: (session: URI, chat: URI, options?: { title?: string; model?: ModelSelection }) => void; onDelete?: (session: URI) => void; depths?: Map<string, number> }): ISessionServerToolAccessor {
 		const depths = overrides?.depths ?? new Map<string, number>();
 		return {
 			listSessions: overrides?.listSessions ?? (async () => [sessionMeta('s1', SessionStatus.InProgress, workspace)]),
 			createSession: overrides?.createSession ?? (async config => { overrides?.onCreate?.(config); return URI.parse('copilot:/new'); }),
 			getModels: overrides?.getModels ?? (() => [model]),
+			getCreationDefaults: overrides?.getCreationDefaults ?? (() => undefined),
 			startPrompt: overrides?.startPrompt ?? (async (session, chat, prompt) => { overrides?.onPrompt?.(session, chat, prompt); }),
 			createChat: overrides?.createChat ?? (async (session, chat, options) => { overrides?.onCreateChat?.(session, chat, options); }),
 			deleteSession: overrides?.deleteSession ?? (async session => { overrides?.onDelete?.(session); }),
@@ -188,6 +190,67 @@ suite('SessionServerTools', () => {
 		store.dispose();
 	});
 
+	test('create_session inherits the calling chat model and permission config', async () => {
+		const source = URI.parse(buildChatUri('copilot:/caller', 'peer'));
+		let creationSource: URI | undefined;
+		let created: IAgentCreateSessionConfig | undefined;
+		const accessor = createAccessor({
+			getCreationDefaults: uri => {
+				creationSource = uri;
+				return {
+					provider: 'copilot',
+					model: { id: 'gpt-inherited' },
+					config: {
+						autoApprove: 'autoApprove',
+						permissions: { allow: ['shell'], deny: ['write'] },
+					},
+				};
+			},
+			onCreate: config => { created = config; },
+		});
+
+		const group = createSessionServerToolGroup(accessor);
+		const store = new DisposableStore();
+		const stateManager = store.add(new AgentHostStateManager(new NullLogService()));
+		await group.execute(stateManager, source.toString(), SessionServerToolName.CreateSession, { workspace: workspace.toString(), prompt: 'do it' });
+
+		assert.deepStrictEqual({
+			creationSource: creationSource?.toString(),
+			created,
+		}, {
+			creationSource: source.toString(),
+			created: {
+				workingDirectories: [workspace],
+				provider: 'copilot',
+				model: { id: 'gpt-inherited' },
+				config: {
+					autoApprove: 'autoApprove',
+					permissions: { allow: ['shell'], deny: ['write'] },
+				},
+			},
+		});
+		store.dispose();
+	});
+
+	test('create_session inherits the calling provider when its model is the provider default', async () => {
+		let created: IAgentCreateSessionConfig | undefined;
+		const accessor = createAccessor({
+			getCreationDefaults: () => ({
+				provider: 'claude',
+				config: { permissionMode: 'acceptEdits' },
+			}),
+			onCreate: config => { created = config; },
+		});
+
+		await applyCreateSessionTool(accessor, { workspace: workspace.toString(), prompt: 'do it' }, URI.parse('claude:/source'));
+
+		assert.deepStrictEqual(created, {
+			workingDirectories: [workspace],
+			provider: 'claude',
+			config: { permissionMode: 'acceptEdits' },
+		});
+	});
+
 	test('list_sessions execute returns serialized sessions', async () => {
 		const store = new DisposableStore();
 		const stateManager = store.add(new AgentHostStateManager(new NullLogService()));
@@ -314,7 +377,7 @@ suite('SessionServerTools', () => {
 	});
 
 	test('create_chat adds a chat to the session, starts the prompt, and returns an open link', async () => {
-		let createdChat: { session: URI; chat: URI; options?: { title?: string; model?: IAgentModelInfo } } | undefined;
+		let createdChat: { session: URI; chat: URI; options?: { title?: string; model?: ModelSelection } } | undefined;
 		let prompted: { session: URI; chat: URI; prompt: string } | undefined;
 		const accessor = createAccessor({
 			listSessions: async () => [sessionMeta('s1', SessionStatus.Idle, workspace)],
@@ -331,6 +394,42 @@ suite('SessionServerTools', () => {
 		assert.strictEqual(createdChat?.chat.toString(), result.chat);
 		assert.strictEqual(prompted?.chat.toString(), result.chat);
 		assert.strictEqual(prompted?.prompt, 'do it');
+	});
+
+	test('create_chat inherits the calling chat model when no override is provided', async () => {
+		const source = URI.parse(buildChatUri('copilot:/s1', 'source'));
+		let creationSource: URI | undefined;
+		let createdModel: ModelSelection | undefined;
+		const accessor = createAccessor({
+			getCreationDefaults: uri => {
+				creationSource = uri;
+				return { provider: 'copilot', model: { id: 'gpt-inherited' } };
+			},
+			onCreateChat: (_session, _chat, options) => { createdModel = options?.model; },
+		});
+
+		await applyCreateChatTool(accessor, { prompt: 'do it' }, source);
+
+		assert.deepStrictEqual({
+			creationSource: creationSource?.toString(),
+			createdModel,
+		}, {
+			creationSource: source.toString(),
+			createdModel: { id: 'gpt-inherited' },
+		});
+	});
+
+	test('create_chat does not inherit a model across providers', async () => {
+		let createdModel: ModelSelection | undefined;
+		const accessor = createAccessor({
+			listSessions: async () => [sessionMeta('s1', SessionStatus.Idle, workspace), { ...sessionMeta('s2', SessionStatus.Idle, workspace), session: URI.parse('claude:/s2') }],
+			getCreationDefaults: () => ({ provider: 'copilot', model: { id: 'gpt-inherited' } }),
+			onCreateChat: (_session, _chat, options) => { createdModel = options?.model; },
+		});
+
+		await applyCreateChatTool(accessor, { session: 'claude:/s2', prompt: 'do it' }, URI.parse(buildDefaultChatUri('copilot:/s1')));
+
+		assert.strictEqual(createdModel, undefined);
 	});
 
 	test('send_message targets the default chat / a specific chat, refuses the current chat, and validates', async () => {


### PR DESCRIPTION
## Summary

- inherit the invoking chat model when Agent Host server tools create a session or peer chat
- delegate provider-owned permission config inheritance to Copilot, Claude, and Codex agents
- preserve provider defaults and avoid carrying incompatible models across providers
- add focused tool and dispatcher coverage

## Validation

- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused Agent Host unit tests (32 passing)