### PR TITLE
sessions: preserve panel height when restoring editor

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -384,7 +384,7 @@ The Changes view's body is a vertical `SplitView` of File Changes, Other Files, 
 
 ### Panel
 
-The panel (terminal / debug output) is hidden by default for all sessions. Each session independently tracks the user's last explicit show/hide action, and that state is restored on session switch.
+The panel (terminal / debug output) is hidden by default for all sessions. Each session independently tracks the user's last explicit show/hide action, and that state is restored on session switch. Its height remains workbench-level state rather than per-session state. In single-pane layout, revealing the Editor preserves the visible panel height; otherwise the grid can shrink the panel to its minimum while it redistributes space for the restored Editor node.
 
 ### Editor Working Sets
 

--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -224,7 +224,10 @@ before un-maximizing, so maximize restoration cannot be captured as an explicit 
 
 The per-session record is updated whenever the user toggles the panel: an
 `onDidChangePartVisibility` listener for `PANEL_PART` writes the new visibility for the active
-session (suppressed while multiple sessions are visible).
+session (suppressed while multiple sessions are visible). Panel height is global workbench state,
+not per-session layout state. When Quick Chat hides the side pane, returning restores the panel first
+and then reveals the single-pane Editor. That Editor reveal must preserve the panel's current height;
+otherwise grid redistribution shrinks the panel to its minimum.
 
 ---
 

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -2361,6 +2361,9 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		}
 
 		const sidePaneWasClosed = !this.partVisibility.editor && !this.partVisibility.auxiliaryBar;
+		const panelSizeBeforeEditorReveal = !hidden && this.isSinglePaneLayoutEnabled && this._effectiveVisible(Parts.PANEL_PART)
+			? this.workbenchGrid.getViewSize(this.panelPartView)
+			: undefined;
 
 		// Track whether this visible state was an explicit user reveal.
 		this._editorRevealedExplicitly = !hidden && explicit;
@@ -2381,6 +2384,9 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 			this._savePartVisibility();
 		});
+		if (panelSizeBeforeEditorReveal) {
+			this.workbenchGrid.resizeView(this.panelPartView, panelSizeBeforeEditorReveal);
+		}
 
 		if (!hidden && sidePaneWasClosed && !skipSidePaneReveal) {
 			this._onSidePaneRevealed();

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -100,6 +100,7 @@ suite('Sessions - Workbench', () => {
 		workbenchGrid: {
 			getViewSize(view: object): IViewSize;
 			isViewVisible(view: object): boolean;
+			resizeView(view: object, size: IViewSize): void;
 		};
 		setEditorHidden(hidden: boolean, explicit?: boolean): void;
 		setAuxiliaryBarHidden(hidden: boolean): void;
@@ -162,6 +163,8 @@ suite('Sessions - Workbench', () => {
 		windowWidth?: number;
 		editorWidth?: number;
 		sideBarWidth?: number;
+		panelHeight?: number;
+		panelHeightOnEditorShow?: number;
 		dockedWidth?: number;
 		hasAppliedInitialEditorSplit?: boolean;
 		/** Use the real `setEditorMaximized` instead of the no-op stub. */
@@ -204,6 +207,7 @@ suite('Sessions - Workbench', () => {
 			[sessionsPartView, { width: options.sessionsWidth ?? 1000, height: 800 }],
 			[sideBarPartView, { width: options.sideBarWidth ?? 280, height: 800 }],
 			[auxiliaryBarPartView, { width: 300, height: 800 }],
+			[panelPartView, { width: 1000, height: options.panelHeight ?? 300 }],
 		]);
 
 		const partVisibility = { sidebar: true, auxiliaryBar: true, editor: false, panel: false, sessions: true, customViewGrid: false, ...options.partVisibility };
@@ -227,6 +231,9 @@ suite('Sessions - Workbench', () => {
 				setViewVisible: (view: object, visible: boolean, sizing?: { type: string }) => {
 					if (view === editorPartView) {
 						editorNodeVisible = visible;
+						if (visible && partVisibility.editor && options.panelHeightOnEditorShow !== undefined) {
+							viewSizes.set(panelPartView, { width: 1000, height: options.panelHeightOnEditorShow });
+						}
 					} else if (view === sideBarPartView && sideBarNodeVisible !== visible) {
 						const sideBarWidth = viewSizes.get(sideBarPartView)!.width;
 						const sessionsSize = viewSizes.get(sessionsPartView)!;
@@ -243,7 +250,13 @@ suite('Sessions - Workbench', () => {
 					}
 					notifyPartVisibility(view, visible);
 				},
-				resizeView: (view: object, size: IViewSize) => { resizes.push(size); viewSizes.set(view, size); },
+				resizeView: (view: object, size: IViewSize) => {
+					resizes.push(size);
+					viewSizes.set(view, size);
+					if (view === editorPartView && partVisibility.editor && options.panelHeightOnEditorShow !== undefined) {
+						viewSizes.set(panelPartView, { width: 1000, height: options.panelHeightOnEditorShow });
+					}
+				},
 			},
 			_mainContainerDimension: { width: options.windowWidth ?? 1000, height: 800 },
 			layoutPolicy: { viewportClass: { get: () => 'desktop' } },
@@ -2065,6 +2078,23 @@ suite('Sessions - Workbench', () => {
 			sidebarVisible: true,
 			sessionsVisible: true,
 		});
+	});
+
+	// --- Panel visibility ---------------------------------------------------
+
+	test('single-pane restores the bottom panel height after navigating through Quick Chat', () => {
+		const singlePane = createHost({ single: true, panelHeight: 520, panelHeightOnEditorShow: 77, partVisibility: { panel: true, editor: true, auxiliaryBar: true } });
+
+		singlePane._editorPartAutoVisibilitySuppressionCount = 1;
+		setPanelHidden.call(singlePane, true);
+		setEditorHidden.call(singlePane, true);
+		singlePane.setAuxiliaryBarHidden(true);
+		singlePane._editorPartAutoVisibilitySuppressionCount = 0;
+		setPanelHidden.call(singlePane, false);
+		singlePane.setAuxiliaryBarHidden(false);
+		setEditorHidden.call(singlePane, false);
+
+		assert.strictEqual(singlePane.workbenchGrid.getViewSize(singlePane.panelPartView).height, 520);
 	});
 
 	// --- Custom view grid ---------------------------------------------------


### PR DESCRIPTION
Fixes #329604

## What changed

- preserve the visible bottom-panel dimensions while revealing the Editor in single-pane layout
- add regression coverage for workspace session → Quick Chat → workspace session navigation
- document panel sizing ownership and restore ordering

## Why

Returning from Quick Chat restores the terminal panel before restoring the single-pane Editor. Revealing the Editor redistributed the grid and shrank the terminal from its previous height to the 77px minimum.

## Validation

- manually reproduced before the fix and verified after the fix
- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/sessions/test/browser/workbench.test.ts --grep "single-pane restores the bottom panel height after navigating through Quick Chat"`