### PR TITLE
Style overrides: Improve layout and visibility of activity and composite bars

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -255,7 +255,46 @@
  * rounded box gives the active item its own shape, so the full-width rule under
  * the top (header) bar — and over the bottom (footer) bar — is removed for the
  * cleaner, default-position look. `.monaco-workbench` is added to outrank the
+ * base part rule.
  */
+
+.style-override.monaco-workbench .pane-composite-part:not(.empty) > .header {
+	border-bottom: none;
+	overflow: visible;
+}
+
+.style-override.monaco-workbench .pane-composite-part:not(.empty) > .footer {
+	border-top: none;
+}
+
+.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
+	overflow: visible;
+}
+
+.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content:empty {
+	padding: 2px;
+}
+
+.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content:empty {
+	padding: 0;
+	border-radius: var(--vscode-cornerRadius-circle);
+}
+
+.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 18px;
+	right: 2px;
+}
+
+.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
+	padding: 0;
+	border-radius: var(--vscode-cornerRadius-circle);
+	width: 16px;
+}
+
+.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 13px;
+	right: 2px;
+}
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
 	padding: 0;
@@ -296,16 +335,6 @@
 .style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	top: 10px;
 	right: 2px;
-}
-
-.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.style-override.monaco-workbench .pane-composite-part > .header-or-footer.header > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.style-override.monaco-workbench .pane-composite-part > .header-or-footer.header > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
-	bottom: 0;
-	border: none;
-	height: 100%;
-	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
 }
 
 .style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -161,7 +161,7 @@
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) .active-item-indicator {
 	z-index: 0;
 	top: 50%;
-	left: 2px;
+	left: var(--vscode-spacing-size20);
 	width: 24px;
 	height: 24px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -177,7 +177,7 @@
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover .active-item-indicator {
 	z-index: 0;
 	top: 50%;
-	left: 2px;
+	left: var(--vscode-spacing-size20);
 	width: 24px;
 	height: 24px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -257,7 +257,6 @@
  * cleaner, default-position look. `.monaco-workbench` is added to outrank the
  * base part rule.
  */
-
 .style-override.monaco-workbench .pane-composite-part:not(.empty) > .header {
 	border-bottom: none;
 	overflow: visible;
@@ -271,8 +270,9 @@
 	overflow: visible;
 }
 
+/* When badge-content is empty (icon-only via ::before, e.g. the update badge), use uniform padding so it stays circular. */
 .style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content:empty {
-	padding: 2px;
+	padding: var(--vscode-spacing-size20);
 }
 
 .style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content:empty {
@@ -282,7 +282,7 @@
 
 .style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
 	top: 18px;
-	right: 2px;
+	right: 3px;
 }
 
 .style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
@@ -293,7 +293,7 @@
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
 	top: 13px;
-	right: 2px;
+	right: 3px;
 }
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
@@ -331,18 +331,7 @@
 	top: 10px;
 }
 
-.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
-.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	top: 10px;
-	right: 2px;
-}
-
-.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 18px;
-	right: 3px;
-}
-
-.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 13px;
-	right: 3px;
+	right: var(--vscode-spacing-size20);
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -195,6 +195,12 @@
 	color: var(--vscode-foreground) !important;
 }
 
+.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon.checked .action-label.codicon::before,
+.style-override.monaco-workbench .part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before,
+.style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
+	left: 0;
+}
+
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked) .action-label.codicon {
 	color: var(--vscode-descriptionForeground) !important;
 }
@@ -289,4 +295,5 @@
 .style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
 .style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	top: 10px;
+	right: 2px;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -161,7 +161,7 @@
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) .active-item-indicator {
 	z-index: 0;
 	top: 50%;
-	left: 0;
+	left: 2px;
 	width: 24px;
 	height: 24px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -177,7 +177,7 @@
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover .active-item-indicator {
 	z-index: 0;
 	top: 50%;
-	left: 0;
+	left: 2px;
 	width: 24px;
 	height: 24px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -249,99 +249,7 @@
  * rounded box gives the active item its own shape, so the full-width rule under
  * the top (header) bar — and over the bottom (footer) bar — is removed for the
  * cleaner, default-position look. `.monaco-workbench` is added to outrank the
- * base part rule.
  */
-.style-override.monaco-workbench .pane-composite-part:not(.empty) > .header {
-	border-bottom: none;
-	overflow: visible;
-}
-
-.style-override.monaco-workbench .pane-composite-part:not(.empty) > .footer {
-	border-top: none;
-}
-
-/* Center the icon and its rounded box within the compact header/footer chrome. */
-.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	height: 32px;
-}
-
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	padding: 0 4px;
-	border-radius: var(--vscode-cornerRadius-small);
-}
-
-/*
- * Text-label composites (`.action-item` without `.icon`, e.g. panel titles)
- * inherit the base ~35px-tall item via `line-height`. Match the icon items at a
- * compact 24px so both tab styles share the same height. `box-sizing` keeps the
- * inherited 2px top/bottom padding inside the 24px box so the item is exactly
- * 24px tall.
- */
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) {
-	box-sizing: border-box;
-	height: 24px;
-	line-height: 24px;
-}
-
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label::before {
-	position: relative;
-	left: 0px;
-	top: 0px;
-}
-
-/*
- * Auxiliary bar only: give its composite icon items a shorter 24px height so the
- * single Chat item reads as a compact, balanced chip. Scoped to the auxiliary
- * bar so the primary activity bar keeps its default item height.
- */
-.style-override.monaco-workbench :is(.part.auxiliarybar > .header-or-footer, .pane-composite-part.basepanel > .title) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	height: 24px;
-	padding: 0;
-	width: 24px;
-}
-
-.style-override.monaco-workbench :is(.part.auxiliarybar > .header-or-footer, .pane-composite-part.basepanel > .title) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
-	display: none;
-}
-
-.style-override.monaco-workbench :is(.part.auxiliarybar > .header-or-footer, .pane-composite-part.basepanel > .title) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .codicon {
-	font-weight: var(--vscode-fontWeight-regular);
-}
-
-/* Space the composite items apart with a small gap in the auxiliary bar and base panel. */
-.style-override.monaco-workbench :is(.part.auxiliarybar > .header-or-footer, .pane-composite-part.basepanel > .title) > .composite-bar-container > .composite-bar > .monaco-action-bar .actions-container {
-	gap: 4px;
-}
-
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
-	overflow: visible;
-}
-
-/* When badge-content is empty (icon-only via ::before, e.g. the update badge), use uniform padding so it stays circular. */
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content:empty {
-	padding: 2px;
-}
-
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content:empty {
-	padding: 0;
-	border-radius: var(--vscode-cornerRadius-circle);
-}
-
-.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 18px;
-	right: 2px;
-}
-
-.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
-	padding: 0;
-	border-radius: var(--vscode-cornerRadius-circle);
-	width: 16px;
-}
-
-.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	top: 13px;
-	right: 2px;
-}
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content:empty {
 	padding: 0;
@@ -375,5 +283,10 @@
 }
 
 .style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge .profile-text-overlay {
+	top: 10px;
+}
+
+.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	top: 10px;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -248,6 +248,7 @@
  */
 .style-override.monaco-workbench .part.auxiliarybar > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more::before {
 	position: relative;
+	left: 0;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -307,3 +307,13 @@
 	height: 100%;
 	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
 }
+
+.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 18px;
+	right: 3px;
+}
+
+.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 13px;
+	right: 3px;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -297,3 +297,13 @@
 	top: 10px;
 	right: 2px;
 }
+
+.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer.header > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer.header > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+	bottom: 0;
+	border: none;
+	height: 100%;
+	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -195,7 +195,7 @@
 	color: var(--vscode-foreground) !important;
 }
 
-.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon.checked .action-label.codicon::before,
+.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon::before,
 .style-override.monaco-workbench .part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before,
 .style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
 	left: 0;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -336,3 +336,7 @@
 	top: 10px;
 	right: var(--vscode-spacing-size20);
 }
+
+.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked) .action-label.codicon.codicon-more:hover {
+	background: transparent;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -50,7 +50,7 @@
 .style-override.monaco-workbench .part > .title,
 .style-override.monaco-workbench .part > .header-or-footer {
 	height: 32px;
-	padding-left: 2px;
+	padding-left: var(--vscode-spacing-size20);
 }
 
 .style-override.monaco-workbench .part > .title {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -50,6 +50,7 @@
 .style-override.monaco-workbench .part > .title,
 .style-override.monaco-workbench .part > .header-or-footer {
 	height: 32px;
+	padding-left: 2px;
 }
 
 .style-override.monaco-workbench .part > .title {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -250,6 +250,7 @@
 
 .style-override.monaco-workbench .part.basepanel:is(.bottom, .top, .left, .right) .composite.title {
 	padding-right: var(--vscode-spacing-size40);
+	padding-left: var(--vscode-spacing-size20);
 	overflow: visible;
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -400,14 +400,65 @@
 }
 
 /*
- * Pane tabs (primary side bar, panel and auxiliary side bar) are text composite
- * actions. Keep icon-only activity items on their existing treatment.
+ * Pane tabs (primary side bar, panel and auxiliary side bar) use the full part
+ * header as a contiguous hit target. The indicator owns the inset 24px visual
+ * fill so spacing between pills does not create dead space between targets.
  */
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container,
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar,
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar,
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar > .actions-container {
+	height: 100%;
+}
+
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar > .actions-container {
+	align-items: stretch;
+	gap: 0;
+}
+
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+	align-self: stretch;
+	box-sizing: border-box;
+	height: var(--vscode-spacing-size320);
+	min-height: var(--vscode-spacing-size320);
+	max-height: var(--vscode-spacing-size320);
+	margin: 0 !important;
+	border-block: var(--vscode-spacing-size40) solid transparent;
+	border-radius: 0;
+	background-color: transparent !important;
+}
+
 .modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon),
 .modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) {
 	text-transform: none !important;
-	padding: 0 8px;
+	padding: 0 var(--vscode-spacing-size100);
+}
+
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
+	flex: 0 0 28px;
+	width: 28px;
+	min-width: 28px;
+	max-width: 28px;
+	padding: 0 var(--vscode-spacing-size60);
+}
+
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator {
+	inset: 0 var(--vscode-spacing-size20);
+	z-index: 0;
+	width: auto;
+	height: auto;
 	border-radius: var(--vscode-cornerRadius-small);
+}
+
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge),
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge) {
+	position: relative;
+	z-index: 1;
 }
 
 .modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
@@ -417,20 +468,18 @@
 	line-height: 22px; /* keep consistent with other 22px title/control heights */
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked,
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .part.auxiliarybar > .header-or-footer > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active),
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part.basepanel > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) {
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked > .active-item-indicator,
+.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) > .active-item-indicator {
 	background-color: var(--modern-ui-tab-active-background) !important;
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover {
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover > .active-item-indicator {
 	background-color: var(--modern-ui-tab-hover-background);
 }
 
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .part.auxiliarybar > .header-or-footer > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover,
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part.basepanel > .title > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover {
+.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover > .active-item-indicator {
 	background-color: var(--vscode-list-hoverBackground);
 }
 
@@ -539,19 +588,6 @@
 	background-color: transparent !important;
 }
 
-:is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon,
-:is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	box-sizing: border-box;
-	flex: 0 0 24px;
-	width: 24px;
-	min-width: 24px;
-	max-width: 24px;
-	height: 24px;
-	min-height: 24px;
-	max-height: 24px;
-	padding: 0;
-}
-
 :is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
 :is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,
 :is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
@@ -564,20 +600,25 @@
 	display: none !important;
 }
 
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus),
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) {
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+	outline: none !important;
+}
+
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) > .active-item-indicator,
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) > .active-item-indicator {
 	outline: var(--vscode-strokeThickness) solid var(--vscode-contrastActiveBorder);
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
 
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):not(:focus):hover,
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):not(:focus):hover {
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):not(:focus):hover > .active-item-indicator,
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):not(:focus):hover > .active-item-indicator {
 	outline: var(--vscode-strokeThickness) dashed var(--vscode-contrastActiveBorder);
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
 
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus,
-:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus {
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus > .active-item-indicator,
+:is(.hc-black, .hc-light).modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus > .active-item-indicator {
 	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder) !important;
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
@@ -586,8 +627,8 @@
  * Drop the checked underline in favour of the rounded background while retaining
  * the base keyboard-focus indicator.
  */
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked:not(:focus) .active-item-indicator:before,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked:not(:focus) .active-item-indicator:before {
+.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
+.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before {
 	border-top-color: transparent !important;
 	border-top-width: 0 !important;
 	border-bottom-color: transparent !important;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -416,8 +416,7 @@
 	gap: 0;
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	align-self: stretch;
 	box-sizing: border-box;
 	height: 100%;
@@ -429,32 +428,26 @@
 	background-color: transparent !important;
 }
 
-.style-override.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
-.style-override.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.style-override.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	height: var(--vscode-spacing-size320);
 	min-height: var(--vscode-spacing-size320);
 	max-height: var(--vscode-spacing-size320);
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon),
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) {
 	text-transform: none !important;
 	padding: 0 var(--vscode-spacing-size100);
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	flex: 0 0 28px;
-	width: 28px;
-	min-width: 28px;
-	max-width: 28px;
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
+	flex: 0 0 var(--vscode-spacing-size280);
+	width: var(--vscode-spacing-size280);
+	min-width: var(--vscode-spacing-size280);
+	max-width: var(--vscode-spacing-size280);
 	padding: 0 var(--vscode-spacing-size60);
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator,
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator {
 	top: 50%;
 	right: var(--vscode-spacing-size20);
 	bottom: auto;
@@ -466,27 +459,23 @@
 	transform: translateY(-50%);
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge),
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge) {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge) {
 	position: relative;
 	z-index: 1;
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
 	font-size: var(--vscode-fontSize-body1);
 	font-weight: var(--vscode-fontWeight-semiBold);
 	line-height: 22px; /* keep consistent with other 22px title/control heights */
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked > .active-item-indicator,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked > .active-item-indicator,
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon).checked > .active-item-indicator,
 .modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) > .active-item-indicator {
 	background-color: var(--modern-ui-tab-active-background) !important;
 }
 
-.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover > .active-item-indicator,
-.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover > .active-item-indicator {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon):not(.checked):hover > .active-item-indicator {
 	background-color: var(--modern-ui-tab-hover-background);
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -420,13 +420,20 @@
 .modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	align-self: stretch;
 	box-sizing: border-box;
-	height: var(--vscode-spacing-size320);
-	min-height: var(--vscode-spacing-size320);
-	max-height: var(--vscode-spacing-size320);
+	height: 100%;
+	min-height: 100%;
+	max-height: 100%;
 	margin: 0 !important;
 	border-block: var(--vscode-spacing-size40) solid transparent;
 	border-radius: 0;
 	background-color: transparent !important;
+}
+
+.style-override.modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
+.style-override.modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+	height: var(--vscode-spacing-size320);
+	min-height: var(--vscode-spacing-size320);
+	max-height: var(--vscode-spacing-size320);
 }
 
 .modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon),
@@ -448,11 +455,15 @@
 .modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > .active-item-indicator,
 .modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator,
 .modern-ui-tabs .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator {
-	inset: 0 var(--vscode-spacing-size20);
+	top: 50%;
+	right: var(--vscode-spacing-size20);
+	bottom: auto;
+	left: var(--vscode-spacing-size20);
 	z-index: 0;
 	width: auto;
-	height: auto;
+	height: var(--vscode-spacing-size240);
 	border-radius: var(--vscode-cornerRadius-small);
+	transform: translateY(-50%);
 }
 
 .modern-ui-tabs .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge),
@@ -481,6 +492,15 @@
 
 .modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover > .active-item-indicator {
 	background-color: var(--vscode-list-hoverBackground);
+}
+
+.modern-ui-tabs.monaco-workbench:not(:is(.hc-black, .hc-light)) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus:not(.clicked) > .active-item-indicator {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
+}
+
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus > .active-item-indicator:before {
+	display: none;
 }
 
 :is(.hc-black, .hc-light).modern-ui-tabs.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-and-actions-container .tabs-container > .tab,

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -422,7 +422,7 @@
 	height: 100%;
 	min-height: 100%;
 	max-height: 100%;
-	margin: 0 !important;
+	margin: 0;
 	border-block: var(--vscode-spacing-size40) solid transparent;
 	border-radius: 0;
 	background-color: transparent !important;

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -13,6 +13,8 @@ import { ConfigurationTarget } from '../../../../../platform/configuration/commo
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestLayoutService } from '../../../../test/browser/workbenchTestServices.js';
 import { LayoutSettings } from '../../../../services/layout/browser/layoutService.js';
+import '../../../../browser/parts/activitybar/media/activityaction.css';
+import '../../../../browser/parts/media/paneCompositePart.css';
 import { StyleOverridesContribution } from '../../browser/styleOverrides.contribution.js';
 
 class StyleOverridesTestPane extends Pane {
@@ -45,6 +47,31 @@ class StyleOverridesTestLayoutService extends TestLayoutService {
 		this.containers.push(container);
 		this.onDidAddContainerEmitter.fire({ container, disposables });
 	}
+}
+
+function appendElement(parent: HTMLElement, className: string): HTMLElement {
+	const element = document.createElement('div');
+	element.className = className;
+	parent.appendChild(element);
+	return element;
+}
+
+function createCompositeAction(root: HTMLElement, titleHeight: number, checked: boolean): { actionItem: HTMLElement; indicator: HTMLElement } {
+	root.style.setProperty('--vscode-spacing-size20', '2px');
+	root.style.setProperty('--vscode-spacing-size40', '4px');
+	root.style.setProperty('--vscode-spacing-size240', '24px');
+	const part = appendElement(root, 'part pane-composite-part');
+	const title = appendElement(part, 'title');
+	title.style.height = `${titleHeight}px`;
+	const compositeBarContainer = appendElement(title, 'composite-bar-container');
+	const compositeBar = appendElement(compositeBarContainer, 'composite-bar');
+	const actionBar = appendElement(compositeBar, 'monaco-action-bar');
+	const actionsContainer = appendElement(actionBar, 'actions-container');
+	const actionItem = appendElement(actionsContainer, `action-item${checked ? ' checked' : ''}`);
+	actionItem.tabIndex = 0;
+	appendElement(actionItem, 'action-label');
+	const indicator = appendElement(actionItem, 'active-item-indicator');
+	return { actionItem, indicator };
 }
 
 suite('StyleOverridesContribution', () => {
@@ -117,6 +144,71 @@ suite('StyleOverridesContribution', () => {
 			paneHeaderLineHeightAfterToggle: '22px',
 			paneHeaderInlineLineHeightAfterToggle: '',
 			layoutCountAfterToggle: 1,
+		});
+	});
+
+	test('pane composite actions fill regular and Agents headers', () => {
+		const regularRoot = document.createElement('div');
+		regularRoot.className = 'monaco-workbench style-override modern-ui-tabs';
+		document.body.appendChild(regularRoot);
+		store.add(toDisposable(() => regularRoot.remove()));
+		const regular = createCompositeAction(regularRoot, 32, true);
+
+		const agentsRoot = document.createElement('div');
+		agentsRoot.className = 'monaco-workbench modern-ui-tabs';
+		document.body.appendChild(agentsRoot);
+		store.add(toDisposable(() => agentsRoot.remove()));
+		const agents = createCompositeAction(agentsRoot, 35, false);
+
+		const targetWindow = getWindow(agents.actionItem);
+		assert.deepStrictEqual({
+			regularTargetHeight: targetWindow.getComputedStyle(regular.actionItem).height,
+			regularIndicatorHeight: targetWindow.getComputedStyle(regular.indicator).height,
+			agentsTargetHeight: targetWindow.getComputedStyle(agents.actionItem).height,
+			agentsIndicatorHeight: targetWindow.getComputedStyle(agents.indicator).height,
+		}, {
+			regularTargetHeight: '32px',
+			regularIndicatorHeight: '24px',
+			agentsTargetHeight: '35px',
+			agentsIndicatorHeight: '24px',
+		});
+	});
+
+	test('preserves Modern UI activity badges and horizontal pane dividers', () => {
+		const root = document.createElement('div');
+		root.className = 'monaco-workbench style-override modern-ui-tabs';
+		root.style.setProperty('--activity-bar-action-height', '36px');
+		root.style.setProperty('--activity-bar-width', '36px');
+		document.body.appendChild(root);
+		store.add(toDisposable(() => root.remove()));
+
+		const activityBar = appendElement(root, 'activitybar');
+		const content = appendElement(activityBar, 'content');
+		const compositeBar = appendElement(content, 'composite-bar');
+		const actionBar = appendElement(compositeBar, 'monaco-action-bar');
+		const actionItem = appendElement(appendElement(actionBar, 'actions-container'), 'action-item');
+		appendElement(actionItem, 'action-label codicon');
+		const badgeContent = appendElement(appendElement(actionItem, 'badge'), 'badge-content');
+
+		const part = appendElement(root, 'part pane-composite-part');
+		const header = appendElement(part, 'header-or-footer header');
+		const footer = appendElement(part, 'header-or-footer footer');
+
+		const targetWindow = getWindow(root);
+		assert.deepStrictEqual({
+			badgeTop: targetWindow.getComputedStyle(badgeContent).top,
+			badgeWidth: targetWindow.getComputedStyle(badgeContent).width,
+			badgeHeight: targetWindow.getComputedStyle(badgeContent).height,
+			headerBorderWidth: targetWindow.getComputedStyle(header).borderBottomWidth,
+			headerOverflow: targetWindow.getComputedStyle(header).overflow,
+			footerBorderWidth: targetWindow.getComputedStyle(footer).borderTopWidth,
+		}, {
+			badgeTop: '18px',
+			badgeWidth: '16px',
+			badgeHeight: '16px',
+			headerBorderWidth: '0px',
+			headerOverflow: 'visible',
+			footerBorderWidth: '0px',
 		});
 	});
 });

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -60,6 +60,7 @@ function createCompositeAction(root: HTMLElement, titleHeight: number, checked: 
 	root.style.setProperty('--vscode-spacing-size20', '2px');
 	root.style.setProperty('--vscode-spacing-size40', '4px');
 	root.style.setProperty('--vscode-spacing-size240', '24px');
+	root.style.setProperty('--vscode-spacing-size320', '32px');
 	const part = appendElement(root, 'part pane-composite-part');
 	const title = appendElement(part, 'title');
 	title.style.height = `${titleHeight}px`;
@@ -152,7 +153,8 @@ suite('StyleOverridesContribution', () => {
 		regularRoot.className = 'monaco-workbench style-override modern-ui-tabs';
 		document.body.appendChild(regularRoot);
 		store.add(toDisposable(() => regularRoot.remove()));
-		const regular = createCompositeAction(regularRoot, 32, true);
+		// Taller container than the fixed 32px override, so the override is verified rather than a 100% fallback.
+		const regular = createCompositeAction(regularRoot, 40, true);
 
 		const agentsRoot = document.createElement('div');
 		agentsRoot.className = 'monaco-workbench modern-ui-tabs';


### PR DESCRIPTION
TL;DR - aligning all UI tabs with the refined editor tabs.

This pull request makes significant improvements to the layout, spacing, and accessibility of the activity bar and pane tabs in the modern UI. The changes standardize the use of CSS variables for spacing, enhance focus and hover indicators for accessibility, and simplify or refactor several style rules for better maintainability and consistency.

**Activity Bar and Composite Bar Spacing and Layout:**

* Updated `.active-item-indicator` and badge positions to use `var(--vscode-spacing-size20)` and other spacing variables for consistent alignment and spacing in `activityBar.css` and `padding.css`. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL164-R164) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL180-R180) [[3]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR198-R203) [[4]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR251) [[5]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbR53) [[6]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbR254)
* Removed and refactored several rules for compact header/footer and auxiliary bar layouts, consolidating and simplifying height, padding, and gap settings.

**Badge and Indicator Positioning:**

* Adjusted badge positions for both regular and compact modes for better visual alignment, and added a new rule for compact badge content positioning. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL332-R286) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL343-R297) [[3]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR334-R342)

**Modern UI Tabs Refactor and Accessibility:**

* Refactored `.modern-ui-tabs` rules to use `:is(.title, .header-or-footer)` for improved selector consistency, and replaced hardcoded sizes with CSS variables for action items and indicators.
* Improved focus and hover outlines for accessibility, especially in high contrast themes, by targeting `.active-item-indicator` instead of the entire action item and ensuring outlines are visible and consistent.
* Simplified and consolidated rules for checked and hovered tab states, and removed redundant or conflicting rules. [[1]](diffhunk://#diff-915cccdddaa0b83d00bb30841bbd79387a84f1f638b32f49633b200309e03024L542-L554) [[2]](diffhunk://#diff-915cccdddaa0b83d00bb30841bbd79387a84f1f638b32f49633b200309e03024L589-R640)

These changes collectively improve the visual consistency, accessibility, and maintainability of the style overrides for the activity bar and pane tabs.