### PR TITLE
Fix allowed remote MCP server initialization

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -471,7 +471,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		]);
 
 		// pre-fill the variables we already resolved to avoid extra prompting
-		const expr = ConfigurationResolverExpression.parse(withRemoteFilled);
+		const expr = ConfigurationResolverExpression.parse(McpServerLaunch.toSerialized(withRemoteFilled));
 		for (const replacement of expr.unresolved()) {
 			if (previouslyStored.hasOwnProperty(replacement.id)) {
 				expr.resolve(replacement, previouslyStored[replacement.id]);
@@ -491,7 +491,8 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		await this._updateStorageWithExpressionInputs(inputStorage, expr);
 
 		// resolve other non-interactive variables, returning the final object
-		return await this._configurationResolverService.resolveAsync(folder, expr);
+		const resolved = await this._configurationResolverService.resolveAsync(folder, expr);
+		return McpServerLaunch.fromSerialized(resolved);
 	}
 
 	private isCollectionAllowed(collection: McpCollectionDefinition, strictPluginOnly: StrictPluginOnlyCustomization): boolean {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -371,6 +371,38 @@ suite('Workbench - MCP - Registry', () => {
 		connection3.dispose();
 	});
 
+	test('resolveConnection preserves URI in resolved HTTP launch', async () => {
+		const definition: McpServerDefinition = {
+			...baseDefinition,
+			launch: {
+				type: McpServerTransportType.HTTP,
+				uri: URI.parse('https://mcp.example.com/mcp'),
+				headers: [],
+			},
+			variableReplacement: {
+				section: 'mcp',
+				target: ConfigurationTarget.WORKSPACE,
+			}
+		};
+
+		const delegate = new TestMcpHostDelegate();
+		store.add(registry.registerDelegate(delegate));
+		testCollection.serverDefinitions.set([definition], undefined);
+		store.add(registry.registerCollection(testCollection));
+
+		const connection = await registry.resolveConnection({ collectionRef: testCollection, definitionRef: definition, logger, trustNonceBearer, taskManager }) as McpServerConnection;
+		const launch = connection.launchDefinition;
+
+		assert.deepStrictEqual(launch.type === McpServerTransportType.HTTP ? {
+			isUri: URI.isUri(launch.uri),
+			url: launch.uri.toString(true),
+		} : { type: launch.type }, {
+			isUri: true,
+			url: 'https://mcp.example.com/mcp',
+		});
+		connection.dispose();
+	});
+
 	test('resolveConnection uses user-provided launch configuration', async () => {
 		// Create a collection with custom launch resolver
 		const customCollection: McpCollectionDefinition = {


### PR DESCRIPTION
Fixes #327627

## Summary
- serialize MCP launch definitions before configuration variable resolution
- revive resolved HTTP launch URIs so URL-based enterprise policy matching receives a real `URI`
- add regression coverage for preserving HTTP launch URIs through connection resolution

## Validation
- `npm run compile` (0 errors)
- targeted `resolveConnection preserves URI in resolved HTTP launch` test (1 passing)
- complete `mcpRegistry.test.ts` suite (48 passing)
- TypeScript editor diagnostics for the changed files (no errors)
- simulated allowlist E2E: unmatched HTTP server blocked; DeepWiki progressed from Running to discovering 3 tools