### PR TITLE
Fix typos in comments and strings across editor source files

### DIFF
--- a/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
@@ -162,7 +162,7 @@ export class TextureAtlas extends Disposable {
 
 	/**
 	 * Warms up the atlas by rasterizing all printable ASCII characters for each token color. This
-	 * is distrubuted over multiple idle callbacks to avoid blocking the main thread.
+	 * is distributed over multiple idle callbacks to avoid blocking the main thread.
 	 */
 	private _warmUpAtlas(rasterizer: IGlyphRasterizer): void {
 		const colorMap = this._colorMap;

--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -128,7 +128,7 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}
 
-		// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position
+		// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position
 		let anchor: IMouseEvent | null = null;
 		if (e.target.type !== MouseTargetType.TEXTAREA) {
 			anchor = e.event;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -330,7 +330,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 					return offsetDigits[i].usableWidthLeftOfLineNumber;
 				}
 			}
-			throw new BugIndicatingError('Could not find avilable width for icon');
+			throw new BugIndicatingError('Could not find available width for icon');
 		};
 	});
 

--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -107,7 +107,7 @@ export class MessageController implements IEditorContribution {
 			}
 
 			if (!bounds) {
-				// define bounding box around position and first mouse occurance
+				// define bounding box around position and first mouse occurrence
 				bounds = new Range(position.lineNumber - 3, 1, e.target.position.lineNumber + 3, 1);
 			} else if (!bounds.containsPosition(e.target.position)) {
 				// check if position is still in bounds

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -138,7 +138,7 @@ export class SnippetController2 implements IEditorContribution {
 		}
 
 		// don't listen while inserting the snippet
-		// as that is the inflight state causing cancelation
+		// as that is the inflight state causing cancellation
 		this._snippetListener.clear();
 
 		if (opts.undoStopBefore) {
@@ -163,7 +163,7 @@ export class SnippetController2 implements IEditorContribution {
 			this._editor.getModel().pushStackElement();
 		}
 
-		// regster completion item provider when there is any choice element
+		// register completion item provider when there is any choice element
 		if (this._session?.hasChoice) {
 			const provider: CompletionItemProvider = {
 				_debugDisplayName: 'snippetChoiceCompletions',

--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -136,7 +136,7 @@ export class OneSnippet {
 
 		} else {
 			// the selection of the current placeholder might
-			// not acurate any more -> simply restore it
+			// not accurate any more -> simply restore it
 		}
 
 		const newSelections = model.changeDecorations(accessor => {
@@ -175,7 +175,7 @@ export class OneSnippet {
 				}
 			}
 
-			// change stickness to never grow when typing at its edges
+			// change stickiness to never grow when typing at its edges
 			// so that in-active tabstops never grow
 			for (const [placeholder, id] of this._placeholderDecorations!) {
 				if (!activePlaceholders.has(placeholder)) {
@@ -319,7 +319,7 @@ export class OneSnippet {
 				console.assert(nested._offset !== -1);
 				console.assert(!nested._placeholderDecorations);
 
-				// Massage placeholder-indicies of the nested snippet to be
+				// Massage placeholder-indices of the nested snippet to be
 				// sorted right after the insertion point. This ensures we move
 				// through the placeholders in the correct order
 				const indexLastPlaceholder = nested._snippet.placeholderInfo.last!.index;
@@ -353,7 +353,7 @@ export class OneSnippet {
 				}
 			}
 
-			// Renormalize fractional placeholder indicies back to small integers.
+			// Renormalize fractional placeholder indices back to small integers.
 			// Without this, deeply nested merges (~16+ levels) lose floating-point
 			// precision so distinct placeholders collapse onto the same index and
 			// produce phantom cursors. #279349
@@ -525,7 +525,7 @@ export class SnippetSession {
 		// `keepWhitespace` should be overruled for secondary selections
 		const firstLineFirstNonWhitespace = model.getLineFirstNonWhitespaceColumn(editor.getSelection().positionLineNumber);
 
-		// sort selections by their start position but remeber
+		// sort selections by their start position but remember
 		// the original index. that allows you to create correct
 		// offset-based selection logic without changing the
 		// primary selection

--- a/src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts
@@ -154,7 +154,7 @@ export class SuggestInlineCompletions extends Disposable implements InlineComple
 		}
 
 		// We consider non-empty leading words and trigger characters. The latter only
-		// when no word is being typed (word characters superseed trigger characters)
+		// when no word is being typed (word characters supersede trigger characters)
 		let wordInfo = model.getWordAtPosition(position);
 		let triggerCharacterInfo: { ch: string; providers: Set<CompletionItemProvider> } | undefined;
 
@@ -188,7 +188,7 @@ export class SuggestInlineCompletions extends Disposable implements InlineComple
 			result = this._lastResult;
 
 		} else {
-			// refesh model is required
+			// refresh model is required
 			const completions = await provideSuggestionItems(
 				this._languageFeatureService.completionProvider,
 				model, position,

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -790,7 +790,7 @@ export class SuggestWidget implements IDisposable {
 		this.element.clearSashHoverState();
 
 		// ensure that a reasonable widget height is persisted so that
-		// accidential "resize-to-single-items" cases aren't happening
+		// accidental "resize-to-single-items" cases aren't happening
 		const dim = this._persistedSize.restore();
 		const minPersistedHeight = Math.ceil(this.getLayoutInfo().itemHeight * 4.3);
 		if (dim && dim.height < minPersistedHeight) {


### PR DESCRIPTION
All fixes are in code comments or string literals, not identifiers:

- snippetController2.ts: cancelation -> cancellation, regster -> register
- snippetSession.ts: acurate -> accurate, stickness -> stickiness,
  indicies -> indices (x2), remeber -> remember
- suggestInlineCompletions.ts: superseed -> supersede, refesh -> refresh
- suggestWidget.ts: accidential -> accidental
- textureAtlas.ts: distrubuted -> distributed
- contextmenu.ts: triggerd -> triggered
- messageController.ts: occurance -> occurrence
- gutterIndicatorView.ts: avilable -> available (user-facing error message)