### PR TITLE
Fix pressed and focus states of the horizontal activity bar in Modern UI

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -13,8 +13,23 @@
 	border-left: none !important;
 }
 
+/*
+ * Keyboard focus is drawn as a ring around the same box the horizontal composite bars use
+ * (tabs.css), so the 2px line the base paints for it goes too. High contrast keeps the line:
+ * there the box is an outline and the line is that theme's only focus marker.
+ */
+.style-override.monaco-workbench:not(:is(.hc-black, .hc-light)) .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+	border-left: none !important;
+}
+
+.style-override.monaco-workbench:not(:is(.hc-black, .hc-light)) .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
+}
+
 /* The indicator owns the inset background for both active and hovered items. */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator,
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator,
 .style-override .activitybar > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .active-item-indicator {
 	z-index: 0;
 	top: 0;
@@ -50,6 +65,7 @@
 
 /* Compact: minimal horizontal inset — 24×24px box centered in the 28px item. */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator,
+.style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator,
 .style-override .activitybar.compact > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .active-item-indicator {
 	width: calc(var(--activity-bar-action-height, 28px) - 4px);
 	height: calc(var(--activity-bar-action-height, 28px) - 4px);
@@ -113,8 +129,13 @@
 	display: none;
 }
 
-/* Active item: inset, rounded background box behind the icon. */
-.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) .active-item-indicator {
+/*
+ * Active item: inset, rounded background box behind the icon. It is kept while the item
+ * is pressed; excluding `:active` would fall back to the full-height base geometry
+ * (paneCompositePart.css) at the same time as the background drops out in tabs.css,
+ * leaving the item unstyled for as long as the mouse is held.
+ */
+.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked .active-item-indicator {
 	z-index: 0;
 	top: 50%;
 	left: var(--vscode-spacing-size20);
@@ -129,7 +150,7 @@
  * shows the box) and while dragging (the action-item `::before`/`::after` are
  * reused for the drop-line indicators).
  */
-.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover .active-item-indicator {
+.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):hover .active-item-indicator {
 	z-index: 0;
 	top: 50%;
 	left: var(--vscode-spacing-size20);

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -15,21 +15,24 @@
 
 /*
  * Keyboard focus is drawn as a ring around the same box the horizontal composite bars use
- * (tabs.css), so the 2px line the base paints for it goes too. High contrast keeps the line:
- * there the box is an outline and the line is that theme's only focus marker.
+ * (tabs.css), so the 2px line the base paints for it goes too. `:focus-visible` keeps the
+ * ring off every mouse path: the base `.clicked` class only suppresses focus feedback for
+ * 800ms after mouse up, so it comes back on its own while the item is still focused.
+ * High contrast keeps the line, since there the box is an outline and the line is that
+ * theme's only focus marker.
  */
 .style-override.monaco-workbench:not(:is(.hc-black, .hc-light)) .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-left: none !important;
 }
 
-.style-override.monaco-workbench:not(:is(.hc-black, .hc-light)) .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator {
+.style-override.monaco-workbench:not(:is(.hc-black, .hc-light)) .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus-visible .active-item-indicator {
 	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }
 
 /* The indicator owns the inset background for both active and hovered items. */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator,
-.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator,
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus-visible .active-item-indicator,
 .style-override .activitybar > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .active-item-indicator {
 	z-index: 0;
 	top: 0;
@@ -65,7 +68,7 @@
 
 /* Compact: minimal horizontal inset — 24×24px box centered in the 28px item. */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator,
-.style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus:not(.clicked) .active-item-indicator,
+.style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus-visible .active-item-indicator,
 .style-override .activitybar.compact > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .active-item-indicator {
 	width: calc(var(--activity-bar-action-height, 28px) - 4px);
 	height: calc(var(--activity-bar-action-height, 28px) - 4px);
@@ -129,12 +132,7 @@
 	display: none;
 }
 
-/*
- * Active item: inset, rounded background box behind the icon. It is kept while the item
- * is pressed; excluding `:active` would fall back to the full-height base geometry
- * (paneCompositePart.css) at the same time as the background drops out in tabs.css,
- * leaving the item unstyled for as long as the mouse is held.
- */
+/* Active item: inset, rounded background box behind the icon, kept while the item is pressed. */
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked .active-item-indicator {
 	z-index: 0;
 	top: 50%;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -521,7 +521,7 @@
 	color: var(--vscode-modernTab-activeForeground) !important;
 }
 
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked:not(:active) > .active-item-indicator {
+.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon.checked > .active-item-indicator {
 	background-color: var(--vscode-modernTab-activeBackground) !important;
 }
 
@@ -541,15 +541,15 @@
 	color: var(--vscode-modernTab-hoverForeground) !important;
 }
 
-.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover > .active-item-indicator {
+.modern-ui-tabs.monaco-workbench:not(.hc-black):not(.hc-light) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):hover > .active-item-indicator {
 	background-color: var(--vscode-modernTab-hoverBackground);
 }
 
-.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover > .action-label.codicon {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):hover > .action-label.codicon {
 	color: var(--vscode-modernTab-hoverForeground) !important;
 }
 
-.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):not(:active):hover > .action-label.uri-icon {
+.modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked):hover > .action-label.uri-icon {
 	background-color: var(--vscode-modernTab-hoverForeground) !important;
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -553,7 +553,7 @@
 	background-color: var(--vscode-modernTab-hoverForeground) !important;
 }
 
-.modern-ui-tabs.monaco-workbench:not(:is(.hc-black, .hc-light)) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus:not(.clicked) > .active-item-indicator {
+.modern-ui-tabs.monaco-workbench:not(:is(.hc-black, .hc-light)) .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible > .active-item-indicator {
 	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
 }


### PR DESCRIPTION
When the activity bar sits at the top or bottom, pressing an item (`:active`) hides the rounded box and reveals the old pre-Modern-UI indicator underneath: a flat, edge-to-edge fill plus a thin border line.

### Fix

- Drop the border line entirely.
- Replace the keyboard focus affordance with a ring around the box.
### Screenshots

**Current behavior**

Neutral (nothing pressed or focused):
<img width="371" height="126" alt="Activity bar in neutral state" src="https://github.com/user-attachments/assets/03131376-3c72-4f9b-a16a-0b4b88e73845" />

Holding click on a nav item, the rounded box disappears and the old flat indicator shows through:
<img width="375" alt="Pressed nav item exposing the old full-bleed indicator underneath" src="https://github.com/user-attachments/assets/1f2b196b-aa03-406b-bec4-739c4f34aa97" />

Focusing a nav item with Tab, the old thin border line is used as the focus affordance:
<img width="369" height="100" alt="Keyboard focus rendered as a thin border line" src="https://github.com/user-attachments/assets/1894c0da-980b-4b96-b630-185f1d9dca32" />

**With the fix**

Neutral:
<img width="296" height="82" alt="Activity bar in neutral state after the fix" src="https://github.com/user-attachments/assets/c2bb2c99-2b90-40be-9109-8fa119f1f296" />

Pressing a nav item, the box stays and gets its own pressed fill:
<img width="390" height="194" alt="Pressed nav item keeps the rounded box with a distinct pressed fill" src="https://github.com/user-attachments/assets/4e538664-94b2-455b-8a0a-3a73192160a8" />

Focusing with Tab, a ring is drawn around the box:
<img width="309" height="83" alt="Keyboard focus rendered as a ring around the rounded box" src="https://github.com/user-attachments/assets/2a4e5d80-91b4-4b0d-9fae-af6aa5dac78e" />