### PR TITLE
Rename Voice Mode voices to approved names

### DIFF
--- a/src/vs/workbench/common/configuration.ts
+++ b/src/vs/workbench/common/configuration.ts
@@ -62,7 +62,7 @@ type ConfigurationValue = { value: unknown | undefined /* Remove */ };
 export type ConfigurationKeyValuePairs = [string, ConfigurationValue][];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ConfigurationMigrationFn = (value: any, valueAccessor: (key: string) => any) => ConfigurationValue | ConfigurationKeyValuePairs | Promise<ConfigurationValue | ConfigurationKeyValuePairs>;
-export type ConfigurationMigration = { key: string; migrateFn: ConfigurationMigrationFn };
+export type ConfigurationMigration = { key: string; migrateFn: ConfigurationMigrationFn; includeApplication?: boolean };
 
 export interface IConfigurationMigrationRegistry {
 	registerConfigurationMigrations(configurationMigrations: ConfigurationMigration[]): void;
@@ -128,6 +128,9 @@ export class ConfigurationMigrationWorkbenchContribution extends Disposable impl
 			['userRemote', ConfigurationTarget.USER_REMOTE],
 			['workspace', ConfigurationTarget.WORKSPACE],
 		];
+		if (migration.includeApplication) {
+			targetPairs.unshift(['application', ConfigurationTarget.APPLICATION]);
+		}
 		for (const [dataKey, target] of targetPairs) {
 			const inspectValue = inspectData[dataKey] as IInspectValue<unknown> | undefined;
 			if (!inspectValue) {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -8,7 +8,7 @@ import '../../chat/browser/voiceClient/micCaptureService.js';
 import '../../chat/browser/voiceClient/ttsPlaybackService.js';
 import '../../chat/browser/voiceClient/voiceClientService.js';
 import { IVoiceSessionController, isVoiceEntitled } from '../../chat/browser/voiceClient/voiceSessionController.js';
-import { VOICE_AGENT_PROGRESS_SETTING } from '../../chat/common/voiceClient/voiceClientService.js';
+import { normalizeAgentsVoiceId, VOICE_AGENT_PROGRESS_SETTING } from '../../chat/common/voiceClient/voiceClientService.js';
 import '../../chat/browser/voiceClient/voiceToolDispatchService.js';
 import '../../chat/common/voicePlaybackService.js';
 
@@ -616,16 +616,16 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.voice': {
 			type: 'string',
-			enum: ['victoria_neutral', 'kevin_neutral', 'maya_neutral', 'daniel_neutral'],
-			enumItemLabels: ['Victoria', 'Kevin', 'Maya', 'Daniel'],
+			enum: ['harper_neutral', 'birch_neutral', 'junho_neutral', 'oak_neutral'],
+			enumItemLabels: ['Harper', 'Birch', 'Junho', 'Oak'],
 			enumDescriptions: [
-				nls.localize('agents.voice.voice.victoria', "Victoria."),
-				nls.localize('agents.voice.voice.kevin', "Kevin."),
-				nls.localize('agents.voice.voice.maya', "Maya."),
-				nls.localize('agents.voice.voice.daniel', "Daniel."),
+				nls.localize('agents.voice.voice.harper', "Harper."),
+				nls.localize('agents.voice.voice.birch', "Birch."),
+				nls.localize('agents.voice.voice.junho', "Junho."),
+				nls.localize('agents.voice.voice.oak', "Oak."),
 			],
 			markdownDescription: nls.localize('agents.voice.voice', "The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately. Use [Voice Mode instructions](command:{0}) to customize Voice Mode behavior and terminology.", CONFIGURE_VOICE_INSTRUCTIONS_ACTION_ID),
-			default: 'maya_neutral',
+			default: 'birch_neutral',
 			scope: ConfigurationScope.APPLICATION,
 		},
 		'agents.voice.language': {
@@ -699,6 +699,10 @@ configurationRegistry.registerConfiguration({
 // old mode was `phrase` or `both`.
 Registry.as<IConfigurationMigrationRegistry>(WorkbenchConfigurationExtensions.ConfigurationMigration)
 	.registerConfigurationMigrations([{
+		key: 'agents.voice.voice',
+		includeApplication: true,
+		migrateFn: (value: unknown) => ({ value: normalizeAgentsVoiceId(value) }),
+	}, {
 		key: 'agents.voice.turn.autoEndMode',
 		migrateFn: (value: unknown) => {
 			const result: ConfigurationKeyValuePairs = [['agents.voice.turn.autoEndMode', { value: undefined }]];

--- a/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding.ts
@@ -62,6 +62,7 @@ type VoiceModeOnboardingActionEvent = {
  */
 interface IVoiceModeVoice {
 	readonly id: string;
+	readonly sampleId: string;
 	readonly label: string;
 	/** This voice's waveform texture. See {@link IWave}. */
 	readonly signature: readonly IWave[];
@@ -81,8 +82,9 @@ interface IWave {
 
 const VOICES: readonly IVoiceModeVoice[] = [
 	{
-		id: 'maya_neutral',
-		label: localize('voiceMode.onboarding.voice.maya', "Maya (Default)"),
+		id: 'birch_neutral',
+		sampleId: 'maya_neutral',
+		label: localize('voiceMode.onboarding.voice.birch', "Birch (Default)"),
 		// Flowing mid-range: even spread, gentle drift.
 		signature: [
 			{ frequency: 1.0, amplitude: 0.42, speed: 0.42, phase: 0.0 },
@@ -92,8 +94,9 @@ const VOICES: readonly IVoiceModeVoice[] = [
 		],
 	},
 	{
-		id: 'victoria_neutral',
-		label: localize('voiceMode.onboarding.voice.victoria', "Victoria"),
+		id: 'harper_neutral',
+		sampleId: 'victoria_neutral',
+		label: localize('voiceMode.onboarding.voice.harper', "Harper"),
 		// Bright and quick: higher frequencies, tighter ripple.
 		signature: [
 			{ frequency: 1.4, amplitude: 0.38, speed: 0.52, phase: 0.0 },
@@ -103,8 +106,9 @@ const VOICES: readonly IVoiceModeVoice[] = [
 		],
 	},
 	{
-		id: 'kevin_neutral',
-		label: localize('voiceMode.onboarding.voice.kevin', "Kevin"),
+		id: 'oak_neutral',
+		sampleId: 'kevin_neutral',
+		label: localize('voiceMode.onboarding.voice.oak', "Oak"),
 		// Low and broad: long swells with little high-frequency detail.
 		signature: [
 			{ frequency: 0.7, amplitude: 0.48, speed: 0.30, phase: 0.4 },
@@ -114,8 +118,9 @@ const VOICES: readonly IVoiceModeVoice[] = [
 		],
 	},
 	{
-		id: 'daniel_neutral',
-		label: localize('voiceMode.onboarding.voice.daniel', "Daniel"),
+		id: 'junho_neutral',
+		sampleId: 'daniel_neutral',
+		label: localize('voiceMode.onboarding.voice.junho', "Junho"),
 		// Steady and measured: slow drift, calm regular crests.
 		signature: [
 			{ frequency: 0.9, amplitude: 0.44, speed: 0.24, phase: 1.3 },
@@ -558,7 +563,7 @@ class VoiceSamplePlayer extends Disposable {
 		return Math.min(1, Math.sqrt(sum / this.levels.length) * 3.2);
 	}
 
-	play(sampleId: string): void {
+	play(sampleId: string, playingVoice = sampleId): void {
 		this.stop();
 		try {
 			const audio = this.ensureAudio();
@@ -570,7 +575,7 @@ class VoiceSamplePlayer extends Disposable {
 			store.add(toDisposable(() => audio.pause()));
 			this.playback.value = store;
 
-			this.setPlayingVoice(sampleId);
+			this.setPlayingVoice(playingVoice);
 			audio.play().catch(error => {
 				this.logService.trace(`[voice] Voice Mode onboarding preview failed: ${error}`);
 				this.stop();
@@ -1063,7 +1068,7 @@ export class VoiceModeOnboardingBanner extends Disposable implements IChatInputO
 		this.logAction('selectVoice');
 		this.selectedVoice = voice;
 		this.updateSelection();
-		this.player.play(voice.id);
+		this.player.play(voice.sampleId, voice.id);
 		status(localize('voiceMode.onboarding.voice.selected', "{0} selected.", voice.label));
 		this.configurationService.updateValue(VOICE_SETTING, voice.id, ConfigurationTarget.USER)
 			.catch(error => this.logService.error(`[voice] Failed to persist the Voice Mode voice: ${error}`));

--- a/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
+++ b/src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts
@@ -57,7 +57,7 @@ suite('Voice Mode onboarding', () => {
 		});
 	}
 
-	function createService(store: Pick<DisposableStore, 'add'>, executed: string[] = [], holds: boolean[] = [], telemetryEvents: ITelemetryEvent[] = [], screenReaderOptimized = false): VoiceModeOnboardingService {
+	function createTestInstantiationService(store: Pick<DisposableStore, 'add'>, screenReaderOptimized = false) {
 		const instantiationService = workbenchInstantiationService(undefined, store);
 		instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
 			override readonly onDidChangeScreenReaderOptimized = Event.None;
@@ -65,6 +65,11 @@ suite('Voice Mode onboarding', () => {
 			override isScreenReaderOptimized(): boolean { return screenReaderOptimized; }
 			override isMotionReduced(): boolean { return false; }
 		});
+		return instantiationService;
+	}
+
+	function createService(store: Pick<DisposableStore, 'add'>, executed: string[] = [], holds: boolean[] = [], telemetryEvents: ITelemetryEvent[] = [], screenReaderOptimized = false): VoiceModeOnboardingService {
+		const instantiationService = createTestInstantiationService(store, screenReaderOptimized);
 		instantiationService.stub(ICommandService, new class extends mock<ICommandService>() {
 			override executeCommand(id: string): Promise<undefined> {
 				executed.push(id);
@@ -126,7 +131,7 @@ suite('Voice Mode onboarding', () => {
 				microphonePickerHidden: true,
 				microphonePickerDisplay: 'none',
 				selectedOnOpen: 0,
-				voices: ['Maya (Default)', 'Victoria', 'Kevin', 'Daniel'],
+				voices: ['Birch (Default)', 'Harper', 'Oak', 'Junho'],
 				voicesLabel: 'Agent Voice:',
 				selectedAfterPick: 1,
 				shownAfterClose: false,
@@ -140,13 +145,7 @@ suite('Voice Mode onboarding', () => {
 	});
 
 	test('clicking the playing voice stops its preview without changing the selection', () => {
-		const instantiationService = workbenchInstantiationService(undefined, disposables);
-		instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
-			override readonly onDidChangeScreenReaderOptimized = Event.None;
-			override readonly onDidChangeReducedMotion = Event.None;
-			override isScreenReaderOptimized(): boolean { return false; }
-			override isMotionReduced(): boolean { return false; }
-		});
+		const instantiationService = createTestInstantiationService(disposables);
 
 		const audio = document.createElement('audio');
 		let playCount = 0;
@@ -165,43 +164,37 @@ suite('Voice Mode onboarding', () => {
 			audioFactory: () => audio,
 		}));
 
-		const maya = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!;
-		maya.click();
-		const playingAfterFirstClick = maya.classList.contains('playing');
-		const ariaLabelAfterFirstClick = maya.getAttribute('aria-label');
-		maya.click();
+		const defaultVoiceOption = host.container.querySelector<HTMLElement>('.voice-mode-onboarding-voice')!;
+		defaultVoiceOption.click();
+		const playingAfterFirstClick = defaultVoiceOption.classList.contains('playing');
+		const ariaLabelAfterFirstClick = defaultVoiceOption.getAttribute('aria-label');
+		defaultVoiceOption.click();
 
 		assert.deepStrictEqual(
 			{
-				label: maya.querySelector('.voice-mode-onboarding-voice-label')?.textContent,
+				label: defaultVoiceOption.querySelector('.voice-mode-onboarding-voice-label')?.textContent,
 				playCount,
 				pauseCount,
 				playingAfterFirstClick,
 				ariaLabelAfterFirstClick,
-				playingAfterSecondClick: maya.classList.contains('playing'),
-				ariaLabelAfterSecondClick: maya.getAttribute('aria-label'),
-				selectedAfterSecondClick: maya.classList.contains('selected'),
+				playingAfterSecondClick: defaultVoiceOption.classList.contains('playing'),
+				ariaLabelAfterSecondClick: defaultVoiceOption.getAttribute('aria-label'),
+				selectedAfterSecondClick: defaultVoiceOption.classList.contains('selected'),
 			},
 			{
-				label: 'Maya (Default)',
+				label: 'Birch (Default)',
 				playCount: 1,
 				pauseCount: 1,
 				playingAfterFirstClick: true,
-				ariaLabelAfterFirstClick: 'Stop Maya (Default) preview.',
+				ariaLabelAfterFirstClick: 'Stop Birch (Default) preview.',
 				playingAfterSecondClick: false,
-				ariaLabelAfterSecondClick: 'Maya (Default). Hear this voice and use it for every conversation.',
+				ariaLabelAfterSecondClick: 'Birch (Default). Hear this voice and use it for every conversation.',
 				selectedAfterSecondClick: true,
 			});
 	});
 
 	test('previews the native voice per language and keeps the chooser only for English', () => {
-		const instantiationService = workbenchInstantiationService(undefined, disposables);
-		instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
-			override readonly onDidChangeScreenReaderOptimized = Event.None;
-			override readonly onDidChangeReducedMotion = Event.None;
-			override isScreenReaderOptimized(): boolean { return false; }
-			override isMotionReduced(): boolean { return false; }
-		});
+		const instantiationService = createTestInstantiationService(disposables);
 
 		// A language Voice Mode speaks natively shows its one voice with no
 		// chooser; English and languages without a native voice keep the four.
@@ -242,13 +235,7 @@ suite('Voice Mode onboarding', () => {
 	});
 
 	test('swaps the chips when the spoken language changes', () => {
-		const instantiationService = workbenchInstantiationService(undefined, disposables);
-		instantiationService.stub(IAccessibilityService, new class extends mock<IAccessibilityService>() {
-			override readonly onDidChangeScreenReaderOptimized = Event.None;
-			override readonly onDidChangeReducedMotion = Event.None;
-			override isScreenReaderOptimized(): boolean { return false; }
-			override isMotionReduced(): boolean { return false; }
-		});
+		const instantiationService = createTestInstantiationService(disposables);
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration('agents.voice.language', 'en');
 		instantiationService.stub(IConfigurationService, configurationService);

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -33,6 +33,7 @@ import {
 	VoiceConfirmationType,
 	VoiceNarrationKind,
 	isVoiceCheckpointId,
+	normalizeAgentsVoiceId,
 } from '../../common/voiceClient/voiceClientService.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 
@@ -204,13 +205,8 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}));
 	}
 
-	/**
-	 * Resolve the configured voice key (e.g. ``maya_neutral``) sent to the
-	 * backend on ``start_session`` and via ``set_voice`` when changed live.
-	 */
 	private _getVoice(): string {
-		const raw = this._configurationService.getValue<string>('agents.voice.voice');
-		return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : 'maya_neutral';
+		return normalizeAgentsVoiceId(this._configurationService.getValue<string>('agents.voice.voice'));
 	}
 
 	private _sendSetVoice(): void {

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -10,6 +10,27 @@ import { hasKey } from '../../../../../base/common/types.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatToolInvocation, type ChatVoiceProgressStage } from '../chatService/chatService.js';
 
+export function normalizeAgentsVoiceId(value: unknown): string {
+	const voiceId = typeof value === 'string' ? value.trim() : '';
+	switch (voiceId) {
+		case 'harper_neutral':
+		case 'birch_neutral':
+		case 'junho_neutral':
+		case 'oak_neutral':
+			return voiceId;
+		case 'victoria_neutral':
+			return 'harper_neutral';
+		case 'maya_neutral':
+			return 'birch_neutral';
+		case 'daniel_neutral':
+			return 'junho_neutral';
+		case 'kevin_neutral':
+			return 'oak_neutral';
+		default:
+			return 'birch_neutral';
+	}
+}
+
 /**
  * One selectable option on a pending question, positioned in *displayed* order.
  *

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts
@@ -12,7 +12,7 @@ import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import product from '../../../../../../platform/product/common/product.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { resolveAutomaticVoiceLanguage, VoiceClientService } from '../../../browser/voiceClient/voiceClientService.js';
-import { IVoiceAudioResponse, IVoiceBargeIn, IVoiceNarrationAck, IVoiceNarrationSignal, IVoiceSpeechStarted, IVoiceTranscription } from '../../../common/voiceClient/voiceClientService.js';
+import { IVoiceAudioResponse, IVoiceBargeIn, IVoiceNarrationAck, IVoiceNarrationSignal, IVoiceSpeechStarted, IVoiceTranscription, normalizeAgentsVoiceId } from '../../../common/voiceClient/voiceClientService.js';
 
 class TestWebSocket {
 	static instance: TestWebSocket | undefined;
@@ -523,7 +523,7 @@ suite('VoiceClientService', () => {
 		assert.deepStrictEqual(socket().sent.filter(message => message.type === 'request_narration'), []);
 	});
 
-	test('serializes configured language in start_session context', async () => {
+	test('normalizes a legacy voice identifier in start_session', async () => {
 		const { service } = createService({
 			'agents.voice.language': 'fr-fr',
 			'agents.voice.voice': 'kevin_neutral',
@@ -540,9 +540,37 @@ suite('VoiceClientService', () => {
 		})), [{
 			type: 'start_session',
 			session_context: { sessions: [], display_locale: 'fr-FR' },
-			voice: 'kevin_neutral',
+			voice: 'oak_neutral',
 			auto_narrate: false,
 		}]);
+	});
+
+	test('normalizes every canonical and legacy voice identifier, and falls back for invalid values', () => {
+		assert.deepStrictEqual(
+			[
+				'harper_neutral', 'birch_neutral', 'junho_neutral', 'oak_neutral',
+				'victoria_neutral', 'maya_neutral', 'daniel_neutral', 'kevin_neutral',
+				undefined, '  ', 42, 'unknown_voice',
+			].map(normalizeAgentsVoiceId),
+			[
+				'harper_neutral', 'birch_neutral', 'junho_neutral', 'oak_neutral',
+				'harper_neutral', 'birch_neutral', 'junho_neutral', 'oak_neutral',
+				'birch_neutral', 'birch_neutral', 'birch_neutral', 'birch_neutral',
+			]
+		);
+	});
+
+	test('uses Birch for missing and legacy Maya values in start_session', async () => {
+		const voices = [];
+		for (const configuration of [undefined, { 'agents.voice.voice': 'maya_neutral' }]) {
+			const { service } = createService(configuration);
+			await service.connect(createTestWindow());
+			service.sendStartSession({ sessions: [], display_locale: '' }, 'machine');
+			voices.push(socket().sent[0].voice);
+			service.disconnect();
+		}
+
+		assert.deepStrictEqual(voices, ['birch_neutral', 'birch_neutral']);
 	});
 
 	test('sends voice instructions when starting a session', async () => {
@@ -660,7 +688,7 @@ suite('VoiceClientService', () => {
 			{
 				type: 'start_session',
 				session_context: { sessions: [], display_locale: 'en' },
-				voice: 'victoria_neutral',
+				voice: 'harper_neutral',
 			},
 			{ type: 'set_language', language: 'fr-FR' },
 		]);
@@ -716,7 +744,7 @@ suite('VoiceClientService', () => {
 				type: 'resume_session',
 				session_id: 'session-1',
 				session_context: { sessions: [], display_locale: 'de-DE' },
-				voice: 'daniel_neutral',
+				voice: 'junho_neutral',
 				voice_instructions: 'Keep replies concise.',
 				auto_narrate: false,
 			}],

--- a/src/vs/workbench/test/common/configuration.test.ts
+++ b/src/vs/workbench/test/common/configuration.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../base/common/async.js';
+import { Event } from '../../../base/common/event.js';
+import { ConfigurationTarget, IConfigurationValue } from '../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
+import { Registry } from '../../../platform/registry/common/platform.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../platform/workspace/common/workspace.js';
+import { mock } from '../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { ConfigurationMigration, ConfigurationMigrationWorkbenchContribution, Extensions, IConfigurationMigrationRegistry } from '../../common/configuration.js';
+
+suite('ConfigurationMigrationWorkbenchContribution', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function migrate(includeApplication: boolean | undefined): Promise<ConfigurationTarget[]> {
+		const key = includeApplication ? 'agents.voice.voice' : 'configurationMigration.test.default';
+		const migration = {
+			key,
+			includeApplication,
+			migrateFn: value => ({ value }),
+		} satisfies ConfigurationMigration;
+		Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration).registerConfigurationMigrations([migration]);
+
+		const targets: ConfigurationTarget[] = [];
+		const completed = new DeferredPromise<void>();
+		const configurationService = new class extends TestConfigurationService {
+			override inspect<T>(inspectKey: string): IConfigurationValue<T> {
+				return inspectKey === key ? {
+					application: { value: 'application' as T },
+					user: { value: 'user' as T },
+				} : {};
+			}
+
+			override updateValue(_key: string, _value: unknown, _overrides?: unknown, target?: ConfigurationTarget): Promise<void> {
+				assert.notStrictEqual(target, undefined, 'expected updateValue to be called with a target');
+				targets.push(target!);
+				if (targets.length === (includeApplication ? 2 : 1)) {
+					completed.complete();
+				}
+				return Promise.resolve();
+			}
+		}();
+		const workspaceService = new class extends mock<IWorkspaceContextService>() {
+			override readonly onDidChangeWorkspaceFolders = Event.None;
+			override getWorkbenchState(): WorkbenchState { return WorkbenchState.EMPTY; }
+			override getWorkspace() { return { id: 'test', folders: [] }; }
+		}();
+
+		disposables.add(new ConfigurationMigrationWorkbenchContribution(configurationService, workspaceService));
+		await completed.p;
+		return targets;
+	}
+
+	test('excludes application configuration by default', async () => {
+		assert.deepStrictEqual(await migrate(undefined), [ConfigurationTarget.USER]);
+	});
+
+	test('includes application configuration for the opted-in voice migration', async () => {
+		assert.deepStrictEqual(await migrate(true), [ConfigurationTarget.APPLICATION, ConfigurationTarget.USER]);
+	});
+});


### PR DESCRIPTION
## Summary

- rename the Voice Mode choices to Harper, Birch, Junho, and Oak
- migrate persisted talent-derived identifiers to canonical product IDs while preserving Birch as the existing frontend default
- retain legacy preview asset names and normalize all wire values before sending them to the backend
- make application-scoped configuration migration explicitly opt-in

Depends on https://github.com/infinity-microsoft/yolo/pull/65877 for backend canonical-ID support.

## Testing

- `npm run transpile-client -- --outputDir out`
- `./scripts/test.sh --run src/vs/workbench/test/common/configuration.test.ts --run src/vs/workbench/contrib/agentsVoice/test/browser/voiceModeOnboarding.test.ts --run src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceClientService.test.ts --timeout 30000` (50 passing)
- `npm run valid-layers-check`
- Fallow audit (pass; no introduced findings)