### PR TITLE
test: fix agent host worktree path flake

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { CopilotSession, CurrentToolMetadata, ElicitationContext, ElicitationFieldValue, ElicitationResult, ElicitationSchema, ElicitationSchemaField, ExitPlanModeCompletedData, ExitPlanModeRequest, ExitPlanModeResult, McpServersLoadedServer, MessageOptions, PermissionAllowAllMode, PermissionAutoApproval, PermissionRequest, PermissionRequestResult, PermissionResult, SessionConfig, SessionHooks, SessionMode as CopilotSdkMode, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
-import { raceCancellation, RunOnceScheduler, Sequencer, Throttler } from '../../../../base/common/async.js';
+import { raceCancellation, RunOnceScheduler, Sequencer, SequencerByKey, Throttler } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -778,6 +778,7 @@ export class CopilotAgentSession extends Disposable {
 	private _lastAppliedPermissionMode: PermissionAllowAllMode | undefined;
 	private _autoApprovalExperimentalModeEnabled = false;
 	private readonly _permissionModeSequencer = new Sequencer();
+	private readonly _mcpServerLifecycleSequencer = new SequencerByKey<string>();
 	private readonly _steeringMessagesInFlight = new Set<string>();
 	/**
 	 * Steering messages that have been accepted by the SDK but not yet
@@ -2538,15 +2539,17 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.warn(`[Copilot:${this.sessionId}] Cannot start unknown MCP server customization ${id}`);
 			return;
 		}
-		try {
-			await this._wrapper.session.rpc.mcp.startServer({ serverName });
-		} finally {
-			// Reconcile against the SDK's real state. The live
-			// `session.mcp_server_status_changed` stream already reports the
-			// connect (`pending` -> `connected`/`failed`); this covers the case
-			// where the start rejects before any status is emitted.
-			this._seedMcpServersFromRpc();
-		}
+		return this._mcpServerLifecycleSequencer.queue(serverName, async () => {
+			try {
+				await this._wrapper.session.rpc.mcp.startServer({ serverName });
+			} finally {
+				// Reconcile against the SDK's real state. The live
+				// `session.mcp_server_status_changed` stream already reports the
+				// connect (`pending` -> `connected`/`failed`); this covers the case
+				// where the start rejects before any status is emitted.
+				this._seedMcpServersFromRpc();
+			}
+		});
 	}
 
 	private async _reconcileMcpServerEnablement(): Promise<void> {
@@ -2597,8 +2600,10 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.warn(`[Copilot:${this.sessionId}] Cannot stop unknown MCP server customization ${id}`);
 			return;
 		}
-		await this._wrapper.session.rpc.mcp.stopServer({ serverName });
-		this._mcpCustomizations.applyOne({ name: serverName, state: { kind: McpServerStatus.Stopped } });
+		return this._mcpServerLifecycleSequencer.queue(serverName, async () => {
+			await this._wrapper.session.rpc.mcp.stopServer({ serverName });
+			this._mcpCustomizations.applyOne({ name: serverName, state: { kind: McpServerStatus.Stopped } });
+		});
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -86,6 +86,7 @@ class MockCopilotSession {
 	readonly mcpStartServerCalls: Array<{ serverName: string }> = [];
 	readonly mcpStopServerCalls: Array<{ serverName: string }> = [];
 	mcpDisableGate: Promise<unknown> | undefined;
+	mcpStopServerGate: Promise<unknown> | undefined;
 	compactResult: { success: boolean; tokensRemoved: number; messagesRemoved: number; contextWindow?: { currentTokens: number; tokenLimit: number; messagesLength: number } } = { success: true, tokensRemoved: 0, messagesRemoved: 0 };
 	compactError: unknown = undefined;
 	/** Invoked inside `rpc.history.compact` before it settles, so tests can emit the SDK's in-flight compaction events. */
@@ -296,6 +297,7 @@ class MockCopilotSession {
 			},
 			stopServer: async (params: { serverName: string }) => {
 				this.mcpStopServerCalls.push(params);
+				await this.mcpStopServerGate;
 				this.mcpListResult = {
 					servers: this.mcpListResult.servers.map(server => server.name === params.serverName ? { ...server, status: 'not_configured' } : server),
 				};
@@ -8548,6 +8550,54 @@ suite('CopilotAgentSession', () => {
 			}, {
 				stopServerCalls: [{ serverName }],
 				state: { kind: McpServerStatus.Stopped },
+			});
+		});
+
+		test('startMcpServer waits for an in-flight stop of the same server', async () => {
+			const serverName = 'db';
+			const id = 'mcp-top-level:copilot:test-session-1:db';
+			const stopGate = new DeferredPromise<void>();
+			const { session, mockSession } = await createAgentSession(disposables, {
+				sessionCustomizations: () => [{
+					type: CustomizationType.McpServer,
+					id,
+					uri: id,
+					name: serverName,
+					enabled: true,
+					state: { kind: McpServerStatus.Ready },
+				}],
+				configureMockSession: mock => {
+					mock.mcpListResult = { servers: [{ name: serverName, status: 'connected' }] };
+					mock.mcpStopServerGate = stopGate.p;
+				},
+			});
+
+			const stopPromise = session.stopMcpServer(id);
+			await timeout(0);
+			const startPromise = session.startMcpServer(id);
+			await timeout(0);
+			const callsWhileStopping = {
+				stop: [...mockSession.mcpStopServerCalls],
+				start: [...mockSession.mcpStartServerCalls],
+			};
+			stopGate.complete();
+			await Promise.all([stopPromise, startPromise]);
+
+			assert.deepStrictEqual({
+				callsWhileStopping,
+				finalCalls: {
+					stop: mockSession.mcpStopServerCalls,
+					start: mockSession.mcpStartServerCalls,
+				},
+			}, {
+				callsWhileStopping: {
+					stop: [{ serverName }],
+					start: [],
+				},
+				finalCalls: {
+					stop: [{ serverName }],
+					start: [{ serverName }],
+				},
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -257,7 +257,7 @@ The blanket `!isWindows` shell exclusion is gone: `portableShellToolReplayEnable
 The following tests remain scoped at their call sites:
 
 - `a bang command runs locally and exposes terminal output` — the successful bang command produces output but does not complete reliably. Not a portability problem.
-- `worktree session uses the resolved worktree as working directory` — the whole scenario is skipped on Windows after CI exposed two blockers unrelated to command portability, described below.
+- `worktree session uses the resolved worktree as working directory` — the whole scenario is skipped on Windows because the host terminal tool does not expose a terminal resource there, as described below.
 
 The prompt snapshots in `providers/copilotPromptsE2E.integrationTest.ts` are also POSIX-only — every model, by construction rather than because of an observed failure.
 
@@ -278,9 +278,9 @@ The E2E workspaces come from `os.tmpdir()`, and what that returns is not what a 
 | Windows CI | `C:\Users\CLOUDT~1\AppData\Local\Temp\…` (8.3 short form) | `C:\Users\cloudtest\AppData\Local\Temp\…` |
 | macOS | `/var/folders/…` (logical) | `/private/var/folders/…` (physical) |
 
-Any assertion that a command's output *contains* a path built from `tmpdir()` is therefore comparing two different spellings of the same directory. `normalizeSnapshotText` already strips `/private` for the macOS case, but a test asserting directly on tool output — rather than through a snapshot — has no such help.
+Any assertion that a command's output *contains* a path built from `tmpdir()` is therefore comparing two different spellings of the same directory. `normalizeSnapshotText` strips `/private` for snapshots, while direct worktree assertions accept both the reported path and its `realpathSync` canonical form.
 
-This is why `worktree session uses the resolved worktree as working directory` fails on Windows CI: the assertion never matches, and the test times out waiting for output that will never arrive in the expected form. Reworking it means resolving both sides with `realpathSync.native` before comparing, which also removes the macOS special case.
+This path aliasing previously made `worktree session uses the resolved worktree as working directory` time out after the tool and turn had already completed on macOS, and would have failed the same way on Windows. The test now canonicalizes direct path comparisons; the separate missing Windows terminal resource remains the platform blocker.
 
 ### The host terminal tool surfaces no content on Windows
 
@@ -631,7 +631,7 @@ Three rows remain, and they are not about command portability:
 |---|---|---|
 | `a bang command runs locally and exposes terminal output` | Windows | The successful bang command produces output but does not complete reliably. |
 | `resource watch reports changes on its subscribed channel` | Windows | The subscribed filesystem watch does not emit `resourceWatch/changed` after a protocol `resourceWrite` within the test timeout. Descriptor, missing-root, and resource mutation coverage remain enabled. |
-| `worktree session uses the resolved worktree as working directory` | Windows | `os.tmpdir()` yields an 8.3 short path while the shell reports the long path, and Copilot's completed host-terminal call publishes no terminal-content notification. |
+| `worktree session uses the resolved worktree as working directory` | Windows | Copilot's completed host-terminal call publishes no terminal-content notification, so the test cannot subscribe to the terminal and assert its working directory. |
 | ``strips redundant `cd <workingDirectory> &&` prefix from shell tool calls`` | Copilot on Windows | The turn completes, but `chat/toolCallReady` omits the `toolInput` needed to assert that the prefix was removed. |
 
 Copilot's ordinary provider shell also omits `ToolResultTerminalContent.result.preview` on Windows, while its terminal-shaped resource is not backed by the host terminal manager and cannot be subscribed. These tests are skipped for Copilot on Windows because their direct output oracle would otherwise be empty:

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { execSync } from 'child_process';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
@@ -112,19 +112,14 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 	});
 
 	// Skipped on Windows. The command and the tool name are portable now, but the
-	// two output assertions are not, for reasons CI surfaced that are specific to
-	// this test rather than to command portability:
+	// host terminal assertion is not, for a reason CI surfaced that is specific
+	// to this test rather than to command portability:
 	//
-	//  - The expected path comes from `os.tmpdir()`, which on Windows CI returns
-	//    an 8.3 short form (`C:\Users\CLOUDT~1\...`), while the shell reports the
-	//    long form. `includes()` therefore never matches. This is the same class
-	//    of mismatch as `/var` versus `/private/var` on macOS.
 	//  - The host terminal tool surfaces no `chat/toolCallContentChanged` on
 	//    Windows, so the terminal resource this test subscribes to never appears,
 	//    even though the tool call itself completes.
 	//
-	// Re-enabling on Windows needs both output assertions reworked against
-	// real-path normalization, and the missing terminal resource understood.
+	// Re-enabling on Windows needs the missing terminal resource understood.
 	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
@@ -200,6 +195,9 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 		assert.ok(addedWorkingDirectory.includes('.worktrees'),
 			`workingDirectory should be under the .worktrees folder, got: ${addedWorkingDirectory}`);
 		const resolvedWorkingDirectoryPath = URI.parse(addedWorkingDirectory).fsPath;
+		const canonicalWorkingDirectoryPath = realpathSync(resolvedWorkingDirectoryPath);
+		const includesWorkingDirectoryPath = (text: string): boolean =>
+			text.includes(resolvedWorkingDirectoryPath) || text.includes(canonicalWorkingDirectoryPath);
 
 		await context.client.waitForNotification(
 			n => isActionNotification(n, 'chat/turnComplete') || isActionNotification(n, 'chat/error'),
@@ -244,19 +242,19 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 				const pwdNotif = await context.client.waitForNotification(n => {
 					if (isActionNotification(n, 'chat/toolCallContentChanged')) {
 						const action = getActionEnvelope(n).action as { content: readonly ToolResultContent[] };
-						return textFromContent(action.content).includes(resolvedWorkingDirectoryPath);
+						return includesWorkingDirectoryPath(textFromContent(action.content));
 					}
 					if (isActionNotification(n, 'chat/toolCallComplete')) {
 						const action = getActionEnvelope(n).action as { result: { content?: readonly ToolResultContent[] } };
-						return textFromContent(action.result.content ?? []).includes(resolvedWorkingDirectoryPath);
+						return includesWorkingDirectoryPath(textFromContent(action.result.content ?? []));
 					}
 					return false;
 				}, 90_000);
 				const pwdText = isActionNotification(pwdNotif, 'chat/toolCallComplete')
 					? textFromContent((getActionEnvelope(pwdNotif).action as { result: { content?: readonly ToolResultContent[] } }).result.content ?? [])
 					: textFromContent((getActionEnvelope(pwdNotif).action as { content: readonly ToolResultContent[] }).content);
-				assert.ok(pwdText.includes(resolvedWorkingDirectoryPath),
-					`pwd output should include the resolved worktree path ${resolvedWorkingDirectoryPath}`);
+				assert.ok(includesWorkingDirectoryPath(pwdText),
+					`pwd output should include the resolved worktree path ${resolvedWorkingDirectoryPath} (${canonicalWorkingDirectoryPath})`);
 			} finally {
 				await approvalLoop.stop();
 			}
@@ -297,13 +295,13 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 
 			const terminalSubscribeResult = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
 			const initialTerminalState = terminalSubscribeResult.snapshot!.state as TerminalState;
-			assert.strictEqual(initialTerminalState.cwd, resolvedWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
+			assert.strictEqual(realpathSync(initialTerminalState.cwd), canonicalWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
 
 			await context.client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);
 			const terminalSnapshot = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
 			const terminalState = terminalSnapshot.snapshot!.state as TerminalState;
-			assert.ok(terminalText(terminalState).includes(resolvedWorkingDirectoryPath),
-				`working directory output should include the resolved worktree path ${resolvedWorkingDirectoryPath}`);
+			assert.ok(includesWorkingDirectoryPath(terminalText(terminalState)),
+				`working directory output should include the resolved worktree path ${resolvedWorkingDirectoryPath} (${canonicalWorkingDirectoryPath})`);
 		} finally {
 			await approvalLoop.stop();
 		}

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -295,6 +295,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 
 			const terminalSubscribeResult = await context.client.call<SubscribeResult>('subscribe', { channel: terminalUri });
 			const initialTerminalState = terminalSubscribeResult.snapshot!.state as TerminalState;
+			assert.ok(initialTerminalState.cwd, 'terminal should report its working directory');
 			assert.strictEqual(realpathSync(initialTerminalState.cwd), canonicalWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
 
 			await context.client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);


### PR DESCRIPTION
Canonicalize worktree paths before comparing shell and terminal output on macOS. (Written by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
