### PR TITLE
agentHost: avoid persisting ephemeral connections

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -342,10 +342,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			}
 		}));
 
-		// Persist entries — await so that the config is written before
-		// onDidChangeConnections fires, ensuring _reconcile creates the provider.
-		// Tunnel entries are filtered out by _storeConfiguredEntries automatically.
-		await this._storeConfiguredEntries(this._upsertConfiguredEntry(entry));
+		if (entry.connection.type === RemoteAgentHostEntryType.WebSocket || entry.connection.type === RemoteAgentHostEntryType.SSH) {
+			// Await persistence before notifying so _reconcile sees the configured entry.
+			await this._storeConfiguredEntries(this._upsertConfiguredEntry(entry));
+		}
 
 		this._onDidChangeConnections.fire();
 

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -10,6 +10,7 @@
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { DeferredPromise, raceTimeout } from '../../../base/common/async.js';
+import { assertNever } from '../../../base/common/assert.js';
 import { ConfigurationTarget, IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -342,9 +343,26 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			}
 		}));
 
-		if (entry.connection.type === RemoteAgentHostEntryType.WebSocket || entry.connection.type === RemoteAgentHostEntryType.SSH) {
-			// Await persistence before notifying so _reconcile sees the configured entry.
-			await this._storeConfiguredEntries(this._upsertConfiguredEntry(entry));
+		switch (entry.connection.type) {
+			case RemoteAgentHostEntryType.WebSocket:
+				// WebSocket hosts are durable user configuration, so persist them in settings.
+				await this._storeConfiguredSettingEntries(this._upsertConfiguredEntry(entry));
+				break;
+			case RemoteAgentHostEntryType.SSH:
+				// SSH hosts are durable but managed by VS Code, so persist them only in application storage.
+				this._storeStoredSSHEntries(this._upsertConfiguredEntry(entry));
+				break;
+			case RemoteAgentHostEntryType.WSL:
+				// The WSL service owns its distro cache, so registration needs no persistence here.
+				break;
+			case RemoteAgentHostEntryType.Tunnel:
+				// The tunnel service owns discovery and its recent-tunnel cache, so registration needs no persistence here.
+				break;
+			case RemoteAgentHostEntryType.CloudSandbox:
+				// Cloud sandbox connections use short-lived credentials and must remain runtime-only.
+				break;
+			default:
+				assertNever(entry.connection);
 		}
 
 		this._onDidChangeConnections.fire();
@@ -677,6 +695,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 	private async _storeConfiguredEntries(entries: IRemoteAgentHostEntry[]): Promise<void> {
 		this._storeStoredSSHEntries(entries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH));
+		await this._storeConfiguredSettingEntries(entries);
+	}
+
+	private async _storeConfiguredSettingEntries(entries: IRemoteAgentHostEntry[]): Promise<void> {
 		const raw = entries.filter(entry => entry.connection.type !== RemoteAgentHostEntryType.SSH).map(entryToRawEntry).filter(isDefined);
 		await this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, this._getConfigurationTarget());
 	}

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -78,6 +78,7 @@ class TestConfigurationService {
 
 	private _entries: IRawRemoteAgentHostEntry[] = [];
 	private _enabled = true;
+	private _updateCallCount = 0;
 
 	getValue(key?: string): unknown {
 		if (key === RemoteAgentHostsEnabledSettingId) {
@@ -93,6 +94,7 @@ class TestConfigurationService {
 	}
 
 	async updateValue(_key: string, value: unknown): Promise<void> {
+		this._updateCallCount++;
 		const entries = (value as IRawRemoteAgentHostEntry[] | undefined) ?? [];
 		const changed = JSON.stringify(this._entries) !== JSON.stringify(entries);
 		this._entries = entries;
@@ -106,6 +108,10 @@ class TestConfigurationService {
 
 	get entries(): readonly IRawRemoteAgentHostEntry[] {
 		return this._entries;
+	}
+
+	get updateCallCount(): number {
+		return this._updateCallCount;
 	}
 
 	setEntries(entries: IRemoteAgentHostEntry[]): void {
@@ -596,6 +602,64 @@ suite('RemoteAgentHostService', () => {
 				() => addManaged('Managed', 'managed:1234'),
 				/not enabled/,
 			);
+		});
+
+		test('does not persist ephemeral managed connections', async () => {
+			const tunnelClient = disposables.add(new MockProtocolClient('tunnel:tunnel-id'));
+			await service.addManagedConnection(
+				{
+					name: 'Tunnel Host',
+					connection: {
+						type: RemoteAgentHostEntryType.Tunnel,
+						tunnelId: 'tunnel-id',
+						clusterId: 'use',
+					},
+				},
+				tunnelClient as unknown as Parameters<typeof service.addManagedConnection>[1],
+			);
+
+			const wslClient = disposables.add(new MockProtocolClient('wsl:Ubuntu'));
+			await service.addManagedConnection(
+				{
+					name: 'WSL Host',
+					connection: {
+						type: RemoteAgentHostEntryType.WSL,
+						address: 'wsl:Ubuntu',
+						distro: 'Ubuntu',
+					},
+				},
+				wslClient as unknown as Parameters<typeof service.addManagedConnection>[1],
+			);
+
+			const cloudSandboxClient = disposables.add(new MockProtocolClient('cloudsandbox:environment-id'));
+			await service.addManagedConnection(
+				{
+					name: 'Cloud Sandbox',
+					connection: {
+						type: RemoteAgentHostEntryType.CloudSandbox,
+						address: 'cloudsandbox:environment-id',
+						environmentId: 'environment-id',
+					},
+				},
+				cloudSandboxClient as unknown as Parameters<typeof service.addManagedConnection>[1],
+			);
+
+			assert.deepStrictEqual({
+				updateCallCount: configService.updateCallCount,
+				configuredEntries: service.configuredEntries,
+				connections: service.connections.map(connection => ({
+					address: connection.address,
+					name: connection.name,
+				})),
+			}, {
+				updateCallCount: 0,
+				configuredEntries: [],
+				connections: [
+					{ address: 'tunnel:tunnel-id', name: 'Tunnel Host' },
+					{ address: 'wsl:Ubuntu', name: 'WSL Host' },
+					{ address: 'cloudsandbox:environment-id', name: 'Cloud Sandbox' },
+				],
+			});
 		});
 
 		test('does NOT dispose previous transportDisposable when entry is replaced', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -604,6 +604,22 @@ suite('RemoteAgentHostService', () => {
 			);
 		});
 
+		test('persists managed WebSocket connections in settings', async () => {
+			await addManaged('WebSocket Host', 'managed:1234');
+
+			assert.deepStrictEqual({
+				updateCallCount: configService.updateCallCount,
+				settings: configService.entries,
+			}, {
+				updateCallCount: 1,
+				settings: [{
+					name: 'WebSocket Host',
+					address: 'managed:1234',
+					connectionToken: undefined,
+				}],
+			});
+		});
+
 		test('does not persist ephemeral managed connections', async () => {
 			const tunnelClient = disposables.add(new MockProtocolClient('tunnel:tunnel-id'));
 			await service.addManagedConnection(
@@ -711,9 +727,11 @@ suite('RemoteAgentHostService', () => {
 			);
 
 			assert.deepStrictEqual({
+				updateCallCount: configService.updateCallCount,
 				settings: configService.entries,
 				configured: service.configuredEntries,
 			}, {
+				updateCallCount: 0,
 				settings: [],
 				configured: [{
 					name: 'SSH Host',


### PR DESCRIPTION
## What changed

- persist managed WebSocket hosts in `chat.remoteAgentHosts`
- persist managed SSH hosts only in application storage
- keep WSL, tunnel, and cloud sandbox connection registration runtime-only because their owning services handle discovery/cache state or use short-lived credentials
- use an exhaustive per-connection-type switch that documents each persistence boundary
- add regression coverage for WebSocket settings writes, SSH storage without settings writes, and ephemeral registration without central persistence

## Why

Registering a dev tunnel rewrote `settings.json` even though tunnel entries are filtered from persisted configuration. On Windows, an existing file lock could make the atomic settings-file rename fail and incorrectly surface an otherwise successful tunnel connection as failed.

Separating the persistence paths also avoids the same redundant settings rewrite for SSH connections, whose durable metadata belongs in application storage rather than user settings.

## Validation

- `npm run typecheck-client`
- `scripts\test.bat --run src\vs\platform\agentHost\test\electron-browser\remoteAgentHostService.test.ts` (32 passing)
- `npm run valid-layers-check`
- changed-file hygiene