### PR TITLE
Refactor attachment widget icons to use compact variants

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachmentWidget.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachmentWidget.ts
@@ -56,7 +56,7 @@ export class AgentFeedbackAttachmentWidget extends Disposable {
 		if (options.supportsDeletion && !deletionCurrentlyNotSupported) {
 			const clearBtn = dom.append(this.element, dom.$('.chat-attached-context-clear-button'));
 			const clearIcon = dom.$('span');
-			clearIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.close));
+			clearIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.closeCompact));
 			clearBtn.appendChild(clearIcon);
 			clearBtn.title = localize('removeAttachment', "Remove");
 			this._store.add(dom.addDisposableListener(clearBtn, dom.EventType.CLICK, (e) => {

--- a/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
@@ -166,7 +166,7 @@ export class NewChatContextAttachments extends Disposable {
 			const removeButton = dom.append(pill, dom.$('.sessions-chat-attachment-remove'));
 			removeButton.title = localize('removeAttachment', "Remove");
 			removeButton.tabIndex = -1;
-			dom.append(removeButton, renderIcon(Codicon.close));
+			dom.append(removeButton, renderIcon(Codicon.closeCompact));
 			this._renderDisposables.add(dom.addDisposableListener(removeButton, dom.EventType.CLICK, (e) => {
 				e.stopPropagation();
 				this._removeAttachment(entry.id);

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -175,7 +175,7 @@ abstract class AbstractChatAttachmentWidget extends Disposable {
 			title: localize('chat.attachment.clearButton', "Remove from context")
 		});
 		clearButton.element.tabIndex = -1;
-		clearButton.icon = Codicon.close;
+		clearButton.icon = Codicon.closeCompact;
 		this._register(clearButton);
 		this._register(event.Event.once(clearButton.onDidClick)((e) => {
 			this._onDidDelete.fire(e);

--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -124,7 +124,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 					? localize('disableImplicitContext', "Disable {0} context {1}", attachmentTypeName, contextLabel)
 					: localize('addToContext', "Add {0} to context", contextLabel);
 				const toggleButton = this.renderDisposables.add(new Button(contextNode, { supportIcons: true, title: buttonMsg }));
-				toggleButton.icon = context.enabled ? Codicon.x : Codicon.plus;
+				toggleButton.icon = context.enabled ? Codicon.x : Codicon.addCompact;
 				this.renderDisposables.add(toggleButton.onDidClick(async (e) => {
 					e.stopPropagation();
 					e.preventDefault();

--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -124,7 +124,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 					? localize('disableImplicitContext', "Disable {0} context {1}", attachmentTypeName, contextLabel)
 					: localize('addToContext', "Add {0} to context", contextLabel);
 				const toggleButton = this.renderDisposables.add(new Button(contextNode, { supportIcons: true, title: buttonMsg }));
-				toggleButton.icon = context.enabled ? Codicon.x : Codicon.addCompact;
+				toggleButton.icon = context.enabled ? Codicon.closeCompact : Codicon.addCompact;
 				this.renderDisposables.add(toggleButton.onDidClick(async (e) => {
 					e.stopPropagation();
 					e.preventDefault();

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2394,9 +2394,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 12px;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
-	padding-left: 4px;
-	font-size: 11px;
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-add-compact {
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .action-item.chat-attached-context-attachment.chat-add-files:hover,
@@ -2428,10 +2427,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	text-decoration: inherit;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-close,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-close,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-plus,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-close-compact,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-close-compact,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-add-compact,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-add-compact {
 	color: var(--vscode-descriptionForeground);
 	cursor: pointer;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
@@ -423,7 +423,13 @@ suite('ChatAttachmentsContentPart', () => {
 
 				await new Promise<void>(resolve => setTimeout(resolve, 0));
 
-				assert.strictEqual(widget.element.ariaLabel, 'Attached image, pasted-image.png (Delete)');
+				assert.deepStrictEqual({
+					ariaLabel: widget.element.ariaLabel,
+					clearButtonClass: widget.element.querySelector('.monaco-button')?.className,
+				}, {
+					ariaLabel: 'Attached image, pasted-image.png (Delete)',
+					clearButtonClass: 'monaco-button codicon codicon-close-compact',
+				});
 			});
 		});
 	});


### PR DESCRIPTION
This pull request updates the chat attachment UI to use the new compact icon variants for add and remove actions, ensuring a more consistent and modern appearance. It also updates related CSS classes and test assertions to match these icon changes.

**UI and Icon Updates:**

* Replaced usage of `Codicon.close` and `Codicon.plus` with `Codicon.closeCompact` and `Codicon.addCompact` for remove and add actions, respectively, in chat attachment widgets (`agentFeedbackAttachmentWidget.ts`, `newChatContextAttachments.ts`, `chatAttachmentWidgets.ts`, `implicitContextAttachment.ts`). [[1]](diffhunk://#diff-935b8b464f20187b489af3b261d8f4e7a25155ae3e09bde7d7903342ea4dcd64L59-R59) [[2]](diffhunk://#diff-f28ee3e492fa69eb51c1718f367a8feb2a1b9afe34c88415ed5aa01b19f9df1bL169-R169) [[3]](diffhunk://#diff-40e26ec3b1567a317947ef37f714bd9b7d4e80943d4e8b7206dac8cdec4f4305L178-R178) [[4]](diffhunk://#diff-dc60f15671531d633f82605ee2dc9f21a52d5a44c83e836296acc8ab49003b35L127-R127)

**CSS and Styling:**

* Updated CSS selectors to target `.codicon-close-compact` and `.codicon-add-compact` instead of the old icon class names, and adjusted the font size for the new compact add icon (`chat.css`). [[1]](diffhunk://#diff-9094a9cafc05002fe1bc40a7d7dbef09ee89390fb1ab1a5352eaaa457f45a3eaL2397-R2398) [[2]](diffhunk://#diff-9094a9cafc05002fe1bc40a7d7dbef09ee89390fb1ab1a5352eaaa457f45a3eaL2431-R2433)

**Testing:**

* Updated the chat attachments content part test to expect the new compact close icon class in the DOM (`chatAttachmentsContentPart.test.ts`).