### PR TITLE
Show output file for truncated shell output when instead of shell_exit preview for now

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1259,13 +1259,15 @@ function getTerminalOutput(tc: ToolCallState) {
 
 	const terminalContent = getTerminalContent(tc.content);
 	const terminalResult = getTerminalCommandResult(tc);
+	const fallbackText = tc.content?.find(isToolResultTextContent)?.text;
 
-	// Prefer the structured terminal snapshot. Text content is a compatibility
-	// fallback for older/restored results and can include legacy bookkeeping.
-	let text = terminalResult?.preview;
+	// A truncated preview omits the completion text that tells the user where the full output was saved.
+	// TODO: Use an SDK API for the large-output file path instead of relying on the tool completion display text.
+	let text = terminalResult?.truncated === true && fallbackText !== undefined
+		? stripLegacyTerminalExitMarkers(fallbackText)
+		: terminalResult?.preview;
 	const hasRetainedNonPtySnapshot = terminalContent?.isPty === false && text !== undefined;
 	if (text === undefined && terminalContent?.isPty !== false) {
-		const fallbackText = tc.content?.find(isToolResultTextContent)?.text;
 		text = fallbackText === undefined ? undefined : stripLegacyTerminalExitMarkers(fallbackText);
 	}
 	if (text === undefined || (!text && !hasRetainedNonPtySnapshot && terminalResult?.truncated !== true)) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1281,7 +1281,7 @@ function getTerminalOutput(tc: ToolCallState) {
 }
 
 function stripLegacyTerminalExitMarkers(text: string): string {
-	return text.replace(/<shellId:[^>\r\n]*completed with exit code \d+>\s*$/i, '');
+	return text.replace(/<shellId:[^>\r\n]*completed with exit code -?\d+>\s*$/i, '');
 }
 
 function isToolResultTextContent(content: ToolResultContent): content is Extract<ToolResultContent, { type: ToolResultContentType.Text }> {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -2385,7 +2385,7 @@ suite('stateToProgressAdapter', () => {
 				_meta: { toolKind: 'terminal' },
 				toolInput: 'cat large-output.txt',
 				content: [
-					{ type: ToolResultContentType.Text, text: 'Output too large to read at once (25 KB). Saved to: /tmp/output.txt\nUse view with view_range to examine portions of the output.' },
+					{ type: ToolResultContentType.Text, text: 'Output too large to read at once (25 KB). Saved to: /tmp/output.txt\nUse view with view_range to examine portions of the output.<shellId: 104 completed with exit code -1>' },
 					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal://shell/copilotNonPtyShells/tc-1', title: 'Run Shell Command', isPty: false, result: { exitCode: 0, preview: 'preview only\n', truncated: true } },
 				],
 				success: true,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -2385,6 +2385,7 @@ suite('stateToProgressAdapter', () => {
 				_meta: { toolKind: 'terminal' },
 				toolInput: 'cat large-output.txt',
 				content: [
+					// TODO: Prefer shell_exit once the SDK exposes the saved output file path as structured data.
 					{ type: ToolResultContentType.Text, text: 'Output too large to read at once (25 KB). Saved to: /tmp/output.txt\nUse view with view_range to examine portions of the output.<shellId: 104 completed with exit code -1>' },
 					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal://shell/copilotNonPtyShells/tc-1', title: 'Run Shell Command', isPty: false, result: { exitCode: 0, preview: 'preview only\n', truncated: true } },
 				],

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -2380,13 +2380,13 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandOutput, undefined);
 		});
 
-		test('uses terminal completion exit code for completed SDK shell tool history', () => {
+		test('uses tool completion text for truncated SDK shell output', () => {
 			const tc = createCompletedToolCall({
 				_meta: { toolKind: 'terminal' },
-				toolInput: 'gti status',
+				toolInput: 'cat large-output.txt',
 				content: [
-					{ type: ToolResultContentType.Text, text: 'command not found\n<shellId: 104 completed with exit code 127>' },
-					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal://shell/copilotNonPtyShells/tc-1', title: 'Run Shell Command', isPty: false, result: { exitCode: 127, preview: 'preview only\n', truncated: true } },
+					{ type: ToolResultContentType.Text, text: 'Output too large to read at once (25 KB). Saved to: /tmp/output.txt\nUse view with view_range to examine portions of the output.' },
+					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal://shell/copilotNonPtyShells/tc-1', title: 'Run Shell Command', isPty: false, result: { exitCode: 0, preview: 'preview only\n', truncated: true } },
 				],
 				success: true,
 			});
@@ -2401,10 +2401,16 @@ suite('stateToProgressAdapter', () => {
 			if (response.type !== 'response') { return; }
 			const serialized = response.parts[0] as IChatToolInvocationSerialized;
 			const termData = getSerializedTerminalData(serialized);
-			assert.strictEqual(termData.terminalCommandState?.exitCode, 127);
-			assert.strictEqual(termData.terminalCommandOutput?.text, 'preview only\r\n');
-			assert.strictEqual(termData.terminalCommandOutput?.truncated, true);
-			assert.ok(!termData.terminalCommandOutput?.text.includes('shellId'));
+			assert.deepStrictEqual({
+				output: termData.terminalCommandOutput,
+				state: termData.terminalCommandState,
+			}, {
+				output: {
+					text: 'Output too large to read at once (25 KB). Saved to: /tmp/output.txt\r\nUse view with view_range to examine portions of the output.',
+					truncated: true,
+				},
+				state: { exitCode: 0 },
+			});
 		});
 
 		test('preserves an explicitly empty non-PTY retained completion snapshot', () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/329720
Part of: https://github.com/microsoft/vscode/issues/328596
Follow-up: https://github.com/microsoft/vscode/issues/329724

The SDK built-in shell completion gives VS Code two representations of completed output:

- `tool.execution_complete.result.content` is display text produced by the runtime. When output spills to a file, this contains the "Output too large... Saved to: ..." message, the saved-file path, and instructions for inspecting it.
- The `shell_exit` content block is structured completion metadata. It carries `exitCode`, `outputTruncated`, and `outputPreview`; for spilled output, that preview is only a capped raw-output head and does not contain the saved-file path.

At completion the live non-PTY output channel is retired and the terminal card is rebuilt from the retained tool result. Previously the card always preferred `shell_exit.outputPreview`, so once `shell_exit` started reaching VS Code again, a large command finished by replacing the useful saved-file message with only the capped preview.

This PR uses the following selection policy:

- When `shell_exit.outputTruncated === true` and completion text exists, display `result.content` so the card shows where the full output was saved.
- Otherwise, prefer the structured `shell_exit.outputPreview`.
- If truncated completion text is unavailable, keep `outputPreview` as the fallback.
- Continue taking exit code and truncation state from structured `shell_exit` metadata; only the displayed text source changes.

This is an intentional bridge, not the final API shape. #329724 tracks adding a structured large-output artifact path or URI to the SDK/runtime contract. Once available, VS Code can render a dedicated user-facing link from typed data and stop depending on model-facing completion prose.

- Update terminal history/live-finalization mapping through the shared adapter policy.
- Keep legacy shell completion trailer stripping when completion text is selected.
- Cover truncated SDK shell completion with a regression test.

-----------------------------------------
Inspirations from:

- Retaining tool completion text alongside structured terminal content follows [`CopilotAgentSession` tool completion mapping](https://github.com/microsoft/vscode/blob/e390f36f69fe6cdf1c1c3262f0b50f1d01552ec4/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts#L4090-L4126).
- The saved-file message comes from the runtime's [`format_shell_output`](https://github.com/github/copilot-agent-runtime/blob/2147954ee33e4a98933cd617aa3aca383d261b20/src/runtime/src/tools/shell_tools.rs#L195-L211).
- Treating `outputPreview` as lossy when truncated follows the SDK wire contract, which states that it may be partial and is not guaranteed to contain full output: [`ExternalToolTextResultForLlmContentShellExit`](https://github.com/github/copilot-agent-runtime/blob/2147954ee33e4a98933cd617aa3aca383d261b20/src/native/sdk-contract/src/api/rpc.rs#L5635-L5663).
