### PR TITLE
Emit agent-host session title spans for Codex 

### DIFF
--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -93,11 +93,11 @@ The host emits a zero-duration `vscode.agent_host.session` anchor and passes its
 
 ## Session Title Metadata
 
-When content capture is enabled, the agent host emits a zero-duration `vscode.agent_host.session.title_changed` span whenever an authoritative Copilot or Claude session title changes. This includes fallback, generated, refined, and manually renamed titles; assigning the same title again does not emit another span. Downstream consumers can use the latest span for a conversation to display its current title.
+When content capture is enabled, the agent host emits a zero-duration `vscode.agent_host.session.title_changed` span whenever an authoritative Copilot, Claude, or Codex session title changes. This includes fallback, generated, refined, and manually renamed titles; assigning the same title again does not emit another span. Downstream consumers can use the latest span for a conversation to display its current title.
 
 | Attribute | Description |
 |---|---|
-| `gen_ai.conversation.id` | Provider conversation identifier (Copilot conversation ID or Claude SDK session ID). |
+| `gen_ai.conversation.id` | Provider conversation identifier (Copilot conversation ID, Claude SDK session ID, or Codex agent host session ID). |
 | `vscode.agent_host.session.title` | Latest session title, bounded to 200 characters. |
 | `vscode.agent_host.session.uri` | Agent Host protocol URI for the session. |
 

--- a/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
+++ b/src/vs/platform/agentHost/common/otel/agentHostOTelService.ts
@@ -81,9 +81,9 @@ export interface IAgentHostOTelService {
 	/**
 	 * Emits a standalone metadata span carrying the latest title for an
 	 * agent-host session, correlated to the provider's telemetry by its
-	 * conversation id (e.g. the Copilot SDK conversation id or the Claude SDK
-	 * session id). No span is emitted when telemetry or content capture is
-	 * disabled.
+	 * conversation id (e.g. the Copilot SDK conversation id, the Claude SDK
+	 * session id, or the Codex agent host session id). No span is emitted when
+	 * telemetry or content capture is disabled.
 	 */
 	emitSessionTitleChanged(conversationId: string, sessionUri: string, title: string): void;
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -49,6 +49,7 @@ import { INativeEnvironmentService } from '../../../environment/common/environme
 import { IAgentPluginManager, type ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { parsePlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
+import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
@@ -876,10 +877,18 @@ export class CodexAgent extends Disposable implements IAgent {
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
+		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
 	) {
 		super();
 		this._metadataStore = this._instantiationService.createInstance(CodexSessionMetadataStore);
 		this._publishAccountInfo({ status: 'unknown' });
+
+		this._register(this._stateManager.onDidChangeSessionTitle(({ session, title }) => {
+			if (AgentSession.provider(session) === this.id) {
+				this._otelService.emitSessionTitleChanged(AgentSession.id(session), session, title);
+			}
+		}));
+
 		this._register(this._configurationService.onDidRootConfigChange(() => {
 			const signInRequest = this._configurationService.getRootConfigValues?.()[CODEX_ACCOUNT_SIGN_IN_REQUEST_KEY];
 			if (typeof signInRequest === 'string' && signInRequest !== this._lastSignInRequest) {

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -14,7 +14,7 @@ import { ILogService, NullLogService } from '../../../../../platform/log/common/
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
-import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
+import { AgentHostStateManager, IAgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
 import { CodexAgent, toCodexModelSelectionId } from '../../../node/codex/codexAgent.js';
@@ -39,6 +39,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>, models: () => Pr
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
 	instantiationService.stub(IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE);
 	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
+	instantiationService.stub(IAgentHostStateManager, stateManager);
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(ILogService, logService);

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -30,7 +30,7 @@ import { buildDefaultChatUri } from '../../../common/state/sessionState.js';
 import { CustomizationType, McpServerStatus } from '../../../common/state/protocol/channels-session/state.js';
 import { ISessionDataService } from '../../../common/sessionDataService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
-import { AgentHostStateManager } from '../../../node/agentHostStateManager.js';
+import { AgentHostStateManager, IAgentHostStateManager } from '../../../node/agentHostStateManager.js';
 import { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
@@ -198,6 +198,7 @@ async function createAgent(disposables: Pick<DisposableStore, 'add'>, options: I
 		getSessionTraceContext: () => undefined,
 		releaseSessionTraceContext: () => { },
 	});
+	instantiationService.stub(IAgentHostStateManager, stateManager);
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
 	instantiationService.stub(IFileService, fileService);

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -22,9 +22,11 @@ import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../c
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
+import { AgentHostStateManager, IAgentHostStateManager } from '../../../node/agentHostStateManager.js';
 
 function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 	const instantiationService = new TestInstantiationService();
+	const logService = new NullLogService();
 	instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
 	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined });
 	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
@@ -36,9 +38,10 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
 	instantiationService.stub(IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE);
 	instantiationService.stub(IAgentHostOTelService, { _serviceBrand: undefined, getNativeSdkTelemetryConfig: async () => undefined });
+	instantiationService.stub(IAgentHostStateManager, disposables.add(new AgentHostStateManager(logService)));
 	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
 	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
-	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ILogService, logService);
 	return disposables.add(instantiationService.createInstance(CodexAgent));
 }
 

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionTitleSpans.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionTitleSpans.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import type { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../../common/agentHostCheckpointService.js';
+import { AgentSession } from '../../../common/agentService.js';
+import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
+import { ISessionDataService } from '../../../common/sessionDataService.js';
+import { ActionType } from '../../../common/state/sessionActions.js';
+import { SessionStatus } from '../../../common/state/sessionState.js';
+import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { AgentHostStateManager, IAgentHostStateManager } from '../../../node/agentHostStateManager.js';
+import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
+import { CodexAgent } from '../../../node/codex/codexAgent.js';
+import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
+import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
+
+/**
+ * Records `emitSessionTitleChanged` invocations so the OTel title-span wiring
+ * test can assert what the agent forwarded to the host telemetry pipeline. All
+ * other {@link IAgentHostOTelService} members are inert no-ops.
+ */
+class RecordingOTelService implements IAgentHostOTelService {
+	readonly _serviceBrand: undefined;
+	readonly titleChanges: Array<{ conversationId: string; sessionUri: string; title: string }> = [];
+	async getSdkTelemetryConfig(): Promise<undefined> { return undefined; }
+	async getNativeSdkTelemetryConfig(): Promise<undefined> { return undefined; }
+	getSessionTraceContext(): undefined { return undefined; }
+	releaseSessionTraceContext(): void { }
+	withTraceContext<T>(_context: undefined, fn: () => T): T { return fn(); }
+	getCurrentTraceContext(): undefined { return undefined; }
+	getSpansDbPath(): undefined { return undefined; }
+	emitSessionTitleChanged(conversationId: string, sessionUri: string, title: string): void {
+		this.titleChanges.push({ conversationId, sessionUri, title });
+	}
+	async flush(): Promise<void> { }
+}
+
+function createTestContext(disposables: Pick<DisposableStore, 'add'>): { stateManager: AgentHostStateManager; otelService: RecordingOTelService } {
+	const instantiationService = new TestInstantiationService();
+	const logService = new NullLogService();
+	const stateManager = disposables.add(new AgentHostStateManager(logService));
+	const otelService = new RecordingOTelService();
+	instantiationService.stub(ISessionDataService, { _serviceBrand: undefined });
+	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined });
+	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentConfigurationService, {
+		_serviceBrand: undefined,
+		onDidRootConfigChange: Event.None,
+		getRootValue: () => undefined,
+	});
+	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE);
+	instantiationService.stub(IAgentHostOTelService, otelService);
+	instantiationService.stub(IAgentHostStateManager, stateManager);
+	instantiationService.stub(IProductService, { _serviceBrand: undefined, version: '1.0.0-test' } as IProductService);
+	instantiationService.stub(INativeEnvironmentService, { userHome: URI.file('/tmp') });
+	instantiationService.stub(ILogService, logService);
+	disposables.add(instantiationService.createInstance(CodexAgent));
+	return { stateManager, otelService };
+}
+
+suite('CodexAgent — host OTel session-title spans', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits a host OTel session-title span when this agent\'s session title changes', () => {
+		const { stateManager, otelService } = createTestContext(disposables);
+		const sessionUri = AgentSession.uri('codex', 'wire-title');
+		stateManager.createSession({
+			resource: sessionUri.toString(),
+			provider: 'codex',
+			title: 'Initial',
+			status: SessionStatus.Idle,
+			createdAt: new Date().toISOString(),
+			modifiedAt: new Date().toISOString(),
+		});
+
+		stateManager.dispatchServerAction(sessionUri.toString(), { type: ActionType.SessionTitleChanged, title: 'Renamed' });
+
+		assert.deepStrictEqual(otelService.titleChanges, [{ conversationId: 'wire-title', sessionUri: sessionUri.toString(), title: 'Renamed' }]);
+	});
+
+	test('ignores session-title changes belonging to another provider', () => {
+		const { stateManager, otelService } = createTestContext(disposables);
+		const foreignUri = AgentSession.uri('claude', 'foreign-title');
+		stateManager.createSession({
+			resource: foreignUri.toString(),
+			provider: 'claude',
+			title: 'Initial',
+			status: SessionStatus.Idle,
+			createdAt: new Date().toISOString(),
+			modifiedAt: new Date().toISOString(),
+		});
+
+		stateManager.dispatchServerAction(foreignUri.toString(), { type: ActionType.SessionTitleChanged, title: 'Renamed' });
+
+		assert.deepStrictEqual(otelService.titleChanges, []);
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #329640

Extends #327744 (host-produced `vscode.agent_host.session.title_changed` OTel spans for Copilot) and #328485 (Claude Code) to Codex agent-host sessions.

`CopilotAgent` and `ClaudeAgent` each subscribe to session title changes and emit a `vscode.agent_host.session.title_changed` span. `CodexAgent` made no equivalent call, so Codex sessions produced no title span and couldn't be correlated the way Copilot and Claude sessions are.

This wires the same provider-gated listener in `CodexAgent`: it subscribes to the shared `AgentHostStateManager.onDidChangeSessionTitle` event and gating on its own provider id, forwards to `IAgentHostOTelService.emitSessionTitleChanged`. Emission stays gated on OTel enablement + content capture.

The conversation id is the agent host session id (`AgentSession.id`), matching what `_traceContext` already passes to `getSessionTraceContext`, so title spans join the session's existing trace rather than forming a standalone one. This is deliberately not the codex app-server `threadId`, which is undefined until the session materializes and so can't serve as a stable key.

`IAgentHostStateManager` is a new required `CodexAgent` dependency, so the three existing test files that construct the agent now stub it.

### Changes
- `node/codex/codexAgent.ts` — wire the title-changed subscription (provider-gated)
- `common/otel/agentHostOTelService.ts` — extend `emitSessionTitleChanged` JSDoc to cover Codex
- `OTEL.md` — document that the span covers Copilot, Claude, and Codex
- `test/node/codex/codexSessionTitleSpans.test.ts` — two tests: emits for this agent's session, ignores another provider's
- `test/node/codex/{codexModelRefresh,codexPrewarmEviction,codexSessionConfigKeys}.test.ts` — stub the new dependency

### Validation
- `tsc --noEmit --project src/tsconfig.json` — clean
- Unit tests — 25 `CodexAgent` tests passing, including the 2 new ones; verified they fail when the wiring is removed
- `npx eslint` — no warnings/errors in the changed files