### PR TITLE
sessions: don't swallow clicks on header meta pills via session drag

### DIFF
--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -248,11 +248,12 @@ export class SessionHeader extends Disposable {
 			}
 
 			// Don't initiate a drag when the gesture starts inside the header
-			// toolbar (Run, Open in VS Code, New Chat, pin, close). A small pointer
-			// move during a button click would otherwise start a session drag
-			// and swallow the click.
+			// toolbar (Run, Open in VS Code, New Chat, pin, close) or the meta
+			// row (workspace folder / changes / pull request pills). A small
+			// pointer move during a button click would otherwise start a
+			// session drag and swallow the click.
 			const target = e.target as Node | null;
-			if (target && this._titleActionsEl.contains(target)) {
+			if (target && (this._titleActionsEl.contains(target) || this._metaRow.contains(target))) {
 				e.preventDefault();
 				return;
 			}

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -81,6 +81,10 @@ export class SessionHeader extends Disposable {
 	private _renameInput: HTMLInputElement | undefined;
 	private _session: IActiveSession | undefined;
 
+	// dragstart's own target is always the draggable container, so this tracks the
+	// preceding pointerdown's target to know where the gesture actually began.
+	private _lastPointerDownTarget: Node | undefined;
+
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
 	readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
 
@@ -240,6 +244,10 @@ export class SessionHeader extends Disposable {
 	private _registerDragSource(): void {
 		this._container.draggable = true;
 
+		this._register(addDisposableGenericMouseDownListener(this._container, (e: MouseEvent) => {
+			this._lastPointerDownTarget = (e.target as Node | null) ?? undefined;
+		}));
+
 		this._register(addDisposableListener(this._container, EventType.DRAG_START, (e: DragEvent) => {
 			const session = this._session;
 			if (!session || !e.dataTransfer) {
@@ -247,19 +255,14 @@ export class SessionHeader extends Disposable {
 				return;
 			}
 
-			// Don't initiate a drag when the gesture starts inside the header
-			// toolbar (Run, Open in VS Code, New Chat, pin, close) or the meta
-			// row (workspace folder / changes / pull request pills). A small
-			// pointer move during a button click would otherwise start a
-			// session drag and swallow the click.
-			const target = e.target as Node | null;
+			// Don't swallow a click on the toolbar or meta row pills into a session drag.
+			const target = this._lastPointerDownTarget;
 			if (target && (this._titleActionsEl.contains(target) || this._metaRow.contains(target))) {
 				e.preventDefault();
 				return;
 			}
 
-			// Don't initiate a drag while the title is being renamed, otherwise
-			// the in-progress text selection / click would also start a drag.
+			// Don't initiate a drag while the title is being renamed.
 			if (this._renameInput) {
 				e.preventDefault();
 				return;

--- a/src/vs/sessions/test/browser/sessionHeader.test.ts
+++ b/src/vs/sessions/test/browser/sessionHeader.test.ts
@@ -74,16 +74,24 @@ function createHarness(disposables: Pick<DisposableStore, 'add'>) {
 suite('Sessions - SessionHeader', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
+	// A native drag always fires dragstart with `target` set to the draggable
+	// container itself (not the descendant the gesture began on), so a real
+	// mousedown must precede it for the header's exclusion logic to see it.
+	function simulateDragFrom(header: SessionHeader, gestureOrigin: HTMLElement): DragEvent {
+		gestureOrigin.dispatchEvent(new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, cancelable: true }));
+
+		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
+		header.element.dispatchEvent(dragEvent);
+		return dragEvent;
+	}
+
 	test('a small pointer move over the meta row (e.g. the changed-files pill) does not start a session drag', () => {
 		const { header } = createHarness(disposables);
 
 		const metaRow = header.element.querySelector<HTMLElement>('.chat-composite-bar-meta-row');
 		assert.ok(metaRow, 'meta row should be rendered');
 
-		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
-		Object.defineProperty(dragEvent, 'target', { value: metaRow });
-
-		header.element.dispatchEvent(dragEvent);
+		const dragEvent = simulateDragFrom(header, metaRow);
 
 		assert.strictEqual(dragEvent.defaultPrevented, true, 'drag-start originating in the meta row must be prevented so the underlying click is not swallowed');
 	});
@@ -94,10 +102,7 @@ suite('Sessions - SessionHeader', () => {
 		const titleActions = header.element.querySelector<HTMLElement>('.chat-composite-bar-title-actions');
 		assert.ok(titleActions, 'title actions should be rendered');
 
-		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
-		Object.defineProperty(dragEvent, 'target', { value: titleActions });
-
-		header.element.dispatchEvent(dragEvent);
+		const dragEvent = simulateDragFrom(header, titleActions);
 
 		assert.strictEqual(dragEvent.defaultPrevented, true);
 	});
@@ -105,10 +110,7 @@ suite('Sessions - SessionHeader', () => {
 	test('a drag starting elsewhere in the header still initiates a session drag', () => {
 		const { header } = createHarness(disposables);
 
-		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
-		Object.defineProperty(dragEvent, 'target', { value: header.element });
-
-		header.element.dispatchEvent(dragEvent);
+		const dragEvent = simulateDragFrom(header, header.element);
 
 		assert.strictEqual(dragEvent.defaultPrevented, false);
 	});

--- a/src/vs/sessions/test/browser/sessionHeader.test.ts
+++ b/src/vs/sessions/test/browser/sessionHeader.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { EventType } from '../../../base/browser/dom.js';
+import { mainWindow } from '../../../base/browser/window.js';
+import { Event } from '../../../base/common/event.js';
+import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { constObservable, IObservable } from '../../../base/common/observable.js';
+import { URI } from '../../../base/common/uri.js';
+import { mock } from '../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
+import { IAccessibilityService } from '../../../platform/accessibility/common/accessibility.js';
+import { workbenchInstantiationService } from '../../../workbench/test/browser/workbenchTestServices.js';
+import { SessionHeader } from '../../browser/parts/sessionHeader.js';
+import { ISessionsListModelService } from '../../services/sessions/browser/sessionsListModelService.js';
+import { ISessionsService } from '../../services/sessions/browser/sessionsService.js';
+import { IChat, ISessionCapabilities, SessionStatus } from '../../services/sessions/common/session.js';
+import { IActiveSession, ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
+
+function createHarness(disposables: Pick<DisposableStore, 'add'>) {
+	const store = disposables.add(new DisposableStore());
+	const instantiationService = workbenchInstantiationService(undefined, store);
+
+	instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
+		override readonly onDidChangeScreenReaderOptimized = Event.None;
+		override readonly onDidChangeReducedMotion = Event.None;
+		override isScreenReaderOptimized(): boolean { return false; }
+	}());
+	instantiationService.stub(ISessionsListModelService, new class extends mock<ISessionsListModelService>() {
+		override readonly onDidChange = Event.None;
+		override isSessionPinned(): boolean { return false; }
+		override getStatusIcon(): ThemeIcon { return ThemeIcon.fromId('circle'); }
+	}());
+	instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+		override readonly onDidChangeSessions = Event.None;
+	}());
+	instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() { }());
+
+	const mainChat = new class extends mock<IChat>() {
+		override readonly title: IObservable<string> = constObservable('Main Chat');
+	}();
+	const session = new class extends mock<IActiveSession>() {
+		override readonly sessionId = 'session';
+		override readonly resource = URI.parse('test-session://session');
+		override readonly providerId = 'test';
+		override readonly title: IObservable<string> = constObservable('My Session');
+		override readonly status: IObservable<SessionStatus> = constObservable(SessionStatus.Completed);
+		override readonly isRead: IObservable<boolean> = constObservable(true);
+		override readonly isArchived: IObservable<boolean> = constObservable(false);
+		override readonly isCreated: IObservable<boolean> = constObservable(true);
+		override readonly sticky: IObservable<boolean> = constObservable(false);
+		override readonly mainChat: IObservable<IChat> = constObservable(mainChat);
+		override readonly activeChat: IObservable<IChat> = constObservable(mainChat);
+		override readonly chats: IObservable<readonly IChat[]> = constObservable([mainChat]);
+		override readonly openChats: IObservable<readonly IChat[]> = constObservable([mainChat]);
+		override readonly closedChats: IObservable<readonly IChat[]> = constObservable([]);
+		override readonly visibleChatTabs: IObservable<readonly IChat[]> = constObservable([mainChat]);
+		override readonly shouldShowChatTabs: IObservable<boolean> = constObservable(false);
+		override readonly capabilities: IObservable<ISessionCapabilities> = constObservable({ supportsMultipleChats: false });
+	}();
+
+	const header = store.add(instantiationService.createInstance(SessionHeader));
+	header.setSession(session);
+	const container = mainWindow.document.createElement('div');
+	container.appendChild(header.element);
+
+	return { store, header, session };
+}
+
+suite('Sessions - SessionHeader', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('a small pointer move over the meta row (e.g. the changed-files pill) does not start a session drag', () => {
+		const { header } = createHarness(disposables);
+
+		const metaRow = header.element.querySelector<HTMLElement>('.chat-composite-bar-meta-row');
+		assert.ok(metaRow, 'meta row should be rendered');
+
+		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
+		Object.defineProperty(dragEvent, 'target', { value: metaRow });
+
+		header.element.dispatchEvent(dragEvent);
+
+		assert.strictEqual(dragEvent.defaultPrevented, true, 'drag-start originating in the meta row must be prevented so the underlying click is not swallowed');
+	});
+
+	test('a small pointer move over the title actions toolbar does not start a session drag', () => {
+		const { header } = createHarness(disposables);
+
+		const titleActions = header.element.querySelector<HTMLElement>('.chat-composite-bar-title-actions');
+		assert.ok(titleActions, 'title actions should be rendered');
+
+		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
+		Object.defineProperty(dragEvent, 'target', { value: titleActions });
+
+		header.element.dispatchEvent(dragEvent);
+
+		assert.strictEqual(dragEvent.defaultPrevented, true);
+	});
+
+	test('a drag starting elsewhere in the header still initiates a session drag', () => {
+		const { header } = createHarness(disposables);
+
+		const dragEvent = new DragEvent(EventType.DRAG_START, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() });
+		Object.defineProperty(dragEvent, 'target', { value: header.element });
+
+		header.element.dispatchEvent(dragEvent);
+
+		assert.strictEqual(dragEvent.defaultPrevented, false);
+	});
+});


### PR DESCRIPTION
sessions: don't swallow clicks on header meta pills via session drag

## What changed

The Agents window session header container is `draggable` so a session
row can be reordered via drag-and-drop. Its `dragstart` handler already
excluded the *title-actions* toolbar (Run / Open in VS Code / New Chat /
pin / close) from initiating a drag, but never excluded the *meta row*
toolbar, which hosts the changed-files ("X files"), workspace-folder, and
pull-request pills.

This PR extends that same exclusion to also cover the meta row.

## Why

Native HTML5 drag-start and `click` are mutually exclusive browser
events: any small pointer movement between `mousedown` and `mouseup`
(common with a mouse or trackpad) starts a `dragstart` on the header,
which suppresses the subsequent `click` on the button underneath. Since
the meta row wasn't excluded, clicking the changed-files "X files"
summary would intermittently start a session drag instead of opening
the Changes view — matching the reported "click might work but usually
does nothing" symptom exactly (it only "worked" when the pointer stayed
perfectly still during the click).

## Testing

- Added `sessionHeader.test.ts` with regression tests asserting that a
  `dragstart` originating in the meta row (and the title-actions
  toolbar) is prevented, while one starting elsewhere in the header
  still proceeds. Verified the new meta-row test fails without the fix
  and passes with it.
- `scripts/test.sh --grep "Sessions - SessionHeader"` — 3 passing
- `npm run typecheck-client` — clean
- `npm run valid-layers-check` — clean
- `npm run hygiene` — clean

Fixes #327373
