### PR TITLE
Implement 120-character truncation for Open Recent labels with Unicode fix

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -116,10 +116,18 @@ export function truncateMiddle(value: string, maxLength: number, suffix = Ellips
 		return value;
 	}
 
-	const prefixLength = Math.ceil(maxLength / 2) - suffix.length / 2;
-	const suffixLength = Math.floor(maxLength / 2) - suffix.length / 2;
+	let prefixLength = Math.floor(Math.ceil(maxLength / 2) - suffix.length / 2);
+	const suffixLength = Math.ceil(Math.floor(maxLength / 2) - suffix.length / 2);
+	let suffixStart = value.length - suffixLength;
 
-	return `${value.substr(0, prefixLength)}${suffix}${value.substr(value.length - suffixLength)}`;
+	if (isHighSurrogate(value.charCodeAt(prefixLength - 1)) && isLowSurrogate(value.charCodeAt(prefixLength))) {
+		prefixLength--;
+	}
+	if (isHighSurrogate(value.charCodeAt(suffixStart - 1)) && isLowSurrogate(value.charCodeAt(suffixStart))) {
+		suffixStart++;
+	}
+
+	return `${value.substring(0, prefixLength)}${suffix}${value.substring(suffixStart)}`;
 }
 
 /**

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -504,6 +504,8 @@ suite('Strings', () => {
 	test('truncateMiddle', () => {
 		assert.strictEqual('hello world', strings.truncateMiddle('hello world', 100));
 		assert.strictEqual('he…ld', strings.truncateMiddle('hello world', 5));
+		assert.strictEqual('a…de', strings.truncateMiddle('a😀bcde', 5));
+		assert.strictEqual('ab…f', strings.truncateMiddle('abcde😀f', 5));
 	});
 
 	test('replaceAsync', async () => {

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -42,6 +42,7 @@ import { getFlatContextMenuActions } from '../../../../platform/actions/browser/
 import { defaultMenuStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { ActivityBarPosition } from '../../../services/layout/browser/layoutService.js';
+import { truncateMiddle } from '../../../../base/common/strings.js';
 
 export type IOpenRecentAction = IAction & { uri: URI; remoteAuthority?: string };
 
@@ -69,6 +70,7 @@ export abstract class MenubarControl extends Disposable {
 	protected menuUpdater: RunOnceScheduler;
 
 	protected static readonly MAX_MENU_RECENT_ENTRIES = 10;
+	protected static readonly MAX_MENU_RECENT_LABEL_LENGTH = 120;
 
 	constructor(
 		protected readonly menuService: IMenuService,
@@ -252,7 +254,7 @@ export abstract class MenubarControl extends Disposable {
 		}
 
 		const ret = toAction({
-			id: commandId, label: unmnemonicLabel(label), run: (browserEvent: KeyboardEvent) => {
+			id: commandId, label: unmnemonicLabel(truncateMiddle(label, MenubarControl.MAX_MENU_RECENT_LABEL_LENGTH)), run: (browserEvent: KeyboardEvent) => {
 				const openInNewWindow = browserEvent && ((!isMacintosh && (browserEvent.ctrlKey || browserEvent.shiftKey)) || (isMacintosh && (browserEvent.metaKey || browserEvent.altKey)));
 
 				return this.hostService.openWindow([openable], {

--- a/src/vs/workbench/test/browser/parts/titlebar/menubarControl.test.ts
+++ b/src/vs/workbench/test/browser/parts/titlebar/menubarControl.test.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Separator } from '../../../../../base/common/actions.js';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IMenu, IMenuService } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IUpdateService, State } from '../../../../../platform/update/common/update.js';
+import { IRecentlyOpened, IWorkspacesService } from '../../../../../platform/workspaces/common/workspaces.js';
+import { IOpenRecentAction, MenubarControl } from '../../../../browser/parts/titlebar/menubarControl.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { TestMenuService, workbenchInstantiationService } from '../../workbenchTestServices.js';
+
+class TestMenubarMenuService extends TestMenuService {
+	override createMenu(): IMenu {
+		return {
+			onDidChange: Event.None,
+			dispose: () => { },
+			getActions: () => [['', []]]
+		};
+	}
+}
+
+class TestMenubarControl extends MenubarControl {
+	constructor(
+		@IMenuService menuService: IMenuService,
+		@IWorkspacesService workspacesService: IWorkspacesService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ILabelService labelService: ILabelService,
+		@IUpdateService updateService: IUpdateService,
+		@IStorageService storageService: IStorageService,
+		@INotificationService notificationService: INotificationService,
+		@IPreferencesService preferencesService: IPreferencesService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@IHostService hostService: IHostService,
+		@ICommandService commandService: ICommandService
+	) {
+		super(menuService, workspacesService, contextKeyService, keybindingService, configurationService, labelService, updateService, storageService, notificationService, preferencesService, environmentService, accessibilityService, hostService, commandService);
+	}
+
+	protected override doUpdateMenubar(_firstTime: boolean): void { }
+
+	getOpenRecentActionsForTest(recentlyOpened: IRecentlyOpened): IOpenRecentAction[] {
+		this.recentlyOpened = recentlyOpened;
+
+		return this.getOpenRecentActions().filter((action): action is IOpenRecentAction => !(action instanceof Separator));
+	}
+}
+
+suite('MenubarControl', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('bounds open recent menu labels without splitting surrogate pairs', () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		instantiationService.stub(IMenuService, new TestMenubarMenuService());
+		instantiationService.stub(IUpdateService, new class extends mock<IUpdateService>() {
+			override readonly onStateChange = Event.None;
+			override readonly state = State.Uninitialized;
+		});
+		instantiationService.stub(IPreferencesService, new class extends mock<IPreferencesService>() { });
+		instantiationService.stub(ICommandService, new class extends mock<ICommandService>() { });
+
+		const control = disposables.add(instantiationService.createInstance(TestMenubarControl));
+		const folderUri = URI.file('folder');
+		const workspaceUri = URI.file('workspace.code-workspace');
+		const fileUri = URI.file('file.txt');
+		const folderLabel = `${'a'.repeat(58)}😀${'b'.repeat(61)}`;
+		const workspaceLabel = 'workspace.code-workspace';
+		const fileLabel = `${'a'.repeat(60)}😀${'b'.repeat(59)}`;
+
+		const actions = control.getOpenRecentActionsForTest({
+			workspaces: [
+				{ folderUri, label: folderLabel },
+				{ workspace: { id: 'workspace', configPath: workspaceUri }, label: workspaceLabel }
+			],
+			files: [{ fileUri, label: fileLabel, remoteAuthority: 'remote' }]
+		});
+
+		assert.deepStrictEqual(actions.map(action => ({
+			label: action.label,
+			labelLength: action.label.length,
+			uri: action.uri,
+			remoteAuthority: action.remoteAuthority
+		})), [
+			{ label: `${'a'.repeat(58)}…${'b'.repeat(60)}`, labelLength: 119, uri: folderUri, remoteAuthority: undefined },
+			{ label: workspaceLabel, labelLength: workspaceLabel.length, uri: workspaceUri, remoteAuthority: undefined },
+			{ label: `${'a'.repeat(59)}…${'b'.repeat(59)}`, labelLength: 119, uri: fileUri, remoteAuthority: 'remote' }
+		]);
+	});
+});


### PR DESCRIPTION
fixes #196054, #170799

This pull request implements a 120-character middle truncation for Open Recent labels in the menu, addressing issues #170799 and #196054. The changes include:

- **Truncation Logic**: Updated the `truncateMiddle` utility to prevent splitting UTF-16 surrogate pairs, ensuring that emoji and other Unicode characters are handled correctly.
- **Menu Control Updates**: Adjusted the label assignment in `menubarControl.ts` to apply the truncation logic consistently across both custom and native menus.
- **Test Coverage**: Added comprehensive tests in `menubarControl.test.ts` to validate the truncation behavior, including edge cases with Unicode characters.

All changes have been validated through targeted tests, ESLint checks, and type validation, ensuring that the implementation is robust and does not introduce regressions.