### PR TITLE
Refresh cloned plugin marketplaces on a TTL

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
@@ -145,7 +145,7 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 
 			const progressTitle = options?.progressTitle ?? localize('preparingMarketplace', "Preparing plugin marketplace '{0}'...", marketplace.displayLabel);
 			const failureLabel = options?.failureLabel ?? marketplace.displayLabel;
-			await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel, marketplace.ref);
+			await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel, marketplace.ref, options?.token);
 			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType, Date.now());
 			return repoDir;
 		});
@@ -352,8 +352,11 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 		this._storageService.store(MARKETPLACE_INDEX_STORAGE_KEY, JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
 	}
 
-	private async _cloneRepository(repoDir: URI, cloneUrl: string, progressTitle: string, failureLabel: string, ref?: string): Promise<void> {
+	private async _cloneRepository(repoDir: URI, cloneUrl: string, progressTitle: string, failureLabel: string, ref?: string, token?: CancellationToken): Promise<void> {
 		const cts = new CancellationTokenSource();
+		// Cancelling the caller (e.g. the marketplace refresh progress) must
+		// also abort a first-time clone, not just an incremental refresh.
+		const tokenListener = token?.onCancellationRequested(() => cts.cancel());
 		try {
 			await this._progressService.withProgress(
 				{
@@ -369,17 +372,20 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 			);
 		} catch (err) {
 			this._logService.error(`[AgentPluginRepositoryService] Failed to clone ${cloneUrl}:`, err);
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: localize('cloneFailed', "Failed to install plugin '{0}': {1}", failureLabel, err?.message ?? String(err)),
-				actions: {
-					primary: [new Action('showGitOutput', localize('showGitOutput', "Show Git Output"), undefined, true, () => {
-						this._commandService.executeCommand('git.showOutput');
-					})],
-				},
-			});
+			if (!isCancellationError(err)) {
+				this._notificationService.notify({
+					severity: Severity.Error,
+					message: localize('cloneFailed', "Failed to install plugin '{0}': {1}", failureLabel, err?.message ?? String(err)),
+					actions: {
+						primary: [new Action('showGitOutput', localize('showGitOutput', "Show Git Output"), undefined, true, () => {
+							this._commandService.executeCommand('git.showOutput');
+						})],
+					},
+				});
+			}
 			throw err;
 		} finally {
+			tokenListener?.dispose();
 			cts.dispose();
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
@@ -5,7 +5,8 @@
 
 import { Action } from '../../../../base/common/actions.js';
 import { SequencerByKey } from '../../../../base/common/async.js';
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { isCancellationError } from '../../../../base/common/errors.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { revive } from '../../../../base/common/marshalling.js';
 import { dirname, isEqual, isEqualOrParent, joinPath } from '../../../../base/common/resources.js';
@@ -29,9 +30,13 @@ import { GitHubPluginSource, GitUrlPluginSource, NpmPluginSource, PipPluginSourc
 
 const MARKETPLACE_INDEX_STORAGE_KEY = 'chat.plugins.marketplaces.index.v1';
 
+/** Full commit SHA — a ref pinned to one has nothing to pull. */
+const SHA_REF_PATTERN = /^[0-9a-f]{40}$/i;
+
 interface IMarketplaceIndexEntry {
 	repositoryUri: URI;
 	marketplaceType?: MarketplaceType;
+	lastRefreshedAt?: number;
 }
 
 type IStoredMarketplaceIndex = Dto<Record<string, IMarketplaceIndexEntry>>;
@@ -127,7 +132,10 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 		return this._cloneSequencer.queue(repoDir.fsPath, async () => {
 			const repoExists = await this._fileService.exists(repoDir);
 			if (repoExists) {
-				this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType);
+				const refreshedAt = this._isRefreshDue(marketplace, options)
+					? await this._refreshRepository(repoDir, marketplace, options?.token)
+					: undefined;
+				this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType, refreshedAt);
 				return repoDir;
 			}
 
@@ -138,9 +146,49 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 			const progressTitle = options?.progressTitle ?? localize('preparingMarketplace', "Preparing plugin marketplace '{0}'...", marketplace.displayLabel);
 			const failureLabel = options?.failureLabel ?? marketplace.displayLabel;
 			await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel, marketplace.ref);
-			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType);
+			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType, Date.now());
 			return repoDir;
 		});
+	}
+
+	/**
+	 * Whether an existing clone is stale enough to warrant a silent pull.
+	 * Local (user-owned) directories and SHA-pinned refs are never refreshed.
+	 */
+	private _isRefreshDue(marketplace: IMarketplaceReference, options: IEnsureRepositoryOptions | undefined): boolean {
+		const refreshIfOlderThanMs = options?.refreshIfOlderThanMs;
+		if (refreshIfOlderThanMs === undefined || options?.token?.isCancellationRequested) {
+			return false;
+		}
+
+		if (marketplace.kind === MarketplaceReferenceKind.LocalFileUri || SHA_REF_PATTERN.test(marketplace.ref ?? '')) {
+			return false;
+		}
+
+		const lastRefreshedAt = this._marketplaceIndex.value.get(marketplace.canonicalId)?.lastRefreshedAt;
+		return lastRefreshedAt === undefined || Date.now() - lastRefreshedAt >= refreshIfOlderThanMs;
+	}
+
+	/**
+	 * Silently pulls an existing clone, never throwing — a marketplace that
+	 * cannot be refreshed still serves its cached contents.
+	 *
+	 * Returns the timestamp to record as the last refresh attempt, or
+	 * `undefined` when the pull was cancelled so that cancellation does not
+	 * suppress the next attempt. Genuine failures are recorded, otherwise an
+	 * unreachable remote would be retried on every single fetch.
+	 */
+	private async _refreshRepository(repoDir: URI, marketplace: IMarketplaceReference, token: CancellationToken | undefined): Promise<number | undefined> {
+		try {
+			await this._pluginGit.pull(repoDir, token);
+		} catch (err) {
+			if (isCancellationError(err)) {
+				return undefined;
+			}
+			this._logService.debug(`[AgentPluginRepositoryService] Failed to refresh ${marketplace.displayLabel}:`, err);
+		}
+
+		return token?.isCancellationRequested ? undefined : Date.now();
 	}
 
 	async pullRepository(marketplace: IMarketplaceReference, options?: IPullRepositoryOptions): Promise<boolean> {
@@ -154,24 +202,16 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 		const updateLabel = options?.pluginName ?? marketplace.displayLabel;
 
 		try {
-			if (options?.silent) {
-				return await this._pluginGit.pull(repoDir);
-			}
+			const changed = options?.silent
+				? await this._pluginGit.pull(repoDir)
+				: await this._pullWithProgress(repoDir, updateLabel);
 
-			const cts = new CancellationTokenSource();
-			try {
-				return await this._progressService.withProgress(
-					{
-						location: ProgressLocation.Notification,
-						title: localize('updatingPlugin', "Updating plugin '{0}'...", updateLabel),
-						cancellable: true,
-					},
-					() => this._pluginGit.pull(repoDir, cts.token),
-					() => cts.dispose(true),
-				);
-			} finally {
-				cts.dispose();
-			}
+			// An explicit pull leaves the clone exactly as fresh as a stale
+			// refresh would, so record it — otherwise flows that pull and then
+			// re-read the marketplace (e.g. `updateAllPlugins`) would pull the
+			// same repository twice in a row.
+			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType, Date.now());
+			return changed;
 		} catch (err) {
 			this._logService.error(`[AgentPluginRepositoryService] Failed to update ${marketplace.displayLabel}:`, err);
 			if (!options?.silent) {
@@ -191,6 +231,24 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 				});
 			}
 			throw err;
+		}
+	}
+
+	/** Pulls a clone behind a cancellable progress notification. */
+	private async _pullWithProgress(repoDir: URI, updateLabel: string): Promise<boolean> {
+		const cts = new CancellationTokenSource();
+		try {
+			return await this._progressService.withProgress(
+				{
+					location: ProgressLocation.Notification,
+					title: localize('updatingPlugin', "Updating plugin '{0}'...", updateLabel),
+					cancellable: true,
+				},
+				() => this._pluginGit.pull(repoDir, cts.token),
+				() => cts.dispose(true),
+			);
+		} finally {
+			cts.dispose();
 		}
 	}
 
@@ -254,23 +312,25 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 			result.set(canonicalId, {
 				repositoryUri: entry.repositoryUri,
 				marketplaceType: entry.marketplaceType,
+				lastRefreshedAt: entry.lastRefreshedAt,
 			});
 		}
 
 		return result;
 	}
 
-	private _updateMarketplaceIndex(marketplace: IMarketplaceReference, repositoryUri: URI, marketplaceType?: MarketplaceType): void {
+	private _updateMarketplaceIndex(marketplace: IMarketplaceReference, repositoryUri: URI, marketplaceType?: MarketplaceType, lastRefreshedAt?: number): void {
 		if (marketplace.kind === MarketplaceReferenceKind.LocalFileUri) {
 			return;
 		}
 
 		const previous = this._marketplaceIndex.value.get(marketplace.canonicalId);
-		if (previous && previous.repositoryUri.toString() === repositoryUri.toString() && previous.marketplaceType === marketplaceType) {
+		const updatedLastRefreshedAt = lastRefreshedAt ?? previous?.lastRefreshedAt;
+		if (previous && previous.repositoryUri.toString() === repositoryUri.toString() && previous.marketplaceType === marketplaceType && previous.lastRefreshedAt === updatedLastRefreshedAt) {
 			return;
 		}
 
-		this._marketplaceIndex.value.set(marketplace.canonicalId, { repositoryUri, marketplaceType });
+		this._marketplaceIndex.value.set(marketplace.canonicalId, { repositoryUri, marketplaceType, lastRefreshedAt: updatedLastRefreshedAt });
 		this._saveMarketplaceIndex();
 	}
 
@@ -280,6 +340,7 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 			serialized[canonicalId] = JSON.parse(JSON.stringify({
 				repositoryUri: entry.repositoryUri,
 				marketplaceType: entry.marketplaceType,
+				lastRefreshedAt: entry.lastRefreshedAt,
 			}));
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -32,6 +32,7 @@ import { ILabelService } from '../../../../platform/label/common/label.js';
 import { WorkbenchPagedList } from '../../../../platform/list/browser/listService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { getLocationBasedViewColors } from '../../../browser/parts/views/viewPane.js';
@@ -52,7 +53,7 @@ import { hasSourceChanged, IMarketplacePlugin, IPluginMarketplaceService } from 
 import { AgentPluginEditorInput } from './agentPluginEditor/agentPluginEditorInput.js';
 import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem, IMarketplacePluginItem } from './agentPluginEditor/agentPluginItems.js';
 import { getInstalledPluginContextMenuActions, InstallPluginAction, OpenPluginReadmeAction } from './agentPluginActions.js';
-import { ForceUpdateAgentPluginsCommandId, HasInstalledAgentPluginsContext, InstalledAgentPluginsViewId, UpdateAgentPluginsCommandId, UpdatingAgentPluginsContext } from './chat.js';
+import { ForceUpdateAgentPluginsCommandId, HasInstalledAgentPluginsContext, InstalledAgentPluginsViewId, RefreshAgentPluginMarketplacesCommandId, UpdateAgentPluginsCommandId, UpdatingAgentPluginsContext } from './chat.js';
 
 //#region Item model
 
@@ -566,15 +567,21 @@ function updatePlugins(accessor: ServicesAccessor, force: boolean): Promise<void
 		return updatePluginsPromise;
 	}
 
+	// Services must be resolved synchronously — the accessor is invalidated as
+	// soon as the command handler returns, so a lookup after the `await` below
+	// would throw instead of showing the notification.
+	const pluginInstallService = accessor.get(IPluginInstallService);
+	const notificationService = accessor.get(INotificationService);
+
 	updatingPluginsContextKey?.set(true);
 	updatePluginsPromise = (async () => {
 		try {
-			const result = await accessor.get(IPluginInstallService).updateAllPlugins({ force }, CancellationToken.None);
+			const result = await pluginInstallService.updateAllPlugins({ force }, CancellationToken.None);
 			if (result.updatedNames.length === 0 && result.failedNames.length === 0) {
-				accessor.get(INotificationService).info(localize('agentPlugins.upToDate', "Plugins are up to date."));
+				notificationService.info(localize('agentPlugins.upToDate', "Plugins are up to date."));
 			}
 		} catch (error) {
-			accessor.get(INotificationService).error(localize('agentPlugins.updateFailed', "Failed to update plugins: {0}", getErrorMessage(error)));
+			notificationService.error(localize('agentPlugins.updateFailed', "Failed to update plugins: {0}", getErrorMessage(error)));
 			throw error;
 		} finally {
 			updatePluginsPromise = undefined;
@@ -660,6 +667,48 @@ class ForceUpdatePluginsCommand extends Action2 {
 	}
 }
 
+class RefreshPluginMarketplacesCommand extends Action2 {
+	constructor() {
+		super({
+			id: RefreshAgentPluginMarketplacesCommandId,
+			title: localize2('agentPlugins.refreshMarketplaces', "Refresh Plugin Marketplaces"),
+			category: localize2('chat.category', "Chat"),
+			icon: Codicon.refresh,
+			precondition: ChatContextKeys.enabled,
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		// Services must be resolved synchronously — the accessor is invalidated
+		// as soon as this method returns its promise.
+		const marketplaceService = accessor.get(IPluginMarketplaceService);
+		const notificationService = accessor.get(INotificationService);
+		const progressService = accessor.get(IProgressService);
+
+		const cts = new CancellationTokenSource();
+		try {
+			await progressService.withProgress(
+				{
+					location: ProgressLocation.Notification,
+					title: localize('agentPlugins.refreshingMarketplaces', "Refreshing plugin marketplaces..."),
+					cancellable: true,
+				},
+				() => marketplaceService.fetchMarketplacePlugins(cts.token, undefined, { refresh: true }),
+				() => cts.dispose(true),
+			);
+			if (!cts.token.isCancellationRequested) {
+				notificationService.info(localize('agentPlugins.marketplacesRefreshed', "Plugin marketplaces refreshed."));
+			}
+		} catch (error) {
+			notificationService.error(localize('agentPlugins.refreshMarketplacesFailed', "Failed to refresh plugin marketplaces: {0}", getErrorMessage(error)));
+			throw error;
+		} finally {
+			cts.dispose();
+		}
+	}
+}
+
 //#endregion
 //#region Views contribution
 
@@ -682,6 +731,7 @@ export class AgentPluginsViewsContribution extends Disposable implements IWorkbe
 		registerAction2(AgentPluginsBrowseCommand);
 		registerAction2(CheckForPluginUpdatesCommand);
 		registerAction2(ForceUpdatePluginsCommand);
+		registerAction2(RefreshPluginMarketplacesCommand);
 
 		Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([
 			{

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -687,6 +687,7 @@ class RefreshPluginMarketplacesCommand extends Action2 {
 		const progressService = accessor.get(IProgressService);
 
 		const cts = new CancellationTokenSource();
+		const failedLabels: string[] = [];
 		try {
 			await progressService.withProgress(
 				{
@@ -694,10 +695,22 @@ class RefreshPluginMarketplacesCommand extends Action2 {
 					title: localize('agentPlugins.refreshingMarketplaces', "Refreshing plugin marketplaces..."),
 					cancellable: true,
 				},
-				() => marketplaceService.fetchMarketplacePlugins(cts.token, undefined, { refresh: true }),
+				() => marketplaceService.fetchMarketplacePlugins(cts.token, undefined, {
+					refresh: true,
+					onMarketplaceError: reference => failedLabels.push(reference.displayLabel),
+				}),
 				() => cts.dispose(true),
 			);
-			if (!cts.token.isCancellationRequested) {
+
+			if (cts.token.isCancellationRequested) {
+				return;
+			}
+
+			// Individual marketplace failures don't reject the fetch, so report
+			// them explicitly rather than claiming an unqualified success.
+			if (failedLabels.length > 0) {
+				notificationService.warn(localize('agentPlugins.marketplacesRefreshedWithErrors', "Refreshed plugin marketplaces, but {0} could not be read: {1}", failedLabels.length, failedLabels.join(', ')));
+			} else {
 				notificationService.info(localize('agentPlugins.marketplacesRefreshed', "Plugin marketplaces refreshed."));
 			}
 		} catch (error) {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -538,4 +538,5 @@ export const HasInstalledAgentPluginsContext = new RawContextKey<boolean>('hasIn
 export const InstalledAgentPluginsViewId = 'workbench.views.agentPlugins.installed';
 export const UpdateAgentPluginsCommandId = 'workbench.agentPlugins.checkForUpdates';
 export const ForceUpdateAgentPluginsCommandId = 'workbench.agentPlugins.forceUpdate';
+export const RefreshAgentPluginMarketplacesCommandId = 'workbench.agentPlugins.refreshMarketplaces';
 export const UpdatingAgentPluginsContext = new RawContextKey<boolean>('agentPluginsUpdating', false);

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginRepositoryService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceType, PluginSourceKind } from './pluginMarketplaceService.js';
@@ -20,6 +21,15 @@ export interface IEnsureRepositoryOptions {
 	readonly failureLabel?: string;
 	/** Marketplace type metadata to persist in the marketplace index. */
 	readonly marketplaceType?: MarketplaceType;
+	/**
+	 * When set, an already-cloned repository whose last refresh is older than
+	 * this many milliseconds is silently pulled before being returned. `0`
+	 * forces a refresh. Refresh failures are logged and non-fatal — the
+	 * existing clone is still returned.
+	 */
+	readonly refreshIfOlderThanMs?: number;
+	/** Cancels an in-flight stale refresh triggered by {@link refreshIfOlderThanMs}. */
+	readonly token?: CancellationToken;
 }
 
 /**
@@ -64,6 +74,7 @@ export interface IAgentPluginRepositoryService {
 
 	/**
 	 * Ensures a marketplace repository is cloned locally and returns its cache URI.
+	 * Optionally refreshes an existing clone when it is stale.
 	 */
 	ensureRepository(marketplace: IMarketplaceReference, options?: IEnsureRepositoryOptions): Promise<URI>;
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -148,6 +148,13 @@ export interface IMarketplaceInstalledPlugin {
 export interface IFetchMarketplacePluginsOptions {
 	/** Bypass the marketplace caches (HTTP TTL cache and cloned-repository TTL) and re-read from the remote. */
 	readonly refresh?: boolean;
+	/**
+	 * Called for each marketplace that could not be read. Individual failures
+	 * are otherwise swallowed so that one bad marketplace cannot fail the
+	 * whole fetch, which leaves callers unable to tell a partial result from
+	 * a complete one.
+	 */
+	readonly onMarketplaceError?: (reference: IMarketplaceReference, error: unknown) => void;
 }
 
 export const IPluginMarketplaceService = createDecorator<IPluginMarketplaceService>('pluginMarketplaceService');
@@ -484,6 +491,13 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			})
 		);
 		const plugins = results.flat();
+
+		// A cancelled fetch yields empty/partial results — committing those
+		// would wipe the observable list and blank out the marketplace UI.
+		if (token.isCancellationRequested) {
+			return plugins;
+		}
+
 		const storedPlugins = marketplaceIds
 			? [...this.lastFetchedPlugins.get().filter(plugin => !marketplaceIds.has(plugin.marketplaceReference.canonicalId)), ...plugins]
 			: plugins;
@@ -538,6 +552,14 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		if (repoMayBePrivate) {
 			this._logService.debug(`[PluginMarketplaceService] ${repo} may be private, attempting clone-based marketplace discovery`);
+
+			// Drop any raw-fetch entry cached while the repository was still
+			// public, otherwise the next non-forced fetch would serve it in
+			// preference to the clone until its original TTL expired.
+			if (cache.delete(reference.canonicalId)) {
+				this._savePersistedGitHubMarketplaceCache(cache);
+			}
+
 			return this._fetchFromClonedRepo(reference, token, options);
 		}
 
@@ -882,6 +904,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			});
 		} catch (err) {
 			this._logService.debug(`[PluginMarketplaceService] Failed to prepare marketplace repository ${reference.rawValue}:`, err);
+			options?.onMarketplaceError?.(reference, err);
 			return [];
 		}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -142,6 +142,14 @@ export interface IMarketplaceInstalledPlugin {
 	readonly plugin: IMarketplacePlugin;
 }
 
+/**
+ * Options for fetching marketplace plugins.
+ */
+export interface IFetchMarketplacePluginsOptions {
+	/** Bypass the marketplace caches (HTTP TTL cache and cloned-repository TTL) and re-read from the remote. */
+	readonly refresh?: boolean;
+}
+
 export const IPluginMarketplaceService = createDecorator<IPluginMarketplaceService>('pluginMarketplaceService');
 
 export interface IPluginMarketplaceService {
@@ -165,7 +173,7 @@ export interface IPluginMarketplaceService {
 	readonly recommendedPlugins: IObservable<ReadonlySet<string>>;
 	/** Clears all reported marketplaces, or only the provided canonical IDs. */
 	clearUpdatesAvailable(marketplaceIds?: ReadonlySet<string>): void;
-	fetchMarketplacePlugins(token: CancellationToken, marketplaceIds?: ReadonlySet<string>): Promise<IMarketplacePlugin[]>;
+	fetchMarketplacePlugins(token: CancellationToken, marketplaceIds?: ReadonlySet<string>, options?: IFetchMarketplacePluginsOptions): Promise<IMarketplacePlugin[]>;
 	getMarketplacePluginMetadata(pluginUri: URI): IMarketplacePlugin | undefined;
 	addInstalledPlugin(pluginUri: URI, plugin: IMarketplacePlugin): void;
 	removeInstalledPlugin(pluginUri: URI): void;
@@ -431,7 +439,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		this._marketplacesWithUpdates.set(remaining, undefined);
 	}
 
-	async fetchMarketplacePlugins(token: CancellationToken, marketplaceIds?: ReadonlySet<string>): Promise<IMarketplacePlugin[]> {
+	async fetchMarketplacePlugins(token: CancellationToken, marketplaceIds?: ReadonlySet<string>, options?: IFetchMarketplacePluginsOptions): Promise<IMarketplacePlugin[]> {
 		if (!this._configurationService.getValue<boolean>(ChatConfiguration.PluginsEnabled)) {
 			return [];
 		}
@@ -470,9 +478,9 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		const results = await Promise.all(
 			refsToFetch.map(ref => {
 				if (ref.kind === MarketplaceReferenceKind.GitHubShorthand && ref.githubRepo) {
-					return this._fetchFromGitHubRepo(ref, ref.githubRepo, token);
+					return this._fetchFromGitHubRepo(ref, ref.githubRepo, token, options);
 				}
-				return this._fetchFromClonedRepo(ref, token);
+				return this._fetchFromClonedRepo(ref, token, options);
 			})
 		);
 		const plugins = results.flat();
@@ -483,10 +491,10 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		return plugins;
 	}
 
-	private async _fetchFromGitHubRepo(reference: IMarketplaceReference, repo: string, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+	private async _fetchFromGitHubRepo(reference: IMarketplaceReference, repo: string, token: CancellationToken, options?: IFetchMarketplacePluginsOptions): Promise<IMarketplacePlugin[]> {
 		const cache = this._gitHubMarketplaceCache.value;
 
-		const cached = this._getCachedGitHubMarketplacePlugins(cache, reference.canonicalId);
+		const cached = options?.refresh ? undefined : this._getCachedGitHubMarketplacePlugins(cache, reference.canonicalId);
 		if (cached) {
 			return cached.map(c => ({
 				...c,
@@ -530,7 +538,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		if (repoMayBePrivate) {
 			this._logService.debug(`[PluginMarketplaceService] ${repo} may be private, attempting clone-based marketplace discovery`);
-			return this._fetchFromClonedRepo(reference, token);
+			return this._fetchFromClonedRepo(reference, token, options);
 		}
 
 		this._logService.debug(`[PluginMarketplaceService] No marketplace.json found in ${repo}`);
@@ -865,10 +873,13 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		}
 	}
 
-	private async _fetchFromClonedRepo(reference: IMarketplaceReference, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+	private async _fetchFromClonedRepo(reference: IMarketplaceReference, token: CancellationToken, options?: IFetchMarketplacePluginsOptions): Promise<IMarketplacePlugin[]> {
 		let repoDir: URI;
 		try {
-			repoDir = await this._pluginRepositoryService.ensureRepository(reference);
+			repoDir = await this._pluginRepositoryService.ensureRepository(reference, {
+				refreshIfOlderThanMs: options?.refresh ? 0 : GITHUB_MARKETPLACE_CACHE_TTL_MS,
+				token,
+			});
 		} catch (err) {
 			this._logService.debug(`[PluginMarketplaceService] Failed to prepare marketplace repository ${reference.rawValue}:`, err);
 			return [];

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { CancellationError } from '../../../../../../base/common/errors.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -64,6 +65,7 @@ suite('AgentPluginRepositoryService', () => {
 
 		const fileService = {
 			exists: async (resource: URI) => onExists ? onExists(resource) : true,
+			createFolder: async () => undefined,
 		} as unknown as IFileService;
 
 		const progressService = {
@@ -137,6 +139,178 @@ suite('AgentPluginRepositoryService', () => {
 
 		assert.strictEqual(checkedPath, '/cache/agentPlugins/github.com/microsoft/vscode');
 		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+	});
+
+	test('refreshes an existing repository without a recorded refresh timestamp', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		const uri = await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.deepStrictEqual({ pullCount, uri: uri.path }, { pullCount: 1, uri: '/cache/agentPlugins/github.com/microsoft/vscode' });
+	});
+
+	test('does not refresh an existing repository with a recent refresh timestamp', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.strictEqual(pullCount, 1);
+	});
+
+	test('records a refresh timestamp for a newly cloned repository', async () => {
+		let repoExists = false;
+		let cloneCount = 0;
+		let pullCount = 0;
+		const service = createService(async () => repoExists, undefined, {
+			cloneRepository: async () => {
+				cloneCount++;
+				repoExists = true;
+			},
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.deepStrictEqual({ cloneCount, pullCount }, { cloneCount: 1, pullCount: 0 });
+	});
+
+	test('refreshes an existing repository when refresh age is zero', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 0 });
+
+		assert.strictEqual(pullCount, 2);
+	});
+
+	test('does not refresh an existing repository without a refresh policy', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference);
+
+		assert.strictEqual(pullCount, 0);
+	});
+
+	test('does not refresh a local file marketplace repository', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('file:///marketplace-repo', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 0 });
+
+		assert.strictEqual(pullCount, 0);
+	});
+
+	test('does not refresh a repository pinned to a commit SHA', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode#a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 0 });
+
+		assert.strictEqual(pullCount, 0);
+	});
+
+	test('does not refresh again after an explicit pull already updated the repository', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				return false;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		// `updateAllPlugins` pulls each installed marketplace and then re-reads
+		// it, which must not pull the same repository a second time.
+		await service.pullRepository(plugin.marketplaceReference, { silent: true });
+		await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.strictEqual(pullCount, 1);
+	});
+
+	test('keeps an existing repository after a refresh failure and records the attempt', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				throw new Error('Network unavailable');
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		const first = await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+		const second = await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.deepStrictEqual({ pullCount, first: first.path, second: second.path }, {
+			pullCount: 1,
+			first: '/cache/agentPlugins/github.com/microsoft/vscode',
+			second: '/cache/agentPlugins/github.com/microsoft/vscode',
+		});
+	});
+
+	test('does not record a cancelled refresh attempt', async () => {
+		let pullCount = 0;
+		const service = createService(async () => true, undefined, {
+			pull: async () => {
+				pullCount++;
+				throw new CancellationError();
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		const first = await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+		const second = await service.ensureRepository(plugin.marketplaceReference, { refreshIfOlderThanMs: 8 * 60 * 60 * 1000 });
+
+		assert.deepStrictEqual({ pullCount, first: first.path, second: second.path }, {
+			pullCount: 2,
+			first: '/cache/agentPlugins/github.com/microsoft/vscode',
+			second: '/cache/agentPlugins/github.com/microsoft/vscode',
+		});
 	});
 
 	test('passes marketplace refs through cloneRepository', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { CancellationError } from '../../../../../../base/common/errors.js';
+import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -291,6 +292,23 @@ suite('AgentPluginRepositoryService', () => {
 			first: '/cache/agentPlugins/github.com/microsoft/vscode',
 			second: '/cache/agentPlugins/github.com/microsoft/vscode',
 		});
+	});
+
+	test('cancels a first-time clone when the caller token is cancelled', async () => {
+		const cts = store.add(new CancellationTokenSource());
+		let cloneCancelled = false;
+		const service = createService(async () => false, undefined, {
+			cloneRepository: async (_cloneUrl, _targetDir, _ref, token) => {
+				// Simulate a long-running clone that the caller aborts.
+				cts.cancel();
+				cloneCancelled = !!token?.isCancellationRequested;
+			},
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+
+		await service.ensureRepository(plugin.marketplaceReference, { token: cts.token });
+
+		assert.strictEqual(cloneCancelled, true);
 	});
 
 	test('does not record a cancelled refresh attempt', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
 import { bufferToStream, VSBuffer } from '../../../../../../base/common/buffer.js';
-import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { joinPath } from '../../../../../../base/common/resources.js';
@@ -438,6 +438,45 @@ suite('PluginMarketplaceService - GitHub marketplace refs', () => {
 		assert.ok(requestUrls.length > 0);
 		assert.ok(requestUrls.every(url => url.includes('/marketplace/')));
 		assert.ok(requestUrls.every(url => !url.includes('/main/')));
+	});
+
+	test('a cancelled fetch does not clear the last fetched plugins', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({
+			[ChatConfiguration.PluginMarketplaces]: ['microsoft/vscode'],
+			[ChatConfiguration.PluginsEnabled]: true,
+		}));
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
+		instantiationService.stub(IFileService, {} as unknown as IFileService);
+		instantiationService.stub(IAgentPluginRepositoryService, {
+			agentPluginsHome: URI.file('/agent-plugins'),
+			ensureRepository: async () => URI.file('/agent-plugins/github.com/microsoft/vscode'),
+		} as Partial<IAgentPluginRepositoryService> as IAgentPluginRepositoryService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IRequestService, {
+			request: async () => ({ res: { headers: {}, statusCode: 404 }, stream: bufferToStream(VSBuffer.fromString('')) }),
+		} as Partial<IRequestService> as IRequestService);
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+		instantiationService.stub(IWorkspacePluginSettingsService, {
+			extraMarketplaces: observableValue('test.extraMarketplaces', []),
+			enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+		instantiationService.stub(IWorkspaceTrustManagementService, {
+			isWorkspaceTrusted: () => true,
+			onDidChangeTrust: Event.None,
+		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
+		instantiationService.stub(IExtensionsWorkbenchService, {
+			getAutoUpdateValue: () => 'on',
+		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
+
+		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
+		const seeded = service.lastFetchedPlugins.get();
+
+		const cts = store.add(new CancellationTokenSource());
+		cts.cancel();
+		await service.fetchMarketplacePlugins(cts.token);
+
+		assert.deepStrictEqual(service.lastFetchedPlugins.get(), seeded);
 	});
 });
 


### PR DESCRIPTION
Fixes #328523

### The bug

Private marketplace repos are discovered by **cloning**, since `raw.githubusercontent.com` returns 4xx for them. `AgentPluginRepositoryService.ensureRepository` short-circuited whenever the clone directory already existed — it never fetched or pulled. Discovery therefore stayed frozen at the originally-cloned commit and newly added plugins never appeared.

Two things made this unrecoverable from the UI:

- The raw-fetch path has an 8h TTL cache; the clone path had **no TTL at all**.
- `_fetchFromGitHubRepo` only populates that TTL cache when it actually finds plugins. For a private repo the raw fetch yields nothing, so it always fell through to the clone — meaning the clone wasn't the cold path, it was the *only* path, and it never expired.
- The sole refresher, `pullRepository`, is reached from `updateAllPlugins`, which iterates **installed** plugins. With nothing installed from a marketplace, there was no way to refresh it.

### The fix

- **`refreshIfOlderThanMs` on `IEnsureRepositoryOptions`** — a stale clone is silently pulled inside the existing clone sequencer, so concurrent fetchers collapse to a single pull. Skipped for local-file marketplaces (user-owned directories) and SHA-pinned refs. Failures are non-fatal and still timestamped, so an unreachable remote can't cause a pull storm; **cancellations are not timestamped**, so navigating away doesn't suppress the next attempt.
- **`_fetchFromClonedRepo` passes `GITHUB_MARKETPLACE_CACHE_TTL_MS`**, giving the clone path parity with the raw-fetch path.
- **`pullRepository` records the timestamp too.** An explicit pull leaves the clone just as fresh, and without this `updateAllPlugins` — which pulls each marketplace and then re-reads it — pulled every repo twice in a row.
- **New `Chat: Refresh Plugin Marketplaces` command** bypasses both caches on demand, behind a cancellable progress notification.

### Drive-by fix

`invokeFunction` invalidates the `ServicesAccessor` as soon as the handler returns its promise, so any `accessor.get()` after an `await` throws `illegalState`. The pre-existing `updatePlugins` helper did exactly that — its "Plugins are up to date." and "Failed to update plugins" notifications could never render. Service lookups in both it and the new command are now hoisted into the synchronous window. Found by E2E validation, since unit tests can't catch it.

### Validation

`typecheck-client` clean; 327 chat-plugin unit tests pass, including 9 new cases covering TTL gating, forced refresh, fresh-clone stamping, SHA-pin and local-file skips, non-fatal failure, cancellation, and the `updateAllPlugins` double-pull regression.

Verified end-to-end against a **real private GitHub marketplace repo** in a running Code OSS build:

| Scenario | Result |
|---|---|
| Private repo clone fallback (raw fetch 404 → clone) | PASS |
| TTL gating — new plugin correctly withheld, HEAD unchanged | PASS |
| `Chat: Refresh Plugin Marketplaces` — progress ends ~1.8s, completion notification, HEAD advances | PASS |
| Cancel — no spurious notifications, retry still pulls | PASS |
| **Stale clone auto-refreshes with no user action** (the reported bug) | PASS |
| Install + `Chat: Update Plugins`, "Plugins are up to date." now renders | PASS |

### Known limitation (pre-existing, not addressed)

On cancel the progress notification can linger ~10s. `LocalGitService.cancel()` only kills the subprocess currently registered for that operation id, but `pull()` runs several sequential `git` invocations with no cancellation check between them, so a cancel landing between steps is a no-op. This affects the existing "Updating plugin…" notification identically today; fixing it means adding inter-step cancellation to a shared platform service, which is out of scope here.
