### PR TITLE
Show the source conversation in a side chat

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sideChatProvider.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/sideChatProvider.contribution.ts
@@ -3,16 +3,25 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { raceTimeout } from '../../../../base/common/async.js';
+import { Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { derived, IObservable, IReader } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { isRequestVM } from '../../../../workbench/contrib/chat/common/model/chatViewModel.js';
 import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
-import { IChatSideChatProvider, IChatSideChatSelection, IChatSideChatService } from '../../../../workbench/contrib/chat/common/chatSideChatService.js';
+import { IChatSideChatOrigin, IChatSideChatProvider, IChatSideChatSelection, IChatSideChatService } from '../../../../workbench/contrib/chat/common/chatSideChatService.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { SessionStatus } from '../../../services/sessions/common/session.js';
+import { ChatOriginKind, IChat, ISession, SessionStatus } from '../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { createAndSendSideChat } from './sideChatOrchestration.js';
+
+const SIDE_CHAT_SOURCE_REVEAL_TIMEOUT = 2_000;
 
 /**
  * Backs the workbench's "Ask in Side Chat" affordance with the Agents window's
@@ -24,16 +33,23 @@ export class SessionsSideChatProviderContribution extends Disposable implements 
 
 	static readonly ID = 'sessions.contrib.sideChatProvider';
 
+	// Cached observables avoid recreating deriveds for every rendered chat row.
+	private readonly _sideChatOrigins = new ResourceMap<IObservable<IChatSideChatOrigin | undefined>>();
+	private readonly _isSessionsWindow: boolean;
+
 	constructor(
 		@IChatSideChatService sideChatService: IChatSideChatService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@IChatService private readonly chatService: IChatService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 
-		if (!environmentService.isSessionsWindow) {
+		this._isSessionsWindow = environmentService.isSessionsWindow;
+		if (!this._isSessionsWindow) {
 			return;
 		}
 
@@ -51,6 +67,94 @@ export class SessionsSideChatProviderContribution extends Disposable implements 
 		}
 		const { session, chatResource, turnId } = source;
 		await createAndSendSideChat(this.sessionsManagementService, this.sessionsService, session, chatResource, turnId, query, selection);
+	}
+
+	/** Observes the source metadata for a side chat. */
+	observeSideChatOrigin(sessionResource: URI): IObservable<IChatSideChatOrigin | undefined> {
+		let sideChatOrigin = this._sideChatOrigins.get(sessionResource);
+		if (!sideChatOrigin) {
+			sideChatOrigin = derived(this, reader => {
+				if (!this._isSessionsWindow) {
+					return undefined;
+				}
+
+				const resolved = this._resolveSessionChat(sessionResource, reader);
+				const origin = resolved?.chat.origin;
+				if (!resolved || origin?.kind !== ChatOriginKind.SideChat || !origin.parentChat || !origin.turnId) {
+					return undefined;
+				}
+
+				const sourceChat = resolved.session.chats.read(reader).find(chat => this.uriIdentityService.extUri.isEqual(chat.resource, origin.parentChat));
+				return {
+					sourceSessionResource: origin.parentChat,
+					sourceTurnId: origin.turnId,
+					sourceTitle: sourceChat?.title.read(reader),
+					selection: origin.selection ? { text: origin.selection.text } : undefined,
+				};
+			});
+			this._sideChatOrigins.set(sessionResource, sideChatOrigin);
+		}
+		return sideChatOrigin;
+	}
+
+	/** Activates a side chat's source and reveals its originating request. */
+	async revealSideChatSource(sessionResource: URI): Promise<void> {
+		if (!this._isSessionsWindow) {
+			return;
+		}
+
+		const origin = this.observeSideChatOrigin(sessionResource).get();
+		if (!origin) {
+			return;
+		}
+
+		const resolved = this._resolveSessionChat(sessionResource);
+		if (!resolved) {
+			return;
+		}
+
+		const widget = this.chatWidgetService.getWidgetBySessionResource(sessionResource);
+		await this.sessionsService.openChat(resolved.session, origin.sourceSessionResource);
+
+		if (!widget) {
+			return;
+		}
+
+		if (!widget.viewModel || !this.uriIdentityService.extUri.isEqual(widget.viewModel.sessionResource, origin.sourceSessionResource)) {
+			const viewModelChanged = Event.toPromise(Event.filter(widget.onDidChangeViewModel, event =>
+				event.currentSessionResource !== undefined && this.uriIdentityService.extUri.isEqual(event.currentSessionResource, origin.sourceSessionResource)
+			), this._store);
+			try {
+				if (!await raceTimeout(viewModelChanged, SIDE_CHAT_SOURCE_REVEAL_TIMEOUT)) {
+					return;
+				}
+			} finally {
+				viewModelChanged.cancel();
+			}
+		}
+
+		const item = widget.viewModel?.getItems().find(item => item.id === origin.sourceTurnId);
+		if (item && isRequestVM(item)) {
+			widget.reveal(item);
+		}
+	}
+
+	private _resolveSessionChat(sessionResource: URI, reader?: IReader): { session: ISession; chat: IChat } | undefined {
+		const visibleSessions = reader ? this.sessionsService.visibleSessions.read(reader) : this.sessionsService.visibleSessions.get();
+		for (const session of visibleSessions) {
+			if (!session) {
+				continue;
+			}
+
+			const chats = reader ? session.chats.read(reader) : session.chats.get();
+			const chat = chats.find(chat => this.uriIdentityService.extUri.isEqual(chat.resource, sessionResource));
+			if (chat) {
+				return { session, chat };
+			}
+		}
+
+		// Non-visible chats can resolve here, but this lookup is not reactive.
+		return this.sessionsManagementService.getSessionForChatResource(sessionResource);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
@@ -4,16 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Event } from '../../../../../base/common/event.js';
+import { timeout } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
 import { extUri } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
-import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { ChatTreeItem, IChatWidget, IChatWidgetService, IChatWidgetViewModelChangeEvent } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSideChatProvider, IChatSideChatService } from '../../../../../workbench/contrib/chat/common/chatSideChatService.js';
 import { IChatModel, IChatRequestModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
@@ -40,6 +42,7 @@ suite('SessionsSideChatProviderContribution', () => {
 		parentChat?: IChat;
 		widget?: IChatWidget;
 		widgetFactory?: (callOrder: string[]) => IChatWidget;
+		onOpenChat?: (callOrder: string[]) => void;
 	} = {}) {
 		const store = disposables.add(new DisposableStore());
 		const instantiationService = store.add(new TestInstantiationService());
@@ -86,6 +89,7 @@ suite('SessionsSideChatProviderContribution', () => {
 			visibleSessions: constObservable([session]),
 			openChat: async (_session, chatUri) => {
 				callOrder.push(`open:${chatUri.toString()}`);
+				options.onOpenChat?.(callOrder);
 			},
 		}));
 		instantiationService.stub(IChatWidgetService, upcastPartial<IChatWidgetService>({
@@ -238,6 +242,64 @@ suite('SessionsSideChatProviderContribution', () => {
 			revealed: [request],
 		});
 	});
+
+	test('reveals the request a side chat branched from after its widget view model changes', async () => {
+		const store = disposables.add(new DisposableStore());
+		const onDidChangeViewModel = store.add(new Emitter<IChatWidgetViewModelChangeEvent>());
+		const revealed: ChatTreeItem[] = [];
+		const request = upcastPartial<IChatRequestViewModel>({ id: 'turn-1', message: { parts: [], text: '' } });
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource, turnId: 'turn-1' },
+		});
+		let viewModel = upcastPartial<IChatViewModel>({ sessionResource: sideChat.resource, getItems: () => [] });
+		const widget = upcastPartial<IChatWidget>({
+			get viewModel() { return viewModel; },
+			onDidChangeViewModel: onDidChangeViewModel.event,
+			reveal: item => {
+				callOrder.push(`reveal:${item.id}`);
+				revealed.push(item);
+			},
+		});
+		const { provider, callOrder } = setup({
+			chat,
+			widget,
+			onOpenChat: () => {
+				void timeout(0).then(() => {
+					viewModel = upcastPartial<IChatViewModel>({ sessionResource: sourceChat.resource, getItems: () => [request] });
+					onDidChangeViewModel.fire({ previousSessionResource: sideChat.resource, currentSessionResource: sourceChat.resource });
+				});
+			},
+		});
+
+		await provider()!.revealSideChatSource(sideChat.resource);
+
+		assert.deepStrictEqual({ callOrder, revealed }, {
+			callOrder: [`open:${sourceChat.resource.toString()}`, 'reveal:turn-1'],
+			revealed: [request],
+		});
+	});
+
+	test('does not reveal a source when its widget view model does not change', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const revealed: ChatTreeItem[] = [];
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource, turnId: 'turn-1' },
+		});
+		const widget = upcastPartial<IChatWidget>({
+			viewModel: upcastPartial<IChatViewModel>({ sessionResource: sideChat.resource, getItems: () => [] }),
+			onDidChangeViewModel: Event.None,
+			reveal: item => { revealed.push(item); },
+		});
+		const { provider, callOrder } = setup({ chat, widget });
+
+		await provider()!.revealSideChatSource(sideChat.resource);
+
+		assert.deepStrictEqual({ callOrder, revealed }, {
+			callOrder: [`open:${sourceChat.resource.toString()}`],
+			revealed: [],
+		});
+	}));
 
 	test('does not reveal a source for a non-side chat', async () => {
 		const revealed: ChatTreeItem[] = [];

--- a/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sideChatProvider.test.ts
@@ -4,25 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { constObservable } from '../../../../../base/common/observable.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { extUri } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSideChatProvider, IChatSideChatService } from '../../../../../workbench/contrib/chat/common/chatSideChatService.js';
 import { IChatModel, IChatRequestModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { IChatRequestViewModel, IChatViewModel } from '../../../../../workbench/contrib/chat/common/model/chatViewModel.js';
 import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
 import { SessionsSideChatProviderContribution } from '../../browser/sideChatProvider.contribution.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ChatOriginKind, IChat, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 
 suite('SessionsSideChatProviderContribution', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	const sourceChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/source') });
+	const sourceChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/source'), title: constObservable('Source Chat') });
 	const sideChat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/side') });
 
 	function setup(options: {
@@ -31,16 +36,23 @@ suite('SessionsSideChatProviderContribution', () => {
 		supportsSideChat?: boolean;
 		hasTurn?: boolean;
 		isSessionsWindow?: boolean;
+		chat?: IChat;
+		parentChat?: IChat;
+		widget?: IChatWidget;
+		widgetFactory?: (callOrder: string[]) => IChatWidget;
 	} = {}) {
 		const store = disposables.add(new DisposableStore());
 		const instantiationService = store.add(new TestInstantiationService());
+		const chat = options.chat ?? sourceChat;
+		const parentChat = options.parentChat ?? sourceChat;
 
-		const session = upcastPartial<ISession>({
+		const session = upcastPartial<IActiveSession>({
 			sessionId: 'session',
 			resource: URI.parse('test:///session'),
 			status: constObservable(options.status ?? SessionStatus.Completed),
 			isArchived: constObservable(options.isArchived ?? false),
 			capabilities: constObservable({ supportsMultipleChats: true, supportsSideChat: options.supportsSideChat ?? true }),
+			chats: constObservable([parentChat, chat]),
 		});
 
 		let registered: IChatSideChatProvider | undefined;
@@ -58,7 +70,10 @@ suite('SessionsSideChatProviderContribution', () => {
 
 		const callOrder: string[] = [];
 		instantiationService.stub(ISessionsManagementService, upcastPartial<ISessionsManagementService>({
-			getSessionForChatResource: resource => resource.toString() === sourceChat.resource.toString() ? { session, chat: sourceChat } : undefined,
+			getSessionForChatResource: resource => {
+				const resolvedChat = [parentChat, chat].find(candidate => extUri.isEqual(candidate.resource, resource));
+				return resolvedChat ? { session, chat: resolvedChat } : undefined;
+			},
 			createSideChatInSession: async (_session, _sourceChat, turnId, selection) => {
 				callOrder.push(`create:${turnId}:${selection?.text ?? ''}`);
 				return sideChat;
@@ -68,10 +83,15 @@ suite('SessionsSideChatProviderContribution', () => {
 			},
 		}));
 		instantiationService.stub(ISessionsService, upcastPartial<ISessionsService>({
+			visibleSessions: constObservable([session]),
 			openChat: async (_session, chatUri) => {
 				callOrder.push(`open:${chatUri.toString()}`);
 			},
 		}));
+		instantiationService.stub(IChatWidgetService, upcastPartial<IChatWidgetService>({
+			getWidgetBySessionResource: () => options.widgetFactory?.(callOrder) ?? options.widget,
+		}));
+		instantiationService.stub(IUriIdentityService, upcastPartial<IUriIdentityService>({ extUri }));
 		instantiationService.stub(IWorkbenchEnvironmentService, upcastPartial<IWorkbenchEnvironmentService>({
 			isSessionsWindow: options.isSessionsWindow ?? true,
 		}));
@@ -119,5 +139,117 @@ suite('SessionsSideChatProviderContribution', () => {
 		const { provider } = setup({ isSessionsWindow: false });
 
 		assert.strictEqual(provider(), undefined);
+	});
+
+	test('observes the source metadata for a side chat', () => {
+		const parentChat = upcastPartial<IChat>({
+			resource: sourceChat.resource,
+			title: constObservable('Source Chat'),
+		});
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: {
+				kind: ChatOriginKind.SideChat,
+				parentChat: sourceChat.resource,
+				turnId: 'turn-1',
+				selection: { text: 'selected text' },
+			},
+		});
+		const { provider } = setup({ chat, parentChat });
+
+		assert.deepStrictEqual(provider()!.observeSideChatOrigin(sideChat.resource).get(), {
+			sourceSessionResource: sourceChat.resource,
+			sourceTurnId: 'turn-1',
+			sourceTitle: 'Source Chat',
+			selection: { text: 'selected text' },
+		});
+	});
+
+	test('returns undefined for chats without a complete side-chat origin', () => {
+		const origin = (chat: IChat) => setup({ chat }).provider()!.observeSideChatOrigin(sideChat.resource).get();
+
+		assert.deepStrictEqual({
+			noOrigin: origin(upcastPartial<IChat>({ resource: sideChat.resource })),
+			user: origin(upcastPartial<IChat>({ resource: sideChat.resource, origin: { kind: ChatOriginKind.User } })),
+			tool: origin(upcastPartial<IChat>({ resource: sideChat.resource, origin: { kind: ChatOriginKind.Tool } })),
+			missingTurn: origin(upcastPartial<IChat>({ resource: sideChat.resource, origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource } })),
+		}, {
+			noOrigin: undefined,
+			user: undefined,
+			tool: undefined,
+			missingTurn: undefined,
+		});
+	});
+
+	test('observes a side chat without a selection', () => {
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource, turnId: 'turn-1' },
+		});
+		const { provider } = setup({ chat });
+
+		assert.deepStrictEqual(provider()!.observeSideChatOrigin(sideChat.resource).get(), {
+			sourceSessionResource: sourceChat.resource,
+			sourceTurnId: 'turn-1',
+			sourceTitle: 'Source Chat',
+			selection: undefined,
+		});
+	});
+
+	test('reacts to source title changes', () => {
+		const title = observableValue('sourceTitle', 'Original Title');
+		const parentChat = upcastPartial<IChat>({ resource: sourceChat.resource, title });
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource, turnId: 'turn-1' },
+		});
+		const { provider } = setup({ chat, parentChat });
+		const origin = provider()!.observeSideChatOrigin(sideChat.resource);
+
+		const before = origin.get();
+		title.set('Renamed Title', undefined);
+
+		assert.deepStrictEqual([before?.sourceTitle, origin.get()?.sourceTitle], ['Original Title', 'Renamed Title']);
+	});
+
+	test('reveals the request a side chat branched from', async () => {
+		const revealed: ChatTreeItem[] = [];
+		const request = upcastPartial<IChatRequestViewModel>({ id: 'turn-1', message: { parts: [], text: '' } });
+		const chat = upcastPartial<IChat>({
+			resource: sideChat.resource,
+			origin: { kind: ChatOriginKind.SideChat, parentChat: sourceChat.resource, turnId: 'turn-1' },
+		});
+		const { provider, callOrder } = setup({
+			chat,
+			widgetFactory: callOrder => upcastPartial<IChatWidget>({
+				viewModel: upcastPartial<IChatViewModel>({ sessionResource: sourceChat.resource, getItems: () => [request] }),
+				onDidChangeViewModel: Event.None,
+				reveal: item => {
+					callOrder.push(`reveal:${item.id}`);
+					revealed.push(item);
+				},
+			}),
+		});
+
+		await provider()!.revealSideChatSource(sideChat.resource);
+
+		assert.deepStrictEqual({ callOrder, revealed }, {
+			callOrder: [`open:${sourceChat.resource.toString()}`, 'reveal:turn-1'],
+			revealed: [request],
+		});
+	});
+
+	test('does not reveal a source for a non-side chat', async () => {
+		const revealed: ChatTreeItem[] = [];
+		const widget = upcastPartial<IChatWidget>({
+			viewModel: upcastPartial<IChatViewModel>({ sessionResource: sourceChat.resource, getItems: () => [] }),
+			onDidChangeViewModel: Event.None,
+			reveal: item => { revealed.push(item); },
+		});
+		const { provider, callOrder } = setup({ chat: upcastPartial<IChat>({ resource: sideChat.resource }), widget });
+
+		await provider()!.revealSideChatSource(sideChat.resource);
+
+		assert.deepStrictEqual({ callOrder, revealed }, { callOrder: [], revealed: [] });
 	});
 });

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -431,6 +431,7 @@ class AdditionalChat extends Disposable {
 			origin: summary.origin ? {
 				kind: toSessionChatOriginKind(summary.origin.kind),
 				parentChat,
+				...((summary.origin.kind === ProtocolChatOriginKind.Fork || summary.origin.kind === ProtocolChatOriginKind.SideChat) ? { turnId: summary.origin.turnId } : {}),
 				...(summary.origin.kind === ProtocolChatOriginKind.SideChat && summary.origin.selection ? { selection: toSessionSideChatSelection(summary.origin.selection) } : {}),
 			} : undefined,
 			// Subagent (tool-origin) worker chats are transient children and can be

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -476,6 +476,12 @@ export interface IChatOrigin {
 	 * resource of the chat that spawned it. Undefined for user-originated chats.
 	 */
 	readonly parentChat?: URI;
+	/**
+	 * For a {@link ChatOriginKind.Fork} or {@link ChatOriginKind.SideChat}, the
+	 * id of the turn in {@link parentChat} the chat branched from. Undefined for
+	 * other origins.
+	 */
+	readonly turnId?: string;
 	readonly selection?: ISideChatSelection;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSideChatOriginPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSideChatOriginPart.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/chatSideChatOrigin.css';
+import * as dom from '../../../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
+import { Gesture, EventType as TouchEventType } from '../../../../../../base/browser/touch.js';
+import { getDefaultHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { onUnexpectedError } from '../../../../../../base/common/errors.js';
+import { KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { Disposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../nls.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { ChatAgentLocation } from '../../../common/constants.js';
+import { IChatService } from '../../../common/chatService/chatService.js';
+import { IChatSideChatOrigin, IChatSideChatService } from '../../../common/chatSideChatService.js';
+import { IChatModel } from '../../../common/model/chatModel.js';
+
+/**
+ * Shows the conversation and prompt a side chat branched from.
+ */
+export class ChatSideChatOriginPart extends Disposable {
+
+	readonly domNode: HTMLElement;
+
+	private readonly _disposeCts = new CancellationTokenSource();
+	private _renderVersion = 0;
+
+	constructor(
+		sessionResource: URI,
+		@IChatService private readonly _chatService: IChatService,
+		@IChatSideChatService private readonly _sideChatService: IChatSideChatService,
+		@IHoverService hoverService: IHoverService,
+	) {
+		super();
+
+		this._register(toDisposable(() => this._disposeCts.dispose(true)));
+		this.domNode = dom.$('.chat-side-chat-origin.hidden');
+		this.domNode.tabIndex = 0;
+		this.domNode.setAttribute('role', 'button');
+		this._register(Gesture.addTarget(this.domNode));
+		this._register(hoverService.setupManagedHover(
+			getDefaultHoverDelegate('element'),
+			this.domNode,
+			localize('chat.sideChatOrigin.showOriginalMessage', "Show the original message"),
+		));
+
+		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
+			this._register(dom.addDisposableListener(this.domNode, eventType, () => {
+				this._revealSource(sessionResource);
+			}));
+		}
+		this._register(dom.addDisposableListener(this.domNode, dom.EventType.KEY_DOWN, e => {
+			const event = new StandardKeyboardEvent(e);
+			if ((event.keyCode === KeyCode.Enter || event.keyCode === KeyCode.Space) && !event.metaKey && !event.ctrlKey && !event.altKey) {
+				event.preventDefault();
+				event.stopPropagation();
+				this._revealSource(sessionResource);
+			}
+		}));
+
+		const origin = this._sideChatService.observeSideChatOrigin(sessionResource);
+		this._register(autorun(reader => {
+			this._renderOrigin(origin.read(reader));
+		}));
+	}
+
+	private _renderOrigin(origin: IChatSideChatOrigin | undefined): void {
+		const renderVersion = ++this._renderVersion;
+
+		if (!origin) {
+			dom.clearNode(this.domNode);
+			this.domNode.classList.add('hidden');
+			this.domNode.removeAttribute('aria-label');
+			return;
+		}
+		const title = origin.sourceTitle ?? localize('chat.sideChatOrigin.originalConversation', "Original conversation");
+		let quote: string | undefined;
+		let shouldLoadSourceSession = false;
+		if (origin.selection) {
+			quote = this._normalizeQuote(origin.selection.text);
+		} else {
+			const sourceSession = this._chatService.getSession(origin.sourceSessionResource);
+			if (sourceSession) {
+				quote = this._getRequestQuote(sourceSession, origin.sourceTurnId);
+			} else {
+				shouldLoadSourceSession = true;
+			}
+		}
+		this._renderContent(title, quote);
+
+		if (shouldLoadSourceSession) {
+			void this._resolveSourceQuote(origin, title, renderVersion);
+		}
+	}
+
+	private async _resolveSourceQuote(origin: IChatSideChatOrigin, title: string, renderVersion: number): Promise<void> {
+		try {
+			const reference = await this._chatService.acquireOrLoadSession(
+				origin.sourceSessionResource,
+				ChatAgentLocation.Chat,
+				this._disposeCts.token,
+				'ChatSideChatOriginPart#resolveSourceQuote',
+			);
+			if (!reference) {
+				return;
+			}
+
+			try {
+				if (this._disposeCts.token.isCancellationRequested || this._store.isDisposed || renderVersion !== this._renderVersion) {
+					return;
+				}
+
+				const quote = this._getRequestQuote(reference.object, origin.sourceTurnId);
+				if (quote && renderVersion === this._renderVersion && !this._store.isDisposed) {
+					this._renderContent(title, quote);
+				}
+			} finally {
+				reference.dispose();
+			}
+		} catch (error) {
+			if (!this._disposeCts.token.isCancellationRequested) {
+				onUnexpectedError(error);
+			}
+		}
+	}
+
+	private _getRequestQuote(sourceSession: IChatModel, sourceTurnId: string): string | undefined {
+		return this._normalizeQuote(sourceSession.getRequests().find(request => request.id === sourceTurnId)?.message.text);
+	}
+
+	private _normalizeQuote(text: string | undefined): string | undefined {
+		const quote = text?.replace(/\s+/g, ' ').trim();
+		return quote || undefined;
+	}
+
+	private _renderContent(title: string, quote: string | undefined): void {
+		dom.clearNode(this.domNode);
+		this.domNode.classList.remove('hidden');
+		this.domNode.classList.toggle('has-no-quote', !quote);
+
+		const header = dom.$('.chat-side-chat-origin-header');
+		const icon = dom.$('span.chat-side-chat-origin-icon');
+		icon.classList.add(...ThemeIcon.asClassNameArray(Codicon.reply));
+		icon.setAttribute('aria-hidden', 'true');
+		const titleElement = dom.$('span.chat-side-chat-origin-title');
+		titleElement.textContent = title;
+		header.append(icon, titleElement);
+		this.domNode.appendChild(header);
+
+		if (quote) {
+			const quoteElement = dom.$('span.chat-side-chat-origin-quote');
+			quoteElement.textContent = quote;
+			this.domNode.appendChild(quoteElement);
+			this.domNode.setAttribute('aria-label', localize(
+				'chat.sideChatOrigin.ariaLabel',
+				"Side chat about {0}: {1}. Select to show the original message.",
+				title,
+				quote,
+			));
+		} else {
+			this.domNode.setAttribute('aria-label', localize(
+				'chat.sideChatOrigin.ariaLabelNoQuote',
+				"Side chat about {0}. Select to show the original message.",
+				title,
+			));
+		}
+	}
+
+	private _revealSource(sessionResource: URI): void {
+		void this._sideChatService.revealSideChatSource(sessionResource).catch(onUnexpectedError);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSideChatOrigin.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSideChatOrigin.css
@@ -34,7 +34,7 @@
 
 .hc-black .chat-side-chat-origin,
 .hc-light .chat-side-chat-origin {
-	border: 1px dotted var(--vscode-focusBorder);
+	border: var(--vscode-strokeThickness) dotted var(--vscode-focusBorder);
 }
 
 .chat-side-chat-origin:focus-visible {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSideChatOrigin.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSideChatOrigin.css
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-side-chat-origin {
+	align-self: flex-end;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	gap: var(--vscode-spacing-size20);
+	max-width: 90%;
+	width: fit-content;
+	margin-block-end: var(--vscode-spacing-size20);
+	padding: var(--vscode-spacing-size60) var(--vscode-spacing-size120);
+	background-color: var(--vscode-chat-requestBubbleBackground);
+	border-radius: var(--vscode-cornerRadius-large);
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	touch-action: manipulation;
+}
+
+.chat-side-chat-origin.hidden {
+	display: none;
+}
+
+.chat-side-chat-origin.has-no-quote {
+	padding-block: var(--vscode-spacing-size40);
+}
+
+.chat-side-chat-origin:hover {
+	background-color: var(--vscode-chat-requestBubbleHoverBackground);
+}
+
+.hc-black .chat-side-chat-origin,
+.hc-light .chat-side-chat-origin {
+	border: 1px dotted var(--vscode-focusBorder);
+}
+
+.chat-side-chat-origin:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: var(--vscode-spacing-size20);
+}
+
+.chat-side-chat-origin-header {
+	display: flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size40);
+	min-width: 0;
+	font-size: var(--vscode-fontSize-label2);
+	font-weight: var(--vscode-fontWeight-regular);
+}
+
+.chat-side-chat-origin-icon {
+	flex: 0 0 auto;
+	font-size: var(--vscode-codiconFontSize-compact);
+}
+
+.chat-side-chat-origin-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.chat-side-chat-origin-quote {
+	display: -webkit-box;
+	overflow: hidden;
+	font-size: var(--vscode-fontSize-label3);
+	font-weight: var(--vscode-fontWeight-regular);
+	line-clamp: 2;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	word-break: break-word;
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -102,6 +102,7 @@ import { ChatProgressContentPart, ChatWorkingProgressContentPart } from './chatC
 import { ChatPullRequestContentPart } from './chatContentParts/chatPullRequestContentPart.js';
 import { ChatQuotaExceededPart } from './chatContentParts/chatQuotaExceededPart.js';
 import { ChatCollapsibleListContentPart, ChatUsedReferencesListContentPart, CollapsibleListPool } from './chatContentParts/chatReferencesContentPart.js';
+import { ChatSideChatOriginPart } from './chatContentParts/chatSideChatOriginPart.js';
 import { ChatTaskContentPart } from './chatContentParts/chatTaskContentPart.js';
 import { ChatSystemNotificationContentPart } from './chatContentParts/chatSystemNotificationContentPart.js';
 import { ChatTextEditContentPart } from './chatContentParts/chatTextEditContentPart.js';
@@ -1985,6 +1986,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		dom.clearNode(templateData.value);
+		if (this.environmentService.isSessionsWindow && this.viewModel?.model.getRequests()[0]?.id === element.id) {
+			const sideChatOriginPart = this.instantiationService.createInstance(ChatSideChatOriginPart, element.sessionResource);
+			templateData.value.appendChild(sideChatOriginPart.domNode);
+			templateData.elementDisposables.add(sideChatOriginPart);
+		}
 		const parts: IChatContentPart[] = [];
 		const explicitImageAttachmentsPart = explicitImageVariables.length ? this.renderAttachments(explicitImageVariables, element.contentReferences, element.modelId, templateData, element.resolvedModelId) : undefined;
 		if (explicitImageAttachmentsPart?.domNode) {

--- a/src/vs/workbench/contrib/chat/common/chatSideChatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSideChatService.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 
@@ -13,6 +15,21 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
  */
 export interface IChatSideChatSelection {
 	readonly text: string;
+}
+
+/**
+ * Describes the conversation and turn a side chat branched from, so chat UI can
+ * show where the side chat came from and navigate back to it.
+ */
+export interface IChatSideChatOrigin {
+	/** Resource of the chat this side chat branched from. */
+	readonly sourceSessionResource: URI;
+	/** Id of the turn in the source chat the side chat branched from. */
+	readonly sourceTurnId: string;
+	/** Display title of the source chat, when known. */
+	readonly sourceTitle: string | undefined;
+	/** Immutable text snapshot the side chat was anchored to, when the user branched from a selection. */
+	readonly selection?: IChatSideChatSelection;
 }
 
 /**
@@ -36,6 +53,19 @@ export interface IChatSideChatProvider {
 	 * sends `query` on it. Rejects if the side chat could not be created.
 	 */
 	askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void>;
+
+	/**
+	 * Observes how `sessionResource` came to exist as a side chat, or `undefined`
+	 * when it is not a side chat. Observable because the source chat's title and
+	 * the origin itself settle asynchronously as session state loads.
+	 */
+	observeSideChatOrigin(sessionResource: URI): IObservable<IChatSideChatOrigin | undefined>;
+
+	/**
+	 * Reveals the turn `sessionResource` branched from, activating the source
+	 * chat. No-ops when `sessionResource` is not a side chat.
+	 */
+	revealSideChatSource(sessionResource: URI): Promise<void>;
 }
 
 export const IChatSideChatService = createDecorator<IChatSideChatService>('chatSideChatService');
@@ -50,17 +80,34 @@ export interface IChatSideChatService {
 
 	/** @see IChatSideChatProvider.askInSideChat */
 	askInSideChat(sessionResource: URI, query: string, selection?: IChatSideChatSelection): Promise<void>;
+
+	/** @see IChatSideChatProvider.observeSideChatOrigin */
+	observeSideChatOrigin(sessionResource: URI): IObservable<IChatSideChatOrigin | undefined>;
+
+	/** @see IChatSideChatProvider.revealSideChatSource */
+	revealSideChatSource(sessionResource: URI): Promise<void>;
 }
 
 export class ChatSideChatService extends Disposable implements IChatSideChatService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _providers = new Set<IChatSideChatProvider>();
+	private readonly _providers = observableValue<readonly IChatSideChatProvider[]>(this, []);
+	// Cheap deriveds keyed by session resource keep observable identities stable across renders.
+	private readonly _sideChatOrigins = new ResourceMap<IObservable<IChatSideChatOrigin | undefined>>();
 
 	registerProvider(provider: IChatSideChatProvider): IDisposable {
-		this._providers.add(provider);
-		return toDisposable(() => this._providers.delete(provider));
+		if (!this._providers.get().includes(provider)) {
+			this._providers.set([...this._providers.get(), provider], undefined);
+		}
+
+		return toDisposable(() => {
+			const providers = this._providers.get();
+			const index = providers.indexOf(provider);
+			if (index !== -1) {
+				this._providers.set([...providers.slice(0, index), ...providers.slice(index + 1)], undefined);
+			}
+		});
 	}
 
 	canAskInSideChat(sessionResource: URI): boolean {
@@ -75,8 +122,34 @@ export class ChatSideChatService extends Disposable implements IChatSideChatServ
 		await provider.askInSideChat(sessionResource, query, selection);
 	}
 
+	observeSideChatOrigin(sessionResource: URI): IObservable<IChatSideChatOrigin | undefined> {
+		let origin = this._sideChatOrigins.get(sessionResource);
+		if (!origin) {
+			origin = derived(this, reader => {
+				for (const provider of this._providers.read(reader)) {
+					const providerOrigin = provider.observeSideChatOrigin(sessionResource).read(reader);
+					if (providerOrigin !== undefined) {
+						return providerOrigin;
+					}
+				}
+				return undefined;
+			});
+			this._sideChatOrigins.set(sessionResource, origin);
+		}
+		return origin;
+	}
+
+	async revealSideChatSource(sessionResource: URI): Promise<void> {
+		for (const provider of this._providers.get()) {
+			if (provider.observeSideChatOrigin(sessionResource).get() !== undefined) {
+				await provider.revealSideChatSource(sessionResource);
+				return;
+			}
+		}
+	}
+
 	private _findProvider(sessionResource: URI): IChatSideChatProvider | undefined {
-		for (const provider of this._providers) {
+		for (const provider of this._providers.get()) {
 			if (provider.canAskInSideChat(sessionResource)) {
 				return provider;
 			}

--- a/src/vs/workbench/contrib/chat/test/common/chatSideChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatSideChatService.test.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, IObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ChatSideChatService, IChatSideChatOrigin, IChatSideChatProvider } from '../../common/chatSideChatService.js';
+
+suite('ChatSideChatService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const resource = URI.parse('test:///side-chat');
+	const origin: IChatSideChatOrigin = {
+		sourceSessionResource: URI.parse('test:///source-chat'),
+		sourceTurnId: 'turn-1',
+		sourceTitle: 'Source Chat',
+	};
+
+	function createProvider(sideChatOrigin: IObservable<IChatSideChatOrigin | undefined>, reveal?: () => void): IChatSideChatProvider {
+		return {
+			canAskInSideChat: () => false,
+			askInSideChat: async () => { },
+			observeSideChatOrigin: sessionResource => sessionResource.toString() === resource.toString() ? sideChatOrigin : constObservable(undefined),
+			revealSideChatSource: async () => { reveal?.(); },
+		};
+	}
+
+	function createService(): { store: DisposableStore; service: ChatSideChatService } {
+		const store = disposables.add(new DisposableStore());
+		return { store, service: store.add(new ChatSideChatService()) };
+	}
+
+	test('reacts when a provider is registered', () => {
+		const { store, service } = createService();
+		const observed = service.observeSideChatOrigin(resource);
+		const before = observed.get();
+		store.add(service.registerProvider(createProvider(constObservable(origin))));
+
+		assert.deepStrictEqual([before, observed.get()], [undefined, origin]);
+	});
+
+	test('returns undefined after a provider is unregistered', () => {
+		const { store, service } = createService();
+		const observed = service.observeSideChatOrigin(resource);
+		const registration = store.add(service.registerProvider(createProvider(constObservable(origin))));
+		const before = observed.get();
+		registration.dispose();
+
+		assert.deepStrictEqual([before, observed.get()], [origin, undefined]);
+	});
+
+	test('caches origin observables by resource', () => {
+		const { service } = createService();
+
+		assert.strictEqual(service.observeSideChatOrigin(resource), service.observeSideChatOrigin(resource));
+	});
+
+	test('uses the first provider that reports an origin', () => {
+		const { store, service } = createService();
+		store.add(service.registerProvider(createProvider(constObservable(undefined))));
+		store.add(service.registerProvider(createProvider(constObservable(origin))));
+
+		assert.deepStrictEqual(service.observeSideChatOrigin(resource).get(), origin);
+	});
+
+	test('reveals through the provider that owns the side chat', async () => {
+		const { store, service } = createService();
+		const calls: string[] = [];
+		store.add(service.registerProvider(createProvider(constObservable(undefined), () => calls.push('first'))));
+		store.add(service.registerProvider(createProvider(constObservable(origin), () => calls.push('second'))));
+
+		await service.revealSideChatSource(resource);
+		await service.revealSideChatSource(URI.parse('test:///not-a-side-chat'));
+
+		assert.deepStrictEqual(calls, ['second']);
+	});
+});


### PR DESCRIPTION
Fixes #327699

A side chat spawned by `/btw` (or by selecting text in a response) carries hidden context from the conversation it branched from, but the transcript gave no sign of it — the first message read as a bare "hello" with no indication anything else was in scope.

This renders a reply card above the first user message of a side chat, quoting the source turn it branched from. Activating it switches to the source chat and reveals that turn.

### Approach

The card is driven by the chat's **origin**, not by a synthetic message attachment — the origin dictates how the first request renders.

The chat layer resolves the origin through the existing `IChatSideChatProvider`, keyed by session resource (`IChatModel.sessionResource` is already `IChat.resource`). That keeps `vs/sessions` out of the chat layer, and because the lookup happens per-element at render time, a single reused chat widget renders the correct card as the user switches between chats.

Quote text prefers the captured selection, falling back to the source turn's prompt and then to the chat title. `turnId` is now carried through `IChatOrigin` — the AHP protocol already provided it, the sessions layer was dropping it.

### Notes

- The card renders only in the Agents window and only for the first request, so cost is zero for regular workbench chat.
- Styling uses the request bubble's surface token one tier down (`cornerRadius-large` vs the bubble's `xLarge`), muted foreground and smaller type, plus a dotted border in HC themes where that background token is unset.

### Testing

61 side-chat tests pass, including 11 new ones covering origin resolution, title reactivity, and the reveal path. Typecheck, ESLint, stylelint, and `valid-layers-check` are clean.
