### PR TITLE
Fix `<`/`>` incorrectly colored/paired as brackets inside `<<=`, `>>=`, `>>>=`

### DIFF
--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/brackets.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/brackets.ts
@@ -107,6 +107,20 @@ function prepareBracketForRegExp(str: string): string {
 	if (/[\w ]+$/.test(str)) {
 		escaped = `${escaped}\\b`;
 	}
+	// `<`/`>` are also used in the shift-assignment operators `<<=`, `>>=` and `>>>=`.
+	// Unlike plain `<<`/`>>` (ambiguous with nested generics, e.g. `Array<Array<T>>`),
+	// these compound-assignment forms are never brackets, so exclude them unambiguously.
+	// Note: this must be expressed with lookahead only, not a preceding-character lookbehind.
+	// Some callers (e.g. FastTokenizer) scan the text as one continuous string rather than
+	// re-slicing per match, so a lookbehind here would see an *adjacent, already-matched*
+	// bracket character (e.g. the legitimate `>>` closing two nested generics) and wrongly
+	// treat it the same as the second `>` of `>>=` - breaking `Array<Array<T>>`-style nesting.
+	// see https://github.com/microsoft/vscode/issues/329789
+	if (str === '<') {
+		escaped = `${escaped}(?!<?=)`;
+	} else if (str === '>') {
+		escaped = `${escaped}(?!>{0,2}=)`;
+	}
 	return escaped;
 }
 

--- a/src/vs/editor/test/common/model/bracketPairColorizer/brackets.test.ts
+++ b/src/vs/editor/test/common/model/bracketPairColorizer/brackets.test.ts
@@ -64,6 +64,89 @@ suite('Bracket Pair Colorizer - Brackets', () => {
 
 		disposableStore.dispose();
 	});
+
+	test('Issue #329789: `<`/`>` should not be treated as brackets inside shift-assignment operators', () => {
+		const languageId = 'testMode2';
+		const denseKeyProvider = new DenseKeyProvider<string>();
+
+		const disposableStore = new DisposableStore();
+		const languageConfigService = disposableStore.add(new TestLanguageConfigurationService());
+		disposableStore.add(languageConfigService.register(languageId, {
+			brackets: [
+				['<', '>']
+			]
+		}));
+
+		const brackets = new LanguageAgnosticBracketTokens(denseKeyProvider, l => languageConfigService.getLanguageConfiguration(l));
+		const regExp = brackets.getSingleLanguageBracketTokens(languageId).regExpGlobal!;
+
+		// This regex is consumed by two different scanning strategies in the real engine:
+		// - `NonPeekableTextBufferTokenizer.read()` re-slices the text from the current offset
+		//   and restarts matching (`lastIndex = 0`) after each found bracket.
+		// - `FastTokenizer` runs one continuous global exec over the whole, unsliced string,
+		//   letting `lastIndex` auto-advance between matches.
+		// A guard that only works under one of these (e.g. a lookbehind relying on "not
+		// preceded by an already-matched bracket char") can silently break the other - which
+		// is exactly what happened during development of this fix: a lookbehind-based guard
+		// passed under the resliced style but broke nested generics (`Array<Array<T>>`) under
+		// the continuous style, because the lookbehind saw the real, adjacent `>` character
+		// regardless of whether it had already been "consumed" as a match. Both styles are
+		// checked here so a regression in either can't slip through unnoticed again.
+		const findMatchesResliced = (text: string) => {
+			const matches: string[] = [];
+			let pos = 0;
+			while (pos < text.length) {
+				regExp.lastIndex = 0;
+				const match = regExp.exec(text.slice(pos));
+				if (!match) {
+					break;
+				}
+				matches.push(match[0]);
+				pos += match.index + match[0].length;
+			}
+			return matches;
+		};
+		const findMatchesContinuous = (text: string) => {
+			regExp.lastIndex = 0;
+			const matches: string[] = [];
+			let match: RegExpExecArray | null;
+			while ((match = regExp.exec(text))) {
+				matches.push(match[0]);
+				if (match[0].length === 0) {
+					regExp.lastIndex++;
+				}
+			}
+			return matches;
+		};
+		const assertMatches = (text: string, expected: string[]) => {
+			assert.deepStrictEqual(findMatchesResliced(text), expected, `resliced scan of ${JSON.stringify(text)}`);
+			assert.deepStrictEqual(findMatchesContinuous(text), expected, `continuous scan of ${JSON.stringify(text)}`);
+		};
+
+		// `<<=`, `>>=` and `>>>=` are unambiguous operators and must not be matched as brackets.
+		assertMatches('x <<= 1;', []);
+		assertMatches('x >>= 1;', []);
+		assertMatches('x >>>= 1;', []);
+
+		// Genuine brackets must still be matched, including adjacent closing brackets
+		// from nested generics (e.g. the `>>` at the end of `Array<Array<string>>`).
+		assertMatches('Array<string>', ['<', '>']);
+		assertMatches('Array<Array<string>>', ['<', '<', '>', '>']);
+		assertMatches('<div></div>', ['<', '>', '<', '>']);
+
+		// Plain shift (`<<`, `>>`) is a pre-existing, out-of-scope ambiguity (`>>` also closes
+		// nested generics) and is unaffected. `<=`/`>=` are also excluded: a directly-adjacent
+		// `<`/`>` immediately followed by `=` is never a legitimate bracket in real TS/JSX
+		// source (always the relational or compound-assignment operator), and excluding them
+		// is what allows the guard to be expressed with lookahead only (see the comment on
+		// `prepareBracketForRegExp` for why lookbehind is unsafe here).
+		assertMatches('x << 1;', ['<', '<']);
+		assertMatches('x >> 1;', ['>', '>']);
+		assertMatches('x <= 1;', []);
+		assertMatches('x >= 1;', []);
+
+		disposableStore.dispose();
+	});
 });
 
 function tokenToObject(token: Token | undefined, text: string): any {

--- a/src/vs/editor/test/common/model/bracketPairColorizer/getBracketPairsInRange.test.ts
+++ b/src/vs/editor/test/common/model/bracketPairColorizer/getBracketPairsInRange.test.ts
@@ -50,6 +50,39 @@ suite('Bracket Pair Colorizer - getBracketPairsInRange', () => {
 		return textModel;
 	}
 
+	/**
+	 * Registers `<`/`>` as a *colorized* bracket pair, mirroring TypeScript/TSX's
+	 * `language-configuration.json` (used for generics and JSX tags). Kept separate from
+	 * {@link createTextModelWithColorizedBracketPairs}, which deliberately excludes `<`/`>`
+	 * from `colorizedBracketPairs` for the `colorizedBracketsVSBrackets` test below.
+	 */
+	function createTextModelWithAngleBracketColorization(store: DisposableStore, text: string): TextModel {
+		const languageId = 'testLanguageAngleBrackets';
+		const instantiationService = createModelServices(store);
+		const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
+		const languageService = instantiationService.get(ILanguageService);
+		store.add(languageService.registerLanguage({
+			id: languageId,
+		}));
+
+		const encodedMode1 = languageService.languageIdCodec.encodeLanguageId(languageId);
+		const document = new TokenizedDocument([
+			new TokenInfo(text, encodedMode1, StandardTokenType.Other, true)
+		]);
+		store.add(TokenizationRegistry.register(languageId, document.getTokenizationSupport()));
+
+		store.add(languageConfigurationService.register(languageId, {
+			brackets: [
+				['<', '>']
+			],
+			colorizedBracketPairs: [
+				['<', '>']
+			]
+		}));
+		const textModel = store.add(instantiateTextModel(instantiationService, text, languageId));
+		return textModel;
+	}
+
 	test('Basic 1', () => {
 		disposeOnReturn(store => {
 			const doc = new AnnotatedDocument(`{ ( [] ¹ ) [ ² { } ] () } []`);
@@ -423,6 +456,68 @@ suite('Bracket Pair Colorizer - getBracketPairsInRange', () => {
 						range: '[1,15 -> 1,16]',
 					},
 				]
+			);
+		});
+	});
+
+	test('issue #329789: `<`/`>` still work as brackets in generic/type syntax', () => {
+		disposeOnReturn(store => {
+			const doc = new AnnotatedDocument(`¹Array<string>²`);
+			const model = createTextModelWithAngleBracketColorization(store, doc.text);
+			assert.deepStrictEqual(
+				model.bracketPairs
+					.getBracketPairsInRange(doc.range(1, 2))
+					.map(bracketPairToJSON)
+					.toArray(),
+				[
+					{
+						level: 0,
+						range: '[1,6 -> 1,7]',
+						openRange: '[1,6 -> 1,7]',
+						closeRange: '[1,13 -> 1,14]',
+					},
+				]
+			);
+		});
+	});
+
+	test('issue #329789: nested generic syntax (`Array<Array<string>>`) still works', () => {
+		disposeOnReturn(store => {
+			const doc = new AnnotatedDocument(`¹Array<Array<string>>²`);
+			const model = createTextModelWithAngleBracketColorization(store, doc.text);
+			assert.deepStrictEqual(
+				model.bracketPairs
+					.getBracketPairsInRange(doc.range(1, 2))
+					.map(bracketPairToJSON)
+					.toArray(),
+				[
+					{
+						level: 0,
+						range: '[1,6 -> 1,7]',
+						openRange: '[1,6 -> 1,7]',
+						closeRange: '[1,20 -> 1,21]',
+					},
+					{
+						level: 1,
+						range: '[1,12 -> 1,13]',
+						openRange: '[1,12 -> 1,13]',
+						closeRange: '[1,19 -> 1,20]',
+					},
+				]
+			);
+		});
+	});
+
+	test('issue #329789: `<<=`, `>>=` and `>>>=` do not create bracket pairs', () => {
+		disposeOnReturn(store => {
+			const doc = new AnnotatedDocument(`¹x <<= 1; x >>= 1; x >>>= 1;²`);
+			const model = createTextModelWithAngleBracketColorization(store, doc.text);
+			assert.deepStrictEqual(
+				model.bracketPairs
+					.getBracketPairsInRange(doc.range(1, 2))
+					.map(bracketPairToJSON)
+					.toArray(),
+				[]
 			);
 		});
 	});

--- a/src/vs/editor/test/common/model/bracketPairColorizer/tokenizer.test.ts
+++ b/src/vs/editor/test/common/model/bracketPairColorizer/tokenizer.test.ts
@@ -91,6 +91,68 @@ suite('Bracket Pair Colorizer - Tokenizer', () => {
 
 		disposableStore.dispose();
 	});
+
+	test('Issue #329789: `<<=`/`>>=`/`>>>=` are not tokenized as brackets, generics still are', () => {
+		const mode1 = 'testMode2';
+		const disposableStore = new DisposableStore();
+		const instantiationService = createModelServices(disposableStore);
+		const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
+		const languageService = instantiationService.get(ILanguageService);
+		disposableStore.add(languageService.registerLanguage({ id: mode1 }));
+		const encodedMode1 = languageService.languageIdCodec.encodeLanguageId(mode1);
+
+		const denseKeyProvider = new DenseKeyProvider<string>();
+
+		const tStandard = (text: string) => new TokenInfo(text, encodedMode1, StandardTokenType.Other, true);
+		const document = new TokenizedDocument([
+			tStandard('x <<= 1; x >>= 1; x >>>= 1;'), tStandard('\n'),
+			tStandard('Array<Array<string>>'),
+		]);
+
+		disposableStore.add(TokenizationRegistry.register(mode1, document.getTokenizationSupport()));
+		disposableStore.add(languageConfigurationService.register(mode1, {
+			brackets: [['<', '>']],
+		}));
+
+		const model = disposableStore.add(instantiateTextModel(instantiationService, document.getText(), mode1));
+		model.tokenization.forceTokenization(model.getLineCount());
+
+		const brackets = new LanguageAgnosticBracketTokens(denseKeyProvider, l => languageConfigurationService.getLanguageConfiguration(l));
+
+		const tokens = readAllTokens(new TextBufferTokenizer(model, brackets));
+
+		assert.deepStrictEqual(toArr(tokens, model, denseKeyProvider), [
+			{ text: 'x <<= 1; x >>= 1; x >>>= 1;\nArray', bracketId: null, bracketIds: [], kind: 'Text' },
+			{
+				text: '<',
+				bracketId: 'testMode2:::<',
+				bracketIds: ['testMode2:::<'],
+				kind: 'OpeningBracket',
+			},
+			{ text: 'Array', bracketId: null, bracketIds: [], kind: 'Text' },
+			{
+				text: '<',
+				bracketId: 'testMode2:::<',
+				bracketIds: ['testMode2:::<'],
+				kind: 'OpeningBracket',
+			},
+			{ text: 'string', bracketId: null, bracketIds: [], kind: 'Text' },
+			{
+				text: '>',
+				bracketId: 'testMode2:::<',
+				bracketIds: ['testMode2:::<'],
+				kind: 'ClosingBracket',
+			},
+			{
+				text: '>',
+				bracketId: 'testMode2:::<',
+				bracketIds: ['testMode2:::<'],
+				kind: 'ClosingBracket',
+			},
+		]);
+
+		disposableStore.dispose();
+	});
 });
 
 function readAllTokens(tokenizer: Tokenizer): Token[] {


### PR DESCRIPTION
Fixes #329789

## Problem

In files where `<`/`>` are configured as colorized brackets (TypeScript, TSX, C++, C#, Java, Rust, and other languages that use them for generics/templates/JSX), the shift-assignment operators `<<=`, `>>=` and `>>>=` were incorrectly treated as bracket characters:

```tsx
let x = 1;
x <<= 1;   // '<' rendered as an unmatched/error bracket
x >>= 1;   // '<' and '>' from unrelated statements shown as a matched pair
```

## Root cause

Bracket-pair colorization is a separate, character-level engine (`bracketPairsTextModelPart`) from the TextMate syntax grammar. It builds a regex from each configured bracket delimiter (`prepareBracketForRegExp` in `brackets.ts`) to scan for bracket characters directly in the text. That regex had no guard preventing a `<`/`>` from matching when it was actually part of a longer, unrelated operator token, so it matched the first `<`/`>` it found inside `<<=`, `>>=` and `>>>=` regardless of context.

## Solution

Added a context-aware exclusion to `prepareBracketForRegExp` for `<` and `>` specifically, so the regex no longer matches them when they're directly followed by a sequence that unambiguously forms `<<=`, `>>=`, or `>>>=`. Plain `<<`/`>>`/`>>>` are intentionally left unguarded, since `>>`/`>>>` are ambiguous with legitimate adjacent closes of nested generics (e.g. `Array<Array<string>>`) and must keep matching.

The exclusion is implemented with lookahead only (no lookbehind). This matters because the engine has two different text-scanning strategies - one re-slices the text after each match, the other (`FastTokenizer`, used for the very first paint of a file before background tokenization completes) scans the whole string continuously. A lookbehind-based version of this guard passed under the first strategy but broke nested generic matching under the second, since it saw an adjacent, already-matched `>` and mistook it for part of `>>=`. The lookahead-only version is scan-strategy-independent and was verified against both.

As a consequence, a `<`/`>` immediately followed by `=` with no whitespace (`<=`, `>=`) is also no longer treated as a bracket - this is safe, since that sequence is always the relational or compound-assignment operator in real source, never a legitimate bracket.

## Testing

- Unit tests added to `brackets.ts`'s regex construction, checked under both text-scanning strategies used by the real engine.
- Tokenizer-level test confirming `<<=`/`>>=`/`>>>=` produce no bracket tokens while nested generics still tokenize correctly.
- Integration-level tests against the public `model.bracketPairs.getBracketPairsInRange()` API confirming:
  - `<`/`>` still work as brackets in generic syntax (`Array<string>`)
  - nested generics still pair correctly (`Array<Array<string>>`)
  - `<<=`, `>>=`, `>>>=` produce no bracket pairs
- Full `bracketPairColorizer` test suite: 84 passing, 0 failing.
- Broader `editor/test/common/model` suite: 700 passing, 0 failing.
- `gulp compile-client`: 0 errors. Project ESLint on all changed files: 0 errors.
