### PR TITLE
sessions: keep aux-only tabs limited to Changes and Files

### DIFF
--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -281,6 +281,9 @@ While the editor area is hidden, the managed Changes editor and Files placeholde
 `EditorInputCapabilities.CannotClose`, so standard close actions cannot remove either tab from the
 visible detail panel. Revealing the editor area makes both tabs closeable again. Managed-tab
 reconciliation uses an explicit forced close when it removes stale inputs or tidies the Files placeholder.
+In a Details-only composition, the tab-collapse strategy re-runs after each session working-set restore
+and editor-list change. Any restored non-docked editors are closed and captured for reopening when the
+editor area is shown, so the hidden-editor tab strip contains only the docked Changes and Files inputs.
 While the detail is visible, every diff editor selects the Changes container and every file editor
 selects the Files container, regardless of whether the file is inside the active session workspace.
 Rendered Markdown preview and Markdown custom editors also select Files.

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneEditorAreaCollapseStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneEditorAreaCollapseStrategy.ts
@@ -74,18 +74,27 @@ export class SinglePaneEditorAreaCollapseStrategy extends SinglePaneLayoutStrate
 				void this._coordinator.sequencer.queue(() => this._collapseNonManagedTabs()).catch(onUnexpectedError);
 			}
 		}));
+
+		this._register(this._ctx.onDidEndSessionLayoutRestore(() => this._queueCollapseIfDetailsOnly()));
+		this._register(this._editorService.onDidEditorsChange(() => {
+			if (!this._ctx.isRestoringSessionLayout) {
+				this._queueCollapseIfDetailsOnly();
+			}
+		}));
+	}
+
+	private _queueCollapseIfDetailsOnly(): void {
+		if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow) && this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+			void this._coordinator.sequencer.queue(() => this._collapseNonManagedTabs()).catch(onUnexpectedError);
+		}
 	}
 
 	private async _collapseNonManagedTabs(): Promise<void> {
-		if (this._coordinator.collapsedEditors) {
-			return; // already collapsed
-		}
-
 		const group = this._editorGroupsService.mainPart.activeGroup;
-		const captured: { editor: IUntypedEditorInput; index: number }[] = [];
+		const captured: { editor: IUntypedEditorInput; index: number }[] = [...(this._coordinator.collapsedEditors ?? [])];
 		const toClose: EditorInput[] = [];
 		group.editors.forEach((editor, index) => {
-			if (editor instanceof DockedEditorInput) {
+			if (editor instanceof DockedEditorInput || this._coordinator.getChangesEditorResource(editor)) {
 				return;
 			}
 			// Capture editors that can be reopened so they are restored when the

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -3207,6 +3207,42 @@ suite('LayoutController (desktop)', () => {
 		});
 	});
 
+	test('[single-pane] closes and reopens non-managed tabs added while only details are visible', async () => {
+		createSinglePaneController({
+			activateAux: true,
+			initialPartVisibility: new Map([[Parts.EDITOR_PART, false], [Parts.AUXILIARYBAR_PART, true]]),
+			sidePaneVisibilityState: {
+				newSession: { editorVisible: false, auxiliaryBarVisible: true },
+				existingSession: { editorVisible: false, auxiliaryBarVisible: true },
+			},
+		});
+		await settle();
+
+		harness.activeSessionObs.set(makeSession(URI.parse('session:1')), undefined);
+		await settle();
+
+		const fileResource = URI.file('/repo/added.ts');
+		harness.activeGroupEditors.splice(1, 0, store.add(new TestStubEditorInput(fileResource)));
+		harness.onDidEditorsChange.fire();
+		await settle();
+
+		const fileTabVisibleWhileDetailsOnly = harness.activeGroupEditors.some(editor => editor.resource && isEqual(editor.resource, fileResource));
+
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.EDITOR_PART, visible: true });
+		await settle();
+
+		assert.deepStrictEqual({
+			closedFile: harness.closedEditors.some(editor => editor.resource && isEqual(editor.resource, fileResource)),
+			fileTabVisibleWhileDetailsOnly,
+			reopenedFile: harness.openedEditors.some(editor => isResourceEditorInput(editor) && isEqual(editor.resource, fileResource)),
+		}, {
+			closedFile: true,
+			fileTabVisibleWhileDetailsOnly: false,
+			reopenedFile: true,
+		});
+	});
+
 	test('[single-pane] closes a non-restorable non-docked tab (e.g. untitled Search) when the editor area hides, without restoring it', async () => {
 		createSinglePaneController({ activateAux: true });
 		await settle();

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -3175,6 +3175,38 @@ suite('LayoutController (desktop)', () => {
 		});
 	});
 
+	test('[single-pane] closes non-managed tabs restored while only details are visible', async () => {
+		const controller = createSinglePaneController({
+			activateAux: true,
+			initialPartVisibility: new Map([[Parts.EDITOR_PART, false], [Parts.AUXILIARYBAR_PART, true]]),
+			sidePaneVisibilityState: {
+				newSession: { editorVisible: false, auxiliaryBarVisible: true },
+				existingSession: { editorVisible: false, auxiliaryBarVisible: true },
+			},
+		});
+		await settle();
+
+		harness.activeSessionObs.set(makeSession(URI.parse('session:1')), undefined);
+		await settle();
+
+		const fileResource = URI.file('/repo/restored.ts');
+		controller.runWithRestore(() => {
+			harness.activeGroupEditors.splice(1, 0, store.add(new TestStubEditorInput(fileResource)));
+			harness.onDidEditorsChange.fire();
+		});
+		await settle();
+
+		assert.deepStrictEqual({
+			closedFile: harness.closedEditors.some(editor => editor.resource && isEqual(editor.resource, fileResource)),
+			fileTabVisible: harness.activeGroupEditors.some(editor => editor.resource && isEqual(editor.resource, fileResource)),
+			filesTabVisible: hasFilesTab(),
+		}, {
+			closedFile: true,
+			fileTabVisible: false,
+			filesTabVisible: true,
+		});
+	});
+
 	test('[single-pane] closes a non-restorable non-docked tab (e.g. untitled Search) when the editor area hides, without restoring it', async () => {
 		createSinglePaneController({ activateAux: true });
 		await settle();


### PR DESCRIPTION
## What changed
- reapply non-docked editor collapse after session working-set restores
- enforce the same Aux-only invariant on editor-list changes
- preserve managed Changes and Files tabs and capture restorable tabs for reopening
- document the behavior and add a regression test

## Why
Session navigation could asynchronously restore file or browser tabs after the one-time Editor-hidden cleanup had already run. Because Editor stayed hidden, there was no later visibility transition to remove those tabs from the Aux-only tab strip.

## Validation
- `npm run transpile-client`
- focused single-pane layout tests (7 passing)
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run hygiene`