### PR TITLE
Fix cache-sensitive HTTP MCP definition equality

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { hash } from '../../../../../base/common/hash.js';
 import { Disposable, DisposableResourceMap } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -106,7 +107,7 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 			label: name,
 			launch,
 			variableReplacement: { target: ConfigurationTarget.USER },
-			cacheNonce: String(McpServerLaunch.hashForCache(launch)),
+			cacheNonce: String(hash(launch)),
 		};
 	}
 

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { hash } from '../../../../../base/common/hash.js';
 import { Disposable, DisposableResourceMap } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -107,7 +106,7 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 			label: name,
 			launch,
 			variableReplacement: { target: ConfigurationTarget.USER },
-			cacheNonce: String(hash(launch)),
+			cacheNonce: String(McpServerLaunch.hashForCache(launch)),
 		};
 	}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -221,6 +221,16 @@ export interface McpServerStaticMetadata {
 	serverInfo?: MCP.Implementation;
 }
 
+function cloneUriWithoutCaches(uri: URI): URI {
+	return URI.revive({
+		scheme: uri.scheme,
+		authority: uri.authority,
+		path: uri.path,
+		query: uri.query,
+		fragment: uri.fragment,
+	});
+}
+
 export namespace McpServerDefinition {
 	export interface Serialized {
 		readonly id: string;
@@ -233,7 +243,10 @@ export namespace McpServerDefinition {
 	}
 
 	export function toSerialized(def: McpServerDefinition): McpServerDefinition.Serialized {
-		return def;
+		return {
+			...def,
+			launch: McpServerLaunch.toSerialized(def.launch),
+		};
 	}
 
 	export function fromSerialized(def: McpServerDefinition.Serialized): McpServerDefinition {
@@ -250,13 +263,13 @@ export namespace McpServerDefinition {
 
 	function normalizePresentation(presentation: McpServerDefinition['presentation']) {
 		return presentation?.origin
-			? { ...presentation, origin: { ...presentation.origin, uri: URI.from(presentation.origin.uri) } }
+			? { ...presentation, origin: { ...presentation.origin, uri: cloneUriWithoutCaches(presentation.origin.uri) } }
 			: presentation;
 	}
 
 	function normalizeVariableReplacement(variableReplacement: McpServerDefinitionVariableReplacement | undefined) {
 		return variableReplacement?.folder
-			? { ...variableReplacement, folder: { ...variableReplacement.folder, uri: URI.from(variableReplacement.folder.uri) } }
+			? { ...variableReplacement, folder: { ...variableReplacement.folder, uri: cloneUriWithoutCaches(variableReplacement.folder.uri) } }
 			: variableReplacement;
 	}
 
@@ -683,13 +696,15 @@ export namespace McpServerLaunch {
 		| { type: McpServerTransportType.HTTP; uri: UriComponents; headers: [string, string][]; oauth?: McpServerTransportHTTPOAuth; authentication?: McpServerTransportHTTPAuthentication }
 		| { type: McpServerTransportType.Stdio; cwd: string | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined; sandbox: IMcpSandboxConfiguration | undefined };
 
-	function normalizeOAuth(oauth: McpServerTransportHTTPOAuth): McpServerTransportHTTPOAuth {
-		const result: Mutable<McpServerTransportHTTPOAuth> = {};
-		if (oauth.clientId !== undefined) {
-			result.clientId = oauth.clientId;
+	function normalizeDefinedProperties<T extends object>(value: T): T {
+		if (value === null || typeof value !== 'object') {
+			return value;
 		}
-		if (oauth.enterpriseManaged !== undefined) {
-			result.enterpriseManaged = oauth.enterpriseManaged;
+		const result = { ...value };
+		for (const [key, property] of Object.entries(result)) {
+			if (property === undefined) {
+				Reflect.deleteProperty(result, key);
+			}
 		}
 		return result;
 	}
@@ -701,17 +716,14 @@ export namespace McpServerLaunch {
 	function normalizeHTTP(launch: McpServerTransportHTTP): McpServerTransportHTTP {
 		const result: Mutable<McpServerTransportHTTP> = {
 			type: McpServerTransportType.HTTP,
-			uri: URI.from(launch.uri),
+			uri: cloneUriWithoutCaches(launch.uri),
 			headers: launch.headers
 		};
 		if (launch.oauth !== undefined) {
-			result.oauth = normalizeOAuth(launch.oauth);
+			result.oauth = normalizeDefinedProperties(launch.oauth);
 		}
 		if (launch.authentication !== undefined) {
-			result.authentication = {
-				providerId: launch.authentication.providerId,
-				scopes: launch.authentication.scopes
-			};
+			result.authentication = normalizeDefinedProperties(launch.authentication);
 		}
 		return result;
 	}

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -708,6 +708,15 @@ export namespace McpServerLaunch {
 		return prototype === Object.prototype || prototype === null;
 	}
 
+	function defineEnumerableOwnProperty(target: object, key: string, value: unknown): void {
+		Object.defineProperty(target, key, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		});
+	}
+
 	function normalizeRuntimeValue(
 		value: unknown,
 		omittedUndefinedProperties?: ReadonlySet<string>,
@@ -741,7 +750,7 @@ export namespace McpServerLaunch {
 			if (property === undefined && omittedUndefinedProperties?.has(key)) {
 				continue;
 			}
-			result[key] = normalizeRuntimeValue(property, undefined, seen);
+			defineEnumerableOwnProperty(result, key, normalizeRuntimeValue(property, undefined, seen));
 		}
 		return result;
 	}
@@ -765,7 +774,7 @@ export namespace McpServerLaunch {
 		}
 		for (const key of Object.keys(launch).sort()) {
 			if (!knownHTTPProperties.has(key)) {
-				Reflect.set(result, key, normalizeRuntimeValue(Reflect.get(launch, key), undefined, seen));
+				defineEnumerableOwnProperty(result, key, normalizeRuntimeValue(Reflect.get(launch, key), undefined, seen));
 			}
 		}
 		return result;

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -8,6 +8,7 @@ import { assertNever } from '../../../../base/common/assert.js';
 import { decodeHex, encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
+import { hash as objectHash } from '../../../../base/common/hash.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { equals as objectsEqual } from '../../../../base/common/objects.js';
@@ -246,14 +247,26 @@ export namespace McpServerDefinition {
 		};
 	}
 
+	function normalizePresentation(presentation: McpServerDefinition['presentation']) {
+		return presentation?.origin
+			? { ...presentation, origin: { ...presentation.origin, uri: URI.from(presentation.origin.uri) } }
+			: presentation;
+	}
+
+	function normalizeVariableReplacement(variableReplacement: McpServerDefinitionVariableReplacement | undefined) {
+		return variableReplacement?.folder
+			? { ...variableReplacement, folder: { ...variableReplacement.folder, uri: URI.from(variableReplacement.folder.uri) } }
+			: variableReplacement;
+	}
+
 	export function equals(a: McpServerDefinition, b: McpServerDefinition): boolean {
 		return a.id === b.id
 			&& a.label === b.label
 			&& a.cacheNonce === b.cacheNonce
 			&& arraysEqual(a.roots, b.roots, (a, b) => a.toString() === b.toString())
-			&& objectsEqual(a.launch, b.launch)
-			&& objectsEqual(a.presentation, b.presentation)
-			&& objectsEqual(a.variableReplacement, b.variableReplacement)
+			&& McpServerLaunch.equals(a.launch, b.launch)
+			&& objectsEqual(normalizePresentation(a.presentation), normalizePresentation(b.presentation))
+			&& objectsEqual(normalizeVariableReplacement(a.variableReplacement), normalizeVariableReplacement(b.variableReplacement))
 			&& objectsEqual(a.devMode, b.devMode)
 			&& a.sandboxEnabled === b.sandboxEnabled;
 
@@ -669,6 +682,20 @@ export namespace McpServerLaunch {
 		| { type: McpServerTransportType.HTTP; uri: UriComponents; headers: [string, string][]; oauth?: McpServerTransportHTTPOAuth; authentication?: McpServerTransportHTTPAuthentication }
 		| { type: McpServerTransportType.Stdio; cwd: string | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined; sandbox: IMcpSandboxConfiguration | undefined };
 
+	function normalize(launch: McpServerLaunch): McpServerLaunch {
+		return launch.type === McpServerTransportType.HTTP
+			? { ...launch, uri: URI.from(launch.uri) }
+			: launch;
+	}
+
+	export function equals(a: McpServerLaunch, b: McpServerLaunch): boolean {
+		return objectsEqual(normalize(a), normalize(b));
+	}
+
+	export function hashForCache(launch: McpServerLaunch): number {
+		return objectHash(normalize(launch));
+	}
+
 	export function toSerialized(launch: McpServerLaunch): McpServerLaunch.Serialized {
 		return launch;
 	}
@@ -691,7 +718,7 @@ export namespace McpServerLaunch {
 	}
 
 	export async function hash(launch: McpServerLaunch): Promise<string> {
-		const nonce = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(launch)));
+		const nonce = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(normalize(launch))));
 		return encodeHex(VSBuffer.wrap(new Uint8Array(nonce)));
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -8,7 +8,6 @@ import { assertNever } from '../../../../base/common/assert.js';
 import { decodeHex, encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
-import { hash as objectHash } from '../../../../base/common/hash.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { equals as objectsEqual } from '../../../../base/common/objects.js';
@@ -243,10 +242,10 @@ export namespace McpServerDefinition {
 	}
 
 	export function toSerialized(def: McpServerDefinition): McpServerDefinition.Serialized {
-		return {
-			...def,
-			launch: McpServerLaunch.toSerialized(def.launch),
-		};
+		const launch = McpServerLaunch.toSerialized(def.launch);
+		return def.variableReplacement
+			? { ...def, launch, variableReplacement: McpServerDefinitionVariableReplacement.toSerialized(def.variableReplacement) }
+			: { ...def, launch };
 	}
 
 	export function fromSerialized(def: McpServerDefinition.Serialized): McpServerDefinition {
@@ -302,7 +301,9 @@ export namespace McpServerDefinitionVariableReplacement {
 	}
 
 	export function toSerialized(def: McpServerDefinitionVariableReplacement): McpServerDefinitionVariableReplacement.Serialized {
-		return def;
+		return def.folder
+			? { ...def, folder: { ...def.folder, uri: cloneUriWithoutCaches(def.folder.uri) } }
+			: def;
 	}
 
 	export function fromSerialized(def: McpServerDefinitionVariableReplacement.Serialized): McpServerDefinitionVariableReplacement {
@@ -696,15 +697,51 @@ export namespace McpServerLaunch {
 		| { type: McpServerTransportType.HTTP; uri: UriComponents; headers: [string, string][]; oauth?: McpServerTransportHTTPOAuth; authentication?: McpServerTransportHTTPAuthentication }
 		| { type: McpServerTransportType.Stdio; cwd: string | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined; sandbox: IMcpSandboxConfiguration | undefined };
 
-	function normalizeDefinedProperties<T extends object>(value: T): T {
+	const knownHTTPProperties = new Set(['type', 'uri', 'headers', 'oauth', 'authentication']);
+	const optionalOAuthProperties = new Set(['clientId', 'enterpriseManaged']);
+
+	function isPlainRecord(value: unknown): value is Record<string, unknown> {
 		if (value === null || typeof value !== 'object') {
+			return false;
+		}
+		const prototype = Object.getPrototypeOf(value);
+		return prototype === Object.prototype || prototype === null;
+	}
+
+	function normalizeRuntimeValue(
+		value: unknown,
+		omittedUndefinedProperties?: ReadonlySet<string>,
+		seen = new WeakMap<object, unknown>()
+	): unknown {
+		if (Array.isArray(value)) {
+			if (seen.has(value)) {
+				return seen.get(value);
+			}
+			const result = new Array<unknown>(value.length);
+			seen.set(value, result);
+			for (let i = 0; i < value.length; i++) {
+				if (Object.hasOwn(value, i)) {
+					result[i] = normalizeRuntimeValue(value[i], undefined, seen);
+				}
+			}
+			return result;
+		}
+
+		if (!isPlainRecord(value)) {
 			return value;
 		}
-		const result = { ...value };
-		for (const [key, property] of Object.entries(result)) {
-			if (property === undefined) {
-				Reflect.deleteProperty(result, key);
+		if (seen.has(value)) {
+			return seen.get(value);
+		}
+
+		const result: Record<string, unknown> = Object.create(Object.getPrototypeOf(value));
+		seen.set(value, result);
+		for (const key of Object.keys(value).sort()) {
+			const property = value[key];
+			if (property === undefined && omittedUndefinedProperties?.has(key)) {
+				continue;
 			}
+			result[key] = normalizeRuntimeValue(property, undefined, seen);
 		}
 		return result;
 	}
@@ -719,11 +756,17 @@ export namespace McpServerLaunch {
 			uri: cloneUriWithoutCaches(launch.uri),
 			headers: launch.headers
 		};
+		const seen = new WeakMap<object, unknown>([[launch, result]]);
 		if (launch.oauth !== undefined) {
-			result.oauth = normalizeDefinedProperties(launch.oauth);
+			Reflect.set(result, 'oauth', normalizeRuntimeValue(launch.oauth, optionalOAuthProperties, seen));
 		}
 		if (launch.authentication !== undefined) {
-			result.authentication = normalizeDefinedProperties(launch.authentication);
+			Reflect.set(result, 'authentication', normalizeRuntimeValue(launch.authentication, undefined, seen));
+		}
+		for (const key of Object.keys(launch).sort()) {
+			if (!knownHTTPProperties.has(key)) {
+				Reflect.set(result, key, normalizeRuntimeValue(Reflect.get(launch, key), undefined, seen));
+			}
 		}
 		return result;
 	}
@@ -736,10 +779,6 @@ export namespace McpServerLaunch {
 		return objectsEqual(normalize(a), normalize(b));
 	}
 
-	export function hashForCache(launch: McpServerLaunch): number {
-		return objectHash(normalize(launch));
-	}
-
 	export function toSerialized(launch: McpServerLaunch): McpServerLaunch.Serialized {
 		return normalize(launch);
 	}
@@ -748,11 +787,8 @@ export namespace McpServerLaunch {
 		switch (launch.type) {
 			case McpServerTransportType.HTTP:
 				return normalizeHTTP({
-					type: launch.type,
+					...launch,
 					uri: URI.revive(launch.uri),
-					headers: launch.headers,
-					oauth: launch.oauth,
-					authentication: launch.authentication
 				});
 			case McpServerTransportType.Stdio:
 				return {
@@ -767,8 +803,51 @@ export namespace McpServerLaunch {
 		}
 	}
 
+	function collectUndefinedPaths(value: unknown, path: string[], result: string[][], ancestors = new WeakSet<object>()): void {
+		if (value === null || typeof value !== 'object' || ancestors.has(value)) {
+			return;
+		}
+		ancestors.add(value);
+
+		if (Array.isArray(value)) {
+			for (let i = 0; i < value.length; i++) {
+				const propertyPath = [...path, String(i)];
+				if (!Object.hasOwn(value, i) || value[i] === undefined) {
+					result.push(propertyPath);
+				} else {
+					collectUndefinedPaths(value[i], propertyPath, result, ancestors);
+				}
+			}
+		} else {
+			for (const key of Object.keys(value).sort()) {
+				const property = Reflect.get(value, key);
+				const propertyPath = [...path, key];
+				if (property === undefined) {
+					result.push(propertyPath);
+				} else {
+					collectUndefinedPaths(property, propertyPath, result, ancestors);
+				}
+			}
+		}
+
+		ancestors.delete(value);
+	}
+
+	function stringifyHTTPForHash(launch: McpServerTransportHTTP): string {
+		const serialized = JSON.stringify(launch);
+		const undefinedPaths: string[][] = [];
+		collectUndefinedPaths(launch, [], undefinedPaths);
+		return undefinedPaths.length === 0
+			? serialized
+			: `${serialized}\nundefined:${JSON.stringify(undefinedPaths)}`;
+	}
+
 	export async function hash(launch: McpServerLaunch): Promise<string> {
-		const nonce = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(normalize(launch))));
+		const normalized = normalize(launch);
+		const serialized = normalized.type === McpServerTransportType.HTTP
+			? stringifyHTTPForHash(normalized)
+			: JSON.stringify(normalized);
+		const nonce = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(serialized));
 		return encodeHex(VSBuffer.wrap(new Uint8Array(nonce)));
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -15,6 +15,7 @@ import { equals as objectsEqual } from '../../../../base/common/objects.js';
 import { IObservable, ObservableMap } from '../../../../base/common/observable.js';
 import { IIterativePager } from '../../../../base/common/paging.js';
 import Severity from '../../../../base/common/severity.js';
+import { Mutable } from '../../../../base/common/types.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { Location } from '../../../../editor/common/languages.js';
 import { localize } from '../../../../nls.js';
@@ -682,10 +683,41 @@ export namespace McpServerLaunch {
 		| { type: McpServerTransportType.HTTP; uri: UriComponents; headers: [string, string][]; oauth?: McpServerTransportHTTPOAuth; authentication?: McpServerTransportHTTPAuthentication }
 		| { type: McpServerTransportType.Stdio; cwd: string | undefined; command: string; args: readonly string[]; env: Record<string, string | number | null>; envFile: string | undefined; sandbox: IMcpSandboxConfiguration | undefined };
 
+	function normalizeOAuth(oauth: McpServerTransportHTTPOAuth): McpServerTransportHTTPOAuth {
+		const result: Mutable<McpServerTransportHTTPOAuth> = {};
+		if (oauth.clientId !== undefined) {
+			result.clientId = oauth.clientId;
+		}
+		if (oauth.enterpriseManaged !== undefined) {
+			result.enterpriseManaged = oauth.enterpriseManaged;
+		}
+		return result;
+	}
+
+	/**
+	 * URI instances cache formatted values in enumerable fields, and callers can
+	 * represent absent optional fields as either missing or explicitly undefined.
+	 */
+	function normalizeHTTP(launch: McpServerTransportHTTP): McpServerTransportHTTP {
+		const result: Mutable<McpServerTransportHTTP> = {
+			type: McpServerTransportType.HTTP,
+			uri: URI.from(launch.uri),
+			headers: launch.headers
+		};
+		if (launch.oauth !== undefined) {
+			result.oauth = normalizeOAuth(launch.oauth);
+		}
+		if (launch.authentication !== undefined) {
+			result.authentication = {
+				providerId: launch.authentication.providerId,
+				scopes: launch.authentication.scopes
+			};
+		}
+		return result;
+	}
+
 	function normalize(launch: McpServerLaunch): McpServerLaunch {
-		return launch.type === McpServerTransportType.HTTP
-			? { ...launch, uri: URI.from(launch.uri) }
-			: launch;
+		return launch.type === McpServerTransportType.HTTP ? normalizeHTTP(launch) : launch;
 	}
 
 	export function equals(a: McpServerLaunch, b: McpServerLaunch): boolean {
@@ -697,13 +729,19 @@ export namespace McpServerLaunch {
 	}
 
 	export function toSerialized(launch: McpServerLaunch): McpServerLaunch.Serialized {
-		return launch;
+		return normalize(launch);
 	}
 
 	export function fromSerialized(launch: McpServerLaunch.Serialized): McpServerLaunch {
 		switch (launch.type) {
 			case McpServerTransportType.HTTP:
-				return { type: launch.type, uri: URI.revive(launch.uri), headers: launch.headers, oauth: launch.oauth, authentication: launch.authentication };
+				return normalizeHTTP({
+					type: launch.type,
+					uri: URI.revive(launch.uri),
+					headers: launch.headers,
+					oauth: launch.oauth,
+					authentication: launch.authentication
+				});
 			case McpServerTransportType.Stdio:
 				return {
 					type: launch.type,

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -192,6 +192,18 @@ suite('MCP Types', () => {
 			});
 			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
 		});
+
+		test('serializes nested HTTP launches without URI cache state', () => {
+			const uri = URI.parse('https://example.com/mcp');
+			uri.toString();
+			void uri.fsPath;
+
+			const serialized = McpServerDefinition.toSerialized(createHttpDefinition(uri));
+
+			assert.strictEqual(serialized.launch.type, McpServerTransportType.HTTP);
+			assert.strictEqual(JSON.stringify(serialized.launch).includes('"external"'), false);
+			assert.strictEqual(JSON.stringify(serialized.launch).includes('"fsPath"'), false);
+		});
 	});
 
 	suite('McpServerLaunch identity', () => {
@@ -253,6 +265,23 @@ suite('MCP Types', () => {
 			assert.strictEqual(JSON.stringify(serialized).includes('"external"'), false);
 			assert.strictEqual(Object.hasOwn(launch, 'authentication'), true);
 			assert.strictEqual(Object.hasOwn(launch.oauth!, 'clientId'), true);
+		});
+
+		test('does not revalidate trusted URI components during normalization', () => {
+			const uri = URI.revive({
+				scheme: 'https',
+				authority: 'example.com',
+				path: 'relative',
+				query: '',
+				fragment: ''
+			});
+			const launch = createHttpLaunch({ uri });
+
+			const serialized = McpServerLaunch.toSerialized(launch);
+			if (serialized.type !== McpServerTransportType.HTTP) {
+				throw new Error('Expected an HTTP launch');
+			}
+			assert.deepStrictEqual(serialized.uri, uri);
 		});
 
 		test('preserves meaningful HTTP authentication identity', async () => {

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { McpResourceURI, McpServerDefinition, McpServerTransportType } from '../../common/mcpTypes.js';
 import * as assert from 'assert';
+import { hash as objectHash } from '../../../../../base/common/hash.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+import { McpResourceURI, McpServerDefinition, McpServerLaunch, McpServerTransportType } from '../../common/mcpTypes.js';
 
 suite('MCP Types', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -44,6 +46,14 @@ suite('MCP Types', () => {
 				sandbox: undefined
 			},
 			...overrides
+		});
+
+		const createHttpDefinition = (uri: URI, headers: [string, string][] = []): McpServerDefinition => createBasicDefinition({
+			launch: {
+				type: McpServerTransportType.HTTP,
+				uri,
+				headers
+			}
 		});
 
 		test('returns true for identical definitions', () => {
@@ -106,6 +116,131 @@ suite('MCP Types', () => {
 				}
 			});
 			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+
+		test('returns true when equivalent HTTP URI cache state differs', () => {
+			const uri1 = URI.parse('https://example.com/mcp');
+			const uri2 = URI.parse('https://example.com/mcp');
+			uri1.toString();
+
+			assert.strictEqual(McpServerDefinition.equals(createHttpDefinition(uri1), createHttpDefinition(uri2)), true);
+		});
+
+		test('returns false when HTTP endpoint differs', () => {
+			const def1 = createHttpDefinition(URI.parse('https://example.com/mcp-one'));
+			const def2 = createHttpDefinition(URI.parse('https://example.com/mcp-two'));
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+
+		test('returns false when HTTP headers differ', () => {
+			const uri = 'https://example.com/mcp';
+			const def1 = createHttpDefinition(URI.parse(uri), [['X-Test-Header', 'one']]);
+			const def2 = createHttpDefinition(URI.parse(uri), [['X-Test-Header', 'two']]);
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+
+		test('returns true when presentation origin URI cache state differs', () => {
+			const uri1 = URI.file('/path/to/mcp.json');
+			const uri2 = URI.file('/path/to/mcp.json');
+			uri1.toString();
+
+			const range = { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 };
+			const def1 = createBasicDefinition({ presentation: { origin: { uri: uri1, range } } });
+			const def2 = createBasicDefinition({ presentation: { origin: { uri: uri2, range } } });
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), true);
+		});
+
+		test('returns false when presentation origin URI differs', () => {
+			const range = { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 };
+			const def1 = createBasicDefinition({ presentation: { origin: { uri: URI.file('/path/to/one.json'), range } } });
+			const def2 = createBasicDefinition({ presentation: { origin: { uri: URI.file('/path/to/two.json'), range } } });
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+
+		test('returns true when variable replacement folder URI cache state differs', () => {
+			const uri1 = URI.file('/workspace');
+			const uri2 = URI.file('/workspace');
+			uri1.toString();
+
+			const def1 = createBasicDefinition({
+				variableReplacement: {
+					target: ConfigurationTarget.USER,
+					folder: { uri: uri1, name: 'workspace', index: 0 }
+				}
+			});
+			const def2 = createBasicDefinition({
+				variableReplacement: {
+					target: ConfigurationTarget.USER,
+					folder: { uri: uri2, name: 'workspace', index: 0 }
+				}
+			});
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), true);
+		});
+
+		test('returns false when variable replacement folder URI differs', () => {
+			const def1 = createBasicDefinition({
+				variableReplacement: {
+					target: ConfigurationTarget.USER,
+					folder: { uri: URI.file('/workspace/one'), name: 'workspace', index: 0 }
+				}
+			});
+			const def2 = createBasicDefinition({
+				variableReplacement: {
+					target: ConfigurationTarget.USER,
+					folder: { uri: URI.file('/workspace/two'), name: 'workspace', index: 0 }
+				}
+			});
+			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+	});
+
+	suite('McpServerLaunch hashing', () => {
+		const createHttpLaunch = (uri: URI): McpServerLaunch => ({
+			type: McpServerTransportType.HTTP,
+			uri,
+			headers: [['X-Test-Header', 'value']]
+		});
+
+		test('returns the same asynchronous hash when HTTP URI cache state differs', async () => {
+			const uri1 = URI.parse('https://example.com/mcp');
+			const uri2 = URI.parse('https://example.com/mcp');
+			uri1.toString();
+			void uri1.fsPath;
+
+			assert.strictEqual(await McpServerLaunch.hash(createHttpLaunch(uri1)), await McpServerLaunch.hash(createHttpLaunch(uri2)));
+		});
+
+		test('returns the same synchronous cache hash when HTTP URI cache state differs', () => {
+			const uri1 = URI.parse('https://example.com/mcp');
+			const uri2 = URI.parse('https://example.com/mcp');
+			uri1.toString();
+			void uri1.fsPath;
+
+			assert.strictEqual(McpServerLaunch.hashForCache(createHttpLaunch(uri1)), McpServerLaunch.hashForCache(createHttpLaunch(uri2)));
+		});
+
+		test('preserves the existing synchronous hash for a fresh HTTP launch', () => {
+			const launch = createHttpLaunch(URI.parse('https://example.com/mcp'));
+			assert.strictEqual(McpServerLaunch.hashForCache(launch), objectHash(launch));
+		});
+
+		test('preserves the existing asynchronous hash for a fresh HTTP launch', async () => {
+			const launch = createHttpLaunch(URI.parse('https://example.com/mcp'));
+			const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(launch)));
+			const existingHash = Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('');
+
+			assert.strictEqual(await McpServerLaunch.hash(launch), existingHash);
+		});
+
+		test('does not populate URI caches while hashing', async () => {
+			const uri = URI.parse('https://example.com/mcp');
+			const launch = createHttpLaunch(uri);
+			const initialUriState = JSON.stringify(uri);
+
+			McpServerLaunch.hashForCache(launch);
+			await McpServerLaunch.hash(launch);
+
+			assert.strictEqual(JSON.stringify(uri), initialUriState);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -324,6 +324,35 @@ suite('MCP Types', () => {
 			assert.deepStrictEqual(Reflect.get(revived, 'futureProperty'), { enabled: true });
 		});
 
+		test('preserves __proto__ HTTP properties without changing prototypes', async () => {
+			const launch = createHttpLaunch();
+			const nestedValue = JSON.parse('{"__proto__":{"nested":true}}');
+			Object.defineProperty(launch, '__proto__', {
+				value: { topLevel: true },
+				enumerable: true,
+				configurable: true,
+				writable: true
+			});
+			Reflect.set(launch, 'futureProperty', nestedValue);
+
+			const serialized = McpServerLaunch.toSerialized(launch);
+			const revived = McpServerLaunch.fromSerialized(serialized);
+			const withoutUnknownProperties = createHttpLaunch();
+
+			assert.strictEqual(Object.getPrototypeOf(serialized), Object.prototype);
+			assert.strictEqual(Object.hasOwn(serialized, '__proto__'), true);
+			assert.deepStrictEqual(Reflect.get(serialized, '__proto__'), { topLevel: true });
+			const serializedNestedValue = Reflect.get(serialized, 'futureProperty');
+			assert.strictEqual(Object.getPrototypeOf(serializedNestedValue), Object.prototype);
+			assert.strictEqual(Object.hasOwn(serializedNestedValue, '__proto__'), true);
+			assert.deepStrictEqual(Reflect.get(serializedNestedValue, '__proto__'), { nested: true });
+			assert.strictEqual(Object.getPrototypeOf(revived), Object.prototype);
+			assert.strictEqual(Object.hasOwn(revived, '__proto__'), true);
+			assert.strictEqual(McpServerLaunch.equals(launch, revived), true);
+			assert.strictEqual(McpServerLaunch.equals(launch, withoutUnknownProperties), false);
+			assert.notStrictEqual(await McpServerLaunch.hash(launch), await McpServerLaunch.hash(withoutUnknownProperties));
+		});
+
 		test('does not revalidate trusted URI components during normalization', () => {
 			const uri = URI.revive({
 				scheme: 'https',

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { hash as objectHash } from '../../../../../base/common/hash.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
@@ -204,6 +203,26 @@ suite('MCP Types', () => {
 			assert.strictEqual(JSON.stringify(serialized.launch).includes('"external"'), false);
 			assert.strictEqual(JSON.stringify(serialized.launch).includes('"fsPath"'), false);
 		});
+
+		test('serializes variable replacement folders without URI cache state', () => {
+			const cachedUri = URI.file('/workspace');
+			const freshUri = URI.file('/workspace');
+			cachedUri.toString();
+			void cachedUri.fsPath;
+
+			const createDefinition = (uri: URI) => createBasicDefinition({
+				variableReplacement: {
+					target: ConfigurationTarget.USER,
+					folder: { uri, name: 'workspace', index: 0 }
+				}
+			});
+			const cached = JSON.stringify(McpServerDefinition.toSerialized(createDefinition(cachedUri)).variableReplacement);
+			const fresh = JSON.stringify(McpServerDefinition.toSerialized(createDefinition(freshUri)).variableReplacement);
+
+			assert.strictEqual(cached, fresh);
+			assert.strictEqual(cached.includes('"external"'), false);
+			assert.strictEqual(cached.includes('"fsPath"'), false);
+		});
 	});
 
 	suite('McpServerLaunch identity', () => {
@@ -213,6 +232,11 @@ suite('MCP Types', () => {
 			headers: [],
 			...overrides
 		});
+		const createMalformedHttpLaunch = (property: 'oauth' | 'authentication', value: unknown): McpServerTransportHTTP => {
+			const launch = createHttpLaunch();
+			Reflect.set(launch, property, value);
+			return launch;
+		};
 
 		test('normalizes missing and undefined HTTP properties', async () => {
 			const omitted = createHttpLaunch();
@@ -222,7 +246,6 @@ suite('MCP Types', () => {
 			});
 
 			assert.strictEqual(McpServerLaunch.equals(omitted, explicitUndefined), true);
-			assert.strictEqual(McpServerLaunch.hashForCache(omitted), McpServerLaunch.hashForCache(explicitUndefined));
 			assert.strictEqual(await McpServerLaunch.hash(omitted), await McpServerLaunch.hash(explicitUndefined));
 		});
 
@@ -234,9 +257,7 @@ suite('MCP Types', () => {
 					enterpriseManaged: undefined
 				}
 			});
-
 			assert.strictEqual(McpServerLaunch.equals(omitted, explicitUndefined), true);
-			assert.strictEqual(McpServerLaunch.hashForCache(omitted), McpServerLaunch.hashForCache(explicitUndefined));
 			assert.strictEqual(await McpServerLaunch.hash(omitted), await McpServerLaunch.hash(explicitUndefined));
 		});
 
@@ -252,9 +273,7 @@ suite('MCP Types', () => {
 
 			const serialized = McpServerLaunch.toSerialized(launch);
 			const revived = McpServerLaunch.fromSerialized(serialized);
-
 			assert.strictEqual(McpServerLaunch.equals(launch, revived), true);
-			assert.strictEqual(McpServerLaunch.hashForCache(launch), McpServerLaunch.hashForCache(revived));
 			assert.strictEqual(await McpServerLaunch.hash(launch), await McpServerLaunch.hash(revived));
 			assert.strictEqual(serialized.type, McpServerTransportType.HTTP);
 			if (serialized.type !== McpServerTransportType.HTTP) {
@@ -265,6 +284,44 @@ suite('MCP Types', () => {
 			assert.strictEqual(JSON.stringify(serialized).includes('"external"'), false);
 			assert.strictEqual(Object.hasOwn(launch, 'authentication'), true);
 			assert.strictEqual(Object.hasOwn(launch.oauth!, 'clientId'), true);
+		});
+
+		test('preserves malformed HTTP authentication identity', async () => {
+			const withUndefinedProvider = createMalformedHttpLaunch('authentication', { providerId: undefined, scopes: [] });
+			const withoutProvider = createMalformedHttpLaunch('authentication', { scopes: [] });
+			const serialized = McpServerLaunch.toSerialized(withUndefinedProvider);
+			assert.strictEqual(McpServerLaunch.equals(withUndefinedProvider, withoutProvider), false);
+			assert.notStrictEqual(await McpServerLaunch.hash(withUndefinedProvider), await McpServerLaunch.hash(withoutProvider));
+			if (serialized.type !== McpServerTransportType.HTTP) {
+				throw new Error('Expected an HTTP launch');
+			}
+			assert.strictEqual(Object.hasOwn(serialized.authentication!, 'providerId'), true);
+		});
+
+		test('does not coerce malformed HTTP OAuth arrays into records', async () => {
+			const arrayValue = createMalformedHttpLaunch('oauth', []);
+			const objectValue = createMalformedHttpLaunch('oauth', {});
+			const serialized = McpServerLaunch.toSerialized(arrayValue);
+			assert.strictEqual(McpServerLaunch.equals(arrayValue, objectValue), false);
+			assert.notStrictEqual(await McpServerLaunch.hash(arrayValue), await McpServerLaunch.hash(objectValue));
+			if (serialized.type !== McpServerTransportType.HTTP) {
+				throw new Error('Expected an HTTP launch');
+			}
+			assert.strictEqual(Array.isArray(serialized.oauth), true);
+		});
+
+		test('preserves unknown HTTP properties', async () => {
+			const left = createHttpLaunch();
+			const right = createHttpLaunch();
+			Reflect.set(left, 'futureProperty', { enabled: true });
+			Reflect.set(right, 'futureProperty', { enabled: false });
+			assert.strictEqual(McpServerLaunch.equals(left, right), false);
+			assert.notStrictEqual(await McpServerLaunch.hash(left), await McpServerLaunch.hash(right));
+
+			const serialized = McpServerLaunch.toSerialized(left);
+			const revived = McpServerLaunch.fromSerialized(serialized);
+			assert.deepStrictEqual(Reflect.get(serialized, 'futureProperty'), { enabled: true });
+			assert.deepStrictEqual(Reflect.get(revived, 'futureProperty'), { enabled: true });
 		});
 
 		test('does not revalidate trusted URI components during normalization', () => {
@@ -302,7 +359,6 @@ suite('MCP Types', () => {
 
 			for (const [left, right] of pairs) {
 				assert.strictEqual(McpServerLaunch.equals(left, right), false);
-				assert.notStrictEqual(McpServerLaunch.hashForCache(left), McpServerLaunch.hashForCache(right));
 				assert.notStrictEqual(await McpServerLaunch.hash(left), await McpServerLaunch.hash(right));
 			}
 		});
@@ -324,18 +380,25 @@ suite('MCP Types', () => {
 			assert.strictEqual(await McpServerLaunch.hash(createHttpLaunch(uri1)), await McpServerLaunch.hash(createHttpLaunch(uri2)));
 		});
 
-		test('returns the same synchronous cache hash when HTTP URI cache state differs', () => {
-			const uri1 = URI.parse('https://example.com/mcp');
-			const uri2 = URI.parse('https://example.com/mcp');
-			uri1.toString();
-			void uri1.fsPath;
+		test('returns the same asynchronous hash when authentication property order differs', async () => {
+			const uri = URI.parse('https://example.com/mcp');
+			const left: McpServerTransportHTTP = {
+				type: McpServerTransportType.HTTP,
+				uri,
+				headers: [],
+				oauth: { clientId: 'client', enterpriseManaged: true },
+				authentication: { providerId: 'provider', scopes: ['scope'] }
+			};
+			const right: McpServerTransportHTTP = {
+				type: McpServerTransportType.HTTP,
+				uri,
+				headers: [],
+				oauth: { enterpriseManaged: true, clientId: 'client' },
+				authentication: { scopes: ['scope'], providerId: 'provider' }
+			};
 
-			assert.strictEqual(McpServerLaunch.hashForCache(createHttpLaunch(uri1)), McpServerLaunch.hashForCache(createHttpLaunch(uri2)));
-		});
-
-		test('preserves the existing synchronous hash for a fresh HTTP launch', () => {
-			const launch = createHttpLaunch(URI.parse('https://example.com/mcp'));
-			assert.strictEqual(McpServerLaunch.hashForCache(launch), objectHash(launch));
+			assert.strictEqual(McpServerLaunch.equals(left, right), true);
+			assert.strictEqual(await McpServerLaunch.hash(left), await McpServerLaunch.hash(right));
 		});
 
 		test('preserves the existing asynchronous hash for a fresh HTTP launch', async () => {
@@ -351,7 +414,6 @@ suite('MCP Types', () => {
 			const launch = createHttpLaunch(uri);
 			const initialUriState = JSON.stringify(uri);
 
-			McpServerLaunch.hashForCache(launch);
 			await McpServerLaunch.hash(launch);
 
 			assert.strictEqual(JSON.stringify(uri), initialUriState);

--- a/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpTypes.test.ts
@@ -8,7 +8,7 @@ import { hash as objectHash } from '../../../../../base/common/hash.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
-import { McpResourceURI, McpServerDefinition, McpServerLaunch, McpServerTransportType } from '../../common/mcpTypes.js';
+import { McpResourceURI, McpServerDefinition, McpServerLaunch, McpServerTransportHTTP, McpServerTransportType } from '../../common/mcpTypes.js';
 
 suite('MCP Types', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -191,6 +191,91 @@ suite('MCP Types', () => {
 				}
 			});
 			assert.strictEqual(McpServerDefinition.equals(def1, def2), false);
+		});
+	});
+
+	suite('McpServerLaunch identity', () => {
+		const createHttpLaunch = (overrides?: Partial<McpServerTransportHTTP>): McpServerTransportHTTP => ({
+			type: McpServerTransportType.HTTP,
+			uri: URI.parse('https://example.com/mcp'),
+			headers: [],
+			...overrides
+		});
+
+		test('normalizes missing and undefined HTTP properties', async () => {
+			const omitted = createHttpLaunch();
+			const explicitUndefined = createHttpLaunch({
+				oauth: undefined,
+				authentication: undefined
+			});
+
+			assert.strictEqual(McpServerLaunch.equals(omitted, explicitUndefined), true);
+			assert.strictEqual(McpServerLaunch.hashForCache(omitted), McpServerLaunch.hashForCache(explicitUndefined));
+			assert.strictEqual(await McpServerLaunch.hash(omitted), await McpServerLaunch.hash(explicitUndefined));
+		});
+
+		test('normalizes missing and undefined OAuth properties', async () => {
+			const omitted = createHttpLaunch({ oauth: {} });
+			const explicitUndefined = createHttpLaunch({
+				oauth: {
+					clientId: undefined,
+					enterpriseManaged: undefined
+				}
+			});
+
+			assert.strictEqual(McpServerLaunch.equals(omitted, explicitUndefined), true);
+			assert.strictEqual(McpServerLaunch.hashForCache(omitted), McpServerLaunch.hashForCache(explicitUndefined));
+			assert.strictEqual(await McpServerLaunch.hash(omitted), await McpServerLaunch.hash(explicitUndefined));
+		});
+
+		test('round trips canonical HTTP properties without mutating the source', async () => {
+			const launch = createHttpLaunch({
+				oauth: {
+					clientId: undefined,
+					enterpriseManaged: true
+				},
+				authentication: undefined
+			});
+			launch.uri.toString();
+
+			const serialized = McpServerLaunch.toSerialized(launch);
+			const revived = McpServerLaunch.fromSerialized(serialized);
+
+			assert.strictEqual(McpServerLaunch.equals(launch, revived), true);
+			assert.strictEqual(McpServerLaunch.hashForCache(launch), McpServerLaunch.hashForCache(revived));
+			assert.strictEqual(await McpServerLaunch.hash(launch), await McpServerLaunch.hash(revived));
+			assert.strictEqual(serialized.type, McpServerTransportType.HTTP);
+			if (serialized.type !== McpServerTransportType.HTTP) {
+				throw new Error('Expected an HTTP launch');
+			}
+			assert.deepStrictEqual(Object.keys(serialized).sort(), ['headers', 'oauth', 'type', 'uri']);
+			assert.deepStrictEqual(Object.keys(serialized.oauth!).sort(), ['enterpriseManaged']);
+			assert.strictEqual(JSON.stringify(serialized).includes('"external"'), false);
+			assert.strictEqual(Object.hasOwn(launch, 'authentication'), true);
+			assert.strictEqual(Object.hasOwn(launch.oauth!, 'clientId'), true);
+		});
+
+		test('preserves meaningful HTTP authentication identity', async () => {
+			const base = createHttpLaunch();
+			const pairs: [McpServerLaunch, McpServerLaunch][] = [
+				[base, createHttpLaunch({ oauth: {} })],
+				[createHttpLaunch({ oauth: { clientId: 'client-a' } }), createHttpLaunch({ oauth: { clientId: 'client-b' } })],
+				[createHttpLaunch({ oauth: { enterpriseManaged: true } }), createHttpLaunch({ oauth: { enterpriseManaged: false } })],
+				[
+					createHttpLaunch({ authentication: { providerId: 'provider-a', scopes: ['scope'] } }),
+					createHttpLaunch({ authentication: { providerId: 'provider-b', scopes: ['scope'] } })
+				],
+				[
+					createHttpLaunch({ authentication: { providerId: 'provider', scopes: ['scope-a'] } }),
+					createHttpLaunch({ authentication: { providerId: 'provider', scopes: ['scope-b'] } })
+				]
+			];
+
+			for (const [left, right] of pairs) {
+				assert.strictEqual(McpServerLaunch.equals(left, right), false);
+				assert.notStrictEqual(McpServerLaunch.hashForCache(left), McpServerLaunch.hashForCache(right));
+				assert.notStrictEqual(await McpServerLaunch.hash(left), await McpServerLaunch.hash(right));
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

- prevent equivalent HTTP MCP definitions from being treated as changed when URI lazy-cache state differs
- normalize HTTP launch identity consistently across equality, serialization, revival, and hashing
- preserve stdio launch behavior and unknown HTTP properties

## Testing

- 30 focused `mcpTypes` tests
- targeted TypeScript analysis with no implementation or non-ambient test diagnostics
- `git diff --check`

Fixes #327970