### PR TITLE
Harden Agent Host end-to-end tests

### DIFF
--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -851,8 +851,14 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 			// Codex defaults to disabled; opt it in for the agent host e2e suite when a
 			// codex SDK root is supplied so the provider actually registers.
 			...(options?.codexSdkRoot ? { [AgentHostCodexAgentEnabledEnvVar]: String(options.codexAgentEnabled ?? true) } : {}),
-			// Fixtures use Codex's unified exec tool, so keep record and replay on the same shell protocol.
-			...(options?.codexSdkRoot && options.capiReplay ? { [AgentHostCodexAgentBinaryArgsEnvVar]: JSON.stringify(['-c', 'features.unified_exec=true']) } : {}),
+			// Keep replay on unified exec and exclude unrelated remote plugin-catalog work.
+			...(options?.codexSdkRoot && options.capiReplay ? {
+				[AgentHostCodexAgentBinaryArgsEnvVar]: JSON.stringify([
+					'-c', 'features.unified_exec=true',
+					'-c', 'features.plugins=false',
+					'-c', 'features.remote_plugin=false',
+				]),
+			} : {}),
 			...(realCapture ? {
 				// Real-CAPI capture/replay: route all CAPI + GitHub-API traffic through
 				// the proxy. The real GitHub token flows via the `authenticate`


### PR DESCRIPTION
This PR is an iterative hardening pass for the deterministic Agent Host end-to-end tests.

The first fix disables Codex native remote plugin-catalog work during replay. That background clone is unrelated to the tested AHP behavior and could keep populating the isolated Codex home while suite teardown removed it, making an otherwise passing suite fail cleanup.

Validation so far:
- Codex E2E suite passed four consecutive runs after the change
- Complete Agent Host E2E matrix passed
- `npm run typecheck-client`
- targeted hygiene and `git diff --check`

I will continue rerunning the relevant cross-platform CI jobs and add focused fixes for any additional flakes found.

(Written by Copilot)