### PR TITLE
agentHost: Read settings through disk provider

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostBootstrap.ts
+++ b/src/vs/platform/agentHost/node/agentHostBootstrap.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { Schemas } from '../../../base/common/network.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ConfigurationService } from '../../configuration/common/configurationService.js';
@@ -50,7 +51,7 @@ export async function registerAgentHostNetworkServices(
 ): Promise<IAgentHostNetworkServices> {
 	const policyService = new NullPolicyService();
 	diServices.set(IPolicyService, policyService);
-	const settingsResource = joinPath(environmentService.userRoamingDataHome, 'settings.json');
+	const settingsResource = joinPath(environmentService.userRoamingDataHome.with({ scheme: Schemas.file }), 'settings.json');
 	const configurationService = disposables.add(new ConfigurationService(settingsResource, fileService, policyService, logService));
 	await configurationService.initialize();
 	diServices.set(IConfigurationService, configurationService);

--- a/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostBootstrap.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { registerAgentHostNetworkServices } from '../../node/agentHostBootstrap.js';
+
+suite('AgentHostBootstrap', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reads settings through the disk file system provider', async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		disposables.add(fileService.registerProvider(Schemas.file, disposables.add(new InMemoryFileSystemProvider())));
+		const userRoamingDataHome = URI.from({ scheme: Schemas.vscodeUserData, path: '/User' });
+		const settingsResource = joinPath(userRoamingDataHome.with({ scheme: Schemas.file }), 'settings.json');
+		await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "http.proxy": "http://proxy.example", "http.proxySupport": "on" }'));
+		const environmentService = upcastPartial<INativeEnvironmentService>({ userRoamingDataHome });
+		const services = new ServiceCollection();
+		const networkServiceDisposables = disposables.add(new DisposableStore());
+
+		const networkServices = await registerAgentHostNetworkServices(services, fileService, environmentService, logService, networkServiceDisposables);
+
+		assert.strictEqual(await networkServices.proxyResolver.resolveProxy('https://example.com'), 'http://proxy.example');
+	});
+});


### PR DESCRIPTION
## Summary

- read Agent Host settings through the registered disk file-system provider
- prevent repeated `ENOPRO` errors for the default `vscode-userdata` settings URI
- add regression coverage for loading proxy settings from the default user data location

## Testing

- `npm run compile`
- `.\scripts\test.bat --run src\vs\platform\agentHost\test\node\agentHostBootstrap.test.ts`
- `npm run eslint -- src\vs\platform\agentHost\node\agentHostBootstrap.ts src\vs\platform\agentHost\test\node\agentHostBootstrap.test.ts`

`npm run hygiene` was attempted but its package check fails before examining the patch because the Windows ESM path is resolved as `C:\C:\Code\...\remote\package.json`.