### PR TITLE
chat: fix: honor disabled built-in skills in the Agents window

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -284,11 +284,16 @@ All built-in customizations bundled with the Sessions app are skills, living in 
 
 #### Enabling and Disabling Built-in Skills
 
-The **Enable** / **Disable** actions on a built-in skill persist to `IPromptsService.setDisabledPromptFiles(PromptsType.skill, …)` (profile-scoped storage). This is a distinct store from the per-harness auto-sync opt-out owned by `ICustomizationSyncProvider`, which the Plugins section writes; both are honored wherever a customization's disabled state is evaluated.
+The **Enable** / **Disable** actions on a built-in skill persist to `IPromptsService.setDisabledPromptFiles(PromptsType.skill, …)` (profile-scoped storage). This is a distinct store from the per-harness auto-sync opt-out owned by `ICustomizationSyncProvider`, which the Plugins section writes.
+
+The two stores are consulted at different points, and deliberately not identically:
+
+- **The wire** honors *both*. `enumerateLocalCustomizationsForHarness` marks a file disabled when either store opts it out, so a disabled skill is excluded from the synthetic Open Plugin bundle and never reaches the agent host.
+- **The list** derives `enabled` from the prompts-service store *only*. `mergeBuiltinSkills` ignores the sync-provider store because that store holds **plugin** URIs — its sole writer is the Plugins section checkbox, and `isDisabled` matches URIs exactly rather than by containment — so it can never opt out an individual built-in skill. If a per-file sync opt-out is ever added, this derivation must account for it; otherwise a skill dropped from the wire would be re-listed as enabled, and the **Enable** action (which writes only the prompts store) could not correct it.
 
 Two places must consult the prompts-service store for the toggle to take effect on an agent-host harness:
 
-- **The wire.** `enumerateLocalCustomizationsForHarness` marks a file disabled when *either* store opts it out, so a disabled skill is excluded from the synthetic Open Plugin bundle and never reaches the agent host.
+- **The wire.** As above — the skill is excluded from the bundle.
 - **The list.** Because a disabled skill is no longer in the bundle, the agent-host item provider stops reporting it. `PureItemProviderItemSource` therefore merges built-in skills in from `IPromptsService.listPromptFilesForStorage(skill, builtIn)` (via the shared `mergeBuiltinSkills` helper, deduped by URI against provider rows) and derives their `enabled` state from `getDisabledPromptFiles`. This keeps a disabled built-in listed — greyed out, with an **Enable** action — instead of vanishing with no way to restore it. Its `onDidAICustomizationItemsChange` includes `onDidChangeSkills` so the row updates immediately.
 
 `ItemProviderItemSource` (non-agent-host harnesses) uses the same helper, so both paths group, dedupe, and gate built-ins identically.

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -282,6 +282,25 @@ All built-in customizations bundled with the Sessions app are skills, living in 
 - Filtered out when a user/workspace skill shares the same name (override behavior)
 - Skills with UI integrations (e.g. `act-on-feedback`, `generate-run-commands`) display a "UI Integration" badge in the management editor
 
+#### Enabling and Disabling Built-in Skills
+
+The **Enable** / **Disable** actions on a built-in skill persist to `IPromptsService.setDisabledPromptFiles(PromptsType.skill, …)` (profile-scoped storage). This is a distinct store from the per-harness auto-sync opt-out owned by `ICustomizationSyncProvider`, which the Plugins section writes; both are honored wherever a customization's disabled state is evaluated.
+
+Two places must consult the prompts-service store for the toggle to take effect on an agent-host harness:
+
+- **The wire.** `enumerateLocalCustomizationsForHarness` marks a file disabled when *either* store opts it out, so a disabled skill is excluded from the synthetic Open Plugin bundle and never reaches the agent host.
+- **The list.** Because a disabled skill is no longer in the bundle, the agent-host item provider stops reporting it. `PureItemProviderItemSource` therefore merges built-in skills in from `IPromptsService.listPromptFilesForStorage(skill, builtIn)` (via the shared `mergeBuiltinSkills` helper, deduped by URI against provider rows) and derives their `enabled` state from `getDisabledPromptFiles`. This keeps a disabled built-in listed — greyed out, with an **Enable** action — instead of vanishing with no way to restore it. Its `onDidAICustomizationItemsChange` includes `onDidChangeSkills` so the row updates immediately.
+
+`ItemProviderItemSource` (non-agent-host harnesses) uses the same helper, so both paths group, dedupe, and gate built-ins identically.
+
+##### Scope: only built-in skills may be hidden by the user-disabled store
+
+The wire consults `getDisabledPromptFiles` **only** for the `(type, storage)` combination the Customizations UI can re-enable, expressed by `isUserToggleableCustomization` in `chat/common/promptSyntax/service/promptsService.ts`. Both the management editor and the sessions tree view register their Enable/Disable actions solely for built-in skills, so that is the only toggleable combination today.
+
+This gate is load-bearing rather than cosmetic. `getDisabledPromptFiles` is a shared store that the chat view agent picker also writes for `PromptsType.agent` ("hidden from agent picker"). Because callers drop opted-out files from the bundle entirely and the Agents-window lists are derived from that bundle, honoring the store for a customization the Customizations UI cannot re-enable would strand it: the row disappears, and the **Enable** action that would bring it back is only rendered for rows that are still listed. The agent picker is unaffected — it owns its own unhide affordance and does not read from the bundle.
+
+Consequently, the wire gate and `mergeBuiltinSkills` must be kept in sync: anything the wire is allowed to hide must have a corresponding restore path in the list.
+
 ### UI Integration Badges
 
 Skills that are directly invoked by UI elements (toolbar buttons, menu items) are annotated with a "UI Integration" badge in the management editor. The mapping is provided by `IAICustomizationWorkspaceService.getSkillUIIntegrations()`, which the Sessions implementation populates with the relevant skill names and tooltip descriptions. The badge appears on both the built-in skill and any user/workspace override, ensuring users understand that overriding the skill affects a UI surface.

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -14,7 +14,7 @@ import { ExtensionIdentifier } from '../../../../../../platform/extensions/commo
 import { IMcpServerConfiguration, McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { AICustomizationSource, AICustomizationSources } from '../../../common/aiCustomizationWorkspaceService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
-import { IPromptsService, matchesSessionType, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
+import { IPromptsService, isUserToggleableCustomization, matchesSessionType, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { type ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
 import { IAgentPlugin, IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { isContributionEnabled } from '../../../common/enablement.js';
@@ -85,6 +85,21 @@ export interface ILocalCustomizationFile {
  * (to render disable affordances) and the agent host wire (to compute the
  * `customizations` set published via `activeClientSet`).
  *
+ * A file counts as opted out when either the per-harness sync provider has it
+ * disabled (the plugin-level auto-sync opt-out) or — for the customizations the
+ * user can toggle from the Customizations UI, see
+ * {@link isUserToggleableCustomization} — the user disabled it there
+ * (`IPromptsService.getDisabledPromptFiles`, the store behind the Enable/Disable
+ * actions on built-in skills). Both stores must be consulted here, otherwise
+ * disabling a built-in skill would leave it on the wire.
+ *
+ * The user-disabled store is deliberately *not* honoured for customizations the
+ * Customizations UI cannot re-enable. Callers drop opted-out files from the
+ * bundle entirely, and the Agents-window lists are derived from that bundle, so
+ * honouring it more widely would make such a file vanish from the UI with no
+ * way to restore it. (`getDisabledPromptFiles(PromptsType.agent)` is written by
+ * the chat view agent picker, which has its own unhide affordance.)
+ *
  * Built-in skills bundled with the Agents app (only present when the
  * sessions-aware prompts service is in play) are also enumerated so that
  * `/create-pr`, `/merge`, etc. are available to every agent host without
@@ -103,11 +118,13 @@ export async function enumerateLocalCustomizationsForHarness(
 		? [PromptsStorage.user, ...SYNCABLE_STORAGE_SOURCES]
 		: SYNCABLE_STORAGE_SOURCES;
 	for (const type of SYNCABLE_PROMPT_TYPES) {
+		const userDisabled = promptsService.getDisabledPromptFiles(type);
 		const lists = await Promise.all(
 			storageSources.map(storage => promptsService.listPromptFilesForStorage(type, storage, token)),
 		);
 		for (let i = 0; i < lists.length; i++) {
 			const source = storageSources[i];
+			const honourUserDisabled = isUserToggleableCustomization(type, source);
 			for (const file of lists[i]) {
 				if (matchesSessionType(file.sessionTypes, sessionType)) {
 					result.push({
@@ -116,7 +133,8 @@ export async function enumerateLocalCustomizationsForHarness(
 						source,
 						pluginUri: file.pluginUri,
 						extensionId: file.extension?.identifier.value,
-						disabled: syncProvider.isDisabled(file.uri),
+						disabled: syncProvider.isDisabled(file.uri)
+							|| (honourUserDisabled && userDisabled.has(file.uri)),
 					});
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -85,20 +85,12 @@ export interface ILocalCustomizationFile {
  * (to render disable affordances) and the agent host wire (to compute the
  * `customizations` set published via `activeClientSet`).
  *
- * A file counts as opted out when either the per-harness sync provider has it
- * disabled (the plugin-level auto-sync opt-out) or — for the customizations the
- * user can toggle from the Customizations UI, see
- * {@link isUserToggleableCustomization} — the user disabled it there
- * (`IPromptsService.getDisabledPromptFiles`, the store behind the Enable/Disable
- * actions on built-in skills). Both stores must be consulted here, otherwise
- * disabling a built-in skill would leave it on the wire.
- *
- * The user-disabled store is deliberately *not* honoured for customizations the
- * Customizations UI cannot re-enable. Callers drop opted-out files from the
- * bundle entirely, and the Agents-window lists are derived from that bundle, so
- * honouring it more widely would make such a file vanish from the UI with no
- * way to restore it. (`getDisabledPromptFiles(PromptsType.agent)` is written by
- * the chat view agent picker, which has its own unhide affordance.)
+ * A file counts as opted out when the per-harness sync provider has it disabled,
+ * or when the user disabled it in the Customizations UI
+ * (`IPromptsService.getDisabledPromptFiles`) and that customization is one the
+ * UI can re-enable ({@link isUserToggleableCustomization}). See "Enabling and
+ * Disabling Built-in Skills" in `src/vs/sessions/AI_CUSTOMIZATIONS.md` for why
+ * the second store is scoped rather than honoured for every prompt type.
  *
  * Built-in skills bundled with the Agents app (only present when the
  * sessions-aware prompts service is in play) are also enumerated so that

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -254,6 +254,113 @@ export class AICustomizationItemNormalizer {
 
 // #endregion
 
+// #region Built-in skills
+
+/**
+ * Merges built-in skills (bundled with the app under `vs/sessions/skills/`)
+ * into an item provider's items. The provider may re-discover the bundled
+ * copies — either by scanning disk, or (on agent-host harnesses) by expanding
+ * the synthetic bundle that carries them to the host. Those duplicates are
+ * dropped (deduped by URI) and replaced with the authoritative built-in entry
+ * tagged `groupKey: BUILTIN_STORAGE` so the UI renders them in the "Built-in"
+ * group. User-authored overrides (different URI, same name) are preserved.
+ *
+ * Deriving the built-in entries from the prompts service rather than from the
+ * provider is what makes the Enable/Disable actions observable: a disabled
+ * built-in skill is excluded from the agent-host bundle, so the provider no
+ * longer reports it, yet it must stay listed (as disabled) so it can be
+ * re-enabled.
+ *
+ * This is the restore path that `isUserToggleableCustomization` (in
+ * `common/promptSyntax/service/promptsService.ts`) guards: the wire only hides
+ * user-disabled customizations for the (type, storage) combination re-added
+ * here, so the two must be kept in sync.
+ *
+ * `enabled` is derived solely from the prompts service, deliberately ignoring
+ * the per-harness `ICustomizationSyncProvider` opt-out that the wire also
+ * honours. That is sound only because the sync store holds *plugin* URIs — its
+ * one writer is the Plugins section checkbox, and `isDisabled` matches URIs
+ * exactly rather than by containment — so it can never opt out an individual
+ * built-in skill. Should a per-file sync opt-out ever be introduced, this
+ * derivation must account for it, otherwise a skill dropped from the wire would
+ * be re-listed here as enabled (and the Enable action, which writes only the
+ * prompts store, could not correct it).
+ *
+ * A workbench that uses the base `PromptsService` contributes no built-in
+ * skills, so `builtinPaths` is empty and the items are returned unchanged.
+ */
+export async function mergeBuiltinSkills(
+	items: readonly IAICustomizationListItem[],
+	promptType: PromptsType,
+	promptsService: IPromptsService,
+	workspaceService: IAICustomizationWorkspaceService,
+	itemNormalizer: AICustomizationItemNormalizer,
+): Promise<IAICustomizationListItem[]> {
+	const builtinPaths: readonly { uri: URI; name?: string; description?: string }[] = await promptsService.listPromptFilesForStorage(PromptsType.skill, PromptsStorage.builtIn, CancellationToken.None);
+	if (builtinPaths.length === 0) {
+		return [...items];
+	}
+
+	const builtinUris = new ResourceMap<typeof builtinPaths[number]>();
+	for (const p of builtinPaths) {
+		builtinUris.set(p.uri, p);
+	}
+
+	// Drop provider items that are the same URI as a built-in (the provider
+	// re-discovered the bundled copy by scanning disk).
+	const deduped = items.filter(item => !builtinUris.has(item.uri));
+
+	const uiIntegrations = workspaceService.getSkillUIIntegrations();
+	const uiIntegrationBadge = localize('uiIntegrationBadge', "UI Integration");
+
+	// Collect names of user/workspace skills so we can hide the built-in
+	// copy once the user has added an override at either level.
+	const overriddenNames = new Set<string>();
+	for (const item of deduped) {
+		if (item.source === AICustomizationSources.local || item.source === AICustomizationSources.user) {
+			if (item.name) {
+				overriddenNames.add(item.name);
+			}
+		}
+	}
+
+	// Append authoritative built-in entries (excluding any that have been
+	// overridden by a workspace or user copy with the same name).
+	const uriUseCounts = new ResourceMap<number>();
+	for (const item of deduped) {
+		uriUseCounts.set(item.uri, (uriUseCounts.get(item.uri) ?? 0) + 1);
+	}
+	const appended: IAICustomizationListItem[] = [];
+	const disabledPromptFiles = promptsService.getDisabledPromptFiles(PromptsType.skill);
+	for (const p of builtinPaths) {
+		const name = p.name ?? basename(p.uri);
+		if (overriddenNames.has(name)) {
+			continue;
+		}
+		const folderName = basename(dirname(p.uri));
+		const uiTooltip = uiIntegrations.get(folderName);
+		const builtinItem: ICustomizationItem = {
+			uri: p.uri,
+			type: PromptsType.skill,
+			name,
+			description: p.description,
+			source: AICustomizationSources.builtin,
+			groupKey: BUILTIN_STORAGE,
+			enabled: !disabledPromptFiles.has(p.uri),
+			badge: uiTooltip ? uiIntegrationBadge : undefined,
+			badgeTooltip: uiTooltip,
+			extensionId: undefined,
+			pluginUri: undefined,
+			userInvocable: true,
+		};
+		appended.push(itemNormalizer.normalizeItem(builtinItem, promptType, uriUseCounts));
+	}
+
+	return [...deduped, ...appended];
+}
+
+// #endregion
+
 /**
  * Item source backed by a session-scoped customization item provider.
  */
@@ -323,7 +430,7 @@ export class ItemProviderItemSource extends Disposable implements IAICustomizati
 
 		const normalized = this.itemNormalizer.normalizeItems(providerItems, promptType);
 		if (promptType === PromptsType.skill) {
-			return this.mergeBuiltinSkills(normalized, promptType);
+			return mergeBuiltinSkills(normalized, promptType, this.promptsService, this.workspaceService, this.itemNormalizer);
 		}
 		return normalized;
 	}
@@ -334,81 +441,6 @@ export class ItemProviderItemSource extends Disposable implements IAICustomizati
 		}
 
 		return (await this.itemProvider.provideSourceFolders(this.sessionResource, promptType, CancellationToken.None)) ?? [];
-	}
-
-	/**
-	 * Merges built-in skills (bundled with the app under `vs/sessions/skills/`)
-	 * into the provider's items. The provider may re-discover the bundled
-	 * copies when scanning disk — those duplicates are dropped (deduped by
-	 * URI) and replaced with the authoritative built-in entry tagged
-	 * `groupKey: BUILTIN_STORAGE` so the UI renders them in the "Built-in"
-	 * group. User-authored overrides (different URI, same name) are preserved.
-	 *
-	 * A workbench that uses the base `PromptsService` contributes no built-in
-	 * skills, so `builtinPaths` is empty and the items are returned unchanged.
-	 */
-	private async mergeBuiltinSkills(items: readonly IAICustomizationListItem[], promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const builtinPaths: readonly { uri: URI; name?: string; description?: string }[] = await this.promptsService.listPromptFilesForStorage(PromptsType.skill, PromptsStorage.builtIn, CancellationToken.None);
-		if (builtinPaths.length === 0) {
-			return [...items];
-		}
-
-		const builtinUris = new ResourceMap<typeof builtinPaths[number]>();
-		for (const p of builtinPaths) {
-			builtinUris.set(p.uri, p);
-		}
-
-		// Drop provider items that are the same URI as a built-in (the provider
-		// re-discovered the bundled copy by scanning disk).
-		const deduped = items.filter(item => !builtinUris.has(item.uri));
-
-		const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
-		const uiIntegrationBadge = localize('uiIntegrationBadge', "UI Integration");
-
-		// Collect names of user/workspace skills so we can hide the built-in
-		// copy once the user has added an override at either level.
-		const overriddenNames = new Set<string>();
-		for (const item of deduped) {
-			if (item.source === AICustomizationSources.local || item.source === AICustomizationSources.user) {
-				if (item.name) {
-					overriddenNames.add(item.name);
-				}
-			}
-		}
-
-		// Append authoritative built-in entries (excluding any that have been
-		// overridden by a workspace or user copy with the same name).
-		const uriUseCounts = new ResourceMap<number>();
-		for (const item of deduped) {
-			uriUseCounts.set(item.uri, (uriUseCounts.get(item.uri) ?? 0) + 1);
-		}
-		const appended: IAICustomizationListItem[] = [];
-		const disabledPromptFiles = this.promptsService.getDisabledPromptFiles(PromptsType.skill);
-		for (const p of builtinPaths) {
-			const name = p.name ?? basename(p.uri);
-			if (overriddenNames.has(name)) {
-				continue;
-			}
-			const folderName = basename(dirname(p.uri));
-			const uiTooltip = uiIntegrations.get(folderName);
-			const builtinItem: ICustomizationItem = {
-				uri: p.uri,
-				type: PromptsType.skill,
-				name,
-				description: p.description,
-				source: AICustomizationSources.builtin,
-				groupKey: BUILTIN_STORAGE,
-				enabled: !disabledPromptFiles.has(p.uri),
-				badge: uiTooltip ? uiIntegrationBadge : undefined,
-				badgeTooltip: uiTooltip,
-				extensionId: undefined,
-				pluginUri: undefined,
-				userInvocable: true,
-			};
-			appended.push(this.itemNormalizer.normalizeItem(builtinItem, promptType, uriUseCounts));
-		}
-
-		return [...deduped, ...appended];
 	}
 
 	private async addSkillDescriptionFallbacks(items: readonly ICustomizationItem[]): Promise<readonly ICustomizationItem[]> {
@@ -462,9 +494,13 @@ export class PureItemProviderItemSource extends Disposable implements IAICustomi
 		readonly sessionResource: URI,
 		private readonly itemProvider: ICustomizationItemProvider,
 		private readonly itemNormalizer: AICustomizationItemNormalizer,
+		private readonly promptsService: IPromptsService,
+		private readonly workspaceService: IAICustomizationWorkspaceService,
 	) {
 		super();
-		this.onDidAICustomizationItemsChange = this.itemProvider.onDidChange;
+		// Built-in skills are merged in from the prompts service, so their
+		// enable/disable state changes must refresh the list too.
+		this.onDidAICustomizationItemsChange = Event.any(this.itemProvider.onDidChange, this.promptsService.onDidChangeSkills);
 
 		// Invalidate cache when the provider changes
 		this._register(this.itemProvider.onDidChange(() => {
@@ -492,7 +528,11 @@ export class PureItemProviderItemSource extends Disposable implements IAICustomi
 
 	async fetchAICustomizationItems(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
 		const allItems = await this.fetchProviderItems();
-		return this.itemNormalizer.normalizeItems(allItems, promptType);
+		const normalized = this.itemNormalizer.normalizeItems(allItems, promptType);
+		if (promptType === PromptsType.skill) {
+			return mergeBuiltinSkills(normalized, promptType, this.promptsService, this.workspaceService, this.itemNormalizer);
+		}
+		return normalized;
 	}
 
 	async fetchSourceFolders(promptType: PromptsType): Promise<readonly ICustomizationSourceFolder[]> {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -258,33 +258,17 @@ export class AICustomizationItemNormalizer {
 
 /**
  * Merges built-in skills (bundled with the app under `vs/sessions/skills/`)
- * into an item provider's items. The provider may re-discover the bundled
- * copies — either by scanning disk, or (on agent-host harnesses) by expanding
- * the synthetic bundle that carries them to the host. Those duplicates are
- * dropped (deduped by URI) and replaced with the authoritative built-in entry
- * tagged `groupKey: BUILTIN_STORAGE` so the UI renders them in the "Built-in"
- * group. User-authored overrides (different URI, same name) are preserved.
+ * into an item provider's items, deduped by URI so a copy the provider
+ * re-discovered is replaced by the authoritative entry, and tagged
+ * `groupKey: BUILTIN_STORAGE`. User-authored overrides (different URI, same
+ * name) are preserved.
  *
- * Deriving the built-in entries from the prompts service rather than from the
- * provider is what makes the Enable/Disable actions observable: a disabled
- * built-in skill is excluded from the agent-host bundle, so the provider no
- * longer reports it, yet it must stay listed (as disabled) so it can be
- * re-enabled.
- *
- * This is the restore path that `isUserToggleableCustomization` (in
- * `common/promptSyntax/service/promptsService.ts`) guards: the wire only hides
- * user-disabled customizations for the (type, storage) combination re-added
- * here, so the two must be kept in sync.
- *
- * `enabled` is derived solely from the prompts service, deliberately ignoring
- * the per-harness `ICustomizationSyncProvider` opt-out that the wire also
- * honours. That is sound only because the sync store holds *plugin* URIs — its
- * one writer is the Plugins section checkbox, and `isDisabled` matches URIs
- * exactly rather than by containment — so it can never opt out an individual
- * built-in skill. Should a per-file sync opt-out ever be introduced, this
- * derivation must account for it, otherwise a skill dropped from the wire would
- * be re-listed here as enabled (and the Enable action, which writes only the
- * prompts store, could not correct it).
+ * `enabled` is derived from `getDisabledPromptFiles` alone, so a built-in that
+ * the wire dropped from the agent-host bundle stays listed as disabled and can
+ * be re-enabled. This is the restore path that `isUserToggleableCustomization`
+ * guards, and it is why that predicate must stay in sync with what this merges
+ * back. See "Enabling and Disabling Built-in Skills" in
+ * `src/vs/sessions/AI_CUSTOMIZATIONS.md`.
  *
  * A workbench that uses the base `PromptsService` contributes no built-in
  * skills, so `builtinPaths` is empty and the items are returned unchanged.

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
@@ -247,7 +247,7 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 					this.logService.warn(`Agent-host session type ${sessionType} has no item provider`);
 					return new EmptyItemProviderItemSource(sessionResource);
 				}
-				return new PureItemProviderItemSource(sessionResource, descriptor.itemProvider, this.itemNormalizer);
+				return new PureItemProviderItemSource(sessionResource, descriptor.itemProvider, this.itemNormalizer, this.promptsService, this.workspaceService);
 			} else {
 				const itemProvider = descriptor.itemProvider ?? this.instantiationService.createInstance(PromptsServiceCustomizationItemProvider);
 				return new ItemProviderItemSource(

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -121,6 +121,29 @@ export enum PromptsStorage {
 }
 
 /**
+ * Whether the AI Customizations UI offers Enable/Disable affordances for a
+ * customization with the given type and storage.
+ *
+ * Both the management editor and the sessions tree view register their
+ * Enable/Disable actions solely for built-in skills, so that is the only
+ * combination a user can toggle — and, crucially, the only one they can turn
+ * back on from that UI.
+ *
+ * Use this to gate any behaviour that *hides* a customization because it is in
+ * {@link IPromptsService.getDisabledPromptFiles}. Those lists are derived from
+ * the agent-host bundle, so hiding an entry the UI cannot restore would strand
+ * it: it disappears from the list, and the Enable action that would bring it
+ * back is only shown for entries that are still listed.
+ *
+ * Note that `getDisabledPromptFiles` is also written for {@link PromptsType.agent}
+ * by the chat view agent picker. That surface owns its own unhide affordance and
+ * does not read from the bundle, so it must *not* be gated on this predicate.
+ */
+export function isUserToggleableCustomization(type: PromptsType, storage: PromptsStorage): boolean {
+	return type === PromptsType.skill && storage === PromptsStorage.builtIn;
+}
+
+/**
  * Represents a prompt path with its type.
  * This is used for both prompt files and prompt source folders.
  */

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -122,22 +122,13 @@ export enum PromptsStorage {
 
 /**
  * Whether the AI Customizations UI offers Enable/Disable affordances for a
- * customization with the given type and storage.
+ * customization with the given type and storage — and therefore whether a user
+ * who disables it can turn it back on again.
  *
- * Both the management editor and the sessions tree view register their
- * Enable/Disable actions solely for built-in skills, so that is the only
- * combination a user can toggle — and, crucially, the only one they can turn
- * back on from that UI.
- *
- * Use this to gate any behaviour that *hides* a customization because it is in
- * {@link IPromptsService.getDisabledPromptFiles}. Those lists are derived from
- * the agent-host bundle, so hiding an entry the UI cannot restore would strand
- * it: it disappears from the list, and the Enable action that would bring it
- * back is only shown for entries that are still listed.
- *
- * Note that `getDisabledPromptFiles` is also written for {@link PromptsType.agent}
- * by the chat view agent picker. That surface owns its own unhide affordance and
- * does not read from the bundle, so it must *not* be gated on this predicate.
+ * Gate any behaviour that *hides* a customization because it is in
+ * {@link IPromptsService.getDisabledPromptFiles} on this predicate; that store
+ * is shared with surfaces that own a separate unhide affordance. See
+ * "Enabling and Disabling Built-in Skills" in `src/vs/sessions/AI_CUSTOMIZATIONS.md`.
  */
 export function isUserToggleableCustomization(type: PromptsType, storage: PromptsStorage): boolean {
 	return type === PromptsType.skill && storage === PromptsStorage.builtIn;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { enumerateLocalCustomizationsForHarness } from '../../../browser/agentSessions/agentHost/agentHostLocalCustomizations.js';
@@ -21,10 +22,14 @@ function makePromptPath(uri: URI, type: PromptsType, storage: PromptsStorage): I
 
 function makePromptsService(
 	files: ReadonlyMap<string, readonly IPromptPath[]>,
+	disabledPromptFiles: ReadonlyMap<PromptsType, ResourceSet> = new Map(),
 ): IPromptsService {
 	return {
 		async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage): Promise<readonly IPromptPath[]> {
 			return files.get(`${type}/${storage}`) ?? [];
+		},
+		getDisabledPromptFiles(type: PromptsType): ResourceSet {
+			return disabledPromptFiles.get(type) ?? new ResourceSet();
 		},
 	} as unknown as IPromptsService;
 }
@@ -141,6 +146,54 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
 			{ uri: enabled.toString(), disabled: false },
 			{ uri: disabled.toString(), disabled: true },
+		]);
+	});
+
+	test('marks built-in skills disabled when the user disabled them in the Customizations UI', async () => {
+		// The Enable/Disable actions write to `IPromptsService`, not to the
+		// per-harness sync provider. Both stores must be honored, otherwise a
+		// disabled built-in skill would still be synced to the agent host.
+		const disabledSkill = URI.file('/builtin/create-pr/SKILL.md');
+		const enabledSkill = URI.file('/builtin/merge/SKILL.md');
+		const promptsService = makePromptsService(
+			new Map([
+				[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [
+					makePromptPath(disabledSkill, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage),
+					makePromptPath(enabledSkill, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage),
+				]],
+			]),
+			new Map([[PromptsType.skill, new ResourceSet([disabledSkill])]]),
+		);
+
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+
+		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
+			{ uri: disabledSkill.toString(), disabled: true },
+			{ uri: enabledSkill.toString(), disabled: false },
+		]);
+	});
+
+	test('does not honor the user-disabled store for prompt types the Customizations UI cannot re-enable', async () => {
+		// `getDisabledPromptFiles(agent)` is also written by the chat view agent
+		// picker ("hidden from agent picker"). The Customizations UI registers
+		// Enable/Disable only for built-in skills, so it has no way to bring a
+		// hidden agent back. Dropping it from the bundle would remove it from the
+		// Agents-window list too, stranding it permanently — so the wire must
+		// ignore that store here and leave the agent enabled.
+		const hiddenAgent = URI.file('/workspace/.github/agents/reviewer.agent.md');
+		const promptsService = makePromptsService(
+			new Map([
+				[`${PromptsType.agent}/${PromptsStorage.local}`, [
+					makePromptPath(hiddenAgent, PromptsType.agent, PromptsStorage.local),
+				]],
+			]),
+			new Map([[PromptsType.agent, new ResourceSet([hiddenAgent])]]),
+		);
+
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+
+		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
+			{ uri: hiddenAgent.toString(), disabled: false },
 		]);
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -8,6 +8,7 @@ import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { PluginFormat } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
@@ -56,10 +57,16 @@ function makeConfigurationResolverService(resolutions: Record<string, string> = 
 	} as unknown as IConfigurationResolverService;
 }
 
-function makePromptsService(files: ReadonlyMap<string, readonly IPromptPath[]>): IPromptsService {
+function makePromptsService(
+	files: ReadonlyMap<string, readonly IPromptPath[]>,
+	disabledPromptFiles: ReadonlyMap<PromptsType, ResourceSet> = new Map(),
+): IPromptsService {
 	return {
 		async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage): Promise<readonly IPromptPath[]> {
 			return files.get(`${type}/${storage}`) ?? [];
+		},
+		getDisabledPromptFiles(type: PromptsType): ResourceSet {
+			return disabledPromptFiles.get(type) ?? new ResourceSet();
 		},
 	} as unknown as IPromptsService;
 }
@@ -233,6 +240,37 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeFileService(),
 			promptsService,
 			new FakeSyncProvider(new Set([disabled.toString()])),
+			makeAgentPluginService(),
+			makeMcpService(),
+			makeConfigurationResolverService(),
+			bundler as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+
+		assert.deepStrictEqual(bundler.received[0].map(f => f.uri.toString()), [enabled.toString()]);
+	});
+
+	test('omits built-in skills the user disabled in the Customizations UI from the bundle', async () => {
+		// Regression: the Enable/Disable actions write to `IPromptsService`,
+		// not to the per-harness sync provider, so a skill disabled from the UI
+		// must still be dropped from the bundle sent to the agent host.
+		const enabled = URI.file('/builtin/create-pr/SKILL.md');
+		const disabled = URI.file('/builtin/merge/SKILL.md');
+		const promptsService = makePromptsService(
+			new Map([
+				[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [
+					makePromptPath(enabled, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage),
+					makePromptPath(disabled, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage),
+				]],
+			]),
+			new Map([[PromptsType.skill, new ResourceSet([disabled])]]),
+		);
+		const bundler = new FakeBundler();
+
+		await resolveCustomizationRefs(
+			makeFileService(),
+			promptsService,
+			new FakeSyncProvider(),
 			makeAgentPluginService(),
 			makeMcpService(),
 			makeConfigurationResolverService(),

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -771,12 +771,14 @@ suite('AICustomizationItemsModel', () => {
 		let providerItems: ICustomizationItem[];
 		let builtinSkills: IPromptPath[];
 		let disabledPromptFiles: ResourceSet;
+		let onDidChangeSkills: Emitter<void>;
 
 		setup(() => {
 			disposables = new DisposableStore();
 			providerItems = [];
 			builtinSkills = [];
 			disabledPromptFiles = new ResourceSet();
+			onDidChangeSkills = disposables.add(new Emitter<void>());
 
 			const sessionType = 'agent-host-test';
 			const provider: ICustomizationItemProvider = {
@@ -796,7 +798,7 @@ suite('AICustomizationItemsModel', () => {
 			instaService.stub(IPromptsService, {
 				onDidChangeCustomAgents: Event.None,
 				onDidChangeSlashCommands: Event.None,
-				onDidChangeSkills: Event.None,
+				onDidChangeSkills: onDidChangeSkills.event,
 				onDidChangeHooks: Event.None,
 				onDidChangeInstructions: Event.None,
 				onDidChangeAgentInstructions: Event.None,
@@ -908,6 +910,40 @@ suite('AICustomizationItemsModel', () => {
 					{ name: 'merge', source: AICustomizationSources.builtin, groupKey: BUILTIN_STORAGE, disabled: false },
 				],
 			);
+		});
+		test('refreshes built-in skill disabled state when onDidChangeSkills fires', async () => {
+			// The Disable action writes to IPromptsService and fires
+			// onDidChangeSkills; the provider is unchanged (its bundle refresh is
+			// asynchronous and may lag). PureItemProviderItemSource must still
+			// re-derive `disabled` from the prompts service, otherwise the row
+			// would stay stale until some unrelated provider change happened.
+			const skill = URI.file('/builtin/create-pr/SKILL.md');
+			builtinSkills = [
+				{ uri: skill, type: PromptsType.skill, storage: PromptsStorage.builtIn, name: 'create-pr' } as IPromptPath,
+			];
+			providerItems = [
+				{ uri: skill, type: PromptsType.skill, name: 'create-pr', source: AICustomizationSources.builtin, groupKey: BUILTIN_STORAGE, extensionId: undefined, pluginUri: undefined, userInvocable: true },
+			];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const skillItems = model.getItems(AICustomizationManagementSection.Skills);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+			// Let any refetch scheduled during construction settle, so the
+			// assertion below can only be satisfied by a refetch that the
+			// onDidChangeSkills subscription itself triggered.
+			await timeout(0);
+			assert.deepStrictEqual(skillItems.get().map(i => ({ name: i.name, disabled: i.disabled })), [
+				{ name: 'create-pr', disabled: false },
+			]);
+
+			disabledPromptFiles = new ResourceSet([skill]);
+			onDidChangeSkills.fire();
+			await timeout(0);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+
+			assert.deepStrictEqual(skillItems.get().map(i => ({ name: i.name, disabled: i.disabled })), [
+				{ name: 'create-pr', disabled: true },
+			]);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -769,10 +769,14 @@ suite('AICustomizationItemsModel', () => {
 		let disposables: DisposableStore;
 		let instaService: TestInstantiationService;
 		let providerItems: ICustomizationItem[];
+		let builtinSkills: IPromptPath[];
+		let disabledPromptFiles: ResourceSet;
 
 		setup(() => {
 			disposables = new DisposableStore();
 			providerItems = [];
+			builtinSkills = [];
+			disabledPromptFiles = new ResourceSet();
 
 			const sessionType = 'agent-host-test';
 			const provider: ICustomizationItemProvider = {
@@ -797,12 +801,14 @@ suite('AICustomizationItemsModel', () => {
 				onDidChangeInstructions: Event.None,
 				onDidChangeAgentInstructions: Event.None,
 				listPromptFiles: async () => [],
-				listPromptFilesForStorage: async () => [],
+				listPromptFilesForStorage: async (type: PromptsType, storage: PromptsStorage) => (
+					type === PromptsType.skill && storage === PromptsStorage.builtIn ? builtinSkills.slice() : []
+				),
 				getCustomAgents: async () => [],
 				findAgentSkills: async () => [],
 				getHooks: async () => undefined,
 				getInstructionFiles: async () => [],
-				getDisabledPromptFiles: () => new ResourceSet(),
+				getDisabledPromptFiles: () => disabledPromptFiles,
 			});
 			instaService.stub(IAICustomizationWorkspaceService, {
 				activeProjectRoot: observableValue('test', undefined),
@@ -867,6 +873,40 @@ suite('AICustomizationItemsModel', () => {
 					agents: ['coder'],
 					instructions: ['style'],
 				},
+			);
+		});
+
+		// Regression: on agent-host harnesses the Skills list used to render
+		// straight from the provider, which reports the synced *bundle*. A
+		// built-in skill disabled from the Customizations UI is dropped from
+		// that bundle, so the skill vanished from the list instead of showing
+		// as disabled — leaving no way to re-enable it and making the Disable
+		// button look like a no-op. Built-ins are now merged in from the
+		// prompts service, which owns the enable/disable state.
+		test('lists disabled built-in skills as disabled instead of dropping them', async () => {
+			const disabledSkill = URI.file('/builtin/create-pr/SKILL.md');
+			const enabledSkill = URI.file('/builtin/merge/SKILL.md');
+			builtinSkills = [
+				{ uri: disabledSkill, type: PromptsType.skill, storage: PromptsStorage.builtIn, name: 'create-pr' } as IPromptPath,
+				{ uri: enabledSkill, type: PromptsType.skill, storage: PromptsStorage.builtIn, name: 'merge' } as IPromptPath,
+			];
+			disabledPromptFiles = new ResourceSet([disabledSkill]);
+			// The provider only reports the still-bundled skill; the disabled
+			// one is absent because it was excluded from the synced bundle.
+			providerItems = [
+				{ uri: enabledSkill, type: PromptsType.skill, name: 'merge', source: AICustomizationSources.builtin, groupKey: BUILTIN_STORAGE, extensionId: undefined, pluginUri: undefined, userInvocable: true },
+			];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const skillItems = model.getItems(AICustomizationManagementSection.Skills);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+
+			assert.deepStrictEqual(
+				skillItems.get().map(i => ({ name: i.name, source: i.source, groupKey: i.groupKey, disabled: i.disabled })).sort((a, b) => a.name.localeCompare(b.name)),
+				[
+					{ name: 'create-pr', source: AICustomizationSources.builtin, groupKey: BUILTIN_STORAGE, disabled: true },
+					{ name: 'merge', source: AICustomizationSources.builtin, groupKey: BUILTIN_STORAGE, disabled: false },
+				],
 			);
 		});
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/329751 

cc @aeschli

Built-in skills in the Agents window's AI Customizations UI show an **Enable**/**Disable** action, but clicking **Disable** did nothing — the skill stayed enabled and kept working.

## Root cause

The Enable/Disable actions persist to `IPromptsService.setDisabledPromptFiles`, but nothing in the Agents window read that store:

- **The wire** (`enumerateLocalCustomizationsForHarness`) consulted only the per-harness `ICustomizationSyncProvider` opt-out, so a disabled skill was still bundled and shipped to the agent host.
- **The list** — agent-host sessions always use `PureItemProviderItemSource` (`isAgentHostTarget()`), which derived items purely from the provider and never consulted the disabled set.

So the toggle wrote to a store that had no readers on this path.

## Fix

**The wire** now treats a file as opted out when *either* store disables it, keeping a disabled skill out of the synthetic bundle.

**The list** merges built-in skills in from `listPromptFilesForStorage(skill, builtIn)` (shared `mergeBuiltinSkills` helper, deduped by URI) and derives `enabled` from `getDisabledPromptFiles`.

Both halves are required. The bundle protocol has no per-file "disabled" flag, so omission is the only way to disable — which means with only the wire fix the provider stops reporting the skill, the row **vanishes**, and it can never be re-enabled (the **Enable** action is only rendered for listed rows). The merge keeps it listed as disabled. Dedupe works because `_applySyncedOrigin` restores the original built-in URI.

`ItemProviderItemSource` already did this; the shared helper brings `PureItemProviderItemSource` to parity.

## Scope gate

`getDisabledPromptFiles` is a **shared** store — the chat view agent picker also writes it for `PromptsType.agent` ("hidden from agent picker"). Since the Agents-window lists are derived from the bundle, honoring it for a `(type, storage)` the Customizations UI cannot re-enable would strand that entry permanently: the row disappears, and the action that would restore it only renders for listed rows.

New predicate `isUserToggleableCustomization(type, storage)` mirrors the menu `when` clauses (built-in skills only) and gates the wire accordingly. It lives beside the store it describes so future consumers find the rule at the source. Behavior for every other `(type, storage)` is byte-for-byte unchanged — the wire never consulted this store before.

## Testing

- 3 regression tests, each **verified failing** without the corresponding half of the fix — including one asserting a picker-hidden *agent* stays on the wire.
- 533 customization/prompts tests passing.
- `typecheck-client` clean (error count matches a stashed baseline); `valid-layers-check` clean.
- Spec updated in `src/vs/sessions/AI_CUSTOMIZATIONS.md`, including why the gate is load-bearing.

## Review

Reviewed by four frontier models independently verifying from source. All four confirmed the root cause and the necessity of both halves, and all four rejected the alternatives considered (registering a built-in harness, replacing `PureItemProviderItemSource`, consolidating the stores, filtering inside `PromptsService` — that last one would break the restore path).

One reviewer noted `mergeBuiltinSkills` derives `enabled` only from the prompts store, ignoring the sync-provider store. Verified **currently unreachable**: `isDisabled` matches URIs exactly, and its only writer passes plugin URIs, so a built-in skill URI can never enter that set. Threading it through would render a disabled row whose **Enable** button couldn't clear it (Enable writes only the prompts store), so the invariant is documented in the helper instead, along with what must change if a per-file sync opt-out is ever added.

## Known follow-ups

- https://github.com/microsoft/vscode/issues/329753 — the two-store split. This PR makes it safer, not gone; splitting the overloaded store into "disabled" vs "hidden from picker" would delete `isUserToggleableCustomization` entirely.
- https://github.com/microsoft/vscode/issues/329752 — unrelated `extractSource` bug, deliberately kept to a separate PR (zero file overlap).

Not exercised in a running build — evidence is static analysis plus fail-without-fix test verification.