### PR TITLE
Replace console.log with logService.trace in extension service error handling

### DIFF
--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -182,7 +182,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			resolverResult = await this._resolveAuthorityInitial(remoteAuthority);
 		} catch (err) {
 			if (RemoteAuthorityResolverError.isHandled(err)) {
-				console.log(`Error handled: Not showing a notification for the error`);
+				this._logService.trace(`Error handled: Not showing a notification for the error`);
 			}
 			this._remoteAuthorityResolverService._setResolvedAuthorityError(remoteAuthority, err);
 

--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -404,7 +404,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 					err.isHandled = await this._handleNoResolverFound(remoteAuthority);
 				} else {
 					if (RemoteAuthorityResolverError.isHandled(err)) {
-						console.log(`Error handled: Not showing a notification for the error`);
+						this._logService.trace(`Error handled: Not showing a notification for the error`);
 					}
 				}
 				this._remoteAuthorityResolverService._setResolvedAuthorityError(remoteAuthority, err);


### PR DESCRIPTION
Both extensionService.ts and nativeExtensionService.ts use ILogService throughout for all logging, but the 'Error handled' branch inside the remote authority resolver catch block used a raw console.log. This means the message never reaches the VS Code Output panel, cannot be filtered by log level, and is invisible in non-devtools environments (e.g. remote extension host, server).

Replaced with this._logService.trace() to be consistent with how all other diagnostic logging in these files is handled.