### PR TITLE
[Perf] Bound Agent Host response file observable caches

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostResponseFileChanges.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostResponseFileChanges.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { LRUCache } from '../../../../../../base/common/map.js';
 import { constObservable, derived, derivedOpts, IObservable, mapObservableArrayCached, observableFromEvent } from '../../../../../../base/common/observable.js';
 import { getComparisonKey, isEqual, isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { isDefined } from '../../../../../../base/common/types.js';
@@ -31,6 +32,7 @@ import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingServic
 import { IChatResponseFileChangesProvider, IChatResponseFileEdit } from '../../chatResponseFileChangesService.js';
 
 const SUBSCRIPTION_OWNER = 'AgentHostResponseFileChangesProvider';
+const REQUEST_CACHE_CAPACITY = 1000;
 
 function uriArrayEquals(a: readonly URI[], b: readonly URI[]): boolean {
 	return a.length === b.length && a.every((uri, index) => isEqual(uri, b[index]));
@@ -67,8 +69,8 @@ function getToolCallFileEdits(toolCall: ToolCallState): ISessionFileDiff[] {
  */
 export class AgentHostResponseFileChangesProvider extends Disposable implements IChatResponseFileChangesProvider {
 
-	private readonly _perRequest = new Map<string, IObservable<readonly IEditSessionEntryDiff[]>>();
-	private readonly _perRequestFileEdits = new Map<string, IObservable<readonly IChatResponseFileEdit[]>>();
+	private readonly _perRequest = new LRUCache<string, IObservable<readonly IEditSessionEntryDiff[]>>(REQUEST_CACHE_CAPACITY);
+	private readonly _perRequestFileEdits = new LRUCache<string, IObservable<readonly IChatResponseFileEdit[]>>(REQUEST_CACHE_CAPACITY);
 
 	constructor(
 		private readonly _connection: IAgentConnection,

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts
@@ -138,6 +138,32 @@ suite('AgentHostResponseFileChangesProvider', () => {
 		], [1, 1]);
 	});
 
+	test('bounds per-request observable caches', () => {
+		const ds = store.add(new DisposableStore());
+		const provider = ds.add(new AgentHostResponseFileChangesProvider(new FakeAgentConnection(), authority, () => backendSession));
+		const firstChanges = provider.getChangesForRequest(chatResource, 'request-0');
+		const firstFileEdits = provider.getFileEditsForRequest(chatResource, 'request-0');
+
+		for (let index = 1; index <= 1100; index++) {
+			provider.getChangesForRequest(chatResource, `request-${index}`);
+			provider.getFileEditsForRequest(chatResource, `request-${index}`);
+		}
+
+		const perRequest = Reflect.get(provider, '_perRequest') as { readonly size: number };
+		const perRequestFileEdits = Reflect.get(provider, '_perRequestFileEdits') as { readonly size: number };
+		assert.deepStrictEqual({
+			perRequestSize: perRequest.size,
+			perRequestFileEditsSize: perRequestFileEdits.size,
+			firstChangesEvicted: provider.getChangesForRequest(chatResource, 'request-0') !== firstChanges,
+			firstFileEditsEvicted: provider.getFileEditsForRequest(chatResource, 'request-0') !== firstFileEdits,
+		}, {
+			perRequestSize: 1000,
+			perRequestFileEditsSize: 1000,
+			firstChangesEvicted: true,
+			firstFileEditsEvicted: true,
+		});
+	});
+
 	test('classifies project files as workspace files without working directories', () => {
 		const ds = store.add(new DisposableStore());
 		const conn = new FakeAgentConnection();


### PR DESCRIPTION
## Summary

- bound the Agent Host response file-change observable memoization stores to the 1,000 most recently used requests
- preserve observables already held by rendered responses while allowing evicted requests to be recreated on demand
- add regression coverage with 1,101 requests for both cache limits and eviction/recreation behavior

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts`
- `npm run typecheck-client`
- `npm run hygiene`

(Written by Copilot)