### PR TITLE
Agent host: resolve session pull requests by remote branch and head commit

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -430,6 +430,22 @@ function getBranchPriority(branch: string, currentBranch: string | undefined, de
 	return 2;
 }
 
+/**
+ * Splits an upstream tracking branch (e.g. `origin/feature`) into its remote
+ * and remote-side branch name. Returns `undefined` when the branch has no
+ * upstream or the value is not of the `<remote>/<branch>` shape.
+ */
+export function parseUpstreamBranchName(upstreamBranchName: string | undefined): { remote: string; branch: string } | undefined {
+	const separatorIndex = upstreamBranchName?.indexOf('/') ?? -1;
+	if (!upstreamBranchName || separatorIndex <= 0 || separatorIndex === upstreamBranchName.length - 1) {
+		return undefined;
+	}
+	return {
+		remote: upstreamBranchName.substring(0, separatorIndex),
+		branch: upstreamBranchName.substring(separatorIndex + 1),
+	};
+}
+
 export function getBranchCompletions(branches: readonly string[], options?: { readonly currentBranch?: string; readonly defaultBranch?: string; readonly query?: string; readonly limit?: number }): string[] {
 	const normalizedQuery = options?.query?.toLowerCase();
 	const filtered = normalizedQuery

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -135,21 +135,14 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 	}
 
 	/**
-	 * Resolves the pull request of the branch that is currently checked out.
-	 *
-	 * The local branch name is not a dependable key. A branch checked out from
-	 * a pull request head (`git switch -c <local> FETCH_HEAD`) or pushed with an
-	 * explicit refspec carries a name that never existed on the remote, and a
-	 * name that happens to collide with an unrelated remote branch would resolve
-	 * to that branch's pull request. So the remote head branch is taken from the
-	 * upstream tracking ref when there is one, and the commit at HEAD — which
-	 * identifies the pull request regardless of how the branch is named locally
-	 * — serves as the fallback for branches that track nothing.
+	 * Resolves the pull request of the branch that is currently checked out,
+	 * preferring the remote head branch and falling back to the commit at HEAD
+	 * for local branches whose name never reached the remote.
 	 */
 	private async _findPullRequestForCheckout(state: ISessionWithDefaultChat, owner: string, repo: string, gitState: ISessionGitState | undefined, branchName: string, authToken: string): Promise<CreatedPullRequest | undefined> {
 		const signal = this._pullRequestAbortController.signal;
-		// Mirrors the create-PR handler: an upstream on a non-GitHub remote
-		// says nothing about GitHub, so its branch name is not used there.
+		// An upstream on a non-GitHub remote says nothing about GitHub, so its
+		// branch is ignored here as it is when creating a pull request.
 		const githubHeadOwner = gitState?.githubHeadOwner;
 		const upstreamBranch = githubHeadOwner ? parseUpstreamBranchName(gitState?.upstreamBranchName) : undefined;
 		const headBranch = upstreamBranch?.branch ?? branchName;

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -8,12 +8,12 @@ import { URI } from '../../../base/common/uri.js';
 import { Emitter } from '../../../base/common/event.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostGitStateService, META_GIT_STATE, META_GITHUB_STATE } from '../common/agentHostGitStateService.js';
-import { ISessionGitHubState, readSessionGitHubState, readSessionGitState, SessionLifecycle, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, type ISessionGitState } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionWithDefaultChat, readSessionGitHubState, readSessionGitState, SessionLifecycle, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, type ISessionGitState } from '../common/state/sessionState.js';
 import { MAX_SESSION_ISSUE_REFERENCES, parseGitHubIssueReferences, toGitHubIssueUrl } from '../common/githubIssueReferences.js';
-import { IAgentHostGitService } from '../common/agentHostGitService.js';
+import { IAgentHostGitService, parseUpstreamBranchName } from '../common/agentHostGitService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
-import { IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
+import { CreatedPullRequest, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import { IAgentService } from '../common/agentService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
@@ -110,12 +110,12 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				return;
 			}
 
-			const pr = await this._octoKitService.findPullRequestByHeadBranch(
-				gitHubState.owner, gitHubState.repo, branchName, authToken, this._pullRequestAbortController.signal, gitState?.githubHeadOwner);
+			const pr = await this._findPullRequestForCheckout(state, gitHubState.owner, gitHubState.repo, gitState, branchName, authToken);
 			if (!pr?.url) {
 				// No pull request for this branch (yet). The previously known
 				// pull request, if any, keeps being reported and the lookup is
 				// retried on the next refresh.
+				this._logService.trace(`[AgentHostGitStateService][attachSessionGitHubPullRequest] No pull request found for ${sessionKey} on branch ${branchName}`);
 				return;
 			}
 
@@ -132,6 +132,43 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		} catch (error) {
 			this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Failed to find pull request for ${sessionKey}`, error);
 		}
+	}
+
+	/**
+	 * Resolves the pull request of the branch that is currently checked out.
+	 *
+	 * The local branch name is not a dependable key. A branch checked out from
+	 * a pull request head (`git switch -c <local> FETCH_HEAD`) or pushed with an
+	 * explicit refspec carries a name that never existed on the remote, and a
+	 * name that happens to collide with an unrelated remote branch would resolve
+	 * to that branch's pull request. So the remote head branch is taken from the
+	 * upstream tracking ref when there is one, and the commit at HEAD — which
+	 * identifies the pull request regardless of how the branch is named locally
+	 * — serves as the fallback for branches that track nothing.
+	 */
+	private async _findPullRequestForCheckout(state: ISessionWithDefaultChat, owner: string, repo: string, gitState: ISessionGitState | undefined, branchName: string, authToken: string): Promise<CreatedPullRequest | undefined> {
+		const signal = this._pullRequestAbortController.signal;
+		// Mirrors the create-PR handler: an upstream on a non-GitHub remote
+		// says nothing about GitHub, so its branch name is not used there.
+		const githubHeadOwner = gitState?.githubHeadOwner;
+		const upstreamBranch = githubHeadOwner ? parseUpstreamBranchName(gitState?.upstreamBranchName) : undefined;
+		const headBranch = upstreamBranch?.branch ?? branchName;
+		const headOwner = upstreamBranch && githubHeadOwner ? githubHeadOwner : owner;
+
+		const pullRequestByBranch = await this._octoKitService.findPullRequestByHeadBranch(owner, repo, headBranch, authToken, signal, headOwner);
+		if (pullRequestByBranch) {
+			return pullRequestByBranch;
+		}
+
+		const workingDirectory = state.workingDirectories?.[0];
+		if (!workingDirectory) {
+			return undefined;
+		}
+
+		const headSha = await this._gitService.revParse(URI.parse(workingDirectory), 'HEAD');
+		return headSha
+			? this._octoKitService.findPullRequestByHeadSha(owner, repo, headSha, authToken, signal)
+			: undefined;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -12,7 +12,7 @@ import { parseChangesetUri } from '../common/changesetUri.js';
 import { AHP_AUTH_REQUIRED, AHP_SESSION_NOT_FOUND, JsonRpcErrorCodes, ProtocolError } from '../common/state/sessionProtocol.js';
 import { readSessionGitHubState, readSessionGitState, type ChangesetOperationFollowUp, type ISessionFileDiff, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import { ILogService } from '../../log/common/log.js';
-import { IAgentHostGitService } from '../common/agentHostGitService.js';
+import { IAgentHostGitService, parseUpstreamBranchName } from '../common/agentHostGitService.js';
 import { type IChangesetOperationHandler } from '../common/agentHostChangesetOperationService.js';
 import { type AutoMergeMethod, type CreatedPullRequest, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
@@ -32,17 +32,6 @@ const MAX_PR_CONVERSATION_CONTEXT_CHARS = 12_000;
  * utility model when generating a PR title and description.
  */
 const MAX_PR_CHANGE_SUMMARY_CHARS = 4_000;
-
-function parseUpstreamBranchName(upstreamBranchName: string | undefined): { remote: string; branch: string } | undefined {
-	const separatorIndex = upstreamBranchName?.indexOf('/') ?? -1;
-	if (!upstreamBranchName || separatorIndex <= 0 || separatorIndex === upstreamBranchName.length - 1) {
-		return undefined;
-	}
-	return {
-		remote: upstreamBranchName.substring(0, separatorIndex),
-		branch: upstreamBranchName.substring(separatorIndex + 1),
-	};
-}
 
 export interface PullRequestCreatedEvent {
 	readonly sessionKey: string;

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -33,6 +33,17 @@ interface GitHubPullRequestResponseItem {
 	readonly number?: unknown;
 	readonly html_url?: unknown;
 	readonly node_id?: unknown;
+	readonly state?: unknown;
+	readonly head?: { readonly sha?: unknown };
+}
+
+function toCreatedPullRequest(item: GitHubPullRequestResponseItem | undefined): CreatedPullRequest | undefined {
+	const html_url = item?.html_url;
+	const number = item?.number;
+	const node_id = item?.node_id;
+	return typeof html_url === 'string' && typeof number === 'number'
+		? { number, url: html_url, nodeId: typeof node_id === 'string' ? node_id : undefined }
+		: undefined;
 }
 
 interface GitHubIssueOrPullRequestResponseItem {
@@ -91,6 +102,16 @@ export interface IAgentHostOctoKitService {
 	/** Finds the most recently updated pull request for `headOwner:branch`, if any. */
 	findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, headOwner?: string): Promise<CreatedPullRequest | undefined>;
 
+	/**
+	 * Finds the pull request whose head commit is exactly `sha`, if any.
+	 *
+	 * Unlike {@link findPullRequestByHeadBranch} this does not depend on the
+	 * local branch carrying the same name as the remote head branch, so it also
+	 * resolves branches checked out from a pull request head under a different
+	 * name or pushed with an explicit refspec.
+	 */
+	findPullRequestByHeadSha(owner: string, repo: string, sha: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined>;
+
 	/** Fetches the title and body of an issue or pull request. */
 	getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest>;
 
@@ -125,9 +146,11 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 	private readonly _fetch: FetchFunction;
 
 	/**
-	 * A cache of ETags for pull request search results.
+	 * Cached pull request listings keyed by route, with the ETag that validated
+	 * them. The items are kept alongside the ETag because a `304` response
+	 * carries no body: without them a revalidated route would look empty.
 	 */
-	private readonly pullRequestSearchEtags = new LRUCache<string, string>(100);
+	private readonly pullRequestSearchCache = new LRUCache<string, { readonly etag: string; readonly items: readonly GitHubPullRequestResponseItem[] }>(100);
 
 	constructor(
 		fetchFn: FetchFunction | undefined,
@@ -168,35 +191,44 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 
 	async findPullRequestByHeadBranch(owner: string, repo: string, branch: string, token: string, signal: AbortSignal, headOwner = owner): Promise<CreatedPullRequest | undefined> {
 		const routeSlug = `repos/${owner}/${repo}/pulls?head=${encodeURIComponent(`${headOwner}:${branch}`)}&state=all&sort=updated&direction=desc&per_page=1`;
+		const items = await this._searchPullRequests(routeSlug, token, signal);
+		return toCreatedPullRequest(items[0]);
+	}
 
-		const etag = this.pullRequestSearchEtags.get(routeSlug);
-		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, etag);
+	async findPullRequestByHeadSha(owner: string, repo: string, sha: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined> {
+		const routeSlug = `repos/${owner}/${repo}/commits/${encodeURIComponent(sha)}/pulls?per_page=100`;
+		const items = await this._searchPullRequests(routeSlug, token, signal);
 
+		// The endpoint lists every pull request that *contains* the commit,
+		// which for a stacked branch also includes the pull requests of the
+		// branches below it. Only a pull request whose head is exactly this
+		// commit describes the branch that is checked out.
+		const atHead = items.filter(item => item?.head?.sha === sha);
+		const open = atHead.filter(item => item.state === 'open');
+		const candidates = open.length > 0 ? open : atHead;
+
+		// Branches that point at the same commit are indistinguishable by
+		// commit alone, so report none rather than guess at one of them.
+		return candidates.length === 1 ? toCreatedPullRequest(candidates[0]) : undefined;
+	}
+
+	/**
+	 * Issues a conditional GET for a pull request listing route, serving the
+	 * previously cached listing when the ETag still validates.
+	 */
+	private async _searchPullRequests(routeSlug: string, token: string, signal: AbortSignal): Promise<readonly GitHubPullRequestResponseItem[]> {
+		const cached = this.pullRequestSearchCache.get(routeSlug);
+		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, cached?.etag);
+
+		if (response.statusCode === 304) {
+			return cached?.items ?? [];
+		}
+
+		const items = Array.isArray(response.data) ? response.data : [];
 		if (response.etag) {
-			this.pullRequestSearchEtags.set(routeSlug, response.etag);
+			this.pullRequestSearchCache.set(routeSlug, { etag: response.etag, items });
 		}
-
-		if (
-			response.statusCode === 304 ||
-			!Array.isArray(response.data) ||
-			response.data.length === 0
-		) {
-			return undefined;
-		}
-
-		const first = response.data[0];
-		const html_url = first?.html_url;
-		const number = first?.number;
-		const node_id = first?.node_id;
-		return typeof html_url === 'string' && typeof number === 'number'
-			? {
-				number,
-				url: html_url,
-				nodeId: typeof node_id === 'string'
-					? node_id
-					: undefined
-			}
-			: undefined;
+		return items;
 	}
 
 	async getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest> {

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -133,6 +133,9 @@ export const IAgentHostOctoKitService = createDecorator<IAgentHostOctoKitService
 const GITHUB_API_VERSION = '2022-11-28';
 const MAX_ERROR_RESPONSE_BODY_LENGTH = 500;
 
+/** Page size, and therefore upper bound, for the pull requests read per commit. */
+const MAX_COMMIT_PULL_REQUESTS = 100;
+
 const ENABLE_AUTO_MERGE_MUTATION = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
 	enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
 		pullRequest { id }
@@ -196,13 +199,22 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 	}
 
 	async findPullRequestByHeadSha(owner: string, repo: string, sha: string, token: string, signal: AbortSignal): Promise<CreatedPullRequest | undefined> {
-		const routeSlug = `repos/${owner}/${repo}/commits/${encodeURIComponent(sha)}/pulls?per_page=100`;
+		const routeSlug = `repos/${owner}/${repo}/commits/${encodeURIComponent(sha)}/pulls?per_page=${MAX_COMMIT_PULL_REQUESTS}`;
 		const items = await this._searchPullRequests(routeSlug, token, signal);
 
-		// The endpoint lists every pull request that *contains* the commit,
-		// which for a stacked branch also includes the pull requests of the
-		// branches below it. Only a pull request whose head is exactly this
-		// commit describes the branch that is checked out.
+		// Only the first page is read. A full page means later pages could hold
+		// further candidates, so neither the match nor its uniqueness can be
+		// established — a commit associated with this many pull requests is not
+		// one this lookup can speak for anyway.
+		if (items.length >= MAX_COMMIT_PULL_REQUESTS) {
+			this._logService.warn(`[AgentHostOctoKitService] Not resolving a pull request for ${sha}: more than ${MAX_COMMIT_PULL_REQUESTS} are associated with it`);
+			return undefined;
+		}
+
+		// The endpoint also lists pull requests that merely *contain* the
+		// commit, such as those of the branches below a stacked branch. Only a
+		// pull request whose head is exactly this commit describes the branch
+		// that is checked out.
 		const atHead = items.filter(item => item?.head?.sha === sha);
 		const open = atHead.filter(item => item.state === 'open');
 		const candidates = open.length > 0 ? open : atHead;
@@ -217,7 +229,10 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 	 * previously cached listing when the ETag still validates.
 	 */
 	private async _searchPullRequests(routeSlug: string, token: string, signal: AbortSignal): Promise<readonly GitHubPullRequestResponseItem[]> {
-		const cached = this.pullRequestSearchCache.get(routeSlug);
+		// Validators and bodies are scoped to the host that issued them, which
+		// can change when the endpoint is repointed at another GitHub instance.
+		const cacheKey = `${this._endpoint.getApiBaseUri()}/${routeSlug}`;
+		const cached = this.pullRequestSearchCache.get(cacheKey);
 		const response = await this._makeGHAPIRequest<GitHubPullRequestResponseItem[]>(routeSlug, 'GET', token, signal, undefined, cached?.etag);
 
 		if (response.statusCode === 304) {
@@ -226,7 +241,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 
 		const items = Array.isArray(response.data) ? response.data : [];
 		if (response.etag) {
-			this.pullRequestSearchCache.set(routeSlug, { etag: response.etag, items });
+			this.pullRequestSearchCache.set(cacheKey, { etag: response.etag, items });
 		}
 		return items;
 	}

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -378,9 +378,8 @@ suite('AgentHostGitStateService', () => {
 
 	test('falls back to the commit at HEAD when the branch name matches no pull request', async () => {
 		await runWithFakedTimers({ useFakeTimers: true }, async () => {
-			// A branch checked out from a pull request head (`git switch -c
-			// <local> FETCH_HEAD`) has neither an upstream nor a name that
-			// exists on the remote, so only the commit identifies the PR.
+			// A branch checked out from a pull request head: no upstream, and a
+			// name that does not exist on the remote.
 			const gitState: ISessionGitState = { branchName: 'local-only', baseBranchName: 'main' };
 			const h = createHarness();
 			seedSession(h.stateManager, {

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -90,6 +90,7 @@ suite('AgentHostGitStateService', () => {
 		const gitCalls: string[] = [];
 		let gitResult: ISessionGitState | undefined;
 		let gitError: Error | undefined;
+		let headSha: string | undefined;
 		const gitService: IAgentHostGitService = {
 			...createNoopGitService(),
 			getSessionGitState: async (workingDirectory: URI) => {
@@ -99,16 +100,23 @@ suite('AgentHostGitStateService', () => {
 				}
 				return gitResult;
 			},
+			revParse: async () => headSha,
 		};
 
 		const pullRequestCalls: string[] = [];
+		const pullRequestShaCalls: string[] = [];
 		const pullRequestsByBranch = new Map<string, CreatedPullRequest>();
+		const pullRequestsBySha = new Map<string, CreatedPullRequest>();
 		let onPullRequestLookup: ((branch: string) => Promise<void>) | undefined;
 		const octoKitService = {
 			findPullRequestByHeadBranch: async (_owner: string, _repo: string, branch: string) => {
 				pullRequestCalls.push(branch);
 				await onPullRequestLookup?.(branch);
 				return pullRequestsByBranch.get(branch);
+			},
+			findPullRequestByHeadSha: async (_owner: string, _repo: string, sha: string) => {
+				pullRequestShaCalls.push(sha);
+				return pullRequestsBySha.get(sha);
 			},
 		} as unknown as IAgentHostOctoKitService;
 		const agentService = { getAuthToken: () => 'token' } as unknown as IAgentService;
@@ -133,9 +141,12 @@ suite('AgentHostGitStateService', () => {
 			gitCalls,
 			runEvents,
 			pullRequestCalls,
+			pullRequestShaCalls,
 			setGitResult: (state: ISessionGitState | undefined) => { gitResult = state; },
 			setGitError: (error: Error) => { gitError = error; },
+			setHeadSha: (sha: string | undefined) => { headSha = sha; },
 			setPullRequest: (branch: string, pullRequest: CreatedPullRequest) => { pullRequestsByBranch.set(branch, pullRequest); },
+			setPullRequestForSha: (sha: string, pullRequest: CreatedPullRequest) => { pullRequestsBySha.set(sha, pullRequest); },
 			setOnPullRequestLookup: (fn: (branch: string) => Promise<void>) => { onPullRequestLookup = fn; },
 		};
 	}
@@ -331,6 +342,88 @@ suite('AgentHostGitStateService', () => {
 					pullRequestBranchName: 'feature',
 				},
 			});
+		});
+	});
+
+	test('looks a pull request up by the upstream branch rather than the local branch name', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = {
+				branchName: 'local-name',
+				baseBranchName: 'main',
+				upstreamBranchName: 'origin/remote-name',
+				githubHeadOwner: 'microsoft',
+			};
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('remote-name', { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 });
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				pullRequestShaCalls: h.pullRequestShaCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['remote-name'],
+				pullRequestShaCalls: [],
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'], pullRequestBranchName: 'local-name' },
+			});
+		});
+	});
+
+	test('falls back to the commit at HEAD when the branch name matches no pull request', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			// A branch checked out from a pull request head (`git switch -c
+			// <local> FETCH_HEAD`) has neither an upstream nor a name that
+			// exists on the remote, so only the commit identifies the PR.
+			const gitState: ISessionGitState = { branchName: 'local-only', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+			h.setHeadSha('1ce2c20d3dcb593273f604b077240543d494e276');
+			h.setPullRequestForSha('1ce2c20d3dcb593273f604b077240543d494e276', { url: 'https://github.com/microsoft/vscode/pull/2', number: 2 });
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				pullRequestShaCalls: h.pullRequestShaCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['local-only'],
+				pullRequestShaCalls: ['1ce2c20d3dcb593273f604b077240543d494e276'],
+				github: { owner: 'microsoft', repo: 'vscode', pullRequestUrls: ['https://github.com/microsoft/vscode/pull/2'], pullRequestBranchName: 'local-only' },
+			});
+		});
+	});
+
+	test('ignores an upstream branch that does not resolve to a GitHub remote', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = {
+				branchName: 'local-name',
+				baseBranchName: 'main',
+				upstreamBranchName: 'gitlab/remote-name',
+			};
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual(h.pullRequestCalls, ['local-name']);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -147,6 +147,9 @@ class TestOctoKitService implements IAgentHostOctoKitService {
 	async getIssueOrPullRequest(): Promise<GitHubIssueOrPullRequest> {
 		throw new Error('not used');
 	}
+	async findPullRequestByHeadSha(): Promise<CreatedPullRequest | undefined> {
+		throw new Error('not used');
+	}
 	async enablePullRequestAutoMerge(pullRequestId: string, mergeMethod: AutoMergeMethod, _token: string, _signal: AbortSignal): Promise<void> {
 		this.calls.push(`enablePullRequestAutoMerge:${pullRequestId}:${mergeMethod}`);
 		if (this.autoMergeError) {

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -63,6 +63,10 @@ class TestAgentHostOctoKitService implements IAgentHostOctoKitService {
 		throw new Error('not used');
 	}
 
+	async findPullRequestByHeadSha(): Promise<CreatedPullRequest | undefined> {
+		throw new Error('not used');
+	}
+
 	async getIssueOrPullRequest(owner: string, repo: string, number: number, token: string, signal: AbortSignal): Promise<GitHubIssueOrPullRequest> {
 		this.calls.push({ owner, repo, number, token, signal });
 		const key = `${owner}/${repo}#${number}`;

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -8,6 +8,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { NullLogService } from '../../../../log/common/log.js';
 import { AgentHostOctoKitService, type FetchFunction } from '../../../node/shared/agentHostOctoKitService.js';
 import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
+import { deriveGitHubEndpoints } from '../../../common/githubEndpoints.js';
+import type { IAgentHostGitHubEndpointService } from '../../../node/agentHostGitHubEndpointService.js';
 
 type Captured = { url: string; init: RequestInit | undefined };
 
@@ -117,8 +119,7 @@ suite('AgentHostOctoKitService', () => {
 	});
 
 	test('findPullRequestByHeadSha returns the pull request whose head is the commit', async () => {
-		// The endpoint also lists pull requests that merely *contain* the
-		// commit, e.g. those of the branches below a stacked branch.
+		// Pull request 1 only contains the commit; 9 has it as its head.
 		const { fetch, captured } = capturingFetch(jsonResponse([
 			{ html_url: 'https://github.com/o/r/pull/1', number: 1, state: 'open', head: { sha: 'aaa' } },
 			{ html_url: 'https://github.com/o/r/pull/9', number: 9, state: 'open', head: { sha: 'bbb' }, node_id: 'PR_node_9' },
@@ -171,6 +172,34 @@ suite('AgentHostOctoKitService', () => {
 			first: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
 			revalidated: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
 		});
+	});
+
+	test('findPullRequestByHeadSha reports none when the commit fills a whole page of pull requests', async () => {
+		const page = Array.from({ length: 100 }, (_, index) => ({ html_url: `https://github.com/o/r/pull/${index}`, number: index, state: 'open', head: { sha: index === 0 ? 'bbb' : 'aaa' } }));
+		const service = makeService(capturingFetch(jsonResponse(page)).fetch);
+
+		assert.strictEqual(await service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal()), undefined);
+	});
+
+	test('scopes the pull request cache to the GitHub host that issued the validator', async () => {
+		let enterpriseUri: string | undefined;
+		const endpointService: IAgentHostGitHubEndpointService = {
+			...createTestGitHubEndpointService(),
+			getApiBaseUri: () => deriveGitHubEndpoints(enterpriseUri).apiBaseUri,
+		};
+		const requests: (string | undefined)[] = [];
+		const service = new AgentHostOctoKitService(async (_input, init) => {
+			requests.push((init?.headers as Record<string, string>)['If-None-Match']);
+			return new Response(JSON.stringify([{ html_url: 'https://github.com/o/r/pull/9', number: 9 }]), { status: 200, headers: { 'content-type': 'application/json', etag: 'W/"tag"' } });
+		}, new NullLogService(), endpointService);
+
+		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+		enterpriseUri = 'https://ghe.example.com';
+		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+
+		// The validator is replayed only against the host that issued it.
+		assert.deepStrictEqual(requests, [undefined, 'W/"tag"', undefined]);
 	});
 
 	test('getIssueOrPullRequest fetches the title and body from the issues endpoint', async () => {

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -116,6 +116,63 @@ suite('AgentHostOctoKitService', () => {
 		assert.strictEqual(captured().url, 'https://api.github.com/repos/o/r/pulls?head=fork-owner%3Afeature%2Ftest&state=all&sort=updated&direction=desc&per_page=1');
 	});
 
+	test('findPullRequestByHeadSha returns the pull request whose head is the commit', async () => {
+		// The endpoint also lists pull requests that merely *contain* the
+		// commit, e.g. those of the branches below a stacked branch.
+		const { fetch, captured } = capturingFetch(jsonResponse([
+			{ html_url: 'https://github.com/o/r/pull/1', number: 1, state: 'open', head: { sha: 'aaa' } },
+			{ html_url: 'https://github.com/o/r/pull/9', number: 9, state: 'open', head: { sha: 'bbb' }, node_id: 'PR_node_9' },
+		]));
+		const service = makeService(fetch);
+
+		const result = await service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal());
+
+		assert.deepStrictEqual({
+			result,
+			url: captured().url,
+			method: captured().init?.method,
+		}, {
+			result: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: 'PR_node_9' },
+			url: 'https://api.github.com/repos/o/r/commits/bbb/pulls?per_page=100',
+			method: 'GET',
+		});
+	});
+
+	test('findPullRequestByHeadSha ignores pull requests that only contain the commit', async () => {
+		const service = makeService(capturingFetch(jsonResponse([
+			{ html_url: 'https://github.com/o/r/pull/1', number: 1, state: 'open', head: { sha: 'aaa' } },
+		])).fetch);
+
+		assert.strictEqual(await service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal()), undefined);
+	});
+
+	test('findPullRequestByHeadSha reports none when several pull requests share the head commit', async () => {
+		const service = makeService(capturingFetch(jsonResponse([
+			{ html_url: 'https://github.com/o/r/pull/1', number: 1, state: 'open', head: { sha: 'bbb' } },
+			{ html_url: 'https://github.com/o/r/pull/2', number: 2, state: 'open', head: { sha: 'bbb' } },
+		])).fetch);
+
+		assert.strictEqual(await service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal()), undefined);
+	});
+
+	test('serves the previously fetched pull request when the ETag still validates', async () => {
+		let call = 0;
+		const service = makeService(async () => {
+			call++;
+			return call === 1
+				? new Response(JSON.stringify([{ html_url: 'https://github.com/o/r/pull/9', number: 9 }]), { status: 200, headers: { 'content-type': 'application/json', etag: 'W/"tag"' } })
+				: new Response(null, { status: 304, headers: { etag: 'W/"tag"' } });
+		});
+
+		const first = await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+		const revalidated = await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
+
+		assert.deepStrictEqual({ first, revalidated }, {
+			first: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
+			revalidated: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: undefined },
+		});
+	});
+
 	test('getIssueOrPullRequest fetches the title and body from the issues endpoint', async () => {
 		const { fetch, captured } = capturingFetch(jsonResponse({ title: 'Issue title', body: 'Issue body' }));
 		const service = makeService(fetch);

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -182,10 +182,10 @@ suite('AgentHostOctoKitService', () => {
 	});
 
 	test('scopes the pull request cache to the GitHub host that issued the validator', async () => {
-		let enterpriseUri: string | undefined;
+		let apiBaseUri = deriveGitHubEndpoints(undefined).apiBaseUri;
 		const endpointService: IAgentHostGitHubEndpointService = {
 			...createTestGitHubEndpointService(),
-			getApiBaseUri: () => deriveGitHubEndpoints(enterpriseUri).apiBaseUri,
+			getApiBaseUri: () => apiBaseUri,
 		};
 		const requests: (string | undefined)[] = [];
 		const service = new AgentHostOctoKitService(async (_input, init) => {
@@ -195,7 +195,7 @@ suite('AgentHostOctoKitService', () => {
 
 		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
 		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
-		enterpriseUri = 'https://ghe.example.com';
+		apiBaseUri = deriveGitHubEndpoints('https://ghe.example.com').apiBaseUri;
 		await service.findPullRequestByHeadBranch('o', 'r', 'feature', 'tok', signal());
 
 		// The validator is replayed only against the host that issued it.


### PR DESCRIPTION
Agent-host sessions did not associate an open pull request when the session worked on that PR's head under a differently named local branch.

### Root cause

`AgentHostGitStateService._attachSessionGitHubPullRequest` looked the pull request up with the **local** branch name from `git status -b --porcelain=v2`:

```ts
findPullRequestByHeadBranch(gitHubState.owner, gitHubState.repo, branchName, ...)
// -> repos/{owner}/{repo}/pulls?head={owner}:{localBranchName}
```

A session that checks out a pull request head with `git fetch origin pull/N/head` + `git switch -c <local> FETCH_HEAD` (no `-u`) and pushes with an explicit refspec has no upstream tracking ref, and no remote branch of that local name. The query therefore correctly returned `[]` on every lookup — the agent host logs show the same request repeated 18 times over three days, always for the local name, never for the PR's actual head branch.

Two failure modes come out of that single line:

- **False negative** — the local branch name differs from the remote head branch name.
- **False positive** — the local branch name happens to collide with an unrelated remote branch that has a pull request.

Detection itself was working: it ran on turn completion, session restore, and branch change, with a valid token and no API errors. It was simply asking the wrong question. The `!pr?.url` path also returned silently, which made this hard to diagnose.

### Fix

- **Resolve the remote head branch from the upstream tracking ref** when there is one, mirroring what `agentHostPullRequestOperationHandler` already does when *creating* a pull request. The two paths now derive `headBranch`/`headOwner` identically, including the guard that ignores an upstream on a non-GitHub remote.
- **Fall back to the commit at HEAD** via a new `findPullRequestByHeadSha` (`GET /repos/{owner}/{repo}/commits/{sha}/pulls`) when the branch name matches nothing. The commit identifies the pull request regardless of how the branch is named locally, so this also covers branches that track nothing at all.

  That endpoint lists every pull request that *contains* the commit, so only pull requests whose `head.sha` is exactly that commit are considered — otherwise the base pull request of a stacked branch could be attached. When several pull requests share the same head commit they are indistinguishable, so none is reported rather than guessing.

  The branch lookup stays first: it is the cheap path, and it keeps working when the session has committed locally beyond what was last pushed (HEAD then no longer equals the pull request head).

- **Cache pull request listings alongside their ETag.** Only the ETag was cached, so a revalidated (`304`) route returned "no pull request" despite the cached response containing one — which could drop a known pull request after switching branches away and back.

- Added a `trace` log on the "no pull request found" path.

`parseUpstreamBranchName` moved from a module-local helper in `agentHostPullRequestOperationHandler.ts` to `common/agentHostGitService.ts` so both paths share it.

### Tests

New coverage in `agentHostGitStateService.test.ts` and `shared/agentHostOctoKitService.test.ts`:

- looks up by the upstream branch rather than the local branch name
- ignores an upstream branch that does not resolve to a GitHub remote
- falls back to the commit at HEAD when the branch name matches no pull request
- `findPullRequestByHeadSha` returns the pull request whose head is the commit
- `findPullRequestByHeadSha` ignores pull requests that only contain the commit
- `findPullRequestByHeadSha` reports none when several pull requests share the head commit
- serves the previously fetched pull request when the ETag still validates

All agent-host unit tests pass (the 6 failures in `sessionPermissions.test.js` are pre-existing on this branch point and unrelated).
