### PR TITLE
agentHost: disable flaky terminal exit code E2E

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -74,6 +74,23 @@ A user can start a shell command in the background, inspect or list the running 
     --grep "managed shell|custom terminal tool manages"
   ```
 
+### Custom Copilot terminal exit codes are intermittently absent
+
+A user can run a failing command through the custom Copilot terminal tool and expects the completed terminal entry to retain its nonzero exit code. The command result sent to the model includes the correct exit code, but the subscribed AHP terminal state intermittently leaves the matching command incomplete and omits its exit code.
+
+- Test: `custom terminal tool preserves a nonzero shell exit code`
+- Scope: Copilot on Linux and macOS.
+- Expected: the completed terminal command reports exit code `9`.
+- Observed: the command result reports exit code `9`, while the terminal command's `exitCode` is sometimes absent.
+- Gate: the scenario requires `AGENT_HOST_RUN_KNOWN_ISSUES=1`.
+- Reproduce:
+
+  ```bash
+  AGENT_HOST_RUN_KNOWN_ISSUES=1 AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts \
+    --grep "custom terminal tool preserves a nonzero shell exit code"
+  ```
+
 ### Copilot deferred tool search cannot be replayed
 
 A Copilot session can defer client-provided tools, search for the relevant tool on demand, and then execute the selected tool. The live workflow succeeds, but the recorded Responses fixture loses the hosted tool-search output that triggers the AHP client-tool exchange, so replay ends the turn before either tool appears.

--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -562,7 +562,7 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 		}
 	});
 
-	test('custom terminal tool preserves a nonzero shell exit code', async function () {
+	(context.runKnownIssueTests ? test : test.skip)('custom terminal tool preserves a nonzero shell exit code', async function () {
 		this.timeout(180_000);
 		const { sessionUri } = await createWorkspaceSession('custom-terminal-exit-code');
 		try {


### PR DESCRIPTION
## Summary

- gate `custom terminal tool preserves a nonzero shell exit code` behind the known-issue opt-in
- document the intermittent missing terminal exit code and focused reproduction command

## Validation

- `npm run typecheck-client`
- `npm run hygiene`
- `npm run compile`
- focused Copilot Agent Host E2E run confirms the test is pending by default

(Written by Copilot)