### PR TITLE
Add new exp TAS assignments endpoint (/api/v1/assignments) alongside legacy TAS

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -54,7 +54,7 @@
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.1",
         "undici": "^7.24.1",
-        "vscode-tas-client": "^0.1.84",
+        "vscode-tas-client": "^0.3.0",
         "web-tree-sitter": "^0.23.0"
       },
       "devDependencies": {
@@ -16327,9 +16327,13 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
-      "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.2.tgz",
+      "integrity": "sha512-6I+52uvsOdqgPsyvlXSz+KtydfnnLngTnMeVnoXgEYMIFxqRT6tWX2IdH/O5JocF4Z0JZDB3ejTLbJMSb6pEdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/teex": {
       "version": "1.0.1",
@@ -17127,11 +17131,12 @@
       "dev": true
     },
     "node_modules/vscode-tas-client": {
-      "version": "0.1.84",
-      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
-      "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.3.0.tgz",
+      "integrity": "sha512-69e8Ek86+LwfNp9oh6b7xEnM9M15IX8W+ZhHo2/tCbbnB/TOPK3aDle3iOZa8aeBoGKeaStUkSKaloIvIkmNXg==",
+      "license": "MIT",
       "dependencies": {
-        "tas-client": "0.2.33"
+        "tas-client": "^0.4.2"
       },
       "engines": {
         "vscode": "^1.85.0"

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -7304,7 +7304,7 @@
     "markdown-it": "^14.2.0",
     "minimatch": "^10.2.1",
     "undici": "^7.24.1",
-    "vscode-tas-client": "^0.1.84",
+    "vscode-tas-client": "^0.3.0",
     "web-tree-sitter": "^0.23.0"
   },
   "overrides": {

--- a/extensions/copilot/src/platform/authentication/common/copilotToken.ts
+++ b/extensions/copilot/src/platform/authentication/common/copilotToken.ts
@@ -322,6 +322,7 @@ export interface Endpoints {
 	'origin-tracker'?: string;
 	proxy?: string;
 	telemetry?: string;
+	exp?: string;
 }
 
 //#endregion
@@ -431,6 +432,7 @@ const tokenEnvelopeValidator = vObj({
 		'origin-tracker': vString(),
 		proxy: vString(),
 		telemetry: vString(),
+		exp: vString(),
 	}),
 	enterprise_list: vNullable(vArray(vNumber())),
 	limited_user_quotas: vNullable(vObj({

--- a/extensions/copilot/src/platform/telemetry/common/baseTelemetryService.ts
+++ b/extensions/copilot/src/platform/telemetry/common/baseTelemetryService.ts
@@ -163,6 +163,19 @@ export class BaseTelemetryService implements ITelemetryService {
 				"errortype": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth"}
 			}
 		*/
+		/* __GDPR__
+			"assignments-validation" : {
+				"FeatureVariableCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"AssignedVariantCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"DataVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"AssignmentContext": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+			}
+		*/
+		/* __GDPR__
+			"call-assignments-error" : {
+				"ErrorType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth"}
+			}
+		*/
 		if (name === 'abexp.assignmentcontext') {
 			this._setOriginalExpAssignments(value);
 			return;

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -124,8 +124,11 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	private readonly _refreshTimer = this._register(new IntervalTimer());
 	private readonly _previouslyReadTreatments = new Map<string, boolean | string | number | undefined>();
 
-	protected readonly _delegate: ITASExperimentationService;
+	protected _delegate: ITASExperimentationService;
 	protected readonly _userInfoStore: UserInfoStore;
+
+	private readonly _delegateFn: TASClientDelegateFn;
+	private readonly _globalState: vscode.Memento;
 
 	protected _onDidTreatmentsChange = this._register(new Emitter<TreatmentsChangeEvent>());
 	readonly onDidTreatmentsChange = this._onDidTreatmentsChange.event;
@@ -155,10 +158,26 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 			this._signalTreatmentsChangeEvent();
 		}, 60 * 60 * 1000);
 
-		this._delegate = delegateFn(context.globalState, this._userInfoStore);
-		this._delegate.initialFetch.then(() => {
+		this._delegateFn = delegateFn;
+		this._globalState = context.globalState;
+		this._delegate = this._createDelegate();
+	}
+
+	private _createDelegate(): ITASExperimentationService {
+		const delegate = this._delegateFn(this._globalState, this._userInfoStore);
+		delegate.initialFetch.then(() => {
 			this._logService.trace(`[BaseExperimentationService] Initial fetch completed`);
 		});
+		return delegate;
+	}
+
+	/**
+	 * Disposes the current delegate (stopping its polling) and creates a fresh one. Used
+	 * when inputs captured at delegate-creation time (e.g. the assignments endpoint) change.
+	 */
+	protected recreateDelegate(): void {
+		(this._delegate as unknown as { dispose?(): void }).dispose?.();
+		this._delegate = this._createDelegate();
 	}
 
 	private _signalTreatmentsChangeEvent = () => {

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -8,7 +8,7 @@ import type { IExperimentationService as ITASExperimentationService } from 'vsco
 import { equals } from '../../../util/vs/base/common/arrays';
 import { IntervalTimer } from '../../../util/vs/base/common/async';
 import { Emitter } from '../../../util/vs/base/common/event';
-import { Disposable } from '../../../util/vs/base/common/lifecycle';
+import { Disposable, MutableDisposable, toDisposable } from '../../../util/vs/base/common/lifecycle';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { IConfigurationService } from '../../configuration/common/configurationService';
 import { IVSCodeExtensionContext } from '../../extContext/common/extensionContext';
@@ -127,6 +127,9 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	protected _delegate: ITASExperimentationService;
 	protected readonly _userInfoStore: UserInfoStore;
 
+	/** Disposes the current delegate (stopping its polling); auto-disposes the previous one on replacement. */
+	private readonly _delegateDisposable = this._register(new MutableDisposable());
+
 	private readonly _delegateFn: TASClientDelegateFn;
 	private readonly _globalState: vscode.Memento;
 
@@ -165,6 +168,7 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 
 	private _createDelegate(): ITASExperimentationService {
 		const delegate = this._delegateFn(this._globalState, this._userInfoStore);
+		this._delegateDisposable.value = toDisposable(() => (delegate as unknown as { dispose?(): void }).dispose?.());
 		delegate.initialFetch.then(() => {
 			this._logService.trace(`[BaseExperimentationService] Initial fetch completed`);
 		});
@@ -172,11 +176,10 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	}
 
 	/**
-	 * Disposes the current delegate (stopping its polling) and creates a fresh one. Used
+	 * Creates a fresh delegate, disposing the previous one (stopping its polling). Used
 	 * when inputs captured at delegate-creation time (e.g. the assignments endpoint) change.
 	 */
 	protected recreateDelegate(): void {
-		(this._delegate as unknown as { dispose?(): void }).dispose?.();
 		this._delegate = this._createDelegate();
 	}
 

--- a/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
+++ b/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
@@ -127,6 +127,8 @@ class MockTASExperimentationService implements ITASExperimentationService {
 		this.refreshCallCount = 0;
 		this.treatmentRequests = [];
 	}
+
+	dispose(): void { }
 }
 
 describe('ExP Service Tests', () => {

--- a/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
@@ -5,7 +5,7 @@
 
 import path from 'path';
 import * as vscode from 'vscode';
-import { getExperimentationService, IExperimentationFilterProvider, TargetPopulation } from 'vscode-tas-client';
+import { getExperimentationServiceFromConfig, IExperimentationFilterProvider, TargetPopulation } from 'vscode-tas-client';
 import { platform, PlatformToString } from '../../../util/vs/base/common/platform';
 import { isObject } from '../../../util/vs/base/common/types';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
@@ -29,6 +29,34 @@ function getTargetPopulation(isPreRelease: boolean): TargetPopulation {
 
 function trimVersionSuffix(version: string): string {
 	return version.split('-')[0];
+}
+
+/**
+ * Formats an ISO date into the `yyyymmddHH` form the experimentation backend expects
+ * (10 digits, fits within int32). Returns an empty string when unavailable.
+ */
+function formatReleaseDate(iso: string): string {
+	if (!iso) {
+		return '';
+	}
+	const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2})/.exec(iso);
+	if (!match) {
+		return '';
+	}
+	return match.slice(1, 5).join('');
+}
+
+/**
+ * Reads and formats the product release date from `product.json`, or `undefined` on failure.
+ */
+function readReleaseDate(logService: ILogService, tag: string): string | undefined {
+	try {
+		const product = require(path.join(vscode.env.appRoot, 'product.json'));
+		return formatReleaseDate(product.date ?? '');
+	} catch (error) {
+		logService.warn(`${tag} Failed to read product.json for release date: ${error}`);
+		return undefined;
+	}
 }
 
 const CopilotRelatedPluginVersionPrefix = 'X-Copilot-RelatedPluginVersion-';
@@ -159,28 +187,7 @@ class PlatformAndReleaseDateFilterProvider implements IExperimentationFilterProv
 	constructor(
 		private _logService: ILogService
 	) {
-		this._releaseDate = this._initReleaseDate();
-	}
-
-	private _initReleaseDate(): string | undefined {
-		try {
-			const product = require(path.join(vscode.env.appRoot, 'product.json'));
-			return this._formatReleaseDate(product.date ?? '');
-		} catch (error) {
-			this._logService.warn(`[PlatformAndReleaseDateFilterProvider]::_initReleaseDate Failed to read product.json for release date: ${error}`);
-			return undefined;
-		}
-	}
-
-	private _formatReleaseDate(iso: string): string {
-		if (!iso) {
-			return '';
-		}
-		const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2})/.exec(iso);
-		if (!match) {
-			return '';
-		}
-		return match.slice(1, 5).join('');
+		this._releaseDate = readReleaseDate(_logService, '[PlatformAndReleaseDateFilterProvider]::readReleaseDate');
 	}
 
 	getFilters(): Map<string, string> {
@@ -215,6 +222,46 @@ class WindowKindFilterProvider implements IExperimentationFilterProvider {
 	}
 }
 
+/**
+ * Emits the Copilot-side filters for the new TAS assignments API (POST /api/v1/assignments)
+ * using the new userParam key names. Reads the Copilot token fresh on each call so refreshed
+ * assignments pick up account changes. The generic `vscode_core_*` app/build/extension/target
+ * filters are added automatically by `vscode-tas-client`.
+ */
+class CopilotAssignmentsFilterProvider implements IExperimentationFilterProvider {
+	private readonly _releaseDate: string | undefined;
+
+	constructor(
+		private readonly _copilotTokenStore: ICopilotTokenStore,
+		private readonly _logService: ILogService
+	) {
+		this._releaseDate = readReleaseDate(_logService, '[CopilotAssignmentsFilterProvider]::readReleaseDate');
+	}
+
+	getFilters(): Map<string, string | undefined> {
+		const token = this._copilotTokenStore.copilotToken;
+		const internalOrg = token
+			? (token.isVscodeTeamMember ? 'vscode' : token.isGitHubInternal ? 'github' : token.isMicrosoftInternal ? 'microsoft' : undefined)
+			: undefined;
+
+		const filters = new Map<string, string | undefined>();
+		filters.set('vscode_core_platform', PlatformToString(platform));
+		if (this._releaseDate) {
+			filters.set('vscode_core_releasedate', this._releaseDate);
+		}
+		filters.set('vscode_core_windowkind', vscode.workspace.isAgentSessionsWorkspace ? 'agents' : 'editor');
+		filters.set('devdeviceid', vscode.env.devDeviceId);
+		filters.set('copilottrackingid', token?.getTokenValue('tid'));
+		filters.set('github_core_organizationid', token?.organizationList.join(','));
+		filters.set('github_core_businessid', token?.enterpriseList.join(','));
+		filters.set('github_core_isghormsftstaff', internalOrg ? '1' : '0');
+		filters.set('github_core_ghmsftorexternal', internalOrg === 'github' ? 'github' : (internalOrg === 'microsoft' || internalOrg === 'vscode') ? 'microsoft' : 'external');
+
+		this._logService.trace(`[CopilotAssignmentsFilterProvider]::getFilters Filters: ${JSON.stringify(Array.from(filters.entries()))}`);
+		return filters;
+	}
+}
+
 export class MicrosoftExperimentationService extends BaseExperimentationService {
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -232,26 +279,54 @@ export class MicrosoftExperimentationService extends BaseExperimentationService 
 		let self: MicrosoftExperimentationService | undefined = undefined;
 		const delegateFn = (globalState: vscode.Memento, userInfoStore: UserInfoStore) => {
 			const wrappedMemento = new ExpMementoWrapper(globalState, envService);
-			return getExperimentationService(
-				id,
-				version,
+			const exp = copilotTokenStore.copilotToken?.endpoints?.exp;
+			const assignmentsEndpoint = exp ? `${exp.replace(/\/+$/, '')}/api/v1/assignments` : undefined;
+			// Route the assignments request through the extension's fetcher service so it gets
+			// proxy handling, retries/fallback, and the standard user-agent for free.
+			const assignmentsFetch = (url: string, init: { method: 'POST'; headers: Record<string, string>; body: string }) =>
+				fetcherService.fetch(url, {
+					method: init.method,
+					headers: init.headers,
+					body: init.body,
+					callSite: 'exp.assignments',
+				});
+			return getExperimentationServiceFromConfig({
+				extensionName: id,
+				extensionVersion: version,
 				targetPopulation,
-				telemetryService,
-				wrappedMemento,
-				new GithubAccountFilterProvider(userInfoStore, logService),
-				new RelatedExtensionsFilterProvider(logService),
-				new CopilotExtensionsFilterProvider(logService),
-				// The callback is called in super ctor. At that time, self/this is not initialized yet (but also, no filter could have been possibly set).
-				new CopilotCompletionsFilterProvider(() => self?.getCompletionsFilters() ?? new Map(), logService),
-				new DevDeviceIdFilterProvider(vscode.env.devDeviceId),
-				new PlatformAndReleaseDateFilterProvider(logService),
-				new WindowKindFilterProvider(logService),
-			);
+				telemetry: telemetryService,
+				memento: wrappedMemento,
+				filterProviders: [
+					new GithubAccountFilterProvider(userInfoStore, logService),
+					new RelatedExtensionsFilterProvider(logService),
+					new CopilotExtensionsFilterProvider(logService),
+					// The callback is called in super ctor. At that time, self/this is not initialized yet (but also, no filter could have been possibly set).
+					new CopilotCompletionsFilterProvider(() => self?.getCompletionsFilters() ?? new Map(), logService),
+					new DevDeviceIdFilterProvider(vscode.env.devDeviceId),
+					new PlatformAndReleaseDateFilterProvider(logService),
+					new WindowKindFilterProvider(logService),
+				],
+				assignmentsEndpoint,
+				assignmentsFilterProviders: assignmentsEndpoint ? [new CopilotAssignmentsFilterProvider(copilotTokenStore, logService)] : undefined,
+				assignmentsFetch: assignmentsEndpoint ? assignmentsFetch : undefined,
+			});
 		};
 
 		super(delegateFn, context, copilotTokenStore, configurationService, logService);
 
 		self = this; // This is now fully initialized.
+
+		// The assignments endpoint is sourced from the Copilot token, which may arrive after
+		// this service is created. Recreate the delegate when its `exp` endpoint changes.
+		let currentExp = copilotTokenStore.copilotToken?.endpoints?.exp;
+		this._register(copilotTokenStore.onDidStoreUpdate(() => {
+			const token = copilotTokenStore.copilotToken;
+			const newExp = token?.endpoints?.exp;
+			if (newExp !== currentExp) {
+				currentExp = newExp;
+				this.recreateDelegate();
+			}
+		}));
 
 		if (fetcherService instanceof FetcherService) {
 			fetcherService.setExperimentationService(this);

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "playwright-core": "1.61.0-alpha-2026-06-04",
         "ssh2": "^1.16.0",
         "tar": "^7.5.20",
-        "tas-client": "0.3.1",
+        "tas-client": "0.4.2",
         "undici": "^7.28.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -18899,9 +18899,9 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.3.1.tgz",
-      "integrity": "sha512-Mn4+4t/KXEf8aIENeI1TkzpKIImzmG+FjPZ2dlaoGNFgxJqBE/pp3MT7nc2032EG4aS73E4OEcr2WiNaWW8mdA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.2.tgz",
+      "integrity": "sha512-6I+52uvsOdqgPsyvlXSz+KtydfnnLngTnMeVnoXgEYMIFxqRT6tWX2IdH/O5JocF4Z0JZDB3ejTLbJMSb6pEdg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "playwright-core": "1.61.0-alpha-2026-06-04",
     "ssh2": "^1.16.0",
     "tar": "^7.5.20",
-    "tas-client": "0.3.1",
+    "tas-client": "0.4.2",
     "undici": "^7.28.0",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -50,7 +50,7 @@
         "node-pty": "^1.2.0-beta.15",
         "ssh2": "^1.16.0",
         "tar": "^7.5.20",
-        "tas-client": "0.3.1",
+        "tas-client": "0.4.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -2015,9 +2015,9 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.3.1.tgz",
-      "integrity": "sha512-Mn4+4t/KXEf8aIENeI1TkzpKIImzmG+FjPZ2dlaoGNFgxJqBE/pp3MT7nc2032EG4aS73E4OEcr2WiNaWW8mdA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.2.tgz",
+      "integrity": "sha512-6I+52uvsOdqgPsyvlXSz+KtydfnnLngTnMeVnoXgEYMIFxqRT6tWX2IdH/O5JocF4Z0JZDB3ejTLbJMSb6pEdg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/remote/package.json
+++ b/remote/package.json
@@ -45,7 +45,7 @@
     "node-pty": "^1.2.0-beta.15",
     "ssh2": "^1.16.0",
     "tar": "^7.5.20",
-    "tas-client": "0.3.1",
+    "tas-client": "0.4.2",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",
     "vscode-textmate": "^9.3.2",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -25,7 +25,7 @@
         "@xterm/xterm": "^6.1.0-beta.291",
         "jschardet": "3.1.4",
         "katex": "^0.16.22",
-        "tas-client": "0.3.1",
+        "tas-client": "0.4.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-textmate": "^9.3.2"
       }
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.3.1.tgz",
-      "integrity": "sha512-Mn4+4t/KXEf8aIENeI1TkzpKIImzmG+FjPZ2dlaoGNFgxJqBE/pp3MT7nc2032EG4aS73E4OEcr2WiNaWW8mdA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.2.tgz",
+      "integrity": "sha512-6I+52uvsOdqgPsyvlXSz+KtydfnnLngTnMeVnoXgEYMIFxqRT6tWX2IdH/O5JocF4Z0JZDB3ejTLbJMSb6pEdg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -20,7 +20,7 @@
     "@xterm/xterm": "^6.1.0-beta.291",
     "jschardet": "3.1.4",
     "katex": "^0.16.22",
-    "tas-client": "0.3.1",
+    "tas-client": "0.4.2",
     "vscode-oniguruma": "1.7.0",
     "vscode-textmate": "^9.3.2"
   }

--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -49,6 +49,7 @@ export interface IEntitlementsData extends ILegacyQuotaSnapshotData {
 		completions?: IQuotaSnapshotData;
 		premium_interactions?: IQuotaSnapshotData;
 	};
+	readonly endpoints?: Record<string, string>;
 }
 
 export interface IPolicyData {

--- a/src/vs/platform/assignment/common/assignment.ts
+++ b/src/vs/platform/assignment/common/assignment.ts
@@ -124,24 +124,10 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 		private windowKind: WindowKind
 	) { }
 
-	/**
-	 * Returns a version string that can be parsed by the TAS client.
-	 * The tas client cannot handle suffixes lke "-insider"
-	 * Ref: https://github.com/microsoft/tas-client/blob/30340d5e1da37c2789049fcf45928b954680606f/vscode-tas-client/src/vscode-tas-client/VSCodeFilterProvider.ts#L35
-	 *
-	 * @param version Version string to be trimmed.
-	*/
-	private static trimVersionSuffix(version: string): string {
-		const regex = /\-[a-zA-Z0-9]+$/;
-		const result = version.split(regex);
-
-		return result[0];
-	}
-
 	getFilterValue(filter: string): string | null {
 		switch (filter) {
 			case Filters.ApplicationVersion:
-				return AssignmentFilterProvider.trimVersionSuffix(this.version); // productService.version
+				return trimVersionSuffix(this.version); // productService.version
 			case Filters.Build:
 				return this.appName; // productService.nameLong
 			case Filters.ClientId:
@@ -159,7 +145,7 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 			case Filters.Platform:
 				return platform.PlatformToString(platform.platform);
 			case Filters.ReleaseDate:
-				return AssignmentFilterProvider.formatReleaseDate(this.releaseDate);
+				return formatReleaseDate(this.releaseDate);
 			case Filters.WindowKind:
 				return this.windowKind;
 			default:
@@ -167,24 +153,98 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 		}
 	}
 
-	private static formatReleaseDate(iso: string): string {
-		// Expect ISO format, fall back to empty string if not provided
-		if (!iso) {
-			return '';
-		}
-		// Remove separators and milliseconds: YYYY-MM-DDTHH:MM:SS.sssZ -> YYYYMMDDHH
-		// Trimmed to 10 digits to fit within int32 bounds (ExP requirement)
-		const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2})/.exec(iso);
-		if (!match) {
-			return '';
-		}
-		return match.slice(1, 5).join('');
-	}
-
 	getFilters(): Map<string, unknown> {
 		const filters: Map<string, unknown> = new Map<string, unknown>();
 		const filterValues = Object.values(Filters);
 		for (const value of filterValues) {
+			filters.set(value, this.getFilterValue(value));
+		}
+
+		return filters;
+	}
+}
+
+/**
+ * Trims a TAS-incompatible version suffix (e.g. `-insider`) so the value can be parsed
+ * into a .NET Build object by the experimentation backend.
+ */
+function trimVersionSuffix(version: string): string {
+	return version.split(/\-[a-zA-Z0-9]+$/)[0];
+}
+
+/**
+ * Formats an ISO release date into the `yyyymmddHH` form the experimentation backend
+ * expects (10 digits, fits within int32). Returns an empty string when unavailable.
+ */
+function formatReleaseDate(iso: string): string {
+	if (!iso) {
+		return '';
+	}
+	const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2})/.exec(iso);
+	if (!match) {
+		return '';
+	}
+	return match.slice(1, 5).join('');
+}
+
+/**
+ * userParam names for the new TAS assignments API (POST /api/v1/assignments), emitted by
+ * {@link VSCodeCoreAssignmentsFilterProvider}. These replace the legacy header keys and
+ * are sent only to the new endpoint.
+ */
+export enum AssignmentsFilters {
+	ApplicationVersion = 'vscode_core_appversion',
+	Build = 'vscode_core_build',
+	DeveloperDeviceId = 'devdeviceid',
+	ExtensionName = 'vscode_core_extensionname',
+	ExtensionNameShort = 'extensionname',
+	TargetPopulation = 'vscode_core_targetpopulation',
+	Platform = 'vscode_core_platform',
+	ReleaseDate = 'vscode_core_releasedate',
+	WindowKind = 'vscode_core_windowkind',
+}
+
+/**
+ * Emits the generic VS Code core filters for the new TAS assignments API using the new
+ * userParam key names, so the assignments endpoint never receives the legacy header keys.
+ */
+export class VSCodeCoreAssignmentsFilterProvider implements IExperimentationFilterProvider {
+	constructor(
+		private version: string,
+		private appName: string,
+		private devDeviceId: string,
+		private targetPopulation: TargetPopulation,
+		private releaseDate: string,
+		private windowKind: WindowKind
+	) { }
+
+	getFilterValue(filter: string): string | null {
+		switch (filter) {
+			case AssignmentsFilters.ApplicationVersion:
+				return trimVersionSuffix(this.version);
+			case AssignmentsFilters.Build:
+				return this.appName;
+			case AssignmentsFilters.DeveloperDeviceId:
+				return this.devDeviceId;
+			case AssignmentsFilters.ExtensionName:
+			case AssignmentsFilters.ExtensionNameShort:
+				return 'vscode-core';
+			case AssignmentsFilters.TargetPopulation:
+				return this.targetPopulation;
+			case AssignmentsFilters.Platform:
+				return platform.PlatformToString(platform.platform);
+			case AssignmentsFilters.ReleaseDate:
+				return formatReleaseDate(this.releaseDate);
+			case AssignmentsFilters.WindowKind:
+				return this.windowKind;
+			default:
+				return null;
+		}
+	}
+
+	getFilters(): Map<string, unknown> {
+		const filters: Map<string, unknown> = new Map<string, unknown>();
+		for (const value of Object.values(AssignmentsFilters)) {
 			filters.set(value, this.getFilterValue(value));
 		}
 

--- a/src/vs/workbench/services/assignment/common/assignmentFilters.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentFilters.ts
@@ -243,3 +243,75 @@ export class CopilotAssignmentFilterProvider extends Disposable implements IExpe
 		return filters;
 	}
 }
+
+/**
+ * userParam names for the new TAS assignments API (POST /api/v1/assignments) that carry
+ * the GitHub account signals available in core. Hex org/business ids are not yet parsed
+ * in core, so they are intentionally omitted here.
+ */
+export enum GitHubAssignmentsFilter {
+	CopilotTrackingId = 'copilottrackingid',
+	IsGhOrMsftStaff = 'github_core_isghormsftstaff',
+	GhMsftOrExternal = 'github_core_ghmsftorexternal',
+}
+
+/**
+ * Emits the core-available GitHub account filters for the new TAS assignments API using
+ * the new userParam key names.
+ */
+export class GitHubCoreAssignmentsFilterProvider extends Disposable implements IExperimentationFilterProvider {
+	private copilotTrackingId: string | undefined;
+	private internalOrg: 'vscode' | 'github' | 'microsoft' | undefined;
+
+	private readonly _onDidChangeFilters = this._register(new Emitter<void>());
+	readonly onDidChangeFilters = this._onDidChangeFilters.event;
+
+	constructor(
+		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
+	) {
+		super();
+
+		this._register(this._chatEntitlementService.onDidChangeEntitlement(() => this.update()));
+		this.update();
+	}
+
+	private update(): void {
+		const newTrackingId = this._chatEntitlementService.copilotTrackingId;
+		const newInternalOrg = getInternalOrg(this._chatEntitlementService.organisations);
+
+		if (this.copilotTrackingId === newTrackingId && this.internalOrg === newInternalOrg) {
+			return;
+		}
+
+		this.copilotTrackingId = newTrackingId;
+		this.internalOrg = newInternalOrg;
+
+		this._onDidChangeFilters.fire();
+	}
+
+	getFilterValue(filter: string): string | null {
+		switch (filter) {
+			case GitHubAssignmentsFilter.CopilotTrackingId:
+				return this.copilotTrackingId ?? null;
+			case GitHubAssignmentsFilter.IsGhOrMsftStaff:
+				return this.internalOrg ? '1' : '0';
+			case GitHubAssignmentsFilter.GhMsftOrExternal:
+				return this.internalOrg === 'github'
+					? 'github'
+					: (this.internalOrg === 'microsoft' || this.internalOrg === 'vscode')
+						? 'microsoft'
+						: 'external';
+			default:
+				return null;
+		}
+	}
+
+	getFilters(): Map<string, string | null> {
+		const filters = new Map<string, string | null>();
+		for (const value of Object.values(GitHubAssignmentsFilter)) {
+			filters.set(value, this.getFilterValue(value));
+		}
+
+		return filters;
+	}
+}

--- a/src/vs/workbench/services/assignment/common/assignmentFilters.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentFilters.ts
@@ -276,7 +276,7 @@ export class GitHubCoreAssignmentsFilterProvider extends Disposable implements I
 	}
 
 	private update(): void {
-		const newTrackingId = this._chatEntitlementService.copilotTrackingId;
+		const newTrackingId = this._chatEntitlementService.copilotTrackingId ?? this.copilotTrackingId;
 		const newInternalOrg = getInternalOrg(this._chatEntitlementService.organisations);
 
 		if (this.copilotTrackingId === newTrackingId && this.internalOrg === newInternalOrg) {
@@ -290,15 +290,24 @@ export class GitHubCoreAssignmentsFilterProvider extends Disposable implements I
 	}
 
 	getFilterValue(filter: string): string | null {
+		// copilotTrackingId is the stable user id (it never changes) but can be unavailable
+		// during sign-in delays. Latch the first known value and fall back to it so the
+		// filter is not dropped from later requests once we have seen it.
+		const liveTrackingId = this._chatEntitlementService.copilotTrackingId;
+		if (liveTrackingId) {
+			this.copilotTrackingId = liveTrackingId;
+		}
+		const copilotTrackingId = liveTrackingId ?? this.copilotTrackingId;
+		const internalOrg = getInternalOrg(this._chatEntitlementService.organisations) ?? this.internalOrg;
 		switch (filter) {
 			case GitHubAssignmentsFilter.CopilotTrackingId:
-				return this.copilotTrackingId ?? null;
+				return copilotTrackingId ?? null;
 			case GitHubAssignmentsFilter.IsGhOrMsftStaff:
-				return this.internalOrg ? '1' : '0';
+				return internalOrg ? '1' : '0';
 			case GitHubAssignmentsFilter.GhMsftOrExternal:
-				return this.internalOrg === 'github'
+				return internalOrg === 'github'
 					? 'github'
-					: (this.internalOrg === 'microsoft' || this.internalOrg === 'vscode')
+					: (internalOrg === 'microsoft' || internalOrg === 'vscode')
 						? 'microsoft'
 						: 'external';
 			default:

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -26,7 +26,7 @@ import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { CopilotAssignmentFilterProvider, GitHubCoreAssignmentsFilterProvider } from './assignmentFilters.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { AssignmentContextFilter } from './assignmentContextFilter.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { experimentsEnabled } from '../../telemetry/common/workbenchTelemetryUtils.js';
 
@@ -194,6 +194,9 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 					this.tasClient = this.setupTASClient();
 				}
 			}));
+
+			// Ensure the final client's auto-polling is stopped when the service is disposed.
+			this._register(toDisposable(() => WorkbenchAssignmentService.disposeTasClient(this.tasClient)));
 		}
 
 		this.contextFilter = this._register(new AssignmentContextFilter(storageService));
@@ -309,6 +312,9 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		// initialFetch cannot flip networkInitialized for a newer client.
 		const generation = ++this.setupGeneration;
 		this.networkInitialized = false;
+
+		// Dispose the previously created client so it stops auto-polling the (legacy) endpoint.
+		WorkbenchAssignmentService.disposeTasClient(this.tasClient);
 
 		const targetPopulation = this.productService.quality === 'stable' ?
 			TargetPopulation.Public : (this.productService.quality === 'exploration' ?
@@ -439,6 +445,11 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 
 	addTelemetryAssignmentFilter(filter: IAssignmentFilter): void {
 		this.contextFilter.addFilter(filter);
+	}
+
+	/** Stops a TAS client's auto-polling once it resolves. Safe to call with `undefined`. */
+	private static disposeTasClient(client: Promise<TASClient> | undefined): void {
+		client?.then(c => (c as unknown as { dispose?(): void }).dispose?.()).catch(() => undefined);
 	}
 }
 

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -5,7 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import type { IKeyValueStorage, IExperimentationTelemetry, ExperimentationService as TASClient } from 'tas-client';
+import type { IKeyValueStorage, IExperimentationTelemetry, IExperimentationFilterProvider, ExperimentationService as TASClient } from 'tas-client';
 import { Memento } from '../../../common/memento.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
@@ -13,15 +13,18 @@ import { ITelemetryData } from '../../../../base/common/actions.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { ASSIGNMENT_REFETCH_INTERVAL, ASSIGNMENT_STORAGE_KEY, AssignmentFilterProvider, IAssignmentService, TargetPopulation, WindowKind } from '../../../../platform/assignment/common/assignment.js';
+import { ASSIGNMENT_REFETCH_INTERVAL, ASSIGNMENT_STORAGE_KEY, AssignmentFilterProvider, IAssignmentService, TargetPopulation, VSCodeCoreAssignmentsFilterProvider, WindowKind } from '../../../../platform/assignment/common/assignment.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
-import { importAMDNodeModule } from '../../../../amdX.js';
+import { resolveAmdNodeModulePath } from '../../../../amdX.js';
+import { asJson, IRequestService } from '../../../../platform/request/common/request.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { timeout } from '../../../../base/common/async.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
-import { CopilotAssignmentFilterProvider } from './assignmentFilters.js';
+import { CopilotAssignmentFilterProvider, GitHubCoreAssignmentsFilterProvider } from './assignmentFilters.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { AssignmentContextFilter } from './assignmentContextFilter.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -123,6 +126,23 @@ class WorkbenchAssignmentServiceTelemetry extends Disposable implements IExperim
 				"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The experimental feature being queried" }
 			}
 		*/
+		/* __GDPR__
+			"assignments-validation" : {
+				"owner": "sbatten",
+				"comment": "Validation data for the new TAS assignments endpoint, compared against the legacy endpoint",
+				"FeatureVariableCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of feature variables returned by the new assignments endpoint" },
+				"AssignedVariantCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Number of assigned variants returned by the new assignments endpoint" },
+				"DataVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Data version returned by the new assignments endpoint" },
+				"AssignmentContext": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Assignment context returned by the new assignments endpoint" }
+			}
+		*/
+		/* __GDPR__
+			"call-assignments-error" : {
+				"owner": "sbatten",
+				"comment": "Logs errors when calling the new TAS assignments endpoint",
+				"ErrorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The type of error encountered when calling the new assignments endpoint" }
+			}
+		*/
 		this.telemetryService.publicLog(eventName, data);
 	}
 }
@@ -131,8 +151,10 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly tasClient: Promise<TASClient> | undefined;
+	private tasClient: Promise<TASClient> | undefined;
 	private readonly tasSetupDisposables = new DisposableStore();
+
+	private assignmentsEndpoint: string | undefined;
 
 	private networkInitialized = false;
 	private readonly overrideInitDelay: Promise<void>;
@@ -153,6 +175,8 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		@IProductService private readonly productService: IProductService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IRequestService private readonly requestService: IRequestService,
 	) {
 		super();
 
@@ -160,6 +184,15 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 
 		if (this.experimentsEnabled) {
 			this.tasClient = this.setupTASClient();
+
+			// The assignments endpoint is sourced from account entitlements, which load
+			// asynchronously. Re-setup the client when it first appears or changes.
+			this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
+				const next = this.getAssignmentsEndpoint();
+				if (next !== this.assignmentsEndpoint) {
+					this.tasClient = this.setupTASClient();
+				}
+			}));
 		}
 
 		this.contextFilter = this._register(new AssignmentContextFilter(storageService));
@@ -235,6 +268,39 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		return result;
 	}
 
+	/**
+	 * Resolves the new TAS assignments API URL from the account entitlements `exp` endpoint,
+	 * or `undefined` when no account/endpoint is available.
+	 */
+	private getAssignmentsEndpoint(): string | undefined {
+		const account = this.defaultAccountService.currentDefaultAccount;
+		const endpoints = account?.entitlementsData?.endpoints;
+		const exp = endpoints?.exp;
+		if (!exp) {
+			return undefined;
+		}
+		return `${exp.replace(/\/+$/, '')}/api/v1/assignments`;
+	}
+
+	/**
+	 * Transport for the new assignments endpoint, backed by the main-process request service
+	 * (avoids renderer CORS). Shape matches tas-client's injectable `assignmentsFetch`.
+	 */
+	private readonly assignmentsFetch = async (url: string, init: { method: 'POST'; headers: Record<string, string>; body: string }): Promise<{ status: number; json(): Promise<unknown> }> => {
+		const context = await this.requestService.request({
+			type: init.method,
+			url,
+			data: init.body,
+			headers: init.headers,
+			disableCache: true,
+			callSite: 'assignmentService.assignments',
+		}, CancellationToken.None);
+		return {
+			status: context.res.statusCode ?? 0,
+			json: async () => (await asJson(context)) ?? {},
+		};
+	};
+
 	private async setupTASClient(): Promise<TASClient> {
 		this.tasSetupDisposables.clear();
 
@@ -256,9 +322,33 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		this.tasSetupDisposables.add(extensionsFilterProvider);
 		this.tasSetupDisposables.add(extensionsFilterProvider.onDidChangeFilters(() => this.refetchAssignments()));
 
+		// New TAS assignments API. Its endpoint is sourced from account entitlements and it
+		// uses dedicated providers that emit the new userParam key names, so the legacy filter
+		// keys never reach it. Its assignments are merged with the legacy provider's results.
+		const assignmentsEndpoint = this.getAssignmentsEndpoint();
+		this.assignmentsEndpoint = assignmentsEndpoint;
+		let assignmentsFilterProviders: IExperimentationFilterProvider[] | undefined;
+		if (assignmentsEndpoint) {
+			const coreAssignmentsFilterProvider = new VSCodeCoreAssignmentsFilterProvider(
+				this.productService.version,
+				this.productService.nameLong,
+				this.telemetryService.devDeviceId,
+				targetPopulation,
+				this.productService.date ?? '',
+				this.environmentService.isSessionsWindow ? WindowKind.Agents : WindowKind.Editor
+			);
+			const githubAssignmentsFilterProvider = this.instantiationService.createInstance(GitHubCoreAssignmentsFilterProvider);
+			this.tasSetupDisposables.add(githubAssignmentsFilterProvider);
+			this.tasSetupDisposables.add(githubAssignmentsFilterProvider.onDidChangeFilters(() => this.refetchAssignments()));
+			assignmentsFilterProviders = [coreAssignmentsFilterProvider, githubAssignmentsFilterProvider];
+		}
+
 		const tasConfig = this.productService.tasConfig!;
 
-		const tasClientModule = await importAMDNodeModule<typeof import('tas-client')>('tas-client', 'dist/tas-client.min.js');
+		// tas-client ships as pure ESM; load it via a runtime-resolved URL so bundlers do not
+		// rewrite the import (mirrors how the editor loads the `@vscode/diff` module).
+		const tasClientUrl = resolveAmdNodeModulePath('tas-client', 'dist/tas-client.min.js');
+		const tasClientModule = await import(/* webpackIgnore: true */ /* @vite-ignore */ `${tasClientUrl}`) as typeof import('tas-client');
 
 		// Measure the client-side latency of the first network call to the
 		// Treatment Assignment Service. The fetch is triggered by constructing
@@ -273,6 +363,11 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 			assignmentContextTelemetryPropertyName: tasConfig.assignmentContextTelemetryPropertyName,
 			telemetryEventName: tasConfig.telemetryEventName,
 			endpoint: tasConfig.endpoint,
+			assignmentsEndpoint,
+			assignmentsFilterProviders,
+			// Route the assignments request through the main-process request service so it is
+			// not subject to renderer CORS (parity with how core reaches api.github.com).
+			assignmentsFetch: assignmentsEndpoint ? this.assignmentsFetch : undefined,
 			refetchInterval: ASSIGNMENT_REFETCH_INTERVAL,
 		});
 

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -157,6 +157,7 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 	private assignmentsEndpoint: string | undefined;
 
 	private networkInitialized = false;
+	private setupGeneration = 0;
 	private readonly overrideInitDelay: Promise<void>;
 
 	private readonly contextFilter: AssignmentContextFilter;
@@ -304,6 +305,11 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 	private async setupTASClient(): Promise<TASClient> {
 		this.tasSetupDisposables.clear();
 
+		// Each setup supersedes the previous client; track a generation so a stale client's
+		// initialFetch cannot flip networkInitialized for a newer client.
+		const generation = ++this.setupGeneration;
+		this.networkInitialized = false;
+
 		const targetPopulation = this.productService.quality === 'stable' ?
 			TargetPopulation.Public : (this.productService.quality === 'exploration' ?
 				TargetPopulation.Exploration : TargetPopulation.Insiders);
@@ -373,6 +379,9 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 
 		await tasClient.initializePromise;
 		tasClient.initialFetch.then(() => {
+			if (generation !== this.setupGeneration) {
+				return; // superseded by a newer setup
+			}
 			this.networkInitialized = true;
 			this.logFetchLatency('initial', fetchStopWatch.elapsed());
 		}).catch(() => undefined);


### PR DESCRIPTION
### Summary
Wires the new Treatment Assignment Service endpoint (`<exp-host>/api/v1/assignments`) into both VS Code core and the Copilot extension, running in parallel with the legacy `default.exp-tas.com/vscode/ab` endpoint and merging the two result sets so the new endpoint can be validated with real experiments before the legacy one is retired.