### PR TITLE
Avoid entitlement lazy re-entry during Agents startup

### DIFF
--- a/src/vs/workbench/services/assignment/common/assignmentFilters.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentFilters.ts
@@ -101,6 +101,10 @@ export class CopilotAssignmentFilterProvider extends Disposable implements IExpe
 		this.copilotIsSn = this._storageService.get(StorageVersionKeys.CopilotIsSn, StorageScope.PROFILE);
 		this.copilotIsFcv1 = this._storageService.get(StorageVersionKeys.CopilotIsFcv1, StorageScope.PROFILE);
 
+		this.updateExtensionVersions();
+		this.updateCopilotEntitlementInfo();
+		this.updateCopilotTokenInfo();
+
 		this._register(this._extensionService.onDidChangeExtensionsStatus(extensionIdentifiers => {
 			if (extensionIdentifiers.some(identifier => ExtensionIdentifier.equals(identifier, 'github.copilot') || ExtensionIdentifier.equals(identifier, 'github.copilot-chat'))) {
 				this.updateExtensionVersions();
@@ -114,10 +118,6 @@ export class CopilotAssignmentFilterProvider extends Disposable implements IExpe
 		this._register(this._defaultAccountService.onDidChangeCopilotTokenInfo(() => {
 			this.updateCopilotTokenInfo();
 		}));
-
-		this.updateExtensionVersions();
-		this.updateCopilotEntitlementInfo();
-		this.updateCopilotTokenInfo();
 	}
 
 	private async updateExtensionVersions() {

--- a/src/vs/workbench/services/assignment/test/common/assignmentFilters.test.ts
+++ b/src/vs/workbench/services/assignment/test/common/assignmentFilters.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Lazy } from '../../../../../base/common/lazy.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService, InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IChatEntitlementService } from '../../../chat/common/chatEntitlementService.js';
+import { IExtensionService } from '../../../extensions/common/extensions.js';
+import { TestExtensionService, mock } from '../../../../test/common/workbenchTestServices.js';
+import { CopilotAssignmentFilterProvider, ExtensionsFilter } from '../../common/assignmentFilters.js';
+
+suite('CopilotAssignmentFilterProvider', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('initializes entitlement filters before subscribing to entitlement changes', () => {
+		const onDidChangeEntitlement = disposables.add(new Emitter<void>());
+		const chatEntitlementService = new class extends mock<IChatEntitlementService>() {
+			override readonly onDidChangeEntitlement = onDidChangeEntitlement.event;
+			override readonly sku = 'pro';
+			override readonly organisations = undefined;
+
+			private readonly trackingId = new Lazy(() => {
+				onDidChangeEntitlement.fire();
+				return 'tracking-id';
+			});
+
+			override get copilotTrackingId(): string {
+				return this.trackingId.value;
+			}
+		}();
+		const defaultAccountService = new class extends mock<IDefaultAccountService>() {
+			override readonly copilotTokenInfo = null;
+			override readonly onDidChangeCopilotTokenInfo = Event.None;
+		}();
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IExtensionService, new TestExtensionService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+		instantiationService.stub(IChatEntitlementService, chatEntitlementService);
+		instantiationService.stub(IDefaultAccountService, defaultAccountService);
+
+		const provider = disposables.add(instantiationService.createInstance(CopilotAssignmentFilterProvider));
+
+		assert.strictEqual(provider.getFilterValue(ExtensionsFilter.CopilotTrackingId), 'tracking-id');
+	});
+});


### PR DESCRIPTION
cc @benibenj 

## Issue

Recent Agents window renderer logs repeatedly report this startup error:

```
Cannot read the value of a lazy that is being initialized
    at get value
    at get copilotTrackingId
    at CopilotAssignmentFilterProvider.updateCopilotEntitlementInfo
```

The lazy is specifically `ChatEntitlementService.context: Lazy<ChatEntitlementContext>`. During `CopilotAssignmentFilterProvider` construction, the provider subscribed to `onDidChangeEntitlement` before reading its initial entitlement filters. Reading `copilotTrackingId` then forced `context.value`, which began constructing `ChatEntitlementContext`. That constructor binds entitlement context keys and synchronously fires the entitlement-change subscription, causing the provider to read `context.value` again while the same lazy is still running.

## Regression timeline

- On February 5, 2026, [#292997](https://github.com/microsoft/vscode/pull/292997) added `copilotTrackingId` as an assignment filter. Unlike SKU and organization, this getter reads `ChatEntitlementService.context.value`, introducing the unsafe re-entrant dependency.
- On August 4, 2026, [#328454](https://github.com/microsoft/vscode/pull/328454) added an Agents window A/A treatment read at `BlockStartup`. This eagerly instantiates the assignment service before another consumer has initialized the entitlement context, making the previously latent cycle deterministic during Agents startup.
- The first substantive retained session logs are from August 6, and every retained Agents launch since then contains the error. The failing August 6 build was commit `780ea331b2861816fe6bb8215d812933c81df83b`.

## Fix

Initialize the assignment provider's extension, entitlement, and token filters before registering their change listeners. The initial entitlement read can then fully construct `ChatEntitlementContext` without re-entering its lazy. Once initialization completes, later entitlement changes remain observed normally.

A focused regression test uses a real `Lazy` whose executor fires `onDidChangeEntitlement`, reproducing the construction-time cycle with the previous ordering.

## Validation

- `./scripts/test.sh --run src/vs/workbench/services/assignment/test/common/assignmentFilters.test.ts`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- Targeted ESLint
- `git diff --check`

(Written by Copilot)
