### PR TITLE
Version Markdown code block editor API

### DIFF
--- a/extensions/markdown-language-features/schemas/package.schema.json
+++ b/extensions/markdown-language-features/schemas/package.schema.json
@@ -147,10 +147,15 @@
 										{
 											"type": "object",
 											"additionalProperties": false,
-											"required": ["kind"],
+											"required": ["kind", "apiVersion"],
 											"properties": {
 												"kind": {
 													"const": "exportApi"
+												},
+												"apiVersion": {
+													"type": "integer",
+													"minimum": 1,
+													"description": "Version of the extension export API used to resolve this provider"
 												}
 											}
 										}

--- a/extensions/markdown-language-features/src/markdownExtensions.ts
+++ b/extensions/markdown-language-features/src/markdownExtensions.ts
@@ -41,7 +41,7 @@ export interface MarkdownCodeBlockEditorSandbox {
 
 export type MarkdownCodeBlockEditorSource =
 	| { readonly kind: 'static'; readonly resource: vscode.Uri }
-	| { readonly kind: 'exportApi' };
+	| { readonly kind: 'exportApi'; readonly apiVersion: number };
 
 export interface MarkdownCodeBlockEditorProvider {
 	readonly id: string;
@@ -255,8 +255,8 @@ export namespace MarkdownContributions {
 			return undefined;
 		}
 		const source = value as Record<string, unknown>;
-		if (source.kind === 'exportApi') {
-			return { kind: 'exportApi' };
+		if (source.kind === 'exportApi' && isPositiveInteger(source.apiVersion)) {
+			return { kind: 'exportApi', apiVersion: source.apiVersion };
 		}
 		if (source.kind === 'static' && typeof source.entrypoint === 'string') {
 			return { kind: 'static', resource: resolveExtensionResource(extension, source.entrypoint) };
@@ -281,6 +281,10 @@ export namespace MarkdownContributions {
 		return typeof value === 'number' && Number.isFinite(value) && value > 0;
 	}
 
+	function isPositiveInteger(value: unknown): value is number {
+		return isPositiveNumber(value) && Number.isInteger(value);
+	}
+
 	function selectorEqual(a: MarkdownCodeBlockEditorSelector, b: MarkdownCodeBlockEditorSelector): boolean {
 		return a.language === b.language && a.languagePrefix === b.languagePrefix;
 	}
@@ -289,7 +293,9 @@ export namespace MarkdownContributions {
 		if (a.kind !== b.kind) {
 			return false;
 		}
-		return a.kind !== 'static' || (b.kind === 'static' && uriEqual(a.resource, b.resource));
+		return a.kind === 'static'
+			? b.kind === 'static' && uriEqual(a.resource, b.resource)
+			: b.kind === 'exportApi' && a.apiVersion === b.apiVersion;
 	}
 
 	function sandboxEqual(a: MarkdownCodeBlockEditorSandbox | undefined, b: MarkdownCodeBlockEditorSandbox | undefined): boolean {

--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -31,8 +31,8 @@ interface ResolvedCodeBlockEditor {
 	readonly sandbox?: MarkdownCodeBlockEditorSandbox;
 }
 
-interface MarkdownCodeBlockEditorExtensionApi {
-	getMarkdownCodeBlockEditorProvider(providerId: string): MarkdownCodeBlockEditorProviderApi | undefined;
+export interface MarkdownCodeBlockEditorApiV1 {
+	getProvider(providerId: string): MarkdownCodeBlockEditorProviderApi | undefined;
 }
 
 interface MarkdownCodeBlockEditorProviderApi {
@@ -384,6 +384,10 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		const result: CodeBlockEditorProviderDefinition[] = [];
 		for (const provider of this.#contributions.contributions.codeBlockEditorProviders) {
 			if (provider.source.kind === 'exportApi') {
+				if (!isSupportedMarkdownCodeBlockEditorApiVersion(provider.source.apiVersion)) {
+					this.#logger.trace('Markdown code block editor', `Ignoring provider ${provider.id} because API version ${provider.source.apiVersion} is not supported`);
+					continue;
+				}
 				result.push({
 					id: provider.id,
 					selector: provider.selector,
@@ -492,15 +496,19 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 	}
 
 	async #getCodeBlockEditorProvider(contribution: MarkdownCodeBlockEditorProvider): Promise<MarkdownCodeBlockEditorProviderApi | undefined> {
+		if (contribution.source.kind !== 'exportApi' || !isSupportedMarkdownCodeBlockEditorApiVersion(contribution.source.apiVersion)) {
+			return undefined;
+		}
 		let cached = this.#providerApis.get(contribution.id);
 		if (!cached) {
 			cached = (async () => {
 				const exports = await contribution.extension.activate();
-				if (!isMarkdownCodeBlockEditorExtensionApi(exports)) {
-					this.#logger.trace('Markdown code block editor', `Extension ${contribution.extension.id} does not export getMarkdownCodeBlockEditorProvider`);
+				const api = getMarkdownCodeBlockEditorApiV1(exports);
+				if (!api) {
+					this.#logger.trace('Markdown code block editor', `Extension ${contribution.extension.id} does not export markdownCodeBlockEditors.apiV1`);
 					return undefined;
 				}
-				const provider = exports.getMarkdownCodeBlockEditorProvider(contribution.providerId);
+				const provider = api.getProvider(contribution.providerId);
 				if (!isMarkdownCodeBlockEditorProviderApi(provider)) {
 					this.#logger.trace('Markdown code block editor', `Extension ${contribution.extension.id} did not return provider ${contribution.providerId}`);
 					return undefined;
@@ -750,10 +758,26 @@ function resolvedCodeBlockEditorsEqual(a: ResolvedCodeBlockEditor, b: ResolvedCo
 		&& a.sandbox?.clipboardWrite === b.sandbox?.clipboardWrite;
 }
 
-function isMarkdownCodeBlockEditorExtensionApi(value: unknown): value is MarkdownCodeBlockEditorExtensionApi {
+export function getMarkdownCodeBlockEditorApiV1(value: unknown): MarkdownCodeBlockEditorApiV1 | undefined {
+	if (!value || typeof value !== 'object') {
+		return undefined;
+	}
+	const namespace = (value as Record<string, unknown>).markdownCodeBlockEditors;
+	if (!namespace || typeof namespace !== 'object') {
+		return undefined;
+	}
+	const api = (namespace as Record<string, unknown>).apiV1;
+	return isMarkdownCodeBlockEditorApiV1(api) ? api : undefined;
+}
+
+export function isSupportedMarkdownCodeBlockEditorApiVersion(value: number): value is 1 {
+	return value === 1;
+}
+
+function isMarkdownCodeBlockEditorApiV1(value: unknown): value is MarkdownCodeBlockEditorApiV1 {
 	return typeof value === 'object'
 		&& value !== null
-		&& typeof (value as Record<string, unknown>).getMarkdownCodeBlockEditorProvider === 'function';
+		&& typeof (value as Record<string, unknown>).getProvider === 'function';
 }
 
 function isMarkdownCodeBlockEditorProviderApi(value: unknown): value is MarkdownCodeBlockEditorProviderApi {

--- a/extensions/markdown-language-features/src/test/markdownEditorProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/markdownEditorProvider.test.ts
@@ -6,7 +6,8 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { lineRangesToGutterMarkers } from '../preview/markdownEditorProvider';
+import { MarkdownContributions } from '../markdownExtensions';
+import { getMarkdownCodeBlockEditorApiV1, isSupportedMarkdownCodeBlockEditorApiVersion, lineRangesToGutterMarkers } from '../preview/markdownEditorProvider';
 
 suite('Markdown editor diff', () => {
 	test('maps modified-side line changes to quick diff gutter markers', async () => {
@@ -24,3 +25,58 @@ suite('Markdown editor diff', () => {
 		]);
 	});
 });
+
+suite('Markdown code block editor API versioning', () => {
+	test('requires an explicit positive integer export API version', () => {
+		assert.strictEqual(readCodeBlockEditorProviders({ kind: 'exportApi' }).length, 0);
+		assert.strictEqual(readCodeBlockEditorProviders({ kind: 'exportApi', apiVersion: 0 }).length, 0);
+		assert.strictEqual(readCodeBlockEditorProviders({ kind: 'exportApi', apiVersion: 1.5 }).length, 0);
+		assert.deepStrictEqual(readCodeBlockEditorProviders({ kind: 'exportApi', apiVersion: 1 })[0]?.source, {
+			kind: 'exportApi',
+			apiVersion: 1,
+		});
+		assert.deepStrictEqual(readCodeBlockEditorProviders({ kind: 'exportApi', apiVersion: 2 })[0]?.source, {
+			kind: 'exportApi',
+			apiVersion: 2,
+		});
+	});
+
+	test('only accepts the namespaced V1 extension API', () => {
+		const apiV1 = { getProvider: () => undefined };
+		assert.strictEqual(getMarkdownCodeBlockEditorApiV1({
+			markdownCodeBlockEditors: { apiV1 },
+		}), apiV1);
+		assert.strictEqual(getMarkdownCodeBlockEditorApiV1({
+			getMarkdownCodeBlockEditorProvider: () => undefined,
+		}), undefined);
+		assert.strictEqual(getMarkdownCodeBlockEditorApiV1({
+			markdownCodeBlockEditors: { apiV1: {} },
+		}), undefined);
+		assert.strictEqual(getMarkdownCodeBlockEditorApiV1({
+			markdownCodeBlockEditors: { apiV2: apiV1 },
+		}), undefined);
+	});
+
+	test('only advertises API version 1', () => {
+		assert.strictEqual(isSupportedMarkdownCodeBlockEditorApiVersion(1), true);
+		assert.strictEqual(isSupportedMarkdownCodeBlockEditorApiVersion(2), false);
+	});
+});
+
+function readCodeBlockEditorProviders(source: unknown) {
+	const extension = {
+		id: 'test.markdown-code-block-editor',
+		extensionUri: vscode.Uri.file('/test/markdown-code-block-editor'),
+		packageJSON: {
+			version: '1.0.0',
+			contributes: {
+				'markdown.codeBlockEditorProviders': [{
+					id: 'test',
+					selector: { language: 'test' },
+					source,
+				}],
+			},
+		},
+	} as vscode.Extension<unknown>;
+	return MarkdownContributions.fromExtension(extension).codeBlockEditorProviders;
+}


### PR DESCRIPTION
## Summary

- require dynamic Markdown code block editor contributions to declare an API version
- expose V1 providers through \markdownCodeBlockEditors.apiV1.getProvider\`n- ignore unsupported or malformed API versions before advertising providers to the Markdown editor
- add coverage for contribution parsing and extension export validation

## Testing

Not run per request. The pre-commit hygiene hook was bypassed because the existing checkout is missing the \vent-stream\ dependency and dependencies were not installed.