### PR TITLE
Add Agent Host turn context telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -140,13 +140,16 @@ export interface IAgentHostTurnCompletedEvent {
 	provider: string;
 	agentSessionId: string;
 	chatSessionId: string;
+	isSubagentSession: boolean;
 	turnId: string;
 	timeToFirstProgress: number | undefined;
 	totalTime: number;
 	result: AgentHostTurnResult;
 	model: string | TelemetryTrustedValue<string> | undefined;
 	modelSelectionKind: AgentHostModelSelectionKind;
+	isBYOK: boolean | undefined;
 	permissionLevel: string | undefined;
+	interactionMode: SessionMode | undefined;
 	errorType: string | undefined;
 	failureStage: AgentHostTurnFailureStage | undefined;
 	isMultiRoot: boolean;
@@ -157,13 +160,16 @@ export type IAgentHostTurnCompletedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat identifier within the agent host session.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the turn belongs to a subagent session.' };
 	turnId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the turn within the agent host session.' };
 	timeToFirstProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from turn start to the first visible progress (text delta, response part, tool call start, or reasoning).' };
 	totalTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time in milliseconds from turn start to turn completion.' };
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the turn completed successfully, with an error, or was cancelled.' };
 	model: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The trusted provider model identifier selected at turn start, or a generic value for BYOK and unknown models.' };
 	modelSelectionKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the client used the provider default, Auto, or an explicit model.' };
+	isBYOK: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the selected model is a bring-your-own-key model, when model context is available.' };
 	permissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The tool auto-approval level configured for the session at turn start (e.g. default, autoApprove, autopilot).' };
+	interactionMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host interaction mode configured at turn start.' };
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type when the turn fails.' };
 	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded stage at which the agent host turn failed.' };
 	isMultiRoot: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the session spans more than one working directory.' };
@@ -176,6 +182,7 @@ export interface IAgentHostTurnFailedEvent {
 	provider: string;
 	agentSessionId: string;
 	chatSessionId: string;
+	isSubagentSession: boolean;
 	turnId: string;
 	failureStage: AgentHostTurnFailureStage;
 	errorType: string;
@@ -191,6 +198,7 @@ export type IAgentHostTurnFailedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the failed agent host turn.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the failed turn belongs to a subagent session.' };
 	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the failed turn within the agent host session.' };
 	failureStage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded stage at which the agent host turn failed.' };
 	errorType: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The structured agent host or provider error type.' };
@@ -223,6 +231,7 @@ export interface IAgentHostTurnCompletedReport {
 	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 	modelSelectionKind: AgentHostModelSelectionKind;
 	permissionLevel: string | undefined;
+	interactionMode: SessionMode | undefined;
 	failure: IAgentHostTurnFailure | undefined;
 	isMultiRoot: boolean;
 	folderCount: number;
@@ -1010,18 +1019,22 @@ export class AgentHostTelemetryReporter {
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		const chatSessionId = getTelemetryChatSessionId(report.session);
+		const isSubagent = isSubagentChatUri(report.session) || isSubagentSession(session);
 		const model = toTelemetryModel(report.model, report.modelTelemetryKind);
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,
 			agentSessionId: AgentSession.id(session),
 			chatSessionId,
+			isSubagentSession: isSubagent,
 			turnId: report.turnId,
 			timeToFirstProgress: report.timeToFirstProgress,
 			totalTime: report.totalTime,
 			result: report.result,
 			model,
 			modelSelectionKind: report.modelSelectionKind,
+			isBYOK: report.modelTelemetryKind === undefined ? undefined : report.modelTelemetryKind === 'byok',
 			permissionLevel: report.permissionLevel,
+			interactionMode: report.interactionMode,
 			errorType: report.failure?.error.errorType,
 			failureStage: report.failure?.stage,
 			isMultiRoot: report.isMultiRoot,
@@ -1033,6 +1046,7 @@ export class AgentHostTelemetryReporter {
 				provider: report.provider,
 				agentSessionId: AgentSession.id(session),
 				chatSessionId,
+				isSubagentSession: isSubagent,
 				turnId: report.turnId,
 				failureStage: report.failure.stage,
 				errorType: report.failure.error.errorType,

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -7,6 +7,7 @@ import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
+import type { SessionMode } from '../common/agentHostSchema.js';
 import { canRefineContributor, toolSourceKindFromContributor } from './agentHostToolCallTracker.js';
 import { SessionInputRequestKind } from '../common/state/protocol/state.js';
 import type { ToolCallContributor } from '../common/state/sessionState.js';
@@ -55,6 +56,7 @@ interface ITurnTiming {
 	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 	readonly modelSelectionKind: 'default' | 'auto' | 'explicit';
 	readonly permissionLevel: string | undefined;
+	readonly interactionMode: SessionMode | undefined;
 	firstProgressMs: number | undefined;
 
 	// Hang watchdog state
@@ -130,7 +132,7 @@ export class AgentHostTurnTracker extends Disposable {
 		}));
 	}
 
-	turnStarted(provider: string, session: string, turnId: string, model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined, permissionLevel: string | undefined): void {
+	turnStarted(provider: string, session: string, turnId: string, model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined, permissionLevel: string | undefined, interactionMode: SessionMode | undefined): void {
 		const key = this._key(session, turnId);
 		this._turnTimings.set(key, {
 			stopWatch: StopWatch.create(false),
@@ -141,6 +143,7 @@ export class AgentHostTurnTracker extends Disposable {
 			modelTelemetryKind,
 			modelSelectionKind: model === undefined ? 'default' : model === 'auto' ? 'auto' : 'explicit',
 			permissionLevel,
+			interactionMode,
 			firstProgressMs: undefined,
 			quietStopWatch: StopWatch.create(false),
 			lastActivityKind: TURN_ACTIVITY_NONE,
@@ -307,6 +310,7 @@ export class AgentHostTurnTracker extends Disposable {
 			modelTelemetryKind: timing.modelTelemetryKind,
 			modelSelectionKind: timing.modelSelectionKind,
 			permissionLevel: timing.permissionLevel,
+			interactionMode: timing.interactionMode,
 			failure,
 			isMultiRoot: workspace?.isMultiRoot ?? false,
 			folderCount: workspace?.folderCount ?? 0,
@@ -478,4 +482,3 @@ export class AgentHostTurnTracker extends Disposable {
 		return `${session}\0${turnId}`;
 	}
 }
-

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1399,8 +1399,8 @@ export class AgentSideEffects extends Disposable {
 				}
 				const attachments = action.message.attachments;
 				this._telemetryReporter.userMessageSent(agent.id, clientId, clientContext, channel, state, 'direct', attachments);
-				const { model, modelTelemetryKind, permissionLevel } = this._getTurnTelemetryContext(agent, state, action.message.model?.id);
-				this._turnTracker.turnStarted(agent.id, channel, action.turnId, model, modelTelemetryKind, permissionLevel);
+				const { model, modelTelemetryKind, permissionLevel, interactionMode } = this._getTurnTelemetryContext(agent, state, action.message.model?.id);
+				this._turnTracker.turnStarted(agent.id, channel, action.turnId, model, modelTelemetryKind, permissionLevel, interactionMode);
 				void this._sendTurnMessage({
 					agent,
 					sessionChannel,
@@ -1842,8 +1842,8 @@ export class AgentSideEffects extends Disposable {
 		const attachments = msg.message.attachments;
 		const queuedState = this._stateManager.getSessionState(session);
 		this._telemetryReporter.userMessageSent(agent.id, sender.clientId, sender.clientContext, session, queuedState, 'queued', attachments);
-		const { model, modelTelemetryKind, permissionLevel } = this._getTurnTelemetryContext(agent, queuedState, msg.message.model?.id);
-		this._turnTracker.turnStarted(agent.id, session, turnId, model, modelTelemetryKind, permissionLevel);
+		const { model, modelTelemetryKind, permissionLevel, interactionMode } = this._getTurnTelemetryContext(agent, queuedState, msg.message.model?.id);
+		this._turnTracker.turnStarted(agent.id, session, turnId, model, modelTelemetryKind, permissionLevel, interactionMode);
 		// Selection travels on the queued message; it is applied before sending.
 		void this._sendTurnMessage({
 			agent,
@@ -1859,13 +1859,14 @@ export class AgentSideEffects extends Disposable {
 	}
 
 
-	private _getTurnTelemetryContext(agent: IAgent, state: SessionState | undefined, modelId: string | undefined): { model: string | undefined; modelTelemetryKind: AgentHostModelTelemetryKind | undefined; permissionLevel: string | undefined } {
+	private _getTurnTelemetryContext(agent: IAgent, state: SessionState | undefined, modelId: string | undefined): { model: string | undefined; modelTelemetryKind: AgentHostModelTelemetryKind | undefined; permissionLevel: string | undefined; interactionMode: SessionMode | undefined } {
 		const permissionValue = state?.config?.values[SessionConfigKey.AutoApprove];
 		const permissionLevel = typeof permissionValue === 'string' ? permissionValue : undefined;
+		const interactionMode = getConfiguredSessionMode(state?.config);
 		const modelContext = modelId === undefined
 			? { model: undefined, modelTelemetryKind: undefined }
 			: this._getModelTelemetryContext(agent, modelId);
-		return { ...modelContext, permissionLevel };
+		return { ...modelContext, permissionLevel, interactionMode };
 	}
 
 	private _getModelTelemetryContext(agent: IAgent, modelId: string): { model: string; modelTelemetryKind: AgentHostModelTelemetryKind } {

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -16,8 +16,10 @@ import { TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
+import type { SessionMode } from '../../common/agentHostSchema.js';
+import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
-import { buildDefaultChatUri, MessageKind, PendingMessageKind, ResponsePartKind, SessionStatus } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, buildSubagentChatUri, MessageKind, PendingMessageKind, ResponsePartKind, SessionStatus } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
@@ -113,7 +115,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		}
 	}
 
-	function setAutoApprove(level: string): void {
+	function setSessionConfig(values: { autoApprove?: string; mode?: SessionMode }): void {
 		// Establish config on the authoritative session state via the state
 		// manager API. Mutating the object returned by `getSessionState` would
 		// strand the change on a detached composite copy (session merged with
@@ -123,14 +125,18 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 			schema: {
 				type: 'object',
 				properties: {
-					autoApprove: { type: 'string', title: 'Approvals', enum: ['default', 'autoApprove', 'autopilot'], default: 'default' },
+					[SessionConfigKey.AutoApprove]: { type: 'string', title: 'Approvals', enum: ['default', 'autoApprove', 'autopilot'], default: 'default' },
+					[SessionConfigKey.Mode]: { type: 'string', title: 'Mode', enum: ['interactive', 'plan', 'autopilot'], default: 'interactive' },
 				},
 			},
-			values: { autoApprove: level },
+			values: {
+				...(values.autoApprove === undefined ? {} : { [SessionConfigKey.AutoApprove]: values.autoApprove }),
+				...(values.mode === undefined ? {} : { [SessionConfigKey.Mode]: values.mode }),
+			},
 		});
 	}
 
-	function startTurn(turnId: string, text = 'hello', modelId?: string): void {
+	function startTurn(turnId: string, text = 'hello', modelId?: string, chatUri = defaultChatUri): void {
 		const action: ChatAction = {
 			type: ActionType.ChatTurnStarted,
 			turnId,
@@ -141,12 +147,12 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		// active turn (the progress-listener path relies on this) and then
 		// invoke `handleAction` so the side-effect (which calls
 		// `agent.sendMessage` and `turnTracker.turnStarted`) runs.
-		stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
-		sideEffects.handleAction(defaultChatUri, action);
+		stateManager.dispatchClientAction(chatUri, action, { clientId: 'test', clientSeq: 1 });
+		sideEffects.handleAction(chatUri, action);
 	}
 
-	function fire(action: ChatAction): void {
-		agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action });
+	function fire(action: ChatAction, chatUri = defaultChatUri): void {
+		agent.fireProgress({ kind: 'action', resource: URI.parse(chatUri), action });
 	}
 
 	function completedEvents(): { eventName: string; data: unknown }[] {
@@ -199,10 +205,10 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 	});
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('emits turnCompleted with timing, model and permissionLevel on success', () => {
+	test('emits turnCompleted with timing and turn-start context on success', () => {
 		setupSession();
 		agent.setModels([{ provider: 'mock', id: 'gpt-5.5', name: 'GPT 5.5', supportsVision: false }]);
-		setAutoApprove('autopilot');
+		setSessionConfig({ autoApprove: 'autopilot', mode: 'interactive' });
 		startTurn('turn-1', 'hello', 'gpt-5.5');
 
 		fire({ type: ActionType.ChatResponsePart, turnId: 'turn-1', part: { kind: ResponsePartKind.Markdown, id: 'p1', content: 'hi' } });
@@ -219,6 +225,9 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.deepStrictEqual(capturedModel(data), { trusted: true, value: 'gpt-5.5' });
 		assert.strictEqual(data.modelSelectionKind, 'explicit');
 		assert.strictEqual(data.permissionLevel, 'autopilot');
+		assert.strictEqual(data.isSubagentSession, false);
+		assert.strictEqual(data.isBYOK, false);
+		assert.strictEqual(data.interactionMode, 'interactive');
 		assert.strictEqual(typeof data.totalTime, 'number');
 		assert.strictEqual(typeof data.timeToFirstProgress, 'number');
 		assert.strictEqual(data.isMultiRoot, false);
@@ -255,10 +264,10 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 
 		assert.deepStrictEqual(completedEvents().map(event => {
 			const data = event.data as Record<string, unknown>;
-			return { model: data.model, modelSelectionKind: data.modelSelectionKind };
+			return { model: data.model, modelSelectionKind: data.modelSelectionKind, isBYOK: data.isBYOK };
 		}), [
-			{ model: 'byokModel', modelSelectionKind: 'explicit' },
-			{ model: 'unknown', modelSelectionKind: 'explicit' },
+			{ model: 'byokModel', modelSelectionKind: 'explicit', isBYOK: true },
+			{ model: 'unknown', modelSelectionKind: 'explicit', isBYOK: false },
 		]);
 	});
 
@@ -345,6 +354,7 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 			return {
 				agentSessionId: data.agentSessionId,
 				chatSessionId: data.chatSessionId,
+				isSubagentSession: data.isSubagentSession,
 				turnId: data.turnId,
 				providerCallId: data.providerCallId,
 				serviceRequestId: data.serviceRequestId,
@@ -352,10 +362,41 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		}), [{
 			agentSessionId: 'session-1',
 			chatSessionId: getTelemetryChatSessionId(defaultChatUri),
+			isSubagentSession: false,
 			turnId: 'turn-1',
 			providerCallId: 'provider-request-id',
 			serviceRequestId: 'service-request-id',
 		}]);
+	});
+
+	test('reports subagent completion and failure without collapsing the chat identity', () => {
+		setupSession();
+		const subagentChatUri = buildSubagentChatUri(sessionUri, 'tool-call-1');
+		stateManager.addChat(sessionKey, subagentChatUri);
+
+		startTurn('subagent-complete', 'hello', undefined, subagentChatUri);
+		fire({ type: ActionType.ChatTurnComplete, turnId: 'subagent-complete', duration: 1000 }, subagentChatUri);
+		startTurn('subagent-failed', 'hello', undefined, subagentChatUri);
+		fire({ type: ActionType.ChatError, turnId: 'subagent-failed', duration: 1000, error: { errorType: 'oops', message: 'fail' } }, subagentChatUri);
+
+		assert.deepStrictEqual({
+			completed: completedEvents().map(event => {
+				const data = event.data as Record<string, unknown>;
+				return { turnId: data.turnId, agentSessionId: data.agentSessionId, chatSessionId: data.chatSessionId, isSubagentSession: data.isSubagentSession };
+			}),
+			failed: failedEvents().map(event => {
+				const data = event.data as Record<string, unknown>;
+				return { turnId: data.turnId, agentSessionId: data.agentSessionId, chatSessionId: data.chatSessionId, isSubagentSession: data.isSubagentSession };
+			}),
+		}, {
+			completed: [
+				{ turnId: 'subagent-complete', agentSessionId: 'session-1', chatSessionId: getTelemetryChatSessionId(subagentChatUri), isSubagentSession: true },
+				{ turnId: 'subagent-failed', agentSessionId: 'session-1', chatSessionId: getTelemetryChatSessionId(subagentChatUri), isSubagentSession: true },
+			],
+			failed: [
+				{ turnId: 'subagent-failed', agentSessionId: 'session-1', chatSessionId: getTelemetryChatSessionId(subagentChatUri), isSubagentSession: true },
+			],
+		});
 	});
 
 	test('emits a single turnCompleted per turn even when followed by duplicate completions', () => {
@@ -371,16 +412,39 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 
 	test('captures permissionLevel at turnStarted, not later mid-turn changes', () => {
 		setupSession();
-		setAutoApprove('default');
+		setSessionConfig({ autoApprove: 'default' });
 		startTurn('turn-1');
 
 		// Change config mid-turn — should not affect the recorded event.
-		setAutoApprove('autopilot');
+		setSessionConfig({ autoApprove: 'autopilot' });
 
 		fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-1', duration: 1000 });
 
 		const data = completedEvents()[0].data as Record<string, unknown>;
 		assert.strictEqual(data.permissionLevel, 'default');
+	});
+
+	test('reports all interaction modes', () => {
+		setupSession();
+
+		for (const mode of ['interactive', 'plan', 'autopilot'] as const) {
+			setSessionConfig({ mode });
+			startTurn(`turn-${mode}`);
+			fire({ type: ActionType.ChatTurnComplete, turnId: `turn-${mode}`, duration: 1000 });
+		}
+
+		assert.deepStrictEqual(completedEvents().map(event => (event.data as Record<string, unknown>).interactionMode), ['interactive', 'plan', 'autopilot']);
+	});
+
+	test('captures interactionMode at turnStarted, not later mid-turn changes', () => {
+		setupSession();
+		setSessionConfig({ mode: 'plan' });
+		startTurn('turn-1');
+
+		setSessionConfig({ mode: 'autopilot' });
+		fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-1', duration: 1000 });
+
+		assert.strictEqual((completedEvents()[0].data as Record<string, unknown>).interactionMode, 'plan');
 	});
 
 	test('model and permissionLevel are undefined when never set', () => {
@@ -392,6 +456,8 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		assert.strictEqual(data.model, undefined);
 		assert.strictEqual(data.modelSelectionKind, 'default');
 		assert.strictEqual(data.permissionLevel, undefined);
+		assert.strictEqual(data.isBYOK, undefined);
+		assert.strictEqual(data.interactionMode, undefined);
 	});
 
 	// The tests below cover completion paths that bypass the agent-progress
@@ -486,6 +552,27 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		const events = completedEvents();
 		assert.strictEqual(events.length, 1);
 		assert.strictEqual((events[0].data as Record<string, unknown>).result, 'error');
+	});
+
+	test('captures interactionMode for queued turns', () => {
+		setupSession();
+		setSessionConfig({ mode: 'autopilot' });
+
+		const setAction: ChatAction = {
+			type: ActionType.ChatPendingMessageSet,
+			kind: PendingMessageKind.Queued,
+			id: 'q-mode',
+			message: { text: 'queued message', origin: { kind: MessageKind.User } },
+		};
+		stateManager.dispatchClientAction(defaultChatUri, setAction, { clientId: 'test', clientSeq: 1 });
+		sideEffects.handleAction(defaultChatUri, setAction);
+		const turnId = stateManager.getActiveTurnId(defaultChatUri);
+		assert.ok(turnId);
+
+		setSessionConfig({ mode: 'interactive' });
+		fire({ type: ActionType.ChatTurnComplete, turnId, duration: 1000 });
+
+		assert.strictEqual((completedEvents()[0].data as Record<string, unknown>).interactionMode, 'autopilot');
 	});
 
 	test('emits a single turnCompleted when both the client cancel and a follow-up agent signal arrive', () => {


### PR DESCRIPTION
## Overview

### What

Widens the existing per-turn Agent Host telemetry without changing its cadence:

- `agentHost.turnCompleted.isSubagentSession`
- `agentHost.turnFailed.isSubagentSession`
- `agentHost.turnCompleted.isBYOK`
- `agentHost.turnCompleted.interactionMode`

Interaction mode is captured from `SessionConfigKey.Mode` when a direct or queued turn starts and remains stable if session configuration changes while the turn is running. Subagent status is derived from the normalized owning session while the original chat URI continues to supply `chatSessionId`, preserving distinct nested chat identities. BYOK status is derived from the existing privacy-safe model telemetry kind; raw BYOK model identifiers remain represented as `byokModel`.

This does not change `copilotCli/response.*`, turn correlation, model-call counting, `ChatUsage` cadence, or `response.*.requestId` semantics.

### Why

This implements the Agent Host-owned portions of [microsoft/vscode#329684](https://github.com/microsoft/vscode/issues/329684): main-versus-subagent analysis, privacy-safe BYOK analysis, and turn interaction mode. These dimensions naturally belong on the existing per-turn events and are already available in local turn context.

The detailed source and production-data audit was supplied as `telemetry-329684-audit.md` with the implementation handoff. It is not added to the repository because it contains internal aggregate validation notes.

## Property-by-property parity

| Field | Source or derivation | Parity |
|---|---|---|
| `turnCompleted.isSubagentSession` | Normalized Agent Host session plus the original subagent chat identity | ✅ Same main/subagent signal |
| `turnFailed.isSubagentSession` | Same derivation as the associated completion event | ✅ Same main/subagent signal |
| `turnCompleted.isBYOK` | `modelTelemetryKind`: `byok` → `true`; `trusted`/`unknown` → `false`; unavailable → omitted | ✅ Same BYOK signal without model-ID disclosure |
| `turnCompleted.interactionMode` | `SessionConfigKey.Mode` snapshotted at turn start | ✅ Same bounded `interactive`/`plan`/`autopilot` signal |

## Measurement-by-measurement parity

No duration, token, or call-count measurements are added or changed. The new boolean dimensions use the repository's existing GDPR `isMeasurement` convention for telemetry booleans.

## Row-count and dashboard implications

- Population remains the existing Agent Host turn population across providers.
- Cadence remains one `turnCompleted` row per tracked turn and one `turnFailed` diagnostic row for failures.
- No new telemetry events or duplicate rows are introduced.
- Existing `provider + agentSessionId + chatSessionId + turnId` correlation remains unchanged.
- `isBYOK` is absent when no model context exists rather than using a placeholder.
- Existing timing, resolved-Auto model reporting, permission level, and error fields retain their semantics.

## Semantic-shift ledger

There are no close-analogue mappings in this change; all four fields are derived from the existing Agent Host turn/session state at the same lifecycle boundary.

## Validation

- `npm run compile-client`
- `.\scripts\test.bat --run src\vs\platform\agentHost\test\node\agentHostTurnTelemetry.test.ts` (21 passing)
## CI follow-up

The macOS Electron integration job exposed tracked Codex issue [#329512](https://github.com/microsoft/vscode/issues/329512): the workspace-list shell command succeeds and the final response contains both filenames, but the completed AHP tool call intermittently has empty result text. The strict test is now gated only for deterministic Codex replay on macOS; recording, Windows, and other-provider coverage remain enabled, while Linux was already gated for Codex shell replay.