### PR TITLE
agentHost: add local host restart command

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -435,6 +435,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			if (isClientTransport(this._transport)) {
 				await this._raceClose(this._transport.connect());
 			}
+			if (this._state.kind !== AgentHostClientState.Connecting) {
+				throw transportLostError(this._address);
+			}
 
 			const result = await this._dispatchRequest<CommandMap['initialize']['result']>('initialize', {
 				channel: ROOT_STATE_URI,
@@ -477,6 +480,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				this._transitionTo({ kind: AgentHostClientState.Incompatible, error: protocolError });
 				throw error;
 			}
+			if (this._state.kind === AgentHostClientState.Reconnecting && this._transportFactory) {
+				throw error;
+			}
 			this._handleClose(protocolError);
 			throw error;
 		}
@@ -511,9 +517,18 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			case AgentHostClientState.Closed:
 				return;
 			case AgentHostClientState.Connecting:
-				// No handshake yet; we can't resume so always treat as fatal
-				// regardless of whether a factory is configured.
-				this._handleClose(connectionClosedError(this._address));
+				if (!this._transportFactory) {
+					this._handleClose(connectionClosedError(this._address));
+					return;
+				}
+				this._logService.info(`[RemoteAgentHostProtocol] Transport lost while connecting to ${this._address}; scheduling a fresh initialize.`);
+				this._transitionTo({
+					kind: AgentHostClientState.Reconnecting,
+					reconnect: { ...this._newReconnectState(), outbox: this._state.outbox },
+				});
+				this._cancelLivenessTimers();
+				this._rejectPendingRequests(transportLostError(this._address));
+				this._scheduleReconnect();
 				return;
 			case AgentHostClientState.Incompatible:
 				this._handleClose(connectionClosedError(this._address));

--- a/src/vs/platform/agentHost/common/agent.ts
+++ b/src/vs/platform/agentHost/common/agent.ts
@@ -18,6 +18,7 @@ export interface IAgentHostConnection {
 
 export interface IAgentHostStarter extends IDisposable {
 	readonly onRequestConnection?: Event<void>;
+	readonly onRequestRestart?: Event<void>;
 	readonly onWillShutdown?: Event<void>;
 
 	/**

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -381,6 +381,12 @@ export interface IAgentHostOTelSettings {
  */
 export const AgentHostOTelPolicyIpcChannel = 'vscode:agentHostOTelPolicy';
 
+/** Renderer-to-main request to replace the shared local Agent Host process. */
+export const AgentHostRestartIpcChannel = 'vscode:restartAgentHost';
+
+/** Main-to-renderer notification sent before replacement so each local client reconnects immediately. */
+export const AgentHostWillRestartIpcChannel = 'vscode:agentHostWillRestart';
+
 /**
  * Resolve the enterprise-policy values for the `chat.agentHost.otel.*` settings from a
  * configuration service whose policy layer includes managed settings (i.e. the renderer's).

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -5,12 +5,12 @@
 
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, DisposableStore, IReference } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IReference, toDisposable } from '../../../base/common/lifecycle.js';
 import { autorun, constObservable, IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
 import { mark } from '../../../base/common/performance.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
-import { getDelayedChannel, IChannelServer, ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { getDelayedChannel, IChannel, IChannelServer, ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { Client as MessagePortClient } from '../../../base/parts/ipc/common/ipc.mp.js';
 import { acquirePort } from '../../../base/parts/ipc/electron-browser/ipc.mp.js';
 import { ipcRenderer } from '../../../base/parts/sandbox/electron-browser/globals.js';
@@ -19,7 +19,7 @@ import { IEnvironmentService } from '../../environment/common/environment.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentHostIpcChannelTransport } from '../browser/agentHostIpcChannelTransport.js';
-import { RemoteAgentHostProtocolClient } from '../browser/remoteAgentHostProtocolClient.js';
+import { AgentHostClientState, RemoteAgentHostProtocolClient } from '../browser/remoteAgentHostProtocolClient.js';
 import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
 import { AGENT_HOST_CLIENT_BYOK_LM_CHANNEL, AgentHostClientByokLmChannel } from '../common/agentHostClientByokLmChannel.js';
 import { AGENT_HOST_CLIENT_PROXY_CHANNEL, AgentHostClientProxyChannel } from '../common/agentHostClientProxyChannel.js';
@@ -31,6 +31,8 @@ import {
 	AgentHostByokModelsEnabledSettingId,
 	AgentHostIpcChannels,
 	AgentHostOTelPolicyIpcChannel,
+	AgentHostRestartIpcChannel,
+	AgentHostWillRestartIpcChannel,
 	AgentSession,
 	IAgentCreateChatOptions,
 	IAgentCreateSessionConfig,
@@ -60,6 +62,13 @@ import type { ComponentToState, RootState, StateComponents } from '../common/sta
 
 const LOG_PREFIX = '[AgentHost:renderer]';
 
+class LocalAgentHostIpcChannelTransport extends AgentHostIpcChannelTransport {
+	constructor(channel: IChannel, connectionStore: DisposableStore, ahpLogger: AhpJsonlLogger | undefined) {
+		super(channel, ahpLogger, AgentHostClientConnectionKind.Local);
+		this._register(connectionStore);
+	}
+}
+
 /**
  * Renderer-side implementation of {@link IAgentHostService} for the local
  * agent host. State and request traffic use AHP over the Protocol channel;
@@ -70,11 +79,11 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 
 	readonly clientId = generateUuid();
 
-	private readonly _clientEventually = new DeferredPromise<MessagePortClient>();
-	private readonly _management: IAgentHostManagementService;
+	private _messagePortClient: MessagePortClient | undefined;
 	private readonly _ahpLogger: AhpJsonlLogger | undefined;
 	private _protocolClient: RemoteAgentHostProtocolClient | undefined;
 	private _connectStarted = false;
+	private _didAcquireInitialMessagePort = false;
 	private _didStartInitialSessionList = false;
 	private _didCompleteInitialSessionList = false;
 
@@ -103,9 +112,6 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
 	) {
 		super();
-		this._management = ProxyChannel.toService<IAgentHostManagementService>(
-			getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Management)))
-		);
 		this._ahpLogger = this._configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId)
 			? this._register(this._instantiationService.createInstance(AhpJsonlLogger, {
 				logsHome: environmentService.logsHome,
@@ -119,24 +125,31 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 				this.startAgentHost();
 			}
 		}));
+
+		const onWillRestart = () => this._protocolClient?.notifyTransportClosed();
+		ipcRenderer.on(AgentHostWillRestartIpcChannel, onWillRestart);
+		this._register(toDisposable(() => ipcRenderer.removeListener(AgentHostWillRestartIpcChannel, onWillRestart)));
 	}
 
 	startAgentHost(): void {
 		if (!this._protocolClient) {
-			const transport = new AgentHostIpcChannelTransport(
-				getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
-				this._ahpLogger,
-				AgentHostClientConnectionKind.Local,
-			);
+			mark('code/agentHost/willStart');
+			this._forwardOTelPolicy();
 			this._protocolClient = this._register(this._instantiationService.createInstance(
 				RemoteAgentHostProtocolClient,
 				LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
-				transport,
+				() => this._createTransport(),
 				undefined,
 				this.clientId,
 				this._clientInfo,
 			));
 			this._register(this._protocolClient.onDidClose(() => this._onAgentHostExit.fire(0)));
+			this._register(this._protocolClient.onDidChangeConnectionState(state => {
+				if (state === AgentHostClientState.Connected) {
+					this._logService.info(`${LOG_PREFIX} Protocol connection established; clientId=${this.clientId}`);
+					this._onAgentHostStart.fire();
+				}
+			}));
 		}
 
 		void this._connect().catch(error => {
@@ -150,29 +163,76 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			return;
 		}
 		this._connectStarted = true;
-		mark('code/agentHost/willStart');
 
+		const protocolClient = this._requireClient();
+		await protocolClient.connect();
+		mark('code/agentHost/didConnect');
+	}
+
+	private _createTransport(): AgentHostIpcChannelTransport {
+		const clientEventually = new DeferredPromise<MessagePortClient>();
+		const connectionStore = new DisposableStore();
+		void this._acquireMessagePort(clientEventually, connectionStore).catch(error => clientEventually.error(error));
+		return new LocalAgentHostIpcChannelTransport(
+			getDelayedChannel(clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.Protocol))),
+			connectionStore,
+			this._ahpLogger,
+		);
+	}
+
+	private async _acquireMessagePort(clientEventually: DeferredPromise<MessagePortClient>, connectionStore: DisposableStore): Promise<void> {
 		this._logService.info(`${LOG_PREFIX} Acquiring MessagePort to agent host...`);
-		ipcRenderer.send(AgentHostOTelPolicyIpcChannel, readAgentHostOTelPolicySettings(this._configurationService));
 		const port = await acquirePort('vscode:createAgentHostMessageChannel', 'vscode:createAgentHostMessageChannelResult');
-		mark('code/agentHost/didAcquireMessagePort');
+		if (!this._didAcquireInitialMessagePort) {
+			this._didAcquireInitialMessagePort = true;
+			mark('code/agentHost/didAcquireMessagePort');
+		}
 		this._logService.info(`${LOG_PREFIX} MessagePort acquired, creating client...`);
 
-		const store = this._register(new DisposableStore());
-		const client = store.add(new MessagePortClient(port, this.clientId));
+		const client = connectionStore.add(new MessagePortClient(port, this.clientId));
 		registerAgentHostClientChannels(
 			client,
 			this._instantiationService,
 			this._logService,
 			this._configurationService.getValue<boolean>(AgentHostByokModelsEnabledSettingId) === true,
 		);
-		this._clientEventually.complete(client);
+		this._messagePortClient = client;
+		connectionStore.add(toDisposable(() => {
+			if (this._messagePortClient === client) {
+				this._messagePortClient = undefined;
+			}
+		}));
+		clientEventually.complete(client);
+	}
 
+	private _forwardOTelPolicy(): void {
+		ipcRenderer.send(AgentHostOTelPolicyIpcChannel, readAgentHostOTelPolicySettings(this._configurationService));
+	}
+
+	private async _getManagementService(): Promise<IAgentHostManagementService> {
 		const protocolClient = this._requireClient();
-		await protocolClient.connect();
-		mark('code/agentHost/didConnect');
-		this._logService.info(`${LOG_PREFIX} Protocol connection established; clientId=${protocolClient.clientId}`);
-		this._onAgentHostStart.fire();
+		const connectionState = protocolClient.connectionState;
+		if (connectionState === AgentHostClientState.Closed || connectionState === AgentHostClientState.Incompatible) {
+			throw new Error('Local agent host is not connected.');
+		}
+		if (connectionState !== AgentHostClientState.Connected) {
+			const state = await Event.toPromise(Event.filter(
+				protocolClient.onDidChangeConnectionState,
+				state => state === AgentHostClientState.Connected || state === AgentHostClientState.Closed || state === AgentHostClientState.Incompatible,
+			));
+			if (state !== AgentHostClientState.Connected) {
+				throw new Error('Local agent host is not connected.');
+			}
+		}
+
+		if (!this._messagePortClient) {
+			throw new Error('Local agent host management connection is not available.');
+		}
+		return ProxyChannel.toService<IAgentHostManagementService>(this._messagePortClient.getChannel(AgentHostIpcChannels.Management));
+	}
+
+	private async _callManagement<T>(callback: (management: IAgentHostManagementService) => Promise<T>): Promise<T> {
+		return callback(await this._getManagementService());
 	}
 
 	private _requireClient(): RemoteAgentHostProtocolClient {
@@ -256,7 +316,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 				throw new Error('Cannot create local agent host session without a provider.');
 			}
 			const session = config.session ?? AgentSession.uri(config.provider, generateUuid());
-			const promise = this._management.createSessionWithExtensions({ ...config, session });
+			const promise = this._callManagement(management => management.createSessionWithExtensions({ ...config, session }));
 			this._requireClient().trackSessionCreate(session, promise);
 			return promise;
 		}
@@ -285,7 +345,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 
 	createChat(session: URI, chat: URI, options?: IAgentCreateChatOptions): Promise<void> {
 		if (options && hasChatExtensions(options)) {
-			return this._management.createChatWithExtensions(session, chat, options);
+			return this._callManagement(management => management.createChatWithExtensions(session, chat, options));
 		}
 		return this._requireClient().createChat(session, chat, options);
 	}
@@ -351,31 +411,32 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	shutdown(): Promise<void> {
-		return this._management.shutdown();
+		return this._callManagement(management => management.shutdown());
 	}
 
 	getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> {
-		return this._management.getNetworkDiagnosticsInfo();
+		return this._callManagement(management => management.getNetworkDiagnosticsInfo());
 	}
 
 	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
-		return this._management.getManagedSettingsDiagnostics();
+		return this._callManagement(management => management.getManagedSettingsDiagnostics());
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {
-		return this._management.diagnosticsFetch(url);
+		return this._callManagement(management => management.diagnosticsFetch(url));
 	}
 
 	async restartAgentHost(): Promise<void> {
-		// Restart is managed by the main process lifecycle owner.
+		this._forwardOTelPolicy();
+		ipcRenderer.send(AgentHostRestartIpcChannel);
 	}
 
 	startWebSocketServer(): Promise<IAgentHostSocketInfo> {
-		return this._management.startWebSocketServer();
+		return this._callManagement(management => management.startWebSocketServer());
 	}
 
 	getInspectInfo(tryEnable: boolean): Promise<IAgentHostInspectInfo | undefined> {
-		return this._management.getInspectInfo(tryEnable);
+		return this._callManagement(management => management.getInspectInfo(tryEnable));
 	}
 }
 

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { IpcMainEvent, WebContents } from 'electron';
@@ -31,6 +31,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 	private utilityProcess: UtilityProcess | undefined = undefined;
 	private utilityProcessStarted: DeferredPromise<void> | undefined = undefined;
 	private readonly _windowSenders = new Map<number, WebContents>();
+	private readonly _windowSenderCleanup = this._register(new DisposableMap<number>());
 
 	private readonly _onRequestConnection = this._register(new Emitter<void>());
 	readonly onRequestConnection = this._onRequestConnection.event;
@@ -245,9 +246,9 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			return;
 		}
 		this._windowSenders.set(sender.id, sender);
-		const onDestroyed = () => this._windowSenders.delete(sender.id);
+		const onDestroyed = () => this._windowSenderCleanup.deleteAndDispose(sender.id);
 		sender.once('destroyed', onDestroyed);
-		this._register(toDisposable(() => {
+		this._windowSenderCleanup.set(sender.id, toDisposable(() => {
 			sender.removeListener('destroyed', onDestroyed);
 			this._windowSenders.delete(sender.id);
 		}));

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
-import { IpcMainEvent } from 'electron';
+import { IpcMainEvent, WebContents } from 'electron';
 import { validatedIpcMain } from '../../../base/parts/ipc/electron-main/ipcMain.js';
 import { Client as MessagePortClient } from '../../../base/parts/ipc/electron-main/ipc.mp.js';
 import { AiAgentEnvValue, AiAgentEnvVar } from '../../chat/common/aiAgentEnv.js';
@@ -22,7 +22,7 @@ import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProces
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 import { buildAgentHostTelemetryIdEnv, IAgentHostForwardedTelemetryIds } from '../common/agentHostTelemetryEnv.js';
 import { AgentHostLaunchKind, AgentHostLaunchKindEnvVar } from '../common/agentHostTelemetry.js';
-import { AgentHostByokModelsEnabledSettingId, AgentHostClaudeAgentEnabledSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOtlpProtocolSettingId, AgentHostOTelOutfileSettingId, AgentHostOTelResourceAttributesSettingId, AgentHostOTelServiceNameSettingId, AgentHostOTelPolicyIpcChannel, buildAgentHostOTelEnv, buildAgentSdkEnv, IAgentHostOTelSettings, sanitizeAgentHostOTelPolicySettings } from '../common/agentService.js';
+import { AgentHostByokModelsEnabledSettingId, AgentHostClaudeAgentEnabledSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOtlpProtocolSettingId, AgentHostOTelOutfileSettingId, AgentHostOTelResourceAttributesSettingId, AgentHostOTelServiceNameSettingId, AgentHostOTelPolicyIpcChannel, AgentHostRestartIpcChannel, AgentHostWillRestartIpcChannel, buildAgentHostOTelEnv, buildAgentSdkEnv, IAgentHostOTelSettings, sanitizeAgentHostOTelPolicySettings } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 import '../common/agentHostStarter.config.contribution.js';
 
@@ -30,9 +30,12 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 
 	private utilityProcess: UtilityProcess | undefined = undefined;
 	private utilityProcessStarted: DeferredPromise<void> | undefined = undefined;
+	private readonly _windowSenders = new Map<number, WebContents>();
 
 	private readonly _onRequestConnection = this._register(new Emitter<void>());
 	readonly onRequestConnection = this._onRequestConnection.event;
+	private readonly _onRequestRestart = this._register(new Emitter<void>());
+	readonly onRequestRestart = this._onRequestRestart.event;
 	private readonly _onWillShutdown = this._register(new Emitter<void>());
 	readonly onWillShutdown = this._onWillShutdown.event;
 
@@ -71,6 +74,19 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		validatedIpcMain.on('vscode:createAgentHostMessageChannel', onWindowConnection);
 		this._register(toDisposable(() => {
 			validatedIpcMain.removeListener('vscode:createAgentHostMessageChannel', onWindowConnection);
+		}));
+
+		const onRestart = () => {
+			for (const sender of this._windowSenders.values()) {
+				if (!sender.isDestroyed()) {
+					sender.send(AgentHostWillRestartIpcChannel);
+				}
+			}
+			this._onRequestRestart.fire();
+		};
+		validatedIpcMain.on(AgentHostRestartIpcChannel, onRestart);
+		this._register(toDisposable(() => {
+			validatedIpcMain.removeListener(AgentHostRestartIpcChannel, onRestart);
 		}));
 	}
 
@@ -202,6 +218,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 	}
 
 	private async _onWindowConnection(e: IpcMainEvent, nonce: string): Promise<void> {
+		this._trackWindowSender(e.sender);
 		this._onRequestConnection.fire();
 
 		// Wait for utilityProcess.start() to actually run before calling connect(),
@@ -221,6 +238,19 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		}
 
 		e.sender.postMessage('vscode:createAgentHostMessageChannelResult', nonce, [port]);
+	}
+
+	private _trackWindowSender(sender: WebContents): void {
+		if (this._windowSenders.has(sender.id)) {
+			return;
+		}
+		this._windowSenders.set(sender.id, sender);
+		const onDestroyed = () => this._windowSenders.delete(sender.id);
+		sender.once('destroyed', onDestroyed);
+		this._register(toDisposable(() => {
+			sender.removeListener('destroyed', onDestroyed);
+			this._windowSenders.delete(sender.id);
+		}));
 	}
 
 	private static readonly _expectedStderrPatterns = [

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -38,7 +38,7 @@ export class AgentHostProcessManager extends Disposable {
 	private _started = false;
 	private _wasQuitRequested = false;
 	private _restartCount = 0;
-	private readonly _lifecycleQueue = new Queue<void>();
+	private readonly _lifecycleQueue = this._register(new Queue<void>());
 	private readonly _connection = this._register(new MutableDisposable<DisposableStore>());
 
 	constructor(

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Queue } from '../../../base/common/async.js';
 import { Event } from '../../../base/common/event.js';
-import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { ILogService, ILoggerService } from '../../log/common/log.js';
 import { RemoteLoggerChannelClient } from '../../log/common/logIpc.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
@@ -37,6 +38,8 @@ export class AgentHostProcessManager extends Disposable {
 	private _started = false;
 	private _wasQuitRequested = false;
 	private _restartCount = 0;
+	private readonly _lifecycleQueue = new Queue<void>();
+	private readonly _connection = this._register(new MutableDisposable<DisposableStore>());
 
 	constructor(
 		private readonly _starter: IAgentHostStarter,
@@ -53,6 +56,9 @@ export class AgentHostProcessManager extends Disposable {
 		if (this._starter.onRequestConnection) {
 			this._register(Event.once(this._starter.onRequestConnection)(() => this._ensureStarted()));
 		}
+		if (this._starter.onRequestRestart) {
+			this._register(this._starter.onRequestRestart(() => void this.restart()));
+		}
 
 		if (this._starter.onWillShutdown) {
 			this._register(this._starter.onWillShutdown(() => this._wasQuitRequested = true));
@@ -60,12 +66,23 @@ export class AgentHostProcessManager extends Disposable {
 	}
 
 	private _ensureStarted(): void {
-		if (!this._started) {
-			this._start();
-		}
+		void this._lifecycleQueue.queue(() => this._start());
+	}
+
+	restart(): Promise<void> {
+		return this._lifecycleQueue.queue(async () => {
+			this._logService.info('AgentHostProcessManager: explicitly restarting agent host');
+			this._connection.clear();
+			this._started = false;
+			this._restartCount = 0;
+			await this._start();
+		});
 	}
 
 	private async _start(): Promise<void> {
+		if (this._started) {
+			return;
+		}
 		this._started = true;
 		try {
 			const connection = await this._starter.start();
@@ -87,7 +104,9 @@ export class AgentHostProcessManager extends Disposable {
 				}
 				if (isExpectedWindowsShutdownExit(this._platform, e.code)) {
 					this._logService.info(`AgentHostProcessManager: agent host terminated during Windows shutdown with code ${e.code}`);
-					connection.store.dispose();
+					if (this._connection.value === connection.store) {
+						this._connection.clear();
+					}
 					return;
 				}
 
@@ -99,18 +118,20 @@ export class AgentHostProcessManager extends Disposable {
 					restartCount: this._restartCount,
 					willRestart,
 				});
-				connection.store.dispose();
+				if (this._connection.value === connection.store) {
+					this._connection.clear();
+				}
 				if (willRestart) {
 					this._logService.error(`AgentHostProcessManager: agent host terminated unexpectedly with code ${e.code}`);
 					this._restartCount++;
 					this._started = false;
-					this._start();
+					this._ensureStarted();
 				} else {
 					this._logService.error(`AgentHostProcessManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
 				}
 			}));
 
-			this._register(toDisposable(() => connection.store.dispose()));
+			this._connection.value = connection.store;
 		} catch (error) {
 			this._started = false;
 			this._logService.error('AgentHostProcessManager: failed to start agent host', error);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -28,7 +28,7 @@ import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommi
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
-import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, type ChatAction, type IRootConfigChangedAction, type SessionAction, type SessionWorkingDirectoryAction, type TerminalAction, type ClientAnnotationsAction, type ClientChangesetAction } from '../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, isSessionAction, type ChatAction, type IRootConfigChangedAction, type SessionAction, type SessionWorkingDirectoryAction, type TerminalAction, type ClientAnnotationsAction, type ClientChangesetAction } from '../common/state/sessionActions.js';
 import { resolveSessionWorkingDirectoryAction } from '../common/state/sessionWorkingDirectories.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult, SessionConfigPropertySchema } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
@@ -2636,15 +2636,19 @@ export class AgentService extends Disposable implements IAgentService {
 		// lookup, telemetry, permissions — all keyed by session).
 		const chatChannel = isAhpChatChannel(channel) ? channel : undefined;
 		const sessionChannel = chatChannel ? parseRequiredSessionUriFromChatUri(chatChannel) : channel;
+		const requiresSessionRestore = (chatChannel !== undefined || isSessionAction(action)) && !this._stateManager.getSessionState(sessionChannel);
 		const requiresPeerResolution = chatChannel !== undefined && !this._stateManager.getChatState(chatChannel);
 		const requiresAttachmentRewrite = this._needsAsyncRewrite(sessionChannel, action);
 
 		const pending = this._clientDispatchQueues.get(clientId);
-		if (!pending && !requiresPeerResolution && !requiresAttachmentRewrite) {
+		if (!pending && !requiresSessionRestore && !requiresPeerResolution && !requiresAttachmentRewrite) {
 			this._dispatchActionNow(channel, sessionChannel, action, clientId, clientSeq, clientContext);
 			return;
 		}
 		const next = (pending ?? Promise.resolve()).then(async () => {
+			if (requiresSessionRestore) {
+				await this.restoreSession(URI.parse(sessionChannel));
+			}
 			if (chatChannel && requiresPeerResolution) {
 				await this._stateManager.resolveChatState(chatChannel);
 			}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2647,7 +2647,13 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		const next = (pending ?? Promise.resolve()).then(async () => {
 			if (requiresSessionRestore) {
-				await this.restoreSession(URI.parse(sessionChannel));
+				const sessionUri = URI.parse(sessionChannel);
+				const subagent = parseSubagentSessionUri(sessionUri);
+				if (subagent) {
+					await this._restoreSubagentSession(sessionChannel, subagent.parentSession);
+				} else {
+					await this.restoreSession(sessionUri);
+				}
 			}
 			if (chatChannel && requiresPeerResolution) {
 				await this._stateManager.resolveChatState(chatChannel);

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -657,8 +657,8 @@ export class ProtocolServerHandler extends Disposable {
 	 *   {@link IConnectedClient.subscriptions} map.
 	 *
 	 * Channels with unsupported shapes (e.g. `ahp-otlp://logs/verbose`
-	 * with no recognised level, or a state channel the state manager
-	 * does not know about) are silently dropped.
+	 * with no recognised level) are silently dropped. Valid state channels
+	 * remain subscribed even when their snapshot has not materialized yet.
 	 */
 	private _addInitialSubscription(client: IConnectedClient, channel: string): IStateSnapshot | undefined {
 		const sub = classifyChannel(channel);
@@ -674,9 +674,6 @@ export class ProtocolServerHandler extends Disposable {
 			return undefined;
 		}
 		const snapshot = this._stateManager.getSnapshot(channel);
-		if (!snapshot) {
-			return undefined;
-		}
 		client.subscriptions.set(sub.uri, sub);
 		this._agentService.addSubscriber(URI.parse(sub.uri), client.clientId);
 		this._clearClientToolCallDisconnectTimeout(client.clientId, sub.uri);

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1674,6 +1674,36 @@ suite('RemoteAgentHostProtocolClient', () => {
 			});
 		});
 
+		test('retries with a fresh initialize when the factory transport closes during initial connect', async function () {
+			this.timeout(10_000);
+			const { client, transports } = createFactoryClient();
+			const connectPromise = assert.rejects(client.connect());
+
+			client.notifyTransportClosed();
+			await waitForReconnecting(client);
+			transports[0].connectDeferred.error(new Error('Initial transport closed'));
+			await connectPromise;
+
+			const reconnectTransport = await waitForTransport(transports, 1);
+			reconnectTransport.connectDeferred.complete();
+			const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: reconnect.id,
+				error: { code: AhpErrorCodes.NotFound, message: 'Reconnect client not found' },
+			});
+
+			const initialize = await waitForRequest(reconnectTransport, 'initialize');
+			reconnectTransport.fireMessage({
+				jsonrpc: '2.0',
+				id: initialize.id,
+				result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
+			});
+			await flushMicrotasks();
+
+			assert.strictEqual(client.connectionState, AgentHostClientState.Connected);
+		});
+
 		test('falls back to initialize with client info when the server forgot the client', async function () {
 			this.timeout(10_000);
 			const { client, transports } = createFactoryClient(createPermissionService(), agentsWindowAgentHostClientInfo);

--- a/src/vs/platform/agentHost/test/node/agentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostService.test.ts
@@ -26,6 +26,9 @@ class TestChannel implements IChannel {
 class TestAgentHostStarter implements IAgentHostStarter {
 	private readonly _onRequestConnection = new Emitter<void>();
 	readonly onRequestConnection = this._onRequestConnection.event;
+	private readonly _onRequestRestart = new Emitter<void>();
+	readonly onRequestRestart = this._onRequestRestart.event;
+	private readonly _onDidStart = new Emitter<number>();
 
 	private readonly _exitEmitters: Emitter<{ code: number; signal: string }>[] = [];
 	private readonly _channel = new TestChannel();
@@ -34,6 +37,7 @@ class TestAgentHostStarter implements IAgentHostStarter {
 
 	async start(): Promise<IAgentHostConnection> {
 		this.startCount++;
+		this._onDidStart.fire(this.startCount);
 		const exitEmitter = new Emitter<{ code: number; signal: string }>();
 		this._exitEmitters.push(exitEmitter);
 		const store = new DisposableStore();
@@ -53,12 +57,25 @@ class TestAgentHostStarter implements IAgentHostStarter {
 		this._onRequestConnection.fire();
 	}
 
+	requestRestart(): void {
+		this._onRequestRestart.fire();
+	}
+
+	async waitForStartCount(startCount: number): Promise<void> {
+		if (this.startCount >= startCount) {
+			return;
+		}
+		await Event.toPromise(Event.filter(this._onDidStart.event, count => count >= startCount));
+	}
+
 	fireProcessExit(code: number): void {
 		this._exitEmitters.at(-1)?.fire({ code, signal: 'unknown' });
 	}
 
 	dispose(): void {
 		this._onRequestConnection.dispose();
+		this._onRequestRestart.dispose();
+		this._onDidStart.dispose();
 		for (const store of this.connectionStores) {
 			store.dispose();
 		}
@@ -79,12 +96,13 @@ suite('AgentHostProcessManager', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	async function createManager(platform: NodeJS.Platform = 'linux'): Promise<{
+		manager: AgentHostProcessManager;
 		starter: TestAgentHostStarter;
 		telemetryService: TestTelemetryService;
 	}> {
 		const starter = new TestAgentHostStarter();
 		const telemetryService = new TestTelemetryService();
-		disposables.add(new AgentHostProcessManager(
+		const manager = disposables.add(new AgentHostProcessManager(
 			starter,
 			platform,
 			new NullLogService(),
@@ -92,8 +110,8 @@ suite('AgentHostProcessManager', () => {
 			telemetryService,
 		));
 		starter.requestConnection();
-		await Promise.resolve();
-		return { starter, telemetryService };
+		await starter.waitForStartCount(1);
+		return { manager, starter, telemetryService };
 	}
 
 	for (const [name, code] of [
@@ -122,7 +140,7 @@ suite('AgentHostProcessManager', () => {
 		const { starter, telemetryService } = await createManager('linux');
 
 		starter.fireProcessExit(0xC000026B);
-		await Promise.resolve();
+		await starter.waitForStartCount(2);
 
 		assert.deepStrictEqual({
 			startCount: starter.startCount,
@@ -143,12 +161,54 @@ suite('AgentHostProcessManager', () => {
 		});
 	});
 
+	test('explicit restart disposes the current process and resets crash recovery', async () => {
+		const { manager, starter, telemetryService } = await createManager();
+
+		starter.fireProcessExit(17);
+		await starter.waitForStartCount(2);
+		await manager.restart();
+		starter.fireProcessExit(18);
+		await starter.waitForStartCount(4);
+
+		assert.deepStrictEqual({
+			startCount: starter.startCount,
+			connectionStoresDisposed: starter.connectionStores.map(store => store.isDisposed),
+			errorEvents: telemetryService.errorEvents,
+		}, {
+			startCount: 4,
+			connectionStoresDisposed: [true, true, true, false],
+			errorEvents: [
+				{ eventName: 'agentHost.processError', data: { hostLaunchKind: 'vscode_main_process', kind: 'unexpectedExit', code: 17, restartCount: 0, willRestart: true, isError: true } },
+				{ eventName: 'agentHost.processError', data: { hostLaunchKind: 'vscode_main_process', kind: 'unexpectedExit', code: 18, restartCount: 0, willRestart: true, isError: true } },
+			],
+		});
+	});
+
+	test('handles restart requests from the starter', async () => {
+		const { starter, telemetryService } = await createManager();
+
+		starter.requestRestart();
+		await starter.waitForStartCount(2);
+
+		assert.deepStrictEqual({
+			startCount: starter.startCount,
+			connectionStoresDisposed: starter.connectionStores.map(store => store.isDisposed),
+			errorEvents: telemetryService.errorEvents,
+		}, {
+			startCount: 2,
+			connectionStoresDisposed: [true, false],
+			errorEvents: [],
+		});
+	});
+
 	test('stops after the configured number of restarts', async () => {
 		const { starter, telemetryService } = await createManager();
 
 		for (let restartCount = 0; restartCount <= 5; restartCount++) {
 			starter.fireProcessExit(17);
-			await Promise.resolve();
+			if (restartCount < 5) {
+				await starter.waitForStartCount(restartCount + 2);
+			}
 		}
 
 		assert.deepStrictEqual({

--- a/src/vs/platform/agentHost/test/node/agentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostService.test.ts
@@ -201,6 +201,13 @@ suite('AgentHostProcessManager', () => {
 		});
 	});
 
+	test('rejects lifecycle work after disposal', async () => {
+		const { manager } = await createManager();
+		manager.dispose();
+
+		assert.throws(() => manager.restart(), /Object has been disposed/);
+	});
+
 	test('stops after the configured number of restarts', async () => {
 		const { starter, telemetryService } = await createManager();
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -3643,6 +3643,38 @@ suite('AgentService (node dispatcher)', () => {
 				childTurns: 1,
 			});
 		});
+
+		test('restores an evicted subagent before applying a dispatched chat action', async () => {
+			service.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			const sessionResource = (await copilotAgent.listSessions())[0].session;
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Review', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: '', toolRequests: [{ toolCallId: 'tc-sub', name: 'task' }] },
+				{ type: 'tool_start', session, toolCallId: 'tc-sub', toolName: 'task', displayName: 'Task', invocationMessage: 'Delegating...', toolKind: 'subagent' as const, subagentDescription: 'Find related files', subagentAgentName: 'explore' },
+				{ type: 'subagent_started', session, toolCallId: 'tc-sub', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Explores the codebase' },
+				{ type: 'tool_start', session, toolCallId: 'tc-inner', toolName: 'bash', displayName: 'Bash', invocationMessage: 'Running ls...', parentToolCallId: 'tc-sub' },
+				{ type: 'tool_complete', session, toolCallId: 'tc-inner', result: { success: true, pastTenseMessage: 'Ran ls', content: [{ type: ToolResultContentType.Text, text: 'file1.ts' }] }, parentToolCallId: 'tc-sub' },
+				{ type: 'tool_complete', session, toolCallId: 'tc-sub', result: { success: true, pastTenseMessage: 'Delegated task', content: [{ type: ToolResultContentType.Text, text: 'Found files' }] } },
+			];
+			await service.restoreSession(sessionResource);
+
+			const childSession = URI.parse(buildSubagentSessionUri(sessionResource.toString(), 'tc-sub'));
+			service.stateManager.deleteSession(childSession.toString());
+			const childChat = buildDefaultChatUri(childSession);
+			service.dispatchAction(childChat.toString(), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'continued-turn',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'Continue', origin: { kind: MessageKind.User } },
+			}, 'client-1', 1);
+
+			for (let i = 0; i < 50 && service.stateManager.getChatState(childChat.toString())?.activeTurn?.id !== 'continued-turn'; i++) {
+				await timeout(0);
+			}
+
+			assert.strictEqual(service.stateManager.getChatState(childChat.toString())?.activeTurn?.id, 'continued-turn');
+		});
 	});
 
 	// ---- createChat (multi-chat) ----------------------------------------

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5304,6 +5304,94 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('restores an evicted session before applying a dispatched default-chat action', async () => {
+			const restoration = new DeferredPromise<void>();
+			let restoreCalls = 0;
+			class RestoringAgent extends MockAgent {
+				override async getSessionMessages(): Promise<readonly Turn[]> {
+					restoreCalls++;
+					await restoration.p;
+					return [];
+				}
+			}
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = disposables.add(new RestoringAgent('copilot'));
+			localService.registerProvider(agent);
+			const session = await localService.createSession({ provider: 'copilot' });
+			const chat = buildDefaultChatUri(session);
+			localService.stateManager.deleteSession(session.toString());
+
+			localService.dispatchAction(chat.toString(), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: '2025-01-01T00:00:00.000Z',
+				message: { text: 'Hello after restart', origin: { kind: MessageKind.User } },
+			}, 'client-1', 1);
+			for (let i = 0; i < 50 && restoreCalls === 0; i++) {
+				await timeout(0);
+			}
+			const stateWhileBlocked = localService.stateManager.getChatState(chat.toString());
+			restoration.complete();
+			for (let i = 0; i < 50 && localService.stateManager.getChatState(chat.toString())?.activeTurn?.id !== 'turn-1'; i++) {
+				await timeout(0);
+			}
+			const stateAfterRestoration = localService.stateManager.getChatState(chat.toString());
+
+			assert.deepStrictEqual({
+				restoreCalls,
+				stateWhileBlocked,
+				activeTurnAfterRestoration: stateAfterRestoration?.activeTurn?.id,
+			}, {
+				restoreCalls: 1,
+				stateWhileBlocked: undefined,
+				activeTurnAfterRestoration: 'turn-1',
+			});
+		});
+
+		test('restores an evicted session before applying a dispatched session action', async () => {
+			const restoration = new DeferredPromise<void>();
+			let restoreCalls = 0;
+			class RestoringAgent extends MockAgent {
+				override async getSessionMessages(): Promise<readonly Turn[]> {
+					restoreCalls++;
+					await restoration.p;
+					return [];
+				}
+			}
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = disposables.add(new RestoringAgent('copilot'));
+			localService.registerProvider(agent);
+			const session = await localService.createSession({
+				provider: 'copilot',
+				config: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+			});
+			localService.stateManager.deleteSession(session.toString());
+
+			localService.dispatchAction(session.toString(), {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.AutoApprove]: 'default' },
+			}, 'client-1', 1);
+			for (let i = 0; i < 50 && restoreCalls === 0; i++) {
+				await timeout(0);
+			}
+			const stateWhileBlocked = localService.stateManager.getSessionState(session.toString());
+			restoration.complete();
+			for (let i = 0; i < 50 && localService.stateManager.getSessionState(session.toString())?.config?.values[SessionConfigKey.AutoApprove] !== 'default'; i++) {
+				await timeout(0);
+			}
+			const stateAfterRestoration = localService.stateManager.getSessionState(session.toString());
+
+			assert.deepStrictEqual({
+				restoreCalls,
+				stateWhileBlocked,
+				autoApproveAfterRestoration: stateAfterRestoration?.config?.values[SessionConfigKey.AutoApprove],
+			}, {
+				restoreCalls: 1,
+				stateWhileBlocked: undefined,
+				autoApproveAfterRestoration: 'default',
+			});
+		});
+
 		test('invalidates a restored peer resolver when its parent session is disposed', async () => {
 			const firstMaterialization = new DeferredPromise<void>();
 			let materializeCalls = 0;

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -446,6 +446,28 @@ suite('ProtocolServerHandler', () => {
 		assert.strictEqual(result.snapshots[0].resource.toString(), sessionUri.toString());
 	});
 
+	test('handshake retains an initial subscription whose state has not materialized', () => {
+		const transport = connectClient('client-1', [defaultChatUri]);
+		const response = findResponse(transport.sent, 1) as { result: InitializeResult };
+		assert.deepStrictEqual(response.result.snapshots, []);
+		transport.sent.length = 0;
+
+		stateManager.createSession(makeSessionSummary());
+		stateManager.dispatchServerAction(defaultChatUri, {
+			type: ActionType.ChatTurnStarted,
+			turnId: 'turn-1',
+			startedAt: '2025-01-01T00:00:00.000Z',
+			message: { text: 'hello after restore', origin: { kind: MessageKind.User } },
+		});
+
+		const actionMessages = findNotifications(transport.sent, 'action');
+		const turnStarted = actionMessages.find(message => {
+			const envelope = message.params as unknown as { action?: { type: string } };
+			return envelope.action?.type === ActionType.ChatTurnStarted;
+		});
+		assert.ok(turnStarted, 'should deliver actions after the initially missing state materializes');
+	});
+
 	test('ping responds before initialize', async () => {
 		const transport = new MockProtocolTransport();
 		disposables.add(transport);

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -38,7 +38,7 @@ Registered by `LocalAgentHostContribution` in `browser/localAgentHost.contributi
   - `AgentHostTerminalContribution` — terminal integration for agent host sessions.
   - The classic chat sidebar item controller is registered separately in the editor window only; the Agents window does not load or register `AgentHostSessionListController`.
 
-The Electron-only `electron-browser/agentHost.contribution.ts` adds desktop-only wiring on top.
+The Electron-only `electron-browser/agentHost.contribution.ts` adds desktop-only Agent Host developer commands, including debugging, profiling, and restarting the local Agent Host process.
 
 ## Identity
 

--- a/src/vs/sessions/contrib/providers/agentHost/electron-browser/agentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/electron-browser/agentHost.contribution.ts
@@ -7,7 +7,9 @@ import { registerAction2 } from '../../../../../platform/actions/common/actions.
 import { DebugAgentHostInDevToolsAction } from '../../../../../workbench/contrib/chat/electron-browser/actions/debugAgentHostAction.js';
 import '../../../../../workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.js';
 import { ProfileAgentHostAction, StopAgentHostProfileAction } from '../../../../../workbench/contrib/chat/electron-browser/actions/profileAgentHostAction.js';
+import { RestartLocalAgentHostAction } from '../../../../../workbench/contrib/chat/electron-browser/actions/restartAgentHostAction.js';
 
 registerAction2(DebugAgentHostInDevToolsAction);
+registerAction2(RestartLocalAgentHostAction);
 registerAction2(ProfileAgentHostAction);
 registerAction2(StopAgentHostProfileAction);

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions.ts
@@ -14,10 +14,12 @@ import { DebugAgentHostInDevToolsAction } from './debugAgentHostAction.js';
 import './exportAgentHostDebugLogsService.js';
 import { ProfileAgentHostAction, StopAgentHostProfileAction } from './profileAgentHostAction.js';
 import { registerNetworkDiagnosticsAction } from './networkDiagnosticsAction.js';
+import { RestartLocalAgentHostAction } from './restartAgentHostAction.js';
 
 export function registerChatDeveloperActions() {
 	registerAction2(OpenChatStorageFolderAction);
 	registerAction2(DebugAgentHostInDevToolsAction);
+	registerAction2(RestartLocalAgentHostAction);
 	registerAction2(ProfileAgentHostAction);
 	registerAction2(StopAgentHostProfileAction);
 	registerNetworkDiagnosticsAction();

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/restartAgentHostAction.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/restartAgentHostAction.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { localize2 } from '../../../../../nls.js';
+import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
+import { Action2 } from '../../../../../platform/actions/common/actions.js';
+import { AGENT_HOST_ENABLED_CONTEXT_KEY } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { RemoteNameContext } from '../../../../common/contextkeys.js';
+import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+
+export class RestartLocalAgentHostAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.restartLocalAgentHost';
+
+	constructor() {
+		super({
+			id: RestartLocalAgentHostAction.ID,
+			title: localize2('restartLocalAgentHost', "Restart Local Agent Host"),
+			category: Categories.Developer,
+			f1: true,
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				AGENT_HOST_ENABLED_CONTEXT_KEY,
+				RemoteNameContext.isEqualTo(''),
+			),
+		});
+	}
+
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IAgentHostService).restartAgentHost();
+	}
+}


### PR DESCRIPTION
## Summary

- add **Developer: Restart Local Agent Host** to desktop editor and Agents windows
- restart the shared utility process through its main-process lifecycle owner and reconnect all local clients immediately
- preserve fresh-host subscriptions and restore cold sessions before applying actions so existing chats and tool confirmations continue after restart

## Validation

- launched an isolated authenticated Code OSS build with three connected windows
- completed a persisted Agent Host turn, restarted the host, and immediately continued the same chat
- verified a real `web_fetch` confirmation appeared, approval reached the provider, and the turn completed
- verified all three windows began reconnecting immediately and reconnected in about 1.1 seconds
- 9 focused lifecycle/protocol tests passed
- `npm run typecheck-client`
- `npm run valid-layers-check`

(Written by Copilot)