### PR TITLE
Automations: migrate to provider supplied automations client side

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -117,6 +117,7 @@ src/vs/sessions/contrib/providers/
 ```
 
 Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while entries migrate idempotently by Automation and run ID.
+When an update changes the resolved owning provider, the aggregate service transfers the updated Automation and run history before removing the source copy.
 Startup recovery attempts every available store independently, so one unavailable provider does not block stale-run recovery in the remaining stores.
 Legacy migration also isolates failures by Automation, leaving failed entries in legacy storage while continuing with later entries.
 

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -119,6 +119,7 @@ src/vs/sessions/contrib/providers/
 Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while entries migrate idempotently by Automation and run ID.
 When an update changes the resolved owning provider, the aggregate service transfers the updated Automation and run history before conditionally removing the matching source snapshot.
 Startup recovery attempts every available store independently, so one unavailable provider does not block stale-run recovery in the remaining stores.
+The scheduler activates stale-run recovery only while its window is leader. Provider stores added during that leadership period are recovered after migration, and leadership loss disables recovery for later registrations.
 Legacy migration also isolates failures by Automation and removes a source copy only when it still matches the imported Automation and run snapshot. Concurrent source changes are retried a bounded number of times, while a concurrent deletion rolls back the unchanged destination copy.
 
 Providers can import from all layers below them (core, services, non-provider contribs). **Non-provider contribs must NOT import from providers.** Shared symbols should be extracted to `services/` or `common/`.

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -116,6 +116,10 @@ src/vs/sessions/contrib/providers/
 └── remoteAgentHost/      # Remote agent host provider (one instance per connection)
 ```
 
+Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while entries migrate idempotently by Automation and run ID.
+Startup recovery attempts every available store independently, so one unavailable provider does not block stale-run recovery in the remaining stores.
+Legacy migration also isolates failures by Automation, leaving failed entries in legacy storage while continuing with later entries.
+
 Providers can import from all layers below them (core, services, non-provider contribs). **Non-provider contribs must NOT import from providers.** Shared symbols should be extracted to `services/` or `common/`.
 
 Permission picker labels and descriptions use provider-neutral language and stay aligned across Copilot Chat and Agent Host providers. Agent Host mode and running-session permission pickers use provider-specific list options in both the workbench and Agents window so their descriptive text has a consistent minimum width. `chat.defaultConfiguration.approvals` sets the initial permission level for new sessions using `default`, `assisted`, or `allowAll`; the live session config continues to use the Agent Host protocol's `autoApprove` value.

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -116,7 +116,7 @@ src/vs/sessions/contrib/providers/
 └── remoteAgentHost/      # Remote agent host provider (one instance per connection)
 ```
 
-Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while entries migrate idempotently by Automation and run ID.
+Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while equivalent entries migrate idempotently by Automation and run ID. Divergent same-ID snapshots remain in both stores for explicit conflict handling rather than silently discarding legacy data.
 When an update changes the resolved owning provider, the aggregate service transfers the updated Automation and run history before conditionally removing the matching source snapshot.
 Startup recovery attempts every available store independently, so one unavailable provider does not block stale-run recovery in the remaining stores.
 The scheduler activates stale-run recovery only while its window is leader. Provider stores added during that leadership period are recovered after migration, and leadership loss disables recovery for later registrations.

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -117,9 +117,9 @@ src/vs/sessions/contrib/providers/
 ```
 
 Providers can expose `automations` to own durable Automation entities and run history. `ProviderAutomationService` aggregates these stores behind `IAutomationService`, routes mutations to the owning store, and keeps the legacy global ledger mounted while entries migrate idempotently by Automation and run ID.
-When an update changes the resolved owning provider, the aggregate service transfers the updated Automation and run history before removing the source copy.
+When an update changes the resolved owning provider, the aggregate service transfers the updated Automation and run history before conditionally removing the matching source snapshot.
 Startup recovery attempts every available store independently, so one unavailable provider does not block stale-run recovery in the remaining stores.
-Legacy migration also isolates failures by Automation, leaving failed entries in legacy storage while continuing with later entries.
+Legacy migration also isolates failures by Automation and removes a source copy only when it still matches the imported Automation and run snapshot. Concurrent source changes are retried a bounded number of times, while a concurrent deletion rolls back the unchanged destination copy.
 
 Providers can import from all layers below them (core, services, non-provider contribs). **Non-provider contribs must NOT import from providers.** Shared symbols should be extracted to `services/` or `common/`.
 

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -75,6 +75,7 @@ export class AutomationSchedulerCore extends Disposable {
 			const isLeader = this._leader.isLeader.read(reader);
 			if (!isLeader) {
 				this._didStartupForCurrentLeadership = false;
+				this.automationService.stopStaleRunRecovery();
 				return;
 			}
 			this.kickoffPendingRuns(() => this.tickOnce(true));
@@ -124,7 +125,7 @@ export class AutomationSchedulerCore extends Disposable {
 
 		if (!this._didStartupForCurrentLeadership) {
 			this._didStartupForCurrentLeadership = true;
-			await this.automationService.markStaleRunsFailed(CRASH_RECOVERY_REASON);
+			await this.automationService.startStaleRunRecovery(CRASH_RECOVERY_REASON);
 			await this.dispatchDue('catch_up');
 			if (isLeadershipTransition) {
 				return;
@@ -194,6 +195,7 @@ export class AutomationSchedulerCore extends Disposable {
 	}
 
 	override dispose(): void {
+		this.automationService.stopStaleRunRecovery();
 		this._runCts.cancel();
 		super.dispose();
 	}

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -584,6 +584,12 @@ export class AutomationService extends AutomationStore implements IAutomationSer
 	) {
 		super(AUTOMATION_STORAGE_KEY, storageService, logService, telemetryService, automationStorageService);
 	}
+
+	startStaleRunRecovery(reason: string): Promise<void> {
+		return this.markStaleRunsFailed(reason);
+	}
+
+	stopStaleRunRecovery(): void { }
 }
 
 function serializeAutomation(a: IAutomation): ISerializedAutomation {

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -288,7 +288,28 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 		});
 	}
 
-	async removeAutomationForMigration(id: string): Promise<void> {
+	async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[], mutationGuard?: AutomationMutationGuard): Promise<void> {
+		await this.mutateLedger(ledger => {
+			const existing = ledger.automations.find(candidate => candidate.id === automation.id);
+			const existingRunIds = new Set(ledger.runs.map(run => run.id));
+			const missingRuns = runs.filter(run => !existingRunIds.has(run.id));
+			if (existing && JSON.stringify(serializeAutomation(existing)) === JSON.stringify(serializeAutomation(automation)) && missingRuns.length === 0) {
+				return { kind: 'noChange', result: undefined };
+			}
+			return {
+				kind: 'commit',
+				ledger: {
+					automations: existing
+						? ledger.automations.map(candidate => candidate.id === automation.id ? automation : candidate)
+						: [automation, ...ledger.automations],
+					runs: [...missingRuns, ...ledger.runs],
+				},
+				result: undefined,
+			};
+		}, mutationGuard);
+	}
+
+	async removeAutomationForTransfer(id: string, mutationGuard?: AutomationMutationGuard): Promise<void> {
 		await this.mutateLedger(ledger => {
 			if (!ledger.automations.some(automation => automation.id === id)) {
 				return { kind: 'noChange', result: undefined };
@@ -301,7 +322,7 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 				},
 				result: undefined,
 			};
-		});
+		}, mutationGuard);
 		this._runsForCache.delete(id);
 	}
 

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -10,6 +10,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IGuardedAutomationTransferRemovalResult } from '../../../services/sessions/common/sessionsProvider.js';
 import {
 	AutomationRunTrigger,
 	AutomationTarget,
@@ -269,13 +270,13 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 		publishAutomationDeleted(this.telemetryService, existing);
 	}
 
-	async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
-		await this.mutateLedger(ledger => {
+	async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
+		return this.mutateLedger(ledger => {
 			const hasAutomation = ledger.automations.some(candidate => candidate.id === automation.id);
 			const existingRunIds = new Set(ledger.runs.map(run => run.id));
 			const missingRuns = runs.filter(run => !existingRunIds.has(run.id));
 			if (hasAutomation && missingRuns.length === 0) {
-				return { kind: 'noChange', result: undefined };
+				return { kind: 'noChange', result: false };
 			}
 			return {
 				kind: 'commit',
@@ -283,12 +284,12 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 					automations: hasAutomation ? ledger.automations : [automation, ...ledger.automations],
 					runs: [...missingRuns, ...ledger.runs],
 				},
-				result: undefined,
+				result: !hasAutomation,
 			};
 		});
 	}
 
-	async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[], mutationGuard?: AutomationMutationGuard): Promise<void> {
+	async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
 		await this.mutateLedger(ledger => {
 			const existing = ledger.automations.find(candidate => candidate.id === automation.id);
 			const existingRunIds = new Set(ledger.runs.map(run => run.id));
@@ -306,24 +307,35 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 				},
 				result: undefined,
 			};
-		}, mutationGuard);
+		});
 	}
 
-	async removeAutomationForTransfer(id: string, mutationGuard?: AutomationMutationGuard): Promise<void> {
-		await this.mutateLedger(ledger => {
-			if (!ledger.automations.some(automation => automation.id === id)) {
-				return { kind: 'noChange', result: undefined };
+	async tryRemoveAutomationSnapshot(expected: IAutomation, expectedRuns: readonly IAutomationRun[]): Promise<IGuardedAutomationTransferRemovalResult> {
+		const result = await this.mutateLedger<IGuardedAutomationTransferRemovalResult>(ledger => {
+			const current = ledger.automations.find(candidate => candidate.id === expected.id);
+			if (!current) {
+				return { kind: 'noChange', result: { kind: 'missing' } };
+			}
+			const currentRuns = ledger.runs.filter(run => run.automationId === expected.id);
+			if (!areAutomationTransferSnapshotsEqual(current, currentRuns, expected, expectedRuns)) {
+				return {
+					kind: 'noChange',
+					result: { kind: 'changed', automation: current, runs: currentRuns },
+				};
 			}
 			return {
 				kind: 'commit',
 				ledger: {
-					automations: ledger.automations.filter(automation => automation.id !== id),
-					runs: ledger.runs.filter(run => run.automationId !== id),
+					automations: ledger.automations.filter(candidate => candidate.id !== expected.id),
+					runs: ledger.runs.filter(run => run.automationId !== expected.id),
 				},
-				result: undefined,
+				result: { kind: 'removed' },
 			};
-		}, mutationGuard);
-		this._runsForCache.delete(id);
+		});
+		if (result.kind === 'removed') {
+			this._runsForCache.delete(expected.id);
+		}
+		return result;
 	}
 
 	async recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRunClaim> {
@@ -587,6 +599,16 @@ function serializeAutomation(a: IAutomation): ISerializedAutomation {
 		lastRunAt: a.lastRunAt,
 		nextRunAt: a.nextRunAt,
 	};
+}
+
+function areAutomationTransferSnapshotsEqual(
+	firstAutomation: IAutomation,
+	firstRuns: readonly IAutomationRun[],
+	secondAutomation: IAutomation,
+	secondRuns: readonly IAutomationRun[],
+): boolean {
+	return JSON.stringify(serializeAutomation(firstAutomation)) === JSON.stringify(serializeAutomation(secondAutomation))
+		&& JSON.stringify(firstRuns) === JSON.stringify(secondRuns);
 }
 
 function deserializeAutomation(s: ISerializedAutomation): IAutomation | undefined {

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -25,6 +25,7 @@ import {
 	IGuardedAutomationUpdateResult,
 	serializeAutomationEditableState,
 	IUpdateAutomationOptions,
+	IAutomationStore,
 	IUpdateAutomationRunOptions,
 } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { publishAutomationCreated, publishAutomationDeleted, publishAutomationUpdated } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
@@ -109,9 +110,7 @@ type ReadLedgerResult =
 	| { kind: 'ledger'; ledger: ILedger; revision: number }
 	| { kind: 'unsupportedSchema' };
 
-export class AutomationService extends Disposable implements IAutomationService {
-
-	declare readonly _serviceBrand: undefined;
+export class AutomationStore extends Disposable implements IAutomationStore {
 
 	private readonly _automations: ISettableObservable<readonly IAutomation[]>;
 	private readonly _runs: ISettableObservable<readonly IAutomationRun[]>;
@@ -124,6 +123,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 	readonly runs: IObservable<readonly IAutomationRun[]>;
 
 	constructor(
+		private readonly storageKey: string,
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -133,7 +133,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 
 		this._now = () => new Date();
 
-		const result = this.readLedger(this.storageService.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION));
+		const result = this.readLedger(this.storageService.get(this.storageKey, StorageScope.APPLICATION));
 		const initial = result.kind === 'ledger' ? result.ledger : EMPTY_LEDGER;
 		if (result.kind === 'ledger') {
 			this._lastSeenRevision = result.revision;
@@ -143,7 +143,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 		this.automations = this._automations;
 		this.runs = this._runs;
 
-		this._register(this.storageService.onDidChangeValue(StorageScope.APPLICATION, AUTOMATION_STORAGE_KEY, this._store)(() => {
+		this._register(this.storageService.onDidChangeValue(StorageScope.APPLICATION, this.storageKey, this._store)(() => {
 			this.refreshFromStorage();
 		}));
 	}
@@ -269,6 +269,42 @@ export class AutomationService extends Disposable implements IAutomationService 
 		publishAutomationDeleted(this.telemetryService, existing);
 	}
 
+	async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
+		await this.mutateLedger(ledger => {
+			const hasAutomation = ledger.automations.some(candidate => candidate.id === automation.id);
+			const existingRunIds = new Set(ledger.runs.map(run => run.id));
+			const missingRuns = runs.filter(run => !existingRunIds.has(run.id));
+			if (hasAutomation && missingRuns.length === 0) {
+				return { kind: 'noChange', result: undefined };
+			}
+			return {
+				kind: 'commit',
+				ledger: {
+					automations: hasAutomation ? ledger.automations : [automation, ...ledger.automations],
+					runs: [...missingRuns, ...ledger.runs],
+				},
+				result: undefined,
+			};
+		});
+	}
+
+	async removeAutomationForMigration(id: string): Promise<void> {
+		await this.mutateLedger(ledger => {
+			if (!ledger.automations.some(automation => automation.id === id)) {
+				return { kind: 'noChange', result: undefined };
+			}
+			return {
+				kind: 'commit',
+				ledger: {
+					automations: ledger.automations.filter(automation => automation.id !== id),
+					runs: ledger.runs.filter(run => run.automationId !== id),
+				},
+				result: undefined,
+			};
+		});
+		this._runsForCache.delete(id);
+	}
+
 	async recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRunClaim> {
 		const now = this._now();
 		const startedAt = now.toISOString();
@@ -378,7 +414,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 	//#region Persistence
 
 	private async mutateLedger<T>(mutate: (ledger: ILedger) => ILedgerMutation<T>, mutationGuard?: AutomationMutationGuard): Promise<T> {
-		let raw = await this.automationStorageService.read();
+		let raw = await this.automationStorageService.read(this.storageKey);
 		while (true) {
 			const readResult = this.readLedger(raw);
 			if (readResult.kind === 'unsupportedSchema') {
@@ -404,7 +440,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 			};
 			const newValue = JSON.stringify(serialized);
 			mutationGuard?.();
-			const writeResult = await this.automationStorageService.compareAndSwap(raw, newValue);
+			const writeResult = await this.automationStorageService.compareAndSwap(this.storageKey, raw, newValue);
 			if (writeResult.swapped) {
 				this.setLedger(ledger, revision);
 				return mutation.result;
@@ -432,10 +468,11 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	private refreshFromStorage(): void {
-		const result = this.readLedger(this.storageService.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION));
+		const result = this.readLedger(this.storageService.get(this.storageKey, StorageScope.APPLICATION));
 		if (result.kind === 'unsupportedSchema') {
 			return;
 		}
+
 		this.acceptLedger(result.ledger, result.revision);
 	}
 
@@ -497,6 +534,20 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	//#endregion
+}
+
+export class AutomationService extends AutomationStore implements IAutomationService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IStorageService storageService: IStorageService,
+		@ILogService logService: ILogService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IAutomationStorageService automationStorageService: IAutomationStorageService,
+	) {
+		super(AUTOMATION_STORAGE_KEY, storageService, logService, telemetryService, automationStorageService);
+	}
 }
 
 function serializeAutomation(a: IAutomation): ISerializedAutomation {

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -10,7 +10,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { IGuardedAutomationTransferRemovalResult } from '../../../services/sessions/common/sessionsProvider.js';
+import { IAutomationSnapshot, IAutomationSnapshotImportResult, IGuardedAutomationSnapshotRemovalResult } from '../../../services/sessions/common/sessionsProvider.js';
 import {
 	AutomationRunTrigger,
 	AutomationTarget,
@@ -270,13 +270,14 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 		publishAutomationDeleted(this.telemetryService, existing);
 	}
 
-	async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
+	async importAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<IAutomationSnapshotImportResult> {
+		const { automation, runs } = snapshot;
 		return this.mutateLedger(ledger => {
 			const hasAutomation = ledger.automations.some(candidate => candidate.id === automation.id);
 			const existingRunIds = new Set(ledger.runs.map(run => run.id));
 			const missingRuns = runs.filter(run => !existingRunIds.has(run.id));
 			if (hasAutomation && missingRuns.length === 0) {
-				return { kind: 'noChange', result: false };
+				return { kind: 'noChange', result: { kind: 'alreadyPresent' } as const };
 			}
 			return {
 				kind: 'commit',
@@ -284,12 +285,13 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 					automations: hasAutomation ? ledger.automations : [automation, ...ledger.automations],
 					runs: [...missingRuns, ...ledger.runs],
 				},
-				result: !hasAutomation,
+				result: { kind: hasAutomation ? 'alreadyPresent' : 'inserted' } as const,
 			};
 		});
 	}
 
-	async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
+	async upsertAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<void> {
+		const { automation, runs } = snapshot;
 		await this.mutateLedger(ledger => {
 			const existing = ledger.automations.find(candidate => candidate.id === automation.id);
 			const existingRunIds = new Set(ledger.runs.map(run => run.id));
@@ -310,30 +312,31 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 		});
 	}
 
-	async tryRemoveAutomationSnapshot(expected: IAutomation, expectedRuns: readonly IAutomationRun[]): Promise<IGuardedAutomationTransferRemovalResult> {
-		const result = await this.mutateLedger<IGuardedAutomationTransferRemovalResult>(ledger => {
-			const current = ledger.automations.find(candidate => candidate.id === expected.id);
+	async removeAutomationSnapshotIfUnchanged(expected: IAutomationSnapshot): Promise<IGuardedAutomationSnapshotRemovalResult> {
+		const result = await this.mutateLedger<IGuardedAutomationSnapshotRemovalResult>(ledger => {
+			const current = ledger.automations.find(candidate => candidate.id === expected.automation.id);
 			if (!current) {
 				return { kind: 'noChange', result: { kind: 'missing' } };
 			}
-			const currentRuns = ledger.runs.filter(run => run.automationId === expected.id);
-			if (!areAutomationTransferSnapshotsEqual(current, currentRuns, expected, expectedRuns)) {
+			const currentRuns = ledger.runs.filter(run => run.automationId === expected.automation.id);
+			const currentSnapshot: IAutomationSnapshot = { automation: current, runs: currentRuns };
+			if (!areAutomationSnapshotsEqual(currentSnapshot, expected)) {
 				return {
 					kind: 'noChange',
-					result: { kind: 'changed', automation: current, runs: currentRuns },
+					result: { kind: 'conflict', current: currentSnapshot },
 				};
 			}
 			return {
 				kind: 'commit',
 				ledger: {
-					automations: ledger.automations.filter(candidate => candidate.id !== expected.id),
-					runs: ledger.runs.filter(run => run.automationId !== expected.id),
+					automations: ledger.automations.filter(candidate => candidate.id !== expected.automation.id),
+					runs: ledger.runs.filter(run => run.automationId !== expected.automation.id),
 				},
 				result: { kind: 'removed' },
 			};
 		});
 		if (result.kind === 'removed') {
-			this._runsForCache.delete(expected.id);
+			this._runsForCache.delete(expected.automation.id);
 		}
 		return result;
 	}
@@ -601,14 +604,9 @@ function serializeAutomation(a: IAutomation): ISerializedAutomation {
 	};
 }
 
-function areAutomationTransferSnapshotsEqual(
-	firstAutomation: IAutomation,
-	firstRuns: readonly IAutomationRun[],
-	secondAutomation: IAutomation,
-	secondRuns: readonly IAutomationRun[],
-): boolean {
-	return JSON.stringify(serializeAutomation(firstAutomation)) === JSON.stringify(serializeAutomation(secondAutomation))
-		&& JSON.stringify(firstRuns) === JSON.stringify(secondRuns);
+function areAutomationSnapshotsEqual(first: IAutomationSnapshot, second: IAutomationSnapshot): boolean {
+	return JSON.stringify(serializeAutomation(first.automation)) === JSON.stringify(serializeAutomation(second.automation))
+		&& JSON.stringify(first.runs) === JSON.stringify(second.runs);
 }
 
 function deserializeAutomation(s: ISerializedAutomation): IAutomation | undefined {

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -272,20 +272,24 @@ export class AutomationStore extends Disposable implements IAutomationStore {
 
 	async importAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<IAutomationSnapshotImportResult> {
 		const { automation, runs } = snapshot;
-		return this.mutateLedger(ledger => {
-			const hasAutomation = ledger.automations.some(candidate => candidate.id === automation.id);
-			const existingRunIds = new Set(ledger.runs.map(run => run.id));
-			const missingRuns = runs.filter(run => !existingRunIds.has(run.id));
-			if (hasAutomation && missingRuns.length === 0) {
-				return { kind: 'noChange', result: { kind: 'alreadyPresent' } as const };
+		return this.mutateLedger<IAutomationSnapshotImportResult>(ledger => {
+			const existing = ledger.automations.find(candidate => candidate.id === automation.id);
+			if (existing) {
+				const current: IAutomationSnapshot = {
+					automation: existing,
+					runs: ledger.runs.filter(run => run.automationId === automation.id),
+				};
+				return areAutomationSnapshotsEqual(current, snapshot)
+					? { kind: 'noChange', result: { kind: 'alreadyPresent' } as const }
+					: { kind: 'noChange', result: { kind: 'conflict', current } as const };
 			}
 			return {
 				kind: 'commit',
 				ledger: {
-					automations: hasAutomation ? ledger.automations : [automation, ...ledger.automations],
-					runs: [...missingRuns, ...ledger.runs],
+					automations: [automation, ...ledger.automations],
+					runs: [...runs, ...ledger.runs],
 				},
-				result: { kind: hasAutomation ? 'alreadyPresent' : 'inserted' } as const,
+				result: { kind: 'inserted' } as const,
 			};
 		});
 	}

--- a/src/vs/sessions/contrib/automations/browser/automationStorageService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationStorageService.ts
@@ -5,7 +5,7 @@
 
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { BrowserStorageService } from '../../../../workbench/services/storage/browser/storageService.js';
-import { AUTOMATION_STORAGE_KEY, IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../common/automationStorageService.js';
+import { IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../common/automationStorageService.js';
 
 /**
  * Uses an IndexedDB transaction so automation writes remain atomic across browser tabs.
@@ -25,11 +25,11 @@ export class BrowserAutomationStorageService implements IAutomationStorageServic
 		this.storageService = storageService;
 	}
 
-	async read(): Promise<string | undefined> {
-		return this.storageService.getApplicationStorageValue(AUTOMATION_STORAGE_KEY);
+	async read(key: string): Promise<string | undefined> {
+		return this.storageService.getApplicationStorageValue(key);
 	}
 
-	async compareAndSwap(expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
-		return this.storageService.compareAndSwapApplicationStorage(AUTOMATION_STORAGE_KEY, expectedValue, newValue);
+	async compareAndSwap(key: string, expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
+		return this.storageService.compareAndSwapApplicationStorage(key, expectedValue, newValue);
 	}
 }

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -19,13 +19,13 @@ import { ChatAutomationsEnabledContext, CHAT_AUTOMATIONS_ENABLED_SETTING, CHAT_A
 import { AutomationDialogService } from './automationDialogService.js';
 import { AutomationRunner } from './automationRunner.js';
 import { AutomationScheduler } from './automationScheduler.js';
-import { AutomationService } from './automationService.js';
+import { ProviderAutomationService } from './providerAutomationService.js';
 import { BrowserAutomationStorageService } from './automationStorageService.js';
 import { AutomationToolsContribution } from './automationTools.js';
 import { IAutomationStorageService } from '../common/automationStorageService.js';
 
 registerSingleton(IAutomationStorageService, BrowserAutomationStorageService, InstantiationType.Delayed);
-registerSingleton(IAutomationService, AutomationService, InstantiationType.Delayed);
+registerSingleton(IAutomationService, ProviderAutomationService, InstantiationType.Delayed);
 registerSingleton(IAutomationRunner, AutomationRunner, InstantiationType.Delayed);
 registerSingleton(IAutomationDialogService, AutomationDialogService, InstantiationType.Delayed);
 

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Sequencer } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableSignalFromEvent } from '../../../../base/common/observable.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IAutomation, IAutomationRun, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import { AutomationMutationGuard, IAutomationRunClaim, IAutomationService, ICreateAutomationOptions, IGuardedAutomationUpdateResult, IUpdateAutomationOptions, IUpdateAutomationRunOptions } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsProviderAutomations } from '../../../services/sessions/common/sessionsProvider.js';
+import { AutomationService } from './automationService.js';
+
+interface IAutomationStoreEntry {
+	readonly providerId: string | undefined;
+	readonly store: ISessionsProviderAutomations;
+}
+
+export class ProviderAutomationService extends Disposable implements IAutomationService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly legacyStore: AutomationService;
+	private readonly providersChanged;
+	private readonly migrationSequencer = new Sequencer();
+	private migrationPromise: Promise<void> = Promise.resolve();
+	private readonly runsForCache = new Map<string, IObservable<readonly IAutomationRun[]>>();
+
+	readonly automations: IObservable<readonly IAutomation[]>;
+	readonly runs: IObservable<readonly IAutomationRun[]>;
+
+	constructor(
+		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+		this.legacyStore = this._register(instantiationService.createInstance(AutomationService));
+		this.providersChanged = observableSignalFromEvent(this, sessionsProvidersService.onDidChangeProviders);
+		this.automations = derived(this, reader => {
+			this.providersChanged.read(reader);
+			return distinctById(
+				this.getStores().flatMap(entry => [...entry.store.automations.read(reader)])
+			).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+		});
+		this.runs = derived(this, reader => {
+			this.providersChanged.read(reader);
+			return distinctById(
+				this.getStores().flatMap(entry => [...entry.store.runs.read(reader)])
+			).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+		});
+		this._register(sessionsProvidersService.onDidChangeProviders(event => {
+			if (event.added.some(provider => provider.automations)) {
+				this.queueMigration();
+			}
+		}));
+		this.queueMigration();
+	}
+
+	getAutomation(id: string): IAutomation | undefined {
+		return this.findAutomationStore(id)?.store.getAutomation(id);
+	}
+
+	runsFor(automationId: string): IObservable<readonly IAutomationRun[]> {
+		let result = this.runsForCache.get(automationId);
+		if (!result) {
+			result = derived(this, reader => this.runs.read(reader).filter(run => run.automationId === automationId));
+			this.runsForCache.set(automationId, result);
+		}
+		return result;
+	}
+
+	createAutomation(options: ICreateAutomationOptions, mutationGuard?: AutomationMutationGuard): Promise<IAutomation> {
+		return this.getCreationStore(options).createAutomation(options, mutationGuard);
+	}
+
+	updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation> {
+		return this.requireAutomationStore(id).updateAutomation(id, patch);
+	}
+
+	updateAutomationIfUnchanged(id: string, patch: IUpdateAutomationOptions, expected: IAutomation, mutationGuard?: AutomationMutationGuard): Promise<IGuardedAutomationUpdateResult> {
+		return this.requireAutomationStore(id).updateAutomationIfUnchanged(id, patch, expected, mutationGuard);
+	}
+
+	async deleteAutomation(id: string, mutationGuard?: AutomationMutationGuard): Promise<void> {
+		await this.requireAutomationStore(id).deleteAutomation(id, mutationGuard);
+		this.runsForCache.delete(id);
+	}
+
+	recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRunClaim> {
+		return this.requireAutomationStore(automationId).recordRunStart(automationId, trigger, leaderWindowId);
+	}
+
+	updateRun(runId: string, patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined> {
+		const store = this.findRunStore(runId);
+		return store ? store.updateRun(runId, patch) : Promise.resolve(undefined);
+	}
+
+	deleteRun(runId: string): Promise<void> {
+		const store = this.findRunStore(runId);
+		return store ? store.deleteRun(runId) : Promise.resolve();
+	}
+
+	getActiveRunFor(automationId: string): IAutomationRun | undefined {
+		return this.findAutomationStore(automationId)?.store.getActiveRunFor(automationId);
+	}
+
+	async markStaleRunsFailed(reason: string): Promise<void> {
+		await this.migrationPromise;
+		const stores = this.getStores();
+		const results = await Promise.allSettled(stores.map(entry => entry.store.markStaleRunsFailed(reason)));
+		for (let index = 0; index < results.length; index++) {
+			const result = results[index];
+			if (result.status === 'rejected') {
+				const providerId = stores[index].providerId ?? 'legacy';
+				this.logService.error(`[ProviderAutomationService] Failed to recover stale Automation runs for '${providerId}'.`, result.reason);
+			}
+		}
+	}
+
+	waitForMigrationForTesting(): Promise<void> {
+		return this.migrationPromise;
+	}
+
+	private getStores(): IAutomationStoreEntry[] {
+		const providerStores = this.sessionsProvidersService.getProviders()
+			.filter(provider => provider.automations)
+			.map(provider => ({ providerId: provider.id, store: provider.automations! }));
+		return [...providerStores, { providerId: undefined, store: this.legacyStore }];
+	}
+
+	private getCreationStore(options: ICreateAutomationOptions): ISessionsProviderAutomations {
+		const providerId = options.target.providerId;
+		if (providerId) {
+			const providerStore = this.sessionsProvidersService.getProvider(providerId)?.automations;
+			if (providerStore) {
+				return providerStore;
+			}
+		}
+
+		return this.legacyStore;
+	}
+
+	private findAutomationStore(id: string): IAutomationStoreEntry | undefined {
+		return this.getStores().find(entry => !!entry.store.getAutomation(id));
+	}
+
+	private requireAutomationStore(id: string): ISessionsProviderAutomations {
+		const entry = this.findAutomationStore(id);
+		if (!entry) {
+			throw new Error(`Automation '${id}' does not exist.`);
+		}
+		return entry.store;
+	}
+
+	private findRunStore(runId: string): ISessionsProviderAutomations | undefined {
+		return this.getStores().find(entry => entry.store.runs.get().some(run => run.id === runId))?.store;
+	}
+
+	private queueMigration(): void {
+		this.migrationPromise = this.migrationSequencer.queue(() => this.migrateLegacyAutomations()).catch(error => {
+			this.logService.error('[ProviderAutomationService] Failed to migrate legacy Automations.', error);
+		});
+	}
+
+	private async migrateLegacyAutomations(): Promise<void> {
+		for (const automation of [...this.legacyStore.automations.get()]) {
+			const providerId = automation.target.providerId;
+			if (!providerId) {
+				continue;
+			}
+			const providerStore = this.sessionsProvidersService.getProvider(providerId)?.automations;
+			if (!providerStore) {
+				continue;
+			}
+			try {
+				await providerStore.importAutomation(automation, this.legacyStore.runsFor(automation.id).get());
+				await this.legacyStore.removeAutomationForMigration(automation.id);
+			} catch (error) {
+				this.logService.error(`[ProviderAutomationService] Failed to migrate Automation '${automation.id}' to provider '${providerId}'.`, error);
+			}
+		}
+	}
+
+}
+
+function distinctById<T extends { readonly id: string }>(items: readonly T[]): T[] {
+	const result: T[] = [];
+	const seen = new Set<string>();
+	for (const item of items) {
+		if (!seen.has(item.id)) {
+			seen.add(item.id);
+			result.push(item);
+		}
+	}
+	return result;
+}

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -77,12 +77,20 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		return this.getCreationStore(options).createAutomation(options, mutationGuard);
 	}
 
-	updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation> {
-		return this.requireAutomationStore(id).updateAutomation(id, patch);
+	async updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation> {
+		const source = this.requireAutomationStore(id);
+		const updated = await source.updateAutomation(id, patch);
+		await this.transferAutomationIfNeeded(source, updated);
+		return updated;
 	}
 
-	updateAutomationIfUnchanged(id: string, patch: IUpdateAutomationOptions, expected: IAutomation, mutationGuard?: AutomationMutationGuard): Promise<IGuardedAutomationUpdateResult> {
-		return this.requireAutomationStore(id).updateAutomationIfUnchanged(id, patch, expected, mutationGuard);
+	async updateAutomationIfUnchanged(id: string, patch: IUpdateAutomationOptions, expected: IAutomation, mutationGuard?: AutomationMutationGuard): Promise<IGuardedAutomationUpdateResult> {
+		const source = this.requireAutomationStore(id);
+		const result = await source.updateAutomationIfUnchanged(id, patch, expected, mutationGuard);
+		if (result.kind === 'updated') {
+			await this.transferAutomationIfNeeded(source, result.automation, mutationGuard);
+		}
+		return result;
 	}
 
 	async deleteAutomation(id: string, mutationGuard?: AutomationMutationGuard): Promise<void> {
@@ -133,7 +141,10 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 	}
 
 	private getCreationStore(options: ICreateAutomationOptions): ISessionsProviderAutomations {
-		const providerId = options.target.providerId;
+		return this.getTargetStore(options.target.providerId);
+	}
+
+	private getTargetStore(providerId: string | undefined): ISessionsProviderAutomations {
 		if (providerId) {
 			const providerStore = this.sessionsProvidersService.getProvider(providerId)?.automations;
 			if (providerStore) {
@@ -142,6 +153,16 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		}
 
 		return this.legacyStore;
+	}
+
+	private async transferAutomationIfNeeded(source: ISessionsProviderAutomations, automation: IAutomation, mutationGuard?: AutomationMutationGuard): Promise<void> {
+		const destination = this.getTargetStore(automation.target.providerId);
+		if (source === destination) {
+			return;
+		}
+
+		await destination.storeAutomationForTransfer(automation, source.runsFor(automation.id).get(), mutationGuard);
+		await source.removeAutomationForTransfer(automation.id, mutationGuard);
 	}
 
 	private findAutomationStore(id: string): IAutomationStoreEntry | undefined {
@@ -178,7 +199,7 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 			}
 			try {
 				await providerStore.importAutomation(automation, this.legacyStore.runsFor(automation.id).get());
-				await this.legacyStore.removeAutomationForMigration(automation.id);
+				await this.legacyStore.removeAutomationForTransfer(automation.id);
 			} catch (error) {
 				this.logService.error(`[ProviderAutomationService] Failed to migrate Automation '${automation.id}' to provider '${providerId}'.`, error);
 			}

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -30,6 +30,9 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 	private readonly migrationSequencer = new Sequencer();
 	private migrationPromise: Promise<void> = Promise.resolve();
 	private readonly runsForCache = new Map<string, IObservable<readonly IAutomationRun[]>>();
+	private staleRunRecoveryGeneration = 0;
+	private staleRunRecoveryReason: string | undefined;
+	private readonly recoveredStores = new Set<ISessionsProviderAutomations>();
 
 	readonly automations: IObservable<readonly IAutomation[]>;
 	readonly runs: IObservable<readonly IAutomationRun[]>;
@@ -55,6 +58,11 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 			).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
 		});
 		this._register(sessionsProvidersService.onDidChangeProviders(event => {
+			for (const provider of event.removed) {
+				if (provider.automations) {
+					this.recoveredStores.delete(provider.automations);
+				}
+			}
 			if (event.added.some(provider => provider.automations)) {
 				this.queueMigration();
 			}
@@ -131,6 +139,23 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		}
 	}
 
+	async startStaleRunRecovery(reason: string): Promise<void> {
+		const generation = ++this.staleRunRecoveryGeneration;
+		this.staleRunRecoveryReason = reason;
+		this.recoveredStores.clear();
+		const stores = this.getStores();
+		this.migrationPromise = this.migrationSequencer.queue(() => this.recoverStores(stores, reason, generation)).catch(error => {
+			this.logService.error('[ProviderAutomationService] Failed to start stale Automation run recovery.', error);
+		});
+		await this.migrationPromise;
+	}
+
+	stopStaleRunRecovery(): void {
+		this.staleRunRecoveryGeneration++;
+		this.staleRunRecoveryReason = undefined;
+		this.recoveredStores.clear();
+	}
+
 	waitForMigrationForTesting(): Promise<void> {
 		return this.migrationPromise;
 	}
@@ -204,9 +229,35 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 	}
 
 	private queueMigration(): void {
-		this.migrationPromise = this.migrationSequencer.queue(() => this.migrateLegacyAutomations()).catch(error => {
+		this.migrationPromise = this.migrationSequencer.queue(async () => {
+			await this.migrateLegacyAutomations();
+			const reason = this.staleRunRecoveryReason;
+			if (reason) {
+				await this.recoverStores(this.getStores(), reason, this.staleRunRecoveryGeneration);
+			}
+		}).catch(error => {
 			this.logService.error('[ProviderAutomationService] Failed to migrate legacy Automations.', error);
 		});
+	}
+
+	private async recoverStores(entries: readonly IAutomationStoreEntry[], reason: string, generation: number): Promise<void> {
+		for (const entry of entries) {
+			if (generation !== this.staleRunRecoveryGeneration || this.staleRunRecoveryReason !== reason) {
+				return;
+			}
+			if (this.recoveredStores.has(entry.store)) {
+				continue;
+			}
+			try {
+				await entry.store.markStaleRunsFailed(reason);
+				if (generation === this.staleRunRecoveryGeneration && this.staleRunRecoveryReason === reason) {
+					this.recoveredStores.add(entry.store);
+				}
+			} catch (error) {
+				const providerId = entry.providerId ?? 'legacy';
+				this.logService.error(`[ProviderAutomationService] Failed to recover stale Automation runs for '${providerId}'.`, error);
+			}
+		}
 	}
 
 	private async migrateLegacyAutomations(): Promise<void> {
@@ -235,6 +286,7 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 			}
 
 			const importResult = await providerStore.importAutomationSnapshot(snapshot);
+			this.recoveredStores.delete(providerStore);
 			const sourceRemoval = await this.legacyStore.removeAutomationSnapshotIfUnchanged(snapshot);
 			switch (sourceRemoval.kind) {
 				case 'removed':

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -19,6 +19,8 @@ interface IAutomationStoreEntry {
 	readonly store: ISessionsProviderAutomations;
 }
 
+const MAX_AUTOMATION_TRANSFER_ATTEMPTS = 3;
+
 export class ProviderAutomationService extends Disposable implements IAutomationService {
 
 	declare readonly _serviceBrand: undefined;
@@ -88,7 +90,7 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		const source = this.requireAutomationStore(id);
 		const result = await source.updateAutomationIfUnchanged(id, patch, expected, mutationGuard);
 		if (result.kind === 'updated') {
-			await this.transferAutomationIfNeeded(source, result.automation, mutationGuard);
+			await this.transferAutomationIfNeeded(source, result.automation);
 		}
 		return result;
 	}
@@ -155,14 +157,33 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		return this.legacyStore;
 	}
 
-	private async transferAutomationIfNeeded(source: ISessionsProviderAutomations, automation: IAutomation, mutationGuard?: AutomationMutationGuard): Promise<void> {
-		const destination = this.getTargetStore(automation.target.providerId);
-		if (source === destination) {
-			return;
-		}
+	private async transferAutomationIfNeeded(source: ISessionsProviderAutomations, initialAutomation: IAutomation): Promise<void> {
+		let automation = initialAutomation;
+		let runs = source.runsFor(automation.id).get();
+		for (let attempt = 0; attempt < MAX_AUTOMATION_TRANSFER_ATTEMPTS; attempt++) {
+			const destination = this.getTargetStore(automation.target.providerId);
+			if (source === destination) {
+				return;
+			}
 
-		await destination.storeAutomationForTransfer(automation, source.runsFor(automation.id).get(), mutationGuard);
-		await source.removeAutomationForTransfer(automation.id, mutationGuard);
+			await destination.storeAutomationForTransfer(automation, runs);
+			const removal = await source.tryRemoveAutomationSnapshot(automation, runs);
+			switch (removal.kind) {
+				case 'removed':
+					return;
+				case 'missing':
+					await this.rollbackAutomationSnapshot(destination, automation, runs);
+					return;
+				case 'changed':
+					if (!await this.rollbackAutomationSnapshot(destination, automation, runs)) {
+						return;
+					}
+					automation = removal.automation;
+					runs = removal.runs;
+					break;
+			}
+		}
+		this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' kept changing while transferring storage ownership; leaving the source copy in place.`);
 	}
 
 	private findAutomationStore(id: string): IAutomationStoreEntry | undefined {
@@ -189,21 +210,56 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 
 	private async migrateLegacyAutomations(): Promise<void> {
 		for (const automation of [...this.legacyStore.automations.get()]) {
+			try {
+				await this.migrateLegacyAutomation(automation);
+			} catch (error) {
+				this.logService.error(`[ProviderAutomationService] Failed to migrate Automation '${automation.id}'.`, error);
+			}
+		}
+	}
+
+	private async migrateLegacyAutomation(initialAutomation: IAutomation): Promise<void> {
+		let automation = initialAutomation;
+		let runs = this.legacyStore.runsFor(automation.id).get();
+		for (let attempt = 0; attempt < MAX_AUTOMATION_TRANSFER_ATTEMPTS; attempt++) {
 			const providerId = automation.target.providerId;
 			if (!providerId) {
-				continue;
+				return;
 			}
 			const providerStore = this.sessionsProvidersService.getProvider(providerId)?.automations;
 			if (!providerStore) {
-				continue;
+				return;
 			}
-			try {
-				await providerStore.importAutomation(automation, this.legacyStore.runsFor(automation.id).get());
-				await this.legacyStore.removeAutomationForTransfer(automation.id);
-			} catch (error) {
-				this.logService.error(`[ProviderAutomationService] Failed to migrate Automation '${automation.id}' to provider '${providerId}'.`, error);
+
+			const destinationCreated = await providerStore.importAutomation(automation, runs);
+			const removal = await this.legacyStore.tryRemoveAutomationSnapshot(automation, runs);
+			switch (removal.kind) {
+				case 'removed':
+					return;
+				case 'missing':
+					if (destinationCreated) {
+						await this.rollbackAutomationSnapshot(providerStore, automation, runs);
+					}
+					return;
+				case 'changed':
+					if (destinationCreated && !await this.rollbackAutomationSnapshot(providerStore, automation, runs)) {
+						return;
+					}
+					automation = removal.automation;
+					runs = removal.runs;
+					break;
 			}
 		}
+		this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' kept changing during legacy migration; leaving it in legacy storage.`);
+	}
+
+	private async rollbackAutomationSnapshot(store: ISessionsProviderAutomations, automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
+		const result = await store.tryRemoveAutomationSnapshot(automation, runs);
+		if (result.kind === 'changed') {
+			this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' changed in the destination store during rollback; leaving both copies in place.`);
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -11,7 +11,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IAutomation, IAutomationRun, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
 import { AutomationMutationGuard, IAutomationRunClaim, IAutomationService, ICreateAutomationOptions, IGuardedAutomationUpdateResult, IUpdateAutomationOptions, IUpdateAutomationRunOptions } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionsProviderAutomations } from '../../../services/sessions/common/sessionsProvider.js';
+import { IAutomationSnapshot, ISessionsProviderAutomations } from '../../../services/sessions/common/sessionsProvider.js';
 import { AutomationService } from './automationService.js';
 
 interface IAutomationStoreEntry {
@@ -82,7 +82,7 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 	async updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation> {
 		const source = this.requireAutomationStore(id);
 		const updated = await source.updateAutomation(id, patch);
-		await this.transferAutomationIfNeeded(source, updated);
+		await this.retargetAutomationStorageIfNeeded(source, updated);
 		return updated;
 	}
 
@@ -90,7 +90,7 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		const source = this.requireAutomationStore(id);
 		const result = await source.updateAutomationIfUnchanged(id, patch, expected, mutationGuard);
 		if (result.kind === 'updated') {
-			await this.transferAutomationIfNeeded(source, result.automation);
+			await this.retargetAutomationStorageIfNeeded(source, result.automation);
 		}
 		return result;
 	}
@@ -157,33 +157,34 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 		return this.legacyStore;
 	}
 
-	private async transferAutomationIfNeeded(source: ISessionsProviderAutomations, initialAutomation: IAutomation): Promise<void> {
-		let automation = initialAutomation;
-		let runs = source.runsFor(automation.id).get();
+	private async retargetAutomationStorageIfNeeded(sourceStore: ISessionsProviderAutomations, initialAutomation: IAutomation): Promise<void> {
+		let snapshot: IAutomationSnapshot = {
+			automation: initialAutomation,
+			runs: sourceStore.runsFor(initialAutomation.id).get(),
+		};
 		for (let attempt = 0; attempt < MAX_AUTOMATION_TRANSFER_ATTEMPTS; attempt++) {
-			const destination = this.getTargetStore(automation.target.providerId);
-			if (source === destination) {
+			const destinationStore = this.getTargetStore(snapshot.automation.target.providerId);
+			if (sourceStore === destinationStore) {
 				return;
 			}
 
-			await destination.storeAutomationForTransfer(automation, runs);
-			const removal = await source.tryRemoveAutomationSnapshot(automation, runs);
-			switch (removal.kind) {
+			await destinationStore.upsertAutomationSnapshot(snapshot);
+			const sourceRemoval = await sourceStore.removeAutomationSnapshotIfUnchanged(snapshot);
+			switch (sourceRemoval.kind) {
 				case 'removed':
 					return;
 				case 'missing':
-					await this.rollbackAutomationSnapshot(destination, automation, runs);
+					await this.rollbackAutomationSnapshotIfUnchanged(destinationStore, snapshot);
 					return;
-				case 'changed':
-					if (!await this.rollbackAutomationSnapshot(destination, automation, runs)) {
+				case 'conflict':
+					if (!await this.rollbackAutomationSnapshotIfUnchanged(destinationStore, snapshot)) {
 						return;
 					}
-					automation = removal.automation;
-					runs = removal.runs;
+					snapshot = sourceRemoval.current;
 					break;
 			}
 		}
-		this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' kept changing while transferring storage ownership; leaving the source copy in place.`);
+		this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' kept changing while transferring storage ownership; leaving the source copy in place.`);
 	}
 
 	private findAutomationStore(id: string): IAutomationStoreEntry | undefined {
@@ -219,10 +220,12 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 	}
 
 	private async migrateLegacyAutomation(initialAutomation: IAutomation): Promise<void> {
-		let automation = initialAutomation;
-		let runs = this.legacyStore.runsFor(automation.id).get();
+		let snapshot: IAutomationSnapshot = {
+			automation: initialAutomation,
+			runs: this.legacyStore.runsFor(initialAutomation.id).get(),
+		};
 		for (let attempt = 0; attempt < MAX_AUTOMATION_TRANSFER_ATTEMPTS; attempt++) {
-			const providerId = automation.target.providerId;
+			const providerId = snapshot.automation.target.providerId;
 			if (!providerId) {
 				return;
 			}
@@ -231,32 +234,31 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 				return;
 			}
 
-			const destinationCreated = await providerStore.importAutomation(automation, runs);
-			const removal = await this.legacyStore.tryRemoveAutomationSnapshot(automation, runs);
-			switch (removal.kind) {
+			const importResult = await providerStore.importAutomationSnapshot(snapshot);
+			const sourceRemoval = await this.legacyStore.removeAutomationSnapshotIfUnchanged(snapshot);
+			switch (sourceRemoval.kind) {
 				case 'removed':
 					return;
 				case 'missing':
-					if (destinationCreated) {
-						await this.rollbackAutomationSnapshot(providerStore, automation, runs);
+					if (importResult.kind === 'inserted') {
+						await this.rollbackAutomationSnapshotIfUnchanged(providerStore, snapshot);
 					}
 					return;
-				case 'changed':
-					if (destinationCreated && !await this.rollbackAutomationSnapshot(providerStore, automation, runs)) {
+				case 'conflict':
+					if (importResult.kind === 'inserted' && !await this.rollbackAutomationSnapshotIfUnchanged(providerStore, snapshot)) {
 						return;
 					}
-					automation = removal.automation;
-					runs = removal.runs;
+					snapshot = sourceRemoval.current;
 					break;
 			}
 		}
-		this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' kept changing during legacy migration; leaving it in legacy storage.`);
+		this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' kept changing during legacy migration; leaving it in legacy storage.`);
 	}
 
-	private async rollbackAutomationSnapshot(store: ISessionsProviderAutomations, automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
-		const result = await store.tryRemoveAutomationSnapshot(automation, runs);
-		if (result.kind === 'changed') {
-			this.logService.warn(`[ProviderAutomationService] Automation '${automation.id}' changed in the destination store during rollback; leaving both copies in place.`);
+	private async rollbackAutomationSnapshotIfUnchanged(store: ISessionsProviderAutomations, snapshot: IAutomationSnapshot): Promise<boolean> {
+		const result = await store.removeAutomationSnapshotIfUnchanged(snapshot);
+		if (result.kind === 'conflict') {
+			this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' changed in the destination store during rollback; leaving both copies in place.`);
 			return false;
 		}
 		return true;

--- a/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/providerAutomationService.ts
@@ -286,6 +286,10 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 			}
 
 			const importResult = await providerStore.importAutomationSnapshot(snapshot);
+			if (importResult.kind === 'conflict') {
+				this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' conflicts with the destination provider store; leaving the legacy copy in place.`);
+				return;
+			}
 			this.recoveredStores.delete(providerStore);
 			const sourceRemoval = await this.legacyStore.removeAutomationSnapshotIfUnchanged(snapshot);
 			switch (sourceRemoval.kind) {
@@ -309,11 +313,16 @@ export class ProviderAutomationService extends Disposable implements IAutomation
 
 	private async rollbackAutomationSnapshotIfUnchanged(store: ISessionsProviderAutomations, snapshot: IAutomationSnapshot): Promise<boolean> {
 		const result = await store.removeAutomationSnapshotIfUnchanged(snapshot);
-		if (result.kind === 'conflict') {
-			this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' changed in the destination store during rollback; leaving both copies in place.`);
-			return false;
+		switch (result.kind) {
+			case 'removed':
+				return true;
+			case 'conflict':
+				this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' changed in the destination store during rollback; leaving both copies in place.`);
+				return false;
+			case 'missing':
+				this.logService.warn(`[ProviderAutomationService] Automation '${snapshot.automation.id}' was deleted from the destination store during rollback; leaving the source copy in place.`);
+				return false;
 		}
-		return true;
 	}
 
 }

--- a/src/vs/sessions/contrib/automations/common/automationStorageService.ts
+++ b/src/vs/sessions/contrib/automations/common/automationStorageService.ts
@@ -7,6 +7,10 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 
 export const AUTOMATION_STORAGE_KEY = 'chat.automations.ledger';
 
+export function providerAutomationStorageKey(providerId: string): string {
+	return `chat.automations.provider.${encodeURIComponent(providerId)}.ledger`;
+}
+
 export interface IAutomationStorageCompareAndSwapResult {
 	readonly swapped: boolean;
 	readonly currentValue: string | undefined;
@@ -20,6 +24,6 @@ export const IAutomationStorageService = createDecorator<IAutomationStorageServi
 export interface IAutomationStorageService {
 	readonly _serviceBrand: undefined;
 
-	read(): Promise<string | undefined>;
-	compareAndSwap(expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult>;
+	read(key: string): Promise<string | undefined>;
+	compareAndSwap(key: string, expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult>;
 }

--- a/src/vs/sessions/contrib/automations/electron-browser/automationStorageService.ts
+++ b/src/vs/sessions/contrib/automations/electron-browser/automationStorageService.ts
@@ -7,7 +7,7 @@ import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
 import { IBaseSerializableStorageRequest, ISerializableCompareAndSwapRequest, ISerializableCompareAndSwapResult, ISerializableGetValueRequest } from '../../../../platform/storage/common/storageIpc.js';
-import { AUTOMATION_STORAGE_KEY, IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../common/automationStorageService.js';
+import { IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../common/automationStorageService.js';
 
 const baseRequest: IBaseSerializableStorageRequest = {
 	profile: undefined,
@@ -26,18 +26,18 @@ class NativeAutomationStorageService implements IAutomationStorageService {
 		this.channel = mainProcessService.getChannel('storage');
 	}
 
-	read(): Promise<string | undefined> {
+	read(key: string): Promise<string | undefined> {
 		const request: ISerializableGetValueRequest = {
 			...baseRequest,
-			key: AUTOMATION_STORAGE_KEY,
+			key,
 		};
 		return this.channel.call('getValue', request);
 	}
 
-	compareAndSwap(expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
+	compareAndSwap(key: string, expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
 		const request: ISerializableCompareAndSwapRequest = {
 			...baseRequest,
-			key: AUTOMATION_STORAGE_KEY,
+			key,
 			expectedValue,
 			newValue,
 		};

--- a/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
@@ -18,7 +18,7 @@ import { IAutomationRunDispatch, IAutomationRunner, IAutomationRunOperation } fr
 import { AutomationSchedulerCore, CRASH_RECOVERY_REASON, RUN_TIMEOUT_REASON_PREFIX } from '../../browser/automationScheduler.js';
 import { AutomationService } from '../../browser/automationService.js';
 import { AutomationRunTrigger, AutomationTarget, IAutomation, IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
-import { createAutomationService } from './automationTestUtils.js';
+import { createAutomationService, TestAutomationStorageService } from './automationTestUtils.js';
 
 const FOLDER = URI.parse('file:///workspace');
 const TARGET: AutomationTarget = { kind: 'workspace', folderUri: FOLDER, isolation: { kind: 'default' } };
@@ -40,6 +40,20 @@ class FakeLeaderElection implements IAutomationLeaderElection {
 
 	evaluateForTesting(): void { /* no-op */ }
 	dispose(): void { /* no-op */ }
+}
+
+class RecordingRecoveryAutomationService extends AutomationService {
+	readonly recoveryLifecycle: string[] = [];
+
+	override async startStaleRunRecovery(reason: string): Promise<void> {
+		this.recoveryLifecycle.push(`start:${reason}`);
+		await super.startStaleRunRecovery(reason);
+	}
+
+	override stopStaleRunRecovery(): void {
+		this.recoveryLifecycle.push('stop');
+		super.stopStaleRunRecovery();
+	}
 }
 
 interface RecordedRun {
@@ -321,6 +335,31 @@ suite('AutomationSchedulerCore', () => {
 		await core.waitForPendingRuns();
 		assert.strictEqual(runner.runs.length, 2);
 		assert.strictEqual(runner.runs[1].trigger, 'catch_up');
+	});
+
+	test('leadership transitions activate and deactivate stale-run recovery', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const service = teardown.add(new RecordingRecoveryAutomationService(storage, log, NullTelemetryService, new TestAutomationStorageService(storage)));
+		const leader = new FakeLeaderElection(false);
+		const core = teardown.add(new AutomationSchedulerCore(service, new RecordingRunner(service), storage, log, {
+			leaderElection: leader,
+			disableAutoTick: true,
+			now: () => T0,
+		}));
+
+		leader.set(true);
+		await core.waitForPendingRuns();
+		leader.set(false);
+		leader.set(true);
+		await core.waitForPendingRuns();
+
+		assert.deepStrictEqual(service.recoveryLifecycle, [
+			'stop',
+			`start:${CRASH_RECOVERY_REASON}`,
+			'stop',
+			`start:${CRASH_RECOVERY_REASON}`,
+		]);
 	});
 
 	test('toggling the feature setting off then on does not crash-recover in-progress runs', async () => {

--- a/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
@@ -10,9 +10,9 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
-import { AutomationService } from '../../browser/automationService.js';
+import { AutomationService, AutomationStore } from '../../browser/automationService.js';
 import { AutomationRunTrigger, AutomationTarget, AutomationWorkspaceIsolation, IAutomationRun, IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
-import { createAutomationService } from './automationTestUtils.js';
+import { createAutomationService, TestAutomationStorageService } from './automationTestUtils.js';
 
 const FOLDER = URI.parse('file:///workspace');
 
@@ -64,6 +64,28 @@ suite('AutomationService', () => {
 		const { service } = createService();
 		assert.deepStrictEqual(service.automations.get(), []);
 		assert.deepStrictEqual(service.runs.get(), []);
+	});
+
+	test('provider stores isolate ledgers by storage key', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const automationStorage = new TestAutomationStorageService(storage);
+		const first = teardown.add(new AutomationStore('automations.first', storage, new NullLogService(), NullTelemetryService, automationStorage));
+		const second = teardown.add(new AutomationStore('automations.second', storage, new NullLogService(), NullTelemetryService, automationStorage));
+
+		await first.createAutomation({ name: 'First', prompt: 'first', schedule: dailySchedule(), target: workspaceTarget() });
+		await second.createAutomation({ name: 'Second', prompt: 'second', schedule: dailySchedule(), target: workspaceTarget() });
+
+		assert.deepStrictEqual({
+			first: first.automations.get().map(automation => automation.name),
+			second: second.automations.get().map(automation => automation.name),
+			firstPersisted: JSON.parse(storage.get('automations.first', StorageScope.APPLICATION)!).automations.map((automation: { name: string }) => automation.name),
+			secondPersisted: JSON.parse(storage.get('automations.second', StorageScope.APPLICATION)!).automations.map((automation: { name: string }) => automation.name),
+		}, {
+			first: ['First'],
+			second: ['Second'],
+			firstPersisted: ['First'],
+			secondPersisted: ['Second'],
+		});
 	});
 
 	test('createAutomation appends an entry and computes nextRunAt for non-manual schedules', async () => {

--- a/src/vs/sessions/contrib/automations/test/browser/automationTestUtils.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationTestUtils.ts
@@ -7,7 +7,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { AutomationService } from '../../browser/automationService.js';
-import { AUTOMATION_STORAGE_KEY, IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../../common/automationStorageService.js';
+import { IAutomationStorageCompareAndSwapResult, IAutomationStorageService } from '../../common/automationStorageService.js';
 
 export class TestAutomationStorageService implements IAutomationStorageService {
 
@@ -17,16 +17,16 @@ export class TestAutomationStorageService implements IAutomationStorageService {
 		private readonly storageService: IStorageService,
 	) { }
 
-	async read(): Promise<string | undefined> {
-		return this.storageService.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION);
+	async read(key: string): Promise<string | undefined> {
+		return this.storageService.get(key, StorageScope.APPLICATION);
 	}
 
-	async compareAndSwap(expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
-		const currentValue = this.storageService.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION);
+	async compareAndSwap(key: string, expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
+		const currentValue = this.storageService.get(key, StorageScope.APPLICATION);
 		if (currentValue !== expectedValue) {
 			return { swapped: false, currentValue };
 		}
-		this.storageService.store(AUTOMATION_STORAGE_KEY, newValue, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		this.storageService.store(key, newValue, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		return { swapped: true, currentValue: newValue };
 	}
 }

--- a/src/vs/sessions/contrib/automations/test/browser/automationTools.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationTools.test.ts
@@ -199,13 +199,13 @@ class ControllableAutomationStorageService implements IAutomationStorageService 
 		return this.currentValue;
 	}
 
-	async read(): Promise<string | undefined> {
+	async read(_key: string): Promise<string | undefined> {
 		await this.readStarted.complete();
 		await this.readBarrier?.p;
 		return this.currentValue;
 	}
 
-	async compareAndSwap(expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
+	async compareAndSwap(_key: string, expectedValue: string | undefined, newValue: string): Promise<IAutomationStorageCompareAndSwapResult> {
 		this.compareAndSwapCalls++;
 		this.beforeCompareAndSwap?.();
 		if (this.nextConflictValue !== undefined) {

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -1,0 +1,353 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IAutomation, IAutomationRun } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { AutomationStore } from '../../browser/automationService.js';
+import { ProviderAutomationService } from '../../browser/providerAutomationService.js';
+import { AUTOMATION_STORAGE_KEY, IAutomationStorageService, providerAutomationStorageKey } from '../../common/automationStorageService.js';
+import { TestAutomationStorageService } from './automationTestUtils.js';
+
+const FOLDER = URI.parse('file:///workspace');
+const PROVIDER_ID = 'local-agent-host';
+const SESSION_TYPE_ID = 'copilotcli';
+
+class FailingStaleRunRecoveryAutomationStore extends AutomationStore {
+	override async markStaleRunsFailed(): Promise<void> {
+		throw new Error('Provider unavailable.');
+	}
+}
+
+class PartiallyFailingMigrationAutomationStore extends AutomationStore {
+	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
+		if (automation.id === 'automation-1') {
+			throw new Error('Import failed.');
+		}
+		await super.importAutomation(automation, runs);
+	}
+}
+
+suite('ProviderAutomationService', () => {
+	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration'): {
+		readonly service: ProviderAutomationService;
+		readonly providerStore: AutomationStore;
+		readonly storage: InMemoryStorageService;
+	} {
+		const storage = teardown.add(new InMemoryStorageService());
+		if (legacyRaw) {
+			storage.store(AUTOMATION_STORAGE_KEY, legacyRaw, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+		if (providerRaw) {
+			storage.store(providerAutomationStorageKey(PROVIDER_ID), providerRaw, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+		const automationStorage = new TestAutomationStorageService(storage);
+		const providerStore = teardown.add(providerFailure === 'staleRunRecovery'
+			? new FailingStaleRunRecoveryAutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage)
+			: providerFailure === 'migration'
+				? new PartiallyFailingMigrationAutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage)
+			: new AutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage));
+		const provider = upcastPartial<ISessionsProvider>({
+			id: PROVIDER_ID,
+			order: 0,
+			automations: providerStore,
+		});
+		const providers = upcastPartial<ISessionsProvidersService>({
+			onDidChangeProviders: Event.None,
+			getProviders: () => [provider],
+			getProvider: <T extends ISessionsProvider>(providerId: string) => providerId === PROVIDER_ID ? provider as T : undefined,
+		});
+		const instantiationService = teardown.add(new TestInstantiationService());
+		instantiationService.stub(IStorageService, storage);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IAutomationStorageService, automationStorage);
+		instantiationService.stub(ISessionsProvidersService, providers);
+		instantiationService.stub(IInstantiationService, instantiationService);
+		const service = teardown.add(instantiationService.createInstance(ProviderAutomationService));
+		return { service, providerStore, storage };
+	}
+
+	test('routes new Automations to their provider store', async () => {
+		const { service, providerStore, storage } = createService();
+		await service.createAutomation({
+			name: 'Provider owned',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+			modelId: 'model',
+			mode: 'agent',
+			permissionLevel: 'autopilot',
+		});
+
+		assert.deepStrictEqual({
+			aggregate: service.automations.get().map(automation => automation.name),
+			provider: providerStore.automations.get().map(automation => automation.name),
+			legacy: storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION),
+		}, {
+			aggregate: ['Provider owned'],
+			provider: ['Provider owned'],
+			legacy: undefined,
+		});
+	});
+
+	test('migrates legacy Automations and runs unchanged into the provider store', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Legacy',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				modelId: 'model',
+				mode: 'agent',
+				permissionLevel: 'autopilot',
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [{
+				id: 'run-1',
+				automationId: 'automation-1',
+				status: 'completed',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service, providerStore, storage } = createService(legacy);
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			automation: providerStore.getAutomation('automation-1'),
+			runIds: providerStore.runs.get().map(run => run.id),
+			legacy: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!),
+		}, {
+			automation: {
+				id: 'automation-1',
+				name: 'Legacy',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				modelId: 'model',
+				mode: 'agent',
+				permissionLevel: 'autopilot',
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				lastRunAt: undefined,
+				nextRunAt: undefined,
+			},
+			runIds: ['run-1'],
+			legacy: { schemaVersion: 3, revision: 2, automations: [], runs: [] },
+		});
+	});
+
+	test('deduplicates overlapping provider and legacy entries during migration', () => {
+		const ledger = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Shared',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [{
+				id: 'run-1',
+				automationId: 'automation-1',
+				status: 'completed',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service } = createService(ledger, ledger);
+
+		assert.deepStrictEqual({
+			automationIds: service.automations.get().map(automation => automation.id),
+			runIds: service.runs.get().map(run => run.id),
+		}, {
+			automationIds: ['automation-1'],
+			runIds: ['run-1'],
+		});
+	});
+
+	test('merges missing runs when the provider already has the Automation', async () => {
+		const automation = {
+			id: 'automation-1',
+			name: 'Shared',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+			enabled: true,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		};
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [automation],
+			runs: [{
+				id: 'legacy-run',
+				automationId: automation.id,
+				status: 'completed',
+				trigger: 'manual',
+				startedAt: '2026-01-02T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const provider = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [automation],
+			runs: [{
+				id: 'provider-run',
+				automationId: automation.id,
+				status: 'completed',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service, providerStore, storage } = createService(legacy, provider);
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			providerRunIds: providerStore.runs.get().map(run => run.id),
+			legacy: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!),
+		}, {
+			providerRunIds: ['legacy-run', 'provider-run'],
+			legacy: { schemaVersion: 3, revision: 2, automations: [], runs: [] },
+		});
+	});
+
+	test('recovers active runs after migration completes', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Legacy',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [{
+				id: 'run-1',
+				automationId: 'automation-1',
+				status: 'running',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service, providerStore } = createService(legacy);
+
+		await service.markStaleRunsFailed('Recovered after restart.');
+
+		assert.deepStrictEqual(providerStore.runs.get().map(run => ({
+			id: run.id,
+			status: run.status,
+			errorMessage: run.errorMessage,
+		})), [{
+			id: 'run-1',
+			status: 'failed',
+			errorMessage: 'Recovered after restart.',
+		}]);
+	});
+
+	test('continues stale-run recovery when a provider store fails', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Legacy',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [{
+				id: 'run-1',
+				automationId: 'automation-1',
+				status: 'running',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service } = createService(legacy, undefined, 'staleRunRecovery');
+
+		await service.markStaleRunsFailed('Recovered after restart.');
+
+		assert.deepStrictEqual(service.runs.get().map(run => ({
+			id: run.id,
+			status: run.status,
+			errorMessage: run.errorMessage,
+		})), [{
+			id: 'run-1',
+			status: 'failed',
+			errorMessage: 'Recovered after restart.',
+		}]);
+	});
+
+	test('continues migrating after an Automation import fails', async () => {
+		const createAutomation = (id: string) => ({
+			id,
+			name: id,
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+			enabled: true,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		});
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [createAutomation('automation-1'), createAutomation('automation-2')],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(legacy, undefined, 'migration');
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			providerAutomationIds: providerStore.automations.get().map(automation => automation.id),
+			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
+		}, {
+			providerAutomationIds: ['automation-2'],
+			legacyAutomationIds: ['automation-1'],
+		});
+	});
+});

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -713,14 +713,16 @@ suite('ProviderAutomationService', () => {
 			legacy: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!),
 		}, {
 			providerRunIds: ['provider-run'],
-			legacy: { schemaVersion: 3, revision: 1, automations: [automation], runs: [{
-				id: 'legacy-run',
-				automationId: automation.id,
-				status: 'completed',
-				trigger: 'manual',
-				startedAt: '2026-01-02T00:00:00.000Z',
-				leaderWindowId: 1,
-			}] },
+			legacy: {
+				schemaVersion: 3, revision: 1, automations: [automation], runs: [{
+					id: 'legacy-run',
+					automationId: automation.id,
+					status: 'completed',
+					trigger: 'manual',
+					startedAt: '2026-01-02T00:00:00.000Z',
+					leaderWindowId: 1,
+				}]
+			},
 		});
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Event } from '../../../../../base/common/event.js';
+import { Emitter } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -14,7 +14,7 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
-import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAutomationSnapshot, IAutomationSnapshotImportResult, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { AutomationStore } from '../../browser/automationService.js';
 import { ProviderAutomationService } from '../../browser/providerAutomationService.js';
@@ -90,6 +90,8 @@ suite('ProviderAutomationService', () => {
 		readonly service: ProviderAutomationService;
 		readonly providerStore: AutomationStore;
 		readonly storage: InMemoryStorageService;
+		readonly automationStorage: TestAutomationStorageService;
+		readonly addProvider: (provider: ISessionsProvider) => void;
 	} {
 		const storage = teardown.add(new InMemoryStorageService());
 		if (legacyRaw) {
@@ -144,10 +146,12 @@ suite('ProviderAutomationService', () => {
 			order: 0,
 			automations: providerStore,
 		});
+		const registeredProviders: ISessionsProvider[] = [provider];
+		const providersChanged = teardown.add(new Emitter<ISessionsProvidersChangeEvent>());
 		const providers = upcastPartial<ISessionsProvidersService>({
-			onDidChangeProviders: Event.None,
-			getProviders: () => [provider],
-			getProvider: <T extends ISessionsProvider>(providerId: string) => providerId === PROVIDER_ID ? provider as T : undefined,
+			onDidChangeProviders: providersChanged.event,
+			getProviders: () => [...registeredProviders],
+			getProvider: <T extends ISessionsProvider>(providerId: string) => registeredProviders.find(candidate => candidate.id === providerId) as T | undefined,
 		});
 		const instantiationService = teardown.add(new TestInstantiationService());
 		instantiationService.stub(IStorageService, storage);
@@ -157,7 +161,16 @@ suite('ProviderAutomationService', () => {
 		instantiationService.stub(ISessionsProvidersService, providers);
 		instantiationService.stub(IInstantiationService, instantiationService);
 		const service = teardown.add(instantiationService.createInstance(ProviderAutomationService));
-		return { service, providerStore, storage };
+		return {
+			service,
+			providerStore,
+			storage,
+			automationStorage,
+			addProvider: addedProvider => {
+				registeredProviders.push(addedProvider);
+				providersChanged.fire({ added: [addedProvider], removed: [] });
+			},
+		};
 	}
 
 	test('routes new Automations to their provider store', async () => {
@@ -621,6 +634,87 @@ suite('ProviderAutomationService', () => {
 		await service.markStaleRunsFailed('Recovered after restart.');
 
 		assert.deepStrictEqual(providerStore.runs.get().map(run => ({
+			id: run.id,
+			status: run.status,
+			errorMessage: run.errorMessage,
+		})), [{
+			id: 'run-1',
+			status: 'failed',
+			errorMessage: 'Recovered after restart.',
+		}]);
+	});
+
+	test('recovers stale runs for providers added only while leader-scoped recovery is active', async () => {
+		const { service, storage, automationStorage, addProvider } = createService();
+		await service.startStaleRunRecovery('Recovered after restart.');
+
+		const activeProviderId = 'late-active-provider';
+		const activeStore = teardown.add(new AutomationStore(providerAutomationStorageKey(activeProviderId), storage, new NullLogService(), NullTelemetryService, automationStorage));
+		const activeAutomation = await activeStore.createAutomation({
+			name: 'Active recovery',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: activeProviderId, sessionTypeId: 'late', isolation: { kind: 'default' } },
+		});
+		await activeStore.recordRunStart(activeAutomation.id, 'manual', 1);
+		addProvider(upcastPartial<ISessionsProvider>({ id: activeProviderId, order: 1, automations: activeStore }));
+		await service.waitForMigrationForTesting();
+
+		service.stopStaleRunRecovery();
+		const inactiveProviderId = 'late-inactive-provider';
+		const inactiveStore = teardown.add(new AutomationStore(providerAutomationStorageKey(inactiveProviderId), storage, new NullLogService(), NullTelemetryService, automationStorage));
+		const inactiveAutomation = await inactiveStore.createAutomation({
+			name: 'Inactive recovery',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: inactiveProviderId, sessionTypeId: 'late', isolation: { kind: 'default' } },
+		});
+		await inactiveStore.recordRunStart(inactiveAutomation.id, 'manual', 1);
+		addProvider(upcastPartial<ISessionsProvider>({ id: inactiveProviderId, order: 2, automations: inactiveStore }));
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			activeStatuses: activeStore.runs.get().map(run => run.status),
+			inactiveStatuses: inactiveStore.runs.get().map(run => run.status),
+		}, {
+			activeStatuses: ['failed'],
+			inactiveStatuses: ['pending'],
+		});
+	});
+
+	test('migrates before recovering a provider added while initial recovery is queued', async () => {
+		const lateProviderId = 'late-provider';
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Late provider',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: lateProviderId, sessionTypeId: 'late', isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [{
+				id: 'run-1',
+				automationId: 'automation-1',
+				status: 'running',
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service, storage, automationStorage, addProvider } = createService(legacy);
+		const recovery = service.startStaleRunRecovery('Recovered after restart.');
+		const lateStore = teardown.add(new AutomationStore(providerAutomationStorageKey(lateProviderId), storage, new NullLogService(), NullTelemetryService, automationStorage));
+		addProvider(upcastPartial<ISessionsProvider>({ id: lateProviderId, order: 1, automations: lateStore }));
+
+		await recovery;
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual(lateStore.runs.get().map(run => ({
 			id: run.id,
 			status: run.status,
 			errorMessage: run.errorMessage,

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -41,10 +41,16 @@ class PartiallyFailingMigrationAutomationStore extends AutomationStore {
 	}
 }
 
+class FailingTransferAutomationStore extends AutomationStore {
+	override async storeAutomationForTransfer(): Promise<void> {
+		throw new Error('Transfer failed.');
+	}
+}
+
 suite('ProviderAutomationService', () => {
 	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration'): {
+	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration' | 'transfer'): {
 		readonly service: ProviderAutomationService;
 		readonly providerStore: AutomationStore;
 		readonly storage: InMemoryStorageService;
@@ -57,11 +63,22 @@ suite('ProviderAutomationService', () => {
 			storage.store(providerAutomationStorageKey(PROVIDER_ID), providerRaw, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		const automationStorage = new TestAutomationStorageService(storage);
-		const providerStore = teardown.add(providerFailure === 'staleRunRecovery'
-			? new FailingStaleRunRecoveryAutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage)
-			: providerFailure === 'migration'
-				? new PartiallyFailingMigrationAutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage)
-			: new AutomationStore(providerAutomationStorageKey(PROVIDER_ID), storage, new NullLogService(), NullTelemetryService, automationStorage));
+		const storageKey = providerAutomationStorageKey(PROVIDER_ID);
+		let providerStore: AutomationStore;
+		switch (providerFailure) {
+			case 'staleRunRecovery':
+				providerStore = new FailingStaleRunRecoveryAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				break;
+			case 'migration':
+				providerStore = new PartiallyFailingMigrationAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				break;
+			case 'transfer':
+				providerStore = new FailingTransferAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				break;
+			default:
+				providerStore = new AutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+		}
+		teardown.add(providerStore);
 		const provider = upcastPartial<ISessionsProvider>({
 			id: PROVIDER_ID,
 			order: 0,
@@ -103,6 +120,104 @@ suite('ProviderAutomationService', () => {
 			aggregate: ['Provider owned'],
 			provider: ['Provider owned'],
 			legacy: undefined,
+		});
+	});
+
+	test('transfers Automations and runs when updates change store ownership', async () => {
+		const { service, providerStore, storage } = createService();
+		const legacyTarget = { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } } as const;
+		const providerTarget = { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } } as const;
+		const created = await service.createAutomation({
+			name: 'Transferred',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: legacyTarget,
+		});
+		const claim = await service.recordRunStart(created.id, 'manual', 1);
+
+		const transferToProvider = await service.updateAutomationIfUnchanged(created.id, { target: providerTarget }, created);
+		const afterProviderTransfer = {
+			result: transferToProvider.kind,
+			providerTarget: providerStore.getAutomation(created.id)?.target,
+			providerRunIds: providerStore.runs.get().map(run => run.id),
+			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
+		};
+
+		await service.updateAutomation(created.id, { target: legacyTarget });
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			claimRunId: claim.run.id,
+			afterProviderTransfer,
+			finalProviderAutomation: providerStore.getAutomation(created.id),
+			finalProviderRunIds: providerStore.runs.get().map(run => run.id),
+			finalLegacyTarget: legacyLedger.automations.find((automation: { id: string }) => automation.id === created.id)?.target,
+			finalLegacyRunIds: legacyLedger.runs.map((run: { id: string }) => run.id),
+		}, {
+			claimRunId: claim.run.id,
+			afterProviderTransfer: {
+				result: 'updated',
+				providerTarget,
+				providerRunIds: [claim.run.id],
+				legacyAutomationIds: [],
+			},
+			finalProviderAutomation: undefined,
+			finalProviderRunIds: [],
+			finalLegacyTarget: {
+				kind: 'workspace',
+				folderUri: FOLDER.toJSON(),
+				providerId: 'provider-without-storage',
+				sessionTypeId: 'other',
+				isolation: { kind: 'default' },
+			},
+			finalLegacyRunIds: [claim.run.id],
+		});
+	});
+
+	test('does not transfer an Automation when a guarded update conflicts', async () => {
+		const { service, providerStore, storage } = createService();
+		const created = await service.createAutomation({
+			name: 'Provider owned',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+		});
+
+		const result = await service.updateAutomationIfUnchanged(created.id, {
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } },
+		}, { ...created, name: 'Stale' });
+
+		assert.deepStrictEqual({
+			result: result.kind,
+			providerAutomationId: providerStore.getAutomation(created.id)?.id,
+			legacy: storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION),
+		}, {
+			result: 'conflict',
+			providerAutomationId: created.id,
+			legacy: undefined,
+		});
+	});
+
+	test('retains the source Automation when ownership transfer fails', async () => {
+		const { service, providerStore, storage } = createService(undefined, undefined, 'transfer');
+		const created = await service.createAutomation({
+			name: 'Legacy',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } },
+		});
+
+		await assert.rejects(service.updateAutomation(created.id, {
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+		}), /Transfer failed/);
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			providerAutomation: providerStore.getAutomation(created.id),
+			legacyAutomationIds: legacyLedger.automations.map((automation: { id: string }) => automation.id),
+		}, {
+			providerAutomation: undefined,
+			legacyAutomationIds: [created.id],
 		});
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -33,11 +33,11 @@ class FailingStaleRunRecoveryAutomationStore extends AutomationStore {
 }
 
 class PartiallyFailingMigrationAutomationStore extends AutomationStore {
-	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
+	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
 		if (automation.id === 'automation-1') {
 			throw new Error('Import failed.');
 		}
-		await super.importAutomation(automation, runs);
+		return super.importAutomation(automation, runs);
 	}
 }
 
@@ -47,10 +47,47 @@ class FailingTransferAutomationStore extends AutomationStore {
 	}
 }
 
+class ConcurrentlyMutatingMigrationAutomationStore extends AutomationStore {
+	legacyWriter!: AutomationStore;
+	mutation!: 'update' | 'delete' | 'run' | 'continuousUpdate';
+	private didMutate = false;
+	private updateCount = 0;
+
+	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
+		const inserted = await super.importAutomation(automation, runs);
+		if (this.mutation === 'continuousUpdate') {
+			await this.legacyWriter.updateAutomation(automation.id, { name: `Concurrent update ${++this.updateCount}` });
+		} else if (!this.didMutate) {
+			this.didMutate = true;
+			if (this.mutation === 'update') {
+				await this.legacyWriter.updateAutomation(automation.id, { name: 'Concurrent update' });
+			} else if (this.mutation === 'delete') {
+				await this.legacyWriter.deleteAutomation(automation.id);
+			} else {
+				await this.legacyWriter.recordRunStart(automation.id, 'manual', 1);
+			}
+		}
+		return inserted;
+	}
+}
+
+class ConcurrentlyMutatingTransferAutomationStore extends AutomationStore {
+	legacyWriter!: AutomationStore;
+	private didMutate = false;
+
+	override async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
+		await super.storeAutomationForTransfer(automation, runs);
+		if (!this.didMutate) {
+			this.didMutate = true;
+			await this.legacyWriter.recordRunStart(automation.id, 'manual', 1);
+		}
+	}
+}
+
 suite('ProviderAutomationService', () => {
 	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration' | 'transfer'): {
+	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration' | 'transfer' | 'concurrentMigrationUpdate' | 'concurrentMigrationDelete' | 'concurrentMigrationRun' | 'continuousMigrationUpdate' | 'concurrentTransferRun'): {
 		readonly service: ProviderAutomationService;
 		readonly providerStore: AutomationStore;
 		readonly storage: InMemoryStorageService;
@@ -75,6 +112,30 @@ suite('ProviderAutomationService', () => {
 			case 'transfer':
 				providerStore = new FailingTransferAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
 				break;
+			case 'concurrentMigrationUpdate':
+			case 'concurrentMigrationDelete':
+			case 'concurrentMigrationRun':
+			case 'continuousMigrationUpdate': {
+				const mutatingStore = new ConcurrentlyMutatingMigrationAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				mutatingStore.legacyWriter = teardown.add(new AutomationStore(AUTOMATION_STORAGE_KEY, storage, new NullLogService(), NullTelemetryService, automationStorage));
+				if (providerFailure === 'concurrentMigrationUpdate') {
+					mutatingStore.mutation = 'update';
+				} else if (providerFailure === 'concurrentMigrationDelete') {
+					mutatingStore.mutation = 'delete';
+				} else if (providerFailure === 'continuousMigrationUpdate') {
+					mutatingStore.mutation = 'continuousUpdate';
+				} else {
+					mutatingStore.mutation = 'run';
+				}
+				providerStore = mutatingStore;
+				break;
+			}
+			case 'concurrentTransferRun': {
+				const mutatingStore = new ConcurrentlyMutatingTransferAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				mutatingStore.legacyWriter = teardown.add(new AutomationStore(AUTOMATION_STORAGE_KEY, storage, new NullLogService(), NullTelemetryService, automationStorage));
+				providerStore = mutatingStore;
+				break;
+			}
 			default:
 				providerStore = new AutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
 		}
@@ -221,6 +282,58 @@ suite('ProviderAutomationService', () => {
 		});
 	});
 
+	test('retries ownership transfer when a run is added concurrently', async () => {
+		const { service, providerStore, storage } = createService(undefined, undefined, 'concurrentTransferRun');
+		const created = await service.createAutomation({
+			name: 'Legacy',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } },
+		});
+
+		await service.updateAutomation(created.id, {
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+		});
+
+		assert.deepStrictEqual({
+			providerRunAutomationIds: providerStore.runs.get().map(run => run.automationId),
+			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
+		}, {
+			providerRunAutomationIds: [created.id],
+			legacyAutomationIds: [],
+		});
+	});
+
+	test('does not re-run the mutation guard after the source update commits', async () => {
+		const { service, providerStore } = createService();
+		const created = await service.createAutomation({
+			name: 'Legacy',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } },
+		});
+		let guardCalls = 0;
+
+		const result = await service.updateAutomationIfUnchanged(created.id, {
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+		}, created, () => {
+			guardCalls++;
+			if (guardCalls > 1) {
+				throw new Error('Guard called after commit.');
+			}
+		});
+
+		assert.deepStrictEqual({
+			result: result.kind,
+			guardCalls,
+			providerAutomationId: providerStore.getAutomation(created.id)?.id,
+		}, {
+			result: 'updated',
+			guardCalls: 1,
+			providerAutomationId: created.id,
+		});
+	});
+
 	test('migrates legacy Automations and runs unchanged into the provider store', async () => {
 		const legacy = JSON.stringify({
 			schemaVersion: 3,
@@ -273,6 +386,127 @@ suite('ProviderAutomationService', () => {
 			},
 			runIds: ['run-1'],
 			legacy: { schemaVersion: 3, revision: 2, automations: [], runs: [] },
+		});
+	});
+
+	test('retries migration when the legacy Automation changes during import', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Original',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(legacy, undefined, 'concurrentMigrationUpdate');
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			providerName: providerStore.getAutomation('automation-1')?.name,
+			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
+		}, {
+			providerName: 'Concurrent update',
+			legacyAutomationIds: [],
+		});
+	});
+
+	test('rolls back migration when the legacy Automation is deleted during import', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Deleted concurrently',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(legacy, undefined, 'concurrentMigrationDelete');
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			providerAutomation: providerStore.getAutomation('automation-1'),
+			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
+		}, {
+			providerAutomation: undefined,
+			legacyAutomationIds: [],
+		});
+	});
+
+	test('retries migration when a run is added during import', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Concurrent run',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(legacy, undefined, 'concurrentMigrationRun');
+
+		await service.waitForMigrationForTesting();
+
+		assert.deepStrictEqual({
+			providerRunCount: providerStore.runs.get().length,
+			providerRunAutomationIds: providerStore.runs.get().map(run => run.automationId),
+			legacyRunIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).runs.map((run: { id: string }) => run.id),
+		}, {
+			providerRunCount: 1,
+			providerRunAutomationIds: ['automation-1'],
+			legacyRunIds: [],
+		});
+	});
+
+	test('bounds migration retries and leaves a continuously changing source in legacy storage', async () => {
+		const legacy = JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name: 'Original',
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(legacy, undefined, 'continuousMigrationUpdate');
+
+		await service.waitForMigrationForTesting();
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			providerAutomation: providerStore.getAutomation('automation-1'),
+			legacyAutomationIds: legacyLedger.automations.map((automation: { id: string }) => automation.id),
+			legacyName: legacyLedger.automations[0]?.name,
+		}, {
+			providerAutomation: undefined,
+			legacyAutomationIds: ['automation-1'],
+			legacyName: 'Concurrent update 3',
 		});
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -14,9 +14,8 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
-import { IAutomation, IAutomationRun } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { IAutomationSnapshot, IAutomationSnapshotImportResult, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { AutomationStore } from '../../browser/automationService.js';
 import { ProviderAutomationService } from '../../browser/providerAutomationService.js';
 import { AUTOMATION_STORAGE_KEY, IAutomationStorageService, providerAutomationStorageKey } from '../../common/automationStorageService.js';
@@ -33,16 +32,16 @@ class FailingStaleRunRecoveryAutomationStore extends AutomationStore {
 }
 
 class PartiallyFailingMigrationAutomationStore extends AutomationStore {
-	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
-		if (automation.id === 'automation-1') {
+	override async importAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<IAutomationSnapshotImportResult> {
+		if (snapshot.automation.id === 'automation-1') {
 			throw new Error('Import failed.');
 		}
-		return super.importAutomation(automation, runs);
+		return super.importAutomationSnapshot(snapshot);
 	}
 }
 
 class FailingTransferAutomationStore extends AutomationStore {
-	override async storeAutomationForTransfer(): Promise<void> {
+	override async upsertAutomationSnapshot(): Promise<void> {
 		throw new Error('Transfer failed.');
 	}
 }
@@ -53,21 +52,21 @@ class ConcurrentlyMutatingMigrationAutomationStore extends AutomationStore {
 	private didMutate = false;
 	private updateCount = 0;
 
-	override async importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean> {
-		const inserted = await super.importAutomation(automation, runs);
+	override async importAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<IAutomationSnapshotImportResult> {
+		const result = await super.importAutomationSnapshot(snapshot);
 		if (this.mutation === 'continuousUpdate') {
-			await this.legacyWriter.updateAutomation(automation.id, { name: `Concurrent update ${++this.updateCount}` });
+			await this.legacyWriter.updateAutomation(snapshot.automation.id, { name: `Concurrent update ${++this.updateCount}` });
 		} else if (!this.didMutate) {
 			this.didMutate = true;
 			if (this.mutation === 'update') {
-				await this.legacyWriter.updateAutomation(automation.id, { name: 'Concurrent update' });
+				await this.legacyWriter.updateAutomation(snapshot.automation.id, { name: 'Concurrent update' });
 			} else if (this.mutation === 'delete') {
-				await this.legacyWriter.deleteAutomation(automation.id);
+				await this.legacyWriter.deleteAutomation(snapshot.automation.id);
 			} else {
-				await this.legacyWriter.recordRunStart(automation.id, 'manual', 1);
+				await this.legacyWriter.recordRunStart(snapshot.automation.id, 'manual', 1);
 			}
 		}
-		return inserted;
+		return result;
 	}
 }
 
@@ -75,11 +74,11 @@ class ConcurrentlyMutatingTransferAutomationStore extends AutomationStore {
 	legacyWriter!: AutomationStore;
 	private didMutate = false;
 
-	override async storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void> {
-		await super.storeAutomationForTransfer(automation, runs);
+	override async upsertAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<void> {
+		await super.upsertAutomationSnapshot(snapshot);
 		if (!this.didMutate) {
 			this.didMutate = true;
-			await this.legacyWriter.recordRunStart(automation.id, 'manual', 1);
+			await this.legacyWriter.recordRunStart(snapshot.automation.id, 'manual', 1);
 		}
 	}
 }

--- a/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/providerAutomationService.test.ts
@@ -83,10 +83,24 @@ class ConcurrentlyMutatingTransferAutomationStore extends AutomationStore {
 	}
 }
 
+class DestinationDeletingTransferAutomationStore extends AutomationStore {
+	destinationStore!: AutomationStore;
+	private didMutate = false;
+
+	override async removeAutomationSnapshotIfUnchanged(expected: IAutomationSnapshot) {
+		if (!this.didMutate) {
+			this.didMutate = true;
+			await this.updateAutomation(expected.automation.id, { name: 'Concurrent source update' });
+			await this.destinationStore.deleteAutomation(expected.automation.id);
+		}
+		return super.removeAutomationSnapshotIfUnchanged(expected);
+	}
+}
+
 suite('ProviderAutomationService', () => {
 	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration' | 'transfer' | 'concurrentMigrationUpdate' | 'concurrentMigrationDelete' | 'concurrentMigrationRun' | 'continuousMigrationUpdate' | 'concurrentTransferRun'): {
+	function createService(legacyRaw?: string, providerRaw?: string, providerFailure?: 'staleRunRecovery' | 'migration' | 'transfer' | 'concurrentMigrationUpdate' | 'concurrentMigrationDelete' | 'concurrentMigrationRun' | 'continuousMigrationUpdate' | 'concurrentTransferRun' | 'destinationDeleteDuringRollback'): {
 		readonly service: ProviderAutomationService;
 		readonly providerStore: AutomationStore;
 		readonly storage: InMemoryStorageService;
@@ -135,6 +149,12 @@ suite('ProviderAutomationService', () => {
 				const mutatingStore = new ConcurrentlyMutatingTransferAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
 				mutatingStore.legacyWriter = teardown.add(new AutomationStore(AUTOMATION_STORAGE_KEY, storage, new NullLogService(), NullTelemetryService, automationStorage));
 				providerStore = mutatingStore;
+				break;
+			}
+			case 'destinationDeleteDuringRollback': {
+				const deletingStore = new DestinationDeletingTransferAutomationStore(storageKey, storage, new NullLogService(), NullTelemetryService, automationStorage);
+				deletingStore.destinationStore = teardown.add(new AutomationStore(AUTOMATION_STORAGE_KEY, storage, new NullLogService(), NullTelemetryService, automationStorage));
+				providerStore = deletingStore;
 				break;
 			}
 			default:
@@ -312,6 +332,29 @@ suite('ProviderAutomationService', () => {
 			legacyAutomationIds: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!).automations.map((automation: { id: string }) => automation.id),
 		}, {
 			providerRunAutomationIds: [created.id],
+			legacyAutomationIds: [],
+		});
+	});
+
+	test('does not recreate a destination deleted during rollback', async () => {
+		const { service, providerStore, storage } = createService(undefined, undefined, 'destinationDeleteDuringRollback');
+		const created = await service.createAutomation({
+			name: 'Provider owned',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+		});
+
+		await service.updateAutomation(created.id, {
+			target: { kind: 'workspace', folderUri: FOLDER, providerId: 'provider-without-storage', sessionTypeId: 'other', isolation: { kind: 'default' } },
+		});
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			sourceName: providerStore.getAutomation(created.id)?.name,
+			legacyAutomationIds: legacyLedger.automations.map((automation: { id: string }) => automation.id),
+		}, {
+			sourceName: 'Concurrent source update',
 			legacyAutomationIds: [],
 		});
 	});
@@ -556,7 +599,75 @@ suite('ProviderAutomationService', () => {
 		});
 	});
 
-	test('merges missing runs when the provider already has the Automation', async () => {
+	test('retains legacy data when the provider Automation payload diverges', async () => {
+		const createLedger = (name: string) => JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [{
+				id: 'automation-1',
+				name,
+				prompt: 'prompt',
+				schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+				target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+				enabled: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+			}],
+			runs: [],
+		});
+		const { service, providerStore, storage } = createService(createLedger('Legacy'), createLedger('Provider'));
+
+		await service.waitForMigrationForTesting();
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			providerName: providerStore.getAutomation('automation-1')?.name,
+			legacyNames: legacyLedger.automations.map((automation: { name: string }) => automation.name),
+		}, {
+			providerName: 'Provider',
+			legacyNames: ['Legacy'],
+		});
+	});
+
+	test('retains legacy data when a same-ID run payload diverges', async () => {
+		const automation = {
+			id: 'automation-1',
+			name: 'Shared',
+			prompt: 'prompt',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			target: { kind: 'workspace', folderUri: FOLDER.toJSON(), providerId: PROVIDER_ID, sessionTypeId: SESSION_TYPE_ID, isolation: { kind: 'default' } },
+			enabled: true,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		};
+		const createLedger = (status: 'completed' | 'failed') => JSON.stringify({
+			schemaVersion: 3,
+			revision: 1,
+			automations: [automation],
+			runs: [{
+				id: 'run-1',
+				automationId: automation.id,
+				status,
+				trigger: 'manual',
+				startedAt: '2026-01-01T00:00:00.000Z',
+				leaderWindowId: 1,
+			}],
+		});
+		const { service, providerStore, storage } = createService(createLedger('failed'), createLedger('completed'));
+
+		await service.waitForMigrationForTesting();
+		const legacyLedger = JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!);
+
+		assert.deepStrictEqual({
+			providerStatuses: providerStore.runs.get().map(run => run.status),
+			legacyStatuses: legacyLedger.runs.map((run: { status: string }) => run.status),
+		}, {
+			providerStatuses: ['completed'],
+			legacyStatuses: ['failed'],
+		});
+	});
+
+	test('retains legacy data when provider run history diverges', async () => {
 		const automation = {
 			id: 'automation-1',
 			name: 'Shared',
@@ -601,8 +712,15 @@ suite('ProviderAutomationService', () => {
 			providerRunIds: providerStore.runs.get().map(run => run.id),
 			legacy: JSON.parse(storage.get(AUTOMATION_STORAGE_KEY, StorageScope.APPLICATION)!),
 		}, {
-			providerRunIds: ['legacy-run', 'provider-run'],
-			legacy: { schemaVersion: 3, revision: 2, automations: [], runs: [] },
+			providerRunIds: ['provider-run'],
+			legacy: { schemaVersion: 3, revision: 1, automations: [automation], runs: [{
+				id: 'legacy-run',
+				automationId: automation.id,
+				status: 'completed',
+				trigger: 'manual',
+				startedAt: '2026-01-02T00:00:00.000Z',
+				leaderWindowId: 1,
+			}] },
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -21,6 +21,9 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { AutomationStore } from '../../../automations/browser/automationService.js';
+import { providerAutomationStorageKey } from '../../../automations/common/automationStorageService.js';
+import { ISessionsProviderAutomations } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
@@ -57,6 +60,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
 	readonly label: string;
+	readonly automations: ISessionsProviderAutomations;
 	readonly icon: ThemeIcon = Codicon.vm;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
@@ -88,6 +92,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 		@IWorkspaceTrustManagementService workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) {
 		super(chatSessionsService, chatService, chatWidgetService, languageModelsService, _configurationService, logService, gitHubService, instantiationService, sessionsService, activeClientService, storageService, dialogService, workspaceTrustManagementService);
+		this.automations = this._register(instantiationService.createInstance(AutomationStore, providerAutomationStorageKey(this.id)));
 
 		this._isSessionsWindow = environmentService.isSessionsWindow;
 

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -67,15 +67,27 @@ export interface ISessionModelsSnapshot {
 	readonly modelTarget: string | undefined;
 }
 
-export type IGuardedAutomationTransferRemovalResult =
+export interface IAutomationSnapshot {
+	readonly automation: IAutomation;
+	readonly runs: readonly IAutomationRun[];
+}
+
+export type IAutomationSnapshotImportResult =
+	| { readonly kind: 'inserted' }
+	| { readonly kind: 'alreadyPresent' };
+
+export type IGuardedAutomationSnapshotRemovalResult =
 	| { readonly kind: 'removed' }
-	| { readonly kind: 'changed'; readonly automation: IAutomation; readonly runs: readonly IAutomationRun[] }
+	| { readonly kind: 'conflict'; readonly current: IAutomationSnapshot }
 	| { readonly kind: 'missing' };
 
 export interface ISessionsProviderAutomations extends IAutomationStore {
-	importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean>;
-	storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void>;
-	tryRemoveAutomationSnapshot(expected: IAutomation, expectedRuns: readonly IAutomationRun[]): Promise<IGuardedAutomationTransferRemovalResult>;
+	/** Imports a snapshot without replacing an Automation already stored under the same ID. */
+	importAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<IAutomationSnapshotImportResult>;
+	/** Inserts or replaces an Automation snapshot without publishing create or update telemetry. */
+	upsertAutomationSnapshot(snapshot: IAutomationSnapshot): Promise<void>;
+	/** Removes a snapshot only when the currently stored Automation and runs still match it. */
+	removeAutomationSnapshotIfUnchanged(expected: IAutomationSnapshot): Promise<IGuardedAutomationSnapshotRemovalResult>;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -9,6 +9,8 @@ import { URI } from '../../../../base/common/uri.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { ModelIdentifierResolution } from '../../../../workbench/contrib/chat/common/modelSelection.js';
+import { IAutomation, IAutomationRun } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import { IAutomationStore } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, ISideChatSelection } from './session.js';
 
 /**
@@ -63,6 +65,10 @@ export interface ISessionModelsSnapshot {
 	readonly desiredModelResolution: ModelIdentifierResolution;
 	/** Concrete chat session type targeted by this model pool, or undefined for the shared pool. */
 	readonly modelTarget: string | undefined;
+}
+
+export interface ISessionsProviderAutomations extends IAutomationStore {
+	importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void>;
 }
 
 /**
@@ -161,6 +167,9 @@ export interface ISessionsProvider {
 	 * {@link supportsQuickChats}) changes at runtime, so they can re-evaluate.
 	 */
 	readonly onDidChangeCapabilities?: Event<void>;
+
+	/** Provider-owned Automation entities, persistence, and run history. */
+	readonly automations?: ISessionsProviderAutomations;
 
 	/**
 	 * Resolve a workspace for the given repository URI.

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -10,7 +10,7 @@ import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/co
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { ModelIdentifierResolution } from '../../../../workbench/contrib/chat/common/modelSelection.js';
 import { IAutomation, IAutomationRun } from '../../../../workbench/contrib/chat/common/automations/automation.js';
-import { IAutomationStore } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { AutomationMutationGuard, IAutomationStore } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, ISideChatSelection } from './session.js';
 
 /**
@@ -69,6 +69,8 @@ export interface ISessionModelsSnapshot {
 
 export interface ISessionsProviderAutomations extends IAutomationStore {
 	importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void>;
+	storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[], mutationGuard?: AutomationMutationGuard): Promise<void>;
+	removeAutomationForTransfer(id: string, mutationGuard?: AutomationMutationGuard): Promise<void>;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -10,7 +10,7 @@ import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/co
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { ModelIdentifierResolution } from '../../../../workbench/contrib/chat/common/modelSelection.js';
 import { IAutomation, IAutomationRun } from '../../../../workbench/contrib/chat/common/automations/automation.js';
-import { AutomationMutationGuard, IAutomationStore } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { IAutomationStore } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, ISideChatSelection } from './session.js';
 
 /**
@@ -67,10 +67,15 @@ export interface ISessionModelsSnapshot {
 	readonly modelTarget: string | undefined;
 }
 
+export type IGuardedAutomationTransferRemovalResult =
+	| { readonly kind: 'removed' }
+	| { readonly kind: 'changed'; readonly automation: IAutomation; readonly runs: readonly IAutomationRun[] }
+	| { readonly kind: 'missing' };
+
 export interface ISessionsProviderAutomations extends IAutomationStore {
-	importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void>;
-	storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[], mutationGuard?: AutomationMutationGuard): Promise<void>;
-	removeAutomationForTransfer(id: string, mutationGuard?: AutomationMutationGuard): Promise<void>;
+	importAutomation(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<boolean>;
+	storeAutomationForTransfer(automation: IAutomation, runs: readonly IAutomationRun[]): Promise<void>;
+	tryRemoveAutomationSnapshot(expected: IAutomation, expectedRuns: readonly IAutomationRun[]): Promise<IGuardedAutomationTransferRemovalResult>;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -74,7 +74,8 @@ export interface IAutomationSnapshot {
 
 export type IAutomationSnapshotImportResult =
 	| { readonly kind: 'inserted' }
-	| { readonly kind: 'alreadyPresent' };
+	| { readonly kind: 'alreadyPresent' }
+	| { readonly kind: 'conflict'; readonly current: IAutomationSnapshot };
 
 export type IGuardedAutomationSnapshotRemovalResult =
 	| { readonly kind: 'removed' }

--- a/src/vs/workbench/contrib/chat/common/automations/automationService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationService.ts
@@ -159,4 +159,8 @@ export interface IAutomationStore {
 
 export interface IAutomationService extends IAutomationStore {
 	readonly _serviceBrand: undefined;
+	/** Starts leader-scoped stale-run recovery and includes provider stores added while active. */
+	startStaleRunRecovery(reason: string): Promise<void>;
+	/** Stops leader-scoped stale-run recovery. */
+	stopStaleRunRecovery(): void;
 }

--- a/src/vs/workbench/contrib/chat/common/automations/automationService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationService.ts
@@ -111,9 +111,7 @@ export interface IAutomationRunClaim {
  * mutation point. Scheduler, runner, and UI all flow through it to keep
  * cross-window propagation, persistence, and observables consistent.
  */
-export interface IAutomationService {
-	readonly _serviceBrand: undefined;
-
+export interface IAutomationStore {
 	/** All defined automations, newest first. */
 	readonly automations: IObservable<readonly IAutomation[]>;
 
@@ -157,4 +155,8 @@ export interface IAutomationService {
 
 	/** Marks all stuck (`pending`/`running`) runs failed. Called on startup to recover from crashes. */
 	markStaleRunsFailed(reason: string): Promise<void>;
+}
+
+export interface IAutomationService extends IAutomationStore {
+	readonly _serviceBrand: undefined;
 }


### PR DESCRIPTION
This change moves from a centrally owned automation service to a provider-served automation service. Providers on the client side can initialize an optional `automations` field, which the new `providerAutomationService` will discover by iterating over all providers to see which one's support automations. Automations and runs will be supplied by providers, stored in the storage service except keyed now on the provider id. Also includes auto migration of older automations that chose supported providers (agent host only for now)

=== AI Generated Description ===

Moves durable Automation storage behind an optional Sessions provider capability.

- Extracts a reusable, keyed `AutomationStore`.
- Gives Local Agent Host its own Automation store.
- Adds an aggregate `ProviderAutomationService` that routes mutations to the owning provider.
- Keeps the legacy global ledger mounted for compatibility.
- Migrates legacy Automations and run history idempotently.
- Isolates migration and stale-run recovery failures by provider/Automation.
- Preserves existing model, mode, permission, UI, and runtime behavior.

### Validation

- Added provider routing, storage isolation, migration, deduplication, and recovery tests.
- `npm run typecheck-client`
- `npm run valid-layers-check`
- Automation browser unit tests