### PR TITLE
Fix Update button spacing on macOS

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -444,7 +444,9 @@
 	margin-left: 4px;
 }
 
-.monaco-workbench.mac:not(.web) .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container {
+.monaco-workbench.mac:not(.web) .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container,
+.monaco-workbench.mac:not(.web) .part.titlebar > .titlebar-container > .titlebar-right > .update-toolbar-container {
+	position: relative;
 	right: 8px;
 }
 


### PR DESCRIPTION
Ensures the right-most Update toolbar uses the same trailing inset as the standard title-bar action toolbar on macOS, keeping the title-bar spacing consistent whether Update is visible or hidden.

Fixes #329606

## Testing

- Verified the Update and standard action toolbars share the existing macOS-only 8px inset rule
- `npm run stylelint -- src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css`