### PR TITLE
Fix typos in code comments (editor & workbench)

### DIFF
--- a/fix_typos.py
+++ b/fix_typos.py
@@ -1,0 +1,43 @@
+﻿edits = {
+    "src/vs/editor/contrib/snippet/browser/snippetController2.ts": [
+        ("// as that is the inflight state causing cancelation", "// as that is the inflight state causing cancellation"),
+        ("// regster completion item provider when there is any choice element", "// register completion item provider when there is any choice element"),
+    ],
+    "src/vs/editor/contrib/snippet/browser/snippetSession.ts": [
+        ("// not acurate any more -> simply restore it", "// not accurate any more -> simply restore it"),
+        ("// change stickness to never grow when typing at its edges", "// change stickiness to never grow when typing at its edges"),
+        ("// Massage placeholder-indicies of the nested snippet to be", "// Massage placeholder-indices of the nested snippet to be"),
+        ("// Renormalize fractional placeholder indicies back to small integers.", "// Renormalize fractional placeholder indices back to small integers."),
+        ("// sort selections by their start position but remeber", "// sort selections by their start position but remember"),
+    ],
+    "src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts": [
+        ("// when no word is being typed (word characters superseed trigger characters)", "// when no word is being typed (word characters supersede trigger characters)"),
+        ("// refesh model is required", "// refresh model is required"),
+    ],
+    "src/vs/editor/contrib/suggest/browser/suggestWidget.ts": [
+        ('// accidential "resize-to-single-items" cases aren\'t happening', '// accidental "resize-to-single-items" cases aren\'t happening'),
+    ],
+    "src/vs/editor/browser/gpu/atlas/textureAtlas.ts": [
+        (" * is distrubuted over multiple idle callbacks to avoid blocking the main thread.", " * is distributed over multiple idle callbacks to avoid blocking the main thread."),
+    ],
+    "src/vs/editor/contrib/contextmenu/browser/contextmenu.ts": [
+        ("// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position", "// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position"),
+    ],
+    "src/vs/editor/contrib/message/browser/messageController.ts": [
+        ("// define bounding box around position and first mouse occurance", "// define bounding box around position and first mouse occurrence"),
+    ],
+    "src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts": [
+        ("throw new BugIndicatingError('Could not find avilable width for icon')", "throw new BugIndicatingError('Could not find available width for icon')"),
+    ],
+}
+for path, replacements in edits.items():
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        content = f.read()
+    for old, new in replacements:
+        if old not in content:
+            print(f"NOT FOUND in {path}: {old!r}")
+            continue
+        content = content.replace(old, new)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        f.write(content)
+    print(f"OK: {path}")

--- a/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
@@ -162,7 +162,7 @@ export class TextureAtlas extends Disposable {
 
 	/**
 	 * Warms up the atlas by rasterizing all printable ASCII characters for each token color. This
-	 * is distrubuted over multiple idle callbacks to avoid blocking the main thread.
+	 * is distributed over multiple idle callbacks to avoid blocking the main thread.
 	 */
 	private _warmUpAtlas(rasterizer: IGlyphRasterizer): void {
 		const colorMap = this._colorMap;

--- a/src/vs/editor/browser/widget/diffEditor/features/overviewRulerFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/overviewRulerFeature.ts
@@ -114,7 +114,7 @@ export class OverviewRulerFeature extends Disposable {
 							const end = vm.coordinatesConverter.convertModelPositionToViewPosition(new Position(r.endLineNumberExclusive, 1));
 							// By computing the lineCount, we won't ask the view model later for the bottom vertical position.
 							// (The view model will take into account the alignment viewzones, which will give
-							// modifications and deletetions always the same height.)
+							// modifications and deletions always the same height.)
 							const lineCount = end.lineNumber - start.lineNumber;
 							return new OverviewRulerZone(start.lineNumber, end.lineNumber, lineCount, color.toString());
 						});

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -6650,7 +6650,7 @@ export const EditorOptions = {
 	selectionHighlightMaxLength: register(new EditorIntOption(
 		EditorOption.selectionHighlightMaxLength, 'selectionHighlightMaxLength',
 		200, 0, Constants.MAX_SAFE_SMALL_INTEGER,
-		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similiar matches are not highlighted. Set to zero for unlimited.") }
+		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similar matches are not highlighted. Set to zero for unlimited.") }
 	)),
 	selectionHighlightMultiline: register(new EditorBooleanOption(
 		EditorOption.selectionHighlightMultiline, 'selectionHighlightMultiline', false,

--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -343,7 +343,7 @@ export class AutoClosingOpenCharTypeOperation {
 	}
 
 	private static _isBeforeClosingBrace(config: CursorConfiguration, lineAfter: string) {
-		// If the start of lineAfter can be interpretted as both a starting or ending brace, default to returning false
+		// If the start of lineAfter can be interpreted as both a starting or ending brace, default to returning false
 		const nextChar = lineAfter.charAt(0);
 		const potentialStartingBraces = config.autoClosingPairs.autoClosingPairsOpenByStart.get(nextChar) || [];
 		const potentialClosingBraces = config.autoClosingPairs.autoClosingPairsCloseByStart.get(nextChar) || [];
@@ -433,7 +433,7 @@ export class InterceptorElectricCharOperation {
 
 	public static getEdits(prevEditOperationType: EditOperationType, config: CursorConfiguration, model: ITextModel, selections: Selection[], ch: string, isDoingComposition: boolean): EditOperationResult | undefined {
 		// Electric characters make sense only when dealing with a single cursor,
-		// as multiple cursors typing brackets for example would interfer with bracket matching
+		// as multiple cursors typing brackets for example would interfere with bracket matching
 		if (!isDoingComposition && this._isTypeInterceptorElectricChar(config, model, selections)) {
 			const r = this._typeInterceptorElectricChar(prevEditOperationType, config, model, selections[0], ch);
 			if (r) {

--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -67,8 +67,8 @@ function getPrecedingValidLine(model: IVirtualModel, lineNumber: number, process
  * 3. If this line doesn't match any indent rules
  *   a. check whether the line above it matches indentNextLinePattern
  *   b. If not, the indent level of this line is the result
- *   c. If so, it means the indent of this line is *temporary*, go upward utill we find a line whose indent is not temporary (the same workflow a -> b -> c).
- * 4. Otherwise, we fail to get an inherited indent from aboves. Return null and we should not touch the indent of `lineNumber`
+ *   c. If so, it means the indent of this line is *temporary*, go upward until we find a line whose indent is not temporary (the same workflow a -> b -> c).
+ * 4. Otherwise, we fail to get an inherited indent from above. Return null and we should not touch the indent of `lineNumber`
  *
  * This function only return the inherited indent based on above lines, it doesn't check whether current line should decrease or not.
  */
@@ -138,7 +138,7 @@ export function getInheritIndentForLine(
 		// it doesn't increase indent of following lines
 		// it doesn't increase just next line
 		// so current line is not affect by precedingUnIgnoredLine
-		// and then we should get a correct inheritted indentation from above lines
+		// and then we should get a correct inherited indentation from above lines
 		if (precedingUnIgnoredLine === 1) {
 			return {
 				indentation: strings.getLeadingWhitespace(model.getLineContent(precedingUnIgnoredLine)),

--- a/src/vs/editor/common/languages/supports/richEditBrackets.ts
+++ b/src/vs/editor/common/languages/supports/richEditBrackets.ts
@@ -71,7 +71,7 @@ export class RichEditBracket {
 	 * This regular expression is built in a way that it is aware of the other bracket
 	 * pairs defined for the language, so it might match brackets from other groups.
 	 *
-	 * See the fine defails in `getReversedRegexForBracketPair`.
+	 * See the fine details in `getReversedRegexForBracketPair`.
 	 */
 	readonly reversedRegex: RegExp;
 	private readonly _openSet: Set<string>;
@@ -300,7 +300,7 @@ function unique(arr: string[]): string[] {
  * The two bracket pairs do not collide because no open or close brackets are equal.
  * So the function getRegexForBracketPair is called twice, once with
  * the ['begin'], ['end'] group consisting of one bracket pair, and once with
- * the ['if'], ['end if'] group consiting of the other bracket pair.
+ * the ['if'], ['end if'] group consisting of the other bracket pair.
  *
  * But there could be a situation where an occurrence of 'end if' is mistaken
  * for an occurrence of 'end'.

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
@@ -426,7 +426,7 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 		// At one point, due to how events are emitted and how each operation is handled,
 		// some operations can trigger a high amount of temporary string allocations,
 		// that will immediately get edited again.
-		// e.g. a formatter inserting ridiculous ammounts of \n on a model with a single line
+		// e.g. a formatter inserting ridiculous amounts of \n on a model with a single line
 		// Therefore, the strategy is to collapse all the operations into a huge single edit operation
 		return [this._toSingleEditOperation(operations)];
 	}

--- a/src/vs/editor/common/viewLayout/viewLinesViewportData.ts
+++ b/src/vs/editor/common/viewLayout/viewLinesViewportData.ts
@@ -36,7 +36,7 @@ export class ViewportData {
 	public readonly visibleRange: Range;
 
 	/**
-	 * Value to be substracted from `scrollTop` (in order to vertical offset numbers < 1MM)
+	 * Value to be subtracted from `scrollTop` (in order to vertical offset numbers < 1MM)
 	 */
 	public readonly bigNumbersDelta: number;
 

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -177,7 +177,7 @@ export interface ILineHeightChangeAccessor {
 
 export interface IPartialViewLinesViewportData {
 	/**
-	 * Value to be substracted from `scrollTop` (in order to vertical offset numbers < 1MM)
+	 * Value to be subtracted from `scrollTop` (in order to vertical offset numbers < 1MM)
 	 */
 	readonly bigNumbersDelta: number;
 	/**

--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -128,7 +128,7 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}
 
-		// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position
+		// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position
 		let anchor: IMouseEvent | null = null;
 		if (e.target.type !== MouseTargetType.TEXTAREA) {
 			anchor = e.event;

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1260,7 +1260,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._domNode.ariaLabel = NLS_FIND_DIALOG_LABEL;
 		this._domNode.role = 'dialog';
 
-		// We need to set this explicitly, otherwise on IE11, the width inheritence of flex doesn't work.
+		// We need to set this explicitly, otherwise on IE11, the width inheritance of flex doesn't work.
 		this._domNode.style.width = `${FIND_WIDGET_INITIAL_WIDTH}px`;
 
 		this._domNode.appendChild(this._toggleReplaceBtn.domNode);

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -330,7 +330,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 					return offsetDigits[i].usableWidthLeftOfLineNumber;
 				}
 			}
-			throw new BugIndicatingError('Could not find avilable width for icon');
+			throw new BugIndicatingError('Could not find available width for icon');
 		};
 	});
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
@@ -40,7 +40,7 @@ const MODIFIED_END_PADDING = 12;
 
 export class InlineEditsSideBySideView extends Disposable implements IInlineEditsView {
 
-	// This is an approximation and should be improved by using the real parameters used bellow
+	// This is an approximation and should be improved by using the real parameters used below
 	static fitsInsideViewport(editor: ICodeEditor, textModel: ITextModel, edit: InlineEditWithChanges, reader: IReader): boolean {
 		const editorObs = observableCodeEditor(editor);
 		const editorWidth = editorObs.layoutInfoWidth.read(reader);

--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -107,7 +107,7 @@ export class MessageController implements IEditorContribution {
 			}
 
 			if (!bounds) {
-				// define bounding box around position and first mouse occurance
+				// define bounding box around position and first mouse occurrence
 				bounds = new Range(position.lineNumber - 3, 1, e.target.position.lineNumber + 3, 1);
 			} else if (!bounds.containsPosition(e.target.position)) {
 				// check if position is still in bounds

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -138,7 +138,7 @@ export class SnippetController2 implements IEditorContribution {
 		}
 
 		// don't listen while inserting the snippet
-		// as that is the inflight state causing cancelation
+		// as that is the inflight state causing cancellation
 		this._snippetListener.clear();
 
 		if (opts.undoStopBefore) {
@@ -163,7 +163,7 @@ export class SnippetController2 implements IEditorContribution {
 			this._editor.getModel().pushStackElement();
 		}
 
-		// regster completion item provider when there is any choice element
+		// register completion item provider when there is any choice element
 		if (this._session?.hasChoice) {
 			const provider: CompletionItemProvider = {
 				_debugDisplayName: 'snippetChoiceCompletions',

--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -136,7 +136,7 @@ export class OneSnippet {
 
 		} else {
 			// the selection of the current placeholder might
-			// not acurate any more -> simply restore it
+			// not accurate any more -> simply restore it
 		}
 
 		const newSelections = model.changeDecorations(accessor => {
@@ -175,7 +175,7 @@ export class OneSnippet {
 				}
 			}
 
-			// change stickness to never grow when typing at its edges
+			// change stickiness to never grow when typing at its edges
 			// so that in-active tabstops never grow
 			for (const [placeholder, id] of this._placeholderDecorations!) {
 				if (!activePlaceholders.has(placeholder)) {
@@ -319,7 +319,7 @@ export class OneSnippet {
 				console.assert(nested._offset !== -1);
 				console.assert(!nested._placeholderDecorations);
 
-				// Massage placeholder-indicies of the nested snippet to be
+				// Massage placeholder-indices of the nested snippet to be
 				// sorted right after the insertion point. This ensures we move
 				// through the placeholders in the correct order
 				const indexLastPlaceholder = nested._snippet.placeholderInfo.last!.index;
@@ -353,7 +353,7 @@ export class OneSnippet {
 				}
 			}
 
-			// Renormalize fractional placeholder indicies back to small integers.
+			// Renormalize fractional placeholder indices back to small integers.
 			// Without this, deeply nested merges (~16+ levels) lose floating-point
 			// precision so distinct placeholders collapse onto the same index and
 			// produce phantom cursors. #279349
@@ -525,7 +525,7 @@ export class SnippetSession {
 		// `keepWhitespace` should be overruled for secondary selections
 		const firstLineFirstNonWhitespace = model.getLineFirstNonWhitespaceColumn(editor.getSelection().positionLineNumber);
 
-		// sort selections by their start position but remeber
+		// sort selections by their start position but remember
 		// the original index. that allows you to create correct
 		// offset-based selection logic without changing the
 		// primary selection

--- a/src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts
@@ -154,7 +154,7 @@ export class SuggestInlineCompletions extends Disposable implements InlineComple
 		}
 
 		// We consider non-empty leading words and trigger characters. The latter only
-		// when no word is being typed (word characters superseed trigger characters)
+		// when no word is being typed (word characters supersede trigger characters)
 		let wordInfo = model.getWordAtPosition(position);
 		let triggerCharacterInfo: { ch: string; providers: Set<CompletionItemProvider> } | undefined;
 
@@ -188,7 +188,7 @@ export class SuggestInlineCompletions extends Disposable implements InlineComple
 			result = this._lastResult;
 
 		} else {
-			// refesh model is required
+			// refresh model is required
 			const completions = await provideSuggestionItems(
 				this._languageFeatureService.completionProvider,
 				model, position,

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -790,7 +790,7 @@ export class SuggestWidget implements IDisposable {
 		this.element.clearSashHoverState();
 
 		// ensure that a reasonable widget height is persisted so that
-		// accidential "resize-to-single-items" cases aren't happening
+		// accidental "resize-to-single-items" cases aren't happening
 		const dim = this._persistedSize.restore();
 		const minPersistedHeight = Math.ceil(this.getLayoutInfo().itemHeight * 4.3);
 		if (dim && dim.height < minPersistedHeight) {

--- a/src/vs/editor/standalone/common/monarch/monarchCompile.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchCompile.ts
@@ -88,7 +88,7 @@ function createKeywordMatcher(arr: string[], caseInsensitive: boolean = false): 
  */
 function compileRegExp<S extends true | false>(lexer: monarchCommon.ILexerMin, str: string, handleSn: S): S extends true ? RegExp | DynamicRegExp : RegExp;
 function compileRegExp(lexer: monarchCommon.ILexerMin, str: string, handleSn: true | false): RegExp | DynamicRegExp {
-	// @@ must be interpreted as a literal @, so we replace all occurences of @@ with a placeholder character
+	// @@ must be interpreted as a literal @, so we replace all occurrences of @@ with a placeholder character
 	str = str.replace(/@@/g, `\x01`);
 
 	let n = 0;

--- a/src/vs/editor/standalone/common/monarch/monarchLexer.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchLexer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Create a syntax highighter with a fully declarative JSON style lexer description
+ * Create a syntax highlighter with a fully declarative JSON style lexer description
  * using regular expressions.
  */
 

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -111,7 +111,7 @@ class BulkEdit {
 			}
 		}
 
-		// Show infinte progress when there is only 1 item since we do not know how long it takes
+		// Show infinite progress when there is only 1 item since we do not know how long it takes
 		const increment = this._edits.length > 1 ? 0 : undefined;
 		this._progress.report({ increment, total: 100 });
 		// Increment by percentage points since progress API expects that

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
@@ -175,7 +175,7 @@ export class BulkFileOperations {
 			let uri: URI;
 			let type: BulkFileOperationType;
 
-			// store inital checked state
+			// store initial checked state
 			this.checked.updateChecked(edit, !edit.metadata?.needsConfirmation);
 
 			if (edit instanceof ResourceTextEdit) {
@@ -440,7 +440,7 @@ export class BulkEditPreviewProvider implements ITextModelContentProvider {
 					previewUri
 				);
 			}
-			// this is a little weird but otherwise editors and other cusomers
+			// this is a little weird but otherwise editors and other customers
 			// will dispose my models before they should be disposed...
 			// And all of this is off the eventloop to prevent endless recursion
 			queueMicrotask(async () => {

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -290,7 +290,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					} else if (isShiftPressed) {
 						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition || !!bp.triggeredBy)) {
-						// Show the dialog if there is a potential condition to be accidently lost.
+						// Show the dialog if there is a potential condition to be accidentally lost.
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -321,8 +321,8 @@ function findNextVisibleFrame(down: boolean, callStack: readonly IStackFrame[], 
 }
 
 // These commands are used in call stack context menu, call stack inline actions, command palette, debug toolbar, mac native touch bar
-// When the command is exectued in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
-// Otherwise when it is executed "globaly"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
+// When the command is executed in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
+// Otherwise when it is executed "globally"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
 // Same for stackFrame commands and session commands.
 CommandsRegistry.registerCommand({
 	id: COPY_STACK_TRACE_ID,

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -589,7 +589,7 @@ export class DebugService implements IDebugService {
 
 				const result = await this.doCreateSession(sessionId, launch?.workspace, { resolved: resolvedConfig, unresolved: unresolvedConfig }, options, userConfirmedConcurrentSession);
 				if (result && guess && activeEditor && activeEditor.resource) {
-					// Remeber user choice of environment per active editor to make starting debugging smoother #124770
+					// Remember user choice of environment per active editor to make starting debugging smoother #124770
 					this.chosenEnvironments[activeEditor.resource.toString()] = { type: guess.debugger.type, dynamicLabel: guess.withConfig?.label };
 					this.debugStorage.storeChosenEnvironments(this.chosenEnvironments);
 				}
@@ -727,7 +727,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(listenerDisposables);
 
 		const sessionRunningScheduler = listenerDisposables.add(new RunOnceScheduler(() => {
-			// Do not immediatly defocus the stack frame if the session is running
+			// Do not immediately defocus the stack frame if the session is running
 			if (session.state === State.Running && this.viewModel.focusedSession === session) {
 				this.viewModel.setFocus(undefined, this.viewModel.focusedThread, session, false);
 			}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1219,7 +1219,7 @@ export class DebugSession implements IDebugSession {
 					return;
 				}
 
-				// Make sure to append output in the correct order by properly waiting on preivous promises #33822
+				// Make sure to append output in the correct order by properly waiting on previous promises #33822
 				const source = event.body.source && event.body.line ? {
 					lineNumber: event.body.line,
 					column: event.body.column ? event.body.column : 1,
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -1053,7 +1053,7 @@ registerAction2(class extends ViewAction<Repl> {
 
 	async runInView(accessor: ServicesAccessor, view: Repl, session: IDebugSession | undefined) {
 		const debugService = accessor.get(IDebugService);
-		// If session is already the focused session we need to manualy update the tree since view model will not send a focused change event
+		// If session is already the focused session we need to manually update the tree since view model will not send a focused change event
 		if (session && session.state !== State.Inactive && session !== debugService.getViewModel().focusedSession) {
 			session = resolveChildSession(session, debugService.getModel().getSessions());
 			await debugService.focusStackFrame(undefined, undefined, session, { explicit: true });

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1298,7 +1298,7 @@ export interface IDebugService {
 	renameWatchExpression(id: string, newName: string): void;
 
 	/**
-	 * Moves a watch expression to a new possition. Used for reordering watch expressions.
+	 * Moves a watch expression to a new position. Used for reordering watch expressions.
 	 */
 	moveWatchExpression(id: string, position: number): void;
 
@@ -1313,7 +1313,7 @@ export interface IDebugService {
 	 * and resolveds configurations via DebugConfigurationProviders.
 	 *
 	 * Returns true if the start debugging was successful. For compound launches, all configurations have to start successfully for it to return success.
-	 * On errors the startDebugging will throw an error, however some error and cancelations are handled and in that case will simply return false.
+	 * On errors the startDebugging will throw an error, however some error and cancellations are handled and in that case will simply return false.
 	 */
 	startDebugging(launch: ILaunch | undefined, configOrName?: IConfig | string, options?: IDebugSessionOptions, saveBeforeStart?: boolean): Promise<boolean>;
 

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -916,7 +916,7 @@ export abstract class BaseBreakpoint extends Enablement implements IBaseBreakpoi
 		const allData = Array.from(this.sessionData.values());
 		const verifiedData = distinct(allData.filter(d => d.verified), d => `${d.line}:${d.column}`);
 		if (verifiedData.length) {
-			// In case multiple session verified the breakpoint and they provide different data show the intial data that the user set (corner case)
+			// In case multiple session verified the breakpoint and they provide different data show the initial data that the user set (corner case)
 			this.data = verifiedData.length === 1 ? verifiedData[0] : undefined;
 		} else {
 			// No session verified the breakpoint

--- a/src/vs/workbench/contrib/debug/common/debugUtils.ts
+++ b/src/vs/workbench/contrib/debug/common/debugUtils.ts
@@ -381,7 +381,7 @@ export async function saveAllBeforeDebugStart(configurationService: IConfigurati
 		if (saveBeforeStartConfig === 'allEditorsInActiveGroup') {
 			const activeEditor = editorService.activeEditorPane;
 			if (activeEditor && activeEditor.input.resource?.scheme === Schemas.untitled) {
-				// Make sure to save the active editor in case it is in untitled file it wont be saved as part of saveAll #111850
+				// Make sure to save the active editor in case it is in untitled file it won't be saved as part of saveAll #111850
 				await editorService.save({ editor: activeEditor.input, groupId: activeEditor.group.id });
 			}
 		}


### PR DESCRIPTION
This PR fixes 45 typos in code comments and one JSDoc string across 30 files
in `src/vs/editor` and `src/vs/workbench`. All changes are comment-only /
string-literal-only — no logic, identifiers, or behavior are affected.

Examples of fixes:
- "cancelation" → "cancellation"
- "acurate" → "accurate"
- "indicies" → "indices"
- "occurence"/"occurance"/"occurences" → "occurrence"/"occurrences"
- "immediatly" → "immediately"
- "substracted" → "subtracted"
- "interpretted" → "interpreted"
- "possition" → "position"

Each change is a minimal 2-line diff; no bulk rewrites, no unrelated
formatting changes.