### PR TITLE
agentHost: gate terminal metadata E2E to recording

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -74,6 +74,23 @@ A user can start a shell command in the background, inspect or list the running 
     --grep "managed shell|custom terminal tool manages"
   ```
 
+### Copilot terminal command-detection state is record-only
+
+A user runs a shell command through the custom terminal tool and expects the resulting terminal to report shell-integration command detection, completion, and the real exit code. The command succeeds in focused source runs, but clean macOS product builds can expose a terminal without command-detection metadata.
+
+- Test: `custom terminal tool preserves a nonzero shell exit code`.
+- Scope: Copilot deterministic replay.
+- Expected: the terminal reports `supportsCommandDetection: true` with a completed command carrying exit code `9`.
+- Observed: clean macOS product builds report `supportsCommandDetection`, `isComplete`, and `exitCode` as `undefined`, while focused and parallel source-mode replay pass.
+- Gate: the scenario runs only when `AGENT_HOST_REPLAY_RECORD=1` through `context.runRecordOnlyTests`.
+- Reproduce:
+
+  ```bash
+  AGENT_HOST_REPLAY_RECORD=1 ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts \
+    --grep "custom terminal tool preserves a nonzero shell exit code"
+  ```
+
 ### Copilot deferred tool search cannot be replayed
 
 A Copilot session can defer client-provided tools, search for the relevant tool on demand, and then execute the selected tool. The live workflow succeeds, but the recorded Responses fixture loses the hosted tool-search output that triggers the AHP client-tool exchange, so replay ends the turn before either tool appears.

--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -562,7 +562,8 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 		}
 	});
 
-	test('custom terminal tool preserves a nonzero shell exit code', async function () {
+	// Live PTY shell-integration metadata is not deterministic in replay; see KNOWN_ISSUES.md.
+	(context.runRecordOnlyTests ? test : test.skip)('custom terminal tool preserves a nonzero shell exit code', async function () {
 		this.timeout(180_000);
 		const { sessionUri } = await createWorkspaceSession('custom-terminal-exit-code');
 		try {


### PR DESCRIPTION
## Summary

Gate the Copilot E2E test `custom terminal tool preserves a nonzero shell exit code` to recording mode and document the known product-build behavior.

The test depends on live PTY shell-integration metadata in addition to replayed model traffic. Clean macOS product builds can expose the terminal without command-detection, completion, or exit-code metadata, while focused and parallel source-mode replay pass. The scenario remains available with `AGENT_HOST_REPLAY_RECORD=1` but no longer blocks deterministic product-build replay.

## History and motivation

Rob Lourens (`roblourens`) added the test in #329602, merged as `d9ea9f8d74e3` on August 7, 2026. That PR expanded Copilot Agent Host E2E coverage for file and shell tools. This scenario specifically verifies that running `node -e \"process.exit(9)\"` through the custom terminal reports:

- shell command detection is available;
- the command completed;
- the real nonzero exit code is `9`.

The test has failed in clean product CI since its first product-build execution:

- **Last build before the test:** [462575](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462575), source `271099cf364a`. Electron integration tests passed on macOS, Linux, and Windows, but this build did not contain the test.
- **First build containing the test:** [462612](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462612), source `1b8f4bb594f0`. The new assertion failed on both macOS and Linux with missing terminal metadata (`undefined !== 9`).
- **Current example:** [462959](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=462959). macOS ARM64 reports `supportsCommandDetection`, `isComplete`, and `exitCode` as `undefined`.

The introducing commit is the certain CI trigger because it added the assertion. The deeper product-shell cause is not fully established: `6e3da3e6e570` fixed one clean `out-build` shell-integration script-path issue, but macOS product builds continued failing afterward. Source-mode focused and four-worker parallel replay both pass locally.

## Validation

- Focused deterministic replay: test skipped as expected (`0 passing`, `1 pending`)
- `npm run compile`
- `npm run hygiene`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `git diff --check`