### PR TITLE
agentHost: run the agent host on the remote server

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -721,6 +721,9 @@ export interface IAgentHostNetworkFetchResult {
 export interface IConnectionTrackerService {
 	readonly onDidChangeConnectionCount: Event<number>;
 
+	/** Resolves after the WebSocket listener configured at process startup is bound. */
+	waitForConfiguredWebSocketServer(): Promise<void>;
+
 	/**
 	 * Request the agent host to start a WebSocket server on a local
 	 * pipe/socket. Returns the socket path.

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DeferredPromise } from '../../../base/common/async.js';
 import { ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { Server as ChildProcessServer } from '../../../base/parts/ipc/node/ipc.cp.js';
 import { Server as UtilityProcessServer } from '../../../base/parts/ipc/node/ipc.mp.js';
@@ -442,8 +443,10 @@ async function startAgentHost(): Promise<void> {
 	// management IPC channel.
 	const connectionCountEmitter = disposables.add(new Emitter<number>());
 	let dynamicSocketInfo: IAgentHostSocketInfo | undefined;
+	const configuredWebSocketServer = new DeferredPromise<void>();
 	const connectionTrackerService: IConnectionTrackerService = {
 		onDidChangeConnectionCount: connectionCountEmitter.event,
+		waitForConfiguredWebSocketServer: () => configuredWebSocketServer.p,
 		async startWebSocketServer(): Promise<IAgentHostSocketInfo> {
 			if (dynamicSocketInfo) {
 				return dynamicSocketInfo;
@@ -535,7 +538,7 @@ async function startAgentHost(): Promise<void> {
 
 	// The configured bridge listener remains separate: tunnel forwarding pipes
 	// raw WebSocket streams and cannot carry the local endpoint's bearer token.
-	startWebSocketServer(
+	const configuredWebSocketServerStart = startWebSocketServer(
 		agentService,
 		clientFileSystemProvider,
 		instantiationService,
@@ -546,7 +549,9 @@ async function startAgentHost(): Promise<void> {
 		hostLaunchKind,
 		connectionTelemetryTracker,
 		count => connectionCountEmitter.fire(count),
-	).catch(err => {
+	);
+	configuredWebSocketServer.settleWith(configuredWebSocketServerStart);
+	void configuredWebSocketServerStart.catch(err => {
 		logService.error('Failed to start WebSocket server', err);
 	});
 

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from 'fs';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
@@ -158,8 +159,9 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			}
 		}
 
-		const client = new Client(FileAccess.asFileUri('bootstrap-fork').fsPath, opts);
+		await this._removeStaleSocket();
 
+		const client = new Client(FileAccess.asFileUri('bootstrap-fork').fsPath, opts);
 		const store = new DisposableStore();
 		store.add(client);
 
@@ -168,6 +170,30 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			store,
 			onDidProcessExit: client.onDidProcessExit
 		};
+	}
+
+	/**
+	 * Unix domain sockets outlive the process that bound them, so an agent host
+	 * that crashed leaves its socket file behind and the replacement's `listen`
+	 * fails with `EADDRINUSE` — which would burn the whole crash-restart budget
+	 * without ever recovering. Windows named pipes are refcounted by the OS and
+	 * disappear with the process, so they need no cleanup.
+	 */
+	private async _removeStaleSocket(): Promise<void> {
+		const socketPath = this._wsConfig?.socketPath;
+		if (!socketPath || process.platform === 'win32') {
+			return;
+		}
+
+		try {
+			await fs.promises.unlink(socketPath);
+		} catch (error) {
+			// Nothing to clean up in the common case; a genuinely undeletable
+			// path surfaces as a bind failure from the child instead.
+			if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+				this._logService.warn(`AgentHostStarter could not remove stale socket at ${socketPath}`, error);
+			}
+		}
 	}
 
 	private async _resolveShellEnv(): Promise<typeof process.env> {

--- a/src/vs/server/node/agentHostChannel.ts
+++ b/src/vs/server/node/agentHostChannel.ts
@@ -385,14 +385,17 @@ export class AgentHostChannel<TContext> extends Disposable implements IServerCha
 			return endpoint;
 		}
 
+		// Only the in-flight resolution is shared, so concurrent renderer connects
+		// collapse into one call. It is dropped once settled: in the lazy server
+		// path resolution *is* `ensureStarted()`, so caching a success would let a
+		// later reconnect dial a dead socket instead of restarting the host.
 		const endpointPromise = this._endpointPromise ??= Promise.resolve().then(() => endpoint());
 		try {
 			return await endpointPromise;
-		} catch (error) {
+		} finally {
 			if (this._endpointPromise === endpointPromise) {
 				this._endpointPromise = undefined;
 			}
-			throw error;
 		}
 	}
 

--- a/src/vs/server/node/agentHostChannel.ts
+++ b/src/vs/server/node/agentHostChannel.ts
@@ -34,6 +34,8 @@ export interface IAgentHostUpstreamEndpoint {
 	readonly connectionToken?: string;
 }
 
+export type AgentHostUpstreamEndpointResolver = () => Promise<IAgentHostUpstreamEndpoint>;
+
 /**
  * Lazy-loaded `ws` module. Imported once on first connection so renderers
  * that never touch the agent host don't pay the cost.
@@ -95,6 +97,86 @@ export class UnavailableAgentHostChannel<TContext> implements IServerChannel<TCo
  */
 const defaultUpstreamFactory = (logService: ILogService): UpstreamConnectionFactory =>
 	(endpoint) => new WebSocketUpstreamConnection(endpoint, logService);
+
+class LazyUpstreamConnection extends Disposable implements IUpstreamConnection {
+	private readonly _onFrame = this._register(new Emitter<string>());
+	readonly onFrame: Event<string> = this._onFrame.event;
+
+	private readonly _onClose = this._register(new Emitter<void>());
+	readonly onClose: Event<void> = this._onClose.event;
+
+	private _connection: IUpstreamConnection | undefined;
+	private _connectPromise: Promise<void> | undefined;
+	private _closeFired = false;
+
+	constructor(
+		private readonly _resolveEndpoint: AgentHostUpstreamEndpointResolver,
+		private readonly _upstreamFactory: UpstreamConnectionFactory,
+		private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	async connect(): Promise<void> {
+		if (this._store.isDisposed) {
+			throw new Error('UpstreamConnection is disposed');
+		}
+
+		const connectPromise = this._connectPromise ??= this._connect();
+		try {
+			await connectPromise;
+		} catch (error) {
+			if (this._connectPromise === connectPromise) {
+				this._connectPromise = undefined;
+			}
+			throw error;
+		}
+	}
+
+	send(frame: string): void {
+		const connection = this._connection;
+		if (!connection) {
+			this._logService.warn('[AgentHostChannel] Drop send: upstream not open');
+			this._fireClose();
+			return;
+		}
+		connection.send(frame);
+	}
+
+	private async _connect(): Promise<void> {
+		const endpoint = await this._resolveEndpoint();
+		if (this._store.isDisposed) {
+			throw new Error('UpstreamConnection is disposed');
+		}
+
+		const connection = this._upstreamFactory(endpoint);
+		this._connection = connection;
+		this._register(connection);
+		this._register(connection.onFrame(frame => this._onFrame.fire(frame)));
+		this._register(connection.onClose(() => this._fireClose()));
+
+		try {
+			await connection.connect();
+		} catch (error) {
+			this._connection = undefined;
+			connection.dispose();
+			throw error;
+		}
+	}
+
+	override dispose(): void {
+		this._fireClose();
+		super.dispose();
+	}
+
+	private _fireClose(): void {
+		if (this._closeFired) {
+			return;
+		}
+		this._closeFired = true;
+		this._onClose.fire();
+	}
+}
 
 class WebSocketUpstreamConnection extends Disposable implements IUpstreamConnection {
 	private readonly _onFrame = this._register(new Emitter<string>());
@@ -226,10 +308,11 @@ export class AgentHostChannel<TContext> extends Disposable implements IServerCha
 
 	private readonly _perCtx = new Map<TContext, IUpstreamConnection>();
 	private readonly _upstreamFactory: UpstreamConnectionFactory;
+	private _endpointPromise: Promise<IAgentHostUpstreamEndpoint> | undefined;
 
 	constructor(
 		ipcServer: IPCServer<TContext>,
-		private readonly _endpoint: IAgentHostUpstreamEndpoint,
+		private readonly _endpoint: IAgentHostUpstreamEndpoint | AgentHostUpstreamEndpointResolver,
 		private readonly _logService: ILogService,
 		upstreamFactory?: UpstreamConnectionFactory,
 	) {
@@ -278,7 +361,9 @@ export class AgentHostChannel<TContext> extends Disposable implements IServerCha
 	private _getOrCreate(ctx: TContext): IUpstreamConnection {
 		let conn = this._perCtx.get(ctx);
 		if (!conn) {
-			conn = this._upstreamFactory(this._endpoint);
+			conn = typeof this._endpoint === 'function'
+				? new LazyUpstreamConnection(() => this._resolveEndpoint(), this._upstreamFactory, this._logService)
+				: this._upstreamFactory(this._endpoint);
 			this._perCtx.set(ctx, conn);
 			// If the upstream closes on its own (e.g. agent host restart or
 			// connection drop), evict it from the cache so the next
@@ -292,6 +377,23 @@ export class AgentHostChannel<TContext> extends Disposable implements IServerCha
 			});
 		}
 		return conn;
+	}
+
+	private async _resolveEndpoint(): Promise<IAgentHostUpstreamEndpoint> {
+		const endpoint = this._endpoint;
+		if (typeof endpoint !== 'function') {
+			return endpoint;
+		}
+
+		const endpointPromise = this._endpointPromise ??= Promise.resolve().then(() => endpoint());
+		try {
+			return await endpointPromise;
+		} catch (error) {
+			if (this._endpointPromise === endpointPromise) {
+				this._endpointPromise = undefined;
+			}
+			throw error;
+		}
 	}
 
 	private _disposeCtx(ctx: TContext): void {

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -93,87 +93,103 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 		return this._startPromise;
 	}
 
+	/**
+	 * Retries startup in-place until it succeeds or the crash-retry budget is
+	 * exhausted, so the caller's `ensureStarted()` stays pending across
+	 * automatic retries instead of rejecting while a retry is still in flight.
+	 * A rejection here therefore means "no agent host, and we stopped trying".
+	 */
 	private async _start(): Promise<void> {
-		try {
-			const connection = await this._starter.start();
-
-			if (this._store.isDisposed) {
-				connection.store.dispose();
-				return;
-			}
-
-			// Handle unexpected exit
-			connection.store.add(connection.onDidProcessExit(e => {
-				if (!this._store.isDisposed) {
-					this._hasActiveSessions = false;
-					this._connectionCount = 0;
-					this._lifetimeToken.clear();
-
-					const willRestart = this._restartCount <= Constants.MaxRestarts;
-					reportAgentHostProcessError(this._telemetryService, {
-						hostLaunchKind: AgentHostLaunchKind.VSCodeCLI,
-						kind: 'unexpectedExit',
-						code: e.code,
-						restartCount: this._restartCount,
-						willRestart,
-					});
-					if (willRestart) {
-						this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
-						this._restartCount++;
-						connection.store.dispose();
-						this._startPromise = undefined;
-						void this.ensureStarted().catch(() => undefined);
-					} else {
-						this._logService.error(`ServerAgentHostManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
-						// A future explicit request gets a fresh crash-retry budget.
-						this._restartCount = 0;
-						this._startPromise = undefined;
-					}
-				}
-			}));
-
-			this._trackActiveSessions(connection);
+		while (true) {
 			try {
-				await this._trackClientConnections(connection);
+				await this._startOnce();
+				return;
 			} catch (error) {
-				connection.store.dispose();
-				throw error;
-			}
-			if (this._store.isDisposed || connection.store.isDisposed) {
-				connection.store.dispose();
-				return;
-			}
+				if (this._store.isDisposed) {
+					return;
+				}
 
-			this._logService.info('ServerAgentHostManager: agent host started');
+				const willRestart = this._restartCount <= Constants.MaxRestarts;
+				reportAgentHostProcessError(this._telemetryService, {
+					hostLaunchKind: AgentHostLaunchKind.VSCodeCLI,
+					kind: 'startFailed',
+					restartCount: this._restartCount,
+					willRestart,
+				}, error);
+				if (!willRestart) {
+					this._logService.error(`ServerAgentHostManager: agent host failed to start, giving up after ${Constants.MaxRestarts} restarts`, error);
+					// A future explicit request gets a fresh crash-retry budget.
+					this._restartCount = 0;
+					throw error;
+				}
 
-			// Connect logger channel so agent host logs appear in the output channel
-			connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
-
-			this._register(toDisposable(() => connection.store.dispose()));
-		} catch (error) {
-			if (this._store.isDisposed) {
-				return;
-			}
-
-			const willRestart = this._restartCount <= Constants.MaxRestarts;
-			reportAgentHostProcessError(this._telemetryService, {
-				hostLaunchKind: AgentHostLaunchKind.VSCodeCLI,
-				kind: 'startFailed',
-				restartCount: this._restartCount,
-				willRestart,
-			}, error);
-			if (willRestart) {
 				this._logService.error('ServerAgentHostManager: agent host failed to start', error);
 				this._restartCount++;
-				this._startPromise = undefined;
-				void this.ensureStarted().catch(() => undefined);
-			} else {
-				this._logService.error(`ServerAgentHostManager: agent host failed to start, giving up after ${Constants.MaxRestarts} restarts`, error);
-				// A future explicit request gets a fresh crash-retry budget.
-				this._restartCount = 0;
-				this._startPromise = undefined;
 			}
+		}
+	}
+
+	private async _startOnce(): Promise<void> {
+		const connection = await this._starter.start();
+
+		if (this._store.isDisposed) {
+			connection.store.dispose();
+			return;
+		}
+
+		this._trackActiveSessions(connection);
+		try {
+			await this._trackClientConnections(connection);
+		} catch (error) {
+			connection.store.dispose();
 			throw error;
+		}
+		if (this._store.isDisposed || connection.store.isDisposed) {
+			connection.store.dispose();
+			return;
+		}
+
+		this._logService.info('ServerAgentHostManager: agent host started');
+
+		// Connect logger channel so agent host logs appear in the output channel
+		connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
+
+		// Only watch for crashes once startup has fully succeeded. An exit during
+		// startup already surfaces as a rejection of the readiness request above,
+		// so the retry loop owns that case exclusively and the two paths can never
+		// both restart the same failure.
+		connection.store.add(connection.onDidProcessExit(e => this._handleUnexpectedExit(connection, e)));
+
+		this._register(toDisposable(() => connection.store.dispose()));
+	}
+
+	private _handleUnexpectedExit(connection: IAgentHostConnection, e: { code: number; signal: string }): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		this._hasActiveSessions = false;
+		this._connectionCount = 0;
+		this._lifetimeToken.clear();
+
+		const willRestart = this._restartCount <= Constants.MaxRestarts;
+		reportAgentHostProcessError(this._telemetryService, {
+			hostLaunchKind: AgentHostLaunchKind.VSCodeCLI,
+			kind: 'unexpectedExit',
+			code: e.code,
+			restartCount: this._restartCount,
+			willRestart,
+		});
+		connection.store.dispose();
+		this._startPromise = undefined;
+		if (willRestart) {
+			this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
+			this._restartCount++;
+			void this.ensureStarted().catch(() => undefined);
+		} else {
+			this._logService.error(`ServerAgentHostManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
+			// A future explicit request gets a fresh crash-retry budget.
+			this._restartCount = 0;
 		}
 	}
 

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -19,7 +19,7 @@ import { IServerLifetimeService } from './serverLifetimeService.js';
 export const IServerAgentHostManager = createDecorator<IServerAgentHostManager>('serverAgentHostManager');
 
 /**
- * Server-specific agent host manager. Eagerly starts the agent host process,
+ * Server-specific agent host manager. Starts the agent host process,
  * handles crash recovery, and tracks active agent sessions plus incoming
  * WebSocket clients to the spawned standalone agent host via
  * {@link IServerLifetimeService}.
@@ -29,6 +29,13 @@ export const IServerAgentHostManager = createDecorator<IServerAgentHostManager>(
  */
 export interface IServerAgentHostManager {
 	readonly _serviceBrand: undefined;
+
+	/** Starts the agent host if necessary and resolves after its IPC connection is established. */
+	ensureStarted(): Promise<void>;
+}
+
+export interface IServerAgentHostManagerOptions {
+	readonly startMode?: 'eager' | 'lazy';
 }
 
 /**
@@ -38,6 +45,7 @@ export interface IServerAgentHostManager {
  */
 interface IConnectionTrackerService {
 	readonly onDidChangeConnectionCount: Event<number>;
+	waitForConfiguredWebSocketServer(): Promise<void>;
 }
 
 enum Constants {
@@ -48,6 +56,7 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 	declare readonly _serviceBrand: undefined;
 
 	private _restartCount = 0;
+	private _startPromise: Promise<void> | undefined;
 
 	/** Lifetime token held while sessions are active or standalone WebSocket clients are connected. */
 	private readonly _lifetimeToken = this._register(new MutableDisposable());
@@ -57,6 +66,7 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 
 	constructor(
 		private readonly _starter: IAgentHostStarter,
+		options: IServerAgentHostManagerOptions = {},
 		@ILogService private readonly _logService: ILogService,
 		@ILoggerService private readonly _loggerService: ILoggerService,
 		@IServerLifetimeService private readonly _serverLifetimeService: IServerLifetimeService,
@@ -64,7 +74,23 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 	) {
 		super();
 		this._register(this._starter);
-		this._start();
+		if (options.startMode !== 'lazy') {
+			void this.ensureStarted().catch(() => undefined);
+		}
+	}
+
+	ensureStarted(): Promise<void> {
+		if (!this._startPromise) {
+			const startPromise = this._start();
+			this._startPromise = startPromise;
+			void startPromise.catch(() => {
+				if (this._startPromise === startPromise) {
+					this._startPromise = undefined;
+				}
+			});
+		}
+
+		return this._startPromise;
 	}
 
 	private async _start(): Promise<void> {
@@ -75,14 +101,6 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 				connection.store.dispose();
 				return;
 			}
-
-			this._logService.info('ServerAgentHostManager: agent host started');
-
-			// Connect logger channel so agent host logs appear in the output channel
-			connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
-
-			this._trackActiveSessions(connection);
-			this._trackClientConnections(connection);
 
 			// Handle unexpected exit
 			connection.store.add(connection.onDidProcessExit(e => {
@@ -103,12 +121,33 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 						this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
 						this._restartCount++;
 						connection.store.dispose();
-						this._start();
+						this._startPromise = undefined;
+						void this.ensureStarted().catch(() => undefined);
 					} else {
 						this._logService.error(`ServerAgentHostManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
+						// A future explicit request gets a fresh crash-retry budget.
+						this._restartCount = 0;
+						this._startPromise = undefined;
 					}
 				}
 			}));
+
+			this._trackActiveSessions(connection);
+			try {
+				await this._trackClientConnections(connection);
+			} catch (error) {
+				connection.store.dispose();
+				throw error;
+			}
+			if (this._store.isDisposed || connection.store.isDisposed) {
+				connection.store.dispose();
+				return;
+			}
+
+			this._logService.info('ServerAgentHostManager: agent host started');
+
+			// Connect logger channel so agent host logs appear in the output channel
+			connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
 
 			this._register(toDisposable(() => connection.store.dispose()));
 		} catch (error) {
@@ -126,10 +165,15 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 			if (willRestart) {
 				this._logService.error('ServerAgentHostManager: agent host failed to start', error);
 				this._restartCount++;
-				this._start();
+				this._startPromise = undefined;
+				void this.ensureStarted().catch(() => undefined);
 			} else {
 				this._logService.error(`ServerAgentHostManager: agent host failed to start, giving up after ${Constants.MaxRestarts} restarts`, error);
+				// A future explicit request gets a fresh crash-retry budget.
+				this._restartCount = 0;
+				this._startPromise = undefined;
 			}
+			throw error;
 		}
 	}
 
@@ -143,12 +187,13 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 		}));
 	}
 
-	private _trackClientConnections(connection: IAgentHostConnection): void {
+	private async _trackClientConnections(connection: IAgentHostConnection): Promise<void> {
 		const connectionTracker = ProxyChannel.toService<IConnectionTrackerService>(connection.client.getChannel(AgentHostIpcChannels.ConnectionTracker));
 		connection.store.add(connectionTracker.onDidChangeConnectionCount(count => {
 			this._connectionCount = count;
 			this._updateLifetimeToken();
 		}));
+		await connectionTracker.waitForConfiguredWebSocketServer();
 	}
 
 	private _updateLifetimeToken(): void {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -3,16 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from 'fs';
 import { hostname, release } from 'os';
 import { Emitter, Event } from '../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../base/common/lifecycle.js';
 import { Schemas } from '../../base/common/network.js';
 import * as path from '../../base/common/path.js';
 import { IURITransformer } from '../../base/common/uriIpc.js';
+import { generateUuid } from '../../base/common/uuid.js';
 import { getMachineId, getSqmMachineId, getDevDeviceId } from '../../base/node/id.js';
 import { Promises } from '../../base/node/pfs.js';
 import { ClientConnectionEvent, IMessagePassingProtocol, IPCServer, StaticRouter } from '../../base/parts/ipc/common/ipc.js';
 import { ProtocolConstants } from '../../base/parts/ipc/common/ipc.net.js';
+import { createRandomIPCHandle } from '../../base/parts/ipc/node/ipc.net.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { ConfigurationService } from '../../platform/configuration/common/configurationService.js';
 import { ExtensionHostDebugBroadcastChannel } from '../../platform/debug/common/extensionHostDebugIpc.js';
@@ -243,18 +246,22 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 
 	// ---- Agent host wiring -------------------------------------------------
 	//
-	// Two independent concerns:
+	// Three independent configurations:
 	//
 	// 1. SPAWN: when `--agent-host-port` / `--agent-host-path` is set, this
-	//    server spawns and owns an agent host child process.
-	// 2. BRIDGE: register the `agentHostProxy` IPC channel so renderers can
+	//    server spawns and owns an agent host child process, then bridges
+	//    renderers to its configured endpoint.
+	// 2. BRIDGE: when `--agent-host-bridge-*` is set without spawn flags,
+	//    register the `agentHostProxy` IPC channel so renderers can
 	//    reach the agent host over the remote-agent connection. The upstream
-	//    is either the agent host we just spawned, or one specified via
-	//    `--agent-host-bridge-port` / `--agent-host-bridge-path` (e.g. when
-	//    a CLI sidecar manages the agent host lifecycle).
+	//    is one specified via `--agent-host-bridge-port` /
+	//    `--agent-host-bridge-path` (e.g. when a CLI sidecar manages the
+	//    agent host lifecycle).
+	// 3. DEFAULT: without either set of flags, lazily start a local agent host
+	//    on a fresh socket when the first renderer connects.
 	//
-	// The two concerns are deliberately separable so that scenarios with an
-	// externally-managed agent host don't accidentally fork a duplicate.
+	// The explicit configurations are deliberately separable so that scenarios
+	// with an externally-managed agent host don't accidentally fork a duplicate.
 
 	const spawnPort = args['agent-host-port'];
 	const spawnPath = args['agent-host-path'];
@@ -267,44 +274,97 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 			host: args.host || 'localhost',
 			connectionToken: connectionToken.type === ServerConnectionTokenType.Mandatory ? connectionToken.value : undefined,
 		});
-		disposables.add(instantiationService.createInstance(ServerAgentHostManager, agentHostStarter));
-	}
+		disposables.add(instantiationService.createInstance(ServerAgentHostManager, agentHostStarter, {}));
 
-	// The bridge upstream defaults to the agent host this server just
-	// spawned, but ONLY when that endpoint is dialable at configuration
-	// time — i.e. an explicit non-zero port or a socket path. When
-	// `--agent-host-port=0` is used the OS picks a port at runtime that
-	// this server has no way of learning, so we refuse to register a
-	// bridge against a placeholder `0`; in that case the caller (the CLI
-	// `code tunnel` flow) is expected to capture the bound port from the
-	// AH's readiness line and pass it back as `--agent-host-bridge-port`
-	// on the renderer-serving servers. Explicit `--agent-host-bridge-*`
-	// always wins over the spawn fallback.
-	const spawnPortNumber = spawnPort ? parseInt(spawnPort, 10) : NaN;
-	const hasUsableSpawnPort = Number.isFinite(spawnPortNumber) && spawnPortNumber > 0;
-	const bridgePort = args['agent-host-bridge-port'] ?? (hasUsableSpawnPort ? spawnPort : undefined);
-	const bridgePath = args['agent-host-bridge-path'] ?? spawnPath;
-	const bridgeHost = args['agent-host-bridge-host'] ?? args.host ?? 'localhost';
-	const bridgeToken = args['agent-host-bridge-connection-token']
-		?? ((bridgePort || bridgePath) && spawnAgentHost && connectionToken.type === ServerConnectionTokenType.Mandatory
-			? connectionToken.value
-			: undefined);
-	if (bridgePort || bridgePath) {
-		const agentHostBridge = disposables.add(new AgentHostChannel<RemoteAgentConnectionContext>(
-			socketServer,
-			{
-				host: bridgeHost,
-				port: bridgePort,
-				socketPath: bridgePath,
-				connectionToken: bridgeToken,
-			},
-			logService,
-		));
-		socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, agentHostBridge);
-		logService.info(`[AgentHostChannel] Registered IPC channel '${AgentHostIpcChannels.RemoteProxy}' (upstream: ${bridgePath ?? `${bridgeHost}:${bridgePort}`})`);
+		// The bridge upstream defaults to the agent host this server just
+		// spawned, but ONLY when that endpoint is dialable at configuration
+		// time — i.e. an explicit non-zero port or a socket path. When
+		// `--agent-host-port=0` is used the OS picks a port at runtime that
+		// this server has no way of learning, so we refuse to register a
+		// bridge against a placeholder `0`; in that case the caller (the CLI
+		// `code tunnel` flow) is expected to capture the bound port from the
+		// AH's readiness line and pass it back as `--agent-host-bridge-port`
+		// on the renderer-serving servers. Explicit `--agent-host-bridge-*`
+		// always wins over the spawn fallback.
+		const spawnPortNumber = spawnPort ? parseInt(spawnPort, 10) : NaN;
+		const hasUsableSpawnPort = Number.isFinite(spawnPortNumber) && spawnPortNumber > 0;
+		const bridgePort = args['agent-host-bridge-port'] ?? (hasUsableSpawnPort ? spawnPort : undefined);
+		const bridgePath = args['agent-host-bridge-path'] ?? spawnPath;
+		const bridgeHost = args['agent-host-bridge-host'] ?? args.host ?? 'localhost';
+		const bridgeToken = args['agent-host-bridge-connection-token']
+			?? ((bridgePort || bridgePath) && connectionToken.type === ServerConnectionTokenType.Mandatory
+				? connectionToken.value
+				: undefined);
+		if (bridgePort || bridgePath) {
+			const agentHostBridge = disposables.add(new AgentHostChannel<RemoteAgentConnectionContext>(
+				socketServer,
+				{
+					host: bridgeHost,
+					port: bridgePort,
+					socketPath: bridgePath,
+					connectionToken: bridgeToken,
+				},
+				logService,
+			));
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, agentHostBridge);
+			logService.info(`[AgentHostChannel] Registered IPC channel '${AgentHostIpcChannels.RemoteProxy}' (upstream: ${bridgePath ?? `${bridgeHost}:${bridgePort}`})`);
+		} else {
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, new UnavailableAgentHostChannel<RemoteAgentConnectionContext>());
+			logService.info(`[AgentHostChannel] Registered unavailable IPC channel '${AgentHostIpcChannels.RemoteProxy}': no --agent-host-bridge-port / --agent-host-bridge-path set.`);
+		}
+	} else if (args['agent-host-bridge-port'] || args['agent-host-bridge-path'] || args['agent-host-bridge-host'] || args['agent-host-bridge-connection-token']) {
+		const bridgePort = args['agent-host-bridge-port'];
+		const bridgePath = args['agent-host-bridge-path'];
+		const bridgeHost = args['agent-host-bridge-host'] ?? args.host ?? 'localhost';
+		const bridgeToken = args['agent-host-bridge-connection-token'];
+		if (bridgePort || bridgePath) {
+			const agentHostBridge = disposables.add(new AgentHostChannel<RemoteAgentConnectionContext>(
+				socketServer,
+				{
+					host: bridgeHost,
+					port: bridgePort,
+					socketPath: bridgePath,
+					connectionToken: bridgeToken,
+				},
+				logService,
+			));
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, agentHostBridge);
+			logService.info(`[AgentHostChannel] Registered IPC channel '${AgentHostIpcChannels.RemoteProxy}' (upstream: ${bridgePath ?? `${bridgeHost}:${bridgePort}`})`);
+		} else {
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, new UnavailableAgentHostChannel<RemoteAgentConnectionContext>());
+			logService.info(`[AgentHostChannel] Registered unavailable IPC channel '${AgentHostIpcChannels.RemoteProxy}': no --agent-host-bridge-port / --agent-host-bridge-path set.`);
+		}
 	} else {
-		socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, new UnavailableAgentHostChannel<RemoteAgentConnectionContext>());
-		logService.info(`[AgentHostChannel] Registered unavailable IPC channel '${AgentHostIpcChannels.RemoteProxy}': no --agent-host-bridge-port / --agent-host-bridge-path set.`);
+		try {
+			const socketPath = createRandomIPCHandle();
+			const connectionToken = generateUuid();
+			disposables.add(toDisposable(() => {
+				if (process.platform !== 'win32') {
+					void fs.promises.unlink(socketPath).catch(() => undefined);
+				}
+			}));
+
+			const agentHostStarter = instantiationService.createInstance(NodeAgentHostStarter);
+			agentHostStarter.setWebSocketConfig({ socketPath, connectionToken });
+			const agentHostManager = disposables.add(instantiationService.createInstance(
+				ServerAgentHostManager,
+				agentHostStarter,
+				{ startMode: 'lazy' },
+			));
+			const agentHostBridge = disposables.add(new AgentHostChannel<RemoteAgentConnectionContext>(
+				socketServer,
+				async () => {
+					await agentHostManager.ensureStarted();
+					return { socketPath, connectionToken };
+				},
+				logService,
+			));
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, agentHostBridge);
+			logService.info(`[AgentHostChannel] Registered lazy IPC channel '${AgentHostIpcChannels.RemoteProxy}' (upstream: ${socketPath})`);
+		} catch (error) {
+			socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, new UnavailableAgentHostChannel<RemoteAgentConnectionContext>());
+			logService.error(`[AgentHostChannel] Failed to register IPC channel '${AgentHostIpcChannels.RemoteProxy}'`, error);
+		}
 	}
 
 	services.set(IAllowedMcpServersService, new SyncDescriptor(AllowedMcpServersService));

--- a/src/vs/server/test/node/agentHostChannel.test.ts
+++ b/src/vs/server/test/node/agentHostChannel.test.ts
@@ -127,6 +127,73 @@ suite('AgentHostChannel', () => {
 		assert.strictEqual(upA.disposed, true);
 		assert.strictEqual(closed, 1);
 	});
+
+	test('resolves a deferred endpoint only when connecting', async () => {
+		const ipc = ds.add(new FakeIPCServer());
+		let resolveCount = 0;
+		const channel = ds.add(new AgentHostChannel<string>(
+			ipc as unknown as IPCServer<string>,
+			async () => {
+				resolveCount++;
+				return { socketPath: 'agent-host.sock' };
+			},
+			new NullLogService(),
+			() => ds.add(new FakeUpstream()),
+		));
+
+		channel.listen('renderer', 'frame');
+		assert.strictEqual(resolveCount, 0);
+
+		await channel.call('renderer', 'connect');
+		assert.strictEqual(resolveCount, 1);
+	});
+
+	test('shares deferred endpoint resolution between renderer contexts', async () => {
+		const ipc = ds.add(new FakeIPCServer());
+		let resolveCount = 0;
+		let resolveEndpoint!: (endpoint: IAgentHostUpstreamEndpoint) => void;
+		const endpoint = new Promise<IAgentHostUpstreamEndpoint>(resolve => resolveEndpoint = resolve);
+		const channel = ds.add(new AgentHostChannel<string>(
+			ipc as unknown as IPCServer<string>,
+			() => {
+				resolveCount++;
+				return endpoint;
+			},
+			new NullLogService(),
+			() => ds.add(new FakeUpstream()),
+		));
+
+		const connect = Promise.all([
+			channel.call('first', 'connect'),
+			channel.call('second', 'connect'),
+		]);
+		await Promise.resolve();
+		assert.strictEqual(resolveCount, 1);
+
+		resolveEndpoint({ socketPath: 'agent-host.sock' });
+		await connect;
+	});
+
+	test('surfaces deferred endpoint resolution failures and allows retry', async () => {
+		const ipc = ds.add(new FakeIPCServer());
+		let resolveCount = 0;
+		const channel = ds.add(new AgentHostChannel<string>(
+			ipc as unknown as IPCServer<string>,
+			async () => {
+				resolveCount++;
+				if (resolveCount === 1) {
+					throw new Error('agent host did not start');
+				}
+				return { socketPath: 'agent-host.sock' };
+			},
+			new NullLogService(),
+			() => ds.add(new FakeUpstream()),
+		));
+
+		await assert.rejects(() => channel.call('renderer', 'connect'), /agent host did not start/);
+		await assert.doesNotReject(() => channel.call('renderer', 'connect'));
+		assert.strictEqual(resolveCount, 2);
+	});
 });
 
 suite('UnavailableAgentHostChannel', () => {

--- a/src/vs/server/test/node/agentHostChannel.test.ts
+++ b/src/vs/server/test/node/agentHostChannel.test.ts
@@ -194,6 +194,27 @@ suite('AgentHostChannel', () => {
 		await assert.doesNotReject(() => channel.call('renderer', 'connect'));
 		assert.strictEqual(resolveCount, 2);
 	});
+
+	test('re-resolves the endpoint for later connections', async () => {
+		const ipc = ds.add(new FakeIPCServer());
+		let resolveCount = 0;
+		const channel = ds.add(new AgentHostChannel<string>(
+			ipc as unknown as IPCServer<string>,
+			async () => {
+				resolveCount++;
+				return { socketPath: 'agent-host.sock' };
+			},
+			new NullLogService(),
+			() => ds.add(new FakeUpstream()),
+		));
+
+		await channel.call('first', 'connect');
+		await channel.call('second', 'connect');
+
+		// Resolution is `ensureStarted()` in the lazy server path, so a later
+		// connection must be able to restart a host that has since died.
+		assert.strictEqual(resolveCount, 2);
+	});
 });
 
 suite('UnavailableAgentHostChannel', () => {

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { DisposableStore, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
@@ -53,6 +54,8 @@ class MockChannel implements IChannel {
 class MockAgentHostStarter implements IAgentHostStarter {
 	private readonly _onDidProcessExit = new Emitter<{ code: number; signal: string }>();
 	private _startError: Error | undefined;
+	startCount = 0;
+	readonly connectionStores: DisposableStore[] = [];
 
 	readonly agentHostChannel = new MockChannel();
 	readonly loggerChannel: MockChannel;
@@ -64,6 +67,7 @@ class MockAgentHostStarter implements IAgentHostStarter {
 	}
 
 	async start(): Promise<IAgentHostConnection> {
+		this.startCount++;
 		if (this._startError) {
 			const error = this._startError;
 			this._startError = undefined;
@@ -71,6 +75,7 @@ class MockAgentHostStarter implements IAgentHostStarter {
 		}
 
 		const store = new DisposableStore();
+		this.connectionStores.push(store);
 		const client: IChannelClient = {
 			getChannel: <T extends IChannel>(name: string): T => {
 				switch (name) {
@@ -148,9 +153,10 @@ suite('ServerAgentHostManager', () => {
 		telemetryService = new TestTelemetryService();
 	});
 
-	function createManager(): ServerAgentHostManager {
+	function createManager(options = {}): ServerAgentHostManager {
 		return ds.add(new ServerAgentHostManager(
 			starter,
+			options,
 			new NullLogService(),
 			ds.add(new NullLoggerService()),
 			lifetimeService,
@@ -263,5 +269,83 @@ suite('ServerAgentHostManager', () => {
 				msg: 'test start failure',
 			},
 		}]);
+	});
+
+	test('starts eagerly by default', async () => {
+		const manager = createManager();
+
+		await manager.ensureStarted();
+		assert.strictEqual(starter.startCount, 1);
+	});
+
+	test('does not start lazily until requested', async () => {
+		const manager = createManager({ startMode: 'lazy' });
+
+		assert.strictEqual(starter.startCount, 0);
+		await manager.ensureStarted();
+		assert.strictEqual(starter.startCount, 1);
+	});
+
+	test('shares concurrent lazy startup', async () => {
+		const manager = createManager({ startMode: 'lazy' });
+
+		await Promise.all([
+			manager.ensureStarted(),
+			manager.ensureStarted(),
+		]);
+		assert.strictEqual(starter.startCount, 1);
+	});
+
+	test('restarts after a lazy agent host crash', async () => {
+		const manager = createManager({ startMode: 'lazy' });
+		await manager.ensureStarted();
+
+		starter.fireProcessExit(1);
+		await manager.ensureStarted();
+		assert.strictEqual(starter.startCount, 2);
+	});
+
+	test('waits for the configured WebSocket listener before resolving startup', async () => {
+		const ready = new DeferredPromise<void>();
+		starter.connectionTrackerChannel.setCallResult('waitForConfiguredWebSocketServer', ready.p);
+		const manager = createManager({ startMode: 'lazy' });
+		const start = manager.ensureStarted();
+		let started = false;
+		void start.then(() => started = true);
+
+		await Promise.resolve();
+		assert.strictEqual(started, false);
+
+		await ready.complete();
+		await start;
+		assert.strictEqual(started, true);
+	});
+
+	test('disposes the agent host connection when the manager shuts down during startup', async () => {
+		const ready = new DeferredPromise<void>();
+		starter.connectionTrackerChannel.setCallResult('waitForConfiguredWebSocketServer', ready.p);
+		const manager = createManager({ startMode: 'lazy' });
+		const start = manager.ensureStarted();
+
+		await Promise.resolve();
+		manager.dispose();
+		await ready.complete();
+		await start;
+
+		assert.strictEqual(starter.connectionStores[0].isDisposed, true);
+	});
+
+	test('allows a new explicit start after exhausting crash restarts', async () => {
+		const manager = createManager({ startMode: 'lazy' });
+		await manager.ensureStarted();
+
+		for (let i = 0; i <= 5; i++) {
+			starter.fireProcessExit(1);
+			await manager.ensureStarted();
+		}
+		starter.fireProcessExit(1);
+		await manager.ensureStarted();
+
+		assert.strictEqual(starter.startCount, 8);
 	});
 });

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -164,10 +164,11 @@ suite('ServerAgentHostManager', () => {
 		));
 	}
 
-	// `ServerAgentHostManager._start()` is async (awaits `starter.start()`).
-	// Wait a microtask so the channel listeners are wired up before tests fire events.
-	async function waitForStart(): Promise<void> {
-		await Promise.resolve();
+	// `ServerAgentHostManager` reports startup complete only once the agent host
+	// confirms its configured WebSocket listener is bound, so wait for the real
+	// signal rather than a fixed number of microtasks.
+	async function waitForStart(manager: ServerAgentHostManager): Promise<void> {
+		await manager.ensureStarted();
 	}
 
 	function fireActiveSessions(count: number): void {
@@ -183,28 +184,28 @@ suite('ServerAgentHostManager', () => {
 	}
 
 	test('no lifetime token initially', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
 	});
 
 	test('acquires token when sessions become active', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 		fireActiveSessions(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
 	test('acquires token when standalone WebSocket clients connect', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 		fireConnectionCount(2);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
 	test('releases token only when both sessions and standalone WebSocket connections are zero', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 
 		fireActiveSessions(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
@@ -220,8 +221,8 @@ suite('ServerAgentHostManager', () => {
 	});
 
 	test('process exit resets both signals and clears token', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 		fireActiveSessions(2);
 		fireConnectionCount(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
@@ -231,8 +232,8 @@ suite('ServerAgentHostManager', () => {
 	});
 
 	test('reports unexpected process exit', async () => {
-		createManager();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 
 		starter.fireProcessExit(17);
 
@@ -253,9 +254,8 @@ suite('ServerAgentHostManager', () => {
 		const error = new Error('test start failure');
 		error.stack = 'test start failure stack';
 		starter.failNextStart(error);
-		createManager();
-		await waitForStart();
-		await waitForStart();
+		const manager = createManager();
+		await waitForStart(manager);
 
 		assert.deepStrictEqual(telemetryService.errorEvents, [{
 			eventName: 'agentHost.processError',
@@ -347,5 +347,31 @@ suite('ServerAgentHostManager', () => {
 		await manager.ensureStarted();
 
 		assert.strictEqual(starter.startCount, 8);
+	});
+
+	test('keeps the original request pending while a transient start failure is retried', async () => {
+		const manager = createManager({ startMode: 'lazy' });
+		starter.failNextStart(new Error('transient'));
+
+		await manager.ensureStarted();
+
+		assert.strictEqual(starter.startCount, 2);
+	});
+
+	test('does not double-restart when the host exits during startup', async () => {
+		const ready = new DeferredPromise<void>();
+		starter.connectionTrackerChannel.setCallResult('waitForConfiguredWebSocketServer', ready.p);
+		const manager = createManager({ startMode: 'lazy' });
+		const start = manager.ensureStarted();
+
+		await Promise.resolve();
+		// The IPC client rejects in-flight requests before surfacing the exit, so
+		// both the readiness rejection and the exit event race to restart.
+		starter.connectionTrackerChannel.setCallResult('waitForConfiguredWebSocketServer', Promise.resolve());
+		ready.error(new Error('canceled'));
+		starter.fireProcessExit(1);
+		await start;
+
+		assert.strictEqual(starter.startCount, 2);
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHost.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHost.contribution.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Agent-host registrations are browser-safe so desktop and web workbenches share the same path.
+ */
+
+import { IAgentHostByokLmHandler } from '../../../../../../platform/agentHost/common/agentHostByokLm.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../common/contributions.js';
+import { AgentHostAllowSignedOutWhenUsableContribution } from './agentHostAllowSignedOutWhenUsableContribution.js';
+import { AgentHostByokLmHandler } from './agentHostByokLmHandler.js';
+import { AgentHostContribution } from './agentHostChatContribution.js';
+import { AgentHostCopilotCliSettingsContribution } from './agentHostCopilotCliSettingsContribution.js';
+import { AgentHostOpenSessionLinkOpenerContribution } from './openSessionLinkOpener.contribution.js';
+import { AgentHostSessionListContribution } from './agentHostSessionListContribution.js';
+import { AgentHostTerminalContribution } from './agentHostTerminalContribution.js';
+import { CopilotConfigSlashSubmitHandlerContribution } from './copilotConfigSlashSubmitHandler.js';
+import './agentHostSettings.contribution.js';
+import './agentSessionSettings.contribution.js';
+
+registerWorkbenchContribution2(AgentHostContribution.ID, AgentHostContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(CopilotConfigSlashSubmitHandlerContribution.ID, CopilotConfigSlashSubmitHandlerContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostSessionListContribution.ID, AgentHostSessionListContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostOpenSessionLinkOpenerContribution.ID, AgentHostOpenSessionLinkOpenerContribution, WorkbenchPhase.BlockStartup);
+registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostCopilotCliSettingsContribution.ID, AgentHostCopilotCliSettingsContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostAllowSignedOutWhenUsableContribution.ID, AgentHostAllowSignedOutWhenUsableContribution, WorkbenchPhase.AfterRestored);
+
+registerSingleton(IAgentHostByokLmHandler, AgentHostByokLmHandler, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHost.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHost.contribution.ts
@@ -5,6 +5,13 @@
 
 /**
  * Agent-host registrations are browser-safe so desktop and web workbenches share the same path.
+ *
+ * Note that `AgentHostContribution` injects `IAgentHostService`, whose remote
+ * implementation connects from its constructor. Instantiating this at
+ * `AfterRestored` therefore starts the agent host once a chat-enabled remote
+ * window has loaded, rather than on first use of a session. That matches the
+ * pre-existing desktop behaviour; the laziness on the server side is about
+ * servers with no connected renderer, not about windows that never chat.
  */
 
 import { IAgentHostByokLmHandler } from '../../../../../../platform/agentHost/common/agentHostByokLm.js';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -17,6 +17,7 @@ import { TerminalSettingId } from '../../../../../../platform/terminal/common/te
 import { IWorkbenchContribution } from '../../../../../../workbench/common/contributions.js';
 import { ITerminalProfileResolverService, ITerminalProfileService } from '../../../../../../workbench/contrib/terminal/common/terminal.js';
 import { IAgentHostTerminalService } from '../../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { AgentHostRootConfigForwarder, type IForwardedRootConfigKey } from './agentHostRootConfigForwarder.js';
 
 /** Terminal settings whose change should re-resolve the agent host shell. */
@@ -57,22 +58,24 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 		@ITerminalProfileResolverService private readonly _terminalProfileResolverService: ITerminalProfileResolverService,
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 		@IAgentHostEnablementService private readonly _agentHostEnablementService: IAgentHostEnablementService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 
-		const keys: readonly IForwardedRootConfigKey[] = [
-			{
-				key: AgentHostConfigKey.DefaultShell,
-				computeValue: () => this._resolveDefaultShell(),
-				registerTriggers: (store, push) => {
-					store.add(this._configurationService.onDidChangeConfiguration(e => {
-						if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
-							push();
-						}
-					}));
-					store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => push()));
-				},
+		const defaultShellKey: IForwardedRootConfigKey = {
+			key: AgentHostConfigKey.DefaultShell,
+			computeValue: () => this._resolveDefaultShell(),
+			registerTriggers: (store, push) => {
+				store.add(this._configurationService.onDidChangeConfiguration(e => {
+					if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
+						push();
+					}
+				}));
+				store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => push()));
 			},
+		};
+		const keys: readonly IForwardedRootConfigKey[] = [
+			...(environmentService.remoteAuthority ? [] : [defaultShellKey]),
 			{
 				key: CopilotCliConfigKey.EnableCustomTerminalTool,
 				computeValue: () => this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId) === true,

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -31,23 +31,12 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { ILifecycleService, ShutdownReason } from '../../../services/lifecycle/common/lifecycle.js';
 import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '../browser/actions/chatActions.js';
-import { AgentHostContribution } from '../browser/agentSessions/agentHost/agentHostChatContribution.js';
-import { AgentHostByokLmHandler } from '../browser/agentSessions/agentHost/agentHostByokLmHandler.js';
-import { AgentHostSessionListContribution } from '../browser/agentSessions/agentHost/agentHostSessionListContribution.js';
-import { AgentHostOpenSessionLinkOpenerContribution } from '../browser/agentSessions/agentHost/openSessionLinkOpener.contribution.js';
-import { AgentHostTerminalContribution } from '../browser/agentSessions/agentHost/agentHostTerminalContribution.js';
-import { AgentHostCopilotCliSettingsContribution } from '../browser/agentSessions/agentHost/agentHostCopilotCliSettingsContribution.js';
-import { AgentHostAllowSignedOutWhenUsableContribution } from '../browser/agentSessions/agentHost/agentHostAllowSignedOutWhenUsableContribution.js';
 import './codexCustomizationSettings.contribution.js';
-import { CopilotConfigSlashSubmitHandlerContribution } from '../browser/agentSessions/agentHost/copilotConfigSlashSubmitHandler.js';
-import '../browser/agentSessions/agentHost/agentHostSettings.contribution.js';
-import '../browser/agentSessions/agentHost/agentSessionSettings.contribution.js';
 import { AgentSessionProviders, getAgentSessionProviderName } from '../browser/agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../browser/agentSessions/agentSessionsService.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../browser/chat.js';
 import { ChatSessionPosition, openChatSession } from '../browser/chatSessions/chatSessions.contribution.js';
 import { IAgentHostService } from '../../../../platform/agentHost/common/agentService.js';
-import { IAgentHostByokLmHandler } from '../../../../platform/agentHost/common/agentHostByokLm.js';
 import { type AgentInfo, type RootState } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IChatService } from '../common/chatService/chatService.js';
@@ -273,19 +262,8 @@ registerWorkbenchContribution2(NativeBuiltinToolsContribution.ID, NativeBuiltinT
 registerWorkbenchContribution2(ChatCommandLineHandler.ID, ChatCommandLineHandler, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatSuspendThrottlingHandler.ID, ChatSuspendThrottlingHandler, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatLifecycleHandler.ID, ChatLifecycleHandler, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(AgentHostContribution.ID, AgentHostContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(CopilotConfigSlashSubmitHandlerContribution.ID, CopilotConfigSlashSubmitHandlerContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(AgentHostSessionListContribution.ID, AgentHostSessionListContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(AgentHostOpenSessionLinkOpenerContribution.ID, AgentHostOpenSessionLinkOpenerContribution, WorkbenchPhase.BlockStartup);
-registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(AgentHostCopilotCliSettingsContribution.ID, AgentHostCopilotCliSettingsContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(AgentHostAllowSignedOutWhenUsableContribution.ID, AgentHostAllowSignedOutWhenUsableContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(OpenWorkspaceInAgentsContribution.ID, OpenWorkspaceInAgentsContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(AgentsHandoffInputTipContribution.ID, AgentsHandoffInputTipContribution, WorkbenchPhase.Eventually);
-
-// Renderer-side BYOK language-model handler that backs the node agent host's
-// OpenAI proxy. Lazily instantiated when AgentHostClientByokLmChannel resolves it.
-registerSingleton(IAgentHostByokLmHandler, AgentHostByokLmHandler, InstantiationType.Delayed);
 
 // How long to wait for the agent host to surface an AgentInfo before
 // throwing an error. Long enough for normal startup, short enough to avoid

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -21,6 +21,7 @@ import { AgentHostCustomTerminalToolEnabledSettingId, CopilotCliConfigKey } from
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import type { ActionEnvelope, IRootConfigChangedAction, INotification, SessionAction, TerminalAction, ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { TerminalSettingId, type ITerminalProfile } from '../../../../../../platform/terminal/common/terminal.js';
@@ -200,7 +201,7 @@ interface ITestSetup {
 	defaultAccountService: MockDefaultAccountService;
 }
 
-function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): ITestSetup {
+function setup(disposables: DisposableStore, agentHostEnabled: boolean = true, remoteAuthority?: string): ITestSetup {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const agentHostService = new MockAgentHostService();
 	disposables.add({ dispose: () => agentHostService.dispose() });
@@ -216,6 +217,9 @@ function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): 
 	instantiationService.stub(IAgentHostService, agentHostService);
 	instantiationService.stub(IConfigurationService, configurationService);
 	instantiationService.stub(IAgentHostEnablementService, { _serviceBrand: undefined, enabled: observableValue('agentHostEnabled', agentHostEnabled) });
+	instantiationService.stub(IWorkbenchEnvironmentService, new class extends mock<IWorkbenchEnvironmentService>() {
+		override readonly remoteAuthority = remoteAuthority;
+	}());
 	instantiationService.stub(ITerminalProfileResolverService, resolver);
 	instantiationService.stub(ITerminalProfileService, profileService);
 	instantiationService.stub(IDefaultAccountService, defaultAccountService);
@@ -250,6 +254,16 @@ suite('AgentHostTerminalContribution', () => {
 
 		// Even with a fully-hydrated rootState, nothing should fire because
 		// the contribution short-circuits in _updateEnabled.
+		agentHostService.setRootState(rootStateWithDefaultShellKey());
+		agentHostService.fireAgentHostStart();
+		await flush();
+
+		assert.deepStrictEqual(agentHostService.dispatchedActions, []);
+	});
+
+	test('does not forward the local default shell to a remote agent host', async () => {
+		const { agentHostService } = setup(disposables, /*agentHostEnabled*/ true, 'ssh-remote+test');
+
 		agentHostService.setRootState(rootStateWithDefaultShellKey());
 		agentHostService.fireAgentHostStart();
 		await flush();

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -228,6 +228,7 @@ import './contrib/speech/browser/speech.contribution.js';
 // Chat
 import './contrib/chat/browser/chat.shared.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
+import './contrib/chat/browser/agentSessions/agentHost/agentHost.contribution.js';
 import './contrib/chat/browser/chat.view.contribution.js';
 import './contrib/inlineChat/browser/inlineChat.contribution.js';
 


### PR DESCRIPTION
Fixes #326125

The agent-host harness never appeared in the session-type picker when connected to a remote — Codespaces (both the web client and Desktop-connected), Remote-SSH, Dev Containers and WSL. Only the "Local" harness showed up.

Most of the plumbing already existed: the renderer picks `EditorRemoteAgentHostServiceClient` when a remote authority is set, speaks AHP over the remote-agent IPC channel, the server has an `agentHostProxy` channel and a `ServerAgentHostManager`, and the REH build already ships the agent host entrypoint and the `@github/copilot` runtime. Two independent gaps meant none of it was ever reachable.

## 1. The server never provisioned an agent host

`serverServices.ts` only spawned an agent host given `--agent-host-port` / `--agent-host-path`, and only registered a working bridge given `--agent-host-bridge-*`. The only caller that passes those flags is the Rust CLI's `code tunnel` agent-host sidecar. Codespaces, Remote-SSH, Dev Containers and WSL all launch `vscode-server` without them, so the server registered `UnavailableAgentHostChannel`, the renderer's `connect()` rejected, `rootState` never arrived, and `AgentHostContribution` registered zero chat session types.

The wiring is now three branches. The two existing flag paths are behaviourally unchanged; a new default branch provisions an agent host itself:

- **Socket-based.** A per-server path from `createRandomIPCHandle()` (handles Windows named pipes and the macOS/Linux socket path length limits), guarded by a random connection token, unlinked on shutdown.
- **Lazy.** Nothing spawns until a renderer actually connects to `agentHostProxy`, so a server with no connected chat-enabled renderer pays no process or memory cost and remote auto-shutdown idle timers are unaffected. Note this means "once a chat-enabled remote window has loaded", not "on first session use": `AgentHostContribution` injects `IAgentHostService`, whose remote implementation connects from its constructor. That is pre-existing desktop behaviour, not new here. The existing `--agent-host-port` path stays eager, because the CLI parses the readiness line from stdout at startup.
- **Race-free.** `ensureStarted()` previously would have resolved as soon as the child-process IPC client was up, while the agent host binds its WebSocket listener asynchronously later — the first connect could hit an unbound socket and reproduce the exact symptom being fixed. Startup now waits for the agent host to confirm the listener is bound, and a failed listener startup rejects rather than hanging.

Crash-restart, the restart budget, process telemetry and the `IServerLifetimeService` lifetime tokens behave as before in both modes.

## 2. Web never registered the agent host chat contributions

`AgentHostContribution` and friends were registered only from `contrib/chat/electron-browser/chat.contribution.ts`, which only the desktop workbench imports — even though `workbench.web.main.ts` already registers `EditorRemoteAgentHostServiceClient` and `WebAgentHostEnablementService` explicitly enables the agent host whenever a remote authority is present. So web had a fully wired client with no consumer, and fixing the server alone would not have fixed the Codespaces browser client.

These registrations move to a new `agentSessions/agentHost/agentHost.contribution.ts` in the browser layer, imported from `workbench.common.main.ts` so web and desktop share one path.

**Gating is unchanged.** The agent host is offered only when a real server-backed remote exists: `WebAgentHostEnablementService` keys off `remoteAuthority`, so serverless web (vscode.dev, Remote Repositories, virtual-filesystem workspaces) stays dark. When a remote *is* server-backed but can't provide an agent host — e.g. an older server — root state never arrives and nothing is registered, so the harness silently doesn't appear rather than showing a broken entry.

## Also

Stop forwarding the client-resolved default shell to a remote agent host. Forwarding a Windows client's shell path to a Linux server is wrong; with the key absent the agent host resolves its own shell server-side (and validates executability before falling back).

## Validation

- `npm run typecheck-client` ✅
- `npm run valid-layers-check` ✅
- `scripts/test.sh` on `agentHostChannel`, `serverAgentHostManager` (21 passing), `agentHostTerminalContribution` (21 passing), `agentHostChatContribution` (291 passing) ✅

New regression coverage: lazy start defers spawn, concurrent starts share one spawn, restart-after-crash, waiting for listener readiness, disposing mid-startup doesn't orphan the process, a fresh start is allowed after the crash budget is exhausted, and deferred endpoint resolution is shared/retryable.

Verified end-to-end against a running remote server: the harness now appears in the picker and sessions work.

Review feedback addressed in the follow-up commit: `ensureStarted()` now stays pending across automatic retries (a transient first-spawn failure was fatal for the window); the crash handler is registered only after startup succeeds (an exit during startup could previously restart twice and burn the budget twice); `AgentHostChannel` caches only the in-flight endpoint resolution (a resolved one meant later reconnects dialed a dead socket); and a stale unix socket is removed before spawning (otherwise every restart failed to bind with `EADDRINUSE`).

## Out of scope

#327339 / #325803 (Remote Repositories): a desktop window over a virtual filesystem has no remote authority, so it takes the local agent host path and the harness is shown but can't see `vscode-vfs://` files. Different root cause, needs the `SessionFsProvider` work.

