### PR TITLE
test: stabilize Copilot terminal metadata E2E

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -12,6 +12,7 @@ import { retry } from '../../../../../../base/common/async.js';
 import { join } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
+import { AgentHostConfigKey } from '../../../../common/agentHostCustomizationConfig.js';
 import { AgentHostAutoReplyEnabledConfigKey } from '../../../../common/agentHostSchema.js';
 import { buildUncommittedChangesetUri } from '../../../../common/changesetUri.js';
 import { CopilotCliConfigKey } from '../../../../common/copilotCliConfig.js';
@@ -565,8 +566,12 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 	test('custom terminal tool preserves a nonzero shell exit code', async function () {
 		this.timeout(180_000);
 		const { sessionUri } = await createWorkspaceSession('custom-terminal-exit-code');
+		const deterministicShellConfig = context.isWindows ? {} : { [AgentHostConfigKey.DefaultShell]: '/bin/bash' };
 		try {
-			await setRootConfig({ [CopilotCliConfigKey.EnableCustomTerminalTool]: true }, 100);
+			await setRootConfig({
+				[CopilotCliConfigKey.EnableCustomTerminalTool]: true,
+				...deterministicShellConfig,
+			}, 100);
 			const turnId = 'turn-custom-terminal-exit-code';
 			await driveTurnToCompletion(context.client, sessionUri, turnId, 'Run exactly `node -e "process.exit(9)"` with bash, then reply exactly "failed as expected".', 1);
 			const shellStart = context.client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallStart'))
@@ -595,7 +600,10 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 				exitCode: 9,
 			});
 		} finally {
-			await setRootConfig({ [CopilotCliConfigKey.EnableCustomTerminalTool]: false }, 101);
+			await setRootConfig({
+				[CopilotCliConfigKey.EnableCustomTerminalTool]: false,
+				...(context.isWindows ? {} : { [AgentHostConfigKey.DefaultShell]: '' }),
+			}, 101);
 		}
 	});
 


### PR DESCRIPTION
## Summary

- configure `/bin/bash` on POSIX for the Copilot E2E scenario that verifies OSC 633 terminal command metadata
- restore the default-shell root configuration after the scenario so shared-server tests remain isolated

## Why

The macOS ARM64 product-build worker resolved the isolated Agent Host system shell to plain `sh`. Sentinel-based completion correctly preserved exit code 9, but `sh` does not emit the OSC 633 command metadata required by the strengthened assertion added in #329703. Selecting a supported shell makes the test exercise packaged shell integration deterministically instead of depending on the build account environment.

## Validation

- `npm run transpile-client`
- `npm run eslint -- src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts`
- focused Copilot Agent Host E2E replay: 1 passing
- complete Copilot Agent Host E2E replay: 143 passing, 18 pending

(Written by Copilot)