### PR TITLE
agentHost: harden test and summarize parallel E2E failures

### DIFF
--- a/scripts/test-agent-host-e2e.ts
+++ b/scripts/test-agent-host-e2e.ts
@@ -32,6 +32,7 @@ interface IRunResult {
 	readonly succeeded: boolean;
 	readonly durationSeconds: number;
 	readonly failure?: string;
+	readonly failureDetails?: string;
 }
 
 interface IObservedSurface {
@@ -93,6 +94,7 @@ async function main(): Promise<void> {
 		console.log(`  ${result.succeeded ? 'PASS' : 'FAIL'} ${result.suite.label}: ${result.durationSeconds.toFixed(1)}s`);
 	}
 	if (failures.length > 0) {
+		printFailureDetails(failures);
 		process.exitCode = 1;
 	}
 }
@@ -205,6 +207,7 @@ async function runSuite(suite: ISuite, forwardedArgs: readonly string[], surface
 				succeeded: false,
 				durationSeconds: elapsedSeconds(startedAt),
 				failure: error.message,
+				failureDetails: extractFailureDetails(output),
 			});
 		});
 		child.on('close', (code, signal) => {
@@ -220,14 +223,34 @@ async function runSuite(suite: ISuite, forwardedArgs: readonly string[], surface
 				succeeded,
 				durationSeconds: elapsedSeconds(startedAt),
 				failure,
+				failureDetails: succeeded ? undefined : extractFailureDetails(output),
 			});
 		});
-	}).then(result => {
-		if (result.failure) {
-			console.error(`Agent Host E2E — ${suite.label} failed with ${result.failure}`);
-		}
-		return result;
 	});
+}
+
+function extractFailureDetails(output: string): string | undefined {
+	const lines = output.split(/\r?\n/);
+	for (let index = lines.length - 1; index >= 0; index--) {
+		const line = lines[index].replace(/\x1b\[[0-9;]*m/g, '').trim();
+		if (/^\d+ failing$/.test(line)) {
+			return `${lines.slice(index).join('\n').trimEnd()}\n`;
+		}
+	}
+
+	const trimmed = output.trim();
+	return trimmed.length > 0 ? `${trimmed}\n` : undefined;
+}
+
+function printFailureDetails(failures: readonly IRunResult[]): void {
+	console.log('\nAgent Host E2E failure details:');
+	for (const result of failures) {
+		console.log(`\n===== Agent Host E2E — ${result.suite.label} failure =====`);
+		if (result.failureDetails) {
+			process.stdout.write(result.failureDetails);
+		}
+		console.log(`Agent Host E2E — ${result.suite.label} failed with ${result.failure ?? 'an unknown error'}`);
+	}
 }
 
 function suiteArguments(args: readonly string[], suite: ISuite): readonly string[] {

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -198,7 +198,7 @@ npm run test-agent-host-e2e -- --jobs 2
 ./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
 ```
 
-The complete-suite runner starts one test process per entrypoint and runs up to four concurrently. `AGENT_HOST_E2E_JOBS` or `--jobs` can lower the worker count. Recording and snapshot-update modes remain per-provider commands so they never make concurrent writes or real CAPI requests.
+The complete-suite runner starts one test process per entrypoint and runs up to four concurrently. `AGENT_HOST_E2E_JOBS` or `--jobs` can lower the worker count. Each process's output is printed as one block when it completes, and any Mocha failure details are repeated after the final suite summary so failures remain easy to find. Recording and snapshot-update modes remain per-provider commands so they never make concurrent writes or real CAPI requests.
 
 Provider availability:
 

--- a/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
@@ -820,10 +820,12 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 		const branchChangeset = buildBranchChangesetUri(sessionUri);
 		const uncommittedChangeset = buildUncommittedChangesetUri(sessionUri);
 		await context.client.call<SubscribeResult>('subscribe', { channel: branchChangeset });
-		await context.client.call<SubscribeResult>('subscribe', { channel: uncommittedChangeset });
+		const subscribed = await context.client.call<SubscribeResult>('subscribe', { channel: uncommittedChangeset });
+		const initialOperations = ((subscribed.snapshot!.state as { operations?: readonly IObservedOperation[] }).operations ?? []);
 		await runBangTurn(sessionUri, 'turn-changeset-discard-last', writeFileCommand('seed.txt', 'edited'), 1);
 		await waitForChangesetFiles(branchChangeset, ['seed.txt']);
 		const [file] = await waitForChangesetFiles(uncommittedChangeset, ['seed.txt']);
+		await waitForIdleResourceOnlyOperation(uncommittedChangeset, 'discard-changes', initialOperations);
 
 		await invokeDiscard(uncommittedChangeset, fileUri(file));
 		await retry(async () => {


### PR DESCRIPTION
## Summary

- repeat each failed Mocha block after the parallel Agent Host E2E suite summary
- retain full captured output as a fallback for non-Mocha process failures
- fix the Conformance race from [Azure build 462435](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462435) by waiting for `discard-changes` to be advertised before invoking it

## Validation

- `npm run compile`
- `npm run hygiene`
- focused Conformance regression test
- controlled failing parallel run verified the final failure summary
- full four-worker Agent Host E2E replay

(Written by Copilot)