### PR TITLE
agentHost: keep the native Claude catalog published through first sign-in

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -631,10 +631,22 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		this._githubToken = token;
 		this._logService.info('[Claude] Auth token updated');
 		oldHandle?.dispose();
-		// A different account can have different model entitlements; do not retain
-		// the previous list if enumeration for the new token fails. The `models`
-		// write also republishes the protected resources downstream.
-		this._models.set([], undefined);
+		// Blank the catalog only on a *replacement*: a different account can have
+		// different model entitlements, so don't retain the previous list if
+		// enumeration for the new token fails.
+		//
+		// A first sign-in (no `oldHandle`) must NOT blank. It has no superseded
+		// account to drop, and the catalog it would clear is native-only — the
+		// bootstrap list, which is account-independent and stays valid. Blanking
+		// there publishes an empty catalog for the length of the refresh, which the
+		// window gate reads as `SessionTypeAuthRequirement.Unusable` (an agent with
+		// no models is unusable). That closes the `allowSignedOutWhenUsable` gate
+		// mid-startup and forces the sign-in dialog on a user who is already signed
+		// in — the GitHub session resolves before the Copilot default account does,
+		// so the welcome flow still believes it is signed out.
+		if (oldHandle) {
+			this._models.set([], undefined);
+		}
 		void this._startModelRefresh();
 		return true;
 	}

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1169,6 +1169,51 @@ suite('ClaudeAgent', () => {
 		assert.deepStrictEqual(agent.models.get(), []);
 	});
 
+	test('first sign-in keeps the native catalog published while the proxy catalog enumerates', async () => {
+		// The window gate reads an agent with no models as `Unusable`, so a *first*
+		// sign-in must never blank the bootstrap native catalog: it has no
+		// superseded account to drop, and blanking would close the
+		// `allowSignedOutWhenUsable` gate mid-startup and force the sign-in dialog
+		// on a user who is already signing in.
+		const userHome = URI.file(await fs.mkdtemp(`${os.tmpdir()}/claude-first-signin-`));
+		await fs.mkdir(join(userHome.fsPath, '.claude'), { recursive: true });
+		await fs.writeFile(join(userHome.fsPath, '.claude', 'settings.json'), JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-test-key' } }), 'utf8');
+		try {
+			const { agent, api, sdk } = createTestContext(disposables, { userHome });
+			sdk.supportedModelsResult = [
+				{ value: 'claude-sonnet-4-5-20250929', displayName: 'Claude Sonnet 4.5', description: '', supportedEffortLevels: ['high'] },
+			];
+			// The constructor's bootstrap refresh publishes native-only (no token yet).
+			for (let i = 0; i < 100 && agent.models.get().length === 0; i++) {
+				await tick();
+			}
+			const bootstrap = agent.models.get().map(model => model.name);
+
+			// Hold the CAPI enumeration open so the post-sign-in refresh is still in
+			// flight when we sample the catalog — that pending window is exactly what
+			// the renderer saw as an empty (and therefore `Unusable`) agent.
+			const gate = new DeferredPromise<void>();
+			api.models = async () => { await gate.p; return [...ALL_MODELS]; };
+			await agent.authenticate('https://api.github.com', 'tok');
+			const whileEnumerating = agent.models.get().map(model => model.name);
+
+			gate.complete();
+			await agent.refreshModels();
+
+			assert.deepStrictEqual({
+				bootstrap,
+				whileEnumerating,
+				merged: agent.models.get().map(model => model.name),
+			}, {
+				bootstrap: ['Claude Sonnet 4.5'],
+				whileEnumerating: ['Claude Sonnet 4.5'],
+				merged: ['Claude Opus 4.6', 'Claude Sonnet 4.6', 'Claude Sonnet 4.5'],
+			});
+		} finally {
+			await fs.rm(userHome.fsPath, { recursive: true, force: true });
+		}
+	});
+
 	test('signed out with a local setup: models populate from supportedModels() with no proxy start and no CAPI models() call', async () => {
 		// Native enumeration only runs when a credential is actually present, so
 		// give this a real `~/.claude/settings.json` under a temp home. Signed out,


### PR DESCRIPTION
Follow-up to #328990, which added `chat.agentHost.allowSignedOutWhenUsable`. The setting did not reliably suppress the sign-in dialog.

### The bug

`ClaudeAgent._onAuthToken` blanked the model catalog unconditionally before kicking off the refresh for the new token:

```ts
oldHandle?.dispose();
this._models.set([], undefined);
void this._startModelRefresh();
```

On a **replacement** token that is correct — a different account can have different model entitlements, so the stale list must not survive a failed enumeration.

On a **first** sign-in it is not. There is no superseded account to drop, and the catalog being cleared is the account-independent native bootstrap list. Blanking there publishes an empty catalog for the length of the refresh.

The Agents window reads an agent with no models as `SessionTypeAuthRequirement.Unusable`, so that empty window closes the `allowSignedOutWhenUsable` gate mid-startup and forces the sign-in dialog on a user who is already signing in — the GitHub session resolves before the Copilot default account does, so the welcome flow still believes it is signed out.

### The fix

Blank only when replacing an existing handle.

### Verification

Unit: new test holds CAPI enumeration open with a `DeferredPromise` and asserts the catalog stays published across the pending window. Negative control confirmed — reverting the fix yields `whileEnumerating: []`. Full `ClaudeAgent` suite: 241 passing.

E2E, matched preconditions on both sides:

| | unfixed (3 runs) | fixed (4 runs) |
|---|---|---|
| `Count: 6` | `seq=12` | `seq=12` |
| `Auth token updated` | `seq=13` ← blank | *(no envelope)* |
| welcome flow | `Showing sign-in dialog` | never logged |
| final count | `Count: 13 → seq=14` | `Count: 13 → seq=13` |
| dialog in DOM | present | absent |

Unfixed reproduced 3/3, fixed clean 4/4.

Also verified on a genuinely signed-out window (`--use-mock-keychain`, no GitHub session at all) with the setting on: no dialog, the inline "discovered your existing Claude configuration" nudge shows instead, and Claude answers prompts normally.

### Not addressed here

Two related defects found while investigating, both pre-existing and out of scope:

1. Once `_showSignInDialog` hands the modal to `workbench.action.chat.triggerSetup`, `dialogRef` never owns it, so `dialogRef.clear()` cannot retract it.
2. Nothing in the chat-setup or Agents stack consults `IAuthenticationService.getSessions('github')` outside the web path — "signed in?" is only ever asked of `IDefaultAccountService`. A user with a live GitHub session but no resolved Copilot entitlement renders their avatar *and* a sign-in prompt at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)