### PR TITLE
Restore the Omni Chat model picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -130,6 +130,7 @@ export class ConfigureToolsAction extends Action2 {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
 					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.inChatInputWindow.negate(),
 				),
 				id: MenuId.ChatInput,
 				group: 'navigation',

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
+import { IAnchor } from '../../../../base/browser/ui/contextview/contextview.js';
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -320,7 +321,9 @@ export interface IChatWidgetViewOptions {
 	submitHandler?: (query: string, mode: ChatModeKind, attachedContext?: IChatRequestVariableEntry[], isVoiceModeInput?: boolean) => Promise<boolean>;
 	onDidChangeModelPickerVisibility?: (visible: boolean) => void | Promise<void>;
 	inputPickerPosition?: AnchorPosition;
-	inputPickerContainer?: HTMLElement;
+	inputPickerContainer?: HTMLElement | (() => HTMLElement | undefined);
+	inputPickerAnchor?: (anchor: HTMLElement) => HTMLElement | IAnchor;
+	inputPickerOpenOnMouseUp?: boolean;
 
 	/**
 	 * Whether we are running in the sessions window.

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -7,6 +7,7 @@ import './media/chatInputWindow.css';
 import * as dom from '../../../../../base/browser/dom.js';
 import { renderAsPlaintext } from '../../../../../base/browser/markdownRenderer.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { IAnchor } from '../../../../../base/browser/ui/contextview/contextview.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
@@ -31,6 +32,7 @@ import { defaultButtonStyles } from '../../../../../platform/theme/browser/defau
 import { editorBackground } from '../../../../../platform/theme/common/colorRegistry.js';
 import { inputBackground, inputBorder } from '../../../../../platform/theme/common/colors/inputColors.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
 import { localize } from '../../../../../nls.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { ChatMode } from '../../common/chatModes.js';
@@ -115,8 +117,12 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 	private _desiredOpen = false;
 	private readonly _ownershipId = mainWindow.crypto.randomUUID();
 	private _ownershipClaim: { readonly timestamp: number; readonly id: string } | undefined;
-	private _actionWidgetRestoreHeight: number | undefined;
+	private readonly _actionWidgetWindow = this._register(new MutableDisposable<IAuxiliaryWindow>());
 	private _actionWidgetLayoutGeneration = 0;
+	private _actionWidgetVisibilityCount = 0;
+	private _actionWidgetOpenOperation: Promise<void> | undefined;
+	private _actionWidgetOwner: IAuxiliaryWindow | undefined;
+	private _actionWidgetWindowAnchorY = 0;
 	/** Immutable bounds of the window that invoked omni, captured before service resolution. */
 	private _invokingWindowBounds: IRectangle = this._windowBounds(mainWindow);
 
@@ -146,6 +152,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IHostService private readonly hostService: IHostService,
 	) {
 		super();
 
@@ -414,18 +421,15 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				enableImplicitContext: false,
 				defaultMode: ChatMode.Agent,
 				menus: { telemetrySource: 'chatInputWindow' },
-				sessionTypePickerDelegate: {
-					getActiveSessionProvider: () => AgentSessionProviders.AgentHostCopilot,
-					// Omni new sessions always use Copilot.
-					setActiveSessionProvider: () => { },
-				},
 				// Routing seam: intercept submission before local execution and
 				// route it to the best-matching existing session (or a new one),
 				// forwarding any explicit attachments on the input.
 				submitHandler: (query, mode, attachedContext, isVoiceModeInput) => this._routingController?.handleSubmit(query, mode, attachedContext, isVoiceModeInput) ?? Promise.resolve(false),
-				onDidChangeModelPickerVisibility: visible => this._layoutForModelPicker(auxiliaryWindow, visible),
+				onDidChangeModelPickerVisibility: visible => this._setModelPickerVisible(auxiliaryWindow, visible),
 				inputPickerPosition: AnchorPosition.BELOW,
-				inputPickerContainer: auxiliaryWindow.container,
+				inputPickerContainer: () => this._actionWidgetWindow.value?.container,
+				inputPickerAnchor: anchor => this._getModelPickerAnchor(anchor),
+				inputPickerOpenOnMouseUp: true,
 			},
 			{
 				inputEditorBackground: inputBackground,
@@ -535,9 +539,6 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			}
 		};
 		fitWindowToInput = () => {
-			if (this._actionWidgetRestoreHeight !== undefined) {
-				return;
-			}
 			const win = this._window?.window;
 			if (!win || win !== auxiliaryWindow.window) {
 				return;
@@ -1061,42 +1062,98 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		return undefined;
 	}
 
-	private async _layoutForModelPicker(auxiliaryWindow: IAuxiliaryWindow, visible: boolean): Promise<void> {
-		const win = auxiliaryWindow.window;
-		const generation = ++this._actionWidgetLayoutGeneration;
-		const hadFocus = win.document.hasFocus();
-		if (visible) {
-			if (this._actionWidgetRestoreHeight !== undefined) {
-				return;
+	private _setModelPickerVisible(auxiliaryWindow: IAuxiliaryWindow, visible: boolean): Promise<void> {
+		if (!visible) {
+			if (this._actionWidgetOwner !== auxiliaryWindow) {
+				return Promise.resolve();
 			}
-
-			this._actionWidgetRestoreHeight = win.outerHeight;
-			const desiredHeight = Math.max(win.outerHeight, CHAT_INPUT_WINDOW_MODEL_PICKER_HEIGHT);
-			const windowChromeHeight = win.outerHeight - win.innerHeight;
-			await auxiliaryWindow.setBounds({ x: win.screenX, y: win.screenY, width: win.outerWidth, height: desiredHeight });
-			await this._waitForWindowHeight(auxiliaryWindow, desiredHeight - windowChromeHeight);
-			if (generation === this._actionWidgetLayoutGeneration
-				&& this._window === auxiliaryWindow
-				&& this._actionWidgetRestoreHeight !== undefined
-				&& hadFocus
-				&& win.document.hasFocus()) {
-				win.focus();
+			this._actionWidgetVisibilityCount = Math.max(0, this._actionWidgetVisibilityCount - 1);
+			if (this._actionWidgetVisibilityCount === 0) {
+				this._actionWidgetLayoutGeneration++;
+				this._actionWidgetOwner = undefined;
+				this._actionWidgetWindow.clear();
 			}
-		} else if (this._actionWidgetRestoreHeight !== undefined) {
-			const restoreHeight = this._actionWidgetRestoreHeight;
-			this._actionWidgetRestoreHeight = undefined;
-			await auxiliaryWindow.setBounds({ x: win.screenX, y: win.screenY, width: win.outerWidth, height: restoreHeight });
-			win.dispatchEvent(new win.Event('resize'));
+			return Promise.resolve();
 		}
+
+		if (this._actionWidgetOwner !== auxiliaryWindow) {
+			this._actionWidgetLayoutGeneration++;
+			this._actionWidgetVisibilityCount = 0;
+			this._actionWidgetOwner = auxiliaryWindow;
+			this._actionWidgetWindow.clear();
+			this._actionWidgetOpenOperation = undefined;
+		}
+		this._actionWidgetVisibilityCount++;
+		if (this._actionWidgetWindow.value) {
+			return Promise.resolve();
+		}
+		if (this._actionWidgetOpenOperation) {
+			return this._actionWidgetOpenOperation;
+		}
+
+		const generation = ++this._actionWidgetLayoutGeneration;
+		const operation = this._openModelPickerWindow(auxiliaryWindow, generation);
+		this._actionWidgetOpenOperation = operation;
+		return operation.finally(() => {
+			if (this._actionWidgetOpenOperation === operation) {
+				this._actionWidgetOpenOperation = undefined;
+			}
+		});
 	}
 
-	private async _waitForWindowHeight(auxiliaryWindow: IAuxiliaryWindow, minimumInnerHeight: number): Promise<void> {
-		for (let attempt = 0; attempt < 30 && this._window === auxiliaryWindow; attempt++) {
-			if (auxiliaryWindow.window.innerHeight >= minimumInnerHeight) {
-				return;
-			}
-			await new Promise<void>(resolve => dom.scheduleAtNextAnimationFrame(auxiliaryWindow.window, () => resolve()));
+	private async _openModelPickerWindow(auxiliaryWindow: IAuxiliaryWindow, generation: number): Promise<void> {
+		const sourceWindow = auxiliaryWindow.window;
+		const screen = sourceWindow.screen;
+		const display = (await this.hostService.getCursorScreenPoint())?.display ?? {
+			x: sourceWindow.screenX,
+			y: sourceWindow.screenY,
+			width: screen.availWidth,
+			height: screen.availHeight,
+		};
+		const height = Math.min(CHAT_INPUT_WINDOW_MODEL_PICKER_HEIGHT, display.height);
+		const sourceBottom = sourceWindow.screenY + sourceWindow.outerHeight;
+		const displayBottom = display.y + display.height;
+		const displayRight = display.x + display.width;
+		const placeBelow = sourceBottom + height <= displayBottom;
+		const preferredY = placeBelow
+			? sourceBottom
+			: sourceWindow.screenY - height;
+		const y = Math.min(Math.max(display.y, preferredY), displayBottom - height);
+		const width = Math.min(sourceWindow.outerWidth, display.width);
+		const x = Math.min(Math.max(display.x, sourceWindow.screenX), displayRight - width);
+		const actionWidgetWindow = await this.auxiliaryWindowService.open({
+			bounds: { x, y, width, height },
+			alwaysOnTop: true,
+			frameless: true,
+			transparent: true,
+			notResizable: true,
+			disableFullscreen: true,
+			nativeTitlebar: false,
+			noBackgroundThrottling: true,
+			backgroundColor: '#00000000',
+		});
+		await actionWidgetWindow.whenStylesHaveLoaded;
+		if (generation !== this._actionWidgetLayoutGeneration || this._window !== auxiliaryWindow) {
+			actionWidgetWindow.dispose();
+			return;
 		}
+
+		actionWidgetWindow.window.document.body.style.setProperty('background-color', 'transparent', 'important');
+		actionWidgetWindow.window.document.body.style.setProperty('margin', '0', 'important');
+		actionWidgetWindow.container.style.backgroundColor = 'transparent';
+		actionWidgetWindow.container.style.overflow = 'hidden';
+		this._actionWidgetWindowAnchorY = placeBelow ? 0 : height;
+		this._actionWidgetWindow.value = actionWidgetWindow;
+	}
+
+	private _getModelPickerAnchor(anchor: HTMLElement): IAnchor {
+		const bounds = anchor.getBoundingClientRect();
+		return {
+			x: bounds.left,
+			y: this._actionWidgetWindowAnchorY,
+			width: bounds.width,
+			height: 1,
+		};
 	}
 
 	private _disposeWidget(): void {
@@ -1110,7 +1167,10 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		this._trail = undefined;
 		this._activePendingSessionResource = undefined;
 		this._voiceConfirmationPending.set(false, undefined);
-		this._actionWidgetRestoreHeight = undefined;
+		this._actionWidgetVisibilityCount = 0;
+		this._actionWidgetOwner = undefined;
+		this._actionWidgetOpenOperation = undefined;
+		this._actionWidgetWindow.clear();
 		this._actionWidgetLayoutGeneration++;
 		this._modelRef?.dispose();
 		this._modelRef = undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
@@ -101,6 +101,14 @@
 	padding-top: 0;
 }
 
+.chat-input-window .interactive-input-part.compact .chat-input-container {
+	align-items: center;
+}
+
+.chat-input-window .chat-input-toolbars {
+	margin-top: 0;
+}
+
 .chat-input-window .chat-input-toolbars .action-item > .codicon-add {
 	display: none;
 }
@@ -135,6 +143,16 @@
 
 .chat-input-window .chat-editor-container {
 	flex: 1 1 auto;
+}
+
+.chat-input-window .voice-transcript-overlay-scrollable {
+	inset: 0;
+}
+
+.chat-input-window .voice-transcript-overlay-scrollable:not(.has-transcript) .voice-transcript-overlay {
+	display: flex;
+	align-items: center;
+	padding-block: 0;
 }
 
 .chat-input-window .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item.chat-submit-button > .action-label {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
@@ -78,7 +78,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 	const store = new DisposableStore();
 	const getPushToTalkKeybindingLabel = () => (
 		keybindingService.lookupKeybinding('workbench.action.chat.voiceInputMode.holdToTalk')
-			?? keybindingService.lookupKeybinding('agentsVoice.pushToTalk')
+		?? keybindingService.lookupKeybinding('agentsVoice.pushToTalk')
 	)?.getLabel();
 
 	inputContainerEl.style.position = 'relative';

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
@@ -76,6 +76,10 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 	};
 
 	const store = new DisposableStore();
+	const getPushToTalkKeybindingLabel = () => (
+		keybindingService.lookupKeybinding('workbench.action.chat.voiceInputMode.holdToTalk')
+			?? keybindingService.lookupKeybinding('agentsVoice.pushToTalk')
+	)?.getLabel();
 
 	inputContainerEl.style.position = 'relative';
 
@@ -178,8 +182,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 				transcriptOverlayNode.classList.remove('has-transcript');
 				transcriptOverlay.replaceChildren();
 				const hint = dom.$('span.partial');
-				const kb = keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
-				const kbLabel = kb?.getLabel();
+				const kbLabel = getPushToTalkKeybindingLabel();
 				hint.textContent = kbLabel
 					? localize('voiceMode.bargeInHint', "Speak or use {0}", kbLabel)
 					: localize('voiceMode.bargeInHintNoKb', "Speak to barge in");
@@ -190,8 +193,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 				transcriptOverlayNode.classList.remove('has-transcript');
 				transcriptOverlay.replaceChildren();
 				const hint = dom.$('span.partial');
-				const kb = keybindingService.lookupKeybinding('agentsVoice.pushToTalk');
-				const kbLabel = kb?.getLabel();
+				const kbLabel = getPushToTalkKeybindingLabel();
 				hint.textContent = kbLabel
 					? localize('voiceMode.pttOrBargeInHint', "Press {0} to talk or barge in", kbLabel)
 					: localize('voiceMode.clickMicOrBargeInHint', "Click voice mode to talk or barge in");

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2123,6 +2123,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			onDidChangeModelPickerVisibility: this.viewOptions.onDidChangeModelPickerVisibility,
 			inputPickerPosition: this.viewOptions.inputPickerPosition,
 			inputPickerContainer: this.viewOptions.inputPickerContainer,
+			inputPickerAnchor: this.viewOptions.inputPickerAnchor,
+			inputPickerOpenOnMouseUp: this.viewOptions.inputPickerOpenOnMouseUp,
 			onDidChangeInputNotificationVisible: visible => this.setInputNotificationVisible(visible),
 		};
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -12,6 +12,7 @@ import { IActionViewItem } from '../../../../../../base/browser/ui/actionbar/act
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../../../base/browser/ui/aria/aria.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
+import { IAnchor } from '../../../../../../base/browser/ui/contextview/contextview.js';
 import { createInstantHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IAction } from '../../../../../../base/common/actions.js';
 import { equals as arraysEqual } from '../../../../../../base/common/arrays.js';
@@ -258,7 +259,9 @@ export interface IChatInputPartOptions {
 	onDidChangeInputOnboardingVisible?: (visible: boolean) => void;
 	onDidChangeModelPickerVisibility?: (visible: boolean) => void | Promise<void>;
 	inputPickerPosition?: AnchorPosition;
-	inputPickerContainer?: HTMLElement;
+	inputPickerContainer?: HTMLElement | (() => HTMLElement | undefined);
+	inputPickerAnchor?: (anchor: HTMLElement) => HTMLElement | IAnchor;
+	inputPickerOpenOnMouseUp?: boolean;
 	onDidChangeInputNotificationVisible?: (visible: boolean) => void;
 }
 
@@ -1212,6 +1215,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	private _createModelPickerDelegate(): IModelPickerDelegate {
+		const inputPickerContainer = this.options.inputPickerContainer;
 		return {
 			currentModel: this._currentLanguageModel,
 			setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
@@ -1224,7 +1228,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			modelConfiguration: this._modelConfigStore,
 			onDidChangeVisibility: this.options.onDidChangeModelPickerVisibility,
 			anchorPosition: this.options.inputPickerPosition,
-			actionWidgetContainer: this.options.inputPickerContainer,
+			get actionWidgetContainer() {
+				return typeof inputPickerContainer === 'function' ? inputPickerContainer() : inputPickerContainer;
+			},
+			getActionWidgetAnchor: this.options.inputPickerAnchor,
+			openOnMouseUp: this.options.inputPickerOpenOnMouseUp,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem.ts
@@ -8,6 +8,7 @@ import { IManagedHoverContent } from '../../../../../../../base/browser/ui/hover
 import { getBaseLayerHoverDelegate } from '../../../../../../../base/browser/ui/hover/hoverDelegate2.js';
 import { getDefaultHoverDelegate } from '../../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { BaseActionViewItem } from '../../../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { IAnchor } from '../../../../../../../base/browser/ui/contextview/contextview.js';
 import { IAction } from '../../../../../../../base/common/actions.js';
 import { IStringDictionary } from '../../../../../../../base/common/collections.js';
 import { Event } from '../../../../../../../base/common/event.js';
@@ -77,6 +78,8 @@ export interface IModelPickerDelegate {
 	onDidChangeVisibility?(visible: boolean): void | Promise<void>;
 	readonly anchorPosition?: AnchorPosition;
 	readonly actionWidgetContainer?: HTMLElement;
+	getActionWidgetAnchor?(anchor: HTMLElement): HTMLElement | IAnchor;
+	readonly openOnMouseUp?: boolean;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../../base/browser/dom.js';
+import { IAnchor } from '../../../../../../../base/browser/ui/contextview/contextview.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { AnchorPosition } from '../../../../../../../base/common/layout.js';
 import { formatTokenCount } from '../../../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../../nls.js';
@@ -54,9 +56,16 @@ export interface IModelPickerConfigurationHost {
 	readonly shouldShowCacheBreakHint: () => boolean;
 	readonly getCacheBreakLearnMoreLink: () => IActionListHeaderLink | undefined;
 	readonly dismissCacheBreakHint: () => void;
+	readonly onDidChangeVisibility?: (visible: boolean) => void | Promise<void>;
+	readonly getActionWidgetContainer?: () => HTMLElement | undefined;
+	readonly getActionWidgetAnchor?: (anchor: HTMLElement) => HTMLElement | IAnchor;
+	readonly getAnchorPosition?: () => AnchorPosition | undefined;
 }
 
 export class ModelPickerConfiguration {
+
+	private _showRequestId = 0;
+	private _activeButton: HTMLElement | undefined;
 
 	constructor(
 		private readonly _host: IModelPickerConfigurationHost,
@@ -114,6 +123,11 @@ export class ModelPickerConfiguration {
 		if (this._host.isDisabled() || !button || !this._host.getSelectedModel()) {
 			return;
 		}
+		if (button.getAttribute('aria-expanded') === 'true') {
+			this._showRequestId++;
+			this._actionWidgetService.hide(true);
+			return;
+		}
 
 		const items = this._buildItems();
 		if (!items.length) {
@@ -121,6 +135,7 @@ export class ModelPickerConfiguration {
 		}
 
 		const previouslyFocusedElement = dom.getActiveElement();
+		const showRequestId = ++this._showRequestId;
 		const delegate = {
 			onSelect: async (action: IActionWidgetDropdownAction) => {
 				this._actionWidgetService.focusItemById(action.id);
@@ -128,7 +143,15 @@ export class ModelPickerConfiguration {
 				this._actionWidgetService.updateItems(this._buildItems(), action.id);
 			},
 			onHide: () => {
+				this._showRequestId++;
+				if (this._activeButton === button) {
+					this._activeButton = undefined;
+				}
 				button.setAttribute('aria-expanded', 'false');
+				const visibilityChange = this._host.onDidChangeVisibility?.(false);
+				if (visibilityChange) {
+					void visibilityChange.catch(() => { });
+				}
 				if (dom.isHTMLElement(previouslyFocusedElement)) {
 					previouslyFocusedElement.focus();
 				}
@@ -136,34 +159,71 @@ export class ModelPickerConfiguration {
 		};
 
 		button.setAttribute('aria-expanded', 'true');
+		this._activeButton = button;
 		const showCacheBreakHint = this._host.shouldShowCacheBreakHint();
-		this._actionWidgetService.show(
-			'ChatModelConfigPicker',
-			false,
-			items,
-			delegate,
-			button,
-			undefined,
-			[],
-			{
-				isChecked: element => element.kind === ActionListItemKind.Action ? !!element.item?.checked : undefined,
-				getRole: element => element.kind === ActionListItemKind.Action ? 'menuitemradio' as const : 'separator' as const,
-				getWidgetRole: () => 'menu' as const,
-			},
-			withChatInputPickerMotion({
-				headerText: showCacheBreakHint ? localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost.") : undefined,
-				headerIcon: showCacheBreakHint ? Codicon.info : undefined,
-				headerLink: showCacheBreakHint ? this._host.getCacheBreakLearnMoreLink() : undefined,
-				headerDismiss: showCacheBreakHint ? this._host.dismissCacheBreakHint : undefined,
-				reserveSubmenuSpace: false,
-			}),
-		);
-
-		if (focusGroup) {
-			const groupItem = items.find(item => item.kind === ActionListItemKind.Action && item.item?.id?.startsWith(`${focusGroup}.`));
-			if (groupItem?.kind === ActionListItemKind.Action && groupItem.item) {
-				this._actionWidgetService.focusItemById(groupItem.item.id);
+		const showActionWidget = () => {
+			if (showRequestId !== this._showRequestId || button.getAttribute('aria-expanded') !== 'true') {
+				return;
 			}
+			this._actionWidgetService.show(
+				'ChatModelConfigPicker',
+				false,
+				items,
+				delegate,
+				this._host.getActionWidgetAnchor?.(button) ?? button,
+				this._host.getActionWidgetContainer?.(),
+				[],
+				{
+					isChecked: element => element.kind === ActionListItemKind.Action ? !!element.item?.checked : undefined,
+					getRole: element => element.kind === ActionListItemKind.Action ? 'menuitemradio' as const : 'separator' as const,
+					getWidgetRole: () => 'menu' as const,
+				},
+				withChatInputPickerMotion({
+					headerText: showCacheBreakHint ? localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost.") : undefined,
+					headerIcon: showCacheBreakHint ? Codicon.info : undefined,
+					headerLink: showCacheBreakHint ? this._host.getCacheBreakLearnMoreLink() : undefined,
+					headerDismiss: showCacheBreakHint ? this._host.dismissCacheBreakHint : undefined,
+					reserveSubmenuSpace: false,
+					anchorPosition: this._host.getAnchorPosition?.(),
+				}),
+			);
+
+			if (focusGroup) {
+				const groupItem = items.find(item => item.kind === ActionListItemKind.Action && item.item?.id?.startsWith(`${focusGroup}.`));
+				if (groupItem?.kind === ActionListItemKind.Action && groupItem.item) {
+					this._actionWidgetService.focusItemById(groupItem.item.id);
+				}
+			}
+		};
+		const visibilityChange = this._host.onDidChangeVisibility?.(true);
+		if (visibilityChange) {
+			void visibilityChange.then(showActionWidget, () => {
+				if (showRequestId !== this._showRequestId) {
+					return;
+				}
+				this._showRequestId++;
+				if (this._activeButton === button) {
+					this._activeButton = undefined;
+				}
+				button.setAttribute('aria-expanded', 'false');
+				const hideVisibilityChange = this._host.onDidChangeVisibility?.(false);
+				if (hideVisibilityChange) {
+					void hideVisibilityChange.catch(() => { });
+				}
+				if (dom.isHTMLElement(previouslyFocusedElement)) {
+					previouslyFocusedElement.focus();
+				}
+			});
+		} else {
+			showActionWidget();
+		}
+	}
+
+	dispose(): void {
+		this._showRequestId++;
+		if (this._activeButton) {
+			this._activeButton = undefined;
+			this._actionWidgetService.hide(true);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget.ts
@@ -153,6 +153,10 @@ export class ModelPickerWidget extends Disposable {
 			shouldShowCacheBreakHint: () => this.shouldShowCacheBreakHint(/* excludeAutoModel */ false),
 			getCacheBreakLearnMoreLink: () => this.getCacheBreakLearnMoreLink(),
 			dismissCacheBreakHint: () => this.dismissCacheBreakHint(),
+			onDidChangeVisibility: visible => this._delegate.onDidChangeVisibility?.(visible),
+			getActionWidgetContainer: () => this._delegate.actionWidgetContainer,
+			getActionWidgetAnchor: anchor => this._delegate.getActionWidgetAnchor?.(anchor) ?? anchor,
+			getAnchorPosition: () => this._delegate.anchorPosition,
 		});
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
 			if (this._activatingAfterTrust && this._delegate.getModels().length > 0) {
@@ -354,13 +358,30 @@ export class ModelPickerWidget extends Disposable {
 	 * Registers mouse-down and Enter/Space key handlers on a button element.
 	 */
 	private _registerButtonAction(element: HTMLElement, action: () => void): void {
-		this._register(dom.addDisposableGenericMouseDownListener(element, e => {
+		let expandedOnMouseDown = false;
+		if (this._delegate.openOnMouseUp) {
+			this._register(dom.addDisposableGenericMouseDownListener(element, e => {
+				// Focusing this window can dismiss a picker in another window before mouse-up.
+				if (e.button === 0) {
+					expandedOnMouseDown = element.getAttribute('aria-expanded') === 'true';
+				}
+			}));
+		}
+		const runAction = (e: MouseEvent) => {
 			if (e.button !== 0) {
 				return;
 			}
 			dom.EventHelper.stop(e, true);
+			if (this._delegate.openOnMouseUp && expandedOnMouseDown && element.getAttribute('aria-expanded') !== 'true') {
+				expandedOnMouseDown = false;
+				return;
+			}
+			expandedOnMouseDown = false;
 			action();
-		}));
+		};
+		this._register(this._delegate.openOnMouseUp
+			? dom.addDisposableGenericMouseUpListener(element, runAction)
+			: dom.addDisposableGenericMouseDownListener(element, runAction));
 		this._register(dom.addDisposableListener(element, dom.EventType.KEY_DOWN, (e) => {
 			const event = new StandardKeyboardEvent(e);
 			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
@@ -582,7 +603,7 @@ export class ModelPickerWidget extends Disposable {
 				false,
 				items,
 				delegate,
-				anchorElement,
+				this._delegate.getActionWidgetAnchor?.(anchorElement) ?? anchorElement,
 				this._delegate.actionWidgetContainer,
 				[],
 				getModelPickerAccessibilityProvider(),
@@ -621,6 +642,7 @@ export class ModelPickerWidget extends Disposable {
 	override dispose(): void {
 		this._showRequestId++;
 		this._activeShowDisposables.clear();
+		this._configuration.dispose();
 		if (this._nameButton?.getAttribute('aria-expanded') === 'true') {
 			this._actionWidgetService.hide(true);
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerConfiguration.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerConfiguration.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { IAnchor } from '../../../../../../../../base/browser/ui/contextview/contextview.js';
+import { AnchorPosition } from '../../../../../../../../base/common/layout.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../../base/test/common/utils.js';
 import { ExtensionIdentifier } from '../../../../../../../../platform/extensions/common/extensions.js';
 import { ActionListItemKind, IActionListItem, IActionListOptions } from '../../../../../../../../platform/actionWidget/browser/actionList.js';
@@ -169,6 +171,73 @@ suite('ModelPickerConfiguration', () => {
 				{ className: 'chat-model-picker-config-option', label: '32K', checked: false, ariaDescription: 'Default' },
 				{ className: 'chat-model-picker-config-option', label: '64K', checked: true, ariaDescription: undefined },
 			],
+		});
+	});
+
+	test('uses the host action widget placement and visibility lifecycle', () => {
+		const model = createModel();
+		const container = document.createElement('div');
+		const button = document.createElement('a');
+		const anchor: IAnchor = { x: 10, y: 20, width: 30, height: 1 };
+		const visibility: boolean[] = [];
+		let shownPlacement: { anchor: unknown; container: unknown; anchorPosition: AnchorPosition | undefined } | undefined;
+		let onHide: (() => void) | undefined;
+		const actionWidgetService = {
+			show: (
+				_id: string,
+				_supportsPreview: boolean,
+				_items: IActionListItem<IActionWidgetDropdownAction>[],
+				delegate: { onHide: () => void },
+				shownAnchor: unknown,
+				shownContainer: unknown,
+				_actions: unknown,
+				_accessibilityProvider: unknown,
+				options: IActionListOptions,
+			) => {
+				onHide = delegate.onHide;
+				shownPlacement = {
+					anchor: shownAnchor,
+					container: shownContainer,
+					anchorPosition: options.anchorPosition,
+				};
+			},
+			focusItemById: () => { },
+			updateItems: () => { },
+			hide: () => onHide?.(),
+		} as unknown as IActionWidgetService;
+		const access: IModelConfigurationAccess = {
+			getModelConfiguration: () => ({}),
+			setModelConfiguration: async () => { },
+			getModelConfigurationActions: () => [],
+		};
+		const controller = new ModelPickerConfiguration({
+			getSelectedModel: () => model,
+			getConfigurationAccess: () => access,
+			isDisabled: () => false,
+			shouldShowCacheBreakHint: () => false,
+			getCacheBreakLearnMoreLink: () => undefined,
+			dismissCacheBreakHint: () => { },
+			onDidChangeVisibility: visible => { visibility.push(visible); },
+			getActionWidgetContainer: () => container,
+			getActionWidgetAnchor: () => anchor,
+			getAnchorPosition: () => AnchorPosition.BELOW,
+		}, actionWidgetService, { publicLog2: () => { } } as unknown as ITelemetryService);
+
+		controller.show(button);
+		controller.show(button);
+		controller.show(button);
+		controller.dispose();
+
+		assert.deepStrictEqual({
+			shownPlacement,
+			visibility,
+		}, {
+			shownPlacement: {
+				anchor,
+				container,
+				anchorPosition: AnchorPosition.BELOW,
+			},
+			visibility: [true, false, true, false],
 		});
 	});
 


### PR DESCRIPTION
Removes the redundant fixed Agent Host session-type delegate from Omni's scratch ChatWidget. That delegate marked the input as locked to a coding agent without targeted models, causing the shared Chat menu to hide the model picker. New Omni sessions remain fixed to Copilot through the routing host. Based on #326698.