### PR TITLE
agentHost: Preserve session worktrees on shutdown

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -229,7 +229,8 @@ export interface IAgentHostGitService {
 	 * whose worktree was previously cleaned up on archive).
 	 */
 	addExistingWorktree(repositoryRoot: URI, worktree: URI, branchName: string): Promise<void>;
-	removeWorktree(repositoryRoot: URI, worktree: URI): Promise<void>;
+	/** Removes a worktree, preserving Git's dirty-worktree protection unless `force` is explicitly requested. */
+	removeWorktree(repositoryRoot: URI, worktree: URI, options?: { readonly force?: boolean }): Promise<void>;
 	/**
 	 * Returns true when the named branch exists in the repository
 	 * (`refs/heads/<branchName>` resolves). Used by archive cleanup to

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -205,8 +205,13 @@ export class AgentHostGitService implements IAgentHostGitService {
 		await this._runGit(repositoryRoot, ['-c', 'checkout.workers=0', 'worktree', 'add', '-f', worktree.fsPath, branchName], { timeout: 180_000, throwOnError: true });
 	}
 
-	async removeWorktree(repositoryRoot: URI, worktree: URI): Promise<void> {
-		await this._runGit(repositoryRoot, ['worktree', 'remove', '--force', worktree.fsPath], { timeout: 60_000, throwOnError: true });
+	async removeWorktree(repositoryRoot: URI, worktree: URI, options?: { readonly force?: boolean }): Promise<void> {
+		const args = ['worktree', 'remove'];
+		if (options?.force) {
+			args.push('--force');
+		}
+		args.push(worktree.fsPath);
+		await this._runGit(repositoryRoot, args, { timeout: 60_000, throwOnError: true });
 	}
 
 	async branchExists(repositoryRoot: URI, branchName: string): Promise<boolean> {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2196,9 +2196,9 @@ export class AgentService extends Disposable implements IAgentService {
 		// the repository can no longer be resolved and the refs would leak
 		// into the main repository (`refs/agents/*` is shared, not per-worktree).
 		const sessionId = AgentSession.id(session);
-		await this._worktree?.prepareSessionDeletion(session, sessionId);
+		const worktree = await this._worktree?.prepareSessionDeletion(session, sessionId);
 		await this._sessionDataService.deleteSessionData(session, workingDirectories);
-		await this._worktree?.removeSessionWorktree(sessionId);
+		await this._worktree?.removeSessionWorktree(sessionId, worktree);
 		this._changesetCoordinator.onSessionDisposed(session.toString());
 		this._sideEffects.cancelSessionTitleGeneration(session.toString());
 		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1934,7 +1934,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// The agent no longer knows about worktrees; the host's worktree project
 		// (created in the first-send hook) wins for worktree-isolated sessions, and
 		// falls back to whatever the agent reported for folder sessions.
-		const project = this._worktree?.createdWorktreeProject(AgentSession.id(e.session)) ?? e.project;
+		const project = this._worktree?.sessionWorktreeProject(AgentSession.id(e.session)) ?? e.project;
 		const currentSet = currentSummary.workingDirectories?.map(d => URI.parse(d));
 		const summary: SessionSummary = {
 			...currentSummary,
@@ -2195,10 +2195,10 @@ export class AgentService extends Disposable implements IAgentService {
 		// session the working directory *is* the worktree, so once it is gone
 		// the repository can no longer be resolved and the refs would leak
 		// into the main repository (`refs/agents/*` is shared, not per-worktree).
+		const sessionId = AgentSession.id(session);
+		await this._worktree?.prepareSessionDeletion(session, sessionId);
 		await this._sessionDataService.deleteSessionData(session, workingDirectories);
-		// Remove any worktree this process created for the session (host-owned;
-		// agents stay unaware).
-		await this._worktree?.removeCreatedWorktree(AgentSession.id(session));
+		await this._worktree?.removeSessionWorktree(sessionId);
 		this._changesetCoordinator.onSessionDisposed(session.toString());
 		this._sideEffects.cancelSessionTitleGeneration(session.toString());
 		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {
@@ -4102,8 +4102,6 @@ export class AgentService extends Disposable implements IAgentService {
 			promises.push(provider.shutdown());
 		}
 		await Promise.all(promises);
-		// Drain any worktrees this process created so none leak on shutdown.
-		await this._worktree?.removeAllCreatedWorktrees();
 		this._sessionToProvider.clear();
 		this._downloadProgressInterest.clear();
 	}

--- a/src/vs/platform/agentHost/node/claude/CONTEXT.md
+++ b/src/vs/platform/agentHost/node/claude/CONTEXT.md
@@ -1177,10 +1177,10 @@ is an internal concern of the agent. The IAgent surface exposes only:
 |---|---|---|
 | `createSession(config)` (no `fork`) → `IAgentCreateSessionResult { provisional: true }` | none (no SDK call) | Records a **provisional** session: id, requested `workingDirectory` (= the repo path the client passed in), title, model, etc. No `Query`. No on-disk session file. The agent reserves the eventual session id locally. The session shows up in `listSessions` but cannot receive messages until materialized. |
 | `createSession({ fork: { session, turnIndex, turnId, turnIdMapping? } })` → `IAgentCreateSessionResult { provisional: false }` | `forkSession(parentSessionId, { upToMessageId: lastUuidOfTurn(turnId), title? })` → `{ sessionId }` | **Materializes immediately on disk** because `forkSession` writes the new session file synchronously. SDK rewrites every message UUID and rebuilds the `parentUuid` chain. Result is **not provisional**. No `Query` is started yet — that still happens lazily on first `sendMessage` — but because the session already exists on disk, the materialization path will use `resume: forkedSessionId` in `Options` (see *Fresh vs resumed* below). The agent fires `onDidMaterializeSession` here, immediately after `forkSession` returns. |
-| (internal) first `sendMessage` on a provisional session | `query({ options })` with `Options.sessionId = sessionId` (fresh) or `Options.resume = sessionId` (resumed) | Triggers internal materialization. Resolves effective `workingDirectory` (Copilot may create a worktree); constructs `Options`; starts `Query`; fires `onDidMaterializeSession`; then proceeds to send the actual user message. Subsequent `sendMessage` calls reuse the live `Query`. |
-| `onArchivedChanged(uri, isArchived)` (optional) | none (SDK untouched) | Soft, reversible. `true`: remove worktree dir from disk if branch is preserved and tree is clean (Copilot's `_cleanupWorktreeOnArchive`). `false`: `git worktree add --existing` against the preserved branch (`_recreateWorktreeOnUnarchive`). SDK session, per-session DB, branch all untouched. Claude does not implement this yet. |
-| `disposeSession(sessionId)` | `Query.interrupt()` + `Query.return()` (or asyncDispose) | Full teardown of one session: kill SDK `Query`, drop in-memory wrapper, delete state-manager entry, and (Copilot) remove the worktree if it was created in this process. Triggered by explicit protocol `disposeSession` or the empty-session GC. |
-| `shutdown()` | per-session `Query.interrupt()` + asyncDispose, serialized through a sequencer; then SDK client stop | Graceful, async, **memoized** drain of all sessions. Walks `_sessions` ∪ `_createdWorktrees`, runs `_destroyAndDisposeSession` per id through `_sessionSequencer` so it interleaves with concurrent `sendMessage` / `disposeSession`. Claude additionally aborts provisional `AbortController`s first so any racing `await sdk.startup()` unwinds cleanly. |
+| (internal) first `sendMessage` on a provisional session | `query({ options })` with `Options.sessionId = sessionId` (fresh) or `Options.resume = sessionId` (resumed) | Triggers internal materialization. The host resolves the effective `workingDirectory`, creating a worktree when configured; the provider constructs `Options`, starts `Query`, fires `onDidMaterializeSession`, and sends the user message. Subsequent `sendMessage` calls reuse the live `Query`. |
+| `onArchivedChanged(uri, isArchived)` (optional) | none (SDK untouched) | The host owns worktree archive/unarchive cleanup for every provider. The provider hook handles provider-specific state only. |
+| `disposeSession(sessionId)` | `Query.interrupt()` + `Query.return()` (or asyncDispose) | Full teardown of one session. After provider teardown, the host loads persisted worktree metadata, deletes session data and checkpoint refs, then removes the worktree. |
+| `shutdown()` | per-session `Query.interrupt()` + asyncDispose, serialized through a sequencer; then SDK client stop | Graceful, async, **memoized** provider drain. Session-owned worktrees remain on disk across host restarts. |
 | `dispose()` | synchronous teardown of provider | Hard provider teardown. Copilot: kicks off `shutdown()` and chains `super.dispose()` in `.finally` (cooperatively reuses the memoized drain). Claude: aborts provisional controllers, then `super.dispose()` synchronously disposes `_sessions` (each wrapper interrupts/asyncDisposes its `Query`), then releases `_proxyHandle` — wrapper-before-proxy ordering is load-bearing. |
 
 #### Birth axis: provisional → materialized
@@ -1209,10 +1209,9 @@ plus an event**, not a method pair.
   agent receives `sendMessage` for a still-undermaterialized session
   (whether the on-disk file exists from fork or doesn't exist yet),
   it:
-  1. Resolves the effective `workingDirectory`. Copilot's
-     `_resolveSessionWorkingDirectory` consults `_createdWorktrees`
-     and may run `git worktree add` on a fresh branch. Claude
-     currently uses the requested path as-is.
+  1. Asks the host to resolve the effective `workingDirectory`.
+     `WorktreeIsolation` may run `git worktree add` on a fresh branch
+     before either provider locks in its SDK working directory.
   2. Constructs SDK `Options` with that `cwd` and all other
      startup-only fields.
   3. Calls `query({ options })` → SDK forks the CLI subprocess,
@@ -1342,8 +1341,8 @@ background.
 
 | Surface | Scope | Sync? | Reuses `shutdown`? | Notes |
 |---|---|---|---|---|
-| `disposeSession(id)` | one session | async | n/a | Routes through `_sessionSequencer` so it serializes against in-flight `sendMessage`. Worktree removal consults the **in-memory** `_createdWorktrees` map — sessions created in a previous process lifetime are not removed by this path; archive cleanup picks them up via the persisted DB metadata. |
-| `shutdown()` | all sessions | async, memoized | self | Walks `_sessions ∪ _createdWorktrees`. Memoization (`_shutdownPromise`) means concurrent calls fold into one drain. Claude aborts provisionals first to unwind racing `sdk.startup()` awaits. |
+| `disposeSession(id)` | one session | async | n/a | Routes through the provider sequencer so it serializes against in-flight `sendMessage`. The host loads persisted worktree metadata before deleting the session database, so deletion also cleans up sessions created in an earlier process. |
+| `shutdown()` | all sessions | async, memoized | self | Drains provider sessions while preserving session-owned worktrees. Memoization (`_shutdownPromise`) means concurrent calls fold into one drain. Claude aborts provisionals first to unwind racing `sdk.startup()` awaits. |
 | `dispose()` | provider | sync surface; may chain async | Copilot: yes; Claude: no | Copilot: `shutdown().finally(super.dispose)` — cooperative. Claude: synchronous wrapper-then-proxy teardown, no graceful drain. The provider choice is intentional: Claude's wrapper is the stronger ownership and must dispose before the IPC handle. |
 
 `AgentService.shutdown` fans out `provider.shutdown()` in parallel;
@@ -1391,9 +1390,9 @@ internally decides whether `dispose` chains `shutdown` or not.
 
 | | CopilotAgent | ClaudeAgent |
 |---|---|---|
-| Worktree on materialize | Yes (`_resolveSessionWorkingDirectory` + `_createdWorktrees`) | No (uses requested `workingDirectory` as-is) |
-| `onArchivedChanged` | Implemented (clean + recreate) | Not implemented |
-| `disposeSession` worktree path | Consults in-memory `_createdWorktrees` | No worktree state to clean |
+| Worktree on materialize | Host-owned `WorktreeIsolation` | Host-owned `WorktreeIsolation` |
+| `onArchivedChanged` | Host performs worktree cleanup/recreation | Host performs worktree cleanup/recreation |
+| `disposeSession` worktree path | Host loads persisted metadata and removes the worktree | Host loads persisted metadata and removes the worktree |
 | `shutdown` provisional handling | Drops provisional records + `_activeClients` snapshot | Aborts provisional `AbortController`s first to unwind racing `sdk.startup()` |
 | `dispose` strategy | Chain `shutdown().finally(super.dispose)` | Synchronous wrapper-then-proxy teardown (no graceful drain) |
 | Sequencer | `_sessionSequencer` (per-session) | `_disposeSequencer` (drain only) |

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -319,16 +319,13 @@ export interface IResolveWorkingDirectoryRequest {
  * A single host-owned instance serves every agent: the orchestrator
  * ({@link AgentService}) creates it and drives the lifecycle so individual
  * agents stay unaware of the folder-vs-worktree distinction. Session state
- * (`_sessionWorktrees`, pending markers, pending announcements) is keyed by the
+ * (`_materializedWorktrees`, pending markers, pending announcements) is keyed by the
  * globally-unique sessionId, so sharing one instance across agents is safe.
  */
 export class WorktreeIsolation extends Disposable {
 
-	/**
-	 * Materialized worktrees keyed by sessionId, including persisted worktrees
-	 * loaded for deletion after a process restart.
-	 */
-	private readonly _sessionWorktrees = new Map<string, ISessionWorktree>();
+	/** Worktrees materialized during this host process, keyed by sessionId. */
+	private readonly _materializedWorktrees = new Map<string, ISessionWorktree>();
 
 	/**
 	 * Per-session announcement (markdown) emitted as a synthetic streaming
@@ -377,11 +374,6 @@ export class WorktreeIsolation extends Disposable {
 		this._branchNameGenerator = branchNameGenerator ?? new AgentBranchNameGenerator(copilotApiService, this._logService);
 	}
 
-	/** SessionIds with a materialized worktree currently tracked by the host. */
-	get trackedWorktreeSessionIds(): readonly string[] {
-		return [...this._sessionWorktrees.keys()];
-	}
-
 	/**
 	 * Marks a fresh worktree-isolation session as pending — its worktree is
 	 * deferred to the first send. Called by the host while a creating session's
@@ -407,7 +399,7 @@ export class WorktreeIsolation extends Disposable {
 
 	/** The worktree created for a session in this process, if any. */
 	getResolvedWorktree(sessionId: string): URI | undefined {
-		return this._sessionWorktrees.get(sessionId)?.worktree;
+		return this._materializedWorktrees.get(sessionId)?.worktree;
 	}
 
 	/**
@@ -564,7 +556,7 @@ export class WorktreeIsolation extends Disposable {
 		// process (e.g. the caller re-enters materialization after a thread
 		// restart or a post-creation failure) reuse it rather than creating a
 		// second branch + worktree.
-		const already = this._sessionWorktrees.get(sessionId);
+		const already = this._materializedWorktrees.get(sessionId);
 		if (already) {
 			return already.worktree;
 		}
@@ -627,7 +619,7 @@ export class WorktreeIsolation extends Disposable {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to copy worktree include files: ${errorMessage(error)}`);
 			}
 		}
-		this._sessionWorktrees.set(sessionId, { repositoryRoot, worktree });
+		this._materializedWorktrees.set(sessionId, { repositoryRoot, worktree });
 		// Queue the worktree announcement so the first turn (live) and any
 		// subsequent restore (history) both surface the message in the chat.
 		this._pendingFirstTurnAnnouncements.set(sessionId, buildWorktreeAnnouncementText(branchName));
@@ -730,11 +722,12 @@ export class WorktreeIsolation extends Disposable {
 		return prependAnnouncementToFirstTurn(turns, buildWorktreeAnnouncementText(notice.branchName));
 	}
 
-	/** Loads persisted worktree ownership before the session database is deleted. */
-	async prepareSessionDeletion(sessionUri: URI, sessionId: string): Promise<void> {
+	/** Resolves the worktree to remove before the session database is deleted. */
+	async prepareSessionDeletion(sessionUri: URI, sessionId: string): Promise<ISessionWorktree | undefined> {
 		return this._sequencer.queue(sessionId, async () => {
-			if (this._sessionWorktrees.has(sessionId)) {
-				return;
+			const materializedWorktree = this._materializedWorktrees.get(sessionId);
+			if (materializedWorktree) {
+				return materializedWorktree;
 			}
 			let meta: IWorktreeMetadata | undefined;
 			try {
@@ -744,25 +737,25 @@ export class WorktreeIsolation extends Disposable {
 				return;
 			}
 			if (meta?.worktreePath && meta.repositoryRoot) {
-				this._sessionWorktrees.set(sessionId, { repositoryRoot: meta.repositoryRoot, worktree: meta.worktreePath });
+				return { repositoryRoot: meta.repositoryRoot, worktree: meta.worktreePath };
 			}
+			return undefined;
 		});
 	}
 
-	/** Force-removes a tracked worktree after the user confirms session deletion. */
-	async removeSessionWorktree(sessionId: string): Promise<void> {
-		return this._sequencer.queue(sessionId, () => this._removeSessionWorktree(sessionId));
+	/** Force-removes the resolved worktree after the user confirms session deletion. */
+	async removeSessionWorktree(sessionId: string, worktree: ISessionWorktree | undefined): Promise<void> {
+		return this._sequencer.queue(sessionId, () => this._removeSessionWorktree(sessionId, worktree));
 	}
 
-	private async _removeSessionWorktree(sessionId: string): Promise<void> {
+	private async _removeSessionWorktree(sessionId: string, worktree: ISessionWorktree | undefined): Promise<void> {
 		this.clearPending(sessionId);
-		const worktree = this._sessionWorktrees.get(sessionId);
 		if (!worktree) {
 			return;
 		}
 		try {
 			await this._gitService.removeWorktree(worktree.repositoryRoot, worktree.worktree, { force: true });
-			this._sessionWorktrees.delete(sessionId);
+			this._materializedWorktrees.delete(sessionId);
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to remove worktree '${worktree.worktree.fsPath}': ${errorMessage(error)}`);
 		}
@@ -789,7 +782,7 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await fs.access(worktreePath.fsPath);
 		} catch {
-			this._sessionWorktrees.delete(sessionId);
+			this._materializedWorktrees.delete(sessionId);
 			return;
 		}
 
@@ -815,7 +808,7 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await this._gitService.removeWorktree(repositoryRoot, worktreePath);
 			this._logService.info(`[${this._logLabel}:${sessionId}] Removed worktree '${worktreePath.fsPath}' on archive`);
-			this._sessionWorktrees.delete(sessionId);
+			this._materializedWorktrees.delete(sessionId);
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to remove worktree '${worktreePath.fsPath}' on archive: ${errorMessage(error)}`);
 		}
@@ -858,7 +851,7 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await fs.mkdir(URI.joinPath(worktreePath, '..').fsPath, { recursive: true });
 			await this._gitService.addExistingWorktree(repositoryRoot, worktreePath, branchName);
-			this._sessionWorktrees.set(sessionId, { repositoryRoot, worktree: worktreePath });
+			this._materializedWorktrees.set(sessionId, { repositoryRoot, worktree: worktreePath });
 			this._logService.info(`[${this._logLabel}:${sessionId}] Recreated worktree '${worktreePath.fsPath}'`);
 			return { ok: true };
 		} catch (error) {
@@ -908,7 +901,7 @@ export class WorktreeIsolation extends Disposable {
 	 * materializes.
 	 */
 	sessionWorktreeProject(sessionId: string): IAgentSessionProjectInfo | undefined {
-		const worktree = this._sessionWorktrees.get(sessionId);
+		const worktree = this._materializedWorktrees.get(sessionId);
 		return worktree ? projectFromRepositoryRoot(worktree.repositoryRoot) : undefined;
 	}
 

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -326,6 +326,7 @@ export class WorktreeIsolation extends Disposable {
 
 	/** Worktrees materialized during this host process, keyed by sessionId. */
 	private readonly _materializedWorktrees = new Map<string, ISessionWorktree>();
+	private readonly _worktreeDeletionRetries = new Map<string, ISessionWorktree>();
 
 	/**
 	 * Per-session announcement (markdown) emitted as a synthetic streaming
@@ -725,21 +726,23 @@ export class WorktreeIsolation extends Disposable {
 	/** Resolves the worktree to remove before the session database is deleted. */
 	async prepareSessionDeletion(sessionUri: URI, sessionId: string): Promise<ISessionWorktree | undefined> {
 		return this._sequencer.queue(sessionId, async () => {
+			const deletionRetry = this._worktreeDeletionRetries.get(sessionId);
+			if (deletionRetry) {
+				return deletionRetry;
+			}
 			const materializedWorktree = this._materializedWorktrees.get(sessionId);
 			if (materializedWorktree) {
 				return materializedWorktree;
 			}
-			let meta: IWorktreeMetadata | undefined;
 			try {
-				meta = await this._readWorktreeMetadata(sessionUri);
+				const meta = await this._readWorktreeMetadata(sessionUri);
+				return meta?.worktreePath && meta.repositoryRoot
+					? { repositoryRoot: meta.repositoryRoot, worktree: meta.worktreePath }
+					: undefined;
 			} catch (error) {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to read worktree metadata before session deletion: ${errorMessage(error)}`);
-				return;
+				throw error;
 			}
-			if (meta?.worktreePath && meta.repositoryRoot) {
-				return { repositoryRoot: meta.repositoryRoot, worktree: meta.worktreePath };
-			}
-			return undefined;
 		});
 	}
 
@@ -756,8 +759,11 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await this._gitService.removeWorktree(worktree.repositoryRoot, worktree.worktree, { force: true });
 			this._materializedWorktrees.delete(sessionId);
+			this._worktreeDeletionRetries.delete(sessionId);
 		} catch (error) {
+			this._worktreeDeletionRetries.set(sessionId, worktree);
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to remove worktree '${worktree.worktree.fsPath}': ${errorMessage(error)}`);
+			throw error;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -52,9 +52,15 @@ export class SessionWorkingDirectoryMissingError extends Error {
 const BRANCH_COMPLETION_LIMIT = 25;
 const WORKTREE_PROGRESS_DEBOUNCE_MS = 40;
 
-interface ICreatedWorktree {
+interface ISessionWorktree {
 	readonly repositoryRoot: URI;
 	readonly worktree: URI;
+}
+
+interface IWorktreeMetadata {
+	readonly branchName: string;
+	readonly worktreePath?: URI;
+	readonly repositoryRoot?: URI;
 }
 
 /**
@@ -308,22 +314,21 @@ export interface IResolveWorkingDirectoryRequest {
  * - creating the worktree on materialization and persisting its metadata
  *   ({@link resolveWorkingDirectory});
  * - surfacing worktree creation success/failure notices live and on restore;
- * - cleaning up / recreating the worktree on dispose, archive, and unarchive.
+ * - cleaning up / recreating the worktree on session deletion, archive, and unarchive.
  *
  * A single host-owned instance serves every agent: the orchestrator
  * ({@link AgentService}) creates it and drives the lifecycle so individual
  * agents stay unaware of the folder-vs-worktree distinction. Session state
- * (`_createdWorktrees`, pending markers, pending announcements) is keyed by the
+ * (`_sessionWorktrees`, pending markers, pending announcements) is keyed by the
  * globally-unique sessionId, so sharing one instance across agents is safe.
  */
 export class WorktreeIsolation extends Disposable {
 
 	/**
-	 * Worktrees created by this agent in the current process, keyed by
-	 * sessionId. Used to remove the worktree on dispose / error and to
-	 * enumerate live worktrees during shutdown.
+	 * Materialized worktrees keyed by sessionId, including persisted worktrees
+	 * loaded for deletion after a process restart.
 	 */
-	private readonly _createdWorktrees = new Map<string, ICreatedWorktree>();
+	private readonly _sessionWorktrees = new Map<string, ISessionWorktree>();
 
 	/**
 	 * Per-session announcement (markdown) emitted as a synthetic streaming
@@ -352,7 +357,7 @@ export class WorktreeIsolation extends Disposable {
 	 * Serializes the worktree lifecycle per session so a first-send creation
 	 * ({@link resolveOnFirstSend}) never interleaves with archive/unarchive
 	 * cleanup ({@link cleanupWorktreeOnArchive} / {@link recreateWorktreeOnUnarchive})
-	 * or dispose ({@link removeCreatedWorktree}) for the same session — the
+	 * or deletion ({@link removeSessionWorktree}) for the same session — the
 	 * guarantee each agent previously enforced with its own sequencer.
 	 */
 	private readonly _sequencer = new SequencerByKey<string>();
@@ -372,9 +377,9 @@ export class WorktreeIsolation extends Disposable {
 		this._branchNameGenerator = branchNameGenerator ?? new AgentBranchNameGenerator(copilotApiService, this._logService);
 	}
 
-	/** SessionIds with a worktree created by this agent in the current process. */
-	get createdWorktreeSessionIds(): readonly string[] {
-		return [...this._createdWorktrees.keys()];
+	/** SessionIds with a materialized worktree currently tracked by the host. */
+	get trackedWorktreeSessionIds(): readonly string[] {
+		return [...this._sessionWorktrees.keys()];
 	}
 
 	/**
@@ -402,7 +407,7 @@ export class WorktreeIsolation extends Disposable {
 
 	/** The worktree created for a session in this process, if any. */
 	getResolvedWorktree(sessionId: string): URI | undefined {
-		return this._createdWorktrees.get(sessionId)?.worktree;
+		return this._sessionWorktrees.get(sessionId)?.worktree;
 	}
 
 	/**
@@ -559,7 +564,7 @@ export class WorktreeIsolation extends Disposable {
 		// process (e.g. the caller re-enters materialization after a thread
 		// restart or a post-creation failure) reuse it rather than creating a
 		// second branch + worktree.
-		const already = this._createdWorktrees.get(sessionId);
+		const already = this._sessionWorktrees.get(sessionId);
 		if (already) {
 			return already.worktree;
 		}
@@ -622,7 +627,7 @@ export class WorktreeIsolation extends Disposable {
 				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to copy worktree include files: ${errorMessage(error)}`);
 			}
 		}
-		this._createdWorktrees.set(sessionId, { repositoryRoot, worktree });
+		this._sessionWorktrees.set(sessionId, { repositoryRoot, worktree });
 		// Queue the worktree announcement so the first turn (live) and any
 		// subsequent restore (history) both surface the message in the chat.
 		this._pendingFirstTurnAnnouncements.set(sessionId, buildWorktreeAnnouncementText(branchName));
@@ -725,36 +730,42 @@ export class WorktreeIsolation extends Disposable {
 		return prependAnnouncementToFirstTurn(turns, buildWorktreeAnnouncementText(notice.branchName));
 	}
 
-	/**
-	 * Removes the worktree created for a session in the current process (if
-	 * any). Used on session dispose and on materialization failure.
-	 */
-	async removeCreatedWorktree(sessionId: string): Promise<void> {
-		return this._sequencer.queue(sessionId, () => this._removeCreatedWorktree(sessionId));
+	/** Loads persisted worktree ownership before the session database is deleted. */
+	async prepareSessionDeletion(sessionUri: URI, sessionId: string): Promise<void> {
+		return this._sequencer.queue(sessionId, async () => {
+			if (this._sessionWorktrees.has(sessionId)) {
+				return;
+			}
+			let meta: IWorktreeMetadata | undefined;
+			try {
+				meta = await this._readWorktreeMetadata(sessionUri);
+			} catch (error) {
+				this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to read worktree metadata before session deletion: ${errorMessage(error)}`);
+				return;
+			}
+			if (meta?.worktreePath && meta.repositoryRoot) {
+				this._sessionWorktrees.set(sessionId, { repositoryRoot: meta.repositoryRoot, worktree: meta.worktreePath });
+			}
+		});
 	}
 
-	private async _removeCreatedWorktree(sessionId: string): Promise<void> {
+	/** Force-removes a tracked worktree after the user confirms session deletion. */
+	async removeSessionWorktree(sessionId: string): Promise<void> {
+		return this._sequencer.queue(sessionId, () => this._removeSessionWorktree(sessionId));
+	}
+
+	private async _removeSessionWorktree(sessionId: string): Promise<void> {
 		this.clearPending(sessionId);
-		const worktree = this._createdWorktrees.get(sessionId);
+		const worktree = this._sessionWorktrees.get(sessionId);
 		if (!worktree) {
 			return;
 		}
 		try {
-			await this._gitService.removeWorktree(worktree.repositoryRoot, worktree.worktree);
+			await this._gitService.removeWorktree(worktree.repositoryRoot, worktree.worktree, { force: true });
+			this._sessionWorktrees.delete(sessionId);
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to remove worktree '${worktree.worktree.fsPath}': ${errorMessage(error)}`);
-		} finally {
-			this._createdWorktrees.delete(sessionId);
 		}
-	}
-
-	/**
-	 * Removes every worktree created by this agent in the current process.
-	 * Called from the agent's `shutdown` so no isolated worktree is leaked when
-	 * the provider is torn down, matching Copilot's shutdown drain.
-	 */
-	async removeAllCreatedWorktrees(): Promise<void> {
-		await Promise.all(this.createdWorktreeSessionIds.map(sessionId => this.removeCreatedWorktree(sessionId)));
 	}
 
 	/**
@@ -778,7 +789,7 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await fs.access(worktreePath.fsPath);
 		} catch {
-			this._createdWorktrees.delete(sessionId);
+			this._sessionWorktrees.delete(sessionId);
 			return;
 		}
 
@@ -804,10 +815,9 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await this._gitService.removeWorktree(repositoryRoot, worktreePath);
 			this._logService.info(`[${this._logLabel}:${sessionId}] Removed worktree '${worktreePath.fsPath}' on archive`);
+			this._sessionWorktrees.delete(sessionId);
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to remove worktree '${worktreePath.fsPath}' on archive: ${errorMessage(error)}`);
-		} finally {
-			this._createdWorktrees.delete(sessionId);
 		}
 	}
 
@@ -848,7 +858,7 @@ export class WorktreeIsolation extends Disposable {
 		try {
 			await fs.mkdir(URI.joinPath(worktreePath, '..').fsPath, { recursive: true });
 			await this._gitService.addExistingWorktree(repositoryRoot, worktreePath, branchName);
-			this._createdWorktrees.set(sessionId, { repositoryRoot, worktree: worktreePath });
+			this._sessionWorktrees.set(sessionId, { repositoryRoot, worktree: worktreePath });
 			this._logService.info(`[${this._logLabel}:${sessionId}] Recreated worktree '${worktreePath.fsPath}'`);
 			return { ok: true };
 		} catch (error) {
@@ -859,7 +869,7 @@ export class WorktreeIsolation extends Disposable {
 	}
 
 	/** Reads the persisted worktree metadata for a session, if any. */
-	async readWorktreeMetadata(sessionUri: URI): Promise<{ branchName: string; worktreePath?: URI; repositoryRoot?: URI } | undefined> {
+	async readWorktreeMetadata(sessionUri: URI): Promise<IWorktreeMetadata | undefined> {
 		return this._readWorktreeMetadata(sessionUri);
 	}
 
@@ -897,8 +907,8 @@ export class WorktreeIsolation extends Disposable {
 	 * metadata read so a fresh worktree groups under the repository the moment it
 	 * materializes.
 	 */
-	createdWorktreeProject(sessionId: string): IAgentSessionProjectInfo | undefined {
-		const worktree = this._createdWorktrees.get(sessionId);
+	sessionWorktreeProject(sessionId: string): IAgentSessionProjectInfo | undefined {
+		const worktree = this._sessionWorktrees.get(sessionId);
 		return worktree ? projectFromRepositoryRoot(worktree.repositoryRoot) : undefined;
 	}
 
@@ -947,7 +957,7 @@ export class WorktreeIsolation extends Disposable {
 	 * Reads worktree metadata and migrates repository roots written before linked checkouts were canonicalized.
 	 * It probes an existing worktree when available and otherwise falls back to the persisted root for archived sessions.
 	 */
-	private async _readWorktreeMetadata(sessionUri: URI): Promise<{ branchName: string; worktreePath?: URI; repositoryRoot?: URI } | undefined> {
+	private async _readWorktreeMetadata(sessionUri: URI): Promise<IWorktreeMetadata | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);
 		if (!ref) {
 			return undefined;

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -15,7 +15,7 @@
 
 import assert from 'assert';
 import * as cp from 'child_process';
-import { mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
@@ -551,6 +551,40 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
+	(hasGit ? test : test.skip)('removeWorktree preserves dirty work unless forced', async () => {
+		const dir = initRepo();
+		const fs = await import('fs/promises');
+		const wtPath = join(dir, '..', `wt-dirty-${Date.now()}`);
+		try {
+			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/dirty-worktree', 'main');
+			await fs.writeFile(join(wtPath, 'untracked.txt'), 'keep me');
+
+			let safeRemovalFailed = false;
+			try {
+				await svc!.removeWorktree(URI.file(dir), URI.file(wtPath));
+			} catch {
+				safeRemovalFailed = true;
+			}
+			const existsAfterSafeRemoval = existsSync(wtPath);
+
+			await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true });
+
+			assert.deepStrictEqual({
+				safeRemovalFailed,
+				existsAfterSafeRemoval,
+				existsAfterForcedRemoval: existsSync(wtPath),
+			}, {
+				safeRemovalFailed: true,
+				existsAfterSafeRemoval: true,
+				existsAfterForcedRemoval: false,
+			});
+		} finally {
+			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
+			rmDirWithRetry(wtPath);
+			try { cp.execFileSync('git', ['branch', '-D', 'agents/dirty-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
+		}
+	});
+
 	(hasGit ? test : test.skip)('addWorktree prefers origin start point when local branch is stale', async () => {
 		const dir = initRepo();
 		const fs = await import('fs/promises');
@@ -569,7 +603,7 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 			assert.ok(stat.isFile(), 'worktree should start from origin/main, not stale local main');
 			assert.throws(() => cp.execFileSync('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], { cwd: wtPath, env, stdio: 'pipe' }), /fatal:/);
 		} finally {
-			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath)); } catch { /* best-effort cleanup */ }
+			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
 			rmDirWithRetry(wtPath);
 			try { cp.execFileSync('git', ['branch', '-D', 'agents/test-origin-start-point'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 		}
@@ -647,7 +681,7 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 				progressDone: 5,
 			});
 		} finally {
-			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath)); } catch { /* best-effort cleanup */ }
+			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
 			rmDirWithRetry(wtPath);
 			try { cp.execFileSync('git', ['branch', '-D', 'agents/include-files'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 		}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1563,13 +1563,18 @@ suite('AgentService (node dispatcher)', () => {
 			svc.registerProvider(copilotAgent);
 			const session = await svc.createSession({ provider: 'copilot' });
 			svc.setWorktreeIsolation({
-				prepareSessionDeletion: async () => { order.push('prepareSessionDeletion'); },
-				removeSessionWorktree: async () => { order.push('removeSessionWorktree'); },
+				prepareSessionDeletion: async () => {
+					order.push('prepareSessionDeletion');
+					return { repositoryRoot: URI.file('/repo'), worktree: URI.file('/worktree') };
+				},
+				removeSessionWorktree: async (_sessionId: string, worktree: { readonly worktree: URI } | undefined) => {
+					order.push(`removeSessionWorktree:${worktree?.worktree.fsPath}`);
+				},
 			} as unknown as WorktreeIsolation);
 
 			await svc.disposeSession(session);
 
-			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree']);
+			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree:/worktree']);
 		});
 	});
 
@@ -2860,10 +2865,10 @@ suite('AgentService (node dispatcher)', () => {
 
 			assert.deepStrictEqual({
 				removeWorktreeCalls,
-				createdSessions: isolation.trackedWorktreeSessionIds,
+				resolvedWorktree: isolation.getResolvedWorktree('session')?.toString(),
 			}, {
 				removeWorktreeCalls: 0,
-				createdSessions: ['session'],
+				resolvedWorktree: URI.joinPath(getWorktreesRoot(workingDirectory), 'test').toString(),
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -14,6 +14,7 @@ import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { join } from '../../../../base/common/path.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -1562,12 +1563,13 @@ suite('AgentService (node dispatcher)', () => {
 			svc.registerProvider(copilotAgent);
 			const session = await svc.createSession({ provider: 'copilot' });
 			svc.setWorktreeIsolation({
-				removeCreatedWorktree: async () => { order.push('removeCreatedWorktree'); },
+				prepareSessionDeletion: async () => { order.push('prepareSessionDeletion'); },
+				removeSessionWorktree: async () => { order.push('removeSessionWorktree'); },
 			} as unknown as WorktreeIsolation);
 
 			await svc.disposeSession(session);
 
-			assert.deepStrictEqual(order, ['deleteSessionData', 'removeCreatedWorktree']);
+			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree']);
 		});
 	});
 
@@ -2819,6 +2821,50 @@ suite('AgentService (node dispatcher)', () => {
 
 			await service.shutdown();
 			assert.ok(copilotShutdown);
+		});
+
+		test('preserves worktrees owned by persistent sessions', async () => {
+			const workingDirectory = URI.file(mkdtempSync(join(tmpdir(), 'agent-service-shutdown-')));
+			const worktreesRoot = getWorktreesRoot(workingDirectory);
+			disposables.add(toDisposable(() => {
+				rmSync(workingDirectory.fsPath, { recursive: true, force: true });
+				rmSync(worktreesRoot.fsPath, { recursive: true, force: true });
+			}));
+			const gitService = createNoopGitService();
+			gitService.getRepositoryRoot = async () => workingDirectory;
+			gitService.revParse = async () => 'head';
+			gitService.getDefaultBranch = async () => ({ name: 'main', startPoint: 'main' });
+			gitService.addWorktree = async () => { };
+			let removeWorktreeCalls = 0;
+			gitService.removeWorktree = async () => { removeWorktreeCalls++; };
+			const isolation = disposables.add(new WorktreeIsolation(
+				{ generateBranchName: async () => 'agents/test' },
+				gitService,
+				new TestCopilotApiService(),
+				nullSessionDataService,
+				new NullLogService(),
+			));
+			service.setWorktreeIsolation(isolation);
+			service.registerProvider(copilotAgent);
+			await isolation.resolveWorkingDirectory({
+				sessionUri: AgentSession.uri('copilot', 'session'),
+				sessionId: 'session',
+				workingDirectory,
+				config: {
+					[SessionConfigKey.Isolation]: 'worktree',
+					[SessionConfigKey.Branch]: 'main',
+				},
+			});
+
+			await service.shutdown();
+
+			assert.deepStrictEqual({
+				removeWorktreeCalls,
+				createdSessions: isolation.trackedWorktreeSessionIds,
+			}, {
+				removeWorktreeCalls: 0,
+				createdSessions: ['session'],
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1576,6 +1576,24 @@ suite('AgentService (node dispatcher)', () => {
 
 			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree:/worktree']);
 		});
+
+		test('preserves session data when worktree metadata cannot be read', async () => {
+			let deletedSessionData = false;
+			const sessionDataService: ISessionDataService = {
+				...nullSessionDataService,
+				deleteSessionData: async () => { deletedSessionData = true; },
+			};
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			svc.registerProvider(copilotAgent);
+			const session = await svc.createSession({ provider: 'copilot' });
+			svc.setWorktreeIsolation({
+				prepareSessionDeletion: async () => { throw new Error('metadata unavailable'); },
+			} as unknown as WorktreeIsolation);
+
+			await assert.rejects(() => svc.disposeSession(session), /metadata unavailable/);
+
+			assert.strictEqual(deletedSessionData, false);
+		});
 	});
 
 	// ---- listSessions / listModels --------------------------------------

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1568,13 +1568,13 @@ suite('AgentService (node dispatcher)', () => {
 					return { repositoryRoot: URI.file('/repo'), worktree: URI.file('/worktree') };
 				},
 				removeSessionWorktree: async (_sessionId: string, worktree: { readonly worktree: URI } | undefined) => {
-					order.push(`removeSessionWorktree:${worktree?.worktree.fsPath}`);
+					order.push(`removeSessionWorktree:${worktree?.worktree.toString()}`);
 				},
 			} as unknown as WorktreeIsolation);
 
 			await svc.disposeSession(session);
 
-			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree:/worktree']);
+			assert.deepStrictEqual(order, ['prepareSessionDeletion', 'deleteSessionData', 'removeSessionWorktree:file:///worktree']);
 		});
 
 		test('preserves session data when worktree metadata cannot be read', async () => {

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -47,7 +47,7 @@ suite('WorktreeIsolation', () => {
 	let db: TestSessionDatabase;
 	let addWorktreeCalls: { worktree: URI; branchName: string; startPoint: string; track: boolean }[];
 	let addExistingCalls: { worktree: URI; branchName: string }[];
-	let removeCalls: URI[];
+	let removeCalls: { worktree: URI; force: boolean }[];
 	let copyIncludeCalls: { repositoryRoot: URI; worktree: URI; globs: readonly string[] }[];
 	let copyIncludeError: Error | undefined;
 	let branchName: string;
@@ -85,8 +85,8 @@ suite('WorktreeIsolation', () => {
 				addExistingCalls.push({ worktree, branchName: branch });
 				mkdirSync(worktree.fsPath, { recursive: true });
 			},
-			removeWorktree: async (_root, worktree) => {
-				removeCalls.push(worktree);
+			removeWorktree: async (_root, worktree, options) => {
+				removeCalls.push({ worktree, force: options?.force === true });
 				rmSync(worktree.fsPath, { recursive: true, force: true });
 			},
 		};
@@ -225,7 +225,7 @@ suite('WorktreeIsolation', () => {
 			announcementHasBranch: announcement?.includes(branchName) ?? false,
 			secondTakeAnnouncement: isolation.takePendingAnnouncement(sessionId),
 			idempotentReturn: second!.toString(),
-			createdSessions: isolation.createdWorktreeSessionIds,
+			createdSessions: isolation.trackedWorktreeSessionIds,
 		}, {
 			returnedWorktree: expectedWorktree.toString(),
 			addWorktreeCallCount: 1,
@@ -265,7 +265,7 @@ suite('WorktreeIsolation', () => {
 			},
 		});
 		const meta = await isolation.readWorktreeMetadata(sessionUri);
-		const project = isolation.createdWorktreeProject(sessionId);
+		const project = isolation.sessionWorktreeProject(sessionId);
 
 		assert.deepStrictEqual({
 			worktree: worktree?.toString(),
@@ -465,7 +465,7 @@ suite('WorktreeIsolation', () => {
 			folder: folder?.toString(),
 			noBranch: noBranch?.toString(),
 			addWorktreeCallCount: addWorktreeCalls.length,
-			createdSessions: isolation.createdWorktreeSessionIds,
+			createdSessions: isolation.trackedWorktreeSessionIds,
 		}, {
 			folder: repoRoot.toString(),
 			noBranch: repoRoot.toString(),
@@ -497,7 +497,7 @@ suite('WorktreeIsolation', () => {
 				worktree: call.worktree.toString(),
 				globs: call.globs,
 			})),
-			createdSessions: isolation.createdWorktreeSessionIds,
+			createdSessions: isolation.trackedWorktreeSessionIds,
 		}, {
 			worktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
 			copyIncludeCalls: [{
@@ -612,7 +612,7 @@ suite('WorktreeIsolation', () => {
 		);
 	});
 
-	test('resolveWorktreeProject / createdWorktreeProject expose the repository as the session project', async () => {
+	test('resolveWorktreeProject / sessionWorktreeProject expose the repository as the session project', async () => {
 		// The worktree lives at `<repo>.worktrees/<name>`, but a worktree session
 		// must group under the repository in the sessions UI. Both accessors return
 		// the repo root as the project so agents can merge it into the reported
@@ -622,19 +622,19 @@ suite('WorktreeIsolation', () => {
 		const expectedDisplayName = basename(repoRoot);
 
 		const beforeAsync = await isolation.resolveWorktreeProject(sessionUri);
-		const beforeSync = isolation.createdWorktreeProject(sessionId);
+		const beforeSync = isolation.sessionWorktreeProject(sessionId);
 
 		await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
 
 		const afterAsync = await isolation.resolveWorktreeProject(sessionUri);
-		const afterSync = isolation.createdWorktreeProject(sessionId);
+		const afterSync = isolation.sessionWorktreeProject(sessionId);
 
 		assert.deepStrictEqual({
 			beforeAsync,
 			beforeSync,
 			afterAsync: { uri: afterAsync?.uri.toString(), displayName: afterAsync?.displayName },
 			afterSync: { uri: afterSync?.uri.toString(), displayName: afterSync?.displayName },
-			unknownSession: isolation.createdWorktreeProject('does-not-exist'),
+			unknownSession: isolation.sessionWorktreeProject('does-not-exist'),
 		}, {
 			beforeAsync: undefined,
 			beforeSync: undefined,
@@ -762,30 +762,63 @@ suite('WorktreeIsolation', () => {
 		const restoredDuringUnarchive = worktree ? existsSync(worktree.fsPath) : false;
 
 		assert.deepStrictEqual({
-			removeCalls: removeCalls.map(u => u.toString()),
+			removeCalls: removeCalls.map(call => ({ worktree: call.worktree.toString(), force: call.force })),
 			removedDuringArchive,
 			addExistingCalls: addExistingCalls.map(c => ({ worktree: c.worktree.toString(), branchName: c.branchName })),
 			restoredDuringUnarchive,
 		}, {
-			removeCalls: [worktree!.toString()],
+			removeCalls: [{ worktree: worktree!.toString(), force: false }],
 			removedDuringArchive: true,
 			addExistingCalls: [{ worktree: worktree!.toString(), branchName }],
 			restoredDuringUnarchive: true,
 		});
 	});
 
-	test('removeAllCreatedWorktrees drains every worktree created in this process', async () => {
+	test('removeSessionWorktree force-removes a worktree for explicit session deletion', async () => {
 		const isolation = createIsolation(disposables);
 		const worktree = await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
 
-		await isolation.removeAllCreatedWorktrees();
+		await isolation.removeSessionWorktree(sessionId);
 
 		assert.deepStrictEqual({
-			removeCalls: removeCalls.map(u => u.toString()),
-			createdSessions: isolation.createdWorktreeSessionIds,
+			removeCalls: removeCalls.map(call => ({ worktree: call.worktree.toString(), force: call.force })),
+			createdSessions: isolation.trackedWorktreeSessionIds,
 		}, {
-			removeCalls: [worktree!.toString()],
+			removeCalls: [{ worktree: worktree!.toString(), force: true }],
 			createdSessions: [],
 		});
+	});
+
+	test('session deletion removes a persisted worktree after a process restart', async () => {
+		const worktree = URI.joinPath(worktreesRoot, 'persisted-worktree');
+		mkdirSync(worktree.fsPath, { recursive: true });
+		await Promise.all([
+			db.setMetadata('copilot.worktree.branchName', 'feature/x'),
+			db.setMetadata('copilot.worktree.path', worktree.toString()),
+			db.setMetadata('copilot.worktree.repositoryRoot', repoRoot.toString()),
+		]);
+		const isolation = createIsolation(disposables);
+
+		await isolation.prepareSessionDeletion(sessionUri, sessionId);
+		await isolation.removeSessionWorktree(sessionId);
+
+		assert.deepStrictEqual({
+			removeCalls: removeCalls.map(call => ({ worktree: call.worktree.toString(), force: call.force })),
+			trackedSessions: isolation.trackedWorktreeSessionIds,
+		}, {
+			removeCalls: [{ worktree: worktree.toString(), force: true }],
+			trackedSessions: [],
+		});
+	});
+
+	test('failed worktree removal remains tracked for a later retry', async () => {
+		const gitService = createGitService();
+		gitService.removeWorktree = async () => { throw new Error('remove failed'); };
+		const isolation = createIsolation(disposables, { gitService });
+		await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
+
+		await isolation.removeSessionWorktree(sessionId);
+
+		assert.deepStrictEqual(isolation.trackedWorktreeSessionIds, [sessionId]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -811,15 +811,27 @@ suite('WorktreeIsolation', () => {
 		});
 	});
 
-	test('failed worktree removal preserves the materialized worktree cache', async () => {
+	test('failed worktree removal rejects and remains available for retry', async () => {
 		const gitService = createGitService();
 		gitService.removeWorktree = async () => { throw new Error('remove failed'); };
 		const isolation = createIsolation(disposables, { gitService });
-		await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
+		const worktree = URI.joinPath(worktreesRoot, 'persisted-worktree');
+		await Promise.all([
+			db.setMetadata('copilot.worktree.branchName', 'feature/x'),
+			db.setMetadata('copilot.worktree.path', worktree.toString()),
+			db.setMetadata('copilot.worktree.repositoryRoot', repoRoot.toString()),
+		]);
 
-		const worktree = await isolation.prepareSessionDeletion(sessionUri, sessionId);
-		await isolation.removeSessionWorktree(sessionId, worktree);
+		const worktreeToRemove = await isolation.prepareSessionDeletion(sessionUri, sessionId);
+		await assert.rejects(() => isolation.removeSessionWorktree(sessionId, worktreeToRemove), /remove failed/);
+		const retry = await isolation.prepareSessionDeletion(sessionUri, sessionId);
 
-		assert.strictEqual(isolation.getResolvedWorktree(sessionId)?.toString(), worktree?.worktree.toString());
+		assert.deepStrictEqual({
+			retryRepositoryRoot: retry?.repositoryRoot.toString(),
+			retryWorktree: retry?.worktree.toString(),
+		}, {
+			retryRepositoryRoot: repoRoot.toString(),
+			retryWorktree: worktree.toString(),
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -225,7 +225,7 @@ suite('WorktreeIsolation', () => {
 			announcementHasBranch: announcement?.includes(branchName) ?? false,
 			secondTakeAnnouncement: isolation.takePendingAnnouncement(sessionId),
 			idempotentReturn: second!.toString(),
-			createdSessions: isolation.trackedWorktreeSessionIds,
+			resolvedWorktree: isolation.getResolvedWorktree(sessionId)?.toString(),
 		}, {
 			returnedWorktree: expectedWorktree.toString(),
 			addWorktreeCallCount: 1,
@@ -236,7 +236,7 @@ suite('WorktreeIsolation', () => {
 			announcementHasBranch: true,
 			secondTakeAnnouncement: undefined,
 			idempotentReturn: expectedWorktree.toString(),
-			createdSessions: [sessionId],
+			resolvedWorktree: expectedWorktree.toString(),
 		});
 	});
 
@@ -465,12 +465,12 @@ suite('WorktreeIsolation', () => {
 			folder: folder?.toString(),
 			noBranch: noBranch?.toString(),
 			addWorktreeCallCount: addWorktreeCalls.length,
-			createdSessions: isolation.trackedWorktreeSessionIds,
+			resolvedWorktree: isolation.getResolvedWorktree(sessionId),
 		}, {
 			folder: repoRoot.toString(),
 			noBranch: repoRoot.toString(),
 			addWorktreeCallCount: 0,
-			createdSessions: [],
+			resolvedWorktree: undefined,
 		});
 	});
 
@@ -497,7 +497,7 @@ suite('WorktreeIsolation', () => {
 				worktree: call.worktree.toString(),
 				globs: call.globs,
 			})),
-			createdSessions: isolation.trackedWorktreeSessionIds,
+			resolvedWorktree: isolation.getResolvedWorktree(sessionId)?.toString(),
 		}, {
 			worktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
 			copyIncludeCalls: [{
@@ -505,7 +505,7 @@ suite('WorktreeIsolation', () => {
 				worktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
 				globs: includeFiles,
 			}],
-			createdSessions: [sessionId],
+			resolvedWorktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
 		});
 	});
 
@@ -778,14 +778,14 @@ suite('WorktreeIsolation', () => {
 		const isolation = createIsolation(disposables);
 		const worktree = await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
 
-		await isolation.removeSessionWorktree(sessionId);
+		await isolation.removeSessionWorktree(sessionId, await isolation.prepareSessionDeletion(sessionUri, sessionId));
 
 		assert.deepStrictEqual({
 			removeCalls: removeCalls.map(call => ({ worktree: call.worktree.toString(), force: call.force })),
-			createdSessions: isolation.trackedWorktreeSessionIds,
+			resolvedWorktree: isolation.getResolvedWorktree(sessionId),
 		}, {
 			removeCalls: [{ worktree: worktree!.toString(), force: true }],
-			createdSessions: [],
+			resolvedWorktree: undefined,
 		});
 	});
 
@@ -799,26 +799,27 @@ suite('WorktreeIsolation', () => {
 		]);
 		const isolation = createIsolation(disposables);
 
-		await isolation.prepareSessionDeletion(sessionUri, sessionId);
-		await isolation.removeSessionWorktree(sessionId);
+		const worktreeToRemove = await isolation.prepareSessionDeletion(sessionUri, sessionId);
+		await isolation.removeSessionWorktree(sessionId, worktreeToRemove);
 
 		assert.deepStrictEqual({
 			removeCalls: removeCalls.map(call => ({ worktree: call.worktree.toString(), force: call.force })),
-			trackedSessions: isolation.trackedWorktreeSessionIds,
+			resolvedWorktree: isolation.getResolvedWorktree(sessionId),
 		}, {
 			removeCalls: [{ worktree: worktree.toString(), force: true }],
-			trackedSessions: [],
+			resolvedWorktree: undefined,
 		});
 	});
 
-	test('failed worktree removal remains tracked for a later retry', async () => {
+	test('failed worktree removal preserves the materialized worktree cache', async () => {
 		const gitService = createGitService();
 		gitService.removeWorktree = async () => { throw new Error('remove failed'); };
 		const isolation = createIsolation(disposables, { gitService });
 		await isolation.resolveWorkingDirectory({ sessionUri, sessionId, workingDirectory: repoRoot, config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' } });
 
-		await isolation.removeSessionWorktree(sessionId);
+		const worktree = await isolation.prepareSessionDeletion(sessionUri, sessionId);
+		await isolation.removeSessionWorktree(sessionId, worktree);
 
-		assert.deepStrictEqual(isolation.trackedWorktreeSessionIds, [sessionId]);
+		assert.strictEqual(isolation.getResolvedWorktree(sessionId)?.toString(), worktree?.worktree.toString());
 	});
 });


### PR DESCRIPTION
## Summary

- preserve session-owned worktrees when the Agent Host shuts down
- keep Git's dirty-worktree protection enabled for archive cleanup
- reserve forced worktree removal for confirmed session deletion
- load persisted worktree metadata before deleting restored sessions so their worktrees are cleaned up correctly
- retain failed removals for retry and update lifecycle documentation

## Why

Agent Host shutdown previously removed every worktree created during that process using `git worktree remove --force`. Process lifetime does not match persistent session lifetime, so an explicit shutdown could delete uncommitted changes. Conversely, explicit deletion after a process restart could leave a worktree behind because cleanup only consulted in-memory ownership.

## Validation

- `npm run transpile-client`
- targeted Agent Host unit tests: 214 passing
- Agent Host Git integration tests: 40 passing
- `npm run typecheck-client`
- `npm run precommit`

(Written by Copilot)