### PR TITLE
Fix Disable extension action for EnabledWorkspace (#244138)

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1779,7 +1779,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

When an extension is enabled in a workspace but globally disabled, the dropdown was showing both 'Disable' and 'Disable (Workspace)'. This fix ensures that the global 'Disable' action is only active when the extension is globally enabled.

@sandy081 - I would love to get your feedback on this fix! I'm very eager to make deeper, more impactful contributions to the VS Code repository. Please let me know if there are any other complex issues or backlog items that I can help take off your plate. Thank you for your work on this awesome project!

---
*Note: This PR was developed with the assistance of an AI coding agent.*
