### PR TITLE
Fix Agent Host user settings loading

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostBootstrap.ts
+++ b/src/vs/platform/agentHost/node/agentHostBootstrap.ts
@@ -32,7 +32,7 @@ export interface IAgentHostNetworkServices {
  * itself, and through it `ClaudeAgentSdkService` / `CodexAgent`) must be
  * constructed AFTER this call.
  *
- * Reads the default profile's `settings.json` from `<userRoamingDataHome>` —
+ * Reads the default profile's `settings.json` from `<appSettingsHome>` —
  * the same file the workbench writes user settings to. Initialization is
  * async because the settings file is read off disk.
  *
@@ -50,7 +50,7 @@ export async function registerAgentHostNetworkServices(
 ): Promise<IAgentHostNetworkServices> {
 	const policyService = new NullPolicyService();
 	diServices.set(IPolicyService, policyService);
-	const settingsResource = joinPath(environmentService.userRoamingDataHome, 'settings.json');
+	const settingsResource = joinPath(environmentService.appSettingsHome, 'settings.json');
 	const configurationService = disposables.add(new ConfigurationService(settingsResource, fileService, policyService, logService));
 	await configurationService.initialize();
 	diServices.set(IConfigurationService, configurationService);

--- a/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { URI } from '../../../../base/common/uri.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { ConfigurationService } from '../../../configuration/common/configurationService.js';
+import { NativeEnvironmentService } from '../../../environment/node/environmentService.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
+import { OPTIONS, parseArgs } from '../../../environment/node/argv.js';
+import { NullLogService } from '../../../log/common/log.js';
+import product from '../../../product/common/product.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { registerAgentHostNetworkServices } from '../../node/agentHostBootstrap.js';
+
+class TestEnvironmentService extends NativeEnvironmentService {
+	override get appSettingsHome(): URI {
+		return URI.from({ scheme: Schemas.file, path: '/User' });
+	}
+}
+
+function createFileService(disposables: DisposableStore): FileService {
+	const fileService = disposables.add(new FileService(new NullLogService()));
+	const provider = disposables.add(new InMemoryFileSystemProvider());
+	disposables.add(fileService.registerProvider(Schemas.file, provider));
+	return fileService;
+}
+
+suite('agentHostBootstrap', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('loads configuration from appSettingsHome', async () => {
+		const testDisposables = disposables.add(new DisposableStore());
+		const environmentService = new TestEnvironmentService(parseArgs(['--force-disable-user-env'], OPTIONS), product);
+		const fileService = createFileService(testDisposables);
+
+		await fileService.createFolder(environmentService.appSettingsHome);
+		await fileService.writeFile(joinPath(environmentService.appSettingsHome, 'settings.json'), VSBuffer.fromString('{ "http.proxy": "http://proxy.example:8080" }'));
+
+		const services = new ServiceCollection();
+		await registerAgentHostNetworkServices(services, fileService, environmentService, new NullLogService(), testDisposables);
+
+		const configurationService = services.get(IConfigurationService);
+		assert.ok(configurationService instanceof ConfigurationService);
+		assert.strictEqual(configurationService.getValue('http.proxy'), 'http://proxy.example:8080');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
@@ -39,7 +39,7 @@ suite('agentHostBootstrap', () => {
 
 	test('loads configuration from appSettingsHome', async () => {
 		const testDisposables = disposables.add(new DisposableStore());
-		const environmentService = new TestEnvironmentService(parseArgs(['--force-disable-user-env'], OPTIONS), product);
+		const environmentService = new TestEnvironmentService(parseArgs(['--force-disable-user-env'], OPTIONS), { _serviceBrand: undefined, ...product });
 		const fileService = createFileService(testDisposables);
 
 		await fileService.createFolder(environmentService.appSettingsHome);


### PR DESCRIPTION
Fix Agent Host configuration initialization to use the disk-backed default profile settings resource supported by its file service.

## Summary

- load `User/settings.json` from `appSettingsHome` instead of the unsupported `vscode-userdata:` resource
- add a focused regression test that registers only the Agent Host's `file:` provider and verifies user settings are loaded

## Testing

- `.\scripts\test.bat --run src\vs\platform\agentHost\test\node\agentHostBootstrap.test.ts` (2 passing)
- fresh local Agent Host mock startup reached `READY` without the `ENOPRO` signature

Fixes #329721

Related #329116
Related #328736