### PR TITLE
Fix chat animation during non-chat dictation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -500,7 +500,7 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		// animate this control.
 		const dictationActive = observableFromEvent(this,
 			this.chatSpeechToTextService.onDidChangeState,
-			() => isDictationActiveOnSurface(this.chatSpeechToTextService, 'chat'));
+			() => isDictationActiveOnSurface(this.chatSpeechToTextService, 'chat') && this.chatSpeechToTextService.state !== ChatSpeechToTextState.Idle);
 
 		// Model preparation: on first use the on-device model downloads/loads. Swap the
 		// mic for a download affordance while preparing, mirroring the standalone button.

--- a/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem.ts
@@ -35,7 +35,7 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IVoiceSessionController } from '../voiceClient/voiceSessionController.js';
 import { IMicCaptureService } from '../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../voiceClient/ttsPlaybackService.js';
-import { ChatSpeechToTextState, IChatSpeechToTextService } from '../speechToText/chatSpeechToTextService.js';
+import { ChatSpeechToTextState, IChatSpeechToTextService, isDictationActiveOnSurface } from '../speechToText/chatSpeechToTextService.js';
 import { setupDictationMicGlow } from '../speechToText/dictationMicGlow.js';
 import { DictationDownloadRing, getDictationPreparingLabel } from '../speechToText/dictationDownloadRing.js';
 import { getDictationHoverContent, getVoiceModeHoverContent } from '../speechToText/micButtonHovers.js';
@@ -496,18 +496,17 @@ export class VoiceInputModeActionViewItem extends BaseActionViewItem {
 		}));
 		this._registerActivationKeys(this._listenCell, () => this._onClickListen());
 
-		// Dictation activity: driven directly by the built-in on-device speech-to-text
-		// service so the mic reliably fills while a dictation session is recording or
-		// transcribing (global, not scope-dependent).
+		// Dictation activity: scoped to chat so editor and terminal dictation do not
+		// animate this control.
 		const dictationActive = observableFromEvent(this,
 			this.chatSpeechToTextService.onDidChangeState,
-			() => this.chatSpeechToTextService.state !== ChatSpeechToTextState.Idle);
+			() => isDictationActiveOnSurface(this.chatSpeechToTextService, 'chat'));
 
 		// Model preparation: on first use the on-device model downloads/loads. Swap the
 		// mic for a download affordance while preparing, mirroring the standalone button.
 		const dictationPreparing = observableFromEvent(this,
 			this.chatSpeechToTextService.onDidChangePreparingModel,
-			() => this.chatSpeechToTextService.isPreparingModel);
+			() => this.chatSpeechToTextService.currentSurface === 'chat' && this.chatSpeechToTextService.isPreparingModel);
 		// Sub-state of preparing: `true` only during a confirmed on-disk download
 		// (cache miss), `false` while loading an already-cached model. Drives the
 		// download-vs-spinner glyph below.


### PR DESCRIPTION
Fixes #328811

Scopes the chat voice-input animation and model-preparation state to chat-owned dictation sessions, so editor and terminal dictation no longer animate the chat control.