### PR TITLE
Fix prompt option disabled and reduced-motion styling

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -38,6 +38,8 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 - **Repository prompt options follow the draft workspace**: keep a contribution-owned watcher after the onboarding run step completes. A workspace change clears stale cards immediately, shows loading skeletons, cancels the old lookup, and resolves a fresh bounded option set for the replacement draft; completed candidates from a timed-out lookup remain available only when their repository context is still current.
 
+- **Prompt-option disabled presentation must not reuse Button's shared `.disabled` opacity**: the base rule is `!important`, so component-specific selected/disabled opacity cannot win without another forbidden override. Keep cards focusable, expose `aria-disabled`, gate activation in the component, and use a component-owned state class; gate skeleton animation with `.monaco-reduce-motion` so the effective `workbench.reduceMotion` setting wins over the OS media query.
+
 - **Agent-host onboarding readiness comes from advertised session types, not provider registration**: an agent-host provider exists before its root state connects, while its `sessionTypes` stay empty. Gate tours that need a usable host on a context key derived from any `local-agent-host`/`agenthost-*` provider exposing a session type, and update it from `ISessionsManagementService.onDidChangeSessionTypes`.
 
 - **Diagnostic log text is not a unit-test contract**: add consistently prefixed, actionable logs, but do not add tests that assert log messages or levels. Validate the underlying behavior and keep diagnostics free to evolve.

--- a/src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css
@@ -58,12 +58,12 @@
 	border-color: currentColor;
 }
 
-.new-session-prompt-options-list > .new-session-prompt-option.monaco-button.disabled {
+.new-session-prompt-options-list > .new-session-prompt-option.monaco-button.option-disabled {
 	cursor: default;
 	opacity: 0.5;
 }
 
-.new-session-prompt-options-list > .new-session-prompt-option.monaco-button.checked.disabled {
+.new-session-prompt-options-list > .new-session-prompt-option.monaco-button.checked.option-disabled {
 	opacity: 0.75;
 }
 
@@ -143,11 +143,9 @@
 	}
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.new-session-prompt-option-skeleton-icon,
-	.new-session-prompt-option-skeleton-line {
-		animation: none;
-	}
+.monaco-reduce-motion .new-session-prompt-option-skeleton-icon,
+.monaco-reduce-motion .new-session-prompt-option-skeleton-line {
+	animation: none;
 }
 
 @container (max-width: 720px) {

--- a/src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts
@@ -162,7 +162,8 @@ export class NewSessionPromptOptionsWidget extends Disposable {
 		const enabled = !this._selecting && (this._inputValue.length === 0 || matchesGeneratedPrompt(selectedOption, this._inputValue));
 		for (const { option, button } of this._buttons) {
 			button.checked = option.id === this._selectedOptionId;
-			button.enabled = enabled;
+			button.element.classList.toggle('option-disabled', !enabled);
+			button.element.setAttribute('aria-disabled', String(!enabled));
 			button.element.tabIndex = 0;
 		}
 	}


### PR DESCRIPTION
## Summary

Follow up on review feedback from #329837:

- use a component-owned disabled state so selected prompt options can retain their stronger opacity without fighting the shared Button `!important` rule
- gate loading skeleton animation on `.monaco-reduce-motion` so `workbench.reduceMotion` controls the effective behavior

## Testing

- `npm run eslint -- src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts`
- `npm run stylelint -- src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css`
- `npm run transpile-client`
- `scripts\test.bat --run src\vs\sessions\contrib\chat\test\browser\newSessionPromptOptions.test.ts --run src\vs\sessions\contrib\chat\test\browser\newChatWidget.test.ts`