### PR TITLE
Ignore audio capture files for Darwin and Linux platforms during Windows build

### DIFF
--- a/build/.moduleignore.win32
+++ b/build/.moduleignore.win32
@@ -1,0 +1,2 @@
+@anthropic-ai/claude-agent-sdk/vendor/audio-capture/*-darwin/**
+@anthropic-ai/claude-agent-sdk/vendor/audio-capture/*-linux/**


### PR DESCRIPTION
This fixes an error during local gulp build.
