### PR TITLE
chat: Preserve scroll position between sessions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -45,6 +45,7 @@ import { EditorAreaFocusContext, SideBarVisibleContext } from '../../../../workb
 import { NEW_SESSION_ACTION_ID } from '../common/constants.js';
 import { SessionsTitleBarNewSessionEnabledContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
+import { ISessionsChatViewStateService, SessionsChatViewStateService } from './chatViewStateService.js';
 
 
 class NewChatInSessionsWindowAction extends Action2 {
@@ -127,6 +128,7 @@ registerSingleton(ISessionsTasksService, SessionsTasksService, InstantiationType
 registerSingleton(IAICustomizationWorkspaceService, SessionsAICustomizationWorkspaceService, InstantiationType.Delayed);
 registerSingleton(ICustomizationHarnessService, SessionsCustomizationHarnessService, InstantiationType.Delayed);
 registerSingleton(IChatViewFactory, ChatViewFactory, InstantiationType.Delayed);
+registerSingleton(ISessionsChatViewStateService, SessionsChatViewStateService, InstantiationType.Delayed);
 
 // register accessibility help
 AccessibleViewRegistry.register(new SessionsChatAccessibilityHelp());

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -273,6 +273,11 @@ export class ChatView extends AbstractChatView {
 	override setChat(chat: IChat, historyKey?: string): void {
 		this.chatPillsDebugService.clear(this._chatPills);
 		const resource = chat.resource;
+		const previousChatResource = this._currentChatResource;
+		const chatChanged = !isEqual(previousChatResource, resource);
+		if (chatChanged) {
+			this._saveCurrentViewState();
+		}
 		this._historyKey = historyKey;
 		this._applyHistoryKey();
 
@@ -290,12 +295,10 @@ export class ChatView extends AbstractChatView {
 		});
 
 		// Skip loading if we're already showing this chat
-		if (isEqual(this._currentChatResource, resource)) {
+		if (!chatChanged) {
 			return;
 		}
 
-		const previousChatResource = this._currentChatResource;
-		this._saveCurrentViewState();
 		this._currentChatResource = resource;
 		this._currentChatResourceObs.set(resource, undefined);
 

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -8,6 +8,7 @@ import './media/voiceChatView.css';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derived, observableValue } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -38,9 +39,9 @@ import { ResponseSelectionSideChatController } from './responseSelectionSideChat
 import { ISessionChatPillsDebugService } from './sessionChatInputToolbarDebug.js';
 import { AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING } from './sessionsChatHistory.js';
 import { activeSessionViewBackground, activeSessionViewForeground, agentsPanelBackground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../../common/theme.js';
-import { isEqual } from '../../../../base/common/resources.js';
 import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
 import { INewChatVoiceTargetService } from './newChatVoice.js';
+import { ISessionsChatViewStateService } from './chatViewStateService.js';
 
 /**
  * A session view that hosts a {@link NewChatWidget} — the "new session" UI
@@ -179,6 +180,7 @@ export class ChatView extends AbstractChatView {
 		@ITtsPlaybackService private readonly ttsPlaybackService: ITtsPlaybackService,
 		@ISessionChatPillsDebugService private readonly chatPillsDebugService: ISessionChatPillsDebugService,
 		@INewChatVoiceTargetService private readonly newChatVoiceTargetService: INewChatVoiceTargetService,
+		@ISessionsChatViewStateService private readonly viewStateService: ISessionsChatViewStateService,
 	) {
 		super();
 
@@ -248,6 +250,7 @@ export class ChatView extends AbstractChatView {
 	}
 
 	override dispose(): void {
+		this._saveCurrentViewState();
 		this._loadCts.value?.cancel();
 		super.dispose();
 	}
@@ -292,6 +295,7 @@ export class ChatView extends AbstractChatView {
 		}
 
 		const previousChatResource = this._currentChatResource;
+		this._saveCurrentViewState();
 		this._currentChatResource = resource;
 		this._currentChatResourceObs.set(resource, undefined);
 
@@ -316,6 +320,10 @@ export class ChatView extends AbstractChatView {
 			this._modelRef.value = ref;
 			this._updateWidgetLockState(getChatSessionType(ref.object.sessionResource));
 			setModelPreservingInputTypedWhileLoading(this._widget, inputBeforeLoad, () => this._widget.setModel(ref.object));
+			const widgetViewState = this.viewStateService.get(resource);
+			if (widgetViewState) {
+				this._widget.restoreViewState(widgetViewState);
+			}
 			// Expose the bound chat resource on the DOM so test automation
 			// can synchronize with the post-rebind state without polling timeouts.
 			// Set AFTER `setModel` so observers see the attribute only once the
@@ -335,6 +343,13 @@ export class ChatView extends AbstractChatView {
 		// matching how each editor group shows progress independently. The short
 		// delay avoids flashing the bar for fast cached loads.
 		this.showProgressWhile(loadPromise, 800);
+	}
+
+	private _saveCurrentViewState(): void {
+		const resource = this._widget.viewModel?.sessionResource;
+		if (resource) {
+			this.viewStateService.set(resource, this._widget.getViewState());
+		}
 	}
 
 	private _clearCurrentChat(): void {

--- a/src/vs/sessions/contrib/chat/browser/chatViewStateService.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatViewStateService.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LRUCache } from '../../../../base/common/map.js';
+import { getComparisonKey } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT, IChatWidgetViewState } from '../../../../workbench/contrib/chat/browser/chat.js';
+
+export const ISessionsChatViewStateService = createDecorator<ISessionsChatViewStateService>('sessionsChatViewStateService');
+
+export interface ISessionsChatViewStateService {
+	readonly _serviceBrand: undefined;
+	get(resource: URI): IChatWidgetViewState | undefined;
+	set(resource: URI, state: IChatWidgetViewState): void;
+}
+
+export class SessionsChatViewStateService implements ISessionsChatViewStateService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _states = new LRUCache<string, IChatWidgetViewState>(CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT);
+
+	get(resource: URI): IChatWidgetViewState | undefined {
+		return this._states.get(getComparisonKey(resource));
+	}
+
+	set(resource: URI, state: IChatWidgetViewState): void {
+		this._states.set(getComparisonKey(resource), state);
+	}
+}

--- a/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
@@ -4,8 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { NewChatView } from '../../browser/chatView.js';
+import { SessionsChatViewStateService } from '../../browser/chatViewStateService.js';
 import { NewChatInSessionWidget } from '../../browser/newChatInSessionWidget.js';
 import { NewChatWidget } from '../../browser/newChatWidget.js';
 
@@ -32,6 +35,38 @@ suite('Sessions - Chat View', () => {
 		});
 
 		assert.doesNotThrow(() => view.setVisible(false));
+	});
+
+	test('stores view state independently by chat resource', () => {
+		const service = new SessionsChatViewStateService();
+		const first = URI.parse('test:///first');
+		const second = URI.parse('test:///second');
+
+		service.set(first, { scrollTop: 120, isAtBottom: false });
+		service.set(second, { scrollTop: 700, isAtBottom: true });
+
+		assert.deepStrictEqual({
+			first: service.get(first),
+			second: service.get(second),
+		}, {
+			first: { scrollTop: 120, isAtBottom: false },
+			second: { scrollTop: 700, isAtBottom: true },
+		});
+	});
+
+	test('bounds stored view state', () => {
+		const service = new SessionsChatViewStateService();
+		for (let index = 0; index <= CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT; index++) {
+			service.set(URI.parse(`test:///${index}`), { scrollTop: index });
+		}
+
+		assert.deepStrictEqual({
+			evicted: service.get(URI.parse('test:///0')),
+			retained: service.get(URI.parse(`test:///${CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT}`)),
+		}, {
+			evicted: undefined,
+			retained: { scrollTop: CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT },
+		});
 	});
 
 });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatMoveActions.ts
@@ -134,7 +134,7 @@ async function executeMoveToAction(accessor: ServicesAccessor, moveTo: MoveToNew
 	const resourceToOpen = widget.viewModel.sessionResource;
 
 	// Todo: can possibly go away with https://github.com/microsoft/vscode/pull/278476
-	const modelInputState = existingWidget.getViewState();
+	const modelInputState = existingWidget.getInputState();
 
 	await widget.clear();
 
@@ -151,14 +151,14 @@ async function moveToSidebar(accessor: ServicesAccessor): Promise<void> {
 	const chatEditorInput = chatEditor?.input;
 	let view: ChatViewPane;
 	if (chatEditor instanceof ChatEditor && chatEditorInput instanceof ChatEditorInput && chatEditorInput.sessionResource) {
-		const previousViewState = chatEditor.widget.getViewState();
+		const previousInputState = chatEditor.widget.getInputState();
 		await editorService.closeEditor({ editor: chatEditor.input, groupId: editorGroupService.activeGroup.id });
 		view = await viewsService.openView(ChatViewId) as ChatViewPane;
 
 		// Todo: can possibly go away with https://github.com/microsoft/vscode/pull/278476
 		const newModel = await view.loadSession(chatEditorInput.sessionResource);
-		if (previousViewState && newModel && !newModel.inputModel.state.get()) {
-			newModel.inputModel.setState(previousViewState);
+		if (previousInputState && newModel && !newModel.inputModel.state.get()) {
+			newModel.inputModel.setState(previousInputState);
 		}
 	} else {
 		view = await viewsService.openView(ChatViewId) as ChatViewPane;

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -386,6 +386,17 @@ export interface IChatWidgetViewModelChangeEvent {
 	readonly currentSessionResource: URI | undefined;
 }
 
+/**
+ * Visual presentation state restored when a widget is rebound to a chat.
+ * Composer data such as text, attachments, mode, and model belongs in {@link IChatModelInputState}.
+ */
+export interface IChatWidgetViewState {
+	readonly scrollTop: number;
+	readonly isAtBottom?: boolean;
+}
+
+export const CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT = 100;
+
 export interface IChatWidget {
 	readonly domNode: HTMLElement;
 	/** DOM node of the scrollable transcript area, excluding the input part. */
@@ -502,7 +513,9 @@ export interface IChatWidget {
 	 */
 	holdAutoScroll(): IDisposable;
 	clear(targetSessionType?: string): Promise<void>;
-	getViewState(): IChatModelInputState | undefined;
+	getInputState(): IChatModelInputState | undefined;
+	getViewState(): IChatWidgetViewState;
+	restoreViewState(state: IChatWidgetViewState): void;
 	lockToCodingAgent(name: string, displayName: string, agentId?: string, agentHostProviderId?: string): void;
 	unlockFromCodingAgent(): void;
 	handleDelegationExitIfNeeded(sourceAgent: Pick<IChatAgentData, 'id' | 'name'> | undefined, targetAgent: IChatAgentData | undefined): Promise<void>;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -72,7 +72,7 @@ import { ILanguageModelToolsService, isToolSet } from '../../common/tools/langua
 import { IHandOff, PromptHeader } from '../../common/promptSyntax/promptFileParser.js';
 import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { GENERATE_AGENT_INSTRUCTIONS_COMMAND_ID, handleModeSwitch } from '../actions/chatActions.js';
-import { ChatTreeItem, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewModelChangeEvent, IChatWidgetViewOptions, isIChatResourceViewContext, isIChatViewViewContext } from '../chat.js';
+import { ChatTreeItem, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewModelChangeEvent, IChatWidgetViewOptions, IChatWidgetViewState, isIChatResourceViewContext, isIChatViewViewContext } from '../chat.js';
 import { ChatAttachmentModel } from '../attachments/chatAttachmentModel.js';
 import { IChatAttachmentResolveService } from '../attachments/chatAttachmentResolveService.js';
 import { ChatDynamicVariableModel } from '../attachments/chatDynamicVariables.js';
@@ -781,6 +781,21 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	set scrollTop(value: number) {
 		this.listWidget.scrollTop = value;
+	}
+
+	getViewState(): IChatWidgetViewState {
+		return {
+			scrollTop: this.listWidget.scrollTop,
+			isAtBottom: this.listWidget.isScrolledToBottom,
+		};
+	}
+
+	restoreViewState(state: IChatWidgetViewState): void {
+		if (state.isAtBottom) {
+			this.listWidget.scrollToEnd();
+		} else {
+			this.listWidget.scrollTop = state.scrollTop;
+		}
 	}
 
 	holdAutoScroll(): IDisposable {
@@ -3436,7 +3451,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// no-op
 	}
 
-	getViewState(): IChatModelInputState | undefined {
+	getInputState(): IChatModelInputState | undefined {
 		return this.input.getCurrentInputState();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/chatQuick.ts
@@ -377,7 +377,7 @@ class QuickChat extends Disposable {
 			}
 		}
 
-		const value = this.widget.getViewState();
+		const value = this.widget.getInputState();
 		if (value) {
 			widget.viewModel.model.inputModel.setState(value);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -10,6 +10,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
 import * as nls from '../../../../../../nls.js';
 import { ITextResourceConfigurationService } from '../../../../../../editor/common/services/textResourceConfiguration.js';
 import { IContextKeyService, IScopedContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
@@ -34,7 +35,7 @@ import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { clearChatEditor } from '../../actions/chatClear.js';
 import { ChatEditorInput } from './chatEditorInput.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
-import { setModelPreservingInputTypedWhileLoading } from '../../chat.js';
+import { IChatWidgetViewState, setModelPreservingInputTypedWhileLoading } from '../../chat.js';
 
 export interface IChatEditorOptions extends IEditorOptions {
 	/**
@@ -57,9 +58,7 @@ export interface IChatEditorOptions extends IEditorOptions {
 	};
 }
 
-export interface IChatEditorViewState {
-	scrollTop: number;
-}
+export type IChatEditorViewState = IChatWidgetViewState;
 
 export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState> {
 	private static readonly VIEW_STATE_KEY = 'chatEditorViewState';
@@ -168,6 +167,7 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 	}
 
 	override clearInput(): void {
+		super.clearInput();
 		this.widget.setModel(undefined);
 		// Clear the bound-resource attribute while the rebind is in flight so
 		// test automation can wait for the next `updateModel` cycle to finish
@@ -175,7 +175,6 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 		if (this._editorContainer) {
 			delete this._editorContainer.dataset.boundChatResource;
 		}
-		super.clearInput();
 	}
 
 	private showLoadingInChatWidget(message: string): void {
@@ -283,7 +282,7 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 
 			const viewState = this.loadEditorViewState(input, context);
 			if (viewState) {
-				this._widget.scrollTop = viewState.scrollTop;
+				this._widget.restoreViewState(viewState);
 			}
 
 			if (isContributedChatSession && options?.title?.preferred && input.sessionResource) {
@@ -307,11 +306,11 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 		}
 	}
 
-	protected computeEditorViewState(_resource: URI): IChatEditorViewState | undefined {
-		if (!this._widget) {
+	protected computeEditorViewState(resource: URI): IChatEditorViewState | undefined {
+		if (!this._widget || !isEqual(this._widget.viewModel?.sessionResource, resource)) {
 			return undefined;
 		}
-		return { scrollTop: this._widget.scrollTop };
+		return this._widget.getViewState();
 	}
 
 	protected tracksEditorViewState(input: EditorInput): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -13,9 +13,10 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { isCancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MutableDisposable, toDisposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { LRUCache } from '../../../../../../base/common/map.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { autorun, IObservable, IReader, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
-import { basename, isEqual } from '../../../../../../base/common/resources.js';
+import { basename, getComparisonKey, isEqual } from '../../../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
@@ -63,7 +64,7 @@ import { IChatViewsWelcomeDescriptor } from '../../viewsWelcome/chatViewsWelcome
 import { IWorkbenchLayoutService, LayoutSettings, Position } from '../../../../../services/layout/browser/layoutService.js';
 import { AgentSessionsViewerOrientation, AgentSessionsViewerPosition } from '../../agentSessions/agentSessions.js';
 import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
-import { ChatViewId, IChatWidgetService, setModelPreservingInputTypedWhileLoading } from '../../chat.js';
+import { CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT, ChatViewId, IChatWidgetService, IChatWidgetViewState, setModelPreservingInputTypedWhileLoading } from '../../chat.js';
 import { IActivityService, ProgressBadge } from '../../../../../services/activity/common/activity.js';
 import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { AgentSessionsFilter, AgentSessionsGrouping } from '../../agentSessions/agentSessionsFilter.js';
@@ -121,6 +122,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	/** While > 0 the sessions list is suppressed so a session transition's transiently-empty widget does not reveal it (see {@link beginSessionsListSuppression}). */
 	private _sessionsListSuppressionCount = 0;
 	private readonly modelRef = this._register(new MutableDisposable<IChatModelReference>());
+	private readonly widgetViewStates = new LRUCache<string, IChatWidgetViewState>(CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT);
 
 	private readonly activityBadge = this._register(new MutableDisposable());
 	private readonly _currentSessionResource = observableValue<URI | undefined>(this, undefined);
@@ -1314,7 +1316,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	private async showModel(token: CancellationToken, modelRef?: IChatModelReference | undefined, startNewSession = true, ignoreTransferredSession = false, inputBeforeLoad?: string): Promise<IChatModel | undefined> {
-		const oldModelResource = this.modelRef.value?.object.sessionResource;
+		const oldModelResource = this._widget.viewModel?.sessionResource;
+		if (oldModelResource) {
+			this.widgetViewStates.set(getComparisonKey(oldModelResource), this._widget.getViewState());
+		}
 		this.modelRef.value = undefined;
 
 		// Baseline draft for preserving text typed during loading. `loadSession`
@@ -1358,6 +1363,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 		if (model) {
 			setModelPreservingInputTypedWhileLoading(this._widget, baselineInput, () => this._widget.setModel(model));
+			const widgetViewState = this.widgetViewStates.get(getComparisonKey(model.sessionResource));
+			if (widgetViewState) {
+				this._widget.restoreViewState(widgetViewState);
+			}
 		} else {
 			this._widget.setModel(model);
 		}
@@ -1776,7 +1785,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	private updateViewState(viewState?: IChatModelInputState): void {
-		const newViewState = viewState ?? this._widget.getViewState();
+		const newViewState = viewState ?? this._widget.getInputState();
 		if (newViewState) {
 			for (const [key, value] of Object.entries(newViewState)) {
 				(this.viewState as Record<string, unknown>)[key] = value; // Assign all props to the memento so they get saved

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
@@ -8,7 +8,7 @@ import { DeferredPromise } from '../../../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { OffsetRange } from '../../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
-import { acceptAndAwaitSentRequest, getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight } from '../../../browser/widget/chatWidget.js';
+import { acceptAndAwaitSentRequest, ChatWidget, getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight } from '../../../browser/widget/chatWidget.js';
 import { ChatSendResult, ChatSendResultSent, IChatSendRequestData } from '../../../common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
 import { ChatRequestSlashCommandPart, ChatRequestTextPart, IParsedChatRequest } from '../../../common/requestParser/chatParserTypes.js';
@@ -85,6 +85,37 @@ suite('ChatWidget', () => {
 			['layoutForInputHeight', 420, 720],
 		]);
 	});
+
+	test('captures and restores transcript scroll state', () => {
+		const listWidget = {
+			scrollTop: 200,
+			scrollHeight: 1000,
+			renderHeight: 300,
+			get isScrolledToBottom() {
+				return this.scrollTop + this.renderHeight >= this.scrollHeight - 2;
+			},
+			scrollToEnd() {
+				this.scrollTop = this.scrollHeight - this.renderHeight;
+			},
+		};
+		const widget: ChatWidget = Object.assign(Object.create(ChatWidget.prototype), { listWidget });
+
+		const scrolledUp = widget.getViewState();
+		widget.restoreViewState({ scrollTop: 350 });
+		const legacyScrollTop = listWidget.scrollTop;
+		widget.restoreViewState({ scrollTop: 200, isAtBottom: true });
+
+		assert.deepStrictEqual({
+			scrolledUp,
+			legacyScrollTop,
+			bottomScrollTop: listWidget.scrollTop,
+		}, {
+			scrolledUp: { scrollTop: 200, isAtBottom: false },
+			legacyScrollTop: 350,
+			bottomScrollTop: 700,
+		});
+	});
+
 });
 
 suite('ChatWidget - acceptAndAwaitSentRequest', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -159,7 +159,7 @@ export class TerminalChatWidget extends Disposable {
 				}
 			},
 		);
-		this._register(this._inlineChatWidget.chatWidget.onDidChangeViewModel(() => this._saveViewState()));
+		this._register(this._inlineChatWidget.chatWidget.onDidChangeViewModel(() => this._saveInputState()));
 		this._register(Event.any(
 			this._inlineChatWidget.onDidChangeHeight,
 			this._instance.onDimensionsChanged,
@@ -352,10 +352,10 @@ export class TerminalChatWidget extends Disposable {
 		this._sessionDisposables.value = toDisposable(() => this._sessionCtor?.cancel());
 	}
 
-	private _saveViewState() {
-		const viewState = this._inlineChatWidget.chatWidget.getViewState();
-		if (viewState) {
-			this._storageService.store(this._viewStateStorageKey, JSON.stringify(viewState), StorageScope.PROFILE, StorageTarget.USER);
+	private _saveInputState() {
+		const inputState = this._inlineChatWidget.chatWidget.getInputState();
+		if (inputState) {
+			this._storageService.store(this._viewStateStorageKey, JSON.stringify(inputState), StorageScope.PROFILE, StorageTarget.USER);
 		}
 	}
 


### PR DESCRIPTION
Preserves each chat transcript's view state when switching between sessions in the Chat panel, chat editors, and the Agents window.

- restores the exact offset when a transcript was scrolled up
- follows appended content when the transcript was pinned to the bottom
- uses the existing editor view-state mechanism for chat editors
- keeps bounded LRU state for multi-session view hosts
- separates visual widget view state from composer input state

Validation:
- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused ChatWidget and Sessions Chat View unit tests

(Written by Copilot)

Fixes #329847