### PR TITLE
agentHost: bump AHP to 0.7.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "ahp"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa7af01c6ff90f8b54fa169a71de21cc26e5a98621249ad882a5b2e137f57c0"
+checksum = "ed0e38f1cb5959958300e43d648624a142becea4fe498ebc62ab11d2bdcdd971"
 dependencies = [
  "ahp-types",
  "serde",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "ahp-types"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1632209b0398b17c4a9928d71eaad0ced329d3617ffcbe32be789f59b1d65c70"
+checksum = "f698acd3312d94d9f4ce9f2d6c2d3fa778bb088548a288d81c7384c71fe7c23d"
 dependencies = [
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,8 +56,8 @@ console = "0.15.7"
 bytes = "1.11.1"
 tar = "0.4.46"
 local-ip-address = "0.6"
-ahp = "0.4"
-ahp-types = "0.4"
+ahp = "0.7.0"
+ahp-types = "0.7.0"
 
 [build-dependencies]
 serde = { version="1.0.163", features = ["derive"] }

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -365,6 +365,7 @@ async fn authenticate_from_error(
 					channel: ROOT_RESOURCE_URI.to_string(),
 					resource: resource.resource.clone(),
 					token: credential.access_token().to_string(),
+					scopes: None,
 				},
 			)
 			.await

--- a/cli/src/commands/agent_discovery.rs
+++ b/cli/src/commands/agent_discovery.rs
@@ -137,7 +137,8 @@ async fn probe_host(
 		"listSessions",
 		ListSessionsParams {
 			channel: ROOT_RESOURCE_URI.to_string(),
-			filter: None,
+			limit: None,
+			cursor: None,
 		},
 	)
 	.await;

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -40,9 +40,7 @@ pub async fn agent_logs(ctx: CommandContext, args: AgentLogsArgs) -> Result<i32,
 			&ctx,
 			&client,
 			"subscribe",
-			SubscribeParams {
-				channel: args.session.clone(),
-			},
+			SubscribeParams::new(args.session.clone()),
 		)
 		.await?;
 		let s = client.attach_subscription(&args.session).await;
@@ -104,7 +102,7 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 	};
 
 	if let SnapshotState::Session(ref session) = snapshot.state {
-		let s = &session.summary;
+		let s = session;
 		if !s.title.is_empty() {
 			println!("  {} {}", label.apply_to("title:"), s.title);
 		}

--- a/cli/src/commands/agent_ps.rs
+++ b/cli/src/commands/agent_ps.rs
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+use ahp::Client;
 use ahp_types::commands::{ListSessionsParams, ListSessionsResult};
 use ahp_types::state::{SessionStatus, SessionSummary};
 use ahp_types::ROOT_RESOURCE_URI;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use jiff::Timestamp;
 use serde::Serialize;
 
 use crate::log;
@@ -61,21 +63,11 @@ async fn agent_ps_single(
 ) -> Result<i32, AnyError> {
 	let client = agent::connect_explicit(ctx, address, tunnel).await?;
 
-	let result: ListSessionsResult = agent::request_with_auth(
-		ctx,
-		&client,
-		"listSessions",
-		ListSessionsParams {
-			channel: ROOT_RESOURCE_URI.to_string(),
-			limit: None,
-			cursor: None,
-		},
-	)
-	.await?;
+	let result = list_sessions(ctx, &client).await?;
 
 	client.shutdown().await;
 
-	let items = select_and_sort(&result.items, args.all);
+	let items = select_and_sort(&result, args.all)?;
 
 	if args.json {
 		let json = serde_json::to_string_pretty(&items)
@@ -108,20 +100,40 @@ async fn query_host_sessions(
 ) -> Result<Vec<SessionSummary>, AnyError> {
 	let client = agent::connect_to_endpoint(endpoint).await?;
 
-	let result: ListSessionsResult = agent::request_with_auth(
-		ctx,
-		&client,
-		"listSessions",
-		ListSessionsParams {
-			channel: ROOT_RESOURCE_URI.to_string(),
-			limit: None,
-			cursor: None,
-		},
-	)
-	.await?;
+	let result = list_sessions(ctx, &client).await?;
 
 	client.shutdown().await;
-	Ok(result.items)
+	Ok(result)
+}
+
+async fn list_sessions(
+	ctx: &CommandContext,
+	client: &Client,
+) -> Result<Vec<SessionSummary>, AnyError> {
+	let mut items = Vec::new();
+	let mut cursor = None;
+
+	loop {
+		let result: ListSessionsResult = agent::request_with_auth(
+			ctx,
+			client,
+			"listSessions",
+			ListSessionsParams {
+				channel: ROOT_RESOURCE_URI.to_string(),
+				limit: None,
+				cursor,
+			},
+		)
+		.await?;
+		items.extend(result.items);
+
+		let Some(next_cursor) = result.next_cursor else {
+			break;
+		};
+		cursor = Some(next_cursor);
+	}
+
+	Ok(items)
 }
 
 /// Multi-host auto-discovery path (requirement 3): connects to and
@@ -163,7 +175,7 @@ async fn agent_ps_multi(
 		if args.json {
 			collected.push(outcome);
 		} else {
-			print_host_outcome_human(&outcome, args.all);
+			print_host_outcome_human(&outcome, args.all)?;
 		}
 	}
 
@@ -186,7 +198,7 @@ async fn agent_ps_multi(
 /// single-host path: paging would buffer output until the whole command
 /// finishes, defeating the point of streaming results as hosts
 /// complete).
-fn print_host_outcome_human(outcome: &HostSessions, all: bool) {
+fn print_host_outcome_human(outcome: &HostSessions, all: bool) -> Result<(), AnyError> {
 	let header = Styles::title();
 	println!(
 		"\n{}",
@@ -195,7 +207,7 @@ fn print_host_outcome_human(outcome: &HostSessions, all: bool) {
 
 	match &outcome.sessions {
 		Ok(sessions) => {
-			let items = select_and_sort(sessions, all);
+			let items = select_and_sort(sessions, all)?;
 			if items.is_empty() {
 				println!("  {}", Styles::muted().apply_to("No active sessions."));
 			} else {
@@ -206,6 +218,8 @@ fn print_host_outcome_human(outcome: &HostSessions, all: bool) {
 			println!("  {}", Styles::error().apply_to(format!("⚠ {e}")));
 		}
 	}
+
+	Ok(())
 }
 
 /// JSON-serializable host provenance tag, kept intentionally small and
@@ -256,16 +270,19 @@ struct HostSessionsJson<'a> {
 fn build_json_output(collected: &[HostSessions], all: bool) -> Result<String, AnyError> {
 	let hosts: Vec<HostSessionsJson> = collected
 		.iter()
-		.map(|outcome| HostSessionsJson {
-			host: HostJson::from(&outcome.endpoint),
-			sessions: outcome
-				.sessions
-				.as_ref()
-				.ok()
-				.map(|s| select_and_sort(s, all)),
-			error: outcome.sessions.as_ref().err().map(|e| e.to_string()),
+		.map(|outcome| {
+			Ok(HostSessionsJson {
+				host: HostJson::from(&outcome.endpoint),
+				sessions: outcome
+					.sessions
+					.as_ref()
+					.ok()
+					.map(|s| select_and_sort(s, all))
+					.transpose()?,
+				error: outcome.sessions.as_ref().err().map(|e| e.to_string()),
+			})
 		})
-		.collect();
+		.collect::<Result<_, AnyError>>()?;
 
 	serde_json::to_string_pretty(&hosts).map_err(|e| wrap(e, "Failed to serialize sessions").into())
 }
@@ -273,15 +290,34 @@ fn build_json_output(collected: &[HostSessions], all: bool) -> Result<String, An
 /// Applies the `--all` filter (active-only unless set) and sorts
 /// most-recently-modified first, shared by every output path so human
 /// and JSON output (single- or multi-host) always agree on ordering.
-fn select_and_sort(sessions: &[SessionSummary], all: bool) -> Vec<&SessionSummary> {
-	let mut items: Vec<&SessionSummary> = if all {
+fn select_and_sort(
+	sessions: &[SessionSummary],
+	all: bool,
+) -> Result<Vec<&SessionSummary>, AnyError> {
+	let items: Vec<&SessionSummary> = if all {
 		sessions.iter().collect()
 	} else {
 		sessions.iter().filter(|s| is_active(s.status)).collect()
 	};
 
-	items.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
-	items
+	let mut timestamps = items
+		.into_iter()
+		.map(|session| {
+			session
+				.modified_at
+				.parse::<Timestamp>()
+				.map(|timestamp| (session, timestamp))
+				.map_err(|e| {
+					wrap(
+						e,
+						"Agent host returned an invalid session modification timestamp",
+					)
+				})
+		})
+		.collect::<Result<Vec<_>, _>>()?;
+	timestamps.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+	Ok(timestamps.drain(..).map(|(session, _)| session).collect())
 }
 
 /// A session is "active" if it is in-progress, needs input, or errored
@@ -391,11 +427,11 @@ mod tests {
 		);
 		let sessions = vec![idle.clone(), active.clone()];
 
-		let filtered = select_and_sort(&sessions, false);
+		let filtered = select_and_sort(&sessions, false).unwrap();
 		assert_eq!(filtered.len(), 1);
 		assert_eq!(filtered[0].resource, "b");
 
-		let all = select_and_sort(&sessions, true);
+		let all = select_and_sort(&sessions, true).unwrap();
 		assert_eq!(all.len(), 2);
 	}
 
@@ -413,9 +449,28 @@ mod tests {
 		);
 		let sessions = vec![older, newer];
 
-		let sorted = select_and_sort(&sessions, true);
+		let sorted = select_and_sort(&sessions, true).unwrap();
 		assert_eq!(sorted[0].resource, "b");
 		assert_eq!(sorted[1].resource, "a");
+	}
+
+	#[test]
+	fn select_and_sort_normalizes_timestamp_offsets() {
+		let later = session(
+			"later",
+			SessionStatus::InProgress.bits(),
+			"2026-01-01T00:30:00Z",
+		);
+		let earlier = session(
+			"earlier",
+			SessionStatus::InProgress.bits(),
+			"2026-01-01T01:00:00+02:00",
+		);
+		let sessions = vec![earlier, later];
+
+		let sorted = select_and_sort(&sessions, true).unwrap();
+		assert_eq!(sorted[0].resource, "later");
+		assert_eq!(sorted[1].resource, "earlier");
 	}
 
 	#[test]

--- a/cli/src/commands/agent_ps.rs
+++ b/cli/src/commands/agent_ps.rs
@@ -67,7 +67,8 @@ async fn agent_ps_single(
 		"listSessions",
 		ListSessionsParams {
 			channel: ROOT_RESOURCE_URI.to_string(),
-			filter: None,
+			limit: None,
+			cursor: None,
 		},
 	)
 	.await?;
@@ -113,7 +114,8 @@ async fn query_host_sessions(
 		"listSessions",
 		ListSessionsParams {
 			channel: ROOT_RESOURCE_URI.to_string(),
-			filter: None,
+			limit: None,
+			cursor: None,
 		},
 	)
 	.await?;
@@ -278,7 +280,7 @@ fn select_and_sort(sessions: &[SessionSummary], all: bool) -> Vec<&SessionSummar
 		sessions.iter().filter(|s| is_active(s.status)).collect()
 	};
 
-	items.sort_by_key(|b| std::cmp::Reverse(b.modified_at));
+	items.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
 	items
 }
 
@@ -333,8 +335,10 @@ fn format_sessions_list(sessions: &[&SessionSummary]) -> String {
 			}
 		}
 
-		if let Some(wd) = &s.working_directory {
-			out.push_str(&format!("    {} {}\n", label_style.apply_to("cwd:"), wd,));
+		if let Some(wds) = &s.working_directories {
+			for wd in wds {
+				out.push_str(&format!("    {} {}\n", label_style.apply_to("cwd:"), wd,));
+			}
 		}
 	}
 
@@ -360,28 +364,31 @@ fn status_styled(status: u32) -> console::StyledObject<String> {
 mod tests {
 	use super::*;
 
-	fn session(resource: &str, status: u32, modified_at: i64) -> SessionSummary {
+	fn session(resource: &str, status: u32, modified_at: &str) -> SessionSummary {
 		SessionSummary {
 			resource: resource.to_string(),
 			provider: "test".to_string(),
 			title: String::new(),
 			status,
 			activity: None,
-			created_at: 0,
-			modified_at,
+			created_at: "2026-01-01T00:00:00.000Z".to_string(),
+			modified_at: modified_at.to_string(),
 			project: None,
-			model: None,
-			agent: None,
-			working_directory: None,
+			working_directories: None,
 			changes: None,
 			annotations: None,
+			meta: None,
 		}
 	}
 
 	#[test]
 	fn select_and_sort_filters_idle_unless_all() {
-		let idle = session("a", SessionStatus::Idle.bits(), 1);
-		let active = session("b", SessionStatus::InProgress.bits(), 2);
+		let idle = session("a", SessionStatus::Idle.bits(), "2026-01-01T00:00:00.000Z");
+		let active = session(
+			"b",
+			SessionStatus::InProgress.bits(),
+			"2026-01-02T00:00:00.000Z",
+		);
 		let sessions = vec![idle.clone(), active.clone()];
 
 		let filtered = select_and_sort(&sessions, false);
@@ -394,8 +401,16 @@ mod tests {
 
 	#[test]
 	fn select_and_sort_orders_most_recently_modified_first() {
-		let older = session("a", SessionStatus::InProgress.bits(), 1);
-		let newer = session("b", SessionStatus::InProgress.bits(), 2);
+		let older = session(
+			"a",
+			SessionStatus::InProgress.bits(),
+			"2026-01-01T00:00:00.000Z",
+		);
+		let newer = session(
+			"b",
+			SessionStatus::InProgress.bits(),
+			"2026-01-02T00:00:00.000Z",
+		);
 		let sessions = vec![older, newer];
 
 		let sorted = select_and_sort(&sessions, true);

--- a/cli/src/commands/agent_stop.rs
+++ b/cli/src/commands/agent_stop.rs
@@ -6,6 +6,7 @@
 use ahp_types::actions::{ChatTurnCancelledAction, StateAction};
 use ahp_types::commands::{SubscribeParams, SubscribeResult};
 use ahp_types::state::{SessionStatus, SnapshotState};
+use jiff::Timestamp;
 
 use crate::log;
 use crate::util::errors::{wrap, AnyError};
@@ -38,9 +39,7 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 		&ctx,
 		&client,
 		"subscribe",
-		SubscribeParams {
-			channel: args.session.clone(),
-		},
+		SubscribeParams::new(args.session.clone()),
 	)
 	.await?;
 
@@ -63,20 +62,26 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 			&ctx,
 			&client,
 			"subscribe",
-			SubscribeParams {
-				channel: chat_uri.clone(),
-			},
+			SubscribeParams::new(chat_uri.clone()),
 		)
 		.await?;
 
-		let turn_id = match chat_result.snapshot.map(|s| s.state) {
-			Some(SnapshotState::Chat(chat)) => chat.active_turn.map(|t| t.id),
+		let active_turn = match chat_result.snapshot.map(|s| s.state) {
+			Some(SnapshotState::Chat(chat)) => chat.active_turn,
 			_ => None,
 		};
 
-		let Some(turn_id) = turn_id else {
+		let Some(active_turn) = active_turn else {
 			continue;
 		};
+		let started_at: Timestamp = active_turn.started_at.parse().map_err(|e| {
+			wrap(
+				e,
+				"Agent host returned an invalid active turn start timestamp",
+			)
+		})?;
+		let duration = Timestamp::now().as_millisecond() - started_at.as_millisecond();
+		let turn_id = active_turn.id;
 
 		debug!(ctx.log, "Cancelling turn {} on {}", turn_id, chat_uri);
 
@@ -85,6 +90,7 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 				chat_uri.clone(),
 				StateAction::ChatTurnCancelled(ChatTurnCancelledAction {
 					turn_id: turn_id.clone(),
+					duration,
 					meta: None,
 				}),
 			)


### PR DESCRIPTION
## Summary
- Update CLI AHP dependencies to 0.7.0
- Adapt authentication, session, subscription, and cancellation protocol calls to the AHP 0.7 API

## Validation
- `cargo check --manifest-path cli/Cargo.toml`
- `cargo test --manifest-path cli/Cargo.toml commands::agent_ps::tests`
- `rustfmt --edition 2021 --check` on changed Rust files