### PR TITLE
test: Disable flaky Agent Host worktree cleanup E2E

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -16,6 +16,23 @@ When a valid E2E scenario exposes a gap:
 
 Capability skips are tracked separately from suspected bugs. A provider that does not advertise a capability is expected to skip positive-path tests for that capability.
 
+### Deleting a worktree session can race background Git work
+
+A user can configure ignored files to be copied into an isolated worktree, complete an agent turn, and then delete the session. Session deletion can fail because background changeset or Git-state work is still using the worktree while Git removes it, leaving the session's worktree behind.
+
+- Test: `worktree materialization copies configured ignored files`.
+- Scope: providers with deterministic worktree include-file coverage.
+- Expected: deleting the completed session stops all work associated with it and removes its isolated worktree.
+- Observed: teardown can fail with `git worktree exited with code 255: error: failed to delete '.git/worktrees/<name>': Directory not empty`.
+- Gate: the scenario requires `AGENT_HOST_RUN_KNOWN_ISSUES=1`.
+- Reproduce:
+
+  ```bash
+  AGENT_HOST_RUN_KNOWN_ISSUES=1 AGENT_HOST_UPDATE_SNAPSHOTS=1 ./scripts/test-integration.sh --run \
+    src/vs/platform/agentHost/test/node/e2e/providers/claudeAgentHostE2E.integrationTest.ts \
+    --grep "worktree materialization copies configured ignored files"
+  ```
+
 ### Client plugin skill is missing from Copilot slash completions
 
 A user can add a skill through a client-pushed plugin and invoke it by name in a Copilot session. The skill works when named explicitly, but it is absent from slash completions, so users cannot discover or select it through completion UI.

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -60,7 +60,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 			`subscribe snapshot summary should carry the requested working directory`);
 	});
 
-	(config.supportsWorktreeIncludeFilesE2E ? test : test.skip)('worktree materialization copies configured ignored files', async function () {
+	(context.runKnownIssueTests && config.supportsWorktreeIncludeFilesE2E ? test : test.skip)('worktree materialization copies configured ignored files', async function () {
 		this.timeout(180_000);
 		const repository = mkdtempSync(`${tmpdir()}/ahp-wt-include-`);
 		tempDirs.push(repository, `${repository}.worktrees`);


### PR DESCRIPTION
## Summary

- skip `worktree materialization copies configured ignored files` in normal Agent Host E2E runs
- retain the scenario behind `AGENT_HOST_RUN_KNOWN_ISSUES=1`
- document the failure and focused reproduction in `KNOWN_ISSUES.md`

## Why

[Azure build 463018](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=463018) failed after this test passed because its teardown raced session worktree removal against background Git work. The product fix is tracked separately in [#329864](https://github.com/microsoft/vscode/pull/329864). Disabling the scenario keeps the E2E pipeline stable while allowing that fix to land independently.

## Validation

- `npm run compile --prefix test/smoke`
- hygiene on `workspaceSuite.ts`
- `npm run transpile-client`
- focused Claude E2E replay: 0 passing, 1 expected pending

(Written by Copilot)