### PR TITLE
agentHost: Keep shell read helpers non-terminal

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4096,7 +4096,8 @@ export class CopilotAgentSession extends Disposable {
 			// SDK result content, so a `shell_exit` lands its completion data on
 			// the terminal block (skip if any terminal block was already added
 			// while the tool was running).
-			const ptyTerminalUri = isShellTool(tracked.toolName) ? this._shellManager?.getTerminalUriForToolCall(e.data.toolCallId) : undefined;
+			const isShellCommandTool = isShellTool(tracked.toolName);
+			const ptyTerminalUri = isShellCommandTool ? this._shellManager?.getTerminalUriForToolCall(e.data.toolCallId) : undefined;
 			let retireNonPtyShellTracking = !!ptyTerminalUri;
 			if (ptyTerminalUri && !content.some(c => c.type === ToolResultContentType.Terminal)) {
 				content.push({
@@ -4106,8 +4107,12 @@ export class CopilotAgentSession extends Disposable {
 				});
 			}
 
-			const shellExit = appendSdkToolResultContent(content, e.data.result?.contents, { session: this.sessionUri, toolCallId: e.data.toolCallId, title: tracked.displayName });
-			if (isShellTool(tracked.toolName) && !ptyTerminalUri) {
+			const shellExit = appendSdkToolResultContent(
+				content,
+				e.data.result?.contents,
+				isShellCommandTool ? { session: this.sessionUri, toolCallId: e.data.toolCallId, title: tracked.displayName } : undefined,
+			);
+			if (isShellCommandTool && !ptyTerminalUri) {
 				const completion = this._nonPtyShellTerminals.completeToolCall(e.data.toolCallId, toolOutput, shellExit);
 				if (completion) {
 					retireNonPtyShellTracking = completion.shouldRetire;

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -798,7 +798,11 @@ function makeCompletedToolCallPart(
 	if (toolOutput !== undefined) {
 		content.push({ type: ToolResultContentType.Text, text: toolOutput });
 	}
-	appendSdkToolResultContent(content, d.result?.contents, { session: sessionUriStr, toolCallId: d.toolCallId, title: info.displayName });
+	appendSdkToolResultContent(
+		content,
+		d.result?.contents,
+		info.toolKind === 'terminal' ? { session: sessionUriStr, toolCallId: d.toolCallId, title: info.displayName } : undefined,
+	);
 
 	// Restore file edit content references from the database.
 	const edits = storedEdits?.get(d.toolCallId);

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -5225,6 +5225,39 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(terminalManager.disposedTerminals, ['agenthost-terminal://shell/test-session-1/tc-shell-exit']);
 		});
 
+		test('live read_bash completion does not render shell_exit metadata as a terminal command', async () => {
+			const { mockSession, signals, terminalManager } = await createAgentSession(disposables);
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-read-bash',
+				toolName: 'read_bash',
+				arguments: { shellId: 'build', delay: 0 },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-read-bash',
+				success: true,
+				result: {
+					content: 'Build completed\n',
+					contents: [{ type: 'shell_exit', shellId: 'build', exitCode: 0, outputPreview: 'Build completed\n' }],
+				},
+			} as SessionEventPayload<'tool.execution_complete'>['data']);
+
+			const completeSignal = signals[2];
+			assert.ok(isAction(completeSignal, ActionType.ChatToolCallComplete));
+			if (isAction(completeSignal, ActionType.ChatToolCallComplete)) {
+				const action = completeSignal.action as ChatToolCallCompleteAction;
+				assert.deepStrictEqual({
+					pastTenseMessage: action.result.pastTenseMessage,
+					content: action.result.content,
+					createdTerminals: terminalManager.outputTerminalsCreated,
+				}, {
+					pastTenseMessage: 'Read Terminal',
+					content: [{ type: ToolResultContentType.Text, text: 'Build completed\n' }],
+					createdTerminals: [],
+				});
+			}
+		});
+
 		test('live task_complete emits root markdown instead of a tool call', async () => {
 			const { mockSession, signals } = await createAgentSession(disposables);
 

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -503,6 +503,7 @@ Three rows remain, and they are not about command portability:
 | `resource watch reports changes on its subscribed channel` | Windows | The subscribed filesystem watch does not emit `resourceWatch/changed` after a protocol `resourceWrite` within the test timeout. Descriptor, missing-root, and resource mutation coverage remain enabled. |
 | `worktree session uses the resolved worktree as working directory` | Windows | `os.tmpdir()` yields an 8.3 short path while the shell reports the long path, and Copilot's completed host-terminal call publishes no terminal-content notification. |
 | ``strips redundant `cd <workingDirectory> &&` prefix from shell tool calls`` | Copilot on Windows | The turn completes, but `chat/toolCallReady` omits the `toolInput` needed to assert that the prefix was removed. |
+| `shell read helper remains a non-terminal tool` | Copilot on Windows | The scenario depends on completed ordinary-shell output, which the Copilot provider does not reliably surface on Windows; the read-helper protocol shape remains covered on POSIX. |
 
 Copilot's ordinary provider shell also omits `ToolResultTerminalContent.result.preview` on Windows, while its terminal-shaped resource is not backed by the host terminal manager and cannot be subscribed. These tests are skipped for Copilot on Windows because their direct output oracle would otherwise be empty:
 

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-shell-read-helper-remains-a-non-terminal-tool.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-shell-read-helper-remains-a-non-terminal-tool.yaml
@@ -1,0 +1,89 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: First use the shell tool exactly once to run `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"` in async mode with shellId "read-shell-e2e" and initial_wait 1. After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns. Then reply with exactly "READ_SHELL_E2E_DONE".
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_0
+          name: ${shell}
+          input:
+            command: node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"
+            description: Run delayed node script
+            mode: async
+            shellId: read-shell-e2e
+            initial_wait: 1
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: First use the shell tool exactly once to run `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"` in async mode with shellId "read-shell-e2e" and initial_wait 1. After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns. Then reply with exactly "READ_SHELL_E2E_DONE".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: bash
+              input:
+                command: node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"
+                description: Run delayed node script
+                mode: async
+                shellId: read-shell-e2e
+                initial_wait: 1
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '<command started in background with shellId: read-shell-e2e>'
+    response:
+      content:
+        - type: tool_use
+          id: toolcall_1
+          name: ${read_shell}
+          input:
+            shellId: read-shell-e2e
+            delay: 5
+      stopReason: tool_use
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: First use the shell tool exactly once to run `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"` in async mode with shellId "read-shell-e2e" and initial_wait 1. After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns. Then reply with exactly "READ_SHELL_E2E_DONE".
+        - role: assistant
+          content:
+            - type: tool_use
+              name: bash
+              input:
+                command: node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"
+                description: Run delayed node script
+                mode: async
+                shellId: read-shell-e2e
+                initial_wait: 1
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_0
+              content: '<command started in background with shellId: read-shell-e2e>'
+        - role: assistant
+          content:
+            - type: tool_use
+              name: read_bash
+              input:
+                shellId: read-shell-e2e
+                delay: 5
+        - role: user
+          content:
+            - type: tool_result
+              tool_use_id: toolcall_1
+              content: |-
+                READ_SHELL_E2E_VALUE
+                <shellId: read-shell-e2e completed with exit code 0>
+    response:
+      content: READ_SHELL_E2E_DONE
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__shell_read_helper_remains_a_non-terminal_tool.traffic.ahp.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/__snapshots__/Agent_Host_E2E___Copilot__Copilot-specific__shell_read_helper_remains_a_non-terminal_tool.traffic.ahp.yaml
@@ -1,0 +1,111 @@
+version: 1
+rounds:
+  - clientToServer:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: First use the shell tool exactly once to run `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"` in async mode with shellId "read-shell-e2e" and initial_wait 1. After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns. Then reply with exactly "READ_SHELL_E2E_DONE".
+            origin:
+              kind: user
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallConfirmed
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          approved: true
+          confirmed: user-action
+    serverToClient:
+      - channel: ${chat_0}
+        action:
+          type: chat/turnStarted
+          turnId: ${turn_0}
+          message:
+            text: First use the shell tool exactly once to run `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"` in async mode with shellId "read-shell-e2e" and initial_wait 1. After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns. Then reply with exactly "READ_SHELL_E2E_DONE".
+            origin:
+              kind: user
+      - method: root/sessionAdded
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          toolName: ${shell}
+          displayName: Run Shell Command
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallReady
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          invocationMessage: Running `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"`
+          toolInput: node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"
+          confirmed: not-needed
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallReady
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          invocationMessage: Run delayed node script
+          toolInput: node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallConfirmed
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          approved: true
+          confirmed: user-action
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_0}
+          result:
+            success: true
+            pastTenseMessage: Ran `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"`
+            content:
+              - type: text
+                text: '<command started in background with shellId: read-shell-e2e>'
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallStart
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
+          toolName: ${read_shell}
+          displayName: Read Terminal
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallReady
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
+          invocationMessage: Reading Terminal
+          toolInput: |-
+            {
+              "shellId": "read-shell-e2e",
+              "delay": 5
+            }
+          confirmed: not-needed
+      - channel: ${chat_0}
+        action:
+          type: chat/toolCallComplete
+          turnId: ${turn_0}
+          toolCallId: ${toolCall_1}
+          result:
+            success: true
+            pastTenseMessage: Read Terminal
+            content:
+              - type: text
+                text: |-
+                  READ_SHELL_E2E_VALUE
+                  <shellId: read-shell-e2e completed with exit code 0>
+      - channel: ${chat_0}
+        action:
+          type: chat/responsePart
+          turnId: ${turn_0}
+          part:
+            kind: markdown
+            content: READ_SHELL_E2E_DONE
+      - channel: ${chat_0}
+        action:
+          type: chat/turnComplete
+          turnId: ${turn_0}

--- a/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts
@@ -29,12 +29,14 @@ import { mkdtemp, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { readToolCallMeta } from '../../../../common/meta/agentToolCallMeta.js';
 import { MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, getInlineToolInput, type MessageAttachment } from '../../../../common/state/sessionState.js';
 import { ActionType, type ChatErrorAction, type ChatToolCallCompleteAction, type ChatToolCallDeltaAction, type ChatToolCallReadyAction, type ChatToolCallStartAction, type ChatUsageAction } from '../../../../common/state/sessionActions.js';
 import {
 	AgentHostE2EServerLease, assertToolCallCompleteText, createRealSession, dispatchTurn,
-	driveTurnWithAttachmentsToCompletion, removeTempDirs, runAhpSnapshotTest,
+	driveTurnToCompletion, driveTurnWithAttachmentsToCompletion, removeTempDirs, runAhpSnapshotTest,
 } from '../harness/agentHostE2ETestHarness.js';
+import { assertRecordedAhpSnapshot } from '../harness/ahpSnapshot.js';
 import { defineAgentHostE2ETests } from '../suites/agentHostE2ESuites.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification, TestProtocolClient } from '../../serverIntegrationTestHelpers.js';
 import { COPILOT_CONFIG } from './copilotTestConfiguration.js';
@@ -481,6 +483,77 @@ suite('Agent Host E2E — Copilot (Copilot-specific)', function () {
 		const result = await driveTurnWithAttachmentsToCompletion(client, sessionUri, 'turn-blob-attachment', prompt, attachments, 1);
 
 		assert.match(result.responseText, /\bsubtract\b/i, `expected the model to identify the attached blob function; got: ${JSON.stringify(result.responseText)}`);
+	});
+
+	(isWindows ? test.skip : test)('shell read helper remains a non-terminal tool', async function () {
+		this.timeout(180_000);
+
+		const workingDirectory = await mkdtemp(join(tmpdir(), 'copilot-read-shell-'));
+		tempDirs.push(workingDirectory);
+		const sessionUri = await createRealSession(client, COPILOT_CONFIG, 'real-sdk-read-shell', createdSessions, URI.file(workingDirectory));
+		const chatUri = buildDefaultChatUri(sessionUri);
+		const turnId = 'turn-read-shell';
+		const command = `node -e "setTimeout(() => console.log('READ_SHELL_E2E_VALUE'), 3000)"`;
+		const prompt = [
+			`First use the shell tool exactly once to run \`${command}\` in async mode with shellId "read-shell-e2e" and initial_wait 1.`,
+			'After that tool returns, use its matching read tool exactly once with shellId "read-shell-e2e" and delay 5 so the command finishes before the read returns.',
+			'Then reply with exactly "READ_SHELL_E2E_DONE".',
+		].join(' ');
+
+		const result = await driveTurnToCompletion(client, sessionUri, turnId, prompt, 1);
+		assert.match(result.responseText, /READ_SHELL_E2E_DONE/);
+
+		const start = client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallStart'))
+			.map(n => ({ envelope: getActionEnvelope(n), action: getActionEnvelope(n).action as ChatToolCallStartAction }))
+			.find(({ envelope, action }) => envelope.channel === chatUri && action.turnId === turnId && /^read_(?:bash|powershell)$/.test(action.toolName));
+		assert.ok(start, 'expected a shell read helper tool call');
+
+		const ready = client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallReady'))
+			.map(n => ({ envelope: getActionEnvelope(n), action: getActionEnvelope(n).action as ChatToolCallReadyAction }))
+			.find(({ envelope, action }) => envelope.channel === chatUri && action.turnId === turnId && action.toolCallId === start.action.toolCallId);
+		const complete = client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallComplete'))
+			.map(n => ({ envelope: getActionEnvelope(n), action: getActionEnvelope(n).action as ChatToolCallCompleteAction }))
+			.find(({ envelope, action }) => envelope.channel === chatUri && action.turnId === turnId && action.toolCallId === start.action.toolCallId);
+		assert.ok(ready, 'expected the shell read helper to become ready');
+		assert.ok(complete, 'expected the shell read helper to complete');
+
+		const toolInput = getInlineToolInput(ready.action.toolInput);
+		assert.deepStrictEqual({
+			displayName: start.action.displayName,
+			toolKinds: [
+				readToolCallMeta(start.action).toolKind,
+				readToolCallMeta(ready.action).toolKind,
+				readToolCallMeta(complete.action).toolKind,
+			],
+			invocationMessage: ready.action.invocationMessage,
+			toolInput: toolInput ? JSON.parse(toolInput) : undefined,
+			success: complete.action.result.success,
+			pastTenseMessage: complete.action.result.pastTenseMessage,
+			contentTypes: complete.action.result.content?.map(content => content.type),
+		}, {
+			displayName: 'Read Terminal',
+			toolKinds: [undefined, undefined, undefined],
+			invocationMessage: 'Reading Terminal',
+			toolInput: { shellId: 'read-shell-e2e', delay: 5 },
+			success: true,
+			pastTenseMessage: 'Read Terminal',
+			contentTypes: [ToolResultContentType.Text],
+		});
+		await assertRecordedAhpSnapshot(this.test!, client, {
+			profile: 'protocol',
+			ignoredActionTypes: [
+				ActionType.ChatUsage,
+				ActionType.ChatToolCallDelta,
+				ActionType.SessionChatUpdated,
+				ActionType.SessionTitleChanged,
+				ActionType.SessionServerToolsChanged,
+				ActionType.SessionReady,
+				ActionType.SessionInputNeededSet,
+				ActionType.SessionInputNeededRemoved,
+				ActionType.SessionChangesetsChanged,
+				ActionType.SessionMetaChanged,
+			],
+		});
 	});
 
 	(isWindows ? test.skip : test)('strips redundant `cd <workingDirectory> &&` prefix from shell tool calls', async function () {

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -272,6 +272,40 @@ suite('mapSessionEvents — history replay', () => {
 		]);
 	});
 
+	test('does not classify read_bash shell_exit metadata as a terminal completion on replay', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'hi' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'read_bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'read_bash', arguments: { shellId: 'build', delay: 0 } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: 'Build completed\n',
+						contents: [{ type: 'shell_exit', shellId: 'build', exitCode: 0, outputPreview: 'Build completed\n' }],
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		const part = turns[0].responseParts[0] as ToolCallResponsePart;
+		assert.strictEqual(part.toolCall.status, ToolCallStatus.Completed);
+		if (part.toolCall.status !== ToolCallStatus.Completed) { return; }
+		assert.deepStrictEqual({
+			toolKind: readToolCallMeta(part.toolCall).toolKind,
+			pastTenseMessage: part.toolCall.pastTenseMessage,
+			content: part.toolCall.content,
+		}, {
+			toolKind: undefined,
+			pastTenseMessage: 'Read Terminal',
+			content: [{ type: ToolResultContentType.Text, text: 'Build completed\n' }],
+		});
+	});
+
 	test('preserves non-zero terminal completion even when SDK tool completion succeeded', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', data: { interactionId: 'm1', content: 'hi' } },


### PR DESCRIPTION
Fixes [#329830](https://github.com/microsoft/vscode/issues/329830)

## Summary

- keep `read_bash` and `read_powershell` completions on the generic tool presentation even when the SDK includes `shell_exit` metadata
- preserve terminal result synthesis for primary `bash` and `powershell` commands in both live events and history replay
- add live/replay regression tests and a recorded Copilot Agent Host E2E scenario that validates the AHP tool shape

## Testing

- `npm run compile`
- `npm run hygiene`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`
- `./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts --grep "shell read helper remains a non-terminal tool"`

The E2E scenario is POSIX-gated because completed ordinary-shell output is not reliably available from the Copilot provider on Windows.

(Written by Copilot)