### PR TITLE
[Perf] Release stale RPC cancellation handlers

### DIFF
--- a/src/vs/workbench/services/extensions/common/rpcProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/rpcProtocol.ts
@@ -109,8 +109,6 @@ export interface IRPCProtocolLogger {
 	logOutgoing(msgLength: number, req: number, initiator: RequestInitiator, str: string, data?: any): void;
 }
 
-const noop = () => { };
-
 const _RPCProtocolSymbol = Symbol.for('rpcProtocol');
 const _RPCProxySymbol = Symbol.for('rpcProxy');
 
@@ -362,19 +360,19 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 		const callId = String(req);
 
 		let promise: Promise<any>;
-		let cancel: () => void;
+		let cancel: (() => void) | undefined;
 		if (usesCancellationToken) {
 			const cancellationTokenSource = new CancellationTokenSource();
 			args.push(cancellationTokenSource.token);
 			promise = this._invokeHandler(rpcId, method, args);
 			cancel = () => cancellationTokenSource.cancel();
 		} else {
-			// cannot be cancelled
 			promise = this._invokeHandler(rpcId, method, args);
-			cancel = noop;
 		}
 
-		this._cancelInvokedHandlers[callId] = cancel;
+		if (cancel) {
+			this._cancelInvokedHandlers[callId] = cancel;
+		}
 
 		// Acknowledge the request
 		const msg = MessageIO.serializeAcknowledged(req);
@@ -397,7 +395,9 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 	private _receiveCancel(msgLength: number, req: number): void {
 		this._logger?.logIncoming(msgLength, req, RequestInitiator.OtherSide, `receiveCancel`);
 		const callId = String(req);
-		this._cancelInvokedHandlers[callId]?.();
+		const cancel = this._cancelInvokedHandlers[callId];
+		delete this._cancelInvokedHandlers[callId];
+		cancel?.();
 	}
 
 	private _receiveReply(msgLength: number, req: number, value: any): void {

--- a/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
@@ -36,6 +36,7 @@ suite('RPCProtocol', () => {
 
 	let delegate: (a1: any, a2: any) => any;
 	let bProxy: BClass;
+	let bProtocol: RPCProtocol;
 	class BClass {
 		$m(a1: any, a2: any): Promise<any> {
 			return Promise.resolve(delegate.call(null, a1, a2));
@@ -51,11 +52,11 @@ suite('RPCProtocol', () => {
 		b_protocol.setPair(a_protocol);
 
 		const A = disposables.add(new RPCProtocol(a_protocol));
-		const B = disposables.add(new RPCProtocol(b_protocol));
+		bProtocol = disposables.add(new RPCProtocol(b_protocol));
 
 		const bIdentifier = new ProxyIdentifier<BClass>('bb');
 		const bInstance = new BClass();
-		B.set(bIdentifier, bInstance);
+		bProtocol.set(bIdentifier, bInstance);
 		bProxy = A.getProxy(bIdentifier);
 	});
 
@@ -156,6 +157,42 @@ suite('RPCProtocol', () => {
 			assert.fail('should not receive error');
 		}).finally(done);
 		tokenSource.cancel();
+	});
+
+	test('releases cancellation handler when the invoked call does not settle', async function () {
+		let resolveRemoteToken!: (token: CancellationToken) => void;
+		const remoteToken = new Promise<CancellationToken>(resolve => resolveRemoteToken = resolve);
+		delegate = (_a1: number, token: CancellationToken) => {
+			resolveRemoteToken(token);
+			return new Promise(() => { });
+		};
+
+		const tokenSource = disposables.add(new CancellationTokenSource());
+		void bProxy.$m(4, tokenSource.token);
+		const token = await remoteToken;
+		const cancellationRequested = new Promise<void>(resolve => {
+			disposables.add(token.onCancellationRequested(() => resolve()));
+		});
+		tokenSource.cancel();
+		await cancellationRequested;
+
+		const cancelInvokedHandlers = Reflect.get(bProtocol, '_cancelInvokedHandlers') as Record<string, () => void>;
+		assert.deepStrictEqual(Object.keys(cancelInvokedHandlers), []);
+	});
+
+	test('does not track uncancellable calls that do not settle', async function () {
+		let resolveInvoked!: () => void;
+		const invoked = new Promise<void>(resolve => resolveInvoked = resolve);
+		delegate = () => {
+			resolveInvoked();
+			return new Promise(() => { });
+		};
+
+		void bProxy.$m(4, 1);
+		await invoked;
+
+		const cancelInvokedHandlers = Reflect.get(bProtocol, '_cancelInvokedHandlers') as Record<string, () => void>;
+		assert.deepStrictEqual(Object.keys(cancelInvokedHandlers), []);
 	});
 
 	test('throwing an error', function (done) {


### PR DESCRIPTION
## Summary
- register cancellation handlers only for RPC invocations that actually accept a cancellation token
- remove a registered handler before invoking cancellation so a target that never settles cannot retain the closure
- cover cancelable and uncancellable targets that never settle

## Validation
- `./scripts/test.sh --run src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts`
- `npm run typecheck-client`
- `npm run eslint -- src/vs/workbench/services/extensions/common/rpcProtocol.ts src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/services/extensions/common/rpcProtocol.ts src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts`

(Written by Copilot)