### PR TITLE
Fix custom context menus on macOS

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -192,6 +192,10 @@ export class Menu extends ActionBar {
 		}));
 
 		this._register(addDisposableListener(this.actionsList, EventType.MOUSE_MOVE, e => {
+			if (e.movementX === 0 && e.movementY === 0) {
+				return;
+			}
+
 			let target = e.target as HTMLElement;
 			if (!target || !isAncestor(target, this.actionsList) || target === this.actionsList) {
 				return;
@@ -796,6 +800,10 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 		}));
 
 		this._register(addDisposableListener(this.element, EventType.MOUSE_MOVE, e => {
+			if (e.movementX === 0 && e.movementY === 0) {
+				return;
+			}
+
 			if (!this.mouseOver) {
 				this.mouseOver = true;
 

--- a/src/vs/base/test/browser/ui/menu/menu.test.ts
+++ b/src/vs/base/test/browser/ui/menu/menu.test.ts
@@ -18,8 +18,8 @@ suite('Menu', () => {
 		sinon.restore();
 	});
 
-	// A menu positioned under a resting pointer receives `mouseover` without any
-	// `mousemove`, so hover must react to `mousemove` to leave keyboard focus alone.
+	// A menu positioned under a resting pointer can receive synthetic pointer events,
+	// so hover must react only when the pointer coordinates actually change.
 	test('stationary mouse does not change focus (#110594, #148158)', () => {
 		const host = append(document.body, $('div'));
 		disposables.add(toDisposable(() => host.remove()));
@@ -39,13 +39,17 @@ suite('Menu', () => {
 		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
 		focusStates.push(getFocusedActions());
 
-		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true, movementX: 1 }));
 		focusStates.push(getFocusedActions());
 
-		actionItems[0].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
+		actionItems[1].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true, movementX: 1 }));
+		focusStates.push(getFocusedActions());
+
+		actionItems[0].dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true, movementX: -1 }));
 		focusStates.push(getFocusedActions());
 
 		assert.deepStrictEqual(focusStates, [
+			[true, false],
 			[true, false],
 			[true, false],
 			[false, true],
@@ -71,12 +75,18 @@ suite('Menu', () => {
 
 		submenuAction.dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true }));
 		clock.tick(250);
+		const expandedAfterStationaryMouseMove = submenuItem.getAttribute('aria-expanded');
+
+		submenuAction.dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true, movementY: 1 }));
+		clock.tick(250);
 
 		assert.deepStrictEqual({
 			expandedAfterMouseOver,
+			expandedAfterStationaryMouseMove,
 			expandedAfterMouseMove: submenuItem.getAttribute('aria-expanded')
 		}, {
 			expandedAfterMouseOver: 'false',
+			expandedAfterStationaryMouseMove: 'false',
 			expandedAfterMouseMove: 'true'
 		});
 	});


### PR DESCRIPTION
Fixes #329675

## Regression

#329507 changed custom-menu hover handling from `mouseover` to `mousemove` so a stationary pointer would not alter keyboard selection. On macOS, opening a custom context menu can itself dispatch a zero-delta `mousemove` under the stationary pointer. Treating that synthetic event as real movement can focus a menu item during the initiating right-click gesture, causing the menu to close immediately.

## Fix

Ignore `mousemove` events whose horizontal and vertical deltas are both zero in the menu focus and submenu hover handlers. Genuine pointer movement continues to focus rows and expand submenus.

The regression tests now cover all three cases:

- `mouseover` from rendering under a stationary pointer is ignored
- zero-delta `mousemove` is ignored
- non-zero `mousemove` still updates focus and expands submenus

## Validation

`./scripts/test.bat --run src/vs/base/test/browser/ui/menu/menu.test.ts`

All 4 tests pass.