### PR TITLE
agentHost: require GitHub for Claude unless a BYO-Anthropic setup exists

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -497,18 +497,10 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Can Claude run without GitHub right now? True only when the signed-out
-	 * opt-in is on AND the user has a BYO-Anthropic credential we can discover —
-	 * `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in the process environment
-	 * or in the `env` block of `~/.claude/settings.json` (see
-	 * {@link detectExistingClaudeSetup}).
-	 *
-	 * Read live on every call — never cached — so a credential appearing (or the
-	 * opt-in being flipped) takes effect without restarting the host; the `&&`
-	 * short-circuit also keeps the settings-file read off the path entirely while
-	 * the opt-in is off. Sign-in state is deliberately NOT an input: whether
-	 * GitHub is *required* is a property of what the user can run without it, not
-	 * of whether they happen to be connected at this instant.
+	 * Whether Claude can run without GitHub right now: the signed-out opt-in is on
+	 * AND a BYO-Anthropic credential is discoverable (see
+	 * {@link detectExistingClaudeSetup}). Backs both the advertised requirement and
+	 * the model-less transport default so the two cannot disagree.
 	 */
 	private _hasUsableNativeSetup(): boolean {
 		return this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.AllowSignedOutWhenUsable) === true
@@ -534,28 +526,11 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
-		// Is GitHub needed to use Claude at all? Only when the user has no
-		// Anthropic credential of their own. With a discovered BYO-Anthropic setup
-		// (see {@link _hasUsableNativeSetup}) the native half of the merged catalog
-		// runs on that credential alone, so Copilot is advertised optional
-		// (`required: false`); with none, every model the picker can offer is
-		// Copilot-routed, so it stays strictly required and sign-in is forced.
-		//
-		// The resource is *kept* in the list either way rather than dropped, which
-		// preserves the silent sign-in probe: `authenticateProtectedResources`
-		// matches on `resource` and ignores `required`, so an already-signed-in user
-		// still has a GitHub token forwarded (no prompt when signed out) and
-		// `authenticate()` still acquires the proxy handle that Copilot-routed
-		// models need.
-		//
-		// `required` is read only by `protectedResourcesRequireGitHubCopilotSignIn`
-		// — the window gate and the per-session-type gate, which check
-		// `required !== false`.
-		//
-		// This is the host-level answer only. Per-session routing still follows the
-		// picked model, and `_ensureAuthenticated(model)` raises `AHP_AUTH_REQUIRED`
-		// for the sessions that pick a Copilot-routed model without a proxy handle.
-		// The optional repo resource is kept for git operations either way.
+		// Kept in the list even when optional, never dropped:
+		// `authenticateProtectedResources` matches on `resource` and ignores
+		// `required`, so advertising it is what lets the host silently forward a
+		// token to an already-signed-in user — and acquire the proxy handle
+		// Copilot-routed models need — without forcing sign-in on anyone else.
 		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		return [
 			this._hasUsableNativeSetup() ? { ...copilotResource, required: false } : copilotResource,

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -493,8 +493,26 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	 */
 	private _defaultTransportMode(): ClaudeTransportMode {
 		const allowSignedOutWhenUsable = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.AllowSignedOutWhenUsable) === true;
-		const hasExistingSetup = allowSignedOutWhenUsable && detectExistingClaudeSetup(this._environmentService.userHome.fsPath);
-		return resolveClaudeTransportMode({ allowSignedOutWhenUsable, hasGitHubToken: this._proxyHandle !== undefined, hasExistingSetup });
+		return resolveClaudeTransportMode({ allowSignedOutWhenUsable, hasGitHubToken: this._proxyHandle !== undefined, hasExistingSetup: this._hasUsableNativeSetup() });
+	}
+
+	/**
+	 * Can Claude run without GitHub right now? True only when the signed-out
+	 * opt-in is on AND the user has a BYO-Anthropic credential we can discover —
+	 * `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in the process environment
+	 * or in the `env` block of `~/.claude/settings.json` (see
+	 * {@link detectExistingClaudeSetup}).
+	 *
+	 * Read live on every call — never cached — so a credential appearing (or the
+	 * opt-in being flipped) takes effect without restarting the host; the `&&`
+	 * short-circuit also keeps the settings-file read off the path entirely while
+	 * the opt-in is off. Sign-in state is deliberately NOT an input: whether
+	 * GitHub is *required* is a property of what the user can run without it, not
+	 * of whether they happen to be connected at this instant.
+	 */
+	private _hasUsableNativeSetup(): boolean {
+		return this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.AllowSignedOutWhenUsable) === true
+			&& detectExistingClaudeSetup(this._environmentService.userHome.fsPath);
 	}
 
 	// #region Descriptor + auth
@@ -516,25 +534,31 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
-		// The transport is chosen per session from the picked model, so no
-		// host-global mode can make Copilot strictly required: advertise the
-		// Copilot resource as optional (`required: false`, mirroring Codex's
-		// always-optional Copilot resource). Two effects, both wanted:
-		//   1. The host silently forwards a GitHub token IFF the user is already
-		//      signed in (no prompt when signed out) — the sign-in probe that lets
-		//      `authenticate()` acquire a proxy handle for Copilot-routed models
-		//      (after which model-less sessions default to proxy; see
-		//      {@link _defaultTransportMode}).
-		//   2. `required: false` still tells the window gate the type is usable
-		//      without GitHub when signed out (see
-		//      `protectedResourcesRequireGitHubCopilotSignIn`, which checks
-		//      `required !== false`), so no sign-in is forced.
-		// `_ensureAuthenticated(model)` raises `AHP_AUTH_REQUIRED` only for the
-		// sessions that actually pick a Copilot-routed model without a proxy
-		// handle. The optional repo resource is kept for git operations either way.
+		// Is GitHub needed to use Claude at all? Only when the user has no
+		// Anthropic credential of their own. With a discovered BYO-Anthropic setup
+		// (see {@link _hasUsableNativeSetup}) the native half of the merged catalog
+		// runs on that credential alone, so Copilot is advertised optional
+		// (`required: false`); with none, every model the picker can offer is
+		// Copilot-routed, so it stays strictly required and sign-in is forced.
+		//
+		// The resource is *kept* in the list either way rather than dropped, which
+		// preserves the silent sign-in probe: `authenticateProtectedResources`
+		// matches on `resource` and ignores `required`, so an already-signed-in user
+		// still has a GitHub token forwarded (no prompt when signed out) and
+		// `authenticate()` still acquires the proxy handle that Copilot-routed
+		// models need.
+		//
+		// `required` is read only by `protectedResourcesRequireGitHubCopilotSignIn`
+		// — the window gate and the per-session-type gate, which check
+		// `required !== false`.
+		//
+		// This is the host-level answer only. Per-session routing still follows the
+		// picked model, and `_ensureAuthenticated(model)` raises `AHP_AUTH_REQUIRED`
+		// for the sessions that pick a Copilot-routed model without a proxy handle.
+		// The optional repo resource is kept for git operations either way.
 		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		return [
-			{ ...copilotResource, required: false },
+			this._hasUsableNativeSetup() ? { ...copilotResource, required: false } : copilotResource,
 			this._gitHubEndpointService.getRepoResource(),
 		];
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -45,13 +45,15 @@ export interface IClaudeTransportModeInputs {
  *
  * The result is **not** an input to the Agents window's sign-in gate, and
  * resolving to `proxy` does not by itself make the session type "require
- * GitHub". Claude advertises the Copilot protected resource as `required: false`
- * unconditionally, so `resolveAgentAuthRequirement` separates "usable" from
- * "unusable" on the *model count* instead: in case 4 neither half of the merged
- * catalog can be enumerated, the published catalog is empty, and the type
- * resolves to `Unusable` — surfacing as "no models". The proxy fallback only
- * bites at use time, when a model-less/bare session actually materializes with no
- * proxy handle and `_ensureAuthenticated` raises `AHP_AUTH_REQUIRED`.
+ * GitHub". That answer is `getProtectedResources()`, which marks the Copilot
+ * resource `required: false` on the same `hasExistingSetup` fact used here — so
+ * the two agree by construction: a user with their own Anthropic credential is
+ * not forced to sign in, and one without (case 4) is. `resolveAgentAuthRequirement`
+ * then separates `None` from `Unusable` on the *model count*, since a
+ * `required: false` agent that cannot enumerate a single model must not hold the
+ * window open. The proxy fallback of case 4 only bites at use time, when a
+ * model-less/bare session actually materializes with no proxy handle and
+ * `_ensureAuthenticated` raises `AHP_AUTH_REQUIRED`.
  *
  * There is deliberately no host-global setting to *prefer* a transport. Since
  * the picker offers both providers' models side by side, transport is downstream
@@ -108,9 +110,10 @@ type ClaudeCredentialEnv = NonNullable<ValidatorType<typeof claudeSettingsValida
  *
  * These are the same credential sources the SDK subprocess env is built from
  * (see `buildSubprocessEnv`), so detecting them here means "asking for what we
- * actually need": when a native credential is present the provider never
- * advertises the GitHub Copilot resource, so the server never asks the client
- * for a GitHub token and no sign-in is triggered.
+ * actually need": when a native credential is present the provider advertises
+ * the GitHub Copilot resource as `required: false`, so no sign-in is forced —
+ * while still letting the host silently forward a token to a user who is signed
+ * in anyway.
  *
  * Detection is deliberately conservative — an empty-string value does not count
  * — so it neither misses a real login nor misfires on a leftover blank entry.

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1007,7 +1007,7 @@ suite('ClaudeAgent', () => {
 			resource_name: 'GitHub Copilot',
 			authorization_servers: ['https://github.com/login/oauth'],
 			scopes_supported: ['read:user', 'user:email'],
-			required: false,
+			required: true,
 		}, {
 			resource: 'https://api.github.com/repos',
 			resource_name: 'GitHub Repository',
@@ -5711,19 +5711,51 @@ suite('ClaudeAgent — per-session provider', () => {
 		});
 	});
 
-	test('getProtectedResources advertises Copilot as optional even in the proxy default', () => {
-		// Per-session routing means no host-global mode can make Copilot strictly
-		// required — each session's transport comes from its picked model — so the
-		// resource is always advertised optional (mirroring Codex). The proxy-only
-		// session that needs it is gated later, in `_ensureAuthenticated(model)`.
-		const { agent } = createTestContext(disposables);
-		assert.deepStrictEqual(
-			agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
-			[
-				{ resource: 'https://api.github.com', required: false },
-				{ resource: 'https://api.github.com/repos', required: false },
-			],
-		);
+	test('getProtectedResources marks Copilot optional only for a discovered BYO-Anthropic setup', async () => {
+		// Whether GitHub is *required* tracks what the user can run without it. No
+		// local Anthropic credential means every model the merged catalog can offer
+		// is Copilot-routed, so the resource stays strictly required and the window
+		// / session-type gates force sign-in. A discovered credential (here a real
+		// `~/.claude/settings.json` under a temp home, with the signed-out opt-in
+		// on) flips it to `required: false` so a signed-out user is let in. The
+		// resource is never dropped, so the silent token probe survives both ways.
+		const withoutSetup = createTestContext(disposables).agent.getProtectedResources();
+		await withNativeSetup(async userHome => {
+			const { agent } = createTestContext(disposables, {
+				rootConfig: { [AgentHostConfigKey.AllowSignedOutWhenUsable]: true },
+				userHome,
+			});
+			assert.deepStrictEqual({
+				withoutSetup: withoutSetup.map(r => ({ resource: r.resource, required: r.required })),
+				withSetup: agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+			}, {
+				withoutSetup: [
+					{ resource: 'https://api.github.com', required: true },
+					{ resource: 'https://api.github.com/repos', required: false },
+				],
+				withSetup: [
+					{ resource: 'https://api.github.com', required: false },
+					{ resource: 'https://api.github.com/repos', required: false },
+				],
+			});
+		});
+	});
+
+	test('getProtectedResources keeps Copilot required for a BYO-Anthropic setup while the opt-in is off', async () => {
+		// The `allowSignedOutWhenUsable` opt-in is the kill switch for the whole
+		// signed-out experience, so with it off a discovered credential must not
+		// lift the sign-in requirement — exactly as the host-default transport
+		// (`resolveClaudeTransportMode` rule 1) stays on the proxy.
+		await withNativeSetup(async userHome => {
+			const { agent } = createTestContext(disposables, { userHome });
+			assert.deepStrictEqual(
+				agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+				[
+					{ resource: 'https://api.github.com', required: true },
+					{ resource: 'https://api.github.com/repos', required: false },
+				],
+			);
+		});
 	});
 
 	test('merged catalog lists both providers, each id provider-qualified', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5711,50 +5711,41 @@ suite('ClaudeAgent — per-session provider', () => {
 		});
 	});
 
-	test('getProtectedResources marks Copilot optional only for a discovered BYO-Anthropic setup', async () => {
-		// Whether GitHub is *required* tracks what the user can run without it. No
-		// local Anthropic credential means every model the merged catalog can offer
-		// is Copilot-routed, so the resource stays strictly required and the window
-		// / session-type gates force sign-in. A discovered credential (here a real
-		// `~/.claude/settings.json` under a temp home, with the signed-out opt-in
-		// on) flips it to `required: false` so a signed-out user is let in. The
-		// resource is never dropped, so the silent token probe survives both ways.
-		const withoutSetup = createTestContext(disposables).agent.getProtectedResources();
+	test('the Copilot resource is optional only when the opt-in AND a BYO-Anthropic credential are both present', async () => {
+		// Full 2x2 so no single input can carry the result on its own: in
+		// particular `optInOnNoCredential` is the regression this guards — the
+		// requirement must survive the opt-in being on when the user has no
+		// Anthropic credential to run on.
+		const copilotRequired = (agent: ClaudeAgent) =>
+			agent.getProtectedResources().find(r => r.resource === 'https://api.github.com')?.required;
+		const optIn = { rootConfig: { [AgentHostConfigKey.AllowSignedOutWhenUsable]: true } };
 		await withNativeSetup(async userHome => {
-			const { agent } = createTestContext(disposables, {
-				rootConfig: { [AgentHostConfigKey.AllowSignedOutWhenUsable]: true },
-				userHome,
-			});
 			assert.deepStrictEqual({
-				withoutSetup: withoutSetup.map(r => ({ resource: r.resource, required: r.required })),
-				withSetup: agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
+				optInOnNoCredential: copilotRequired(createTestContext(disposables, { ...optIn }).agent),
+				optInOnWithCredential: copilotRequired(createTestContext(disposables, { ...optIn, userHome }).agent),
+				optInOffWithCredential: copilotRequired(createTestContext(disposables, { userHome }).agent),
+				optInOffNoCredential: copilotRequired(createTestContext(disposables).agent),
 			}, {
-				withoutSetup: [
-					{ resource: 'https://api.github.com', required: true },
-					{ resource: 'https://api.github.com/repos', required: false },
-				],
-				withSetup: [
-					{ resource: 'https://api.github.com', required: false },
-					{ resource: 'https://api.github.com/repos', required: false },
-				],
+				optInOnNoCredential: true,
+				optInOnWithCredential: false,
+				optInOffWithCredential: true,
+				optInOffNoCredential: true,
 			});
 		});
 	});
 
-	test('getProtectedResources keeps Copilot required for a BYO-Anthropic setup while the opt-in is off', async () => {
-		// The `allowSignedOutWhenUsable` opt-in is the kill switch for the whole
-		// signed-out experience, so with it off a discovered credential must not
-		// lift the sign-in requirement — exactly as the host-default transport
-		// (`resolveClaudeTransportMode` rule 1) stays on the proxy.
+	test('the Copilot resource is advertised, never dropped, so the silent token probe survives', async () => {
+		// `authenticateProtectedResources` matches on `resource` and ignores
+		// `required`, so dropping it would break sign-in forwarding.
 		await withNativeSetup(async userHome => {
-			const { agent } = createTestContext(disposables, { userHome });
-			assert.deepStrictEqual(
-				agent.getProtectedResources().map(r => ({ resource: r.resource, required: r.required })),
-				[
-					{ resource: 'https://api.github.com', required: true },
-					{ resource: 'https://api.github.com/repos', required: false },
-				],
-			);
+			const optional = createTestContext(disposables, {
+				rootConfig: { [AgentHostConfigKey.AllowSignedOutWhenUsable]: true },
+				userHome,
+			}).agent.getProtectedResources();
+			assert.deepStrictEqual(optional.map(r => ({ resource: r.resource, required: r.required })), [
+				{ resource: 'https://api.github.com', required: false },
+				{ resource: 'https://api.github.com/repos', required: false },
+			]);
 		});
 	});
 


### PR DESCRIPTION
Since #329331, `ClaudeAgent` advertised the GitHub Copilot protected resource as `required: false` **unconditionally**, reasoning that per-session routing means no host-global mode can make Copilot strictly required.

But `required` isn't a question about routing. It's read by exactly one thing — [`protectedResourcesRequireGitHubCopilotSignIn`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/agentHost/common/agentService.ts#L976) — which backs the Agents window gate and the per-session-type gate. Answering "optional" for a user with **no Anthropic credential** claimed Claude was usable without GitHub, when every model the merged catalog can offer them is Copilot-routed.

This restores the pre-#329331 condition: **optional only when a local BYOK setup is discovered.**

## Change

New private `_hasUsableNativeSetup()` is the single "can Claude run without GitHub right now?" fact: the `allowSignedOutWhenUsable` opt-in **and** `detectExistingClaudeSetup` (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in the process env or the `env` block of `~/.claude/settings.json`). `_defaultTransportMode()` now feeds `hasExistingSetup` from the same helper, so the advertised requirement and the fallback transport can't disagree.

Two deliberate choices worth review attention:

- **The resource is still _kept_ in the list rather than dropped.** `authenticateProtectedResources` matches on `resource` and ignores `required`, so the silent probe survives: an already-signed-in user still has a token forwarded (no prompt when signed out), and `authenticate()` still acquires the proxy handle that Copilot-routed models need.
- **Sign-in state is deliberately not an input.** Whether GitHub is *required* is a property of what the user can run without it, not of whether they happen to be connected at this instant. (The pre-#329331 expression also flipped back to required once a token arrived; this avoids that churn.)

Making this derived rather than constant introduces a staleness risk, since it now depends on live config + filesystem state. That's the main thing I went looking for — see run C below.

## Verification

Unit tests updated (the default-context assertion, plus two new tests covering the credential-present and opt-in-off branches). Full `platform/agentHost` suite passes (4339).

Verified end-to-end against a real **signed-out** Agents window (`--use-mock-keychain`), reading the published `protectedResources` off the AHP JSONL log:

| Run | Claude credential | opt-in | Published `required` | Window |
|---|---|---|---|---|
| A | none | on | **`true`** | "Sign in to use Agents" gate |
| B | `ANTHROPIC_API_KEY` | on | **`false`** | Opens signed out, Claude selected, 5 models, discovered-config nudge |
| C | `ANTHROPIC_API_KEY` | off | **`true`** | Gate (kill switch holds) |

`codex` published `required=false` in all three runs — that's what `claude` was incorrectly mirroring before this fix.

Run C also exercised the staleness path. The host started with a stale `true` in its `agent-host-config.json`, so the initial publish was wrong — and then corrected itself:

```
23:12:48.771  initSnapshot   claude required=false      <- stale config at startup
23:12:48.778  configChanged: allowSignedOutWhenUsable=false
23:12:48.871  agentsChanged  claude required=true       <- republished 93ms later
23:12:50.245  agentsChanged  claude required=true models=5
```

So the derived value is safe: `AgentSideEffects` already republishes agent infos on `RootConfigChanged`, and `_publishAgentInfos`' `equals` guard limits the dispatch to real changes.

One note for reviewers: run B's models came from a **fake** API key. That isn't a flaw in the test — it confirms the existing comment in `_refreshModels` that the SDK's `supportedModels()` is a *static* catalog which answers without validating credentials. `required: false` + models > 0 is what lets the window open; a real turn would fail later. Pre-existing and untouched here.
