### PR TITLE
Fix headless tool preapproval

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -838,6 +838,10 @@ existing risk-badge position with safety-appropriate visuals. A live
 approval-level change is pushed to every in-memory SDK
 chat immediately, including during an active turn, so leaving Allow all
 cannot leave the SDK in allow-all mode for later tool calls in that turn.
+Client tools preserve this approval when they execute without a live chat
+observer: the Agent Host's `autoApproveBySetting` metadata becomes the tool
+invocation's `preApproved` reason, and the headless invocation path honors it
+unless a pre-tool-use hook explicitly requests confirmation.
 `chat.experimental.autoApprovals.enabled` controls whether Assisted permissions is
 offered in approval pickers and defaults on outside Stable builds. Enterprise
 policy still leaves Approve When Safe and Allow All visible, but disables both with an

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -706,7 +706,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 				const { autoConfirmed: fallbackAutoConfirmed, preparedInvocation: updatedPreparedInvocation } = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, undefined);
 				preparedInvocation = updatedPreparedInvocation;
-				if (preparedInvocation?.confirmationMessages?.title && !fallbackAutoConfirmed) {
+				const autoConfirmed = fallbackAutoConfirmed
+					?? (preToolUseHookResult?.permissionDecision === 'ask' ? undefined : dto.preApproved);
+				if (preparedInvocation?.confirmationMessages?.title && !autoConfirmed) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
 						throw new CancellationError();

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -18,6 +18,8 @@ import { ConfigurationTarget, IConfigurationChangeEvent } from '../../../../../.
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ContextKeyService } from '../../../../../../platform/contextkey/browser/contextKeyService.js';
 import { ContextKeyEqualsExpr, ContextKeyExpr, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IConfirmation, IConfirmationResult, IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
+import { TestDialogService } from '../../../../../../platform/dialogs/test/common/testDialogService.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
 import { ConfirmationOptionKind } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
@@ -68,6 +70,15 @@ class TestTelemetryService implements Partial<ITelemetryService> {
 
 	reset() {
 		this.events = [];
+	}
+}
+
+class CountingDialogService extends TestDialogService {
+	confirmCalls = 0;
+
+	override confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {
+		this.confirmCalls++;
+		return super.confirm(confirmation);
 	}
 }
 
@@ -169,6 +180,7 @@ interface TestToolsServiceOptions {
 	accessibilitySignalService?: Partial<IAccessibilitySignalService>;
 	telemetryService?: Partial<ITelemetryService>;
 	commandService?: Partial<ICommandService>;
+	dialogService?: IDialogService;
 	/** Called after configurationService is created but before the service is instantiated */
 	configureServices?: (config: TestConfigurationService) => void;
 }
@@ -207,6 +219,9 @@ function createTestToolsService(store: ReturnType<typeof ensureNoDisposablesAreL
 	}
 	if (options?.commandService) {
 		instaService.stub(ICommandService, options.commandService as ICommandService);
+	}
+	if (options?.dialogService) {
+		instaService.stub(IDialogService, options.dialogService);
 	}
 
 	const service = store.add(instaService.createInstance(LanguageModelToolsService));
@@ -5075,6 +5090,61 @@ suite('LanguageModelToolsService', () => {
 
 			IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
 			await invokePromise;
+		});
+
+		test('a headless confirmable tool with dto.preApproved does not show a dialog', async () => {
+			const dialogService = new CountingDialogService({ confirmed: true });
+			const setup = createTestToolsService(store, { dialogService });
+			let invokeCompleted = false;
+			const tool = registerToolForTest(setup.service, store, 'headlessPreApprovedTool', {
+				invoke: async () => {
+					invokeCompleted = true;
+					return { content: [{ kind: 'text', value: 'success' }] };
+				},
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool would normally require confirmation',
+						allowAutoConfirm: true,
+					},
+				}),
+			});
+			const dto = tool.makeDto({ test: 1 });
+			dto.preApproved = { type: ToolConfirmKind.Setting, id: 'autoApprove' };
+
+			const result = await setup.service.invokeTool(dto, async () => 0, CancellationToken.None);
+
+			assert.deepStrictEqual({
+				invokeCompleted,
+				value: (result.content[0] as IToolResultTextPart).value,
+				confirmCalls: dialogService.confirmCalls,
+			}, {
+				invokeCompleted: true,
+				value: 'success',
+				confirmCalls: 0,
+			});
+		});
+
+		test('a headless preToolUse hook ask overrides dto.preApproved', async () => {
+			const dialogService = new CountingDialogService({ confirmed: true });
+			const setup = createTestToolsService(store, { dialogService });
+			const tool = registerToolForTest(setup.service, store, 'headlessPreApprovedAskTool', {
+				invoke: async () => ({ content: [{ kind: 'text', value: 'success' }] }),
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool requires confirmation',
+						allowAutoConfirm: true,
+					},
+				}),
+			});
+			const dto = tool.makeDto({ test: 1 });
+			dto.preApproved = { type: ToolConfirmKind.Setting, id: 'autoApprove' };
+			dto.preToolUseResult = { permissionDecision: 'ask', permissionDecisionReason: 'Requires user confirmation' };
+
+			await setup.service.invokeTool(dto, async () => 0, CancellationToken.None);
+
+			assert.strictEqual(dialogService.confirmCalls, 1);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #329787

Agent Host already propagates **Allow All** client-tool approval as `preApproved`, but context-free tool execution ignored it and displayed a native confirmation dialog.

## Changes

- Honor caller-provided `preApproved` reasons in the context-free tool invocation path.
- Preserve explicit pre-tool-use hook `ask` decisions over preapproval.
- Add regression tests for both headless preapproval bypass and hook-ask precedence.
- Document the Agent Host headless approval behavior in the Sessions specification.

## Validation

- `npm run precommit`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts --grep "preApproved"` — 4 passing
- `npm run typecheck-client` — attempted; currently blocked by unrelated existing Copilot SDK/native/component-fixture type drift outside this change.
- `npm run valid-layers-check` — attempted; blocked by the same unrelated existing errors; no changed file was reported.