### PR TITLE
Prevent transient duplicate Agent Host sessions

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -2531,14 +2531,18 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// Subclasses whose `_shouldAdvertiseAgent` can change at runtime MUST
 		// fire `onDidChangeSessions` when it does, so consumers re-query and
 		// re-filter (see the local provider's `preferAgentHost` listener).
+		const pendingSession = this._pendingSession;
 		const sessions: ISession[] = [];
 		for (const cached of this._sessionCache.values()) {
+			if (pendingSession && isEqual(cached.resource, pendingSession.resource)) {
+				continue;
+			}
 			if (this._shouldAdvertiseAgent(cached.agentProvider)) {
 				sessions.push(cached);
 			}
 		}
-		if (this._pendingSession && this._shouldAdvertiseAgent(this._pendingSession.sessionType)) {
-			sessions.push(this._pendingSession);
+		if (pendingSession && this._shouldAdvertiseAgent(pendingSession.sessionType)) {
+			sessions.push(pendingSession);
 		}
 		return sessions;
 	}
@@ -4710,7 +4714,6 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return !existingKeys.has(rawId) && !this._inFlightNewSessionOwnIds.has(rawId);
 		};
 
-		await this._refreshSessions();
 		// Prefer this send's own id; fall back to any acceptable novel session.
 		const scan = (): ISession | undefined => {
 			let fallback: ISession | undefined;
@@ -4726,7 +4729,14 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}
 			return fallback;
 		};
-		const immediate = scan();
+		let immediate = scan();
+		if (immediate) {
+			this._committingSessionRawIds.add(immediate.resource.path.substring(1));
+			return immediate;
+		}
+
+		await this._refreshSessions();
+		immediate = scan();
 		if (immediate) {
 			this._committingSessionRawIds.add(immediate.resource.path.substring(1));
 			return immediate;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -4714,6 +4714,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return !existingKeys.has(rawId) && !this._inFlightNewSessionOwnIds.has(rawId);
 		};
 
+		await this._refreshSessions();
 		// Prefer this send's own id; fall back to any acceptable novel session.
 		const scan = (): ISession | undefined => {
 			let fallback: ISession | undefined;
@@ -4729,14 +4730,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}
 			return fallback;
 		};
-		let immediate = scan();
-		if (immediate) {
-			this._committingSessionRawIds.add(immediate.resource.path.substring(1));
-			return immediate;
-		}
-
-		await this._refreshSessions();
-		immediate = scan();
+		const immediate = scan();
 		if (immediate) {
 			this._committingSessionRawIds.add(immediate.resource.path.substring(1));
 			return immediate;

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -116,8 +116,10 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	 */
 	public failListSessionsCount = 0;
 	public listSessionsCallCount = 0;
+	public listSessionsBarrier: DeferredPromise<void> | undefined;
 	override async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this.listSessionsCallCount++;
+		await this.listSessionsBarrier?.p;
 		if (this.failListSessionsCount > 0) {
 			this.failListSessionsCount--;
 			throw new Error('AHP_AUTH_REQUIRED');
@@ -4390,7 +4392,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(committed.title.get(), 'Committed Late');
 	}));
 
-	test('sendRequest coalesces a committed session notification without refreshing the session list', async () => {
+	test('sendRequest does not advertise a cached committed session alongside its draft', async () => {
 		const provider = createProvider(disposables, agentHost, undefined, {
 			openSession: true,
 			sendRequest: async (resource): Promise<ChatSendResult> => {
@@ -4404,22 +4406,62 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
 		const chat = await provider.createNewChat(session.sessionId);
-		const listSessionsCallCount = agentHost.listSessionsCallCount;
-		let advertised: ISession[] | undefined;
+		const draftAdvertised = new DeferredPromise<void>();
 		disposables.add(provider.onDidChangeSessions(e => {
 			if (e.added.includes(session)) {
-				advertised = provider.getSessions().filter(candidate => isEqual(candidate.resource, session.resource));
+				draftAdvertised.complete();
 			}
 		}));
-		await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+		agentHost.listSessionsBarrier = new DeferredPromise<void>();
+		const request = provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+
+		await draftAdvertised.p;
+		const advertised = provider.getSessions().filter(candidate => isEqual(candidate.resource, session.resource));
+		agentHost.listSessionsBarrier.complete();
+		await request;
 
 		assert.deepStrictEqual({
-			listSessionsCallsDuringCommit: agentHost.listSessionsCallCount - listSessionsCallCount,
-			count: advertised?.length,
-			isDraft: advertised?.[0] === session,
-			resources: advertised?.map(candidate => candidate.resource.toString()),
+			count: advertised.length,
+			isDraft: advertised[0] === session,
+			resources: advertised.map(candidate => candidate.resource.toString()),
 		}, {
-			listSessionsCallsDuringCommit: 0,
+			count: 1,
+			isDraft: true,
+			resources: [session.resource.toString()],
+		});
+	});
+
+	test('sessionAdded does not advertise a committed session alongside its pending draft', async () => {
+		const provider = createProvider(disposables, agentHost, undefined, {
+			openSession: true,
+			sendRequest: async (): Promise<ChatSendResult> => ({ kind: 'sent' as const, data: {} as ChatSendResult extends { kind: 'sent'; data: infer D } ? D : never }),
+		});
+		await timeout(0);
+
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+		const chat = await provider.createNewChat(session.sessionId);
+		const draftAdvertised = new DeferredPromise<void>();
+		disposables.add(provider.onDidChangeSessions(e => {
+			if (e.added.includes(session)) {
+				draftAdvertised.complete();
+			}
+		}));
+		agentHost.listSessionsBarrier = new DeferredPromise<void>();
+		const request = provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+
+		await draftAdvertised.p;
+		const rawId = AgentSession.id(session.resource);
+		agentHost.addSession(createSession(rawId, { summary: 'Committed Session' }));
+		fireSessionAdded(agentHost, rawId, { title: 'Committed Session' });
+		const advertised = provider.getSessions().filter(candidate => isEqual(candidate.resource, session.resource));
+		agentHost.listSessionsBarrier.complete();
+		await request;
+
+		assert.deepStrictEqual({
+			count: advertised.length,
+			isDraft: advertised[0] === session,
+			resources: advertised.map(candidate => candidate.resource.toString()),
+		}, {
 			count: 1,
 			isDraft: true,
 			resources: [session.resource.toString()],

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -4390,6 +4390,42 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(committed.title.get(), 'Committed Late');
 	}));
 
+	test('sendRequest coalesces a committed session notification without refreshing the session list', async () => {
+		const provider = createProvider(disposables, agentHost, undefined, {
+			openSession: true,
+			sendRequest: async (resource): Promise<ChatSendResult> => {
+				const rawId = AgentSession.id(resource);
+				agentHost.addSession(createSession(rawId, { summary: 'Committed Session' }));
+				fireSessionAdded(agentHost, rawId, { title: 'Committed Session' });
+				return { kind: 'sent' as const, data: {} as ChatSendResult extends { kind: 'sent'; data: infer D } ? D : never };
+			},
+		});
+		await timeout(0);
+
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+		const chat = await provider.createNewChat(session.sessionId);
+		const listSessionsCallCount = agentHost.listSessionsCallCount;
+		let advertised: ISession[] | undefined;
+		disposables.add(provider.onDidChangeSessions(e => {
+			if (e.added.includes(session)) {
+				advertised = provider.getSessions().filter(candidate => isEqual(candidate.resource, session.resource));
+			}
+		}));
+		await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+
+		assert.deepStrictEqual({
+			listSessionsCallsDuringCommit: agentHost.listSessionsCallCount - listSessionsCallCount,
+			count: advertised?.length,
+			isDraft: advertised?.[0] === session,
+			resources: advertised?.map(candidate => candidate.resource.toString()),
+		}, {
+			listSessionsCallsDuringCommit: 0,
+			count: 1,
+			isDraft: true,
+			resources: [session.resource.toString()],
+		});
+	});
+
 	test('sendRequest rejects when the provisional session is abandoned before commit', async () => {
 		const provider = createProvider(disposables, agentHost, undefined, {
 			openSession: true,


### PR DESCRIPTION
## Summary

- keep the pending Agent Host draft authoritative while the same-resource committed adapter is cached
- add regression coverage for both `SessionAdded` orderings around first-send commit
- leave commit detection and session matching semantics unchanged

## Root cause

The provider briefly owns two `ISession` representations for the same resource: the sent draft skeleton and the committed adapter inserted into the session cache by `SessionAdded`. `getSessions()` advertised both during the replacement window.

Fixes [#329796](https://github.com/microsoft/vscode/issues/329796).

## Validation

- `scripts/test.sh --run src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts` — 175 passing
- `npm run typecheck-client`
- `npm run valid-layers-check`
- live Agents window first-send validation with a MutationObserver over the sessions tree: the new row never appeared more than once

(Written by Copilot)