### PR TITLE
Invalidate Markdown code block editor providers

### DIFF
--- a/extensions/markdown-language-features/CONTRIBUTING.md
+++ b/extensions/markdown-language-features/CONTRIBUTING.md
@@ -26,6 +26,10 @@ Build outputs are written to `out/` (desktop), `dist/` (web), and `notebook-out/
 
 ### Developing the Markdown editor
 
+See [Markdown code block editor extensions](./markdown-code-block-editor-extensions.md)
+for the experimental extension contribution that embeds custom editors in
+fenced code blocks.
+
 1. **Know the repositories and integration points**
 
    `@vscode/markdown-editor` lives in the sibling `microsoft/vscode-packages` checkout at `vscode-team-tools/packages/markdown-editor`. In this repo, the integration is in `extensions/markdown-language-features`, especially `markdown-editor-src`, `src/preview/markdownEditorProvider.ts`, and `esbuild.markdownEditor.mts`. These instructions assume `vscode` and `vscode-packages` are sibling folders.

--- a/extensions/markdown-language-features/markdown-code-block-editor-extensions.md
+++ b/extensions/markdown-language-features/markdown-code-block-editor-extensions.md
@@ -1,0 +1,396 @@
+# Markdown code block editor extensions
+
+> **Experimental:** This extension contribution is under development and may
+> change before it becomes a stable VS Code extension API.
+
+Extensions can replace fenced Markdown code blocks with iframe-backed editors
+in VS Code's Markdown editor. The iframe edits the code block body; the
+surrounding fence and its info string remain part of the Markdown document.
+
+For example, an extension can turn:
+
+````markdown
+```diagram theme=dark
+{"nodes":[],"edges":[]}
+```
+````
+
+into a visual diagram editor while keeping the JSON between the fences as the
+document source.
+
+## Architecture
+
+The integration has three parts:
+
+1. The extension manifest selects the fenced code blocks it handles.
+2. The extension optionally resolves the HTML used for each document and info
+   string.
+3. A self-contained browser guest uses `@vscode/web-editors` to synchronize the
+   code block body with the Markdown editor.
+
+The Markdown editor virtualizes guest iframes. A guest must therefore derive
+all persistent state from the code block content or another explicit store and
+must tolerate being disposed and recreated.
+
+## Contribute a static editor
+
+Use a static provider when every matching block uses the same HTML:
+
+```json
+{
+  "contributes": {
+    "markdown.codeBlockEditorProviders": [
+      {
+        "id": "diagram",
+        "selector": {
+          "language": "diagram"
+        },
+        "source": {
+          "kind": "static",
+          "entrypoint": "./dist/diagram-editor.html"
+        },
+        "contentType": "json",
+        "initialHeight": 360,
+        "sandbox": {
+          "forms": false,
+          "downloads": false,
+          "pointerLock": false,
+          "clipboardWrite": false
+        }
+      }
+    ]
+  }
+}
+```
+
+The entrypoint is relative to the extension root. The HTML must be
+self-contained because the Markdown editor reads it and uses it as iframe
+content. Inline scripts and styles or a single-file HTML bundle are suitable;
+relative script and stylesheet references are not.
+
+## Select code blocks
+
+A selector uses exactly one of these properties:
+
+- `language` matches the first language token exactly.
+- `languagePrefix` matches the beginning of the first language token.
+
+The info string is all text after the opening fence. For
+<code>```diagram theme=dark</code>, it is `diagram theme=dark`, not only
+`diagram`, while the language token is `diagram`.
+
+Use an exact selector for one language. It also matches blocks that have
+additional info-string metadata:
+
+```json
+{ "language": "diagram" }
+```
+
+Use a prefix selector for a family of languages:
+
+```json
+{ "languagePrefix": "diagram-" }
+```
+
+If more than one provider matches a language, the Markdown editor reports
+the ambiguity and does not choose between them.
+
+## Contribute a dynamically resolved editor
+
+Use a dynamic provider when the HTML depends on the document URI, info-string
+parameters, extension settings, or another resource:
+
+```json
+{
+  "contributes": {
+    "markdown.codeBlockEditorProviders": [
+      {
+        "id": "diagram",
+        "selector": {
+          "language": "diagram"
+        },
+        "source": {
+          "kind": "exportApi",
+          "apiVersion": 1
+        },
+        "contentType": "json",
+        "initialHeight": 360,
+        "sandbox": {
+          "forms": false,
+          "downloads": false,
+          "pointerLock": false,
+          "clipboardWrite": false
+        }
+      }
+    ]
+  }
+}
+```
+
+Dynamic providers are resolved only in trusted workspaces.
+
+### Export API V1
+
+The extension's `activate` function returns a
+`markdownCodeBlockEditors.apiV1` object:
+
+```ts
+import * as vscode from 'vscode';
+
+interface MarkdownCodeBlockEditorApiV1 {
+	getProvider(providerId: string): MarkdownCodeBlockEditorProvider | undefined;
+}
+
+interface MarkdownCodeBlockEditorProvider {
+	readonly onDidChange: vscode.Event<void>;
+
+	resolve(
+		request: {
+			readonly providerId: string;
+			readonly documentUri: vscode.Uri;
+			readonly infoString: string;
+		},
+		token: vscode.CancellationToken,
+	): vscode.ProviderResult<ResolvedMarkdownCodeBlockEditor>;
+}
+
+interface ResolvedMarkdownCodeBlockEditor {
+	readonly content:
+		| { readonly html: string }
+		| { readonly uri: vscode.Uri };
+	readonly contentType?: 'text' | 'json';
+	readonly initialHeight?: number;
+	readonly sandbox?: {
+		readonly forms?: boolean;
+		readonly downloads?: boolean;
+		readonly pointerLock?: boolean;
+		readonly clipboardWrite?: boolean;
+	};
+}
+
+interface ExtensionApi {
+	readonly markdownCodeBlockEditors: {
+		readonly apiV1: MarkdownCodeBlockEditorApiV1;
+	};
+}
+```
+
+Return this API from activation:
+
+```ts
+export function activate(context: vscode.ExtensionContext): ExtensionApi {
+	const diagramProvider = createDiagramProvider(context);
+
+	return {
+		markdownCodeBlockEditors: {
+			apiV1: {
+				getProvider: providerId =>
+					providerId === 'diagram' ? diagramProvider : undefined,
+			},
+		},
+	};
+}
+```
+
+The ID passed to `getProvider` is the manifest contribution's `id`, not the
+fully qualified extension ID.
+
+### Resolve an editor
+
+The provider may return HTML directly or a URI for a UTF-8 HTML file inside the
+extension or workspace:
+
+```ts
+function createDiagramProvider(
+	context: vscode.ExtensionContext,
+): MarkdownCodeBlockEditorProvider {
+	const onDidChange = new vscode.EventEmitter<void>();
+	context.subscriptions.push(onDidChange);
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
+		if (event.affectsConfiguration('example.diagram')) {
+			onDidChange.fire();
+		}
+	}));
+
+	return {
+		onDidChange: onDidChange.event,
+
+		async resolve(request, token) {
+			const html = await createEditorHtml({
+				documentUri: request.documentUri,
+				infoString: request.infoString,
+			});
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+
+			return {
+				content: { html },
+				contentType: 'json',
+				initialHeight: 360,
+			};
+		},
+	};
+}
+```
+
+The Markdown editor caches a successful resolution by provider, document URI,
+and complete info string. Fire `onDidChange` whenever a setting or external
+resource can change a previously resolved descriptor. This drops the cached
+resolutions and recreates mounted editors. The provider does not construct or
+manage cache keys.
+
+Check the cancellation token after every asynchronous operation. Resolution is
+also subject to a host timeout.
+
+`contentType`, `initialHeight`, and `sandbox` in the resolved value override the
+manifest defaults. Requested sandbox capabilities are intersected with the
+manifest declaration, so the resolved value cannot acquire permissions that
+the extension did not declare.
+
+## Build the browser guest
+
+Install `@vscode/web-editors` in the extension and build a separate browser
+entrypoint. The guest connects to its parent iframe host:
+
+```ts
+import { WebEditorClient } from '@vscode/web-editors';
+
+async function main(): Promise<void> {
+	const input = document.querySelector<HTMLTextAreaElement>('#value');
+	if (!input) {
+		throw new Error('Missing editor input');
+	}
+
+	const client = await WebEditorClient.connect({
+		connection: 'windowParent',
+		contentType: 'text',
+	});
+
+	let renderedText = asText(client.getContent());
+	let readOnly = client.getReadOnly();
+	input.value = renderedText;
+	input.disabled = readOnly;
+
+	const contentSubscription = client.onDidChangeContent(({ content }) => {
+		const text = asText(content);
+		if (text === renderedText) {
+			return;
+		}
+		renderedText = text;
+		input.value = text;
+	});
+
+	const readOnlySubscription = client.onDidChangeReadOnly(event => {
+		readOnly = event.readOnly;
+		input.disabled = readOnly;
+	});
+
+	input.addEventListener('input', () => {
+		if (readOnly) {
+			return;
+		}
+		renderedText = input.value;
+		client.applyEdits([{
+			kind: 'replace',
+			path: [],
+			newValue: renderedText,
+		}]);
+	});
+
+	const reportSize = () => client.reportSize(
+		document.documentElement.scrollHeight,
+	);
+	const resizeObserver = new ResizeObserver(reportSize);
+	resizeObserver.observe(document.documentElement);
+	reportSize();
+
+	window.addEventListener('pagehide', () => {
+		resizeObserver.disconnect();
+		contentSubscription.dispose();
+		readOnlySubscription.dispose();
+		client.dispose();
+	}, { once: true });
+}
+
+function asText(content: unknown): string {
+	return typeof content === 'string' ? content : '';
+}
+
+void main().catch(error => {
+	document.body.textContent = error instanceof Error ? error.message : String(error);
+});
+```
+
+For `contentType: "text"`, content and whole-document replacement values are
+strings. For `contentType: "json"`, the client receives parsed JSON values and
+replacement values must also be JSON values.
+
+`applyEdits` updates the client's local content synchronously and forwards the
+edit to the host. The host broadcasts canonical content back through
+`onDidChangeContent`. Ignore identical self-echoes so a focused input is not
+rebuilt and does not lose its caret or selection.
+
+Read the initial read-only state with `getReadOnly()` and subscribe to
+`onDidChangeReadOnly`. Disable every mutation path while read-only, including
+keyboard shortcuts and messages from nested applications.
+
+Call `reportSize` after the initial render and when the desired height changes.
+The Markdown editor uses this value to size the iframe and preserve its layout
+while virtualizing editors.
+
+Dispose the `WebEditorClient`, event subscriptions, observers, and application
+resources when the iframe unloads.
+
+## Bundle self-contained HTML
+
+The guest runs in a browser, not the extension host. Build it with a browser
+target and include it in the packaged extension.
+
+When the dynamic provider embeds a JavaScript bundle into generated HTML, emit
+one bundle chunk and escape closing script tags:
+
+```ts
+function createEditorHtml(bundle: string): string {
+	const safeBundle = bundle.replace(/<\/script/gi, '<\\/script');
+	return `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<style>
+		html, body { margin: 0; }
+		body {
+			background: var(--vscode-editor-background);
+			color: var(--vscode-foreground);
+			font-family: var(--vscode-font-family);
+		}
+	</style>
+</head>
+<body>
+	<textarea id="value"></textarea>
+	<script>${safeBundle}</script>
+</body>
+</html>`;
+}
+```
+
+VS Code theme variables are made available to the guest. Use them instead of
+hard-coded colors.
+
+## Security and nested applications
+
+- Request only the sandbox capabilities the editor needs.
+- Treat the code block content and info string as untrusted input.
+- Escape values inserted into generated HTML.
+- Validate `message` event sources and origins when embedding another iframe.
+- Add explicit connection and initialization error states instead of leaving a
+  permanent loading indicator.
+- Do not depend on same-origin storage or access to the parent document.
+
+## Compatibility
+
+The `apiVersion` is the major version of the extension export contract.
+Backward-compatible additions to V1 are optional. Breaking changes use a
+sibling export such as `apiV2`; an extension may expose multiple versions at
+the same time.

--- a/extensions/markdown-language-features/markdown-editor-src/editor.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/editor.ts
@@ -406,11 +406,11 @@ class Editor extends Disposable {
 			selector: definition.selector,
 			resolve: definition.source.kind === 'static'
 				? async () => definition.source.kind === 'static' ? definition.source.descriptor : undefined
-				: language => this.#resolveCodeBlockEditor(definition.id, language),
+				: infoString => this.#resolveCodeBlockEditor(definition.id, infoString),
 		}));
 	}
 
-	#resolveCodeBlockEditor(providerId: string, language: string): Promise<ResolvedIframeEmbeddedEditor | undefined> {
+	#resolveCodeBlockEditor(providerId: string, infoString: string): Promise<ResolvedIframeEmbeddedEditor | undefined> {
 		const requestId = this.#nextCodeBlockEditorRequestId++;
 		return new Promise(resolve => {
 			this.#codeBlockEditorRequests.set(requestId, resolve);
@@ -418,7 +418,7 @@ class Editor extends Disposable {
 				type: 'resolveCodeBlockEditor',
 				requestId,
 				providerId,
-				language,
+				infoString,
 			});
 		});
 	}
@@ -525,7 +525,6 @@ function readResolvedCodeBlockEditor(value: unknown): ResolvedIframeEmbeddedEdit
 	if (
 		typeof descriptor.html !== 'string'
 		|| (descriptor.contentType !== 'text' && descriptor.contentType !== 'json')
-		|| (descriptor.cacheKey !== undefined && typeof descriptor.cacheKey !== 'string')
 		|| (descriptor.initialHeight !== undefined && (typeof descriptor.initialHeight !== 'number' || !Number.isFinite(descriptor.initialHeight) || descriptor.initialHeight <= 0))
 		|| !isResolvedSandbox(descriptor.sandbox)
 	) {

--- a/extensions/markdown-language-features/schemas/package.schema.json
+++ b/extensions/markdown-language-features/schemas/package.schema.json
@@ -110,7 +110,7 @@
 												"language": {
 													"type": "string",
 													"minLength": 1,
-													"description": "Exact fenced code block info string handled by this provider"
+													"description": "Exact fenced code block language handled by this provider"
 												}
 											}
 										},
@@ -122,7 +122,7 @@
 												"languagePrefix": {
 													"type": "string",
 													"minLength": 1,
-													"description": "Fenced code block info string prefix handled by this provider"
+													"description": "Fenced code block language prefix handled by this provider"
 												}
 											}
 										}

--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { Disposable } from '../util/dispose';
+import { Disposable, disposeAll } from '../util/dispose';
 import { MdLinkOpener } from '../util/openDocumentLink';
 import { getMarkdownLocalResourceRoots } from '../util/resources';
 import { ChangedLineRange, MarkdownPreviewLineDiffProvider } from './lineDiff';
@@ -25,7 +25,6 @@ interface CodeBlockEditorProviderDefinition {
 }
 
 interface ResolvedCodeBlockEditor {
-	readonly cacheKey?: string;
 	readonly html: string;
 	readonly contentType: 'text' | 'json';
 	readonly initialHeight?: number;
@@ -37,10 +36,11 @@ export interface MarkdownCodeBlockEditorApiV1 {
 }
 
 interface MarkdownCodeBlockEditorProviderApi {
+	readonly onDidChange: vscode.Event<void>;
 	resolve(
 		request: {
 			readonly providerId: string;
-			readonly language: string;
+			readonly infoString: string;
 			readonly documentUri: vscode.Uri;
 		},
 		token: vscode.CancellationToken,
@@ -52,7 +52,6 @@ interface ProviderResolvedCodeBlockEditor {
 	| { readonly html: string; readonly uri?: undefined }
 	| { readonly html?: undefined; readonly uri: vscode.Uri };
 	readonly contentType?: 'text' | 'json';
-	readonly cacheKey?: string;
 	readonly initialHeight?: number;
 	readonly sandbox?: MarkdownCodeBlockEditorSandbox;
 }
@@ -101,8 +100,11 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 	readonly #webviewPanels = new Map<vscode.WebviewPanel, AuthenticatedWebview>();
 	readonly #focusedWebviewPanels = new Set<vscode.WebviewPanel>();
 	readonly #providerApis = new Map<string, Promise<MarkdownCodeBlockEditorProviderApi | undefined>>();
+	readonly #providerApiSubscriptions = new Map<string, vscode.Disposable>();
 	readonly #resolvedCodeBlockEditors = new Map<string, Promise<ResolvedCodeBlockEditor | undefined>>();
 	readonly #resolvedCodeBlockEditorResources = new Set<string>();
+	readonly #onDidChangeCodeBlockEditorProvider = this._register(new vscode.EventEmitter<void>());
+	#codeBlockEditorResolutionGeneration = 0;
 
 	constructor(
 		extensionUri: vscode.Uri,
@@ -121,6 +123,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		this._register(new vscode.Disposable(() => {
 			void vscode.commands.executeCommand('setContext', 'markdownEditorFocus', false);
 		}));
+		this._register(new vscode.Disposable(() => this.#clearCodeBlockEditorCaches()));
 	}
 
 	public async resolveCustomTextEditor(
@@ -226,8 +229,8 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 					const provider = typeof message.providerId === 'string'
 						? this.#contributions.contributions.codeBlockEditorProviders.find(candidate => candidate.id === message.providerId)
 						: undefined;
-					const descriptor = provider && typeof message.language === 'string'
-						? await this.#resolveCodeBlockEditor(provider, document.uri, message.language)
+					const descriptor = provider && typeof message.infoString === 'string'
+						? await this.#resolveCodeBlockEditor(provider, document.uri, message.infoString)
 						: undefined;
 					if (resolveCancellation.token.isCancellationRequested) {
 						break;
@@ -322,14 +325,8 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			webviewReady = false;
 			this.#configureWebview(document, editorWebview);
 		});
-		const refreshCodeBlockEditorProviders = async (clearProviderApis: boolean, force: boolean): Promise<void> => {
+		const reloadCodeBlockEditorProviders = async (force: boolean): Promise<void> => {
 			const update = ++contributionUpdate;
-			if (clearProviderApis) {
-				this.#clearCodeBlockEditorCaches();
-			} else {
-				this.#resolvedCodeBlockEditors.clear();
-				this.#resolvedCodeBlockEditorResources.clear();
-			}
 			const updatedCodeBlockEditorProviders = await this.#loadCodeBlockEditorProviders();
 			if (
 				update !== contributionUpdate
@@ -341,7 +338,11 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			await postCodeBlockEditorProviders();
 		};
 		const onContributionsChanged = this.#contributions.onContributionsChanged(() => {
-			void refreshCodeBlockEditorProviders(true, false);
+			this.#clearCodeBlockEditorCaches();
+			void reloadCodeBlockEditorProviders(false);
+		});
+		const onDidChangeCodeBlockEditorProvider = this.#onDidChangeCodeBlockEditorProvider.event(() => {
+			void reloadCodeBlockEditorProviders(true);
 		});
 		const invalidateResourceCache = (resources: readonly vscode.Uri[]): void => {
 			const resourceKeys = resources.map(resource => resource.toString());
@@ -349,7 +350,8 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			const staticResourceChanged = this.#contributions.contributions.codeBlockEditorProviders.some(provider =>
 				provider.source.kind === 'static' && resourceKeys.includes(provider.source.resource.toString()));
 			if (dynamicResourceChanged || staticResourceChanged) {
-				void refreshCodeBlockEditorProviders(false, dynamicResourceChanged);
+				this.#clearResolvedCodeBlockEditorCaches();
+				void reloadCodeBlockEditorProviders(dynamicResourceChanged);
 			}
 		};
 		const onDidSaveTextDocument = vscode.workspace.onDidSaveTextDocument(document => invalidateResourceCache([document.uri]));
@@ -373,6 +375,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			comments.dispose();
 			onDidGrantWorkspaceTrust.dispose();
 			onContributionsChanged.dispose();
+			onDidChangeCodeBlockEditorProvider.dispose();
 			onDidSaveTextDocument.dispose();
 			onDidCreateFiles.dispose();
 			onDidDeleteFiles.dispose();
@@ -435,35 +438,35 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 	async #resolveCodeBlockEditor(
 		contribution: MarkdownCodeBlockEditorProvider,
 		documentUri: vscode.Uri,
-		language: string,
+		infoString: string,
 	): Promise<ResolvedCodeBlockEditor | undefined> {
 		if (contribution.source.kind !== 'exportApi' || !vscode.workspace.isTrusted) {
 			return undefined;
 		}
-		const requestCacheKey = `${contribution.id}\0${documentUri.toString()}\0${language}`;
+		const generation = this.#codeBlockEditorResolutionGeneration;
+		const requestCacheKey = codeBlockEditorResolutionKey(contribution.id, documentUri, infoString);
 		let cached = this.#resolvedCodeBlockEditors.get(requestCacheKey);
 		if (!cached) {
-			cached = this.#doResolveCodeBlockEditor(contribution, documentUri, language);
+			cached = this.#doResolveCodeBlockEditor(contribution, documentUri, infoString);
 			this.#resolvedCodeBlockEditors.set(requestCacheKey, cached);
 			cached.then(result => {
 				if (!result) {
 					if (this.#resolvedCodeBlockEditors.get(requestCacheKey) === cached) {
 						this.#resolvedCodeBlockEditors.delete(requestCacheKey);
 					}
-				} else if (result.cacheKey) {
-					this.#resolvedCodeBlockEditors.set(`${contribution.id}\0${result.cacheKey}`, Promise.resolve(result));
 				}
 			}, () => {
 				this.#resolvedCodeBlockEditors.delete(requestCacheKey);
 			});
 		}
-		return cached;
+		const result = await cached;
+		return generation === this.#codeBlockEditorResolutionGeneration ? result : undefined;
 	}
 
 	async #doResolveCodeBlockEditor(
 		contribution: MarkdownCodeBlockEditorProvider,
 		documentUri: vscode.Uri,
-		language: string,
+		infoString: string,
 	): Promise<ResolvedCodeBlockEditor | undefined> {
 		const cancellation = new vscode.CancellationTokenSource();
 		let timedOut = false;
@@ -483,7 +486,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 				}
 				const value = await provider.resolve({
 					providerId: contribution.providerId,
-					language,
+					infoString,
 					documentUri,
 				}, cancellation.token);
 				if (!value || cancellation.token.isCancellationRequested) {
@@ -496,12 +499,12 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			};
 			const result = await Promise.race([operation(), cancelled]);
 			if (timedOut) {
-				this.#logger.trace('Markdown code block editor', `Provider ${contribution.id} timed out resolving ${language}`);
+				this.#logger.trace('Markdown code block editor', `Provider ${contribution.id} timed out resolving ${infoString}`);
 				return undefined;
 			}
 			return result;
 		} catch (error) {
-			this.#logger.trace('Markdown code block editor', `Provider ${contribution.id} failed to resolve ${language}`, error);
+			this.#logger.trace('Markdown code block editor', `Provider ${contribution.id} failed to resolve ${infoString}`, error);
 			return undefined;
 		} finally {
 			clearTimeout(timeout);
@@ -514,9 +517,9 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		if (contribution.source.kind !== 'exportApi' || !isSupportedMarkdownCodeBlockEditorApiVersion(contribution.source.apiVersion)) {
 			return undefined;
 		}
-		let cached = this.#providerApis.get(contribution.id);
-		if (!cached) {
-			cached = (async () => {
+		let providerPromise = this.#providerApis.get(contribution.id);
+		if (!providerPromise) {
+			providerPromise = (async () => {
 				const exports = await contribution.extension.activate();
 				const api = getMarkdownCodeBlockEditorApiV1(exports);
 				if (!api) {
@@ -528,11 +531,21 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 					this.#logger.trace('Markdown code block editor', `Extension ${contribution.extension.id} did not return provider ${contribution.providerId}`);
 					return undefined;
 				}
+				const subscription = provider.onDidChange(() => {
+					this.#clearResolvedCodeBlockEditorCaches();
+					this.#onDidChangeCodeBlockEditorProvider.fire();
+				});
+				if (this.#providerApis.get(contribution.id) !== providerPromise) {
+					subscription.dispose();
+					return provider;
+				}
+				this.#providerApiSubscriptions.get(contribution.id)?.dispose();
+				this.#providerApiSubscriptions.set(contribution.id, subscription);
 				return provider;
 			})();
-			this.#providerApis.set(contribution.id, cached);
+			this.#providerApis.set(contribution.id, providerPromise);
 		}
-		return cached;
+		return providerPromise;
 	}
 
 	async #readResolvedCodeBlockEditor(
@@ -555,7 +568,6 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			html = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
 		}
 		return {
-			cacheKey: value.cacheKey,
 			html,
 			contentType: value.contentType ?? contribution.contentType,
 			initialHeight: value.initialHeight ?? contribution.initialHeight,
@@ -564,7 +576,14 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 	}
 
 	#clearCodeBlockEditorCaches(): void {
+		disposeAll(this.#providerApiSubscriptions.values());
+		this.#providerApiSubscriptions.clear();
 		this.#providerApis.clear();
+		this.#clearResolvedCodeBlockEditorCaches();
+	}
+
+	#clearResolvedCodeBlockEditorCaches(): void {
+		this.#codeBlockEditorResolutionGeneration++;
 		this.#resolvedCodeBlockEditors.clear();
 		this.#resolvedCodeBlockEditorResources.clear();
 	}
@@ -769,14 +788,17 @@ function codeBlockEditorDefinitionsEqual(
 }
 
 function resolvedCodeBlockEditorsEqual(a: ResolvedCodeBlockEditor, b: ResolvedCodeBlockEditor): boolean {
-	return a.cacheKey === b.cacheKey
-		&& a.html === b.html
+	return a.html === b.html
 		&& a.contentType === b.contentType
 		&& a.initialHeight === b.initialHeight
 		&& a.sandbox?.forms === b.sandbox?.forms
 		&& a.sandbox?.downloads === b.sandbox?.downloads
 		&& a.sandbox?.pointerLock === b.sandbox?.pointerLock
 		&& a.sandbox?.clipboardWrite === b.sandbox?.clipboardWrite;
+}
+
+function codeBlockEditorResolutionKey(providerId: string, documentUri: vscode.Uri, infoString: string): string {
+	return `${providerId}\0${documentUri.toString()}\0${infoString}`;
 }
 
 export function getMarkdownCodeBlockEditorApiV1(value: unknown): MarkdownCodeBlockEditorApiV1 | undefined {
@@ -804,6 +826,7 @@ function isMarkdownCodeBlockEditorApiV1(value: unknown): value is MarkdownCodeBl
 function isMarkdownCodeBlockEditorProviderApi(value: unknown): value is MarkdownCodeBlockEditorProviderApi {
 	return typeof value === 'object'
 		&& value !== null
+		&& typeof (value as Record<string, unknown>).onDidChange === 'function'
 		&& typeof (value as Record<string, unknown>).resolve === 'function';
 }
 
@@ -814,7 +837,6 @@ function isProviderResolvedCodeBlockEditor(value: unknown): value is ProviderRes
 	const descriptor = value as Record<string, unknown>;
 	if (
 		(descriptor.contentType !== undefined && descriptor.contentType !== 'text' && descriptor.contentType !== 'json')
-		|| (descriptor.cacheKey !== undefined && typeof descriptor.cacheKey !== 'string')
 		|| (descriptor.initialHeight !== undefined && (!Number.isFinite(descriptor.initialHeight) || (descriptor.initialHeight as number) <= 0))
 		|| !isSandbox(descriptor.sandbox)
 		|| !descriptor.content


### PR DESCRIPTION
## Summary

- remove provider-defined descriptor cache keys and cache resolutions by provider, Markdown document URI, and complete fenced-code info string
- add a required `onDidChange` event so dynamic providers can invalidate resolved descriptors when settings or resources change
- rename the resolver request field from `language` to `infoString`
- add an extension authoring guide covering static and dynamic contributions, API V1, invalidation, self-contained browser bundles, and `@vscode/web-editors`

## Dependency

Depends on microsoft/vscode-packages#231, which preserves the complete fenced info string separately from the language token and passes it to embedded editor providers. The Markdown editor dependency must be updated after that package change is published.

## Testing

Not run per request. `git diff --check` passes in both repositories.