### PR TITLE
Fix compact menu issues and add regression tests

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -206,6 +206,7 @@ export class MenuBar extends Disposable {
 		menus.forEach((menuBarMenu) => {
 			const menuIndex = this.menus.length;
 			const cleanMenuLabel = cleanMnemonic(menuBarMenu.label);
+			const actions = [...menuBarMenu.actions];
 
 			const mnemonicMatches = MENU_MNEMONIC_REGEX.exec(menuBarMenu.label);
 
@@ -217,7 +218,7 @@ export class MenuBar extends Disposable {
 			}
 
 			if (this.isCompact) {
-				this.menus.push(menuBarMenu);
+				this.menus.push({ label: menuBarMenu.label, actions });
 			} else {
 				const buttonElement = $('div.menubar-menu-button', { 'role': 'menuitem', 'tabindex': -1, 'aria-label': cleanMenuLabel, 'aria-haspopup': true });
 				const titleElement = $('div.menubar-menu-title', { 'role': 'none', 'aria-hidden': true });
@@ -306,7 +307,7 @@ export class MenuBar extends Disposable {
 
 				this.menus.push({
 					label: menuBarMenu.label,
-					actions: menuBarMenu.actions,
+					actions,
 					buttonElement: buttonElement,
 					titleElement: titleElement
 				});
@@ -422,9 +423,9 @@ export class MenuBar extends Disposable {
 	}
 
 	updateMenu(menu: MenuBarMenu): void {
-		const menuToUpdate = this.menus.filter(menuBarMenu => menuBarMenu.label === menu.label);
-		if (menuToUpdate && menuToUpdate.length) {
-			menuToUpdate[0].actions = menu.actions;
+		const menuToUpdate = this.menus.find(menuBarMenu => menuBarMenu.label === menu.label);
+		if (menuToUpdate) {
+			menuToUpdate.actions = [...menu.actions];
 		}
 	}
 
@@ -521,17 +522,7 @@ export class MenuBar extends Disposable {
 
 		// Overflow
 		if (this.isCompact) {
-			this.overflowMenu.actions = [];
-			for (let idx = this.numMenusShown; idx < this.menus.length; idx++) {
-				this.overflowMenu.actions.push(new SubmenuAction(`menubar.submenu.${this.menus[idx].label}`, this.menus[idx].label, this.menus[idx].actions || []));
-			}
-
-			const compactMenuActions = this.options.getCompactMenuActions?.();
-			if (compactMenuActions && compactMenuActions.length) {
-				this.overflowMenu.actions.push(new Separator());
-				this.overflowMenu.actions.push(...compactMenuActions);
-			}
-
+			this.updateOverflowMenuActions();
 			this.overflowMenu.buttonElement.style.visibility = 'visible';
 		} else if (full) {
 			// Can't fit the more button, need to remove more menus
@@ -542,10 +533,7 @@ export class MenuBar extends Disposable {
 				currentSize -= size;
 			}
 
-			this.overflowMenu.actions = [];
-			for (let idx = this.numMenusShown; idx < showableMenus.length; idx++) {
-				this.overflowMenu.actions.push(new SubmenuAction(`menubar.submenu.${showableMenus[idx].label}`, showableMenus[idx].label, showableMenus[idx].actions || []));
-			}
+			this.updateOverflowMenuActions();
 
 			if (this.overflowMenu.buttonElement.nextElementSibling !== showableMenus[this.numMenusShown].buttonElement) {
 				this.overflowMenu.buttonElement.remove();
@@ -561,6 +549,24 @@ export class MenuBar extends Disposable {
 
 		// If we are only showing the overflow, add this class to avoid taking up space
 		this.container.classList.toggle(overflowMenuOnlyClass, this.numMenusShown === 0);
+	}
+
+	private updateOverflowMenuActions(): void {
+		const actions: IAction[] = [];
+		const firstMenuIndex = this.isCompact ? 0 : this.numMenusShown;
+		for (let index = firstMenuIndex; index < this.menus.length; index++) {
+			const menu = this.menus[index];
+			actions.push(new SubmenuAction(`menubar.submenu.${menu.label}`, menu.label, menu.actions));
+		}
+
+		if (this.isCompact) {
+			const compactMenuActions = this.options.getCompactMenuActions?.();
+			if (compactMenuActions?.length) {
+				actions.push(new Separator(), ...compactMenuActions);
+			}
+		}
+
+		this.overflowMenu.actions = actions;
 	}
 
 	private updateLabels(titleElement: HTMLElement, buttonElement: HTMLElement, label: string): void {
@@ -1000,6 +1006,9 @@ export class MenuBar extends Disposable {
 
 	private showCustomMenu(menuIndex: number, selectFirst = true): void {
 		const actualMenuIndex = menuIndex >= this.numMenusShown ? MenuBar.OVERFLOW_INDEX : menuIndex;
+		if (actualMenuIndex === MenuBar.OVERFLOW_INDEX) {
+			this.updateOverflowMenuActions();
+		}
 		const customMenu = actualMenuIndex === MenuBar.OVERFLOW_INDEX ? this.overflowMenu : this.menus[actualMenuIndex];
 
 		if (!customMenu.actions || !customMenu.buttonElement || !customMenu.titleElement) {

--- a/src/vs/base/test/browser/ui/menu/menubar.test.ts
+++ b/src/vs/base/test/browser/ui/menu/menubar.test.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { $, ModifierKeyEmitter } from '../../../../browser/dom.js';
-import { unthemedMenuStyles } from '../../../../browser/ui/menu/menu.js';
+import sinon from 'sinon';
+import { $, append, EventType, ModifierKeyEmitter } from '../../../../browser/dom.js';
+import { HorizontalDirection, unthemedMenuStyles, VerticalDirection } from '../../../../browser/ui/menu/menu.js';
 import { MenuBar } from '../../../../browser/ui/menu/menubar.js';
+import { Action, IAction, SubmenuAction } from '../../../../common/actions.js';
+import { toDisposable } from '../../../../common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
 
 function getButtonElementByAriaLabel(menubarElement: HTMLElement, ariaLabel: string): HTMLElement | null {
@@ -62,8 +65,14 @@ function validateMenuBarItem(menubar: MenuBar, menubarContainer: HTMLElement, la
 }
 
 suite('Menubar', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
-	const container = $('.container');
+	let container: HTMLElement;
+
+	teardown(() => {
+		ModifierKeyEmitter.disposeInstance();
+		sinon.restore();
+	});
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const withMenuMenubar = (callback: (menubar: MenuBar) => void) => {
 		const menubar = new MenuBar(container, {
@@ -74,8 +83,39 @@ suite('Menubar', () => {
 		callback(menubar);
 
 		menubar.dispose();
-		ModifierKeyEmitter.disposeInstance();
 	};
+
+	function createCompactMenubar(actions: IAction[], getCompactMenuActions?: () => IAction[]): MenuBar {
+		const menubar = disposables.add(new MenuBar(container, {
+			enableMnemonics: true,
+			visibility: 'compact',
+			compactMode: {
+				horizontal: HorizontalDirection.Right,
+				vertical: VerticalDirection.Below
+			},
+			getCompactMenuActions
+		}, unthemedMenuStyles));
+		menubar.push({ label: '&View', actions });
+		menubar.update();
+
+		return menubar;
+	}
+
+	function dispatchKeyboardEvent(element: HTMLElement, type: string, keyCode: number): void {
+		const event = new KeyboardEvent(type, { bubbles: true });
+		Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+		element.dispatchEvent(event);
+	}
+
+	function openSubmenuWithPointer(actionItem: HTMLElement, clock: sinon.SinonFakeTimers): void {
+		actionItem.dispatchEvent(new MouseEvent(EventType.MOUSE_MOVE, { bubbles: true, movementX: 1 }));
+		clock.tick(250);
+	}
+
+	setup(() => {
+		container = append(document.body, $('.container'));
+		disposables.add(toDisposable(() => container.remove()));
+	});
 
 	test('English File menu renders mnemonics', function () {
 		withMenuMenubar(menubar => {
@@ -92,6 +132,174 @@ suite('Menubar', () => {
 	test('Chinese File menu renders mnemonics', function () {
 		withMenuMenubar(menubar => {
 			validateMenuBarItem(menubar, container, '文件(&F)', '文件', 'F');
+		});
+	});
+
+	test('compact menu uses updated action state on first open (#273020)', () => {
+		const clock = sinon.useFakeTimers();
+		const initialAction = disposables.add(new Action('wordWrap', 'Word Wrap', undefined, true));
+		initialAction.checked = false;
+		const callerActions = [initialAction];
+		const menubar = createCompactMenubar(callerActions);
+		clock.tick(20);
+
+		const updatedAction = disposables.add(new Action('wordWrap', 'Word Wrap', undefined, false));
+		updatedAction.checked = true;
+		menubar.updateMenu({ label: '&View', actions: [updatedAction] });
+
+		const applicationMenuButton = getButtonElementByAriaLabel(container, 'Application Menu')!;
+		applicationMenuButton.dispatchEvent(new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, button: 0 }));
+		openSubmenuWithPointer(container.querySelector<HTMLElement>('.action-item')!, clock);
+
+		const wordWrapItem = container.querySelector<HTMLElement>('.monaco-submenu .action-menu-item')!;
+		assert.deepStrictEqual({
+			role: wordWrapItem.getAttribute('role'),
+			checked: wordWrapItem.getAttribute('aria-checked'),
+			disabled: wordWrapItem.getAttribute('aria-disabled'),
+			callerActionsUnchanged: callerActions.length === 1 && callerActions[0] === initialAction
+		}, {
+			role: 'menuitemcheckbox',
+			checked: 'true',
+			disabled: 'true',
+			callerActionsUnchanged: true
+		});
+	});
+
+	test('compact menu uses updated extra action state on first open', () => {
+		const clock = sinon.useFakeTimers();
+		const staleAction = disposables.add(new Action('back', 'Back', undefined, false));
+		let compactMenuActions: IAction[] = [staleAction];
+		const menubar = createCompactMenubar([], () => compactMenuActions);
+		clock.tick(20);
+
+		const updatedAction = disposables.add(new Action('back', 'Back', undefined, true));
+		updatedAction.checked = true;
+		compactMenuActions = [updatedAction];
+		menubar.updateMenu({ label: '&View', actions: [] });
+
+		const applicationMenuButton = getButtonElementByAriaLabel(container, 'Application Menu')!;
+		applicationMenuButton.dispatchEvent(new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, button: 0 }));
+
+		const backLabel = container.querySelector<HTMLElement>('.action-label[aria-label="Back"]')!;
+		const backItem = backLabel.closest<HTMLElement>('.action-menu-item')!;
+		assert.deepStrictEqual({
+			role: backItem.getAttribute('role'),
+			checked: backItem.getAttribute('aria-checked'),
+			disabled: backItem.getAttribute('aria-disabled')
+		}, {
+			role: 'menuitemcheckbox',
+			checked: 'true',
+			disabled: null
+		});
+	});
+
+	test('non-compact overflow uses updated action state on first open', () => {
+		const clock = sinon.useFakeTimers();
+		const staleAction = disposables.add(new Action('wordWrap', 'Word Wrap', undefined, true));
+		staleAction.checked = false;
+		const menubar = disposables.add(new MenuBar(container, {
+			enableMnemonics: true,
+			visibility: 'visible'
+		}, unthemedMenuStyles));
+		menubar.push([
+			{ label: '&File', actions: [] },
+			{ label: '&View', actions: [staleAction] }
+		]);
+
+		Object.defineProperty(container, 'offsetWidth', { get: () => 10 });
+		Object.defineProperty(getButtonElementByAriaLabel(container, 'File')!, 'offsetWidth', { get: () => 20 });
+		Object.defineProperty(getButtonElementByAriaLabel(container, 'View')!, 'offsetWidth', { get: () => 20 });
+		menubar.update();
+		clock.tick(20);
+
+		const updatedAction = disposables.add(new Action('wordWrap', 'Word Wrap', undefined, false));
+		updatedAction.checked = true;
+		menubar.updateMenu({ label: '&View', actions: [updatedAction] });
+
+		const moreButton = getButtonElementByAriaLabel(container, 'More')!;
+		moreButton.dispatchEvent(new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, button: 0 }));
+		const viewLabel = container.querySelector<HTMLElement>('.action-label[aria-label="View"]')!;
+		openSubmenuWithPointer(viewLabel.closest<HTMLElement>('.action-item')!, clock);
+
+		const wordWrapItem = container.querySelector<HTMLElement>('.monaco-submenu .action-menu-item')!;
+		assert.deepStrictEqual({
+			role: wordWrapItem.getAttribute('role'),
+			checked: wordWrapItem.getAttribute('aria-checked'),
+			disabled: wordWrapItem.getAttribute('aria-disabled')
+		}, {
+			role: 'menuitemcheckbox',
+			checked: 'true',
+			disabled: 'true'
+		});
+	});
+
+	test('compact menu dismisses updated nested leaf action with pointer', () => {
+		const clock = sinon.useFakeTimers();
+		let runCount = 0;
+		const staleMinimapAction = disposables.add(new Action('minimap', 'Minimap', undefined, false));
+		const menubar = createCompactMenubar([
+			new SubmenuAction('appearance', 'Appearance', [staleMinimapAction])
+		]);
+		clock.tick(20);
+
+		const minimapAction = disposables.add(new Action('minimap', 'Minimap', undefined, true, () => runCount++));
+		menubar.updateMenu({ label: '&View', actions: [
+			new SubmenuAction('appearance', 'Appearance', [minimapAction])
+		] });
+
+		const applicationMenuButton = getButtonElementByAriaLabel(container, 'Application Menu')!;
+		applicationMenuButton.dispatchEvent(new MouseEvent(EventType.MOUSE_DOWN, { bubbles: true, button: 0 }));
+		openSubmenuWithPointer(container.querySelector<HTMLElement>('.action-item')!, clock);
+		openSubmenuWithPointer(container.querySelector<HTMLElement>('.monaco-submenu .action-item')!, clock);
+		clock.tick(100);
+
+		const minimapItem = container.querySelector<HTMLElement>('.monaco-submenu .monaco-submenu .action-item')!;
+		minimapItem.dispatchEvent(new MouseEvent(EventType.MOUSE_UP, { bubbles: true, button: 0 }));
+		clock.tick(0);
+
+		assert.deepStrictEqual({
+			runCount,
+			menuVisible: !!container.querySelector('.menubar-menu-items-holder')
+		}, {
+			runCount: 1,
+			menuVisible: false
+		});
+	});
+
+	test('compact menu dismisses nested leaf action with keyboard and restores focus', () => {
+		const clock = sinon.useFakeTimers();
+		let runCount = 0;
+		const staleMinimapAction = disposables.add(new Action('minimap', 'Minimap', undefined, false));
+		const menubar = createCompactMenubar([
+			new SubmenuAction('appearance', 'Appearance', [staleMinimapAction])
+		]);
+		clock.tick(20);
+
+		const minimapAction = disposables.add(new Action('minimap', 'Minimap', undefined, true, () => runCount++));
+		menubar.updateMenu({ label: '&View', actions: [
+			new SubmenuAction('appearance', 'Appearance', [minimapAction])
+		] });
+
+		const focusTarget = append(document.body, $('button'));
+		disposables.add(toDisposable(() => focusTarget.remove()));
+		focusTarget.focus();
+		menubar.toggleFocus();
+
+		const applicationMenuButton = getButtonElementByAriaLabel(container, 'Application Menu')!;
+		applicationMenuButton.dispatchEvent(new FocusEvent(EventType.FOCUS_IN, { bubbles: true, relatedTarget: focusTarget }));
+		dispatchKeyboardEvent(applicationMenuButton, EventType.KEY_UP, 13);
+		dispatchKeyboardEvent(document.activeElement as HTMLElement, EventType.KEY_UP, 13);
+		dispatchKeyboardEvent(document.activeElement as HTMLElement, EventType.KEY_UP, 13);
+		dispatchKeyboardEvent(document.activeElement as HTMLElement, EventType.KEY_DOWN, 13);
+
+		assert.deepStrictEqual({
+			runCount,
+			menuVisible: !!container.querySelector('.menubar-menu-items-holder'),
+			activeElement: document.activeElement
+		}, {
+			runCount: 1,
+			menuVisible: false,
+			activeElement: focusTarget
 		});
 	});
 });

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -351,6 +351,7 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 				} else {
 					this.uninstallMenubar();
 				}
+				this.registerKeyboardNavigationListeners();
 			}
 		}));
 	}
@@ -411,7 +412,9 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 		if (this.menuBarContainer) {
 			this.keyboardNavigationDisposables.add(addDisposableListener(this.menuBarContainer, EventType.KEY_DOWN, e => {
 				const kbEvent = new StandardKeyboardEvent(e);
-				if (kbEvent.equals(KeyCode.DownArrow) || kbEvent.equals(KeyCode.RightArrow)) {
+				const movesTowardActivityBar = kbEvent.equals(KeyCode.DownArrow)
+					|| (this.layoutService.getSideBarPosition() === Position.RIGHT && kbEvent.equals(KeyCode.RightArrow));
+				if (movesTowardActivityBar) {
 					this.focus();
 				}
 			}));

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -4,13 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import sinon from 'sinon';
+import { ActionsOrientation } from '../../../../../base/browser/ui/actionbar/actionbar.js';
+import { EventType, ModifierKeyEmitter } from '../../../../../base/browser/dom.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { isMacintosh, isNative } from '../../../../../base/common/platform.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { MenuSettings } from '../../../../../platform/window/common/window.js';
 import { TestStorageService } from '../../../common/workbenchTestServices.js';
-import { TestLayoutService } from '../../workbenchTestServices.js';
-import { ActivitybarPart } from '../../../../browser/parts/activitybar/activitybarPart.js';
+import { TestLayoutService, TestViewsService, workbenchInstantiationService } from '../../workbenchTestServices.js';
+import { ActivityBarCompositeBar, ActivitybarPart } from '../../../../browser/parts/activitybar/activitybarPart.js';
+import { CustomMenubarControl } from '../../../../browser/parts/titlebar/menubarControl.js';
 import { IViewSize } from '../../../../../base/browser/ui/grid/grid.js';
 import { LayoutSettings, Parts, Position } from '../../../../services/layout/browser/layoutService.js';
 import { mainWindow } from '../../../../../base/browser/window.js';
@@ -20,7 +27,10 @@ import { Event, Emitter } from '../../../../../base/common/event.js';
 import { IPaneComposite } from '../../../../common/panecomposite.js';
 import { Extensions, PaneCompositeDescriptor } from '../../../../browser/panecomposite.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { ViewContainerLocation } from '../../../../common/views.js';
+import { IViewDescriptorService, ViewContainer, ViewContainerLocation } from '../../../../common/views.js';
+import { IPaneCompositeBarOptions } from '../../../../browser/parts/paneCompositeBar.js';
+import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
+import { IViewsService } from '../../../../services/views/common/viewsService.js';
 
 class StubPaneCompositePart implements IPaneCompositePart {
 	declare readonly _serviceBrand: undefined;
@@ -55,6 +65,40 @@ class TestFloatingPanelsLayoutService extends TestLayoutService {
 	override getSideBarPosition(): Position { return this.sideBarPosition; }
 }
 
+class TestViewDescriptorService extends mock<IViewDescriptorService>() {
+	override readonly viewContainers: readonly ViewContainer[] = [];
+	override readonly onDidChangeViewContainers = Event.None;
+	override readonly onDidChangeContainerLocation = Event.None;
+	override readonly onDidChangeContainer = Event.None;
+	override readonly onDidChangeLocation = Event.None;
+
+	override getViewContainersByLocation(): ViewContainer[] {
+		return [];
+	}
+}
+
+class TestCompactMenubarControl {
+	private button: HTMLElement | undefined;
+
+	create(parent: HTMLElement): HTMLElement {
+		this.dispose();
+		this.button = document.createElement('div');
+		this.button.setAttribute('aria-label', 'Application Menu');
+		this.button.tabIndex = 0;
+		parent.appendChild(this.button);
+		return parent;
+	}
+
+	toggleFocus(): void {
+		this.button?.focus();
+	}
+
+	dispose(): void {
+		this.button?.remove();
+		this.button = undefined;
+	}
+}
+
 suite('ActivitybarPart', () => {
 
 	const disposables = new DisposableStore();
@@ -71,6 +115,8 @@ suite('ActivitybarPart', () => {
 	teardown(() => {
 		fixture.remove();
 		disposables.clear();
+		ModifierKeyEmitter.disposeInstance();
+		sinon.restore();
 	});
 
 	function createActivitybarPart(compact: boolean, floatingPanelsEnabled = false, sideBarPosition = Position.LEFT): { part: ActivitybarPart; configService: TestConfigurationService; layoutService: TestFloatingPanelsLayoutService } {
@@ -109,6 +155,48 @@ suite('ActivitybarPart', () => {
 		configService.onDidChangeConfigurationEmitter.fire({
 			affectsConfiguration: (k: string) => k === key,
 		} satisfies Partial<IConfigurationChangeEvent> as unknown as IConfigurationChangeEvent);
+	}
+
+	function dispatchKeyboardEvent(element: HTMLElement, type: string, keyCode: number): void {
+		const event = new KeyboardEvent(type, { bubbles: true });
+		Object.defineProperty(event, 'keyCode', { get: () => keyCode });
+		element.dispatchEvent(event);
+	}
+
+	function createActivityBarCompositeBar(configService: TestConfigurationService): ActivityBarCompositeBar {
+		const instantiationService = workbenchInstantiationService({ configurationService: () => configService }, disposables);
+		instantiationService.stubInstance(CustomMenubarControl, new TestCompactMenubarControl());
+		instantiationService.stub(IViewDescriptorService, new TestViewDescriptorService());
+		instantiationService.stub(IViewsService, new TestViewsService());
+
+		const options: IPaneCompositeBarOptions = {
+			partContainerClass: 'activitybar',
+			pinnedViewContainersKey: 'activitybar.test.pinned',
+			placeholderViewContainersKey: 'activitybar.test.placeholder',
+			viewContainersWorkspaceStateKey: 'activitybar.test.workspace',
+			orientation: ActionsOrientation.VERTICAL,
+			icon: true,
+			iconSize: 16,
+			recomputeSizes: false,
+			activityHoverOptions: { position: () => HoverPosition.RIGHT },
+			fillExtraContextMenuActions: () => { },
+			compositeSize: 52,
+			overflowActionSize: 48,
+			colors: () => ({
+				activeForegroundColor: undefined,
+				inactiveForegroundColor: undefined,
+				activeBorderColor: undefined,
+				activeBackground: undefined,
+				badgeBackground: undefined,
+				badgeForeground: undefined,
+				dragAndDropBorder: undefined,
+				activeBackgroundColor: undefined,
+				inactiveBackgroundColor: undefined,
+				activeBorderBottomColor: undefined,
+			})
+		};
+
+		return disposables.add(instantiationService.createInstance(ActivityBarCompositeBar, ViewContainerLocation.Sidebar, options, Parts.ACTIVITYBAR_PART, new StubPaneCompositePart(), false));
 	}
 
 	// --- Static constants ---------------------------------------------------
@@ -231,6 +319,37 @@ suite('ActivitybarPart', () => {
 			{ min: part.minimumWidth, max: part.maximumWidth },
 			{ min: ActivitybarPart.ACTIVITYBAR_WIDTH, max: ActivitybarPart.ACTIVITYBAR_WIDTH }
 		);
+	});
+
+	(isMacintosh && isNative ? test.skip : test)('Modern UI menu bar visibility preserves compact menu keyboard navigation', async () => {
+		const configService = new TestConfigurationService({
+			[LayoutSettings.MODERN_UI]: true,
+			[MenuSettings.MenuBarVisibility]: 'compact'
+		});
+		const compositeBar = createActivityBarCompositeBar(configService);
+		const focusSpy = sinon.spy(compositeBar, 'focus');
+		compositeBar.create(fixture);
+		const menuCounts = [fixture.querySelectorAll('.menubar').length];
+
+		for (const visibility of ['visible', 'hidden', 'compact', 'compact']) {
+			await configService.setUserConfiguration(MenuSettings.MenuBarVisibility, visibility);
+			fireConfigChange(configService, MenuSettings.MenuBarVisibility);
+			menuCounts.push(fixture.querySelectorAll('.menubar').length);
+		}
+
+		focusSpy.resetHistory();
+		const applicationMenu = fixture.querySelector<HTMLElement>('[aria-label="Application Menu"]')!;
+		dispatchKeyboardEvent(applicationMenu, EventType.KEY_DOWN, 39);
+		dispatchKeyboardEvent(applicationMenu, EventType.KEY_UP, 39);
+		dispatchKeyboardEvent(applicationMenu, EventType.KEY_DOWN, 40);
+
+		assert.deepStrictEqual({
+			menuCounts,
+			focusCount: focusSpy.callCount
+		}, {
+			menuCounts: [1, 0, 0, 1, 1],
+			focusCount: 1
+		});
 	});
 
 	// --- onDidChange fires for grid ----------------------------------------


### PR DESCRIPTION
This pull request addresses several issues related to the compact menu in Visual Studio Code, specifically focusing on the stale state of overflow actions and menu dismissal behavior. The changes include:

- **Bug Fixes**:
  - Implemented lazy composition for overflow actions when the Application Menu or More menu is opened, resolving stale state issues in both compact and non-compact modes.
  - Ensured that compact composition starts at menu index 0, independent of any deferred layout state.

- **Testing Enhancements**:
  - Added regression tests to cover the new behavior, ensuring that the fixes are validated across both Electron and Chromium environments.
  - Removed unnecessary assertions and focused tests on relevant behaviors, improving test reliability.

These changes were made in response to user feedback and are intended to enhance the overall user experience by ensuring that the compact menu behaves consistently and as expected.