### PR TITLE
Stop auto-update policy from being overridden per extension

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -67,7 +67,7 @@ import { ILanguageModelToolsService } from '../../chat/common/tools/languageMode
 import { CONTEXT_KEYBINDINGS_EDITOR } from '../../preferences/common/preferences.js';
 import { IWebview } from '../../webview/browser/webview.js';
 import { Query } from '../common/extensionQuery.js';
-import { AutoRestartConfigurationKey, AutoUpdateConfigurationKey, CONTEXT_EXTENSIONS_GALLERY_STATUS, CONTEXT_HAS_GALLERY, DefaultViewsContext, ExtensionEditorTab, ExtensionRuntimeActionType, EXTENSIONS_CATEGORY, extensionsFilterSubMenu, extensionsSearchActionsMenu, HasOutdatedExtensionsContext, IExtensionArg, IExtensionsViewPaneContainer, IExtensionsWorkbenchService, INSTALL_ACTIONS_GROUP, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, IWorkspaceRecommendedExtensionsView, LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID, OUTDATED_EXTENSIONS_VIEW_ID, SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID, THEME_ACTIONS_GROUP, TOGGLE_IGNORE_EXTENSION_ACTION_ID, UPDATE_ACTIONS_GROUP, VIEWLET_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID } from '../common/extensions.js';
+import { AutoRestartConfigurationKey, AutoUpdateConfigLockedByPolicyContext, AutoUpdateConfigurationKey, CONTEXT_EXTENSIONS_GALLERY_STATUS, CONTEXT_HAS_GALLERY, DefaultViewsContext, ExtensionEditorTab, ExtensionRuntimeActionType, EXTENSIONS_CATEGORY, extensionsFilterSubMenu, extensionsSearchActionsMenu, HasOutdatedExtensionsContext, IExtensionArg, IExtensionsViewPaneContainer, IExtensionsWorkbenchService, INSTALL_ACTIONS_GROUP, INSTALL_EXTENSION_FROM_VSIX_COMMAND_ID, IWorkspaceRecommendedExtensionsView, LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID, OUTDATED_EXTENSIONS_VIEW_ID, SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID, THEME_ACTIONS_GROUP, TOGGLE_IGNORE_EXTENSION_ACTION_ID, UPDATE_ACTIONS_GROUP, VIEWLET_ID, WORKSPACE_RECOMMENDATIONS_VIEW_ID } from '../common/extensions.js';
 import { ExtensionsConfigurationSchema, ExtensionsConfigurationSchemaId } from '../common/extensionsFileTemplate.js';
 import { ExtensionsInput } from '../common/extensionsInput.js';
 import { KeymapExtensions } from '../common/extensionsUtils.js';
@@ -762,7 +762,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			}
 		});
 
-		const enableAutoUpdateWhenCondition = ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off');
+		const enableAutoUpdateWhenCondition = ContextKeyExpr.and(ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'), ContextKeyExpr.not(AutoUpdateConfigLockedByPolicyContext.key));
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.enableAutoUpdate',
 			title: localize2('enableAutoUpdate', 'Enable Auto Update for Extensions'),
@@ -779,7 +779,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			run: (accessor: ServicesAccessor) => accessor.get(IExtensionsWorkbenchService).updateAutoUpdateForAllExtensions(true)
 		});
 
-		const disableAutoUpdateWhenCondition = ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'off');
+		const disableAutoUpdateWhenCondition = ContextKeyExpr.and(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'off'), ContextKeyExpr.not(AutoUpdateConfigLockedByPolicyContext.key));
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.disableAutoUpdate',
 			title: localize2('disableAutoUpdate', 'Disable Auto Update for Extensions'),
@@ -1474,7 +1474,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdateForExtensionAction.ID,
 			title: ToggleAutoUpdateForExtensionAction.LABEL,
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'on'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed')),
+			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'on'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed'), ContextKeyExpr.not(AutoUpdateConfigLockedByPolicyContext.key)),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,
@@ -1501,7 +1501,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdatesForPublisherAction.ID,
 			title: { value: ToggleAutoUpdatesForPublisherAction.LABEL, original: 'Auto Update (Publisher)' },
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'),
+			precondition: ContextKeyExpr.and(ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'), ContextKeyExpr.not(AutoUpdateConfigLockedByPolicyContext.key)),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1083,6 +1083,11 @@ export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 		if (this.extension.deprecationInfo?.disallowInstall) {
 			return;
 		}
+		if (this.extensionsWorkbenchService.isAutoUpdateConfigLockedByPolicy()) {
+			// Managed by organization policy: reflect the effective state, but don't allow overriding it.
+			this.checked = this.extensionsWorkbenchService.isAutoUpdateEnabledFor(this.extension);
+			return;
+		}
 
 		const extension = this.extension.local ?? this.extension.gallery;
 		if (extension && this.allowedExtensionsService.isAllowed(extension) !== true) {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1084,7 +1084,8 @@ export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 			return;
 		}
 		if (this.extensionsWorkbenchService.isAutoUpdateConfigLockedByPolicy()) {
-			// Managed by organization policy: reflect the effective state, but don't allow overriding it.
+			// Managed by organization policy: show the effective state, but keep it disabled so it can't be overridden.
+			this.class = ToggleAutoUpdateForExtensionAction.EnabledClass;
 			this.checked = this.extensionsWorkbenchService.isAutoUpdateEnabledFor(this.extension);
 			return;
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -2388,12 +2388,12 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return false;
 		}
 
-		if (extension.pinned) {
-			return false;
-		}
-
-		// Per-extension opt-outs can't override an organization policy.
+		// A pin (whether set explicitly or as a side effect of installing a specific
+		// version) is a per-extension override too, so it can't defeat the policy either.
 		if (!autoUpdateLockedByPolicy) {
+			if (extension.pinned) {
+				return false;
+			}
 			const disabledAutoUpdateExtensions = this.getDisabledAutoUpdateExtensions();
 			if (disabledAutoUpdateExtensions.includes(extension.identifier.id.toLowerCase())) {
 				return false;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -34,7 +34,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IExtension, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, AutoUpdateDelayConfigurationKey, AutoCheckUpdatesConfigurationKey, HasOutdatedExtensionsContext, AutoUpdateConfigurationValue, InstallExtensionOptions, ExtensionRuntimeState, ExtensionRuntimeActionType, AutoRestartConfigurationKey, VIEWLET_ID, IExtensionsViewPaneContainer, IExtensionsNotification } from '../common/extensions.js';
+import { IExtension, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, AutoUpdateDelayConfigurationKey, AutoCheckUpdatesConfigurationKey, HasOutdatedExtensionsContext, AutoUpdateConfigLockedByPolicyContext, AutoUpdateConfigurationValue, InstallExtensionOptions, ExtensionRuntimeState, ExtensionRuntimeActionType, AutoRestartConfigurationKey, VIEWLET_ID, IExtensionsViewPaneContainer, IExtensionsNotification } from '../common/extensions.js';
 import { ACTIVE_GROUP, IEditorService, MODAL_GROUP, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { IURLService, IURLHandler, IOpenURLOptions } from '../../../../platform/url/common/url.js';
 import { ExtensionsInput, IExtensionEditorOptions } from '../common/extensionsInput.js';
@@ -978,6 +978,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	declare readonly _serviceBrand: undefined;
 
 	private hasOutdatedExtensionsContextKey: IContextKey<boolean>;
+	private autoUpdateConfigLockedByPolicyContextKey: IContextKey<boolean>;
 
 	private readonly localExtensions: Extensions | null = null;
 	private readonly remoteExtensions: Extensions | null = null;
@@ -1045,6 +1046,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		super();
 
 		this.hasOutdatedExtensionsContextKey = HasOutdatedExtensionsContext.bindTo(contextKeyService);
+		this.autoUpdateConfigLockedByPolicyContextKey = AutoUpdateConfigLockedByPolicyContext.bindTo(contextKeyService);
 		if (extensionManagementServerService.localExtensionManagementServer) {
 			this.localExtensions = this._register(instantiationService.createInstance(Extensions,
 				extensionManagementServerService.localExtensionManagementServer,
@@ -1132,9 +1134,11 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	private initializeAutoUpdate(): void {
+		this.autoUpdateConfigLockedByPolicyContextKey.set(this.isAutoUpdateConfigLockedByPolicy());
 		// Register listeners for auto updates
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AutoUpdateConfigurationKey)) {
+				this.autoUpdateConfigLockedByPolicyContextKey.set(this.isAutoUpdateConfigLockedByPolicy());
 				if (!this.isAutoUpdateEnabled()) {
 					// Auto update disabled — cancel any pending delayed re-check
 					this.delayedAutoUpdateCheckTimer.value = undefined;
@@ -1236,6 +1240,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		return 'on';
 	}
 
+	isAutoUpdateConfigLockedByPolicy(): boolean {
+		return this.configurationService.inspect(AutoUpdateConfigurationKey).policyValue !== undefined;
+	}
+
 	isAutoUpdateDelayed(extension: IExtension): boolean {
 		if (!extension.outdated) {
 			return false;
@@ -1280,6 +1288,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	async updateAutoUpdateForAllExtensions(isAutoUpdateEnabled: boolean): Promise<void> {
+		if (this.isAutoUpdateConfigLockedByPolicy()) {
+			return;
+		}
+
 		const wasAutoUpdateEnabled = this.isAutoUpdateEnabled();
 		if (wasAutoUpdateEnabled === isAutoUpdateEnabled) {
 			return;
@@ -2358,8 +2370,13 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		}
 
 		const autoUpdateValue = this.getAutoUpdateValue();
+		const autoUpdateLockedByPolicy = this.isAutoUpdateConfigLockedByPolicy();
 
 		if (autoUpdateValue === 'off') {
+			// Per-extension/publisher opt-ins can't override an organization policy.
+			if (autoUpdateLockedByPolicy) {
+				return false;
+			}
 			const extensionsToAutoUpdate = this.getEnabledAutoUpdateExtensions();
 			const extensionId = extension.identifier.id.toLowerCase();
 			if (extensionsToAutoUpdate.includes(extensionId)) {
@@ -2375,9 +2392,12 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return false;
 		}
 
-		const disabledAutoUpdateExtensions = this.getDisabledAutoUpdateExtensions();
-		if (disabledAutoUpdateExtensions.includes(extension.identifier.id.toLowerCase())) {
-			return false;
+		// Per-extension opt-outs can't override an organization policy.
+		if (!autoUpdateLockedByPolicy) {
+			const disabledAutoUpdateExtensions = this.getDisabledAutoUpdateExtensions();
+			if (disabledAutoUpdateExtensions.includes(extension.identifier.id.toLowerCase())) {
+				return false;
+			}
 		}
 
 		// Auto-update is on; only update enabled extensions.

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -161,6 +161,7 @@ export interface IExtensionsWorkbenchService {
 	open(extension: IExtension | string, options?: IExtensionEditorOptions): Promise<void>;
 	openSearch(searchValue: string, focus?: boolean): Promise<void>;
 	getAutoUpdateValue(): AutoUpdateConfigurationValue;
+	isAutoUpdateConfigLockedByPolicy(): boolean;
 	isAutoUpdateDelayed(extension: IExtension): boolean;
 	getAutoUpdateDelayRemaining(extension: IExtension): number;
 	getAutoUpdateDelay(): number;
@@ -261,6 +262,7 @@ export const LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID = 'workbench.exten
 // Context Keys
 export const DefaultViewsContext = new RawContextKey<boolean>('defaultExtensionViews', true);
 export const HasOutdatedExtensionsContext = new RawContextKey<boolean>('hasOutdatedExtensions', false);
+export const AutoUpdateConfigLockedByPolicyContext = new RawContextKey<boolean>('autoUpdateConfigLockedByPolicy', false);
 export const CONTEXT_HAS_GALLERY = new RawContextKey<boolean>('hasGallery', false);
 export const CONTEXT_EXTENSIONS_GALLERY_STATUS = new RawContextKey<string>('extensionsGalleryStatus', ExtensionGalleryManifestStatus.Unavailable);
 export const ExtensionResultsListFocused = new RawContextKey<boolean>('extensionResultListFocused ', true);

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -1797,6 +1797,19 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		assert.strictEqual(testObject.isAutoUpdateEnabledFor(testObject.local[0]), true);
 	});
 
+	test('Test a pre-existing pin is ignored when locked by policy (#325909)', async () => {
+		stubConfiguration(true, undefined, true);
+
+		const extension1 = aLocalExtension('a', undefined, { pinned: true });
+		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [extension1]);
+		testObject = await aWorkbenchService();
+
+		// The extension was pinned before (or independently of) the policy taking effect,
+		// but the policy still wins.
+		assert.strictEqual(testObject.local[0].local?.pinned, true);
+		assert.strictEqual(testObject.isAutoUpdateEnabledFor(testObject.local[0]), true);
+	});
+
 	test('Test updateAutoUpdateForAllExtensions is a no-op when locked by policy (#325909)', async () => {
 		stubConfiguration(true, undefined, true);
 		instantiationService.stub(IDialogService, {

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -1778,6 +1778,41 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		assert.deepStrictEqual(testObject.getDisabledAutoUpdateExtensions(), []);
 	});
 
+	test('Test per-extension auto update opt-out is ignored when locked by policy (#325909)', async () => {
+		stubConfiguration(true, undefined, true);
+
+		const extension1 = aLocalExtension('a');
+		const extension2 = aLocalExtension('b');
+		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [extension1, extension2]);
+		instantiationService.stub(IExtensionManagementService, 'updateMetadata', (local: Mutable<ILocalExtension>, metadata: Partial<Metadata>) => {
+			local.pinned = !!metadata.pinned;
+			return local;
+		});
+		testObject = await aWorkbenchService();
+
+		await testObject.updateAutoUpdateEnablementFor(testObject.local[0], false);
+
+		// The opt-out is still recorded, but must not be honored while the policy is in effect.
+		assert.deepStrictEqual(testObject.getDisabledAutoUpdateExtensions(), ['pub.a']);
+		assert.strictEqual(testObject.isAutoUpdateEnabledFor(testObject.local[0]), true);
+	});
+
+	test('Test updateAutoUpdateForAllExtensions is a no-op when locked by policy (#325909)', async () => {
+		stubConfiguration(true, undefined, true);
+		instantiationService.stub(IDialogService, {
+			confirm: () => Promise.resolve({ confirmed: true })
+		});
+
+		const extension1 = aLocalExtension('a');
+		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [extension1]);
+		testObject = await aWorkbenchService();
+
+		await testObject.updateAutoUpdateForAllExtensions(false);
+
+		assert.strictEqual(testObject.getAutoUpdateValue(), 'on');
+		assert.strictEqual(testObject.isAutoUpdateEnabledFor(testObject.local[0]), true);
+	});
+
 	async function aWorkbenchService(): Promise<ExtensionsWorkbenchService> {
 		const workbenchService: ExtensionsWorkbenchService = disposableStore.add(instantiationService.createInstance(ExtensionsWorkbenchService));
 		await workbenchService.queryLocal();
@@ -1796,7 +1831,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		return workbenchService;
 	}
 
-	function stubConfiguration(autoUpdateValue?: any, autoCheckUpdatesValue?: any): void {
+	function stubConfiguration(autoUpdateValue?: any, autoCheckUpdatesValue?: any, autoUpdatePolicyValue?: any): void {
 		const values: any = {
 			[AutoUpdateConfigurationKey]: autoUpdateValue ?? true,
 			[AutoUpdateDelayConfigurationKey]: 2,
@@ -1820,6 +1855,9 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 				});
 			},
 			inspect: (key: string) => {
+				if (key === AutoUpdateConfigurationKey && autoUpdatePolicyValue !== undefined) {
+					return { policyValue: autoUpdatePolicyValue };
+				}
 				return {};
 			}
 		});


### PR DESCRIPTION
Fixes #325909.

I went looking into why the auto-update policy wasn't sticking, and it turns out there are three separate ways around it once `extensions.autoUpdate` is locked by an org policy.

The per-extension "Auto Update" checkbox writes an extension id to a storage-backed opt-out list, and `shouldAutoUpdateExtension` honors that list unconditionally — it never checks whether the top-level value came from policy. So a user can uncheck auto-update for a specific extension and it'll actually stop updating, policy or not.

"Disable Auto Update for Extensions" is worse: it doesn't go through configuration at all for the actual enforcement, it pins every installed extension directly via `updateMetadata({ pinned: true })`. Pinned extensions never auto-update, full stop, regardless of anything else. That's exactly what the issue reporter saw — clicking it clears every extension's checkbox.

And the publisher-level toggle lets someone opt a publisher's extensions back in when policy has auto-update forced off.

None of this is really a UI bug so much as the enforcement never being policy-aware in the first place. So an org that turns this policy on specifically to guarantee security patches land could have that quietly undone extension by extension, without anything telling them it happened.

Fix is a small `isAutoUpdateConfigLockedByPolicy()` check (backed by `configurationService.inspect(...).policyValue`) plus a context key for it, wired into three places: `shouldAutoUpdateExtension` now ignores the override lists while locked, `updateAutoUpdateForAllExtensions` becomes a no-op while locked (so the pinning bypass can't fire), and the per-extension checkbox / the three related commands grey out so the UI stops implying you can change something you actually can't.

Ran the full `ExtensionsWorkbenchServiceTest` suite (89 tests) plus two new ones covering the locked-by-policy cases specifically — all passing. Also ran `npm run typecheck-client` clean.