### PR TITLE
Refresh model catalogs when authentication changes

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -26,6 +26,8 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 ## Common Pitfalls
 
+- **Auth changes must refresh model producers and rebuild consumers, not add view-local model policy**: Manage Models reflects `ILanguageModelsService` and must call its existing full refresh when the resolved account changes. Agent Host authentication must also forward token removal so providers republish their model catalogs; do not hide stale Copilot entries with widget-specific filtering.
+
 - **Paired experiment treatments must resolve atomically**: when a prompt and its editable placeholder are separate treatment values, use them only when both are non-empty; otherwise use both defaults so copy from different variants is never mixed. The prompt may omit the placeholder token entirely, in which case it is used literally and placeholder highlighting is simply absent.
 
 - **Onboarding variations share structural steps and vary only their run step**: keep one scenario for workspace selection, then resolve the experiment/developer variation when the run step executes. Personalized GitHub prompts use existing authentication silently, stay within a bounded cancellable lookup, verify that the selected draft workspace is still current, and fall back to the default prompt without surfacing an error.

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1836,6 +1836,7 @@ export interface IAgent {
 	/**
 	 * Authenticate for a specific resource. Returns true if accepted.
 	 * The `resource` matches {@link IAuthorizationProtectedResourceMetadata.resource}.
+	 * An empty token revokes the previously forwarded credential.
 	 */
 	authenticate(resource: string, token: string): Promise<boolean>;
 

--- a/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
+++ b/src/vs/platform/agentHost/node/agentHostAuthenticationService.ts
@@ -71,7 +71,12 @@ export class AgentHostAuthenticationService {
 			authenticated = this._tokens.get(this._key(params.resource, scopes))?.token === params.token;
 		}
 		if (authenticated) {
-			this._tokens.set(this._key(params.resource, scopes), { resource: params.resource, scopes, token: params.token });
+			const key = this._key(params.resource, scopes);
+			if (params.token) {
+				this._tokens.set(key, { resource: params.resource, scopes, token: params.token });
+			} else {
+				this._tokens.delete(key);
+			}
 		}
 		return { authenticated };
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -579,6 +579,15 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		if (resource !== this._gitHubEndpointService.getCopilotResource().resource) {
 			return false;
 		}
+		if (!token) {
+			const oldHandle = this._proxyHandle;
+			this._proxyHandle = undefined;
+			this._githubToken = undefined;
+			oldHandle?.dispose();
+			this._models.set([], undefined);
+			void this._startModelRefresh();
+			return true;
+		}
 		// A GitHub Copilot token is arriving (sign-in). Always start the proxy so a
 		// session that picks a Copilot-routed model from the merged catalog has a
 		// started handle to run against — even while model-less sessions still

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1116,6 +1116,25 @@ suite('ClaudeAgent', () => {
 		}
 	});
 
+	test('sign-out revokes the Copilot proxy and refreshes the model catalog', async () => {
+		const { agent, proxy } = createTestContext(disposables);
+		await agent.authenticate('https://api.github.com', 'gh-token');
+		await tick();
+
+		await agent.authenticate('https://api.github.com', '');
+		await tick();
+
+		assert.deepStrictEqual({
+			proxyStarts: proxy.startCalls.length,
+			disposeCount: proxy.disposeCount,
+			models: agent.models.get(),
+		}, {
+			proxyStarts: 1,
+			disposeCount: 1,
+			models: [],
+		});
+	});
+
 	test('coalesces concurrent refreshModels calls onto one CAPI models request', async () => {
 		const { agent, api } = createTestContext(disposables);
 		// Block the first request in flight so the second caller has something

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -276,6 +276,8 @@ export async function authenticateProtectedResources(
 			);
 			if (!token) {
 				logService.info(`${options.logPrefix} No token resolved for resource: ${resource.resource}`);
+				// An empty token revokes the credential previously forwarded for this resource.
+				await forwardAuthenticationToken(options, resource.resource, scopes, '');
 				continue;
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -1177,11 +1177,13 @@ export class ChatModelsWidget extends Disposable {
 		this.create(this.element);
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
 			this.defaultAccountResolved = true;
+			void this.viewModel.refresh();
 			this.updateAddModelsButton();
 		}));
 		this.defaultAccountService.getDefaultAccount().then(() => {
 			if (!this._store.isDisposed) {
 				this.defaultAccountResolved = true;
+				void this.viewModel.refresh();
 				this.updateAddModelsButton();
 			}
 		});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
@@ -61,7 +61,7 @@ export function buildUnavailableStateItems(options: IBuildModelPickerItemsOption
 	}
 	if (setupRequired) {
 		const enabled = !!options.actions.onRequestSetup;
-		return [
+		const items: IActionListItem<IActionWidgetDropdownAction>[] = [
 			{ kind: ActionListItemKind.Header, label: localize('chat.modelPicker.setupRequired', "Sign in to use Copilot") },
 			{
 				item: {
@@ -80,6 +80,20 @@ export function buildUnavailableStateItems(options: IBuildModelPickerItemsOption
 				hideIcon: false,
 			},
 		];
+		if (options.manageModelsAction) {
+			items.push(
+				{ kind: ActionListItemKind.Separator },
+				{
+					item: options.manageModelsAction,
+					kind: ActionListItemKind.Action,
+					label: options.manageModelsAction.label,
+					group: { title: '', icon: Codicon.blank },
+					hideIcon: false,
+					showAlways: true,
+				}
+			);
+		}
+		return items;
 	}
 	if (options.models.length > 0) {
 		return undefined;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
@@ -988,6 +988,36 @@ suite('authenticateProtectedResources', () => {
 
 		assert.deepStrictEqual(requests, [{ resource: protectedResource.resource, scopes: ['read'], token: 'cached-token' }]);
 	});
+
+	test('forwards token removal when the account signs out', async () => {
+		let token: string | undefined = 'cached-token';
+		const authService = createMockAuthService({
+			getOrActivateProviderIdForServer: () => Promise.resolve('provider-1'),
+			getSessions: (_providerId, scopes) => scopes && token
+				? Promise.resolve([{ scopes: ['read'], accessToken: token }])
+				: Promise.resolve([]),
+		});
+		const cache = new AgentHostAuthTokenCache();
+		const requests: { resource: string; scopes?: readonly string[]; token: string }[] = [];
+		const agents = [{ protectedResources: [protectedResource] }] as unknown as readonly AgentInfo[];
+		const instantiationService = createAuthInstantiationService(disposables, authService);
+		const options: IAgentHostAuthenticationOptions = {
+			authTokenCache: cache,
+			logPrefix: '[AgentHost]',
+			authenticate: async request => {
+				requests.push(request);
+			},
+		};
+
+		await instantiationService.invokeFunction(authenticateProtectedResources, agents, options);
+		token = undefined;
+		await instantiationService.invokeFunction(authenticateProtectedResources, agents, options);
+
+		assert.deepStrictEqual(requests, [
+			{ resource: protectedResource.resource, scopes: ['read'], token: 'cached-token' },
+			{ resource: protectedResource.resource, scopes: ['read'], token: '' },
+		]);
+	});
 });
 
 suite('resolveAuthenticationInteractively', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -342,11 +342,11 @@ suite('buildModelPickerItems', () => {
 		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { } });
 		const actions = getActionItems(items);
 		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Sign in to use Copilot'));
-		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions.length, 2);
 		assert.strictEqual(actions[0].item?.id, 'setupRequiredSignIn');
 		assert.strictEqual(actions[0].item?.enabled, true);
 		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
-		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+		assert.strictEqual(actions[1].item?.id, 'manageModels');
 	});
 
 	test('setupRequired Sign In action is disabled without a setup callback', () => {


### PR DESCRIPTION
## Summary

- rebuild the Manage Models catalog when the resolved default account changes
- forward Agent Host credential removal when a user signs out
- remove revoked credentials from the Agent Host authentication cache
- refresh provider model catalogs after revocation, including disposing Claude's stale Copilot proxy

Related to #329667.