### PR TITLE
docs: fix typos in comments and documentation across core codebase

### DIFF
--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -374,7 +374,7 @@ export interface IChatEndpoint extends IEndpoint {
 	 * @param expectedNumChoices The expected number of choices in the response
 	 * @param finishCallback A finish callback to indicate when the response should be complete
 	 * @param telemetryData GH telemetry data from the originating request, will be extended with request information
-	 * @param cancellationToken A cancellation tokenf for cancelling the request
+	 * @param cancellationToken A cancellation token for cancelling the request
 	 * @returns An async iterable object of chat completions
 	 */
 	processResponseFromChatEndpoint(

--- a/src/vs/base/browser/ui/hover/hoverDelegateFactory.ts
+++ b/src/vs/base/browser/ui/hover/hoverDelegateFactory.ts
@@ -32,7 +32,7 @@ export function getDefaultHoverDelegate(placement: 'mouse' | 'element'): IHoverD
 // TODO: Create equivalent in IHoverService
 export function createInstantHoverDelegate(): IScopedHoverDelegate {
 	// Creates a hover delegate with instant hover enabled.
-	// This hover belongs to the consumer and requires the them to dispose it.
+	// This hover belongs to the consumer and requires them to dispose it.
 	// Instant hover only makes sense for 'element' placement.
 	return hoverDelegateFactory('element', true);
 }

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -682,7 +682,7 @@ export class SplitView<TLayoutContext = undefined, TView extends IView<TLayoutCo
 				}
 			}
 
-			// Save referene view, in case of `split` sizing
+			// Save reference view, in case of `split` sizing
 			const referenceViewItem = sizing?.type === 'split' ? this.viewItems[sizing.index] : undefined;
 
 			// Remove view

--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -76,7 +76,7 @@ type InlineCompletionsEndOfLifeClassification = {
 	extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version of the extension that contributed the inline completion' };
 	groupId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The group ID of the extension that contributed the inline completion' };
 	availableProviders: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The list of available inline completion providers at the time of the request' };
-	skuPlan: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The the plan the user is subscribed to' };
+	skuPlan: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The plan the user is subscribed to' };
 	skuType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sku type of the user' };
 	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user' };
 	shownDuration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration for which the inline completion was shown' };

--- a/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
+++ b/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
@@ -334,10 +334,10 @@ suite('ParameterHintsModel', () => {
 			assert.strictEqual(-1, didRequestCancellationOf);
 
 			return new Promise<void>((resolve, reject) =>
-				disposables.add(hintsModel.onChangedHints(newParamterHints => {
+				disposables.add(hintsModel.onChangedHints(newParameterHints => {
 					try {
 						assert.strictEqual(0, didRequestCancellationOf);
-						assert.strictEqual('1', newParamterHints!.signatures[0].label);
+						assert.strictEqual('1', newParameterHints!.signatures[0].label);
 						resolve();
 					} catch (e) {
 						reject(e);
@@ -401,7 +401,7 @@ suite('ParameterHintsModel', () => {
 		const triggerChar = 'a';
 		const firstProviderId = 'firstProvider';
 		const secondProviderId = 'secondProvider';
-		const paramterLabel = 'parameter';
+		const parameterLabel = 'parameter';
 
 		const editor = createMockEditor('');
 		const model = disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -423,7 +423,7 @@ suite('ParameterHintsModel', () => {
 								signatures: [{
 									label: firstProviderId,
 									parameters: [
-										{ label: paramterLabel }
+										{ label: parameterLabel }
 									]
 								}]
 							},
@@ -468,12 +468,12 @@ suite('ParameterHintsModel', () => {
 			const firstHint = (await getNextHint(model))!.value;
 			assert.strictEqual(firstHint.signatures[0].label, firstProviderId);
 			assert.strictEqual(firstHint.activeSignature, 0);
-			assert.strictEqual(firstHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(firstHint.signatures[0].parameters[0].label, parameterLabel);
 
 			const secondHint = (await getNextHint(model))!.value;
 			assert.strictEqual(secondHint.signatures[0].label, secondProviderId);
 			assert.strictEqual(secondHint.activeSignature, 1);
-			assert.strictEqual(secondHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(secondHint.signatures[0].parameters[0].label, parameterLabel);
 		});
 	});
 

--- a/src/vs/editor/contrib/snippet/browser/snippet.md
+++ b/src/vs/editor/contrib/snippet/browser/snippet.md
@@ -133,4 +133,4 @@ int         ::= [0-9]+
 text        ::= .*
 ```
 
-Escaping is done with with the `\` (backslash) character. The rule of thumb is that you can escape characters that otherwise would have a syntactic meaning, e.g within text you can escape `$`, `}` and `\`, within choice elements you can escape `|`, `,` and `\`, and within transform elements you can escape `/` and `\`. Also note that in JSON you need to escape `\` as `\\`.
+Escaping is done with the `\` (backslash) character. The rule of thumb is that you can escape characters that otherwise would have a syntactic meaning, e.g within text you can escape `$`, `}` and `\`, within choice elements you can escape `|`, `,` and `\`, and within transform elements you can escape `/` and `\`. Also note that in JSON you need to escape `\` as `\\`.

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3130,7 +3130,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -130,7 +130,7 @@ export class GettingStartedPage extends EditorPane {
 	private readonly detailsPageDisposables: DisposableStore = new DisposableStore();
 	private readonly mediaDisposables: DisposableStore = new DisposableStore();
 
-	// Ensure that the these are initialized before use.
+	// Ensure that these are initialized before use.
 	// Currently initialized before use in buildCategoriesSlide and scrollToCategory
 	private recentlyOpened!: Promise<IRecentlyOpened>;
 	private gettingStartedCategories!: IResolvedWalkthrough[];


### PR DESCRIPTION
### Description
This PR fixes several small typos in JSDoc comments, inline code documentation, and unit test variables across `src/vs/` and built-in extensions to improve code clarity and documentation quality:

- `src/vs/base/browser/ui/splitview/splitview.ts`: Fix typo `referene` -> `reference` in inline comment.
- `src/vs/base/browser/ui/hover/hoverDelegateFactory.ts`: Fix phrasing `requires the them to dispose it` -> `requires them to dispose it`.
- `src/vs/editor/contrib/snippet/browser/snippet.md`: Fix duplicate word `with with` -> `with`.
- `src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts`: Fix duplicate word `The the plan` -> `The plan`.
- `src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts`: Fix parameter label variable typos `paramter` -> `parameter`.
- `src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts`: Fix phrasing `Ensure that the these` -> `Ensure that these`.
- `src/vs/workbench/api/common/extHostTypes.ts`: Fix spelling `seperate` -> `separate`.
- `src/vs/workbench/contrib/files/browser/views/explorerViewer.ts`: Fix spelling `seperately` -> `separately`.
- `src/vs/base/parts/sandbox/electron-browser/electronTypes.ts`: Fix spelling `superceded` -> `superseded`.
- `extensions/copilot/src/platform/networking/common/networking.ts`: Fix JSDoc typo `cancellation tokenf` -> `cancellation token`.

### Testing
- Verified all edits via `git diff` to ensure strictly non-functional documentation/comment fixes.
- No logical code or API contract changes were introduced.
