### PR TITLE
agentHost: Support Copilot root session forks

### DIFF
--- a/src/vs/platform/agentHost/common/sessionDataService.ts
+++ b/src/vs/platform/agentHost/common/sessionDataService.ts
@@ -291,8 +291,10 @@ export interface ISessionDatabase extends IDisposable {
 	/**
 	 * Bulk-remaps turn IDs using the provided old→new mapping.
 	 * Used after copying a database file for a forked session.
+	 * When provided, `eventIds` replaces the SDK event ID for each remapped
+	 * turn, keyed by the new turn ID.
 	 */
-	remapTurnIds(mapping: ReadonlyMap<string, string>): Promise<void>;
+	remapTurnIds(mapping: ReadonlyMap<string, string>, eventIds?: ReadonlyMap<string, string>): Promise<void>;
 
 	// ---- Reviewed files --------------------------------------------------
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -2112,6 +2112,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		this._logService.info(`[Copilot] Creating session... ${sessionConfig.model ? `model=${sessionConfig.model.id}` : ''}`);
 		const sessionId = sessionConfig.session ? AgentSession.id(sessionConfig.session) : generateUuid();
+		if (sessionConfig.fork && AgentSession.id(sessionConfig.fork.session) === sessionId) {
+			throw new Error(`Cannot fork Copilot session ${sessionId} onto itself`);
+		}
 		// Workspace-less is inferred at create from an absent input
 		// `workingDirectory`: such a session is run in a stable scratch dir. The
 		// AH service persists the marker centrally (`agentHost.workspaceless`) and
@@ -2178,7 +2181,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 							if (turnIdMapping) {
 								const targetDbRef = this._sessionDataService.openDatabase(session);
 								try {
-									await targetDbRef.object.remapTurnIds(turnIdMapping);
+									const importedEventIds = new Map(importedTurns.map(turn => [turn.id, turn.id]));
+									await targetDbRef.object.remapTurnIds(turnIdMapping, importedEventIds);
 								} finally {
 									targetDbRef.dispose();
 								}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1933,6 +1933,17 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * (no `workingDirectory` supplied) — a stable per-session scratch directory.
 	 */
 	private async _resolveCreateWorkingDirectory(sessionConfig: IAgentCreateSessionConfig, sessionId: string, isWorkspaceless: boolean): Promise<URI> {
+		if (sessionConfig.fork) {
+			const sourceSessionId = AgentSession.id(sessionConfig.fork.session);
+			const liveWorkingDirectory = this._findAnySession(sourceSessionId)?.workingDirectory;
+			if (liveWorkingDirectory) {
+				return liveWorkingDirectory;
+			}
+			const storedWorkingDirectory = (await this._readSessionMetadata(sessionConfig.fork.session)).workingDirectory;
+			if (storedWorkingDirectory) {
+				return storedWorkingDirectory;
+			}
+		}
 		const existing = sessionConfig.workingDirectories?.[0] ?? this._provisionalSessions.get(sessionId)?.workingDirectory;
 		if (existing) {
 			return existing;
@@ -2110,39 +2121,53 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// `workingDirectory` is passed.
 		const isWorkspaceless = !sessionConfig.fork && sessionConfig.workingDirectories === undefined;
 		const workingDirectory = await this._resolveCreateWorkingDirectory(sessionConfig, sessionId, isWorkspaceless);
-		const client = await this._ensureClient();
-		// When forking, use the SDK's sessions.fork RPC. Forking from a source
-		// session that has no turns is equivalent to creating a fresh session;
-		// in that case the agent service drops `config.fork` before calling us,
-		// so we never enter this branch with a provisional source.
+		await this._ensureClient();
+		// Forking from a source session that has no turns is equivalent to
+		// creating a fresh session; in that case the agent service drops
+		// `config.fork` before calling us, so we never enter this branch with a
+		// provisional source.
 		if (sessionConfig.fork) {
-			const sourceSessionId = AgentSession.id(sessionConfig.fork.session);
+			const fork = sessionConfig.fork;
+			const sourceSessionId = AgentSession.id(fork.session);
 
 			// Serialize against the source session to prevent concurrent
 			// modifications while we read its state.
 			return this._queueSession(sourceSessionId, async () => {
-				this._logService.info(`[Copilot] Forking session ${sourceSessionId} at turnId=${sessionConfig.fork!.turnId}`);
+				this._logService.info(`[Copilot] Forking session ${sourceSessionId} at turnId=${fork.turnId}`);
 
 				const sourceEntry = this._findAnySession(sourceSessionId) ?? await this._resumeSession(sourceSessionId);
-
-				// Look up the SDK event ID for the turn *after* the fork point.
-				// toEventId is exclusive — events before it are included.
-				// If there's no next turn, omit toEventId to include all events.
-				const toEventId = await sourceEntry.getNextTurnEventId(sessionConfig.fork!.turnId);
-
-				const forkResult = await client.rpc.sessions.fork({
-					sessionId: sourceSessionId,
-					...(toEventId ? { toEventId } : {}),
-				});
-				const newSessionId = forkResult.sessionId;
+				const sourceTurns = await sourceEntry.getMessages();
+				const sourceTurnEventId = await sourceEntry.getTurnEventId(fork.turnId);
+				const sourceTurnIndex = sourceTurns.findIndex(turn => turn.id === sourceTurnEventId);
+				if (sourceTurnIndex < 0) {
+					throw new Error(`Cannot fork Copilot session ${sourceSessionId}: turn ${fork.turnId} is not in the provider history`);
+				}
+				const inheritedTurns = sourceTurns.slice(0, sourceTurnIndex + 1);
+				const turnIdMapping = fork.turnIdMapping;
+				const targetTurnIdByEventId = new Map<string, string>();
+				if (turnIdMapping) {
+					await Promise.all([...turnIdMapping].map(async ([sourceTurnId, targetTurnId]) => {
+						const eventId = await sourceEntry.getTurnEventId(sourceTurnId);
+						if (eventId) {
+							targetTurnIdByEventId.set(eventId, targetTurnId);
+						}
+					}));
+				}
+				const importedTurns = inheritedTurns.map(turn => ({ ...turn, id: targetTurnIdByEventId.get(turn.id) ?? turn.id }));
+				const session = AgentSession.uri(this.id, sessionId);
+				const sourceMetadata = await this._readSessionMetadata(fork.session);
+				const inheritedWorkingDirectories = sourceMetadata.workingDirectories
+					?? (sourceEntry.workingDirectory ? [sourceEntry.workingDirectory] : [workingDirectory]);
+				const model = sessionConfig.model ?? sourceMetadata.model;
+				const agent = sessionConfig.agent ?? sourceMetadata.agent;
 
 				// Copy the source session's database using VACUUM INTO so the
 				// forked session inherits turn event IDs and file-edit snapshots.
 				// VACUUM INTO is safe even while the source DB is open.
-				const targetDbDir = this._sessionDataService.getSessionDataDirById(newSessionId);
+				const targetDbDir = this._sessionDataService.getSessionDataDir(session);
 				const targetDbPath = URI.joinPath(targetDbDir, SESSION_DB_FILENAME);
 				try {
-					const sourceDbRef = await this._sessionDataService.tryOpenDatabase(sessionConfig.fork!.session);
+					const sourceDbRef = await this._sessionDataService.tryOpenDatabase(fork.session);
 					if (sourceDbRef) {
 						try {
 							await fs.mkdir(targetDbDir.fsPath, { recursive: true });
@@ -2150,40 +2175,43 @@ export class CopilotAgent extends Disposable implements IAgent {
 							// any stale DB left by a previous (e.g. crashed) attempt.
 							await fs.rm(targetDbPath.fsPath, { force: true });
 							await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
+							if (turnIdMapping) {
+								const targetDbRef = this._sessionDataService.openDatabase(session);
+								try {
+									await targetDbRef.object.remapTurnIds(turnIdMapping);
+								} finally {
+									targetDbRef.dispose();
+								}
+							}
 						} finally {
 							sourceDbRef.dispose();
 						}
 					}
 				} catch (err) {
 					this._logService.warn(`[Copilot] Failed to copy session database for fork: ${err instanceof Error ? err.message : String(err)}`);
+					await fs.rm(targetDbPath.fsPath, { force: true });
 				}
 
-				// Resume the forked session so the SDK loads the forked history
-				const agentSession = await this._resumeSession(newSessionId);
-
-				// Remap turn IDs to match the new protocol turn IDs
-				if (sessionConfig.fork!.turnIdMapping) {
-					await agentSession.remapTurnIds(sessionConfig.fork!.turnIdMapping);
-				}
-
-				const session = agentSession.sessionUri;
+				const created = await this._importConversation({
+					...sessionConfig,
+					model,
+					agent,
+					workingDirectories: inheritedWorkingDirectories,
+					fork: undefined,
+					importConversation: { turns: importedTurns, model },
+				}, sessionId, workingDirectory);
 				this._logService.info(`[Copilot] Forked session created: ${session.toString()}`);
 
 				// Copy the source session's reviewed ref so the fork starts with
 				// the parent's review progress (best-effort; a failure just means
 				// the fork starts unreviewed).
 				try {
-					await this._reviewService.copyReviewedRef(sessionConfig.fork!.session.toString(), session.toString(), workingDirectory);
+					await this._reviewService.copyReviewedRef(fork.session.toString(), session.toString(), workingDirectory);
 				} catch (err) {
 					this._logService.warn(`[Copilot] Failed to copy reviewed ref for fork: ${err instanceof Error ? err.message : String(err)}`);
 				}
 
-				const project = await projectFromCopilotContext({ cwd: workingDirectory.fsPath }, this._gitService);
-				await this._storeSessionMetadata(session, sessionConfig.model, workingDirectory, sessionConfig.workingDirectories ?? ([workingDirectory]), workingDirectory, project, true);
-				if (sessionConfig.agent !== undefined) {
-					await this._storeSessionAgentMetadata(session, sessionConfig.agent);
-				}
-				return { session, resolvedWorkingDirectory: workingDirectory, ...(project ? { project } : {}) };
+				return created;
 			});
 		}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -5336,6 +5336,13 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/**
+	 * Returns the SDK event ID associated with the given protocol turn.
+	 */
+	getTurnEventId(turnId: string): Promise<string | undefined> {
+		return this._databaseRef.object.getTurnEventId(turnId);
+	}
+
+	/**
 	 * Returns the SDK event ID of the earliest turn.
 	 */
 	getFirstTurnEventId(): Promise<string | undefined> {

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1305,6 +1305,9 @@ export class ProtocolServerHandler extends Disposable {
 			// turn list in the state manager.
 			let fork: { session: URI; turnIndex: number; turnId: string } | undefined;
 			if (params.fork) {
+				if (URI.parse(params.fork.session).toString() === URI.parse(params.channel).toString()) {
+					throw new ProtocolError(AhpErrorCodes.SessionAlreadyExists, `Fork target session must differ from source session: ${params.channel}`);
+				}
 				const sourceState = this._stateManager.getSessionState(params.fork.session);
 				if (!sourceState) {
 					throw new ProtocolError(AHP_SESSION_NOT_FOUND, `Fork source session not found: ${params.fork.session}`);

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -377,7 +377,7 @@ export class SessionDatabase implements ISessionDatabase {
 
 	async getTurnEventId(turnId: string): Promise<string | undefined> {
 		const db = await this._ensureDb();
-		const row = await dbGet(db, 'SELECT event_id FROM turns WHERE id = ?', [turnId]);
+		const row = await dbGet(db, 'SELECT event_id FROM turns WHERE id = ?1 OR event_id = ?1 LIMIT 1', [turnId]);
 		return row?.event_id as string | undefined ?? undefined;
 	}
 
@@ -751,7 +751,7 @@ export class SessionDatabase implements ISessionDatabase {
 		return !!row;
 	}
 
-	remapTurnIds(mapping: ReadonlyMap<string, string>): Promise<void> {
+	remapTurnIds(mapping: ReadonlyMap<string, string>, eventIds?: ReadonlyMap<string, string>): Promise<void> {
 		// Mutates `turn_usage`, so it must serialize with every other such
 		// mutation — a usage write racing the fork transaction would otherwise
 		// land against either the old or the new turn id unpredictably.
@@ -777,6 +777,9 @@ export class SessionDatabase implements ISessionDatabase {
 				for (const [oldId, newId] of mapping) {
 					await dbRun(db, 'UPDATE turns SET id = ? WHERE id = ?', [newId, oldId]);
 					await dbRun(db, 'UPDATE file_edits SET turn_id = ? WHERE turn_id = ?', [newId, oldId]);
+				}
+				for (const [turnId, eventId] of eventIds ?? []) {
+					await dbRun(db, 'UPDATE turns SET event_id = ? WHERE id = ?', [eventId, turnId]);
 				}
 
 				if (oldIds.length > 0) {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -3410,6 +3410,22 @@ suite('CopilotAgent', () => {
 	});
 
 	suite('createSession fork', () => {
+		test('rejects a fork targeting its source session', async () => {
+			const client = new TestCopilotClient([]);
+			const agent = createTestAgent(disposables, { copilotClient: client });
+			const session = AgentSession.uri('copilotcli', 'same-session');
+
+			try {
+				await assert.rejects(() => agent.createSession({
+					session,
+					fork: { session, turnIndex: 0, turnId: 'turn-1' },
+				}), /Cannot fork Copilot session same-session onto itself/);
+				assert.strictEqual(client.startCallCount, 0);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
 		test('materializes provider history under the client-chosen session ID', async () => {
 			const sessionDataService = disposables.add(new TestSessionDataService());
 			const agent = createTestAgent(disposables, { sessionDataService, copilotClient: new TestCopilotClient([]) });

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -36,7 +36,7 @@ import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
 import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
-import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentCreateChatForkSource, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
+import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentCreateChatForkSource, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { buildDefaultChatUri, buildChatUri, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, CustomizationLoadStatus, MessageKind, readSessionEhcliAdoptable, ResponsePartKind, ROOT_STATE_URI, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
 import { CustomizationType, SessionStatus, ToolCallContributorKind, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
@@ -3404,6 +3404,71 @@ suite('CopilotAgent', () => {
 				);
 			} finally {
 				await fs.rm(userHome.fsPath, { recursive: true, force: true });
+				await disposeAgent(agent);
+			}
+		});
+	});
+
+	suite('createSession fork', () => {
+		test('materializes provider history under the client-chosen session ID', async () => {
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const agent = createTestAgent(disposables, { sessionDataService, copilotClient: new TestCopilotClient([]) });
+			const source = AgentSession.uri('copilotcli', 'source-session');
+			const target = AgentSession.uri('copilotcli', 'target-session');
+			const sourceWorkingDirectory = URI.file('/source-workspace');
+			const sourceEventId = '00000000-0000-4000-8000-000000000000';
+			const sourceTurn: Turn = {
+				id: 'source-turn',
+				state: TurnState.Complete,
+				message: { text: 'Remember FORK_ALPHA.', origin: { kind: MessageKind.User } },
+				responseParts: [{ kind: ResponsePartKind.Markdown, id: 'response', content: 'ready' }],
+				usage: {},
+			};
+			setDefaultSessionStub(agent, AgentSession.id(source), {
+				getMessages: async () => [{ ...sourceTurn, id: sourceEventId }],
+				getTurnEventId: async (turnId: string) => turnId === sourceTurn.id ? sourceEventId : undefined,
+				workingDirectory: sourceWorkingDirectory,
+				dispose: () => { },
+			});
+
+			let imported: { config: IAgentCreateSessionConfig; sessionId: string; workingDirectory: URI } | undefined;
+			const internals = agent as unknown as {
+				_importConversation(config: IAgentCreateSessionConfig, sessionId: string, directory: URI): Promise<IAgentCreateSessionResult>;
+			};
+			internals._importConversation = async (config, sessionId, directory) => {
+				imported = { config, sessionId, workingDirectory: directory };
+				return { session: target, resolvedWorkingDirectory: directory };
+			};
+
+			try {
+				const forkedTurnId = '11111111-1111-4111-8111-111111111111';
+				const result = await agent.createSession({
+					session: target,
+					workingDirectories: [URI.file('/ignored-client-workspace')],
+					fork: {
+						session: source,
+						turnIndex: 0,
+						turnId: sourceTurn.id,
+						turnIdMapping: new Map([[sourceTurn.id, forkedTurnId]]),
+					},
+				});
+
+				assert.deepStrictEqual({
+					resultSession: result.session.toString(),
+					importSessionId: imported?.sessionId,
+					importWorkingDirectory: imported?.workingDirectory.toString(),
+					importWorkingDirectories: imported?.config.workingDirectories?.map(directory => directory.toString()),
+					importFork: imported?.config.fork,
+					importedTurnIds: imported?.config.importConversation?.turns.map(turn => turn.id),
+				}, {
+					resultSession: target.toString(),
+					importSessionId: AgentSession.id(target),
+					importWorkingDirectory: sourceWorkingDirectory.toString(),
+					importWorkingDirectories: [sourceWorkingDirectory.toString()],
+					importFork: undefined,
+					importedTurnIds: [forkedTurnId],
+				});
+			} finally {
 				await disposeAgent(agent);
 			}
 		});

--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -16,25 +16,6 @@ When a valid E2E scenario exposes a gap:
 
 Capability skips are tracked separately from suspected bugs. A provider that does not advertise a capability is expected to skip positive-path tests for that capability.
 
-### Copilot cannot create a session-level fork from a materialized source
-
-A user can ask the client to create a new session from an earlier turn of an existing session so they can explore a different path without losing the original conversation. Copilot currently rejects that request even after the source session has completed and remains available, so clients cannot offer session-level branching for Copilot conversations through AHP.
-
-- Tests:
-  - `session fork inherits provider history through the selected source turn`
-  - `session fork excludes provider history after the selected source turn`
-- Scope: Copilot.
-- Expected: `createSession` with a `fork` source creates a new session whose provider history ends at the selected source turn.
-- Observed: the source has completed a model turn and appears in `listSessions`, but `createSession` still fails with `Session not found on backend`.
-- Gate: the Copilot variants require `AGENT_HOST_RUN_KNOWN_ISSUES=1`.
-- Reproduce:
-
-  ```bash
-  AGENT_HOST_RUN_KNOWN_ISSUES=1 AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
-    src/vs/platform/agentHost/test/node/e2e/providers/copilotAgentHostE2E.integrationTest.ts \
-    --grep "session fork"
-  ```
-
 ### Client plugin skill is missing from Copilot slash completions
 
 A user can add a skill through a client-pushed plugin and invoke it by name in a Copilot session. The skill works when named explicitly, but it is absent from slash completions, so users cannot discover or select it through completion UI.

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-session-fork-excludes-provider-history-after-the-selected-source-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-session-fork-excludes-provider-history-after-the-selected-source-turn.yaml
@@ -1,0 +1,38 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember FORK_FIRST. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember FORK_FIRST. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Now remember FORK_LATER too. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember FORK_FIRST. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Reply exactly "bounded" if you remember FORK_FIRST but not FORK_LATER.
+    response:
+      content: bounded
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-session-fork-inherits-provider-history-through-the-selected-source-turn.yaml
+++ b/src/vs/platform/agentHost/test/node/e2e/captures/copilotcli-session-fork-inherits-provider-history-through-the-selected-source-turn.yaml
@@ -1,0 +1,25 @@
+version: 1
+dialect: anthropic
+exchanges:
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember FORK_ALPHA. Reply exactly "ready".
+    response:
+      content: ready
+      stopReason: end_turn
+  - request:
+      model: claude-sonnet-5
+      system: ${system}
+      messages:
+        - role: user
+          content: Remember FORK_ALPHA. Reply exactly "ready".
+        - role: assistant
+          content: ready
+        - role: user
+          content: Reply with only the code word you were asked to remember.
+    response:
+      content: FORK_ALPHA
+      stopReason: end_turn

--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -421,7 +421,7 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 		}
 	});
 
-	(context.runKnownIssueTests ? test : test.skip)('session fork inherits provider history through the selected source turn', async function () {
+	test('session fork inherits provider history through the selected source turn', async function () {
 		this.timeout(240_000);
 		const { sessionUri } = await createWorkspaceSession('session-fork-history');
 		await driveTurnToCompletion(context.client, sessionUri, 'turn-fork-alpha', 'Remember FORK_ALPHA. Reply exactly "ready".', 1);
@@ -432,7 +432,7 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 		assert.ok(result.responseText.includes('FORK_ALPHA'));
 	});
 
-	(context.runKnownIssueTests ? test : test.skip)('session fork excludes provider history after the selected source turn', async function () {
+	test('session fork excludes provider history after the selected source turn', async function () {
 		this.timeout(240_000);
 		const { sessionUri } = await createWorkspaceSession('session-fork-bounded');
 		await driveTurnToCompletion(context.client, sessionUri, 'turn-fork-first', 'Remember FORK_FIRST. Reply exactly "ready".', 1);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -423,12 +423,20 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 
 	test('session fork inherits provider history through the selected source turn', async function () {
 		this.timeout(240_000);
-		const { sessionUri } = await createWorkspaceSession('session-fork-history');
+		const { sessionUri, workspace } = await createWorkspaceSession('session-fork-history');
 		await driveTurnToCompletion(context.client, sessionUri, 'turn-fork-alpha', 'Remember FORK_ALPHA. Reply exactly "ready".', 1);
 		await assertSessionListed(sessionUri);
 		const forkUri = await createFork(sessionUri, 'turn-fork-alpha');
 
-		const result = await driveTurnToCompletion(context.client, forkUri, 'turn-fork-followup', 'Reply with only the code word you were asked to remember.', 10);
+		await context.restartServer();
+		await initialize('session-fork-history-restored-client', workspace);
+		await context.client.call<SubscribeResult>('subscribe', { channel: forkUri });
+		await context.client.call<SubscribeResult>('subscribe', { channel: buildDefaultChatUri(forkUri) });
+		const restored = await fetchSessionWithChat(context.client, forkUri);
+		assert.deepStrictEqual(restored.turns.map(turn => turn.message.text), ['Remember FORK_ALPHA. Reply exactly "ready".']);
+
+		const reforkUri = await createFork(forkUri, restored.turns[0].id);
+		const result = await driveTurnToCompletion(context.client, reforkUri, 'turn-fork-followup', 'Reply with only the code word you were asked to remember.', 10);
 		assert.ok(result.responseText.includes('FORK_ALPHA'));
 	});
 

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -896,6 +896,30 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
+	test('createSession rejects a fork targeting its source session', async () => {
+		const transport = connectClient('client-self-fork');
+		transport.sent.length = 0;
+		const responsePromise = waitForResponse(transport, 2);
+		const session = URI.parse('copilot:///same-session').toString();
+
+		transport.simulateMessage(request(2, 'createSession', {
+			channel: session,
+			provider: 'copilot',
+			fork: { session, turnId: 'turn-1' },
+		}));
+		const response = await responsePromise as { error?: { code: number; message: string } };
+
+		assert.deepStrictEqual({
+			errorCode: response.error?.code,
+			errorMessage: response.error?.message,
+			createCalls: agentService.createSessionConfigs.length,
+		}, {
+			errorCode: AhpErrorCodes.SessionAlreadyExists,
+			errorMessage: `Fork target session must differ from source session: ${session}`,
+			createCalls: 0,
+		});
+	});
+
 	suite('createChat / disposeChat', () => {
 		const peerChat = buildChatUri(sessionUri, 'peer-1');
 

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -439,6 +439,20 @@ suite('SessionDatabase', () => {
 
 	suite('turn event ids', () => {
 
+		test('getTurnEventId resolves protocol and restored SDK turn IDs', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('turn-1');
+			await db.setTurnEventId('turn-1', 'evt-1');
+
+			assert.deepStrictEqual({
+				protocol: await db.getTurnEventId('turn-1'),
+				restored: await db.getTurnEventId('evt-1'),
+			}, {
+				protocol: 'evt-1',
+				restored: 'evt-1',
+			});
+		});
+
 		test('getNextTurnEventId returns the next turn\'s event id by `turns.id`', async () => {
 			db = disposables.add(await SessionDatabase.open(':memory:'));
 			await db.createTurn('turn-1');
@@ -578,7 +592,7 @@ suite('SessionDatabase', () => {
 			assert.deepStrictEqual([...(await db.getTurnUsages()).entries()], [['turn-1', '{"inputTokens":1}']]);
 		});
 
-		test('remapTurnIds carries usage onto the forked turn ids and drops the rest', async () => {
+		test('remapTurnIds carries usage and replaces event IDs on imported forks', async () => {
 			// Fork file-copies the source database then remaps turn ids. Without
 			// remapping `turn_usage` the forked session restores with no gauge
 			// and zero cost, and rows past the fork point leak permanently
@@ -586,13 +600,27 @@ suite('SessionDatabase', () => {
 			db = disposables.add(await SessionDatabase.open(':memory:'));
 			await db.createTurn('old-1');
 			await db.createTurn('old-2');
+			await db.setTurnEventId('old-1', 'old-event-1');
+			await db.setTurnEventId('old-2', 'old-event-2');
 			await db.setTurnUsage('old-1', '{"inputTokens":1}');
 			await db.setTurnUsage('old-2', '{"inputTokens":2}');
 
 			// Fork keeping only `old-1`, remapped to a fresh id.
-			await db.remapTurnIds(new Map([['old-1', 'new-1']]));
+			await db.remapTurnIds(
+				new Map([['old-1', 'new-1']]),
+				new Map([['new-1', 'new-event-1']]),
+			);
 
-			assert.deepStrictEqual([...(await db.getTurnUsages()).entries()], [['new-1', '{"inputTokens":1}']]);
+			assert.deepStrictEqual({
+				usages: [...(await db.getTurnUsages()).entries()],
+				eventId: await db.getTurnEventId('new-1'),
+			}, {
+				usages: [
+					['new-1', '{"inputTokens":1}'],
+					['new-event-1', '{"inputTokens":1}'],
+				],
+				eventId: 'new-event-1',
+			});
 		});
 	});
 


### PR DESCRIPTION
tl;dr- this is not actually used in the product today, we only fork to a chat, not a session. But it's supported in the protocol and we mostly had code for it, so just fixing it and reenabling the tests.

## Summary

- preserve the client-chosen AHP session URI when Copilot handles `createSession` with a fork source
- import provider history through the selected source turn while retaining copied/remapped session data
- enable the two Copilot root-session fork E2E scenarios and remove the resolved known issue

The Agents window’s existing **Fork Conversation** action is a separate peer-chat workflow using `createChat`; it is unchanged by this PR. This fixes the protocol-level root-session workflow used by AHP clients.

## Root cause

The Copilot provider used the runtime `sessions.fork` RPC, which always generates a new SDK session ID. AHP `createSession` requires the server to honor the client-chosen target channel. The host returned success for the SDK-generated session, then a subscription to the requested AHP URI failed with `Session not found on backend`.

The provider now resolves protocol turn IDs to SDK event IDs, imports the bounded provider transcript under the requested session ID, and copies/remaps the existing session database so per-turn data remains aligned.

## Validation

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts` — 182 passing
- real-CAPI recording of the two Copilot session-fork E2E scenarios — 2 passing
- deterministic replay of the two scenarios — 2 passing

(Written by Copilot)