### PR TITLE
Keep restored system notifications in one turn

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -568,15 +568,12 @@ export async function mapSessionEvents(
 				if (!notification) {
 					break;
 				}
-				if (rootAssistantTurnActive && parentBuilder) {
+				if (parentBuilder && (rootAssistantTurnActive || notification.startsTurn)) {
 					parentBuilder.responseParts.push({
 						kind: ResponsePartKind.SystemNotification,
 						content: notification.messageText,
 					});
 					touch(parentBuilder);
-				} else if (notification.startsTurn) {
-					flushParent();
-					parentBuilder = newTurnBuilder(e.id, notification.messageText, { origin: MessageKind.SystemNotification, startedAt: currentEventTimestamp });
 				}
 				break;
 			}

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -460,7 +460,7 @@ suite('mapSessionEvents — history replay', () => {
 		}]);
 	});
 
-	test('restores an idle system notification as a system-initiated turn', async () => {
+	test('restores an idle system notification and resumed response in the preceding turn', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', id: 'user-event', data: { interactionId: 'interaction-1', content: 'Start the background agent' } },
 			{ type: 'assistant.turn_start', data: { turnId: '0', interactionId: 'interaction-1' } },
@@ -486,20 +486,16 @@ suite('mapSessionEvents — history replay', () => {
 			message: turn.message,
 			state: turn.state,
 			parts: partKinds(turn.responseParts),
-		})), [
-			{
-				id: 'user-event',
-				message: { text: 'Start the background agent', origin: { kind: MessageKind.User } },
-				state: TurnState.Complete,
-				parts: [{ kind: ResponsePartKind.Markdown, content: 'The background agent is running.' }],
-			},
-			{
-				id: 'notification-event',
-				message: { text: 'Background agent agent-a is complete', origin: { kind: MessageKind.SystemNotification } },
-				state: TurnState.Complete,
-				parts: [{ kind: ResponsePartKind.Markdown, content: 'Reading the background agent result.' }],
-			},
-		]);
+		})), [{
+			id: 'user-event',
+			message: { text: 'Start the background agent', origin: { kind: MessageKind.User } },
+			state: TurnState.Complete,
+			parts: [
+				{ kind: ResponsePartKind.Markdown, content: 'The background agent is running.' },
+				{ kind: ResponsePartKind.SystemNotification, content: 'Background agent agent-a is complete' },
+				{ kind: ResponsePartKind.Markdown, content: 'Reading the background agent result.' },
+			],
+		}]);
 	});
 
 	test('does not restore a passive notification outside an assistant turn', async () => {


### PR DESCRIPTION
Doing this because it just looks nicer, and people are not liking the split into multiple turns

## Summary

- keep wake-capable system notifications in the preceding restored user turn
- represent the notification as a system-notification response part
- keep resumed assistant output in the same turn while preserving passive-notification filtering

## Testing

- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts` (33 passing)

(Written by Copilot)