### PR TITLE
Remove padding from sessions github reference list

### DIFF
--- a/src/vs/sessions/contrib/github/browser/media/githubReferenceList.css
+++ b/src/vs/sessions/contrib/github/browser/media/githubReferenceList.css
@@ -9,7 +9,7 @@
 	flex-direction: column;
 	min-width: 260px;
 	max-width: 420px;
-	padding: var(--vscode-spacing-size40) 0;
+	padding: 0;
 }
 
 .sessions-github-reference-list-item {


### PR DESCRIPTION
This PR removes the padding from the sessions GitHub reference list CSS to match the requested styling.