### PR TITLE
agentHost: skip unaffected E2E tests in PR CI

### DIFF
--- a/.github/actions/detect-agent-host-e2e-changes/action.yml
+++ b/.github/actions/detect-agent-host-e2e-changes/action.yml
@@ -1,0 +1,26 @@
+name: Detect Agent Host E2E changes
+description: Determines whether a pull request can affect the Agent Host end-to-end tests.
+
+inputs:
+  token:
+    description: GitHub token used to list the pull request files.
+    required: true
+
+outputs:
+  affected:
+    description: "'true' when the Agent Host E2E tests may be affected."
+    value: ${{ steps.detect.outputs.affected }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect relevant changes
+      id: detect
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const { pathToFileURL } = require('url');
+          const scriptUrl = pathToFileURL(process.env.GITHUB_WORKSPACE + '/.github/actions/detect-agent-host-e2e-changes/detect.ts');
+          const { detectAgentHostE2EChanges } = await import(scriptUrl.href);
+          await detectAgentHostE2EChanges(github, context, core);

--- a/.github/actions/detect-agent-host-e2e-changes/detect.ts
+++ b/.github/actions/detect-agent-host-e2e-changes/detect.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface IChangedFile {
+	readonly filename: string;
+	readonly previous_filename?: string;
+}
+
+interface IListFilesParameters {
+	readonly owner: string;
+	readonly repo: string;
+	readonly pull_number: number;
+	readonly per_page: number;
+}
+
+interface IGitHub {
+	readonly paginate: (method: object, parameters: IListFilesParameters) => Promise<readonly IChangedFile[]>;
+	readonly rest: { readonly pulls: { readonly listFiles: object } };
+}
+
+interface IContext {
+	readonly repo: { readonly owner: string; readonly repo: string };
+	readonly issue: { readonly number: number };
+	readonly payload: { readonly pull_request?: { readonly changed_files?: number } };
+}
+
+interface ICore {
+	info(message: string): void;
+	warning(message: string): void;
+	setOutput(name: string, value: string): void;
+}
+
+const exactPaths = new Set([
+	'.nvmrc',
+	'.npmrc',
+	'package.json',
+	'package-lock.json',
+	'product.json',
+	'scripts/test-agent-host-e2e.ts',
+	'scripts/test-agent-host-e2e-child.ps1',
+	'scripts/test-integration.sh',
+	'scripts/test-integration.bat',
+	'scripts/test.sh',
+	'scripts/test.bat',
+	'src/vs/nls.ts',
+]);
+
+const pathPrefixes = [
+	'.github/actions/detect-agent-host-e2e-changes/',
+	'.github/workflows/pr',
+	'build/',
+	'src/bootstrap',
+	'src/tsconfig',
+	'src/vs/base/',
+	'src/vs/platform/',
+	'test/unit/electron/',
+];
+
+function affectsAgentHostE2E(path: string): boolean {
+	if (path.endsWith('.md')) {
+		return false;
+	}
+	return exactPaths.has(path) || pathPrefixes.some(prefix => path.startsWith(prefix));
+}
+
+export async function detectAgentHostE2EChanges(github: IGitHub, context: IContext, core: ICore): Promise<void> {
+	const files = await github.paginate(github.rest.pulls.listFiles, {
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		pull_number: context.issue.number,
+		per_page: 100,
+	});
+
+	const paths = files.flatMap(file =>
+		file.previous_filename ? [file.filename, file.previous_filename] : [file.filename]);
+	const expectedFileCount = context.payload.pull_request?.changed_files;
+	const incomplete = typeof expectedFileCount === 'number' && files.length < expectedFileCount;
+	const affected = incomplete || paths.some(affectsAgentHostE2E);
+
+	if (incomplete) {
+		core.warning(`GitHub returned ${files.length} of ${expectedFileCount} changed files; running Agent Host E2E tests.`);
+	} else {
+		core.info(affected
+			? 'Agent Host E2E tests may be affected.'
+			: 'No changes can affect Agent Host E2E tests.');
+	}
+	core.setOutput('affected', affected ? 'true' : 'false');
+}

--- a/.github/actions/detect-agent-host-e2e-changes/detect.ts
+++ b/.github/actions/detect-agent-host-e2e-changes/detect.ts
@@ -66,12 +66,20 @@ function affectsAgentHostE2E(path: string): boolean {
 }
 
 export async function detectAgentHostE2EChanges(github: IGitHub, context: IContext, core: ICore): Promise<void> {
-	const files = await github.paginate(github.rest.pulls.listFiles, {
-		owner: context.repo.owner,
-		repo: context.repo.repo,
-		pull_number: context.issue.number,
-		per_page: 100,
-	});
+	let files: readonly IChangedFile[];
+	try {
+		files = await github.paginate(github.rest.pulls.listFiles, {
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			pull_number: context.issue.number,
+			per_page: 100,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		core.warning(`Unable to list pull request files; running Agent Host E2E tests. ${message}`);
+		core.setOutput('affected', 'true');
+		return;
+	}
 
 	const paths = files.flatMap(file =>
 		file.previous_filename ? [file.filename, file.previous_filename] : [file.filename]);

--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           lfs: true
 
+      - name: Detect Agent Host E2E changes
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        id: agent-host-e2e-changes
+        uses: ./.github/actions/detect-agent-host-e2e-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -164,6 +171,7 @@ jobs:
         timeout-minutes: 20
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
         env:
+          VSCODE_SKIP_AGENT_HOST_E2E: ${{ steps.agent-host-e2e-changes.outputs.affected == 'false' && '1' || '0' }}
           VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Webkit)

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           lfs: true
 
+      - name: Detect Agent Host E2E changes
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        id: agent-host-e2e-changes
+        uses: ./.github/actions/detect-agent-host-e2e-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -366,6 +373,7 @@ jobs:
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
         env:
           DISPLAY: ":10"
+          VSCODE_SKIP_AGENT_HOST_E2E: ${{ steps.agent-host-e2e-changes.outputs.affected == 'false' && '1' || '0' }}
           VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Chromium)

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           lfs: true
 
+      - name: Detect Agent Host E2E changes
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        id: agent-host-e2e-changes
+        uses: ./.github/actions/detect-agent-host-e2e-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
@@ -184,6 +191,7 @@ jobs:
         shell: pwsh
         run: .\scripts\test-integration.bat --tfs "Integration Tests"
         env:
+          VSCODE_SKIP_AGENT_HOST_E2E: ${{ steps.agent-host-e2e-changes.outputs.affected == 'false' && '1' || '0' }}
           VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Chromium)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   VSCODE_QUALITY: 'oss'

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -129,8 +129,12 @@ if defined RUN_GLOB (
 ) else if defined RUN_FILE (
 	call .\scripts\test.bat %*
 ) else (
-	call node .\scripts\test-agent-host-e2e.ts %*
-	if errorlevel 1 exit /b 1
+	if "%VSCODE_SKIP_AGENT_HOST_E2E%"=="1" (
+		echo Skipping Agent Host E2E tests because no relevant files changed.
+	) else (
+		call node .\scripts\test-agent-host-e2e.ts %*
+		if errorlevel 1 exit /b 1
+	)
 	set VSCODE_SKIP_PRELAUNCH=1
 	call .\scripts\test.bat --runGlob **\*.integrationTest.js --excludeRunGlob "**/agentHost/test/node/e2e/{providers/*AgentHostE2E,conformance/*}.integrationTest.js" %*
 )

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -173,7 +173,11 @@ if [[ -z "$SUITE_FILTER" ]]; then
 	echo "### node.js integration tests"
 	echo
 	if [[ -z "$RUN_GLOB" && -z "$RUN_FILE" ]]; then
-		node ./scripts/test-agent-host-e2e.ts "${EXTRA_ARGS[@]}"
+		if [[ "$VSCODE_SKIP_AGENT_HOST_E2E" == "1" ]]; then
+			echo "Skipping Agent Host E2E tests because no relevant files changed."
+		else
+			node ./scripts/test-agent-host-e2e.ts "${EXTRA_ARGS[@]}"
+		fi
 		VSCODE_SKIP_PRELAUNCH=1 ./scripts/test.sh --runGlob "**/*.integrationTest.js" --excludeRunGlob "$AGENT_HOST_E2E_GLOB" "${EXTRA_ARGS[@]}"
 	else
 		./scripts/test.sh "${EXTRA_ARGS[@]}"

--- a/src/vs/platform/agentHost/test/node/e2e/README.md
+++ b/src/vs/platform/agentHost/test/node/e2e/README.md
@@ -201,6 +201,8 @@ npm run test-agent-host-e2e -- --jobs 2
 
 The complete-suite runner starts one test process per entrypoint and runs up to four concurrently. `AGENT_HOST_E2E_JOBS` or `--jobs` can lower the worker count. Each process's output is printed as one block when it completes, and any Mocha failure details are repeated after the final suite summary so failures remain easy to find. Recording and snapshot-update modes remain per-provider commands so they never make concurrent writes or real CAPI requests.
 
+Pull request Electron jobs run the complete suite only when the changed files can affect the Agent Host, its shared platform dependencies, provider SDK versions, build infrastructure, or the E2E harness. The classification happens inside each already-allocated Electron runner so Linux, macOS, and Windows jobs remain parallel. When no relevant files changed, CI sets `VSCODE_SKIP_AGENT_HOST_E2E=1`; `test-integration.sh` and `test-integration.bat` then skip this suite while continuing with every other integration test.
+
 Provider availability:
 
 - **Copilot** (`copilotcli`) — always enabled (the CLI is a dev dependency).


### PR DESCRIPTION
## Summary

- Detect pull request changes that can affect bundled-provider Agent Host E2E tests.
- Skip only the Agent Host E2E suite for unrelated changes while continuing the remaining integration tests.
- Classify changes inside the existing platform runners to preserve Linux, macOS, and Windows job parallelism.

## Testing

- Exercised the classifier against README-only, Agent Host, shared base, SDK lockfile, rename, and truncated-response cases.
- Parsed the changed workflow YAML and validated the shell script syntax.
- Passed the repository pre-commit hygiene hook.

(Written by Copilot)