### PR TITLE
agentHost: gate flaky Codex shell result tests

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -655,21 +655,28 @@ Use the affected provider command with `--grep "<exact test title>"` and tempora
 
   Temporarily clear `shellToolReplayUnstableOnLinux`.
 
-### Codex structured file-read result text
+### Codex successful shell result text
 
 - Tests:
+  - `worktree session uses the resolved worktree as working directory`
+  - `reads an existing text file`
   - `reads a file from a nested directory`
+  - `lists workspace entries`
   - `reads a value from JSON`
   - `counts lines in a file`
+  - `handles a missing file without a session error`
+  - `runs a deterministic shell command`
+  - `inspects git status`
 - Scope: Codex.
-- Expected: successful file-read tool completions include the file contents in their result text.
+- Expected: successful shell tool completions include the command output in their result text.
 - Observed: the turn response contains the expected value, but the successful tool completion can have an empty `text` field.
-- Gate: these three tests remain enabled for other providers and are skipped for Codex.
+- Gate: these nine tests remain enabled for other providers and are skipped for Codex.
 - Tracking issue: [#329512](https://github.com/microsoft/vscode/issues/329512).
 - Failing runs:
   - [PR #329485](https://github.com/microsoft/vscode/actions/runs/31132506547/job/92724492870?pr=329485)
   - [PR #329492](https://github.com/microsoft/vscode/actions/runs/31130785836/job/92718953820?pr=329492)
   - [PR #329517](https://github.com/microsoft/vscode/actions/runs/31148098482/job/92771783938?pr=329517)
+  - [PR #329867](https://github.com/microsoft/vscode/actions/runs/31342377741/job/93319069992?pr=329867)
 
 ### Claude subagent replay on Windows
 

--- a/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/harness/agentHostE2ETestHarness.ts
@@ -350,6 +350,8 @@ export interface IAgentHostE2EProviderConfig {
 	 * notifications there. Recording and other platforms keep full coverage.
 	 */
 	readonly shellToolReplayUnstableOnLinux?: boolean;
+	/** Provider intermittently completes successful shell calls without exposing result text. */
+	readonly shellToolResultTextUnreliable?: boolean;
 	/**
 	 * When set, the subagent-reopen ("replay path") test is skipped on Windows for
 	 * this provider, which rebuilds the reopened transcript from the bundled SDK's

--- a/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/providers/codexTestConfiguration.ts
@@ -33,4 +33,5 @@ export const CODEX_CONFIG: IAgentHostE2EProviderConfig = {
 	supportsChatFork: false,
 	supportsChatForkE2E: false,
 	shellToolReplayUnstableOnLinux: true,
+	shellToolResultTextUnreliable: true,
 };

--- a/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/fileOperationsSuite.ts
@@ -57,9 +57,8 @@ function fileOperationTest(context: IAgentHostE2ETestContext, title: string, run
 
 export function defineFileOperationsTests(context: IAgentHostE2ETestContext): void {
 	const { config, createdSessions, tempDirs, portableShellToolReplayEnabled, isWindows } = context;
-	const shellOutputOracleAvailable = !(isWindows && config.provider === 'copilotcli');
-	// Codex intermittently reports successful structured reads with empty result text: https://github.com/microsoft/vscode/issues/329512
-	const structuredReadResultTextAvailable = config.provider !== 'codex';
+	const shellResultTextAvailable = !config.shellToolResultTextUnreliable;
+	const shellOutputOracleAvailable = shellResultTextAvailable && !(isWindows && config.provider === 'copilotcli');
 	const BEHAVIOR_SNAPSHOT = {
 		profile: 'behavior',
 		// Codex occasionally omits command completion; direct filesystem and response assertions are the success oracle.
@@ -268,7 +267,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	});
+	}, shellResultTextAvailable);
 
 	fileOperationTest(context, 'reads a file from a nested directory', async function () {
 		this.timeout(180_000);
@@ -296,7 +295,7 @@ export function defineFileOperationsTests(context: IAgentHostE2ETestContext): vo
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	}, structuredReadResultTextAvailable);
+	}, shellResultTextAvailable);
 
 	(portableShellToolReplayEnabled && shellOutputOracleAvailable ? test : test.skip)('lists workspace entries', async function () {
 		this.timeout(180_000);
@@ -399,7 +398,7 @@ Use your file creation tool; do not run a shell command. Then reply exactly "don
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	}, structuredReadResultTextAvailable);
+	}, shellResultTextAvailable);
 
 	fileOperationTest(context, 'counts lines in a file', async function () {
 		this.timeout(180_000);
@@ -430,7 +429,7 @@ Use your file creation tool; do not run a shell command. Then reply exactly "don
 			success: true,
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	}, structuredReadResultTextAvailable);
+	}, shellResultTextAvailable);
 
 	fileOperationTest(context, 'handles a missing file without a session error', async function () {
 		this.timeout(180_000);
@@ -456,7 +455,7 @@ Use your file creation tool; do not run a shell command. Then reply exactly "don
 			success: config.fileOperationStrategy === 'shell',
 		});
 		await assertRecordedAhpSnapshot(this.test!, context.client, BEHAVIOR_SNAPSHOT);
-	});
+	}, shellResultTextAvailable);
 
 	fileOperationTest(context, 'creates a new text file', async function () {
 		this.timeout(180_000);

--- a/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/workspaceSuite.ts
@@ -120,7 +120,7 @@ export function defineWorkspaceTests(context: IAgentHostE2ETestContext): void {
 	//    even though the tool call itself completes.
 	//
 	// Re-enabling on Windows needs the missing terminal resource understood.
-	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
+	(config.supportsWorktreeIsolation && !isWindows && portableShellToolReplayEnabled && !config.shellToolResultTextUnreliable ? test : test.skip)('worktree session uses the resolved worktree as working directory', async function () {
 		this.timeout(120_000);
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-wt-test-`);


### PR DESCRIPTION
## Summary

- add a provider capability for unreliable successful shell result text
- skip all nine Codex E2E scenarios whose protocol oracle requires that text
- retain lifecycle-only Codex coverage and all Copilot/Claude coverage
- update the known-issues inventory with the latest failing run

Refs #329512.

## Validation

- `npm run hygiene`
- `npm run transpile-client`
- focused Codex replay: lifecycle-only read passes; nine affected scenarios are skipped
- focused Copilot replay: 12 passing
- focused Claude replay: 12 passing
- `npm run compile-client` was attempted; the changed sources compiled, but the repository typecheck currently fails on unrelated implicit-any errors in `assignmentService.ts:432`

(Written by Copilot)