### PR TITLE
agentHost: describe entry persistence with a static config table

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -22,9 +22,10 @@ import { AgentHostAhpJsonlLoggingSettingId, type IAgentConnection } from '../com
 import {
 	IRemoteAgentHostService,
 	RemoteAgentHostConnectionStatus,
-	RemoteAgentHostEntryType,
 	RemoteAgentHostsEnabledSettingId,
 	RemoteAgentHostsSettingId,
+	SSH_ENTRY_TYPE_CONFIG,
+	WEBSOCKET_ENTRY_TYPE_CONFIG,
 	getEntryTypeConfig,
 	parseLegacyRawEntry,
 	type IRawRemoteAgentHostEntry,
@@ -279,7 +280,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		const existingConnection = this._getConnectionInfo(address);
 		const config = getEntryTypeConfig(entry.connection.type);
 		if (config.store !== 'runtime') {
-			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry), config.store);
+			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry));
 		}
 
 		if (existingConnection) {
@@ -360,7 +361,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 		const config = getEntryTypeConfig(entry.connection.type);
 		if (config.store !== 'runtime') {
-			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry), config.store);
+			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry));
 		}
 
 		this._onDidChangeConnections.fire();
@@ -381,7 +382,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			const config = getEntryTypeConfig(entry.connection.type);
 			if (config.store !== 'runtime') {
 				const entries = this._getConfiguredEntries(true).filter(entry => this._entryAddress(entry) !== normalized);
-				await this._storeConfiguredEntries(entries, config.store);
+				await this._storeConfiguredEntries(entries);
 			}
 		}
 
@@ -451,6 +452,14 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		const oldNames = new Map(this._names);
 		this._names.clear();
 		this._tokens.clear();
+		// Runtime-registered connections are not part of the persisted set, so
+		// seed their metadata first; without this a live tunnel/WSL/cloud
+		// connection survives reconcile but reports its address as its name,
+		// which downstream provider reconciliation treats as a rename.
+		for (const [address, entry] of this._registeredEntries) {
+			this._names.set(address, entry.name);
+			this._tokens.set(address, entry.connectionToken);
+		}
 		for (const { entry, address } of entriesWithAddress) {
 			this._names.set(address, entry.name);
 			this._tokens.set(address, entry.connectionToken);
@@ -656,11 +665,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _getConfiguredEntries(targetSettings = false): IRemoteAgentHostEntry[] {
-		const config = getEntryTypeConfig(RemoteAgentHostEntryType.WebSocket);
 		let entries = this._getSettings(targetSettings).entries
 			.filter(isRawRemoteAgentHostEntry)
 			.filter(entry => !isLegacySshRawEntry(entry))
-			.map(entry => config.fromRaw!(entry));
+			.map(entry => WEBSOCKET_ENTRY_TYPE_CONFIG.fromRaw(entry));
 		for (const entry of this._getStoredSSHEntries()) {
 			entries = this._upsertEntry(entries, entry);
 		}
@@ -694,21 +702,30 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		};
 	}
 
-	private async _storeConfiguredEntries(entries: readonly IRemoteAgentHostEntry[], store: 'settings' | 'storage'): Promise<void> {
-		const raw = entries
-			.filter(entry => getEntryTypeConfig(entry.connection.type).store === store)
-			.map(entry => {
-				const config = getEntryTypeConfig(entry.connection.type);
-				return config.toRaw!(entry, entry.connection);
-			});
-		if (store === 'storage') {
-			this._storeStoredSSHEntries(raw);
-			return;
+	/**
+	 * Writes both durable projections of `entries`, which must be the full
+	 * merged set. Entries are keyed globally by normalized address, so a
+	 * replacement can move an address between stores; writing only the
+	 * destination would leave the source row behind for
+	 * {@link _getConfiguredEntries} to resurrect. Each store is left
+	 * untouched when its projection is unchanged.
+	 */
+	private async _storeConfiguredEntries(entries: readonly IRemoteAgentHostEntry[]): Promise<void> {
+		const settingsRaw: IRawRemoteAgentHostEntry[] = [];
+		const storageRaw: IRawRemoteAgentHostEntry[] = [];
+		for (const entry of entries) {
+			const config = getEntryTypeConfig(entry.connection.type);
+			if (config.store === 'runtime') {
+				continue;
+			}
+			(config.store === 'storage' ? storageRaw : settingsRaw).push(config.toRaw(entry, entry.connection));
 		}
 
+		this._storeStoredSSHEntries(storageRaw);
+
 		const settings = this._getSettings(true);
-		if (JSON.stringify(settings.entries) !== JSON.stringify(raw)) {
-			await this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, settings.target);
+		if (JSON.stringify(settings.entries) !== JSON.stringify(settingsRaw)) {
+			await this._configurationService.updateValue(RemoteAgentHostsSettingId, settingsRaw, settings.target);
 		}
 	}
 
@@ -719,9 +736,8 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 		try {
 			const parsed: unknown = JSON.parse(raw);
-			const config = getEntryTypeConfig(RemoteAgentHostEntryType.SSH);
 			return Array.isArray(parsed)
-				? parsed.filter(isRawRemoteAgentHostEntry).filter(isLegacySshRawEntry).map(entry => config.fromRaw!(entry))
+				? parsed.filter(isRawRemoteAgentHostEntry).filter(isLegacySshRawEntry).map(entry => SSH_ENTRY_TYPE_CONFIG.fromRaw(entry))
 				: [];
 		} catch {
 			return [];
@@ -757,9 +773,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		for (const entry of sshEntries) {
 			migratedEntries = this._upsertEntry(migratedEntries, entry);
 		}
-		void this._storeConfiguredEntries(migratedEntries, 'storage');
 		const settingsEntries = legacyEntries.filter(entry => getEntryTypeConfig(entry.connection.type).store === 'settings');
-		this._storeConfiguredEntries(settingsEntries, 'settings').catch(err => {
+		// One write of the whole merged set: SSH entries land in storage and
+		// are dropped from settings in the same pass.
+		this._storeConfiguredEntries([...migratedEntries, ...settingsEntries]).catch(err => {
 			this._logService.error('[RemoteAgentHost] Failed to migrate SSH connection details from settings to storage', err);
 		});
 	}

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from '../../instantiation/common/instantiation.
 import { ILabelService } from '../../label/common/label.js';
 import { ILogService } from '../../log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
+import { hasKey } from '../../../base/common/types.js';
 
 import { AgentHostAhpJsonlLoggingSettingId, type IAgentConnection } from '../common/agentService.js';
 import {
@@ -24,9 +25,8 @@ import {
 	RemoteAgentHostEntryType,
 	RemoteAgentHostsEnabledSettingId,
 	RemoteAgentHostsSettingId,
-	entryToRawEntry,
-	getEntryAddress,
-	rawEntryToEntry,
+	getEntryTypeConfig,
+	parseLegacyRawEntry,
 	type IRawRemoteAgentHostEntry,
 	type IRemoteAgentHostConnectionInfo,
 	type IRemoteAgentHostEntry,
@@ -34,7 +34,6 @@ import {
 import { RemoteAgentHostProtocolClient, AgentHostClientState } from './remoteAgentHostProtocolClient.js';
 import { WebSocketClientTransport } from './webSocketClientTransport.js';
 import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
-import { isDefined } from '../../../base/common/types.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 import { type IVscodeUpgradeResult } from '../common/state/protocolUpgrade.js';
 import { agentsWindowAgentHostClientInfo, editorWindowAgentHostClientInfo } from '../common/agentHostClientInfo.js';
@@ -67,6 +66,7 @@ function isRawRemoteAgentHostEntry(value: unknown): value is IRawRemoteAgentHost
 	if (typeof value !== 'object' || value === null) {
 		return false;
 	}
+
 	const candidate = value as Partial<Record<keyof IRawRemoteAgentHostEntry, unknown>>;
 	return typeof candidate.address === 'string'
 		&& typeof candidate.name === 'string'
@@ -75,6 +75,13 @@ function isRawRemoteAgentHostEntry(value: unknown): value is IRawRemoteAgentHost
 		&& (candidate.sshHostName === undefined || typeof candidate.sshHostName === 'string')
 		&& (candidate.sshUser === undefined || typeof candidate.sshUser === 'string')
 		&& (candidate.sshPort === undefined || typeof candidate.sshPort === 'number');
+}
+
+function isLegacySshRawEntry(entry: IRawRemoteAgentHostEntry): boolean {
+	return entry.sshConfigHost !== undefined
+		|| entry.sshHostName !== undefined
+		|| entry.sshUser !== undefined
+		|| entry.sshPort !== undefined;
 }
 
 export class RemoteAgentHostService extends Disposable implements IRemoteAgentHostService {
@@ -149,6 +156,22 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		this._reconcileConnections();
 	}
 
+	private _entryAddress(entry: IRemoteAgentHostEntry): string {
+		const config = getEntryTypeConfig(entry.connection.type);
+		const address = config.address(entry.connection);
+		return config.normalizedAddress ? normalizeRemoteAgentHostAddress(address) : address;
+	}
+
+	private _normalizeEntry(entry: IRemoteAgentHostEntry): IRemoteAgentHostEntry {
+		const config = getEntryTypeConfig(entry.connection.type);
+		// `hasKey` narrows the connection union for the spread below;
+		// `normalizedAddress` is the actual policy (only tunnels opt out).
+		if (!config.normalizedAddress || !hasKey(entry.connection, { address: true })) {
+			return entry;
+		}
+		return { ...entry, connection: { ...entry.connection, address: normalizeRemoteAgentHostAddress(entry.connection.address) } };
+	}
+
 	get connections(): readonly IRemoteAgentHostConnectionInfo[] {
 		const result: IRemoteAgentHostConnectionInfo[] = [];
 		for (const [address, entry] of this._entries) {
@@ -164,12 +187,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	get configuredEntries(): readonly IRemoteAgentHostEntry[] {
-		return this._getConfiguredEntries().map(e => {
-			if (e.connection.type === RemoteAgentHostEntryType.Tunnel) {
-				return e;
-			}
-			return { ...e, connection: { ...e.connection, address: normalizeRemoteAgentHostAddress(e.connection.address) } };
-		});
+		return this._getConfiguredEntries().map(entry => this._normalizeEntry(entry));
 	}
 
 	getConnection(address: string): IAgentConnection | undefined {
@@ -197,7 +215,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 		// Fall back to configured entries from settings.
 		return this.configuredEntries.find(
-			e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalized
+			entry => this._entryAddress(entry) === normalized
 		);
 	}
 
@@ -228,9 +246,9 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 		// SSH/tunnel entries are reconnected by their respective services
 		const configuredEntry = this._getConfiguredEntries().find(
-			e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalized
+			entry => this._entryAddress(entry) === normalized
 		);
-		if (configuredEntry && configuredEntry.connection.type !== RemoteAgentHostEntryType.WebSocket) {
+		if (configuredEntry && !getEntryTypeConfig(configuredEntry.connection.type).selfConnecting) {
 			return;
 		}
 
@@ -256,12 +274,13 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			throw new Error('Remote agent host connections are not enabled.');
 		}
 
-		const entry: IRemoteAgentHostEntry = input.connection.type === RemoteAgentHostEntryType.Tunnel
-			? input
-			: { ...input, connection: { ...input.connection, address: normalizeRemoteAgentHostAddress(input.connection.address) } };
-		const address = getEntryAddress(entry);
+		const entry = this._normalizeEntry(input);
+		const address = this._entryAddress(entry);
 		const existingConnection = this._getConnectionInfo(address);
-		await this._storeConfiguredEntries(this._upsertConfiguredEntry(entry));
+		const config = getEntryTypeConfig(entry.connection.type);
+		if (config.store !== 'runtime') {
+			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry), config.store);
+		}
 
 		if (existingConnection) {
 			return {
@@ -270,10 +289,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			};
 		}
 
-		// SSH entries are connected externally — just persist
-		// the entry and return a disconnected placeholder. The connection
-		// will be established by the SSH contribution.
-		if (entry.connection.type === RemoteAgentHostEntryType.SSH) {
+		if (!config.selfConnecting) {
 			return {
 				address,
 				name: entry.name,
@@ -303,7 +319,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			throw new Error('Remote agent host connections are not enabled.');
 		}
 
-		const address = getEntryAddress(entry);
+		const address = this._entryAddress(entry);
 
 		// Dispose any existing entry for this address to avoid leaking
 		// old protocol clients and relay transports on reconnect.
@@ -342,10 +358,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			}
 		}));
 
-		// Persist entries — await so that the config is written before
-		// onDidChangeConnections fires, ensuring _reconcile creates the provider.
-		// Tunnel entries are filtered out by _storeConfiguredEntries automatically.
-		await this._storeConfiguredEntries(this._upsertConfiguredEntry(entry));
+		const config = getEntryTypeConfig(entry.connection.type);
+		if (config.store !== 'runtime') {
+			await this._storeConfiguredEntries(this._upsertEntry(this._getConfiguredEntries(true), entry), config.store);
+		}
 
 		this._onDidChangeConnections.fire();
 
@@ -360,12 +376,14 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 	async removeRemoteAgentHost(address: string): Promise<void> {
 		const normalized = normalizeRemoteAgentHostAddress(address);
-		// This setting is only used in the sessions app (user scope), so we
-		// don't need to inspect per-scope values like _upsertConfiguredEntry does.
-		const entries = this._getConfiguredEntries().filter(
-			e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) !== normalized
-		);
-		await this._storeConfiguredEntries(entries);
+		const entry = this._registeredEntries.get(normalized) ?? this._getConfiguredEntries().find(entry => this._entryAddress(entry) === normalized);
+		if (entry) {
+			const config = getEntryTypeConfig(entry.connection.type);
+			if (config.store !== 'runtime') {
+				const entries = this._getConfiguredEntries(true).filter(entry => this._entryAddress(entry) !== normalized);
+				await this._storeConfiguredEntries(entries, config.store);
+			}
+		}
 
 		// Eagerly clear in-memory state so the UI updates immediately
 		// (the config change listener will reconcile, but this is instant).
@@ -382,6 +400,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		const entry = this._entries.get(address);
 		if (entry) {
 			this._entries.delete(address);
+			this._registeredEntries.delete(address);
 			disposeEntry(entry);
 			this._rejectPendingConnectionWait(address, new Error(`Connection closed: ${address}`));
 			this._onDidChangeConnections.fire();
@@ -422,7 +441,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 
 		const configuredEntries = this._getConfiguredEntries();
-		const entriesWithAddress = configuredEntries.map(e => ({ entry: e, address: normalizeRemoteAgentHostAddress(getEntryAddress(e)) }));
+		const entriesWithAddress = configuredEntries.map(entry => ({ entry, address: this._entryAddress(entry) }));
 		const desired = new Set(entriesWithAddress.map(e => e.address));
 
 		this._logService.info(`[RemoteAgentHost] Reconciling: desired=[${[...desired].join(', ')}], current=[${[...this._entries.keys()].map(a => `${a}(${this._entries.get(a)!.connected ? 'connected' : 'pending'})`).join(', ')}]`);
@@ -451,7 +470,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 		// Remove connections no longer in the setting
 		for (const address of [...this._entries.keys()]) {
-			if (!desired.has(address)) {
+			if (!desired.has(address) && !this._registeredEntries.has(address)) {
 				this._logService.info(`[RemoteAgentHost] Disconnecting from ${address}`);
 				this._cancelReconnect(address);
 				this._reconnectAttempts.delete(address);
@@ -459,10 +478,9 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			}
 		}
 
-		// Add new connections (skip SSH entries — those are handled by ISSHRemoteAgentHostService,
-		// and skip tunnel entries — those are handled by ITunnelAgentHostService)
+		// Add entries that this service owns.
 		for (const { entry, address } of entriesWithAddress) {
-			if (!this._entries.has(address) && entry.connection.type === RemoteAgentHostEntryType.WebSocket) {
+			if (!this._entries.has(address) && getEntryTypeConfig(entry.connection.type).selfConnecting) {
 				this._connectTo(address, entry.connectionToken);
 			}
 		}
@@ -600,7 +618,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	 */
 	private _scheduleReconnect(address: string, connectionToken?: string): void {
 		// Don't reconnect if the address was removed from settings
-		if (!this._isAddressConfigured(address)) {
+		if (!this._getConfiguredEntries().some(entry => this._entryAddress(entry) === address)) {
 			this._logService.info(`[RemoteAgentHost] Not reconnecting to ${address}: no longer configured`);
 			return;
 		}
@@ -617,7 +635,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		this._cancelReconnect(address);
 		const timeout = setTimeout(() => {
 			this._reconnectTimeouts.delete(address);
-			if (this._isAddressConfigured(address)) {
+			if (this._getConfiguredEntries().some(entry => this._entryAddress(entry) === address)) {
 				this._connectTo(address, connectionToken ?? this._tokens.get(address));
 			}
 		}, delay);
@@ -633,72 +651,64 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 	}
 
-	/** Check whether the given normalized address is still in the configured entries. */
-	private _isAddressConfigured(address: string): boolean {
-		const entries = this._getConfiguredEntries();
-		return entries.some(e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === address);
-	}
-
 	private _getConnectionInfo(address: string): IRemoteAgentHostConnectionInfo | undefined {
 		return this.connections.find(connection => connection.address === address && RemoteAgentHostConnectionStatus.isConnected(connection.status));
 	}
 
-	private _getConfiguredEntries(): IRemoteAgentHostEntry[] {
-		return this._mergeConfiguredEntries(this._getConfiguredSettingEntries(), this._getStoredSSHEntries());
-	}
-
-	private _upsertConfiguredEntry(entry: IRemoteAgentHostEntry): IRemoteAgentHostEntry[] {
-		// Read from the same scope we'll write to, so we don't accidentally
-		// merge entries from an overriding scope (e.g. workspace) into the
-		// user scope and then lose them on the next read.
-		const configuredEntries = this._mergeConfiguredEntries(this._getConfiguredSettingEntriesForTarget(), this._getStoredSSHEntries());
-		const normalizedAddress = normalizeRemoteAgentHostAddress(getEntryAddress(entry));
-		const existingIndex = configuredEntries.findIndex(e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalizedAddress);
-		if (existingIndex === -1) {
-			return [...configuredEntries, entry];
+	private _getConfiguredEntries(targetSettings = false): IRemoteAgentHostEntry[] {
+		const config = getEntryTypeConfig(RemoteAgentHostEntryType.WebSocket);
+		let entries = this._getSettings(targetSettings).entries
+			.filter(isRawRemoteAgentHostEntry)
+			.filter(entry => !isLegacySshRawEntry(entry))
+			.map(entry => config.fromRaw!(entry));
+		for (const entry of this._getStoredSSHEntries()) {
+			entries = this._upsertEntry(entries, entry);
 		}
-
-		return configuredEntries.map((e, index) => index === existingIndex ? entry : e);
+		return entries;
 	}
 
-	private _getConfigurationTarget(): ConfigurationTarget {
+	private _upsertEntry(entries: readonly IRemoteAgentHostEntry[], entry: IRemoteAgentHostEntry): IRemoteAgentHostEntry[] {
+		const address = this._entryAddress(entry);
+		const existingIndex = entries.findIndex(candidate => this._entryAddress(candidate) === address);
+		return existingIndex === -1
+			? [...entries, entry]
+			: entries.map((candidate, index) => index === existingIndex ? entry : candidate);
+	}
+
+	private _getSettings(targetOnly = false): { readonly target: ConfigurationTarget; readonly entries: readonly IRawRemoteAgentHostEntry[] } {
 		const inspected = this._configurationService.inspect<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
-		if (inspected.userLocalValue !== undefined) {
-			return ConfigurationTarget.USER_LOCAL;
+		const target = inspected.userLocalValue !== undefined
+			? ConfigurationTarget.USER_LOCAL
+			: inspected.userRemoteValue !== undefined
+				? ConfigurationTarget.USER_REMOTE
+				: ConfigurationTarget.USER;
+		return {
+			target,
+			entries: !targetOnly
+				? this._configurationService.getValue<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? []
+				: target === ConfigurationTarget.USER_LOCAL
+					? inspected.userLocalValue ?? []
+					: target === ConfigurationTarget.USER_REMOTE
+						? inspected.userRemoteValue ?? []
+						: inspected.userValue ?? [],
+		};
+	}
+
+	private async _storeConfiguredEntries(entries: readonly IRemoteAgentHostEntry[], store: 'settings' | 'storage'): Promise<void> {
+		const raw = entries
+			.filter(entry => getEntryTypeConfig(entry.connection.type).store === store)
+			.map(entry => {
+				const config = getEntryTypeConfig(entry.connection.type);
+				return config.toRaw!(entry, entry.connection);
+			});
+		if (store === 'storage') {
+			this._storeStoredSSHEntries(raw);
+			return;
 		}
-		if (inspected.userRemoteValue !== undefined) {
-			return ConfigurationTarget.USER_REMOTE;
-		}
-		if (inspected.userValue !== undefined) {
-			return ConfigurationTarget.USER;
-		}
-		return ConfigurationTarget.USER;
-	}
 
-	private async _storeConfiguredEntries(entries: IRemoteAgentHostEntry[]): Promise<void> {
-		this._storeStoredSSHEntries(entries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH));
-		const raw = entries.filter(entry => entry.connection.type !== RemoteAgentHostEntryType.SSH).map(entryToRawEntry).filter(isDefined);
-		await this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, this._getConfigurationTarget());
-	}
-
-	private _getConfiguredSettingEntries(): IRemoteAgentHostEntry[] {
-		return (this._configurationService.getValue<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? []).map(rawEntryToEntry).filter(isDefined);
-	}
-
-	private _getConfiguredSettingEntriesForTarget(): IRemoteAgentHostEntry[] {
-		return this._getConfiguredRawEntriesForTarget().map(rawEntryToEntry).filter(isDefined);
-	}
-
-	private _getConfiguredRawEntriesForTarget(): readonly IRawRemoteAgentHostEntry[] {
-		const target = this._getConfigurationTarget();
-		const inspected = this._configurationService.inspect<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
-		switch (target) {
-			case ConfigurationTarget.USER_LOCAL:
-				return inspected.userLocalValue ?? [];
-			case ConfigurationTarget.USER_REMOTE:
-				return inspected.userRemoteValue ?? [];
-			default:
-				return inspected.userValue ?? [];
+		const settings = this._getSettings(true);
+		if (JSON.stringify(settings.entries) !== JSON.stringify(raw)) {
+			await this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, settings.target);
 		}
 	}
 
@@ -709,53 +719,49 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 		try {
 			const parsed: unknown = JSON.parse(raw);
-			if (!Array.isArray(parsed)) {
-				return [];
-			}
-			return parsed.map(item => isRawRemoteAgentHostEntry(item) ? rawEntryToEntry(item) : undefined)
-				.filter((entry): entry is IRemoteAgentHostEntry => entry?.connection.type === RemoteAgentHostEntryType.SSH);
+			const config = getEntryTypeConfig(RemoteAgentHostEntryType.SSH);
+			return Array.isArray(parsed)
+				? parsed.filter(isRawRemoteAgentHostEntry).filter(isLegacySshRawEntry).map(entry => config.fromRaw!(entry))
+				: [];
 		} catch {
 			return [];
 		}
 	}
 
-	private _storeStoredSSHEntries(entries: IRemoteAgentHostEntry[]): void {
-		const raw = entries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH).map(entryToRawEntry).filter(isDefined);
-		if (raw.length === 0) {
-			this._storageService.remove(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, StorageScope.APPLICATION);
-		} else {
-			this._storageService.store(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, JSON.stringify(raw), StorageScope.APPLICATION, StorageTarget.USER);
+	private _storeStoredSSHEntries(entries: readonly IRawRemoteAgentHostEntry[]): void {
+		const raw = JSON.stringify(entries);
+		const stored = this._storageService.get(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, StorageScope.APPLICATION);
+		if (stored === raw) {
+			return;
 		}
+		if (entries.length === 0) {
+			if (stored !== undefined) {
+				this._storageService.remove(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, StorageScope.APPLICATION);
+			}
+			return;
+		}
+		this._storageService.store(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, raw, StorageScope.APPLICATION, StorageTarget.USER);
 	}
 
 	private _migrateSSHEntriesFromSetting(): void {
-		const configuredEntries = this._getConfiguredSettingEntriesForTarget();
-		const sshEntries = configuredEntries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH);
+		const settings = this._getSettings(true);
+		const legacyEntries = settings.entries
+			.filter(isRawRemoteAgentHostEntry)
+			.map(parseLegacyRawEntry);
+		const sshEntries = legacyEntries.filter(entry => getEntryTypeConfig(entry.connection.type).store === 'storage');
 		if (sshEntries.length === 0) {
 			return;
 		}
 
-		const migratedEntries = this._mergeConfiguredEntries(this._getStoredSSHEntries(), sshEntries);
-		this._storeStoredSSHEntries(migratedEntries);
-		const nonSSHEntries = configuredEntries.filter(entry => entry.connection.type !== RemoteAgentHostEntryType.SSH);
-		const raw = nonSSHEntries.map(entryToRawEntry).filter(isDefined);
-		this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, this._getConfigurationTarget()).catch(err => {
+		let migratedEntries = this._getStoredSSHEntries();
+		for (const entry of sshEntries) {
+			migratedEntries = this._upsertEntry(migratedEntries, entry);
+		}
+		void this._storeConfiguredEntries(migratedEntries, 'storage');
+		const settingsEntries = legacyEntries.filter(entry => getEntryTypeConfig(entry.connection.type).store === 'settings');
+		this._storeConfiguredEntries(settingsEntries, 'settings').catch(err => {
 			this._logService.error('[RemoteAgentHost] Failed to migrate SSH connection details from settings to storage', err);
 		});
-	}
-
-	private _mergeConfiguredEntries(base: IRemoteAgentHostEntry[], incoming: IRemoteAgentHostEntry[]): IRemoteAgentHostEntry[] {
-		let result = base;
-		for (const entry of incoming) {
-			const normalizedAddress = normalizeRemoteAgentHostAddress(getEntryAddress(entry));
-			const existingIndex = result.findIndex(e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalizedAddress);
-			if (existingIndex === -1) {
-				result = [...result, entry];
-			} else {
-				result = result.map((e, index) => index === existingIndex ? entry : e);
-			}
-		}
-		return result;
 	}
 
 	private _getOrCreateConnectionWait(address: string): DeferredPromise<IRemoteAgentHostConnectionInfo> {

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -212,10 +212,8 @@ export type RemoteAgentHostEntryStore = 'settings' | 'storage' | 'runtime';
  * transports into one table so the service does not branch on
  * {@link RemoteAgentHostEntryType} in a dozen places.
  */
-export interface IRemoteAgentHostEntryTypeConfig<TConnection extends RemoteAgentHostConnection = RemoteAgentHostConnection> {
+interface IRemoteAgentHostEntryTypeConfigBase<TConnection extends RemoteAgentHostConnection> {
 	readonly type: TConnection['type'];
-	/** Durable home for entries of this type. `runtime` entries are never written to disk. */
-	readonly store: RemoteAgentHostEntryStore;
 	/**
 	 * Whether RemoteAgentHostService dials this entry itself. When `false`,
 	 * an owning transport service establishes the connection and registers
@@ -226,17 +224,31 @@ export interface IRemoteAgentHostEntryTypeConfig<TConnection extends RemoteAgent
 	readonly normalizedAddress: boolean;
 	/** Stable identity for the entry. */
 	address(connection: TConnection): string;
-	/** Serialize for persistence. Present iff `store !== 'runtime'`. */
-	toRaw?(entry: IRemoteAgentHostEntry, connection: TConnection): IRawRemoteAgentHostEntry;
-	/** Rehydrate from persisted form. Present iff `store !== 'runtime'`. */
-	fromRaw?(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry;
 }
 
-/** An entry type that has a durable home, and therefore always converts to and from {@link IRawRemoteAgentHostEntry}. */
-type IPersistedEntryTypeConfig<TConnection extends RemoteAgentHostConnection> =
-	IRemoteAgentHostEntryTypeConfig<TConnection> & Required<Pick<IRemoteAgentHostEntryTypeConfig<TConnection>, 'toRaw' | 'fromRaw'>>;
+/**
+ * An entry type with a durable home. Narrowing a config on
+ * `store !== 'runtime'` guarantees both converters are present.
+ */
+export interface IPersistedEntryTypeConfig<TConnection extends RemoteAgentHostConnection = RemoteAgentHostConnection> extends IRemoteAgentHostEntryTypeConfigBase<TConnection> {
+	readonly store: 'settings' | 'storage';
+	/** Serialize for persistence. */
+	toRaw(entry: IRemoteAgentHostEntry, connection: TConnection): IRawRemoteAgentHostEntry;
+	/** Rehydrate from persisted form. */
+	fromRaw(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry;
+}
 
-const WEBSOCKET_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostWebSocketConnection> = {
+/** An entry type that lives only for the lifetime of its connection and is never written to disk. */
+interface IRuntimeEntryTypeConfig<TConnection extends RemoteAgentHostConnection = RemoteAgentHostConnection> extends IRemoteAgentHostEntryTypeConfigBase<TConnection> {
+	readonly store: 'runtime';
+	readonly toRaw?: never;
+	readonly fromRaw?: never;
+}
+
+export type IRemoteAgentHostEntryTypeConfig<TConnection extends RemoteAgentHostConnection = RemoteAgentHostConnection> =
+	IPersistedEntryTypeConfig<TConnection> | IRuntimeEntryTypeConfig<TConnection>;
+
+export const WEBSOCKET_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostWebSocketConnection> = {
 	type: RemoteAgentHostEntryType.WebSocket,
 	store: 'settings',
 	selfConnecting: true,
@@ -248,7 +260,7 @@ const WEBSOCKET_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostWeb
 	fromRaw: raw => ({ name: raw.name, connectionToken: raw.connectionToken, connection: { type: RemoteAgentHostEntryType.WebSocket, address: raw.address } }),
 };
 
-const SSH_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostSSHConnection> = {
+export const SSH_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostSSHConnection> = {
 	type: RemoteAgentHostEntryType.SSH,
 	store: 'storage',
 	selfConnecting: false,
@@ -264,7 +276,7 @@ const SSH_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostSSHConnec
 	}),
 };
 
-function runtimeEntryTypeConfig<TConnection extends RemoteAgentHostConnection>(type: TConnection['type'], normalizedAddress: boolean, address: (connection: TConnection) => string): IRemoteAgentHostEntryTypeConfig<TConnection> {
+function runtimeEntryTypeConfig<TConnection extends RemoteAgentHostConnection>(type: TConnection['type'], normalizedAddress: boolean, address: (connection: TConnection) => string): IRuntimeEntryTypeConfig<TConnection> {
 	return { type, store: 'runtime', selfConnecting: false, normalizedAddress, address };
 }
 

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -192,16 +192,101 @@ export interface IRemoteAgentHostEntry {
 	readonly connection: RemoteAgentHostConnection;
 }
 
+/** Raw shape of persisted remote agent host entries. */
+export interface IRawRemoteAgentHostEntry {
+	readonly address: string;
+	readonly name: string;
+	readonly connectionToken?: string;
+	readonly sshConfigHost?: string;
+	readonly sshHostName?: string;
+	readonly sshUser?: string;
+	readonly sshPort?: number;
+}
+
+/** Where durable copies of a remote agent host entry live. */
+export type RemoteAgentHostEntryStore = 'settings' | 'storage' | 'runtime';
+
+/**
+ * Static, per-connection-type description of how an entry is addressed,
+ * persisted and connected. Collects the behavioural differences between
+ * transports into one table so the service does not branch on
+ * {@link RemoteAgentHostEntryType} in a dozen places.
+ */
+export interface IRemoteAgentHostEntryTypeConfig<TConnection extends RemoteAgentHostConnection = RemoteAgentHostConnection> {
+	readonly type: TConnection['type'];
+	/** Durable home for entries of this type. `runtime` entries are never written to disk. */
+	readonly store: RemoteAgentHostEntryStore;
+	/**
+	 * Whether RemoteAgentHostService dials this entry itself. When `false`,
+	 * an owning transport service establishes the connection and registers
+	 * it via `addManagedConnection`.
+	 */
+	readonly selfConnecting: boolean;
+	/** Whether the address is subject to `normalizeRemoteAgentHostAddress`. */
+	readonly normalizedAddress: boolean;
+	/** Stable identity for the entry. */
+	address(connection: TConnection): string;
+	/** Serialize for persistence. Present iff `store !== 'runtime'`. */
+	toRaw?(entry: IRemoteAgentHostEntry, connection: TConnection): IRawRemoteAgentHostEntry;
+	/** Rehydrate from persisted form. Present iff `store !== 'runtime'`. */
+	fromRaw?(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry;
+}
+
+/** An entry type that has a durable home, and therefore always converts to and from {@link IRawRemoteAgentHostEntry}. */
+type IPersistedEntryTypeConfig<TConnection extends RemoteAgentHostConnection> =
+	IRemoteAgentHostEntryTypeConfig<TConnection> & Required<Pick<IRemoteAgentHostEntryTypeConfig<TConnection>, 'toRaw' | 'fromRaw'>>;
+
+const WEBSOCKET_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostWebSocketConnection> = {
+	type: RemoteAgentHostEntryType.WebSocket,
+	store: 'settings',
+	selfConnecting: true,
+	normalizedAddress: true,
+	address: connection => connection.address,
+	toRaw: (entry, connection) => ({
+		address: connection.address, name: entry.name, connectionToken: entry.connectionToken,
+	}),
+	fromRaw: raw => ({ name: raw.name, connectionToken: raw.connectionToken, connection: { type: RemoteAgentHostEntryType.WebSocket, address: raw.address } }),
+};
+
+const SSH_ENTRY_TYPE_CONFIG: IPersistedEntryTypeConfig<IRemoteAgentHostSSHConnection> = {
+	type: RemoteAgentHostEntryType.SSH,
+	store: 'storage',
+	selfConnecting: false,
+	normalizedAddress: true,
+	address: connection => connection.address,
+	toRaw: (entry, connection) => ({
+		address: connection.address, name: entry.name, connectionToken: entry.connectionToken,
+		sshConfigHost: connection.sshConfigHost, sshHostName: connection.hostName, sshUser: connection.user, sshPort: connection.port,
+	}),
+	fromRaw: raw => ({
+		name: raw.name, connectionToken: raw.connectionToken,
+		connection: { type: RemoteAgentHostEntryType.SSH, address: raw.address, sshConfigHost: raw.sshConfigHost, hostName: raw.sshHostName ?? raw.address, user: raw.sshUser, port: raw.sshPort },
+	}),
+};
+
+function runtimeEntryTypeConfig<TConnection extends RemoteAgentHostConnection>(type: TConnection['type'], normalizedAddress: boolean, address: (connection: TConnection) => string): IRemoteAgentHostEntryTypeConfig<TConnection> {
+	return { type, store: 'runtime', selfConnecting: false, normalizedAddress, address };
+}
+
+const WSL_ENTRY_TYPE_CONFIG = runtimeEntryTypeConfig<IRemoteAgentHostWSLConnection>(RemoteAgentHostEntryType.WSL, true, connection => connection.address);
+const TUNNEL_ENTRY_TYPE_CONFIG = runtimeEntryTypeConfig<IRemoteAgentHostTunnelConnection>(RemoteAgentHostEntryType.Tunnel, false, connection => `${TUNNEL_ADDRESS_PREFIX}${connection.tunnelId}`);
+const CLOUD_SANDBOX_ENTRY_TYPE_CONFIG = runtimeEntryTypeConfig<IRemoteAgentHostCloudSandboxConnection>(RemoteAgentHostEntryType.CloudSandbox, true, connection => connection.address);
+
+const ENTRY_TYPE_CONFIGS: { readonly [K in RemoteAgentHostEntryType]: IRemoteAgentHostEntryTypeConfig<Extract<RemoteAgentHostConnection, { type: K }>> } = {
+	[RemoteAgentHostEntryType.WebSocket]: WEBSOCKET_ENTRY_TYPE_CONFIG,
+	[RemoteAgentHostEntryType.SSH]: SSH_ENTRY_TYPE_CONFIG,
+	[RemoteAgentHostEntryType.WSL]: WSL_ENTRY_TYPE_CONFIG,
+	[RemoteAgentHostEntryType.Tunnel]: TUNNEL_ENTRY_TYPE_CONFIG,
+	[RemoteAgentHostEntryType.CloudSandbox]: CLOUD_SANDBOX_ENTRY_TYPE_CONFIG,
+};
+
+/** Gets the static persistence and connection policy for an entry type. */
+export function getEntryTypeConfig(type: RemoteAgentHostEntryType): IRemoteAgentHostEntryTypeConfig {
+	return ENTRY_TYPE_CONFIGS[type] as IRemoteAgentHostEntryTypeConfig;
+}
+
 export function getEntryAddress(entry: IRemoteAgentHostEntry): string {
-	switch (entry.connection.type) {
-		case RemoteAgentHostEntryType.WebSocket:
-		case RemoteAgentHostEntryType.SSH:
-		case RemoteAgentHostEntryType.WSL:
-		case RemoteAgentHostEntryType.CloudSandbox:
-			return entry.connection.address;
-		case RemoteAgentHostEntryType.Tunnel:
-			return `${TUNNEL_ADDRESS_PREFIX}${entry.connection.tunnelId}`;
-	}
+	return getEntryTypeConfig(entry.connection.type).address(entry.connection);
 }
 
 export function remoteAgentHostLogOutputChannelId(address: string): string {
@@ -450,63 +535,15 @@ function formatRemoteAgentHostAddress(url: URL, protocol: 'ws:' | 'wss:' | undef
 	return `${base}${path}${query}`;
 }
 
-/** Raw shape of persisted remote agent host entries. */
-export interface IRawRemoteAgentHostEntry {
-	readonly address: string;
-	readonly name: string;
-	readonly connectionToken?: string;
-	readonly sshConfigHost?: string;
-	readonly sshHostName?: string;
-	readonly sshUser?: string;
-	readonly sshPort?: number;
-}
-
-export function rawEntryToEntry(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry | undefined {
-	if (raw.sshConfigHost || raw.sshHostName || raw.sshUser || raw.sshPort) {
-		return {
-			name: raw.name,
-			connectionToken: raw.connectionToken,
-			connection: {
-				type: RemoteAgentHostEntryType.SSH,
-				address: raw.address,
-				sshConfigHost: raw.sshConfigHost,
-				hostName: raw.sshHostName ?? raw.address,
-				user: raw.sshUser,
-				port: raw.sshPort,
-			},
-		};
+/**
+ * Parses an entry persisted before each store became type-specific, when a
+ * single flat shape held both WebSocket and SSH entries and the variant had
+ * to be inferred from which `ssh*` fields were present. Used only by the
+ * migration path.
+ */
+export function parseLegacyRawEntry(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry {
+	if (raw.sshConfigHost !== undefined || raw.sshHostName !== undefined || raw.sshUser !== undefined || raw.sshPort !== undefined) {
+		return SSH_ENTRY_TYPE_CONFIG.fromRaw(raw);
 	}
-	return {
-		name: raw.name,
-		connectionToken: raw.connectionToken,
-		connection: {
-			type: RemoteAgentHostEntryType.WebSocket,
-			address: raw.address,
-		},
-	};
-}
-
-export function entryToRawEntry(entry: IRemoteAgentHostEntry): IRawRemoteAgentHostEntry | undefined {
-	switch (entry.connection.type) {
-		case RemoteAgentHostEntryType.SSH:
-			return {
-				address: entry.connection.address,
-				name: entry.name,
-				connectionToken: entry.connectionToken,
-				sshConfigHost: entry.connection.sshConfigHost,
-				sshHostName: entry.connection.hostName,
-				sshUser: entry.connection.user,
-				sshPort: entry.connection.port,
-			};
-		case RemoteAgentHostEntryType.WebSocket:
-			return {
-				address: entry.connection.address,
-				name: entry.name,
-				connectionToken: entry.connectionToken,
-			};
-		case RemoteAgentHostEntryType.WSL:
-		case RemoteAgentHostEntryType.Tunnel:
-		case RemoteAgentHostEntryType.CloudSandbox:
-			return undefined;
-	}
+	return WEBSOCKET_ENTRY_TYPE_CONFIG.fromRaw(raw);
 }

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -816,6 +816,41 @@ suite('RemoteAgentHostService', () => {
 				configured: [],
 			});
 		});
+
+		test('replacing a stored SSH entry with a WebSocket entry clears the storage row', async () => {
+			service.dispose();
+			configService.setRawEntries([{
+				address: 'host1:8080',
+				name: 'SSH Host',
+				sshConfigHost: 'legacy',
+				sshHostName: 'legacy.example',
+			}]);
+			service = disposables.add(instantiationService.createInstance(RemoteAgentHostService));
+
+			const added = service.addRemoteAgentHost({ name: 'WebSocket Host', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'host1:8080' } });
+			createdClients[createdClients.length - 1].connectDeferred.complete();
+			await added;
+
+			// The stale SSH row must not survive in storage, or _getConfiguredEntries
+			// overlays it back on top of the new WebSocket entry.
+			assert.deepStrictEqual(service.configuredEntries, [{
+				name: 'WebSocket Host',
+				connectionToken: undefined,
+				connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'host1:8080' },
+			}]);
+		});
+
+		test('keeps runtime connection names across reconciliation', async () => {
+			const tunnel: IRemoteAgentHostEntry = { name: 'My Tunnel', connection: { type: RemoteAgentHostEntryType.Tunnel, tunnelId: 'tunnel', clusterId: 'cluster' } };
+			const client = disposables.add(new MockProtocolClient('tunnel:tunnel'));
+			await service.addManagedConnection(tunnel, client as unknown as Parameters<typeof service.addManagedConnection>[1]);
+
+			configService.setEntries([{ name: 'WebSocket', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'host1:8080' } }]);
+
+			assert.deepStrictEqual(
+				service.connections.find(connection => connection.address === 'tunnel:tunnel')?.name,
+				'My Tunnel');
+		});
 	});
 
 	suite('host label formatter', () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -15,10 +15,11 @@ import { IConfigurationService, type IConfigurationChangeEvent } from '../../../
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILabelService, type ResourceLabelFormatter } from '../../../label/common/label.js';
 import { AgentsWindowRemoteAgentHostService, RemoteAgentHostService } from '../../browser/remoteAgentHostServiceImpl.js';
-import { parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, entryToRawEntry, type IRawRemoteAgentHostEntry, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
+import { getEntryTypeConfig, parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, type IRawRemoteAgentHostEntry, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority } from '../../common/agentHostUri.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
-import { InMemoryStorageService, IStorageService } from '../../../storage/common/storage.js';
+import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../storage/common/storage.js';
+import type { StorageValue } from '../../../../base/parts/storage/common/storage.js';
 import type { Implementation } from '../../common/state/protocol/common/commands.js';
 import { agentsWindowAgentHostClientInfo, editorWindowAgentHostClientInfo } from '../../common/agentHostClientInfo.js';
 
@@ -78,6 +79,7 @@ class TestConfigurationService {
 
 	private _entries: IRawRemoteAgentHostEntry[] = [];
 	private _enabled = true;
+	updateValueCalls = 0;
 
 	getValue(key?: string): unknown {
 		if (key === RemoteAgentHostsEnabledSettingId) {
@@ -93,6 +95,7 @@ class TestConfigurationService {
 	}
 
 	async updateValue(_key: string, value: unknown): Promise<void> {
+		this.updateValueCalls++;
 		const entries = (value as IRawRemoteAgentHostEntry[] | undefined) ?? [];
 		const changed = JSON.stringify(this._entries) !== JSON.stringify(entries);
 		this._entries = entries;
@@ -109,7 +112,10 @@ class TestConfigurationService {
 	}
 
 	setEntries(entries: IRemoteAgentHostEntry[]): void {
-		this._entries = entries.map(entryToRawEntry).filter((e): e is IRawRemoteAgentHostEntry => e !== undefined);
+		this._entries = entries.flatMap(entry => {
+			const config = getEntryTypeConfig(entry.connection.type);
+			return config.store === 'settings' ? [config.toRaw!(entry, entry.connection)] : [];
+		});
 		this._onDidChangeConfiguration.fire({
 			affectsConfiguration: (key: string) => key === RemoteAgentHostsSettingId || key === RemoteAgentHostsEnabledSettingId,
 		});
@@ -134,6 +140,20 @@ class TestConfigurationService {
 	}
 }
 
+class TestStorageService extends InMemoryStorageService {
+	writeCalls = 0;
+
+	override store(key: string, value: StorageValue, scope: StorageScope, target: StorageTarget, external = false): void {
+		this.writeCalls++;
+		super.store(key, value, scope, target, external);
+	}
+
+	override remove(key: string, scope: StorageScope, external = false): void {
+		this.writeCalls++;
+		super.remove(key, scope, external);
+	}
+}
+
 suite('RemoteAgentHostService', () => {
 
 	const disposables = new DisposableStore();
@@ -143,6 +163,7 @@ suite('RemoteAgentHostService', () => {
 	let registeredFormatters: ResourceLabelFormatter[];
 	let instantiationService: TestInstantiationService;
 	let service: RemoteAgentHostService;
+	let storageService: TestStorageService;
 
 	setup(() => {
 		configService = new TestConfigurationService();
@@ -155,7 +176,7 @@ suite('RemoteAgentHostService', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IEnvironmentService, { logsHome: URI.file('/logs') } as Partial<IEnvironmentService>);
 		instantiationService.stub(IConfigurationService, configService as Partial<IConfigurationService>);
-		const storageService = disposables.add(new InMemoryStorageService());
+		storageService = disposables.add(new TestStorageService());
 		instantiationService.stub(IStorageService, storageService);
 		registeredFormatters = [];
 		instantiationService.stub(ILabelService, {
@@ -191,6 +212,18 @@ suite('RemoteAgentHostService', () => {
 		instantiationService.stub(IInstantiationService, mockInstantiationService as Partial<IInstantiationService>);
 
 		service = disposables.add(instantiationService.createInstance(RemoteAgentHostService));
+	});
+
+	test('round-trips persisted entry types through their configuration', () => {
+		const entries: IRemoteAgentHostEntry[] = [
+			{ name: 'WebSocket', connectionToken: 'ws-token', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host:8080' } },
+			{ name: 'SSH', connectionToken: 'ssh-token', connection: { type: RemoteAgentHostEntryType.SSH, address: 'localhost:1234', sshConfigHost: 'host', hostName: 'host.example', user: 'me', port: 2222 } },
+		];
+
+		assert.deepStrictEqual(entries.map(entry => {
+			const config = getEntryTypeConfig(entry.connection.type);
+			return config.fromRaw!(config.toRaw!(entry, entry.connection));
+		}), entries);
 	});
 
 	teardown(() => disposables.clear());
@@ -664,6 +697,45 @@ suite('RemoteAgentHostService', () => {
 					},
 				}],
 			});
+		});
+
+		test('does not persist runtime managed connections or their removal', async () => {
+			const entries: IRemoteAgentHostEntry[] = [
+				{ name: 'Tunnel', connection: { type: RemoteAgentHostEntryType.Tunnel, tunnelId: 'runtime-tunnel', clusterId: 'cluster' } },
+				{ name: 'WSL', connection: { type: RemoteAgentHostEntryType.WSL, address: 'wsl:runtime', distro: 'runtime' } },
+				{ name: 'Cloud Sandbox', connection: { type: RemoteAgentHostEntryType.CloudSandbox, address: 'cloud:runtime', environmentId: 'env_runtime' } },
+			];
+			const addresses = ['tunnel:runtime-tunnel', 'wsl:runtime', 'cloud:runtime'];
+
+			for (let index = 0; index < entries.length; index++) {
+				const client = disposables.add(new MockProtocolClient(addresses[index]));
+				await service.addManagedConnection(entries[index], client as unknown as Parameters<typeof service.addManagedConnection>[1]);
+			}
+			for (const address of addresses) {
+				await service.removeRemoteAgentHost(address);
+			}
+
+			assert.deepStrictEqual({
+				settingsWrites: configService.updateValueCalls,
+				storageWrites: storageService.writeCalls,
+				settings: configService.entries,
+			}, {
+				settingsWrites: 0,
+				storageWrites: 0,
+				settings: [],
+			});
+		});
+
+		test('keeps a registered tunnel connected when WebSocket settings change', async () => {
+			const tunnel = disposables.add(new MockProtocolClient('tunnel:live'));
+			await service.addManagedConnection(
+				{ name: 'Tunnel', connection: { type: RemoteAgentHostEntryType.Tunnel, tunnelId: 'live', clusterId: 'cluster' } },
+				tunnel as unknown as Parameters<typeof service.addManagedConnection>[1],
+			);
+
+			configService.setEntries([{ name: 'WebSocket', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host:8080' } }]);
+
+			assert.strictEqual(service.getConnection('tunnel:live'), tunnel);
 		});
 
 		test('migrates legacy SSH connection details from settings to storage', async () => {


### PR DESCRIPTION
Fixes the tunnel connection failure reported as:

> Failed to connect to tunnel 'CPC-aamun-ILU2J': Unable to write file `vscode-userdata:/c:/Users/…/settings.json` (NoPermissions (FileSystemError): EPERM: operation not permitted, rename `settings.json.vsctmp` -> `settings.json`)

Supersedes #329634, which fixed the same symptom with an exhaustive switch. This takes the structural route instead, and also fixes a second bug found along the way.

## The problem

Entries were persisted by branching on `RemoteAgentHostEntryType` in about a dozen places, and "this type is not persisted" was expressed by `entryToRawEntry` returning `undefined` and getting dropped by `.filter(isDefined)`.

So registering a tunnel still called `updateValue('chat.remoteAgentHosts', …)` — writing an array **byte-identical** to what was already on disk. On Windows that write can fail with `EPERM` when the atomic `.vsctmp` rename hits a file lock (AV, indexer, another editor). Because the write was `await`ed inline in the connect path, the rejection propagated into `tunnelAgentHostServiceImpl`, which caught it, called `disconnect(connectionId)`, and **tore down a perfectly healthy tunnel**.

## The change

Collect the per-type differences into a static `IRemoteAgentHostEntryTypeConfig` table, modelled on `IPluginFormatConfig`. Each connection type declares its durable `store`, whether it is self-connecting, whether its address is normalized, and how it converts to/from its persisted form.

| Type | `store` | self-connecting |
|---|---|---|
| WebSocket | `settings` | yes |
| SSH | `storage` | no |
| WSL / Tunnel / CloudSandbox | `runtime` | no |

The table is an exhaustive mapped type, so **adding a connection type is now a compile error** rather than an entry that silently vanishes on save.

This absorbs and deletes `entryToRawEntry`, `rawEntryToEntry` (including its flat-shape SSH sniffing, `if (raw.sshConfigHost || raw.sshHostName || …)`) and the `getEntryAddress` switch, and collapses the duplicated upsert/merge helpers and the four configuration-scope helpers into one each.

## Two fixes follow from the model

1. **The reported bug.** Entries whose store is `runtime` are never written, so connecting *or disconnecting* a tunnel, WSL or cloud sandbox host now performs no I/O at all. Settings and storage writes are additionally skipped when the value is unchanged.

2. **A second, unreported bug.** `_reconcileConnections` built `desired` only from persisted entries, then disconnected every `_entries` key not in it — so runtime connections were always eligible for teardown. The label-formatter loop 7 lines above already guarded with `_registeredEntries`; the connection-removal loop had simply missed it. Net effect today: **an unrelated SSH connect silently kills a live tunnel**, since the SSH storage write fires reconcile. There was no test covering this.

## Behaviour

No user-visible behaviour change beyond the two bugs above. Storage locations, storage targets, the settings schema and the `IRemoteAgentHostService` interface are all unchanged; the legacy SSH-in-settings migration still runs.

## Validation

- `tsc --noEmit` clean (two `assignmentService.ts` errors are pre-existing on `main`, verified by typechecking `origin/main` directly)
- `layersChecker` clean
- ESLint clean on all changed files
- 86 tests passing across `remoteAgentHostService` + `sshRemoteAgentHostService`

New coverage: managed connect/remove of Tunnel/WSL/CloudSandbox performs **zero** `updateValue` and zero storage writes; a live tunnel survives both a settings change and a reconcile; config round-trips for WebSocket and SSH; legacy migration still works.

Manual verification of the original repro (exclusive lock on `settings.json` while connecting a tunnel) is worth a pass before merge, since no unit test can reproduce a real Windows file lock.
