### PR TITLE
agentHost: Classify cancelled model call telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -26,18 +26,9 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"dev_device_id": { "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight", "comment": "Pseudonymous device identifier supplied by the runtime." },
 		"is_staff": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the user is a GitHub or Microsoft staff member.", "isMeasurement": true },
 		"restricted": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the SDK marked the event as restricted telemetry.", "isMeasurement": true },
-		"git_root": { "classification": "CustomerContent", "purpose": "PerformanceAndHealth", "comment": "Restricted local root path of the repository associated with the SDK session." },
-		"repository": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository identifier associated with the SDK session." },
-		"host_type": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Restricted bounded category of repository host." },
-		"repository_host": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository host associated with the SDK session." },
-		"branch": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository branch associated with the SDK session." },
-		"head_commit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Restricted repository head commit identifier associated with the SDK session." },
 		"${wildcard}": [{
 			"${prefix}": "feature.",
 			"${classification}": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Feature flag value supplied by the Copilot CLI runtime." }
-		}, {
-			"${prefix}": "sdk_correlation_",
-			"${classification}": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "SDK correlation identifier supplied by the Copilot CLI runtime." }
 		}]
 	}
 */

--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -26,9 +26,18 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"dev_device_id": { "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight", "comment": "Pseudonymous device identifier supplied by the runtime." },
 		"is_staff": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the user is a GitHub or Microsoft staff member.", "isMeasurement": true },
 		"restricted": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the SDK marked the event as restricted telemetry.", "isMeasurement": true },
+		"git_root": { "classification": "CustomerContent", "purpose": "PerformanceAndHealth", "comment": "Restricted local root path of the repository associated with the SDK session." },
+		"repository": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository identifier associated with the SDK session." },
+		"host_type": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Restricted bounded category of repository host." },
+		"repository_host": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository host associated with the SDK session." },
+		"branch": { "classification": "CustomerContent", "purpose": "FeatureInsight", "comment": "Restricted repository branch associated with the SDK session." },
+		"head_commit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Restricted repository head commit identifier associated with the SDK session." },
 		"${wildcard}": [{
 			"${prefix}": "feature.",
 			"${classification}": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Feature flag value supplied by the Copilot CLI runtime." }
+		}, {
+			"${prefix}": "sdk_correlation_",
+			"${classification}": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "SDK correlation identifier supplied by the Copilot CLI runtime." }
 		}]
 	}
 */
@@ -89,6 +98,38 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
 		"engagement_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an engagement." },
 		"transport": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Transport used for the request." }
+	}
+*/
+
+/* __GDPR__
+	"copilotSdk/model_call_cancelled": {
+		"owner": "amunger",
+		"comment": "Reports performance and request-shape details for cancelled Copilot CLI model-call attempts forwarded by the Copilot SDK.",
+		"${include}": [ "${CopilotSdkForwardedTelemetry}" ],
+		"event_id": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Unique identifier for the cancellation telemetry event." },
+		"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Telemetry-safe product model selected for the cancelled attempt; omitted for custom and BYOK models." },
+		"api_endpoint": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model API endpoint used by the cancelled attempt." },
+		"transport": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Transport used by the cancelled attempt." },
+		"cancellation_source": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Bounded runtime category identifying where cancellation was detected." },
+		"attempt_id": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Runtime identifier for the physical model-call attempt." },
+		"interaction_type": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Allowlisted interaction type that initiated the cancelled attempt." },
+		"initiator": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Bounded user or agent initiator of the cancelled attempt." },
+		"is_byok": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the cancelled attempt used a bring-your-own-key provider." },
+		"copilot_pid": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Process identifier for the Copilot CLI runtime." },
+		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
+		"engagement_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an engagement." },
+		"duration_ms": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Elapsed time for the cancelled attempt in milliseconds.", "isMeasurement": true },
+		"attempt_index": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Zero-based physical model-call attempt index within the runtime model loop.", "isMeasurement": true },
+		"retry_index": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Zero-based retry index within the current logical model call.", "isMeasurement": true },
+		"prompt_token_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Prompt token count calculated before the cancelled attempt.", "isMeasurement": true },
+		"max_prompt_tokens": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Effective maximum prompt-token limit for the cancelled attempt.", "isMeasurement": true },
+		"max_output_tokens": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Effective maximum output-token limit for the cancelled attempt.", "isMeasurement": true },
+		"request_message_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of messages in the cancelled request.", "isMeasurement": true },
+		"request_tool_result_message_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of tool-result messages in the cancelled request.", "isMeasurement": true },
+		"request_tool_call_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of tool calls represented in the cancelled request.", "isMeasurement": true },
+		"request_nameless_tool_call_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of tool calls without a name in the cancelled request.", "isMeasurement": true },
+		"request_image_part_count": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of image parts in the cancelled request.", "isMeasurement": true },
+		"request_image_parts_missing_media_type": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of image parts missing a media type in the cancelled request.", "isMeasurement": true }
 	}
 */
 


### PR DESCRIPTION
## What

Declare the SDK-forwarded `copilotSdk/model_call_cancelled` event in the Agent Host telemetry forwarder.

The declaration is intentionally standard-only:

- no `CustomerContent` classifications;
- no request or agent identifiers;
- no custom/BYOK model identity;
- only allowlisted interaction types, bounded categories, system-generated attempt/event ids, and aggregate measurements.

No Agent Host turn behavior or public protocol surface changes.

## Why

Part of [microsoft/vscode-internalbacklog#8247](https://github.com/microsoft/vscode-internalbacklog/issues/8247).

The paired runtime change, [github/copilot-agent-runtime#15211](https://github.com/github/copilot-agent-runtime/pull/15211), adds per-physical-attempt `model_call_cancelled` telemetry. The generic SDK callback already forwards runtime telemetry into Microsoft telemetry; this change supplies the required GDPR contract.

Existing `agentHost.turnCompleted(result=cancelled)` remains the cross-provider turn-cancellation signal. This event instead completes the Copilot runtime model-attempt success/error/cancelled denominator.

## Data parity

| Analytical signal | Historical source | Agent Host source | Parity |
|---|---|---|---|
| Cancelled physical model attempts | Copilot Chat `response.cancelled` | `copilotSdk/model_call_cancelled` | ≈ Legacy also counted premature stream closure |
| First-party model/API/transport | Local response payload | Standard-safe runtime payload | ✅ |
| BYOK incidence | `isBYOK` | `is_byok` | ✅ |
| Custom/BYOK model identity | Raw local model | Omitted | ⊗ |
| Request kind | `requestKind` | Allowlisted `interaction_type` | ✅ for known values |
| Source/request/agent correlation | Local source and request ids | Omitted | ⊗ |
| Timing/token/request-shape dimensions | Local aggregate measurements | Runtime aggregate measurements | ✅ / ≈ |
| TTFT, bytes, Auto, suspend/resume | Local measurements | Not emitted | ⊗ |

## Query and row implications

- Historical model-attempt queries should filter local rows to agent, subagent, background, and compaction request kinds.
- New Agent Host queries should combine `copilotSdk/response.success`, `copilotSdk/response.error`, and `copilotSdk/model_call_cancelled`.
- `agentHost.turnCompleted(result=cancelled)` remains a separate per-turn metric.
- The runtime event is one row per actually dispatched cancelled physical model attempt.
- Custom/BYOK model identity is deliberately omitted; audited valid non-BYOK model parity covers 99.76% of the migration cohort.

Validation: current-main compile passes; the formerly failing CopilotAgent and CopilotGitHubTelemetryForwarder suites pass 191 tests; the Agent Host-scoped telemetry extractor accepts the declaration. The full-repository extractor still reports unrelated existing duplicate-property declarations.
