### PR TITLE
agentHost: widen native Claude setup detection

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -78,66 +78,96 @@ export function resolveClaudeTransportMode(inputs: IClaudeTransportModeInputs): 
 }
 
 /**
- * Validator for the slice of `~/.claude/settings.json` we care about: an
- * optional `env` block that may carry either recognized Anthropic credential.
- * Reuses the shared combinators in `base/common/validation.ts` so parsing the
- * untrusted file is type-safe without hand-rolled shape checks. This validator
- * is the single source of truth for the credential-key set — {@link
- * ClaudeCredentialEnv} is derived from it rather than hand-authored.
+ * Validator for the slice of `~/.claude/settings.json` we care about: the
+ * top-level `apiKeyHelper`, plus an optional `env` block that may carry any
+ * recognized Anthropic credential or endpoint override. Reuses the shared
+ * combinators in `base/common/validation.ts` so parsing the untrusted file is
+ * type-safe without hand-rolled shape checks. Unknown properties (`model`,
+ * `permissions`, …) are ignored rather than rejected, so a real settings file
+ * still validates. This validator is the single source of truth for the key
+ * set — {@link ClaudeNativeEnv} is derived from it rather than hand-authored.
  */
 const claudeSettingsValidator = vObj({
+	// A command the CLI runs to mint an API key. File-only: it has no
+	// environment-variable counterpart, hence its place outside `env`.
+	apiKeyHelper: vOptionalProp(vString()),
 	env: vOptionalProp(vObj({
 		ANTHROPIC_API_KEY: vOptionalProp(vString()),
+		ANTHROPIC_AUTH_TOKEN: vOptionalProp(vString()),
+		ANTHROPIC_BASE_URL: vOptionalProp(vString()),
 		CLAUDE_CODE_OAUTH_TOKEN: vOptionalProp(vString()),
 	})),
 });
 
+type ClaudeSettings = ValidatorType<typeof claudeSettingsValidator>;
+
 /**
  * The `env` block shape both `process.env` and `~/.claude/settings.json` are
  * probed for, derived from {@link claudeSettingsValidator} so the two never
- * drift. A non-empty value under either key is a usable native credential.
+ * drift. A non-empty value under any key means Claude can reach Anthropic
+ * without Copilot: a credential of its own, or a base-URL override pointing at
+ * a gateway that supplies one.
  */
-type ClaudeCredentialEnv = NonNullable<ValidatorType<typeof claudeSettingsValidator>['env']>;
+type ClaudeNativeEnv = NonNullable<ClaudeSettings['env']>;
 
 /**
  * Detects whether a local Claude configuration exists that lets Claude run
- * natively (without GitHub). Returns `true` when either:
+ * natively (without GitHub). Returns `true` when any of the following is set to
+ * a non-empty value:
  *
- *  - an `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` is set in the
- *    environment, or
- *  - either of those keys appears in the `env` block of
- *    `<homeDir>/.claude/settings.json`.
+ *  - `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or
+ *    `CLAUDE_CODE_OAUTH_TOKEN` in the environment,
+ *  - any of those keys in the `env` block of `<homeDir>/.claude/settings.json`,
+ *  - the top-level `apiKeyHelper` in that same file — a command the CLI runs to
+ *    mint a key, so a setup can be complete with no credential stored anywhere.
  *
- * These are the same credential sources the SDK subprocess env is built from
- * (see `buildSubprocessEnv`), so detecting them here means "asking for what we
- * actually need": when a native credential is present the provider advertises
- * the GitHub Copilot resource as `required: false`, so no sign-in is forced —
- * while still letting the host silently forward a token to a user who is signed
- * in anyway.
+ * The first two are the credential sources the SDK subprocess env is built from
+ * (`buildSubprocessEnv` spreads the real `process.env` in native mode); the
+ * third is honored by the CLI itself, which reads the same user settings file
+ * (`settingSources` includes `'user'`). A base URL counts on its own because it
+ * points Claude at a gateway that supplies the credential. The proxy transport
+ * also injects `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`, but into the
+ * subprocess *settings* env rather than this process's, so its own plumbing
+ * can't read back as a native setup.
  *
- * Detection is deliberately conservative — an empty-string value does not count
- * — so it neither misses a real login nor misfires on a leftover blank entry.
+ * Detecting what the SDK will actually go on to use means "asking for what we
+ * really need": when a native setup is present the provider advertises the
+ * GitHub Copilot resource as `required: false`, so no sign-in is forced — while
+ * still letting the host silently forward a token to a user who is signed in
+ * anyway.
+ *
+ * Only presence is tested, never the value: nothing here reads a credential
+ * beyond asking whether it is a non-empty string. Detection is deliberately
+ * conservative — an empty-string value does not count — so it neither misses a
+ * real login nor misfires on a leftover blank entry.
  *
  * `env` and the settings-file path are the only external inputs, so both are
  * injectable: `env` defaults to `process.env` and the file is located under
  * `homeDir`, letting tests exercise real detection without stubbing globals.
  */
 export function detectExistingClaudeSetup(homeDir: string, env: NodeJS.ProcessEnv = process.env): boolean {
-	return hasClaudeCredential(env)
-		|| hasClaudeCredential(readClaudeSettingsEnv(join(homeDir, '.claude', 'settings.json')));
+	if (hasNativeClaudeEnv(env)) {
+		return true;
+	}
+	const settings = readClaudeSettings(join(homeDir, '.claude', 'settings.json'));
+	return hasNativeClaudeEnv(settings?.env) || !!settings?.apiKeyHelper;
 }
 
-/** True when either recognized Anthropic credential is present and non-empty. */
-function hasClaudeCredential(env: ClaudeCredentialEnv | undefined): boolean {
-	return !!(env?.ANTHROPIC_API_KEY || env?.CLAUDE_CODE_OAUTH_TOKEN);
+/** True when any recognized native-Claude key is present and non-empty. */
+function hasNativeClaudeEnv(env: ClaudeNativeEnv | undefined): boolean {
+	return !!(env?.ANTHROPIC_API_KEY
+		|| env?.ANTHROPIC_AUTH_TOKEN
+		|| env?.ANTHROPIC_BASE_URL
+		|| env?.CLAUDE_CODE_OAUTH_TOKEN);
 }
 
 /**
- * Reads and validates the `env` block of `~/.claude/settings.json`. Returns
- * `undefined` when the file is missing, unreadable, not valid JSON, or does not
- * match the expected shape.
+ * Reads and validates `~/.claude/settings.json`. Returns `undefined` when the
+ * file is missing, unreadable, not valid JSON, or does not match the expected
+ * shape — unknown properties are ignored, so only a wrong *type* on a
+ * recognized key fails validation.
  */
-function readClaudeSettingsEnv(path: string): ClaudeCredentialEnv | undefined {
+function readClaudeSettings(path: string): ClaudeSettings | undefined {
 	let text: string;
 	try {
 		text = readFileSync(path, 'utf8');
@@ -150,5 +180,5 @@ function readClaudeSettingsEnv(path: string): ClaudeCredentialEnv | undefined {
 	} catch {
 		return undefined;
 	}
-	return claudeSettingsValidator.validate(parsed).content?.env;
+	return claudeSettingsValidator.validate(parsed).content;
 }

--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from '../../../../base/common/path.js';
-import { vObj, vOptionalProp, vString, type ValidatorType } from '../../../../base/common/validation.js';
+import { vObj, vOptionalProp, vUnknown, type ValidatorType } from '../../../../base/common/validation.js';
 
 /**
  * Resolved Claude host transport. `proxy` routes Anthropic traffic through the
@@ -78,107 +78,63 @@ export function resolveClaudeTransportMode(inputs: IClaudeTransportModeInputs): 
 }
 
 /**
- * Validator for the slice of `~/.claude/settings.json` we care about: the
- * top-level `apiKeyHelper`, plus an optional `env` block that may carry any
- * recognized Anthropic credential or endpoint override. Reuses the shared
- * combinators in `base/common/validation.ts` so parsing the untrusted file is
- * type-safe without hand-rolled shape checks. Unknown properties (`model`,
- * `permissions`, …) are ignored rather than rejected, so a real settings file
- * still validates. This validator is the single source of truth for the key
- * set — {@link ClaudeNativeEnv} is derived from it rather than hand-authored.
+ * Validators for the `~/.claude/settings.json` sources that indicate a usable
+ * native setup, kept separate — and holding `unknown` rather than `vString()` —
+ * so one malformed entry reads as absent instead of voiding its siblings.
+ * {@link isNonEmptyString} is what decides usability.
  */
-const claudeSettingsValidator = vObj({
-	// A command the CLI runs to mint an API key. File-only: it has no
-	// environment-variable counterpart, hence its place outside `env`.
-	apiKeyHelper: vOptionalProp(vString()),
+const claudeApiKeyHelperValidator = vObj({
+	apiKeyHelper: vOptionalProp(vUnknown()),
+});
+
+const claudeSettingsEnvValidator = vObj({
 	env: vOptionalProp(vObj({
-		ANTHROPIC_API_KEY: vOptionalProp(vString()),
-		ANTHROPIC_AUTH_TOKEN: vOptionalProp(vString()),
-		ANTHROPIC_BASE_URL: vOptionalProp(vString()),
-		CLAUDE_CODE_OAUTH_TOKEN: vOptionalProp(vString()),
+		ANTHROPIC_API_KEY: vOptionalProp(vUnknown()),
+		ANTHROPIC_AUTH_TOKEN: vOptionalProp(vUnknown()),
+		ANTHROPIC_BASE_URL: vOptionalProp(vUnknown()),
+		CLAUDE_CODE_OAUTH_TOKEN: vOptionalProp(vUnknown()),
 	})),
 });
 
-type ClaudeSettings = ValidatorType<typeof claudeSettingsValidator>;
-
 /**
- * The `env` block shape both `process.env` and `~/.claude/settings.json` are
- * probed for, derived from {@link claudeSettingsValidator} so the two never
- * drift. A non-empty value under any key means Claude can reach Anthropic
- * without Copilot: a credential of its own, or a base-URL override pointing at
- * a gateway that supplies one.
+ * The `env` shape both `process.env` and `~/.claude/settings.json` are probed
+ * for, derived from {@link claudeSettingsEnvValidator} so the two never drift.
  */
-type ClaudeNativeEnv = NonNullable<ClaudeSettings['env']>;
+type ClaudeNativeEnv = NonNullable<ValidatorType<typeof claudeSettingsEnvValidator>['env']>;
 
 /**
- * Detects whether a local Claude configuration exists that lets Claude run
- * natively (without GitHub). Returns `true` when any of the following is set to
- * a non-empty value:
- *
- *  - `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or
- *    `CLAUDE_CODE_OAUTH_TOKEN` in the environment,
- *  - any of those keys in the `env` block of `<homeDir>/.claude/settings.json`,
- *  - the top-level `apiKeyHelper` in that same file — a command the CLI runs to
- *    mint a key, so a setup can be complete with no credential stored anywhere.
- *
- * The first two are the credential sources the SDK subprocess env is built from
- * (`buildSubprocessEnv` spreads the real `process.env` in native mode); the
- * third is honored by the CLI itself, which reads the same user settings file
- * (`settingSources` includes `'user'`). A base URL counts on its own because it
- * points Claude at a gateway that supplies the credential. The proxy transport
- * also injects `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`, but into the
- * subprocess *settings* env rather than this process's, so its own plumbing
- * can't read back as a native setup.
- *
- * Detecting what the SDK will actually go on to use means "asking for what we
- * really need": when a native setup is present the provider advertises the
- * GitHub Copilot resource as `required: false`, so no sign-in is forced — while
- * still letting the host silently forward a token to a user who is signed in
- * anyway.
- *
- * Only presence is tested, never the value: nothing here reads a credential
- * beyond asking whether it is a non-empty string. Detection is deliberately
- * conservative — an empty-string value does not count — so it neither misses a
- * real login nor misfires on a leftover blank entry.
- *
- * `env` and the settings-file path are the only external inputs, so both are
- * injectable: `env` defaults to `process.env` and the file is located under
- * `homeDir`, letting tests exercise real detection without stubbing globals.
+ * Whether a local Claude setup exists that can run without GitHub: a recognized
+ * credential or endpoint key in `env` or `<homeDir>/.claude/settings.json`, or
+ * that file's `apiKeyHelper`. Each source is read independently, so a malformed
+ * value never masks a usable one.
  */
 export function detectExistingClaudeSetup(homeDir: string, env: NodeJS.ProcessEnv = process.env): boolean {
 	if (hasNativeClaudeEnv(env)) {
 		return true;
 	}
-	const settings = readClaudeSettings(join(homeDir, '.claude', 'settings.json'));
-	return hasNativeClaudeEnv(settings?.env) || !!settings?.apiKeyHelper;
+	const settings = readJsonFile(join(homeDir, '.claude', 'settings.json'));
+	return hasNativeClaudeEnv(claudeSettingsEnvValidator.validate(settings).content?.env)
+		|| isNonEmptyString(claudeApiKeyHelperValidator.validate(settings).content?.apiKeyHelper);
 }
 
-/** True when any recognized native-Claude key is present and non-empty. */
+/** True when any recognized native-Claude key carries a usable value. */
 function hasNativeClaudeEnv(env: ClaudeNativeEnv | undefined): boolean {
-	return !!(env?.ANTHROPIC_API_KEY
-		|| env?.ANTHROPIC_AUTH_TOKEN
-		|| env?.ANTHROPIC_BASE_URL
-		|| env?.CLAUDE_CODE_OAUTH_TOKEN);
+	return isNonEmptyString(env?.ANTHROPIC_API_KEY)
+		|| isNonEmptyString(env?.ANTHROPIC_AUTH_TOKEN)
+		|| isNonEmptyString(env?.ANTHROPIC_BASE_URL)
+		|| isNonEmptyString(env?.CLAUDE_CODE_OAUTH_TOKEN);
 }
 
-/**
- * Reads and validates `~/.claude/settings.json`. Returns `undefined` when the
- * file is missing, unreadable, not valid JSON, or does not match the expected
- * shape — unknown properties are ignored, so only a wrong *type* on a
- * recognized key fails validation.
- */
-function readClaudeSettings(path: string): ClaudeSettings | undefined {
-	let text: string;
+/** A setting counts only when it actually carries a value, never a blank leftover. */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0;
+}
+
+/** Parsed JSON, or `undefined` when the file is missing, unreadable or malformed. */
+function readJsonFile(path: string): unknown {
 	try {
-		text = readFileSync(path, 'utf8');
+		return JSON.parse(readFileSync(path, 'utf8'));
 	} catch {
 		return undefined;
 	}
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(text);
-	} catch {
-		return undefined;
-	}
-	return claudeSettingsValidator.validate(parsed).content;
 }

--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { readFileSync } from 'fs';
+import { parse as parseJSONC } from '../../../../base/common/json.js';
 import { join } from '../../../../base/common/path.js';
+import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
+import { isString } from '../../../../base/common/types.js';
 import { vObj, vOptionalProp, vUnknown, type ValidatorType } from '../../../../base/common/validation.js';
 
 /**
@@ -81,7 +84,7 @@ export function resolveClaudeTransportMode(inputs: IClaudeTransportModeInputs): 
  * Validators for the `~/.claude/settings.json` sources that indicate a usable
  * native setup, kept separate — and holding `unknown` rather than `vString()` —
  * so one malformed entry reads as absent instead of voiding its siblings.
- * {@link isNonEmptyString} is what decides usability.
+ * {@link hasValue} is what decides usability.
  */
 const claudeApiKeyHelperValidator = vObj({
 	apiKeyHelper: vOptionalProp(vUnknown()),
@@ -114,26 +117,26 @@ export function detectExistingClaudeSetup(homeDir: string, env: NodeJS.ProcessEn
 	}
 	const settings = readJsonFile(join(homeDir, '.claude', 'settings.json'));
 	return hasNativeClaudeEnv(claudeSettingsEnvValidator.validate(settings).content?.env)
-		|| isNonEmptyString(claudeApiKeyHelperValidator.validate(settings).content?.apiKeyHelper);
+		|| hasValue(claudeApiKeyHelperValidator.validate(settings).content?.apiKeyHelper);
 }
 
 /** True when any recognized native-Claude key carries a usable value. */
 function hasNativeClaudeEnv(env: ClaudeNativeEnv | undefined): boolean {
-	return isNonEmptyString(env?.ANTHROPIC_API_KEY)
-		|| isNonEmptyString(env?.ANTHROPIC_AUTH_TOKEN)
-		|| isNonEmptyString(env?.ANTHROPIC_BASE_URL)
-		|| isNonEmptyString(env?.CLAUDE_CODE_OAUTH_TOKEN);
+	return hasValue(env?.ANTHROPIC_API_KEY)
+		|| hasValue(env?.ANTHROPIC_AUTH_TOKEN)
+		|| hasValue(env?.ANTHROPIC_BASE_URL)
+		|| hasValue(env?.CLAUDE_CODE_OAUTH_TOKEN);
 }
 
 /** A setting counts only when it actually carries a value, never a blank leftover. */
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === 'string' && value.length > 0;
+function hasValue(value: unknown): value is string {
+	return isString(value) && !isFalsyOrWhitespace(value);
 }
 
 /** Parsed JSON, or `undefined` when the file is missing, unreadable or malformed. */
 function readJsonFile(path: string): unknown {
 	try {
-		return JSON.parse(readFileSync(path, 'utf8'));
+		return parseJSONC(readFileSync(path, 'utf8'));
 	} catch {
 		return undefined;
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeTransportMode.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { readFileSync } from 'fs';
-import { parse as parseJSONC } from '../../../../base/common/json.js';
+import { parse as parseJSONC, type ParseError } from '../../../../base/common/json.js';
 import { join } from '../../../../base/common/path.js';
 import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
 import { isString } from '../../../../base/common/types.js';
@@ -135,9 +135,16 @@ function hasValue(value: unknown): value is string {
 
 /** Parsed JSON, or `undefined` when the file is missing, unreadable or malformed. */
 function readJsonFile(path: string): unknown {
+	let text: string;
 	try {
-		return parseJSONC(readFileSync(path, 'utf8'));
+		text = readFileSync(path, 'utf8');
 	} catch {
 		return undefined;
 	}
+	// The tolerant parser reports on `errors` rather than throwing, and salvages a
+	// partial result from broken input — so a truncated file has to be rejected
+	// here, or half a credential reads as a setup the CLI could not load either.
+	const errors: ParseError[] = [];
+	const parsed: unknown = parseJSONC(text, errors, { allowTrailingComma: true, allowEmptyContent: true });
+	return errors.length === 0 ? parsed : undefined;
 }

--- a/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
@@ -59,7 +59,7 @@ suite('claudeTransportMode', () => {
 			fs.writeFileSync(join(dir, 'settings.json'), contents, 'utf8');
 		}
 
-		test('detects each env-var credential (and ignores an empty value)', () => {
+		test('detects each env-var credential (and ignores a blank value)', () => {
 			assert.deepStrictEqual({
 				none: detectExistingClaudeSetup(homeDir, {}),
 				apiKey: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: 'sk-ant-api-x' }),
@@ -67,7 +67,8 @@ suite('claudeTransportMode', () => {
 				baseUrl: detectExistingClaudeSetup(homeDir, { ANTHROPIC_BASE_URL: 'https://gateway.example/v1' }),
 				oauthToken: detectExistingClaudeSetup(homeDir, { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-x' }),
 				emptyValue: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: '' }),
-			}, { none: false, apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false });
+				whitespaceValue: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: '   ' }),
+			}, { none: false, apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, whitespaceValue: false });
 		});
 
 		test('detects a credential in the settings.json env block (empty env injected)', () => {
@@ -82,12 +83,18 @@ suite('claudeTransportMode', () => {
 			results.oauthToken = detectExistingClaudeSetup(homeDir, {});
 			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: '' } }));
 			results.emptyValue = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: '   ' } }));
+			results.whitespaceValue = detectExistingClaudeSetup(homeDir, {});
 			writeSettings(JSON.stringify({ model: 'claude-sonnet-4-5' }));
 			results.noEnvBlock = detectExistingClaudeSetup(homeDir, {});
 			writeSettings('not json');
 			results.malformed = detectExistingClaudeSetup(homeDir, {});
+			// Read with the same tolerant parser VS Code uses for every other
+			// hand-edited config, so comments and a trailing comma still resolve.
+			writeSettings('{\n\t// my key\n\t"env": { "ANTHROPIC_API_KEY": "sk-ant-api-x", },\n}');
+			results.jsonc = detectExistingClaudeSetup(homeDir, {});
 
-			assert.deepStrictEqual(results, { apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, noEnvBlock: false, malformed: false });
+			assert.deepStrictEqual(results, { apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, whitespaceValue: false, noEnvBlock: false, malformed: false, jsonc: true });
 		});
 
 		test('detects the top-level apiKeyHelper alongside unrecognized settings', () => {

--- a/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
@@ -105,5 +105,19 @@ suite('claudeTransportMode', () => {
 
 			assert.deepStrictEqual(results, { helper: true, helperAmongOthers: true, emptyValue: false, wrongType: false });
 		});
+
+		test('a malformed source never masks a usable one', () => {
+			const results: Record<string, boolean> = {};
+			writeSettings(JSON.stringify({ apiKeyHelper: '/bin/mint-key.sh', env: { ANTHROPIC_API_KEY: 42 } }));
+			results.helperWithMistypedEnvKey = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ apiKeyHelper: 42, env: { ANTHROPIC_API_KEY: 'sk-ant-api-x' } }));
+			results.apiKeyWithMistypedHelper = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-api-x', ANTHROPIC_BASE_URL: 8080 } }));
+			results.apiKeyWithMistypedSibling = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ apiKeyHelper: '/bin/mint-key.sh', env: 'not an object' }));
+			results.helperWithNonObjectEnv = detectExistingClaudeSetup(homeDir, {});
+
+			assert.deepStrictEqual(results, { helperWithMistypedEnvKey: true, apiKeyWithMistypedHelper: true, apiKeyWithMistypedSibling: true, helperWithNonObjectEnv: true });
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
@@ -89,12 +89,17 @@ suite('claudeTransportMode', () => {
 			results.noEnvBlock = detectExistingClaudeSetup(homeDir, {});
 			writeSettings('not json');
 			results.malformed = detectExistingClaudeSetup(homeDir, {});
+			// The tolerant parser salvages a partial object from a truncated file
+			// rather than failing, so the credential it recovers must not count —
+			// the CLI reading the same file would not get one.
+			writeSettings('{ "env": { "ANTHROPIC_API_KEY": "sk-ant-api-x"');
+			results.truncated = detectExistingClaudeSetup(homeDir, {});
 			// Read with the same tolerant parser VS Code uses for every other
 			// hand-edited config, so comments and a trailing comma still resolve.
 			writeSettings('{\n\t// my key\n\t"env": { "ANTHROPIC_API_KEY": "sk-ant-api-x", },\n}');
 			results.jsonc = detectExistingClaudeSetup(homeDir, {});
 
-			assert.deepStrictEqual(results, { apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, whitespaceValue: false, noEnvBlock: false, malformed: false, jsonc: true });
+			assert.deepStrictEqual(results, { apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, whitespaceValue: false, noEnvBlock: false, malformed: false, truncated: false, jsonc: true });
 		});
 
 		test('detects the top-level apiKeyHelper alongside unrecognized settings', () => {

--- a/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeTransportMode.test.ts
@@ -63,15 +63,21 @@ suite('claudeTransportMode', () => {
 			assert.deepStrictEqual({
 				none: detectExistingClaudeSetup(homeDir, {}),
 				apiKey: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: 'sk-ant-api-x' }),
+				authToken: detectExistingClaudeSetup(homeDir, { ANTHROPIC_AUTH_TOKEN: 'sk-ant-auth-x' }),
+				baseUrl: detectExistingClaudeSetup(homeDir, { ANTHROPIC_BASE_URL: 'https://gateway.example/v1' }),
 				oauthToken: detectExistingClaudeSetup(homeDir, { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-x' }),
 				emptyValue: detectExistingClaudeSetup(homeDir, { ANTHROPIC_API_KEY: '' }),
-			}, { none: false, apiKey: true, oauthToken: true, emptyValue: false });
+			}, { none: false, apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false });
 		});
 
 		test('detects a credential in the settings.json env block (empty env injected)', () => {
 			const results: Record<string, boolean> = {};
 			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-api-x' } }));
 			results.apiKey = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: 'sk-ant-auth-x' } }));
+			results.authToken = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'https://gateway.example/v1' } }));
+			results.baseUrl = detectExistingClaudeSetup(homeDir, {});
 			writeSettings(JSON.stringify({ env: { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-x' } }));
 			results.oauthToken = detectExistingClaudeSetup(homeDir, {});
 			writeSettings(JSON.stringify({ env: { ANTHROPIC_API_KEY: '' } }));
@@ -81,7 +87,23 @@ suite('claudeTransportMode', () => {
 			writeSettings('not json');
 			results.malformed = detectExistingClaudeSetup(homeDir, {});
 
-			assert.deepStrictEqual(results, { apiKey: true, oauthToken: true, emptyValue: false, noEnvBlock: false, malformed: false });
+			assert.deepStrictEqual(results, { apiKey: true, authToken: true, baseUrl: true, oauthToken: true, emptyValue: false, noEnvBlock: false, malformed: false });
+		});
+
+		test('detects the top-level apiKeyHelper alongside unrecognized settings', () => {
+			const results: Record<string, boolean> = {};
+			writeSettings(JSON.stringify({ apiKeyHelper: '/bin/mint-key.sh' }));
+			results.helper = detectExistingClaudeSetup(homeDir, {});
+			// A real settings file carries keys the validator doesn't declare; they
+			// must be ignored rather than fail validation for the whole file.
+			writeSettings(JSON.stringify({ apiKeyHelper: '/bin/mint-key.sh', model: 'claude-sonnet-4-5', permissions: { allow: [] } }));
+			results.helperAmongOthers = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ apiKeyHelper: '' }));
+			results.emptyValue = detectExistingClaudeSetup(homeDir, {});
+			writeSettings(JSON.stringify({ apiKeyHelper: 42 }));
+			results.wrongType = detectExistingClaudeSetup(homeDir, {});
+
+			assert.deepStrictEqual(results, { helper: true, helperAmongOthers: true, emptyValue: false, wrongType: false });
 		});
 	});
 });


### PR DESCRIPTION
`detectExistingClaudeSetup` recognized only `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN`, so several ordinary BYO-Anthropic setups read as "no local Claude" and got forced into a GitHub sign-in. This widens the `~/.claude/settings.json` validator — the single source of truth for the key set — with three more sources:

| Source | Why it counts |
| --- | --- |
| `env.ANTHROPIC_AUTH_TOKEN` | First-class in Anthropic's own resolution order, immediately after `ANTHROPIC_API_KEY`. |
| `env.ANTHROPIC_BASE_URL` | Counts on its own: it points Claude at a gateway that supplies the credential. |
| `apiKeyHelper` (top-level) | A command the CLI runs to mint a key, so a setup can be complete with no credential stored anywhere. |

`apiKeyHelper` sits outside the `env` block, so `readClaudeSettingsEnv` became `readClaudeSettings` and returns the whole validated object. The env predicate and its derived type are renamed (`hasClaudeCredential` → `hasNativeClaudeEnv`, `ClaudeCredentialEnv` → `ClaudeNativeEnv`) since a base URL is an endpoint override rather than a credential.

Presence-only and empty-string-doesn't-count both still hold — nothing here reads a credential beyond asking whether it is a non-empty string. Confirmed `ObjValidator` iterates only declared properties, so a real settings file full of undeclared keys (`model`, `permissions`, `hooks`, …) still validates.

No self-detection loop with the proxy transport: it injects `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` into the SDK's *subprocess settings* env, not this process's, so its own plumbing can't read back as a native setup.

## Validation

- `./scripts/test.sh --grep 'claudeTransportMode'` — 4 passing (new coverage for all three sources on both the env-var and settings.json paths, plus empty-value, wrong-type, and undeclared-key cases).
- `npm run typecheck-client` — clean.

## Follow-up, not in this PR

Sniffing files and env vars is a hand-maintained reimplementation of the CLI's own credential resolution, and it's wrong in both directions:

- **False negative** — a user who runs `claude login` and never `claude setup-token` keeps their credential in the OS keychain, with no env var, no `settings.json` entry, and no `apiKeyHelper`. Detection says "no setup" while they are fully logged in.
- **False positive** — an inherited `ANTHROPIC_BASE_URL` pointing at loopback (another tool's local proxy) now reads as a gateway setup, which routes `native` and then fails inside the SDK.

The SDK exposes `Query.accountInfo()`, which returns the CLI's *own* resolution (`apiProvider: 'firstParty' | 'gateway' | 'bedrock' | …`) and drifts from it by construction never. It can't replace this outright — it needs a live `Query` (a spawned CLI subprocess), while `getProtectedResources()` and `_defaultTransportMode()` are both synchronous. The shape that works is two tiers: `accountInfo()` as the authority, called on the query `_fetchNativeModels` already opens (no extra spawn) and cached for the sync call sites, with this detection demoted to a cheap pre-filter that decides *whether to ask* — so a false positive costs one wasted spawn instead of a wrong sign-in gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)