### PR TITLE
Avoid oversized restricted telemetry requests

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
@@ -71,6 +71,7 @@ export type FetchFn = typeof globalThis.fetch;
  */
 const MAX_PROPERTY_LENGTH = 8192;
 const MAX_CONCATENATED_PROPERTIES = 50;
+const MAX_TELEMETRY_ITEM_BODY_LENGTH = MAX_PROPERTY_LENGTH * MAX_CONCATENATED_PROPERTIES;
 
 // Suffix appended to the base property name for the compressed (gzip + base64) chunk family.
 const COMPRESSED_CHUNK_SUFFIX = 'Chunk';
@@ -104,8 +105,9 @@ export async function multiplexProperties(properties: TelemetryProps): Promise<T
 		// the full value gzip + base64 compressed as <key>Chunk, <key>Chunk_2, … (no zero padding).
 		newProperties[key] = value!.slice(0, MAX_PROPERTY_LENGTH);
 		const compressed = await compressTelemetryValue(value!);
+		const compressedChunkKey = key === 'messagesJson' ? 'messagesJSON' : key;
 		for (let offset = 0, index = 1; offset < compressed.length && index <= MAX_CONCATENATED_PROPERTIES; offset += MAX_PROPERTY_LENGTH, index++) {
-			const columnName = index === 1 ? `${key}${COMPRESSED_CHUNK_SUFFIX}` : `${key}${COMPRESSED_CHUNK_SUFFIX}_${index}`;
+			const columnName = index === 1 ? `${compressedChunkKey}${COMPRESSED_CHUNK_SUFFIX}` : `${compressedChunkKey}${COMPRESSED_CHUNK_SUFFIX}_${index}`;
 			newProperties[columnName] = compressed.slice(offset, offset + MAX_PROPERTY_LENGTH);
 		}
 	}
@@ -270,6 +272,13 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 			},
 		};
 
+		const body = JSON.stringify(envelope);
+		const bodyLength = Buffer.byteLength(body, 'utf8');
+		if (bodyLength > MAX_TELEMETRY_ITEM_BODY_LENGTH) {
+			this._logService.trace(`[ahp-restricted] drop ${name}: serialized body is ${bodyLength} bytes (maximum ${MAX_TELEMETRY_ITEM_BODY_LENGTH})`);
+			return;
+		}
+
 		this._logService.trace(`[ahp-restricted] emit ${name} (iKey ${iKey.slice(0, 8)})`);
 
 		if (typeof this._fetchFn !== 'function') {
@@ -283,7 +292,7 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 		this._fetchFn(context?.endpointUrl || (context ? GH_TELEMETRY_URL : this._endpointUrl), {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-json-stream' },
-			body: JSON.stringify(envelope),
+			body,
 		}).then(res => {
 			if (!res.ok) {
 				this._logService.warn(`[ahp-restricted] ${name} rejected: HTTP ${res.status}`);

--- a/src/vs/platform/agentHost/test/node/agentHostGitHubTelemetryRouter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitHubTelemetryRouter.test.ts
@@ -157,7 +157,7 @@ suite('AgentHostGitHubTelemetryRouter', () => {
 			// No plain continuation family is produced.
 			plainContinuation: event.properties?.messagesJson_02,
 			// The full value round-trips from the compressed chunk family.
-			roundTrip: gunzip([event.properties?.messagesJsonChunk, event.properties?.messagesJsonChunk_2]),
+			roundTrip: gunzip([event.properties?.messagesJSONChunk, event.properties?.messagesJSONChunk_2]),
 		})), [
 			{ destination: 'enhancedGH', original: original.slice(0, 8192), plainContinuation: undefined, roundTrip: original },
 			{ destination: 'internalMSFT', original: original.slice(0, 8192), plainContinuation: undefined, roundTrip: original },

--- a/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
@@ -95,6 +95,21 @@ suite('AgentHostRestrictedTelemetrySender', () => {
 		});
 	});
 
+	test('oversized enhanced telemetry is not posted', () => {
+		const { sender, posts } = createSender();
+		sender.setRestrictedTelemetryEnabled(true);
+
+		const properties: TelemetryProps = { messagesJson: 'x'.repeat(8192) };
+		properties.messagesJSONChunk = 'x'.repeat(8192);
+		for (let index = 2; index <= 50; index++) {
+			properties[`messagesJSONChunk_${index}`] = 'x'.repeat(8192);
+		}
+
+		sender.sendEnhancedGHTelemetryEvent('engine.messages', properties);
+
+		assert.deepStrictEqual(posts, []);
+	});
+
 	test('internal telemetry is independently gated on internal identity', () => {
 		const internalSink = new TestInternalSink();
 		const sender = new AgentHostRestrictedTelemetrySender(commonProperties, new NullLogService(), 'https://default.example/telemetry', internalSink);

--- a/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
@@ -99,15 +99,35 @@ suite('AgentHostRestrictedTelemetrySender', () => {
 		const { sender, posts } = createSender();
 		sender.setRestrictedTelemetryEnabled(true);
 
-		const properties: TelemetryProps = { messagesJson: 'x'.repeat(8192) };
-		properties.messagesJSONChunk = 'x'.repeat(8192);
+		const maxPropertyLength = 8192;
+		const maxTelemetryItemBodyLength = maxPropertyLength * 50;
+		const totalPropertyCharacterCount = 407_000;
+		const nonAsciiCharacterCount = 1000;
+		const properties: TelemetryProps = {
+			messagesJSONChunk: 'é'.repeat(nonAsciiCharacterCount) + 'x'.repeat(maxPropertyLength - nonAsciiCharacterCount),
+		};
 		for (let index = 2; index <= 50; index++) {
-			properties[`messagesJSONChunk_${index}`] = 'x'.repeat(8192);
+			const chunkLength = index < 50 ? maxPropertyLength : totalPropertyCharacterCount - maxPropertyLength * 49;
+			properties[`messagesJSONChunk_${index}`] = 'x'.repeat(chunkLength);
 		}
 
+		const propertyCharacterCount = Object.values(properties).reduce((total, value) => total + (value?.length ?? 0), 0);
+		const propertyByteCount = Object.values(properties).reduce((total, value) => total + Buffer.byteLength(value ?? '', 'utf8'), 0);
 		sender.sendEnhancedGHTelemetryEvent('engine.messages', properties);
 
-		assert.deepStrictEqual(posts, []);
+		assert.deepStrictEqual({
+			propertyCharacterCount,
+			propertyByteCount,
+			propertyCharacterCountBelowLimit: propertyCharacterCount < maxTelemetryItemBodyLength,
+			propertyByteCountBelowLimit: propertyByteCount < maxTelemetryItemBodyLength,
+			posts,
+		}, {
+			propertyCharacterCount: 407_000,
+			propertyByteCount: 408_000,
+			propertyCharacterCountBelowLimit: true,
+			propertyByteCountBelowLimit: true,
+			posts: [],
+		});
 	});
 
 	test('internal telemetry is independently gated on internal identity', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -88,7 +88,7 @@ suite('AgentHostTelemetryReporter', () => {
 				conversationId: AgentSession.id(session),
 				initiatorClientType: 'agents_window',
 				messagesJson: JSON.stringify(tools),
-				messagesJsonChunk: zlib.gzipSync(Buffer.from(JSON.stringify(tools), 'utf8')).toString('base64'),
+				messagesJSONChunk: zlib.gzipSync(Buffer.from(JSON.stringify(tools), 'utf8')).toString('base64'),
 			},
 		}]);
 	});


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8741

`engine.messages` carries the cumulative conversation in `messagesJson`. Long agent sessions can fill all 50 compressed telemetry chunks, producing a serialized envelope above the collector request limit and repeatedly returning HTTP 413.

This change:
- measures the complete serialized UTF-8 restricted telemetry envelope before posting and drops oversized items locally;
- reuses the measured request body rather than serializing twice;
- aligns Agent Host compressed chunk names with the backend contract (`messagesJSONChunk*`);
- adds coverage for oversized drops and the corrected chunk family.

## Validation

- `npm run transpile-client`
- `scripts\test.bat --run src\vs\platform\agentHost\test\node\agentHostRestrictedTelemetry.test.ts --run src\vs\platform\agentHost\test\node\agentHostGitHubTelemetryRouter.test.ts --run src\vs\platform\agentHost\test\node\agentHostTelemetryReporter.test.ts` (18 passing)
- Launched an authenticated Code OSS build with telemetry enabled from the Insiders product configuration.
- Confirmed a real Agent Host request completed and restricted telemetry was enabled for the account.
- Probed the compiled sender in the live Agent Host process: a below-limit event performed one fetch; an oversized `engine.messages` envelope was dropped before fetch; no HTTP 413 was logged; and compression emitted `messagesJSONChunk`.