### PR TITLE
Add keepOpen option to chat input notifications and fix overlap gap

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -675,6 +675,10 @@
 	display: none;
 }
 
+.new-chat-input-container > .chat-input-notification-container.has-notification {
+	margin-bottom: calc(-1 * var(--vscode-spacing-size80));
+}
+
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification {
 	/* Padding needs to be -6px for top to account for -10px margin in parent container and 4px for half of chat border radius. */
 	padding: 10px 16px 16px 16px;
@@ -702,11 +706,4 @@
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification.severity-error {
 	border-color: var(--vscode-editorError-foreground);
 	background-color: color-mix(in srgb, var(--vscode-editorError-foreground) 6%, var(--vscode-editorWidget-background));
-}
-
-/* Remove the top border-radius from the input area when a notification is visible */
-.new-chat-input-container > .chat-input-notification-container.has-notification + .new-chat-input-area {
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
-	border-top: none;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -676,11 +676,11 @@
 }
 
 .new-chat-input-container > .chat-input-notification-container.has-notification {
+	/* Overlap the following input-stack surface to avoid a gap between their rounded edges. */
 	margin-bottom: calc(-1 * var(--vscode-spacing-size80));
 }
 
 .new-chat-input-container > .chat-input-notification-container .chat-input-notification {
-	/* Padding needs to be -6px for top to account for -10px margin in parent container and 4px for half of chat border radius. */
 	padding: 10px 16px 16px 16px;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-input-border, transparent);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
@@ -27,6 +27,7 @@ export const enum ChatInputNotificationActionKind {
 
 interface IChatInputNotificationActionBase {
 	readonly label: string;
+	readonly keepOpen?: boolean;
 }
 
 export interface IChatInputNotificationCommandAction extends IChatInputNotificationActionBase {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts
@@ -299,7 +299,9 @@ export class ChatInputNotificationWidget extends Disposable {
 				this._switchToModel(action.modelIdentifier);
 				break;
 		}
-		this._notificationService.dismissNotification(notification.id);
+		if (!action.keepOpen) {
+			this._notificationService.dismissNotification(notification.id);
+		}
 	}
 
 	private _switchToModel(modelIdentifier: string): void {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
@@ -339,6 +339,28 @@ suite('ChatInputNotificationWidget', () => {
 		assert.strictEqual(notificationService.dismissed.join(','), 'info');
 	});
 
+	test('keep-open actions execute without dismissing the notification', async () => {
+		const commandService = new TestCommandService();
+		const { notificationService, widget } = createWidget({ commandService });
+		showNotification(notificationService, {
+			id: 'setup',
+			message: 'Setup',
+			actions: [{ kind: ChatInputNotificationActionKind.Command, label: 'Sign In', commandId: 'test.signIn', keepOpen: true }],
+		});
+
+		clickAction(widget);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			executed: commandService.executed,
+			dismissed: notificationService.dismissed,
+		}, {
+			executed: [{ id: 'test.signIn', args: [] }],
+			dismissed: [],
+		});
+	});
+
 	test('catches rejected command actions', async () => {
 		const logService = store.add(new RecordingLogService());
 		const commandService = new class extends TestCommandService {


### PR DESCRIPTION
For upcoming changes to the no-auth experience in Agents Window