### PR TITLE
Mute GitHub numbers in onboarding prompt options

### DIFF
--- a/.github/skills/sessions/SKILL.md
+++ b/.github/skills/sessions/SKILL.md
@@ -44,6 +44,8 @@ Then read the relevant spec for the area you are changing (see table below). If 
 
 - **Three prompt options must fill every row**: render three equal growing cards on one row when space allows. At the two-column breakpoint keep `flex-grow` enabled so the third card occupies the full wrapped row instead of leaving an empty column.
 
+- **GitHub prompt-option numbers are secondary title metadata**: model the issue/PR number separately from the action title, render it beside the title using the same muted color as the second line, and combine both only for ARIA and full-content hovers. Do not parse or color substrings inside one title string.
+
 - **Agent-host onboarding readiness comes from advertised session types, not provider registration**: an agent-host provider exists before its root state connects, while its `sessionTypes` stay empty. Gate tours that need a usable host on a context key derived from any `local-agent-host`/`agenthost-*` provider exposing a session type, and update it from `ISessionsManagementService.onDidChangeSessionTypes`.
 
 - **Diagnostic log text is not a unit-test contract**: add consistently prefixed, actionable logs, but do not add tests that assert log messages or levels. Validate the underlying behavior and keep diagnostics free to evolve.

--- a/src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css
@@ -82,10 +82,24 @@
 }
 
 .new-session-prompt-option-title {
+	display: flex;
 	font-size: var(--vscode-agents-fontSize-body1);
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	gap: var(--vscode-spacing-size40);
 	grid-column: 2;
 	grid-row: 1;
+}
+
+.new-session-prompt-option-title-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.new-session-prompt-option-title-detail {
+	color: var(--vscode-agentsChatInput-placeholderForeground, var(--vscode-descriptionForeground));
+	flex-shrink: 0;
+	font-weight: var(--vscode-agents-fontWeight-regular);
 }
 
 .new-session-prompt-option-description {

--- a/src/vs/sessions/contrib/chat/browser/newSessionComposerService.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSessionComposerService.ts
@@ -15,6 +15,7 @@ export const NEW_SESSION_PROMPT_TYPING_DURATION_MS = 2_500;
 export interface INewSessionPromptOption {
 	readonly id: string;
 	readonly title: string;
+	readonly titleDetail?: string;
 	readonly description: string;
 	readonly prompt: string;
 	readonly placeholder: string;

--- a/src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts
@@ -110,14 +110,15 @@ export class NewSessionPromptOptionsWidget extends Disposable {
 		this._renderDisposables.value = store;
 		const buttons: IPromptOptionButton[] = [];
 		for (const option of options) {
-			const ariaLabel = localize('newSessionPromptOptions.optionAriaLabel', "{0}: {1}", option.title, option.description);
+			const fullTitle = getFullTitle(option);
+			const ariaLabel = localize('newSessionPromptOptions.optionAriaLabel', "{0}: {1}", fullTitle, option.description);
 			const button = store.add(new Button(this._optionsContainer, {
 				...promptOptionButtonStyles,
 				ariaLabel,
 			}));
 			const hoverContent = new MarkdownString()
 				.appendMarkdown('**')
-				.appendText(option.title)
+				.appendText(fullTitle)
 				.appendMarkdown('**\n\n')
 				.appendText(option.description);
 			store.add(this._hoverService.setupDelayedHover(button.element, {
@@ -137,7 +138,11 @@ export class NewSessionPromptOptionsWidget extends Disposable {
 			} else {
 				button.element.classList.add('no-icon');
 			}
-			dom.append(button.element, dom.$('.new-session-prompt-option-title')).textContent = option.title;
+			const title = dom.append(button.element, dom.$('.new-session-prompt-option-title'));
+			dom.append(title, dom.$('.new-session-prompt-option-title-label')).textContent = option.title;
+			if (option.titleDetail) {
+				dom.append(title, dom.$('.new-session-prompt-option-title-detail')).textContent = option.titleDetail;
+			}
 			dom.append(button.element, dom.$('.new-session-prompt-option-description')).textContent = option.description;
 			store.add(button.onDidClick(() => {
 				void this._select(option);
@@ -191,4 +196,8 @@ function matchesGeneratedPrompt(option: INewSessionPromptOption | undefined, val
 		return true;
 	}
 	return !!option.placeholder && option.prompt.includes(option.placeholder) && value === option.prompt.replace(option.placeholder, '');
+}
+
+function getFullTitle(option: INewSessionPromptOption): string {
+	return option.titleDetail ? `${option.title} ${option.titleDetail}` : option.title;
 }

--- a/src/vs/sessions/contrib/chat/test/browser/newChatWidget.fixture.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newChatWidget.fixture.ts
@@ -434,7 +434,8 @@ function createMixedPromptOptions(): readonly INewSessionPromptOption[] {
 	return [
 		{
 			id: 'githubIssue:327101',
-			title: 'Tackle issue #327101',
+			title: 'Tackle issue',
+			titleDetail: '#327101',
 			description: 'Improve the accessibility of inline chat controls',
 			prompt: 'Tackle the following issue and create a pull request for it: "Improve the accessibility of inline chat controls" (https://github.com/microsoft/vscode/issues/327101).',
 			placeholder: '',
@@ -442,7 +443,8 @@ function createMixedPromptOptions(): readonly INewSessionPromptOption[] {
 		},
 		{
 			id: 'githubIssue:326842',
-			title: 'Tackle issue #326842',
+			title: 'Tackle issue',
+			titleDetail: '#326842',
 			description: 'Preserve editor state when switching sessions',
 			prompt: 'Tackle the following issue and create a pull request for it: "Preserve editor state when switching sessions" (https://github.com/microsoft/vscode/issues/326842).',
 			placeholder: '',
@@ -450,7 +452,8 @@ function createMixedPromptOptions(): readonly INewSessionPromptOption[] {
 		},
 		{
 			id: 'githubCiFailure:329629',
-			title: 'Fix CI #329629',
+			title: 'Fix CI',
+			titleDetail: '#329629',
 			description: 'Add GitHub prompt variation to onboarding',
 			prompt: 'The following pull request has failing CI checks: "Add GitHub prompt variation to onboarding" (https://github.com/microsoft/vscode/pull/329629). Investigate the failures and resolve them.',
 			placeholder: '',

--- a/src/vs/sessions/contrib/chat/test/browser/newSessionPromptOptions.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/newSessionPromptOptions.test.ts
@@ -152,6 +152,32 @@ suite('NewSessionPromptOptionsWidget', () => {
 		});
 	});
 
+	test('renders title details separately while preserving full accessible text', () => {
+		const container = document.createElement('div');
+		const hoverService = new TestHoverService();
+		const widget = disposables.add(new NewSessionPromptOptionsWidget(container, async () => true, hoverService));
+		const gitHubOption: INewSessionPromptOption = {
+			...option('issue', 'Tackle issue'),
+			titleDetail: '#123',
+			description: 'A complete issue title',
+		};
+
+		widget.setState({ kind: 'resolved', options: [gitHubOption] });
+		const button = widget.element.querySelector<HTMLElement>('.new-session-prompt-option');
+
+		assert.deepStrictEqual({
+			title: button?.querySelector('.new-session-prompt-option-title-label')?.textContent,
+			detail: button?.querySelector('.new-session-prompt-option-title-detail')?.textContent,
+			ariaLabel: button?.getAttribute('aria-label'),
+			hover: hoverService.contents,
+		}, {
+			title: 'Tackle issue',
+			detail: '#123',
+			ariaLabel: 'Tackle issue #123: A complete issue title',
+			hover: ['**Tackle issue \\#123**\n\nA complete issue title'],
+		});
+	});
+
 	test('cancels stale prompt option refreshes', async () => {
 		const first = new DeferredPromise<NewSessionPromptOptionsState>();
 		const tokens: CancellationToken[] = [];

--- a/src/vs/sessions/contrib/onboardingTours/browser/newSessionViewV3Prompt.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/newSessionViewV3Prompt.ts
@@ -837,10 +837,10 @@ export class NewSessionViewV3PromptRunner {
 	private _createGitHubPromptOption(candidate: INewSessionViewV3GitHubCandidate): INewSessionPromptOption {
 		const plan = this._createGitHubPrompt(candidate);
 		const title = candidate.strategy === 'githubIssue'
-			? localize('sessions.onboarding.newSessionViewV3.options.githubIssue.title', "Tackle issue #{0}", candidate.number)
+			? localize('sessions.onboarding.newSessionViewV3.options.githubIssue.title', "Tackle issue")
 			: candidate.strategy === 'githubCiFailure'
-				? localize('sessions.onboarding.newSessionViewV3.options.githubCi.title', "Fix CI #{0}", candidate.number)
-				: localize('sessions.onboarding.newSessionViewV3.options.githubReview.title', "Address PR comments #{0}", candidate.number);
+				? localize('sessions.onboarding.newSessionViewV3.options.githubCi.title', "Fix CI")
+				: localize('sessions.onboarding.newSessionViewV3.options.githubReview.title', "Address PR comments");
 		const icon = candidate.strategy === 'githubIssue'
 			? computeIssueIcon(GitHubIssueState.Open, undefined)
 			: computePullRequestIcon(GitHubPullRequestState.Open, {
@@ -850,6 +850,7 @@ export class NewSessionViewV3PromptRunner {
 		return {
 			id: `${candidate.strategy}:${candidate.url}`,
 			title,
+			titleDetail: `#${candidate.number}`,
 			description: candidate.title,
 			prompt: plan.prompt,
 			placeholder: '',

--- a/src/vs/sessions/contrib/onboardingTours/test/browser/newSessionViewV3Prompt.test.ts
+++ b/src/vs/sessions/contrib/onboardingTours/test/browser/newSessionViewV3Prompt.test.ts
@@ -688,7 +688,7 @@ function summarizePromptOptionStates(states: readonly NewSessionPromptOptionsSta
 		: {
 			kind: state.kind,
 			options: state.options.map(option => ({
-				title: option.title,
+				title: option.titleDetail ? `${option.title} ${option.titleDetail}` : option.title,
 				description: option.description,
 				icon: option.icon ? { id: option.icon.id, color: option.icon.color?.id } : undefined,
 			})),


### PR DESCRIPTION
## Summary

- model GitHub issue/PR numbers separately from prompt-option action titles
- render the number beside the action using the same muted color as the second-line repository title
- preserve the combined title in ARIA labels and managed full-text hovers

## Testing

- `npm run eslint -- src/vs/sessions/contrib/chat/browser/newSessionComposerService.ts src/vs/sessions/contrib/chat/browser/newSessionPromptOptions.ts src/vs/sessions/contrib/chat/test/browser/newChatWidget.fixture.ts src/vs/sessions/contrib/onboardingTours/browser/newSessionViewV3Prompt.ts src/vs/sessions/contrib/onboardingTours/test/browser/newSessionViewV3Prompt.test.ts`
- `npm run stylelint -- src/vs/sessions/contrib/chat/browser/media/newSessionPromptOptions.css`
- `npm run transpile-client`
- `scripts\test.bat --run src\vs\sessions\contrib\onboardingTours\test\browser\newSessionViewV3Prompt.test.ts --run src\vs\sessions\contrib\chat\test\browser\newSessionPromptOptions.test.ts --run src\vs\sessions\contrib\chat\test\browser\newChatWidget.test.ts`