### PR TITLE
Improve Agent Host large-output guidance

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -16,8 +16,8 @@ data the SDK accepts directly.
   shared identity text, the `fullSystemPrompt` / `sectionOverrides` builders, and
   `describeSystemMessageConfig` (the one-line log summary).
 - `toolInstructions.ts` — the model-agnostic `tool_instructions` layer: gated
-  one-line nudges (`TOOL_INSTRUCTION_LINES`) composed into the SDK's
-  `tool_instructions` section. The browser line is the one registered today.
+  or unconditional one-line nudges (`TOOL_INSTRUCTION_LINES`) composed into the
+  SDK's `tool_instructions` section.
 - `anthropicPrompt.ts` — example per-model contributor (Claude Opus 4.8).
 - `allPrompts.ts` — side-effect import hub; importing it registers every
   contributor into the shared `agentHostPromptRegistry`.
@@ -44,12 +44,13 @@ There are two ways to customize, and a model can use both at once.
 
 ## Lever 1 — universal, all models (`toolInstructions.ts`)
 
-Guidance for a tool that should apply to **every** model whenever that tool is in
-the session. This is what the browser line does.
+Guidance that should apply to **every** model. A line can be unconditional for
+host-wide behavior such as reading offloaded tool output, or gated on a client
+tool as the browser line is.
 
 1. Write a `ToolInstructionLine` — a function `(hasTool) => string | undefined`
-   that returns one sentence (no surrounding newlines) when its tool is present,
-   or `undefined` to contribute nothing.
+   that returns one sentence (no surrounding newlines), or `undefined` when its
+   gate does not apply.
 2. Add it to `TOOL_INSTRUCTION_LINES`.
 
 ```ts
@@ -58,7 +59,7 @@ const exampleToolInstructions: ToolInstructionLine = hasTool =>
 		? 'One sentence of guidance, shown only when that tool is present.'
 		: undefined;
 
-const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstructions, exampleToolInstructions];
+const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [largeOutputToolInstructions, browserToolInstructions, exampleToolInstructions];
 ```
 
 **Caveat — `hasTool` sees CLIENT tools only.** It is `context.hasClientTool`,

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -13,24 +13,22 @@ import { CLIENT_TOOL_SEARCH_REFERENCE_NAME } from '../../../common/toolSearchCon
  *
  * This is the agent-host home for the Copilot extension's `toolUseInstructions`
  * pattern (`defaultAgentInstructions.tsx` and the per-model agent prompts): a
- * sequence of one-line nudges, each gated on the relevant tool being present in
- * the session, composed into the single SDK `tool_instructions` section. The
- * agent host sees client tools under their camelCase `toolReferenceName`, so a
- * line's gate and any tool name it mentions use that form (NOT the extension's
- * snake_case ids).
+ * sequence of one-line nudges, either unconditional or gated on the relevant
+ * tool being present in the session, composed into the single SDK
+ * `tool_instructions` section. The agent host sees client tools under their
+ * camelCase `toolReferenceName`, so a line's gate and any tool name it mentions
+ * use that form (NOT the extension's snake_case ids).
  *
- * To add guidance for a tool, write a {@link ToolInstructionLine} and add it to
- * {@link TOOL_INSTRUCTION_LINES}. The browser guidance ({@link browserToolInstructions})
- * is the first such hookup: it gates on `openBrowserPage` (plus an agentic browser
- * tool) being present and returns the extension's "Use the browser tools (...)"
- * sentence.
+ * To add guidance, write a {@link ToolInstructionLine} and add it to
+ * {@link TOOL_INSTRUCTION_LINES}. The browser guidance
+ * ({@link browserToolInstructions}) demonstrates a line gated on
+ * `openBrowserPage` plus an agentic browser tool.
  */
 
 /**
- * A single gated tool-instructions line. Returns its content (a single
- * sentence, no surrounding newlines) when the session exposes the tools it
- * applies to, or `undefined` to contribute nothing. Mirrors one gated `<>…</>`
- * fragment in the extension's `toolUseInstructions` block.
+ * A single tool-instructions line. Returns its content (a single sentence, no
+ * surrounding newlines) when it applies, or `undefined` to contribute nothing.
+ * Mirrors one `<>…</>` fragment in the extension's `toolUseInstructions` block.
  *
  * @param hasTool predicate for whether a tool name is available in the session.
  */
@@ -42,6 +40,10 @@ type ToolInstructionLine = (hasTool: (name: string) => boolean) => string | unde
  * list so it stays in sync as browser tools are added or removed.
  */
 const agenticBrowserToolNames = browserChatToolReferenceNames.filter(name => name !== BrowserChatToolReferenceName.OpenBrowserPage);
+
+/** Prevents oversized tool-output temp files from being re-offloaded by shell reads. */
+export const COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION = 'When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.';
+const largeOutputToolInstructions: ToolInstructionLine = () => COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION;
 
 /**
  * Front-end guidance for the integrated browser tools, ported from the Copilot
@@ -61,10 +63,9 @@ const browserToolInstructions: ToolInstructionLine = hasTool => {
 };
 
 /**
- * The registered tool-instruction lines, in render order. Add new per-tool
- * guidance here.
+ * The registered tool-instruction lines, in render order.
  */
-const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstructions];
+const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [largeOutputToolInstructions, browserToolInstructions];
 
 /** Tool-search guidance mirrored from the Copilot extension prompt. */
 const toolSearchToolInstructions: ToolInstructionLine = hasTool =>

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -10,6 +10,7 @@ import type { SchemaValues } from '../../common/agentHostSchema.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { AgentHostPromptRegistry, agentHostPromptRegistry, type IAgentHostPromptContext } from '../../node/copilot/prompts/promptRegistry.js';
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS, COPILOT_AGENT_HOST_WORKSPACELESS_INSTRUCTIONS, COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from '../../node/copilot/prompts/systemMessage.js';
+import { COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION } from '../../node/copilot/prompts/toolInstructions.js';
 import { BrowserChatToolReferenceName } from '../../../browserView/common/browserChatToolReferenceNames.js';
 import { CLIENT_TOOL_SEARCH_REFERENCE_NAME } from '../../common/toolSearchConstants.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -33,19 +34,31 @@ suite('AgentHostPromptRegistry', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	const withFileLinkInstructions = (config: SystemMessageConfig): SystemMessageConfig => ({
-		...config,
-		content: config.content ? `${config.content}\n\n${COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS}` : COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS,
-	});
+	const LARGE_OUTPUT_LINE = COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION;
+
+	const withUniversalAgentHostInstructions = (config: SystemMessageConfig): SystemMessageConfig => {
+		const content = config.content ? `${config.content}\n\n${COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS}` : COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS;
+		if (config.mode !== 'customize' || config.sections?.tool_instructions) {
+			return { ...config, content };
+		}
+		return {
+			...config,
+			sections: {
+				...config.sections,
+				tool_instructions: { action: 'append', content: `\n${LARGE_OUTPUT_LINE}` } satisfies SectionOverride,
+			},
+			content,
+		};
+	};
 
 	test('falls back to the default system message when no model is provided', () => {
 		const registry = new AgentHostPromptRegistry();
-		assert.deepStrictEqual(registry.resolveSystemMessageConfig(undefined, context()), withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
+		assert.deepStrictEqual(registry.resolveSystemMessageConfig(undefined, context()), withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
 	});
 
 	test('falls back to the default when no contributor matches the model', () => {
 		const registry = new AgentHostPromptRegistry();
-		assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'unknown-model' }, context()), withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
+		assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'unknown-model' }, context()), withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
 	});
 
 	test('a contributor can fully replace the system prompt (replace mode)', () => {
@@ -72,7 +85,7 @@ suite('AgentHostPromptRegistry', () => {
 		});
 		assert.deepStrictEqual(
 			registry.resolveSystemMessageConfig({ id: 'claude-sonnet' }, context()),
-			withFileLinkInstructions({ mode: 'customize', sections: { guidelines: { action: 'append', content: 'Be concise.' } } })
+			withUniversalAgentHostInstructions({ mode: 'customize', sections: { guidelines: { action: 'append', content: 'Be concise.' } } })
 		);
 	});
 
@@ -86,7 +99,7 @@ suite('AgentHostPromptRegistry', () => {
 		});
 		assert.deepStrictEqual(
 			registry.resolveSystemMessageConfig({ id: 'claude-sonnet' }, context()),
-			withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+			withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
 		);
 	});
 
@@ -117,11 +130,11 @@ suite('AgentHostPromptRegistry', () => {
 		});
 		assert.deepStrictEqual(
 			registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({ [CopilotCliConfigKey.Opus48Prompt]: true })),
-			withFileLinkInstructions({ mode: 'customize', sections: { tone: { action: 'append', content: 'GATED' } } })
+			withUniversalAgentHostInstructions({ mode: 'customize', sections: { tone: { action: 'append', content: 'GATED' } } })
 		);
 		assert.deepStrictEqual(
 			registry.resolveSystemMessageConfig({ id: 'claude-x' }, context()),
-			withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+			withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
 		);
 	});
 
@@ -133,8 +146,8 @@ suite('AgentHostPromptRegistry', () => {
 		}
 
 		test('applies customize overrides only when enabled', () => {
-			assert.deepStrictEqual(resolveOpus(undefined), withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
-			assert.deepStrictEqual(resolveOpus(false), withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
+			assert.deepStrictEqual(resolveOpus(undefined), withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
+			assert.deepStrictEqual(resolveOpus(false), withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
 			assert.strictEqual(resolveOpus(true).mode, 'customize');
 		});
 	});
@@ -161,7 +174,10 @@ suite('AgentHostPromptRegistry', () => {
 				registry.resolveSystemMessageConfig(undefined, context({}, [], true)),
 				{
 					mode: 'customize',
-					sections: COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections,
+					sections: {
+						...COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections,
+						tool_instructions: { action: 'append', content: `\n${LARGE_OUTPUT_LINE}` },
+					},
 					content: `${COPILOT_AGENT_HOST_WORKSPACELESS_INSTRUCTIONS}\n\n${COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS}`,
 				}
 			);
@@ -171,7 +187,7 @@ suite('AgentHostPromptRegistry', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig(undefined, context({}, [], false)),
-				withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+				withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
 			);
 		});
 
@@ -187,7 +203,10 @@ suite('AgentHostPromptRegistry', () => {
 				registry.resolveSystemMessageConfig({ id: 'claude-sonnet' }, context({}, [], true)),
 				{
 					mode: 'customize',
-					sections: { guidelines: { action: 'append', content: 'Be concise.' } },
+					sections: {
+						guidelines: { action: 'append', content: 'Be concise.' },
+						tool_instructions: { action: 'append', content: `\n${LARGE_OUTPUT_LINE}` },
+					},
 					content: `${COPILOT_AGENT_HOST_WORKSPACELESS_INSTRUCTIONS}\n\n${COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS}`,
 				}
 			);
@@ -209,26 +228,25 @@ suite('AgentHostPromptRegistry', () => {
 	});
 
 	suite('universal tool instructions wiring', () => {
-		// The browser line is the registered universal tool-instruction (see
-		// toolInstructions.ts). These guard that the registry layers it end-to-end;
-		// the composition/gating itself is covered in toolInstructions.test.ts.
+		// These guard that the registry layers the registered universal instructions
+		// end-to-end; composition and gating are covered in toolInstructions.test.ts.
 		const BROWSER_LINE = 'Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.';
 		const browserTools = [BrowserChatToolReferenceName.OpenBrowserPage, BrowserChatToolReferenceName.ReadPage];
 
-		test('is a no-op when the session exposes no matching tools', () => {
+		test('layers the unconditional large-output instruction onto the default config', () => {
 			const registry = new AgentHostPromptRegistry();
-			assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'])), withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
+			assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'])), withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE));
 		});
 
 		test('layers the browser tool_instructions onto the default config when browser tools are present', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, browserTools)),
-				withFileLinkInstructions({
+				withUniversalAgentHostInstructions({
 					mode: 'customize',
 					sections: {
 						identity: COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections.identity,
-						tool_instructions: { action: 'append', content: `\n${BROWSER_LINE}` },
+						tool_instructions: { action: 'append', content: `\n${LARGE_OUTPUT_LINE}\n${BROWSER_LINE}` },
 					},
 				})
 			);
@@ -244,11 +262,11 @@ suite('AgentHostPromptRegistry', () => {
 			});
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, browserTools)),
-				withFileLinkInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${BROWSER_LINE}` } } })
+				withUniversalAgentHostInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${LARGE_OUTPUT_LINE}\n${BROWSER_LINE}` } } })
 			);
 		});
 
-		test('leaves a per-model tool_instructions override untouched when no browser tools are present', () => {
+		test('composes the unconditional large-output instruction with a per-model override', () => {
 			const registry = new AgentHostPromptRegistry();
 			registry.registerPrompt(class {
 				static readonly familyPrefixes = ['claude'];
@@ -258,7 +276,7 @@ suite('AgentHostPromptRegistry', () => {
 			});
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, ['anyTool'])),
-				withFileLinkInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } } })
+				withUniversalAgentHostInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${LARGE_OUTPUT_LINE}` } } })
 			);
 		});
 	});
@@ -274,29 +292,29 @@ suite('AgentHostPromptRegistry', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, true)),
-				withFileLinkInstructions({
+				withUniversalAgentHostInstructions({
 					mode: 'customize',
 					sections: {
 						identity: COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections.identity,
-						tool_instructions: { action: 'append', content: `\n${TOOL_SEARCH_LINE}` },
+						tool_instructions: { action: 'append', content: `\n${LARGE_OUTPUT_LINE}\n${TOOL_SEARCH_LINE}` },
 					},
 				})
 			);
 		});
 
-		test('is a no-op when tool search is inactive even if the tool-search tool is present', () => {
+		test('does not add the tool-search instruction when tool search is inactive', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, false)),
-				withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+				withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
 			);
 		});
 
-		test('is a no-op when active but the client does not expose the tool-search tool', () => {
+		test('does not add the tool-search instruction when the client tool is unavailable', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'], false, true)),
-				withFileLinkInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
+				withUniversalAgentHostInstructions(COPILOT_AGENT_HOST_SYSTEM_MESSAGE)
 			);
 		});
 
@@ -310,7 +328,7 @@ suite('AgentHostPromptRegistry', () => {
 			});
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, [CLIENT_TOOL_SEARCH_REFERENCE_NAME], false, true)),
-				withFileLinkInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${TOOL_SEARCH_LINE}` } } })
+				withUniversalAgentHostInstructions({ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${LARGE_OUTPUT_LINE}\n${TOOL_SEARCH_LINE}` } } })
 			);
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -50,6 +50,7 @@ import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js
 import { AgentHostCompletions, IAgentHostCompletions } from '../../node/agentHostCompletions.js';
 import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, rebaseUnder, REFRESH_DEBOUNCE_MS, resolveCopilotOtlpMetricsEndpoint } from '../../node/copilot/copilotAgent.js';
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS } from '../../node/copilot/prompts/systemMessage.js';
+import { COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION } from '../../node/copilot/prompts/toolInstructions.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostReviewService, NULL_REVIEW_SERVICE } from '../../common/agentHostReviewService.js';
 import { getCopilotHomePath } from '../../common/copilotHome.js';
@@ -4113,6 +4114,13 @@ suite('CopilotAgent', () => {
 				const systemMessage = capturedConfig.systemMessage;
 				assert.deepStrictEqual(systemMessage, {
 					...COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
+					sections: {
+						...COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections,
+						tool_instructions: {
+							action: 'append',
+							content: `\n${COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION}`,
+						},
+					},
 					content: COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS,
 				});
 				if (!systemMessage || systemMessage.mode !== 'customize') {

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-haiku-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-haiku-4_5.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_5.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_6.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_6.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_7.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_7.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_8.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-4_8.prompt.md
@@ -326,7 +326,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-opus-5.prompt.md
@@ -326,7 +326,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_5.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_6.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-4_6.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_claude-sonnet-5.prompt.md
@@ -325,7 +325,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gemini-2_0-flash.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gemini-2_0-flash.prompt.md
@@ -344,7 +344,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-codex.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-codex.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-mini.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5-mini.prompt.md
@@ -316,7 +316,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5.prompt.md
@@ -316,7 +316,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex-mini.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex-mini.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1-codex.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_1.prompt.md
@@ -316,7 +316,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > grep with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-luna.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-luna.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-sol.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-sol.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-terra.prompt.md
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot_prompts_gpt-5_6-terra.prompt.md
@@ -292,7 +292,8 @@ Best practices:
 * Prefer calling in the following order: Code Intelligence Tools (if available) > lsp (if available) > glob > rg with glob pattern
 * PARALLELIZE - make multiple independent search calls in ONE call.
 </code_search_tools>
-</tools>
+
+When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.</tools>
 
 <custom_instruction>${repository_instructions}</custom_instruction>
 

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import type { SectionOverride } from '@github/copilot-sdk';
-import { resolveToolInstructionsOverride, toolSearchInstructionLines, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
+import { COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION, resolveToolInstructionsOverride, toolSearchInstructionLines, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
 import { CLIENT_TOOL_SEARCH_REFERENCE_NAME } from '../../common/toolSearchConstants.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
@@ -24,17 +24,28 @@ suite('toolInstructions', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	const LARGE_OUTPUT_LINE = COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION;
+
 	suite('universalToolInstructions', () => {
 		test('joins applicable lines in order and drops gated-out ones', () => {
 			assert.strictEqual(universalToolInstructions(hasTools('a', 'c'), [lineFor('a'), lineFor('b'), lineFor('c')]), 'use a\nuse c');
 		});
 
-		test('returns undefined when no line applies (including the default registry when its lines do not apply)', () => {
+		test('returns undefined when no injected line applies', () => {
 			assert.strictEqual(universalToolInstructions(hasTools('x'), [lineFor('a')]), undefined);
-			assert.strictEqual(universalToolInstructions(hasTools('a')), undefined);
 		});
 
-		test('renders the registered browser line from the default registry only when openBrowserPage + an agentic browser tool are present', () => {
+		test('always renders the registered large-output line from the default registry', () => {
+			assert.deepStrictEqual([
+				COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION,
+				universalToolInstructions(hasTools()),
+			], [
+				'When a tool reports that its output was saved to a temporary file because it was too large, ONLY use the `view` tool with a narrow `view_range` to inspect that file. NEVER read it with shell commands such as `cat`, `head`, `tail`, or `sed`, because their output may be offloaded again.',
+				LARGE_OUTPUT_LINE,
+			]);
+		});
+
+		test('adds the registered browser line only when openBrowserPage + an agentic browser tool are present', () => {
 			assert.deepStrictEqual(
 				[
 					universalToolInstructions(hasTools('openBrowserPage', 'readPage')),
@@ -42,9 +53,9 @@ suite('toolInstructions', () => {
 					universalToolInstructions(hasTools('readPage')),
 				],
 				[
-					'Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.',
-					undefined,
-					undefined,
+					`${LARGE_OUTPUT_LINE}\nUse the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.`,
+					LARGE_OUTPUT_LINE,
+					LARGE_OUTPUT_LINE,
 				]
 			);
 		});
@@ -92,32 +103,34 @@ suite('toolInstructions', () => {
 		const TOOL_SEARCH_LINE = `Most tools are deferred and hidden until you search for them. Before calling a tool that has not already been loaded, ALWAYS use tool search first with a short description of the capability you need, then call the specific tool it returns; tools it returns are immediately available and must not be searched for again.`;
 
 		test('active tool search contributes the tool-search line only when the client exposes the tool-search tool', () => {
-			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)), TOOL_SEARCH_LINE);
-			// Active, but the client didn't expose the tool-search tool → gated out.
-			assert.strictEqual(universalToolInstructions(hasTools('other'), toolSearchInstructionLines(true)), undefined);
+			assert.deepStrictEqual([
+				universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)),
+				universalToolInstructions(hasTools('other'), toolSearchInstructionLines(true)),
+			], [
+				`${LARGE_OUTPUT_LINE}\n${TOOL_SEARCH_LINE}`,
+				LARGE_OUTPUT_LINE,
+			]);
 		});
 
 		test('inactive tool search never contributes the tool-search line', () => {
-			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(false)), undefined);
+			assert.strictEqual(universalToolInstructions(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(false)), LARGE_OUTPUT_LINE);
 		});
 
-		test('composes the tool-search line after the registered browser line', () => {
+		test('composes the tool-search line after the registered large-output and browser lines', () => {
 			assert.strictEqual(
 				universalToolInstructions(hasTools('openBrowserPage', 'readPage', CLIENT_TOOL_SEARCH_REFERENCE_NAME), toolSearchInstructionLines(true)),
-				`Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.\n${TOOL_SEARCH_LINE}`
+				`${LARGE_OUTPUT_LINE}\nUse the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.\n${TOOL_SEARCH_LINE}`
 			);
 		});
 
 		test('folds the tool-search line into an existing per-model override only while active', () => {
-			assert.deepStrictEqual(
+			assert.deepStrictEqual([
 				resolveToolInstructionsOverride(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), { action: 'append', content: 'A' }, toolSearchInstructionLines(true)),
-				{ action: 'append', content: `\nA\n${TOOL_SEARCH_LINE}` }
-			);
-			// Inactive with no other applicable line → keep the existing override (undefined).
-			assert.strictEqual(
 				resolveToolInstructionsOverride(hasTools(CLIENT_TOOL_SEARCH_REFERENCE_NAME), { action: 'append', content: 'A' }, toolSearchInstructionLines(false)),
-				undefined
-			);
+			], [
+				{ action: 'append', content: `\nA\n${LARGE_OUTPUT_LINE}\n${TOOL_SEARCH_LINE}` },
+				{ action: 'append', content: `\nA\n${LARGE_OUTPUT_LINE}` },
+			]);
 		});
 	});
 });


### PR DESCRIPTION
Direct Agent Host models to inspect spilled tool output with bounded `view` ranges, avoiding recursive offloads.

Tests: focused unit tests and Copilot prompt E2E replay.