### PR TITLE
[Perf] Fix retained snippet initialization work

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
@@ -208,7 +208,7 @@ export class SnippetsService implements ISnippetsService {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _disposables = new DisposableStore();
-	private readonly _pendingWork: Promise<any>[] = [];
+	private readonly _pendingWork = new Set<Promise<void>>();
 	private readonly _files = new ResourceMap<SnippetFile>();
 	private readonly _enablement: SnippetEnablement;
 	private readonly _usageTimestamps: SnippetUsageTimestamps;
@@ -226,7 +226,7 @@ export class SnippetsService implements ISnippetsService {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILanguageConfigurationService languageConfigurationService: ILanguageConfigurationService,
 	) {
-		this._pendingWork.push(Promise.resolve(lifecycleService.when(LifecyclePhase.Restored).then(() => {
+		this._trackPendingWork(Promise.resolve(lifecycleService.when(LifecyclePhase.Restored).then(() => {
 			this._initExtensionSnippets();
 			this._initUserSnippets();
 			this._initWorkspaceSnippets();
@@ -254,10 +254,21 @@ export class SnippetsService implements ISnippetsService {
 		this._usageTimestamps.updateUsageTimestamp(snippet.snippetIdentifier);
 	}
 
-	private _joinSnippets(): Promise<any> {
-		const promises = this._pendingWork.slice(0);
-		this._pendingWork.length = 0;
-		return Promise.all(promises);
+	private async _joinSnippets(): Promise<void> {
+		const promises = [...this._pendingWork];
+		this._pendingWork.clear();
+		await Promise.all(promises);
+	}
+
+	private _trackPendingWork(work: Promise<void>): void {
+		this._pendingWork.add(work);
+		work.then(
+			() => this._pendingWork.delete(work),
+			error => {
+				this._pendingWork.delete(work);
+				this._logService.error(error);
+			}
+		);
 	}
 
 	async getSnippetFiles(): Promise<Iterable<SnippetFile>> {
@@ -422,7 +433,7 @@ export class SnippetsService implements ISnippetsService {
 		const disposables = new DisposableStore();
 		const updateWorkspaceSnippets = () => {
 			disposables.clear();
-			this._pendingWork.push(this._initWorkspaceFolderSnippets(this._contextService.getWorkspace(), disposables));
+			this._trackPendingWork(this._initWorkspaceFolderSnippets(this._contextService.getWorkspace(), disposables));
 		};
 		this._disposables.add(disposables);
 		this._disposables.add(this._contextService.onDidChangeWorkspaceFolders(updateWorkspaceSnippets));
@@ -430,7 +441,7 @@ export class SnippetsService implements ISnippetsService {
 		updateWorkspaceSnippets();
 	}
 
-	private async _initWorkspaceFolderSnippets(workspace: IWorkspace, bucket: DisposableStore): Promise<any> {
+	private async _initWorkspaceFolderSnippets(workspace: IWorkspace, bucket: DisposableStore): Promise<void> {
 		const promises = workspace.folders.map(async folder => {
 			const snippetFolder = folder.toResource('.vscode');
 			const value = await this._fileService.exists(snippetFolder);
@@ -458,7 +469,7 @@ export class SnippetsService implements ISnippetsService {
 		};
 		this._disposables.add(disposables);
 		this._disposables.add(this._userDataProfileService.onDidChangeCurrentProfile(e => e.join((async () => {
-			this._pendingWork.push(updateUserSnippets());
+			this._trackPendingWork(updateUserSnippets());
 		})())));
 		await updateUserSnippets();
 	}

--- a/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
@@ -256,7 +256,6 @@ export class SnippetsService implements ISnippetsService {
 
 	private async _joinSnippets(): Promise<void> {
 		const promises = [...this._pendingWork];
-		this._pendingWork.clear();
 		await Promise.all(promises);
 	}
 


### PR DESCRIPTION
## Problem

`SnippetsService` starts asynchronous extension, user, and workspace snippet discovery after the workbench is restored. Workspace-folder and workbench-state changes enqueue additional workspace discovery promises in `_pendingWork`.

`_pendingWork` was an array that was cleared only when `getSnippets` or `getSnippetFiles` happened to join it. Agents Window session switches trigger workspace initialization, but they do not necessarily query snippets afterward. The initialization promises therefore settled successfully but remained strongly referenced by the array. In the memory campaign, 100 session switches left 106 settled promises under `SnippetsService._pendingWork` and correlated with approximately 0.92–1.00 MB of renderer growth per switch.

## Fix

Track initialization promises in a `Set` and remove each promise from the set as soon as it fulfills or rejects. This changes `_pendingWork` from a history of work that depends on a later consumer to drain it into a bounded collection of only currently in-flight work.

`_joinSnippets` snapshots the set without clearing it. As a result, concurrent snippet queries all wait for the same initialization work; the settlement handlers remain solely responsible for removal. Rejections are removed and logged while preserving the existing rejection seen by callers awaiting initialization.

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts` (32 passing, 1 pending)
- `npm run eslint -- src/vs/workbench/contrib/snippets/browser/snippetsService.ts`
- `npm run typecheck-client`
- pre-commit hygiene
- `git diff --check origin/main...HEAD`

(Written by Copilot)