### PR TITLE
agentHost: add generic agent turn hang telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -222,6 +222,124 @@ export interface IAgentHostTurnCompletedReport {
 	failure: IAgentHostTurnFailure | undefined;
 }
 
+/**
+ * Why a turn was quiet when the hang watchdog fired.
+ *
+ * Unexpected (these are real bugs and are what dashboards should alert on):
+ *  - `noProgress`: the turn started but literally nothing was ever observed for
+ *    it — no text, no reasoning, no tool call, no error, no completion. This is
+ *    the signature of a lost turn (e.g. a dropped provider callback
+ *    registration) where the UI sits on "Working…" forever.
+ *  - `stalledAfterProgress`: the turn made progress and then went quiet without
+ *    anything outstanding to explain the silence.
+ *
+ * Expected (the turn is legitimately waiting; reported so the two populations
+ * can be told apart in queries rather than silently dropped):
+ *  - `waitingOnUser`: a session input request (tool confirmation, client tool
+ *    execution, tool authentication, or an elicitation) is outstanding, so the
+ *    turn is blocked on a human.
+ *  - `runningTool`: a tool call is still in flight. Covers genuinely long tool
+ *    invocations (builds, test runs) and subagents, whose work is reported on
+ *    the subagent's own chat channel rather than the parent turn's.
+ */
+export type AgentHostTurnHangReason = 'noProgress' | 'stalledAfterProgress' | 'waitingOnUser' | 'runningTool';
+
+export interface IAgentHostTurnHungEvent {
+	provider: string;
+	agentSessionId: string;
+	chatSessionId: string;
+	isSubagentSession: boolean;
+	turnId: string;
+	hangReason: AgentHostTurnHangReason;
+	isExpected: boolean;
+	hadAnyProgress: boolean;
+	lastActivityKind: string;
+	blockedOn: SessionInputRequestKind | undefined;
+	inFlightToolCallCount: number;
+	quietTimeMs: number;
+	turnElapsedMs: number;
+	model: string | TelemetryTrustedValue<string> | undefined;
+	modelSelectionKind: AgentHostModelSelectionKind;
+	permissionLevel: string | undefined;
+}
+
+export type IAgentHostTurnHungClassification = {
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the hung agent host turn.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the hung turn belongs to a subagent session.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the hung turn within the agent host session.' };
+	hangReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded state the turn was quiet in: noProgress, stalledAfterProgress, waitingOnUser, or runningTool.' };
+	isExpected: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the quiet period is explained by a legitimate wait (blocked on the user or running a tool) rather than an unexplained hang.' };
+	hadAnyProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether any turn activity at all was observed before the watchdog fired.' };
+	lastActivityKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The protocol action type of the last observed turn activity, or none when the turn never produced any.' };
+	blockedOn: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of outstanding session input request the turn is blocked on, when there is one.' };
+	inFlightToolCallCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of tool calls that had started but not completed when the watchdog fired.' };
+	quietTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds since the last observed turn activity.' };
+	turnElapsedMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from turn start to the hang report.' };
+	model: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The trusted provider model identifier for the turn, or a generic value for BYOK and unknown models.' };
+	modelSelectionKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the client used the provider default, Auto, or an explicit model.' };
+	permissionLevel: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The tool auto-approval level configured for the session at turn start (e.g. default, autoApprove, autopilot).' };
+	owner: 'roblourens';
+	comment: 'Tracks agent host turns that stop making progress for longer than the hang threshold, so permanently stuck sessions are visible as a positive signal instead of missing turnCompleted events.';
+};
+
+export interface IAgentHostTurnHungReport {
+	provider: string;
+	session: string;
+	turnId: string;
+	hangReason: AgentHostTurnHangReason;
+	hadAnyProgress: boolean;
+	lastActivityKind: string;
+	blockedOn: SessionInputRequestKind | undefined;
+	inFlightToolCallCount: number;
+	quietTimeMs: number;
+	turnElapsedMs: number;
+	model: string | undefined;
+	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
+	modelSelectionKind: AgentHostModelSelectionKind;
+	permissionLevel: string | undefined;
+}
+
+export interface IAgentHostHungTurnCompletedEvent {
+	provider: string;
+	agentSessionId: string;
+	chatSessionId: string;
+	isSubagentSession: boolean;
+	turnId: string;
+	hangReason: AgentHostTurnHangReason;
+	result: AgentHostTurnResult;
+	hangReportCount: number;
+	totalTimeMs: number;
+	timeAfterHangMs: number;
+}
+
+export type IAgentHostHungTurnCompletedClassification = {
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the recovered agent host turn.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the recovered turn belongs to a subagent session.' };
+	turnId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the recovered turn within the agent host session.' };
+	hangReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The most recently reported hang reason for the turn before it completed.' };
+	result: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the previously hung turn eventually completed successfully, with an error, or was cancelled.' };
+	hangReportCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of hang reports emitted for the turn before it completed.' };
+	totalTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time in milliseconds from turn start to turn completion.' };
+	timeAfterHangMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from the most recent hang report to turn completion.' };
+	owner: 'roblourens';
+	comment: 'Tracks agent host turns that complete after previously being reported as hung, so permanent hangs can be separated from merely slow ones.';
+};
+
+export interface IAgentHostHungTurnCompletedReport {
+	provider: string;
+	session: string;
+	turnId: string;
+	hangReason: AgentHostTurnHangReason;
+	result: AgentHostTurnResult;
+	hangReportCount: number;
+	totalTimeMs: number;
+	timeAfterHangMs: number;
+}
+
 export interface IAgentHostToolInvokedReport {
 	provider: string;
 	session: string;
@@ -910,6 +1028,50 @@ export class AgentHostTelemetryReporter {
 				callstack: report.failure.errorStack ?? report.failure.error.stack,
 			});
 		}
+	}
+
+	/**
+	 * Reports a turn that has stopped producing activity for longer than the
+	 * hang threshold. See {@link AgentHostTurnHangReason} for which reasons are
+	 * expected waits and which indicate a real hang.
+	 */
+	turnHung(report: IAgentHostTurnHungReport): void {
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<IAgentHostTurnHungEvent, IAgentHostTurnHungClassification>('agentHost.turnHung', {
+			provider: report.provider,
+			agentSessionId: AgentSession.id(session),
+			chatSessionId: getTelemetryChatSessionId(report.session),
+			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
+			turnId: report.turnId,
+			hangReason: report.hangReason,
+			isExpected: report.hangReason === 'waitingOnUser' || report.hangReason === 'runningTool',
+			hadAnyProgress: report.hadAnyProgress,
+			lastActivityKind: report.lastActivityKind,
+			blockedOn: report.blockedOn,
+			inFlightToolCallCount: report.inFlightToolCallCount,
+			quietTimeMs: report.quietTimeMs,
+			turnElapsedMs: report.turnElapsedMs,
+			model: toTelemetryModel(report.model, report.modelTelemetryKind),
+			modelSelectionKind: report.modelSelectionKind,
+			permissionLevel: report.permissionLevel,
+		});
+	}
+
+	/** Paired recovery event for a turn previously reported by {@link turnHung}. */
+	hungTurnCompleted(report: IAgentHostHungTurnCompletedReport): void {
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<IAgentHostHungTurnCompletedEvent, IAgentHostHungTurnCompletedClassification>('agentHost.hungTurnCompleted', {
+			provider: report.provider,
+			agentSessionId: AgentSession.id(session),
+			chatSessionId: getTelemetryChatSessionId(report.session),
+			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
+			turnId: report.turnId,
+			hangReason: report.hangReason,
+			result: report.result,
+			hangReportCount: report.hangReportCount,
+			totalTimeMs: report.totalTimeMs,
+			timeAfterHangMs: report.timeAfterHangMs,
+		});
 	}
 
 	toolInvoked(report: IAgentHostToolInvokedReport): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -235,12 +235,14 @@ export interface IAgentHostTurnCompletedReport {
  *
  * Expected (the turn is legitimately waiting; reported so the two populations
  * can be told apart in queries rather than silently dropped):
- *  - `waitingOnUser`: a session input request (tool confirmation, client tool
- *    execution, tool authentication, or an elicitation) is outstanding, so the
- *    turn is blocked on a human.
+ *  - `waitingOnUser`: a request that blocks on a *human* is outstanding — a
+ *    tool confirmation, a tool authentication, or an elicitation. Client tool
+ *    execution is deliberately excluded: it is delegated running work rather
+ *    than a prompt, and is reported as `runningTool` instead.
  *  - `runningTool`: a tool call is still in flight. Covers genuinely long tool
- *    invocations (builds, test runs) and subagents, whose work is reported on
- *    the subagent's own chat channel rather than the parent turn's.
+ *    invocations (builds, test runs), client-executed tools, and subagents,
+ *    whose work is reported on the subagent's own chat channel rather than the
+ *    parent turn's.
  */
 export type AgentHostTurnHangReason = 'noProgress' | 'stalledAfterProgress' | 'waitingOnUser' | 'runningTool';
 
@@ -273,7 +275,7 @@ export type IAgentHostTurnHungClassification = {
 	isExpected: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the quiet period is explained by a legitimate wait (blocked on the user or running a tool) rather than an unexplained hang.' };
 	hadAnyProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether any turn activity at all was observed before the watchdog fired.' };
 	lastActivityKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The protocol action type of the last observed turn activity, or none when the turn never produced any.' };
-	blockedOn: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of outstanding session input request the turn is blocked on, when there is one.' };
+	blockedOn: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of outstanding user-blocking session input request, when there is one. Client tool execution is not counted, since it is delegated work rather than a prompt.' };
 	inFlightToolCallCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Number of tool calls that had started but not completed when the watchdog fired.' };
 	quietTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds since the last observed turn activity.' };
 	turnElapsedMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from turn start to the hang report.' };

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -7,7 +7,7 @@ import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
-import type { SessionInputRequestKind } from '../common/state/protocol/state.js';
+import { SessionInputRequestKind } from '../common/state/protocol/state.js';
 import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter, AgentHostTurnHangReason, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
 
 /**
@@ -50,8 +50,7 @@ interface ITurnTiming {
 	/** Tool calls that have started but not completed, by tool call id. */
 	readonly inFlightToolCalls: Set<string>;
 	/** Outstanding session input requests for this turn, by request id. */
-	readonly blockers: Map<string, SessionInputRequestKind>;
-	/** Hang reasons already reported, so each is emitted at most once per turn. */
+	readonly blockers: Map<string, SessionInputRequestKind>;	/** Hang reasons already reported, so each is emitted at most once per turn. */
 	readonly reportedHangReasons: Set<AgentHostTurnHangReason>;
 	/** Number of hang reports emitted for this turn. */
 	hangReportCount: number;
@@ -187,11 +186,20 @@ export class AgentHostTurnTracker extends Disposable {
 	}
 
 	/**
-	 * Records that the turn is blocked on a session input request (tool
-	 * confirmation, client tool execution, tool authentication, or an
-	 * elicitation). These are legitimate waits on a human, so a hang reported
-	 * while one is outstanding is tagged `waitingOnUser` and can be filtered
-	 * apart from real hangs.
+	 * Records that a session input request is outstanding for the turn.
+	 *
+	 * Only requests that block on a *human* make the turn `waitingOnUser`.
+	 * {@link SessionInputRequestKind.ToolClientExecution} is delegated running
+	 * work, not a prompt: the call has already cleared its confirmation gate
+	 * and is simply executing on a client. Counting it would report every
+	 * long-running client tool as waiting on the user. This mirrors the
+	 * `awaitsUser` predicate the protocol reducer uses for session status
+	 * (`channels-session/reducer.ts`), which cannot be imported here because
+	 * that file is generated. Client execution is still represented — the
+	 * in-flight tool set covers it and yields `runningTool`.
+	 *
+	 * Every outstanding request is recorded regardless, so unblocking can find
+	 * its turn and teardown can clean up its bookkeeping.
 	 */
 	turnBlocked(session: string, turnId: string, requestId: string, kind: SessionInputRequestKind): void {
 		const turnKey = this._key(session, turnId);
@@ -338,7 +346,7 @@ export class AgentHostTurnTracker extends Disposable {
 			timing.hangReportCount++;
 			timing.lastHangReason = hangReason;
 			timing.lastHangStopWatch = StopWatch.create(true);
-			const blockedOn = timing.blockers.values().next();
+			const userBlocker = this._firstUserBlocker(timing);
 			this._reporter.turnHung({
 				provider: timing.provider,
 				session: timing.session,
@@ -346,7 +354,7 @@ export class AgentHostTurnTracker extends Disposable {
 				hangReason,
 				hadAnyProgress: timing.lastActivityKind !== TURN_ACTIVITY_NONE,
 				lastActivityKind: timing.lastActivityKind,
-				blockedOn: blockedOn.done ? undefined : blockedOn.value,
+				blockedOn: userBlocker,
 				inFlightToolCallCount: timing.inFlightToolCalls.size,
 				quietTimeMs: timing.quietStopWatch.elapsed(),
 				turnElapsedMs: timing.stopWatch.elapsed(),
@@ -362,11 +370,25 @@ export class AgentHostTurnTracker extends Disposable {
 		}
 	}
 
+	/**
+	 * The kind of the first outstanding request that blocks on the user, or
+	 * `undefined` when none does. See {@link turnBlocked} for why client tool
+	 * execution is not a user blocker.
+	 */
+	private _firstUserBlocker(timing: ITurnTiming): SessionInputRequestKind | undefined {
+		for (const kind of timing.blockers.values()) {
+			if (kind !== SessionInputRequestKind.ToolClientExecution) {
+				return kind;
+			}
+		}
+		return undefined;
+	}
+
 	private _deriveHangReason(timing: ITurnTiming): AgentHostTurnHangReason {
-		// A blocker takes precedence over an in-flight tool call: a tool call
-		// awaiting confirmation is both, and the human is the real reason the
-		// turn is quiet.
-		if (timing.blockers.size > 0) {
+		// A user blocker takes precedence over an in-flight tool call: a tool
+		// call awaiting confirmation is both, and the human is the real reason
+		// the turn is quiet.
+		if (this._firstUserBlocker(timing) !== undefined) {
 			return 'waitingOnUser';
 		}
 		if (timing.inFlightToolCalls.size > 0) {

--- a/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostTurnTracker.ts
@@ -3,21 +3,64 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
-import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
+import type { SessionInputRequestKind } from '../common/state/protocol/state.js';
+import type { AgentHostModelTelemetryKind, AgentHostTelemetryReporter, AgentHostTurnHangReason, AgentHostTurnResult, IAgentHostTurnFailure } from './agentHostTelemetryReporter.js';
+
+/**
+ * How long a turn must go without any observed activity before the watchdog
+ * reports it. Matches {@link TOOL_CALL_STALL_THRESHOLD_MS} in
+ * `agentHostToolCallTracker.ts` so the two hang signals line up on dashboards.
+ */
+export const TURN_HANG_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * How many consecutive quiet windows the watchdog re-arms for. Each report is
+ * deduped per {@link AgentHostTurnHangReason}, so re-arming exists only to
+ * catch a *change* of state (e.g. the user answers a confirmation and the turn
+ * then hangs for real). After this many quiet windows the watchdog stops
+ * arming; any later activity re-arms it. This keeps the number of live timers
+ * and emitted events bounded for a permanently dead turn.
+ */
+const MAX_HANG_CHECK_WINDOWS = 6;
+
+/** Sentinel `lastActivityKind` for a turn that never produced any activity. */
+export const TURN_ACTIVITY_NONE = 'none';
 
 /** Per-turn timing state, keyed by `session:turnId`. */
 interface ITurnTiming {
 	readonly stopWatch: StopWatch;
 	readonly provider: string;
 	readonly session: string;
+	readonly turnId: string;
 	model: string | undefined;
 	modelTelemetryKind: AgentHostModelTelemetryKind | undefined;
 	readonly modelSelectionKind: 'default' | 'auto' | 'explicit';
 	readonly permissionLevel: string | undefined;
 	firstProgressMs: number | undefined;
+
+	// Hang watchdog state
+	/** Reset on every observed activity; measures the current quiet period. */
+	quietStopWatch: StopWatch;
+	/** Protocol action type of the last observed activity, or `none`. */
+	lastActivityKind: string;
+	/** Tool calls that have started but not completed, by tool call id. */
+	readonly inFlightToolCalls: Set<string>;
+	/** Outstanding session input requests for this turn, by request id. */
+	readonly blockers: Map<string, SessionInputRequestKind>;
+	/** Hang reasons already reported, so each is emitted at most once per turn. */
+	readonly reportedHangReasons: Set<AgentHostTurnHangReason>;
+	/** Number of hang reports emitted for this turn. */
+	hangReportCount: number;
+	/** The most recently reported hang reason, for the paired recovery event. */
+	lastHangReason: AgentHostTurnHangReason | undefined;
+	/** Started when the first hang report is emitted; measures recovery time. */
+	lastHangStopWatch: StopWatch | undefined;
+	/** Consecutive quiet windows the watchdog has observed. */
+	quietWindows: number;
 }
 
 /**
@@ -25,14 +68,28 @@ interface ITurnTiming {
  * event via the provided {@link AgentHostTelemetryReporter} when a turn ends.
  *
  * Lifecycle per turn:
- *   1. {@link turnStarted} — begins a stopwatch for the turn
+ *   1. {@link turnStarted} — begins a stopwatch for the turn and arms the hang
+ *      watchdog
  *   2. {@link markFirstProgress} — records elapsed time to first visible output
  *      (only the first call per turn has an effect)
- *   3. {@link turnCompleted} — emits the telemetry event and clears state
+ *   3. {@link markActivity} — records any observed turn activity and debounces
+ *      the hang watchdog
+ *   4. {@link turnCompleted} — emits the telemetry event and clears state
+ *
+ * The hang watchdog gives a *positive* signal for stuck turns. Without it a
+ * turn that starts and never completes is only visible as the absence of an
+ * `agentHost.turnCompleted` event, which does not show up on dashboards. When
+ * a turn goes {@link TURN_HANG_THRESHOLD_MS} without activity the tracker
+ * reports `agentHost.turnHung` with the state it was quiet in; if such a turn
+ * later completes, it also reports `agentHost.hungTurnCompleted` so permanent
+ * hangs can be separated from merely slow ones.
  */
 export class AgentHostTurnTracker extends Disposable {
 
 	private readonly _turnTimings = new Map<string, ITurnTiming>();
+	private readonly _hangWatchdogs = this._register(new DisposableMap<string>());
+	/** Maps `session:requestId` to the turn key blocked on that request. */
+	private readonly _blockerTurnKeys = new Map<string, string>();
 
 	/**
 	 * Fires with the provider id whenever a turn starts, i.e. whenever the host
@@ -49,6 +106,10 @@ export class AgentHostTurnTracker extends Disposable {
 
 	constructor(private readonly _reporter: AgentHostTelemetryReporter) {
 		super();
+		this._register(toDisposable(() => {
+			this._turnTimings.clear();
+			this._blockerTurnKeys.clear();
+		}));
 	}
 
 	turnStarted(provider: string, session: string, turnId: string, model: string | undefined, modelTelemetryKind: AgentHostModelTelemetryKind | undefined, permissionLevel: string | undefined): void {
@@ -57,12 +118,23 @@ export class AgentHostTurnTracker extends Disposable {
 			stopWatch: StopWatch.create(false),
 			provider,
 			session,
+			turnId,
 			model,
 			modelTelemetryKind,
 			modelSelectionKind: model === undefined ? 'default' : model === 'auto' ? 'auto' : 'explicit',
 			permissionLevel,
 			firstProgressMs: undefined,
+			quietStopWatch: StopWatch.create(false),
+			lastActivityKind: TURN_ACTIVITY_NONE,
+			inFlightToolCalls: new Set(),
+			blockers: new Map(),
+			reportedHangReasons: new Set(),
+			hangReportCount: 0,
+			lastHangReason: undefined,
+			lastHangStopWatch: undefined,
+			quietWindows: 0,
 		});
+		this._armHangWatchdog(key);
 		this._onDidStartTurn.fire(provider);
 	}
 
@@ -71,6 +143,86 @@ export class AgentHostTurnTracker extends Disposable {
 		if (timing && timing.firstProgressMs === undefined) {
 			timing.firstProgressMs = timing.stopWatch.elapsed();
 		}
+	}
+
+	/**
+	 * Records observed activity for a turn. `activityKind` is the protocol
+	 * action type that produced it, which is emitted verbatim in the hang event
+	 * so a hang can be attributed to what the turn was last doing.
+	 *
+	 * Every call debounces the hang watchdog, so a turn that keeps producing
+	 * signals of any kind is never reported as hung. This is deliberately
+	 * broader than {@link markFirstProgress}, which only counts *visible*
+	 * progress for the time-to-first-progress metric.
+	 */
+	markActivity(session: string, turnId: string, activityKind: string): void {
+		const key = this._key(session, turnId);
+		const timing = this._turnTimings.get(key);
+		if (!timing) {
+			return;
+		}
+		timing.lastActivityKind = activityKind;
+		this._touch(key, timing);
+	}
+
+	/** Resets the quiet period and re-arms the watchdog for a live turn. */
+	private _touch(key: string, timing: ITurnTiming): void {
+		timing.quietStopWatch = StopWatch.create(true);
+		timing.quietWindows = 0;
+		this._armHangWatchdog(key);
+	}
+
+	/**
+	 * Records that a tool call is in flight for the turn. An in-flight tool
+	 * call explains an otherwise quiet turn (a long build, or a subagent whose
+	 * progress is reported on its own chat channel), so the hang is reported
+	 * with the `runningTool` reason rather than as an unexplained stall.
+	 */
+	toolCallStarted(session: string, turnId: string, toolCallId: string): void {
+		this._turnTimings.get(this._key(session, turnId))?.inFlightToolCalls.add(toolCallId);
+	}
+
+	toolCallEnded(session: string, turnId: string, toolCallId: string): void {
+		this._turnTimings.get(this._key(session, turnId))?.inFlightToolCalls.delete(toolCallId);
+	}
+
+	/**
+	 * Records that the turn is blocked on a session input request (tool
+	 * confirmation, client tool execution, tool authentication, or an
+	 * elicitation). These are legitimate waits on a human, so a hang reported
+	 * while one is outstanding is tagged `waitingOnUser` and can be filtered
+	 * apart from real hangs.
+	 */
+	turnBlocked(session: string, turnId: string, requestId: string, kind: SessionInputRequestKind): void {
+		const turnKey = this._key(session, turnId);
+		const timing = this._turnTimings.get(turnKey);
+		if (!timing) {
+			return;
+		}
+		timing.blockers.set(requestId, kind);
+		this._blockerTurnKeys.set(this._key(session, requestId), turnKey);
+		// A request appearing or being answered is itself a state change, so it
+		// restarts the quiet period. Without this, a user who answers just
+		// before the watchdog expires would be misreported as an unexplained
+		// stall on the very next tick, and a turn whose watchdog had stopped
+		// re-arming while blocked would never be watched again after the
+		// answer.
+		this._touch(turnKey, timing);
+	}
+
+	turnUnblocked(session: string, requestId: string): void {
+		const blockerKey = this._key(session, requestId);
+		const turnKey = this._blockerTurnKeys.get(blockerKey);
+		if (turnKey === undefined) {
+			return;
+		}
+		this._blockerTurnKeys.delete(blockerKey);
+		const timing = this._turnTimings.get(turnKey);
+		if (!timing) {
+			return;
+		}
+		timing.blockers.delete(requestId);
+		this._touch(turnKey, timing);
 	}
 
 	updateModel(session: string, turnId: string, model: string, modelTelemetryKind: AgentHostModelTelemetryKind): void {
@@ -92,7 +244,7 @@ export class AgentHostTurnTracker extends Disposable {
 		if (!timing) {
 			return;
 		}
-		this._turnTimings.delete(key);
+		this._disposeTurn(key, timing);
 
 		this._reporter.turnCompleted({
 			provider: timing.provider,
@@ -107,9 +259,128 @@ export class AgentHostTurnTracker extends Disposable {
 			permissionLevel: timing.permissionLevel,
 			failure,
 		});
+
+		// Paired recovery event: the turn was reported as hung but did finish,
+		// which distinguishes a permanent hang from a merely slow turn.
+		if (timing.lastHangReason !== undefined) {
+			this._reporter.hungTurnCompleted({
+				provider: timing.provider,
+				session: timing.session,
+				turnId,
+				hangReason: timing.lastHangReason,
+				result,
+				hangReportCount: timing.hangReportCount,
+				totalTimeMs: timing.stopWatch.elapsed(),
+				timeAfterHangMs: timing.lastHangStopWatch?.elapsed() ?? 0,
+			});
+		}
+	}
+
+	/**
+	 * Drops any in-flight (never-completed) turns for a session without
+	 * reporting them. Called on session teardown so neither the timing map nor
+	 * the watchdog timers can outlive the session they describe.
+	 */
+	clearSession(session: string): void {
+		const prefix = `${session}\0`;
+		for (const [key, timing] of this._turnTimings) {
+			if (key.startsWith(prefix)) {
+				this._disposeTurn(key, timing);
+			}
+		}
+		for (const key of this._blockerTurnKeys.keys()) {
+			if (key.startsWith(prefix)) {
+				this._blockerTurnKeys.delete(key);
+			}
+		}
+	}
+
+	/**
+	 * Drops tracked turns for a channel that are not in `keepTurnIds`, without
+	 * reporting them. Used after a chat is truncated: the turns are gone from
+	 * state and will never complete, so their watchdogs must not survive to
+	 * report a hang for a turn that no longer exists.
+	 */
+	clearTurnsExcept(session: string, keepTurnIds: ReadonlySet<string>): void {
+		const prefix = `${session}\0`;
+		for (const [key, timing] of this._turnTimings) {
+			if (key.startsWith(prefix) && !keepTurnIds.has(timing.turnId)) {
+				this._disposeTurn(key, timing);
+			}
+		}
+	}
+
+	private _disposeTurn(key: string, timing: ITurnTiming): void {
+		this._turnTimings.delete(key);
+		this._hangWatchdogs.deleteAndDispose(key);
+		for (const requestId of timing.blockers.keys()) {
+			this._blockerTurnKeys.delete(this._key(timing.session, requestId));
+		}
+	}
+
+	private _armHangWatchdog(key: string): void {
+		this._hangWatchdogs.set(key, disposableTimeout(() => this._onHangWatchdogFired(key), TURN_HANG_THRESHOLD_MS));
+	}
+
+	private _onHangWatchdogFired(key: string): void {
+		const timing = this._turnTimings.get(key);
+		if (!timing) {
+			return;
+		}
+		timing.quietWindows++;
+
+		const hangReason = this._deriveHangReason(timing);
+		// Report each reason at most once per turn: a turn quiet for an hour
+		// should not produce a dozen identical events, but a turn that moves
+		// from `waitingOnUser` to a genuine stall should still be reported.
+		if (!timing.reportedHangReasons.has(hangReason)) {
+			timing.reportedHangReasons.add(hangReason);
+			timing.hangReportCount++;
+			timing.lastHangReason = hangReason;
+			timing.lastHangStopWatch = StopWatch.create(true);
+			const blockedOn = timing.blockers.values().next();
+			this._reporter.turnHung({
+				provider: timing.provider,
+				session: timing.session,
+				turnId: timing.turnId,
+				hangReason,
+				hadAnyProgress: timing.lastActivityKind !== TURN_ACTIVITY_NONE,
+				lastActivityKind: timing.lastActivityKind,
+				blockedOn: blockedOn.done ? undefined : blockedOn.value,
+				inFlightToolCallCount: timing.inFlightToolCalls.size,
+				quietTimeMs: timing.quietStopWatch.elapsed(),
+				turnElapsedMs: timing.stopWatch.elapsed(),
+				model: timing.model,
+				modelTelemetryKind: timing.modelTelemetryKind,
+				modelSelectionKind: timing.modelSelectionKind,
+				permissionLevel: timing.permissionLevel,
+			});
+		}
+
+		if (timing.quietWindows < MAX_HANG_CHECK_WINDOWS) {
+			this._armHangWatchdog(key);
+		}
+	}
+
+	private _deriveHangReason(timing: ITurnTiming): AgentHostTurnHangReason {
+		// A blocker takes precedence over an in-flight tool call: a tool call
+		// awaiting confirmation is both, and the human is the real reason the
+		// turn is quiet.
+		if (timing.blockers.size > 0) {
+			return 'waitingOnUser';
+		}
+		if (timing.inFlightToolCalls.size > 0) {
+			return 'runningTool';
+		}
+		// Nothing outstanding to explain the silence — this is a real hang.
+		// `noProgress` in particular is the signature of a lost turn: the turn
+		// started, no activity of any kind was ever observed, and it never
+		// completed.
+		return timing.lastActivityKind === TURN_ACTIVITY_NONE ? 'noProgress' : 'stalledAfterProgress';
 	}
 
 	private _key(session: string, turnId: string): string {
 		return `${session}\0${turnId}`;
 	}
 }
+

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1649,7 +1649,7 @@ export class AgentService extends Disposable implements IAgentService {
 		const provider = this._findProviderForSession(session);
 		this._sideEffects.clearQueuedMessageSenders(chat.toString());
 		this._sideEffects.cancelSubagentSessions(chat.toString());
-		this._sideEffects.clearToolCallTelemetry(chat.toString());
+		this._sideEffects.clearChannelTelemetry(chat.toString());
 		this._stateManager.removeChat(sessionKey, chat.toString());
 		// Drop the chat from the orchestrator-owned catalog so it isn't
 		// re-materialized on the next restore.
@@ -2198,9 +2198,9 @@ export class AgentService extends Disposable implements IAgentService {
 		this._logService.trace(`[AgentService] disposeSession: ${session.toString()}`);
 		this._stateManager.invalidateSessionChatResolutions(session.toString());
 		for (const chat of this._stateManager.getSessionState(session.toString())?.chats ?? []) {
-			this._sideEffects.clearToolCallTelemetry(chat.resource);
+			this._sideEffects.clearChannelTelemetry(chat.resource);
 		}
-		this._sideEffects.clearToolCallTelemetry(session.toString());
+		this._sideEffects.clearChannelTelemetry(session.toString());
 		// Resolve the working directories up front and pass them explicitly:
 		// the checkpoint and review services need them to locate the
 		// repositories holding this session's refs, and reading them from

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -876,6 +876,15 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.toolCallStarted(sessionKey, turnId, action.toolCallId);
 		}
 
+		// A denied confirmation is a terminal transition to `cancelled`: the
+		// reducer ignores any later completion for the call, so drop it from
+		// the turn's in-flight set here or a subsequent hang would be reported
+		// as `runningTool` for a tool that will never run. Denials reach the
+		// host on this path as well as via `handleAction`.
+		if (action.type === ActionType.ChatToolCallConfirmed && !action.approved) {
+			this._turnTracker.toolCallEnded(sessionKey, turnId, action.toolCallId);
+		}
+
 		if (action.type === ActionType.ChatToolCallComplete) {
 			this._turnTracker.toolCallEnded(sessionKey, turnId, action.toolCallId);
 
@@ -1399,6 +1408,13 @@ export class AgentSideEffects extends Disposable {
 				const toolCallKey = `${channel}:${action.toolCallId}`;
 				if (action.approved) {
 					this._toolCallTracker.toolCallExecutionStarted(channel, action.toolCallId);
+				} else {
+					// A denial is terminal: the reducer moves the call to
+					// `cancelled` and ignores any later completion for it, so
+					// this is the last chance to drop it from the turn's
+					// in-flight set. Leaving it would make a subsequent hang
+					// report `runningTool` for a tool that will never run.
+					this._turnTracker.toolCallEnded(channel, action.turnId, action.toolCallId);
 				}
 				const managedApprovalRequired = this._managedApprovalToolCalls.delete(toolCallKey);
 				const agentId = this._toolCallAgents.get(toolCallKey);

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -561,6 +561,14 @@ export class AgentSideEffects extends Disposable {
 			return;
 		}
 		this._stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionInputNeededSet, request });
+		// Record the blocker on the turn so a hang reported while the request is
+		// outstanding is tagged as an expected wait on the user rather than as
+		// an unexplained stall. A `ChatInput` elicitation carries no `turnId`,
+		// so fall back to the chat's active turn.
+		const blockedTurnId = hasKey(request, { turnId: true }) ? request.turnId : this._stateManager.getActiveTurnId(chatUri);
+		if (blockedTurnId) {
+			this._turnTracker.turnBlocked(chatUri, blockedTurnId, request.id, request.kind);
+		}
 		if (request.kind !== SessionInputRequestKind.ChatInput) {
 			const agent = this._options.getAgent(sessionUri);
 			if (agent) {
@@ -572,6 +580,7 @@ export class AgentSideEffects extends Disposable {
 	private _removeSessionInputNeeded(chatUri: ProtocolURI, id: string): void {
 		const sessionUri = parseRequiredSessionUriFromChatUri(chatUri);
 		this._toolCallTracker.toolCallUnblocked(chatUri, id);
+		this._turnTracker.turnUnblocked(chatUri, id);
 		if (!this._stateManager.getSessionState(sessionUri)?.inputNeeded?.some(r => r.id === id)) {
 			return;
 		}
@@ -846,6 +855,15 @@ export class AgentSideEffects extends Disposable {
 
 		this._stateManager.dispatchServerAction(sessionKey, action);
 
+		// Any turn-scoped action counts as activity for the hang watchdog: it is
+		// proof the agent loop is still alive, even when the action produces
+		// nothing visible. Session-scoped actions (title, customizations, MCP
+		// state, …) are deliberately excluded — they can arrive while a turn is
+		// genuinely stuck and would otherwise mask the hang.
+		if (hasKey(action, { turnId: true })) {
+			this._turnTracker.markActivity(sessionKey, turnId, action.type);
+		}
+
 		// Mark first visible progress for TTFT telemetry
 		if (action.type === ActionType.ChatDelta
 			|| action.type === ActionType.ChatResponsePart
@@ -854,7 +872,13 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.markFirstProgress(sessionKey, turnId);
 		}
 
+		if (action.type === ActionType.ChatToolCallStart) {
+			this._turnTracker.toolCallStarted(sessionKey, turnId, action.toolCallId);
+		}
+
 		if (action.type === ActionType.ChatToolCallComplete) {
+			this._turnTracker.toolCallEnded(sessionKey, turnId, action.toolCallId);
+
 			// Emit `languageModelToolInvoked` telemetry for the completed tool
 			// call. `action.result` carries `success`/`error.code` even after the
 			// subagent-content merge above (which only touches `result.content`).
@@ -1117,6 +1141,7 @@ export class AgentSideEffects extends Disposable {
 				this._turnTracker.turnCompleted(subagent.chatUri, turnId, 'cancelled');
 			}
 			this._toolCallTracker.clearSession(subagent.chatUri);
+			this._turnTracker.clearSession(subagent.chatUri);
 		}
 		this._subagentChats.deleteAll(parentChatURI);
 		// Drop any buffered events targeted at subagents that never started.
@@ -1166,6 +1191,7 @@ export class AgentSideEffects extends Disposable {
 			if (subagent.sessionUri === parentSession) {
 				this._stateManager.removeChat(subagent.sessionUri, subagent.chatUri);
 				this._toolCallTracker.clearSession(subagent.chatUri);
+				this._turnTracker.clearSession(subagent.chatUri);
 				parentChatURIs.add(subagent.parentChatUri);
 			}
 		}
@@ -1175,8 +1201,15 @@ export class AgentSideEffects extends Disposable {
 		}
 	}
 
-	clearToolCallTelemetry(channel: ProtocolURI): void {
+	/**
+	 * Drops per-channel telemetry tracking on teardown. In-flight tool calls
+	 * and never-completed turns are discarded without reporting, so neither
+	 * their tracking maps nor the turn hang watchdog timers outlive the
+	 * channel they describe.
+	 */
+	clearChannelTelemetry(channel: ProtocolURI): void {
 		this._toolCallTracker.clearSession(channel);
+		this._turnTracker.clearSession(channel);
 	}
 
 	clearInputRequestsForSession(session: ProtocolURI): void {
@@ -1291,6 +1324,9 @@ export class AgentSideEffects extends Disposable {
 			this._toolCallTracker.toolCallExecutionStarted(sessionKey, readyAction.toolCallId);
 		}
 		this._stateManager.dispatchServerAction(sessionKey, readyAction);
+		// This action is synthesized here rather than routed through
+		// `_dispatchActionForSession`, so feed the hang watchdog explicitly.
+		this._turnTracker.markActivity(sessionKey, turnId, readyAction.type);
 	}
 
 	handleAction(channel: ProtocolURI, action: StateAction, clientId?: string, clientContextOrType: IAgentHostClientTelemetryContext | AgentHostClientType = AgentHostClientType.Unknown): void {
@@ -1473,6 +1509,16 @@ export class AgentSideEffects extends Disposable {
 				const survivingIds = new Set((this._stateManager.getChatState(chatChannel)?.turns ?? []).map(t => t.id));
 				const removed = this._options.localTurns.getLocalTurnIds(chatChannel).filter(id => !survivingIds.has(id));
 				this._options.localTurns.deleteLocals(sessionChannel, removed);
+				// Turns removed by the truncation will never complete, so their
+				// hang watchdogs must not survive to report a turn that no
+				// longer exists. The active turn is tracked separately from
+				// `turns` in chat state, so keep it explicitly.
+				const trackedTurnIds = new Set(survivingIds);
+				const activeTurnId = this._stateManager.getActiveTurnId(chatChannel);
+				if (activeTurnId) {
+					trackedTurnIds.add(activeTurnId);
+				}
+				this._turnTracker.clearTurnsExcept(chatChannel, trackedTurnIds);
 				this._changesets.onSessionTruncated(sessionChannel);
 				break;
 			}

--- a/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
@@ -18,7 +18,7 @@ import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelatio
 import { AgentSession, IAgent } from '../../common/agentService.js';
 import { SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
-import { buildDefaultChatUri, MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, MessageKind, ResponsePartKind, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallContributorKind } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
@@ -442,6 +442,89 @@ suite('AgentSideEffects — turn hang telemetry', () => {
 			{ hangReason: 'waitingOnUser', isExpected: true },
 			{ hangReason: 'stalledAfterProgress', isExpected: false },
 		]);
+	});
+
+	test('tags a client-executed tool as runningTool, not as a wait on the user', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-client');
+			fire({
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-client',
+				toolCallId: 'tc-client',
+				toolName: 'run_tests',
+				displayName: 'run_tests',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: 'client-1' },
+			});
+			// Confirmation is not needed, so the call goes straight to running
+			// and is surfaced as a `toolClientExecution` input request. That is
+			// delegated work, not a prompt — the turn is not waiting on a human.
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-client',
+				toolCallId: 'tc-client',
+				invocationMessage: 'Run tests',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({
+			hangReason: e.data.hangReason,
+			isExpected: e.data.isExpected,
+			blockedOn: e.data.blockedOn,
+			inFlightToolCallCount: e.data.inFlightToolCallCount,
+		})), [{
+			hangReason: 'runningTool',
+			isExpected: true,
+			blockedOn: undefined,
+			inFlightToolCallCount: 1,
+		}]);
+	});
+
+	test('reports a real stall when the agent goes quiet after a denied confirmation', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-denied');
+			fire({
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-denied',
+				toolCallId: 'tc-denied',
+				toolName: 'write',
+				displayName: 'write',
+			});
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-denied',
+				toolCallId: 'tc-denied',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+
+			// Denial is terminal — no `ChatToolCallComplete` follows, so the
+			// tool must not stay in the turn's in-flight set.
+			const denied: ChatAction = {
+				type: ActionType.ChatToolCallConfirmed,
+				turnId: 'turn-denied',
+				toolCallId: 'tc-denied',
+				approved: false,
+				reason: ToolCallCancellationReason.Denied,
+			};
+			stateManager.dispatchClientAction(defaultChatUri, denied, { clientId: 'test', clientSeq: 2 });
+			sideEffects.handleAction(defaultChatUri, denied);
+
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({
+			hangReason: e.data.hangReason,
+			isExpected: e.data.isExpected,
+			inFlightToolCallCount: e.data.inFlightToolCallCount,
+		})), [{
+			hangReason: 'stalledAfterProgress',
+			isExpected: false,
+			inFlightToolCallCount: 0,
+		}]);
 	});
 
 	test('does not report after a turn is cancelled or its session is torn down', async () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
@@ -1,0 +1,461 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../base/common/async.js';
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../base/test/common/virtualScheduling/runWithFakedTimers.js';
+import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
+import { AgentSession, IAgent } from '../../common/agentService.js';
+import { SessionInputRequestKind } from '../../common/state/protocol/state.js';
+import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
+import { buildDefaultChatUri, MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason } from '../../common/state/sessionState.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
+import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
+import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
+import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { IAgentHostChangesetService } from '../../common/agentHostChangesetService.js';
+import { AgentSideEffects } from '../../node/agentSideEffects.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { TURN_ACTIVITY_NONE, TURN_HANG_THRESHOLD_MS } from '../../node/agentHostTurnTracker.js';
+import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
+import { MockAgent } from './mockAgent.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
+
+class FakeChangesetService implements IAgentHostChangesetService {
+	declare readonly _serviceBrand: undefined;
+	registerStaticChangesets(): void { }
+	restoreStaticChangeset(): void { }
+	parsePersistedStaticChangesets(): { session?: undefined } { return {}; }
+	applyPersistedStaticChangesets(): void { }
+	restorePersistedStaticChangesets(): { session?: undefined } { return {}; }
+	persistChangesSummary(): void { }
+	isStaticChangesetComputeActive(): boolean { return false; }
+	getListMetadataKeys() { return undefined; }
+	computeListEntryChanges() { return undefined; }
+	refreshBranchChangeset(): void { }
+	refreshSessionChangeset(): void { }
+	refreshChangesetCatalog(): void { }
+	onWorkingDirectoryAvailable(): void { }
+	recomputeSubscribedChangesets(): void { }
+	onSessionDisposed(): void { }
+	async computeUncommittedChangeset(session: string): Promise<string> { return `${session}/changeset/uncommitted`; }
+	async computeTurnChangeset(session: string): Promise<string> { return `${session}/x`; }
+	async computeCompareTurnsChangeset(session: string): Promise<string> { return `${session}/y`; }
+	onToolCallEditsApplied(): void { }
+	onTurnComplete(): void { }
+	onSessionTruncated(): void { }
+}
+
+class CapturingTelemetryService implements ITelemetryService {
+	declare readonly _serviceBrand: undefined;
+	readonly telemetryLevel = TelemetryLevel.USAGE;
+	readonly sessionId = 'test-session';
+	readonly machineId = 'test-machine';
+	readonly sqmId = 'test-sqm';
+	readonly devDeviceId = 'test-dev-device';
+	readonly firstSessionDate = 'test-first-session-date';
+	readonly sendErrorTelemetry = false;
+	readonly events: { eventName: string; data: unknown }[] = [];
+
+	publicLog(): void { }
+	publicLog2(eventName: string, data?: unknown): void {
+		this.events.push({ eventName, data });
+	}
+	publicLogError(): void { }
+	publicLogError2(): void { }
+	setExperimentProperty(): void { }
+	setCommonProperty(): void { }
+}
+
+/**
+ * Integration tests for the turn hang watchdog owned by
+ * {@link AgentHostTurnTracker}, driven through {@link AgentSideEffects} so the
+ * activity, blocker and tool-call signals are exercised through their real
+ * wiring rather than by calling the tracker directly.
+ */
+suite('AgentSideEffects — turn hang telemetry', () => {
+
+	const disposables = new DisposableStore();
+	let stateManager: AgentHostStateManager;
+	let agent: MockAgent;
+	let sideEffects: AgentSideEffects;
+	let telemetry: CapturingTelemetryService;
+
+	const sessionUri = AgentSession.uri('mock', 'session-1');
+	const sessionKey = sessionUri.toString();
+	const defaultChatUri = buildDefaultChatUri(sessionUri);
+
+	function setupSession(): void {
+		stateManager.createSession({
+			resource: sessionKey,
+			provider: 'mock',
+			title: 'Test',
+			status: SessionStatus.Idle,
+			createdAt: new Date().toISOString(),
+			modifiedAt: new Date().toISOString(),
+		});
+		stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
+	}
+
+	function startTurn(turnId: string): void {
+		const action: ChatAction = {
+			type: ActionType.ChatTurnStarted,
+			turnId,
+			startedAt: '2025-01-01T00:00:00.000Z',
+			message: { text: 'hello', origin: { kind: MessageKind.User } },
+		};
+		stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
+		sideEffects.handleAction(defaultChatUri, action);
+	}
+
+	function fire(action: ChatAction): void {
+		agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action });
+	}
+
+	function responsePart(turnId: string): void {
+		fire({ type: ActionType.ChatResponsePart, turnId, part: { kind: ResponsePartKind.Markdown, id: 'p1', content: '' } });
+	}
+
+	function delta(turnId: string, content: string): void {
+		fire({ type: ActionType.ChatDelta, turnId, partId: 'p1', content });
+	}
+
+	/** Normalizes the non-deterministic timing fields to booleans for snapshotting. */
+	function hangEvents(): { eventName: string; data: Record<string, unknown> }[] {
+		return telemetry.events
+			.filter(e => e.eventName === 'agentHost.turnHung')
+			.map(e => {
+				const data = e.data as Record<string, unknown>;
+				return {
+					eventName: e.eventName,
+					data: {
+						...data,
+						quietTimeMs: typeof data.quietTimeMs === 'number' && data.quietTimeMs >= TURN_HANG_THRESHOLD_MS,
+						turnElapsedMs: typeof data.turnElapsedMs === 'number' && data.turnElapsedMs >= TURN_HANG_THRESHOLD_MS,
+					},
+				};
+			});
+	}
+
+	function hangRecoveryEvents(): { eventName: string; data: Record<string, unknown> }[] {
+		return telemetry.events
+			.filter(e => e.eventName === 'agentHost.hungTurnCompleted')
+			.map(e => {
+				const data = e.data as Record<string, unknown>;
+				return {
+					eventName: e.eventName,
+					data: {
+						...data,
+						totalTimeMs: typeof data.totalTimeMs === 'number' && data.totalTimeMs >= 0,
+						timeAfterHangMs: typeof data.timeAfterHangMs === 'number' && data.timeAfterHangMs >= 0,
+					},
+				};
+			});
+	}
+
+	setup(() => {
+		agent = new MockAgent();
+		disposables.add(toDisposable(() => agent.dispose()));
+		stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+		const agentList = observableValue<readonly IAgent[]>('agents', [agent]);
+		telemetry = new CapturingTelemetryService();
+
+		const logService = new NullLogService();
+		const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const telemetryService = disposables.add(new AgentHostTelemetryService(telemetry));
+		const sessionDataService = createNullSessionDataService();
+		const instantiationService = disposables.add(new InstantiationService(new ServiceCollection(
+			[ILogService, logService],
+			[IAgentConfigurationService, configService],
+			[IAgentHostChangesetService, new FakeChangesetService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
+			[ITelemetryService, telemetryService],
+			[IAgentHostTerminalManager, disposables.add(new TestAgentHostTerminalManager())],
+			[ISessionDataService, sessionDataService],
+		), /*strict*/ true));
+		sideEffects = disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, {
+			getAgent: () => agent,
+			agents: agentList,
+			sessionDataService,
+			localTurns: new AgentHostLocalTurns(sessionDataService, logService),
+			onTurnComplete: () => { },
+		}));
+		disposables.add(sideEffects.registerProgressListener(agent));
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reports noProgress for a turn that starts and is never heard from again', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-lost');
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents(), [{
+			eventName: 'agentHost.turnHung',
+			data: {
+				provider: 'mock',
+				agentSessionId: 'session-1',
+				chatSessionId: getTelemetryChatSessionId(defaultChatUri),
+				isSubagentSession: false,
+				turnId: 'turn-lost',
+				hangReason: 'noProgress',
+				isExpected: false,
+				hadAnyProgress: false,
+				lastActivityKind: TURN_ACTIVITY_NONE,
+				blockedOn: undefined,
+				inFlightToolCallCount: 0,
+				quietTimeMs: true,
+				turnElapsedMs: true,
+				model: undefined,
+				modelSelectionKind: 'default',
+				permissionLevel: undefined,
+			},
+		}]);
+	});
+
+	test('reports stalledAfterProgress once a turn goes quiet after streaming', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-stalled');
+			responsePart('turn-stalled');
+			delta('turn-stalled', 'thinking');
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({
+			hangReason: e.data.hangReason,
+			isExpected: e.data.isExpected,
+			hadAnyProgress: e.data.hadAnyProgress,
+			lastActivityKind: e.data.lastActivityKind,
+		})), [{
+			hangReason: 'stalledAfterProgress',
+			isExpected: false,
+			hadAnyProgress: true,
+			lastActivityKind: ActionType.ChatDelta,
+		}]);
+	});
+
+	test('does not report while activity keeps arriving inside the threshold', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-busy');
+			responsePart('turn-busy');
+			// Ten windows' worth of elapsed time, but never a full quiet window.
+			for (let i = 0; i < 10; i++) {
+				await timeout(TURN_HANG_THRESHOLD_MS - 1000);
+				delta('turn-busy', `chunk-${i}`);
+			}
+			fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-busy', duration: 1000 });
+		});
+
+		assert.deepStrictEqual({ hangs: hangEvents(), recoveries: hangRecoveryEvents() }, { hangs: [], recoveries: [] });
+	});
+
+	test('tags a turn blocked on a tool confirmation as an expected wait on the user', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-confirm');
+			fire({
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-confirm',
+				toolCallId: 'tc-confirm',
+				toolName: 'write',
+				displayName: 'write',
+			});
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-confirm',
+				toolCallId: 'tc-confirm',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({
+			hangReason: e.data.hangReason,
+			isExpected: e.data.isExpected,
+			blockedOn: e.data.blockedOn,
+			inFlightToolCallCount: e.data.inFlightToolCallCount,
+		})), [{
+			hangReason: 'waitingOnUser',
+			isExpected: true,
+			blockedOn: SessionInputRequestKind.ToolConfirmation,
+			inFlightToolCallCount: 1,
+		}]);
+	});
+
+	test('tags a silent long-running tool call as runningTool, then reports a real stall once it completes', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-tool');
+			fire({
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-tool',
+				toolCallId: 'tc-slow',
+				toolName: 'bash',
+				displayName: 'bash',
+			});
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-tool',
+				toolCallId: 'tc-slow',
+				invocationMessage: 'Run build',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+			await timeout(TURN_HANG_THRESHOLD_MS);
+
+			// The tool finally returns, but the agent loop never picks the turn
+			// back up — the second report distinguishes that from the first.
+			fire({ type: ActionType.ChatToolCallComplete, turnId: 'turn-tool', toolCallId: 'tc-slow', result: { success: true, pastTenseMessage: 'built' } });
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({
+			hangReason: e.data.hangReason,
+			isExpected: e.data.isExpected,
+			inFlightToolCallCount: e.data.inFlightToolCallCount,
+		})), [
+			{ hangReason: 'runningTool', isExpected: true, inFlightToolCallCount: 1 },
+			{ hangReason: 'stalledAfterProgress', isExpected: false, inFlightToolCallCount: 0 },
+		]);
+	});
+
+	test('reports each hang reason at most once no matter how long the turn stays quiet', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-forever');
+			await timeout(10 * TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => e.data.hangReason), ['noProgress']);
+	});
+
+	test('reports the paired recovery event when a hung turn later completes', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-recovered');
+			await timeout(TURN_HANG_THRESHOLD_MS);
+			fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-recovered', duration: 1000 });
+		});
+
+		assert.deepStrictEqual(hangRecoveryEvents(), [{
+			eventName: 'agentHost.hungTurnCompleted',
+			data: {
+				provider: 'mock',
+				agentSessionId: 'session-1',
+				chatSessionId: getTelemetryChatSessionId(defaultChatUri),
+				isSubagentSession: false,
+				turnId: 'turn-recovered',
+				hangReason: 'noProgress',
+				result: 'success',
+				hangReportCount: 1,
+				totalTimeMs: true,
+				timeAfterHangMs: true,
+			},
+		}]);
+	});
+
+	test('does not report a recovery event for a turn that never hung', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-quick');
+			responsePart('turn-quick');
+			delta('turn-quick', 'hi');
+			fire({ type: ActionType.ChatTurnComplete, turnId: 'turn-quick', duration: 1000 });
+			await timeout(2 * TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual({ hangs: hangEvents(), recoveries: hangRecoveryEvents() }, { hangs: [], recoveries: [] });
+	});
+
+	test('does not report a turn that a truncation removed from the chat', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-truncated');
+
+			// Omitting `turnId` clears every turn including the active one.
+			const truncate: ChatAction = { type: ActionType.ChatTruncated };
+			stateManager.dispatchClientAction(defaultChatUri, truncate, { clientId: 'test', clientSeq: 2 });
+			sideEffects.handleAction(defaultChatUri, truncate);
+
+			await timeout(10 * TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual({ hangs: hangEvents(), recoveries: hangRecoveryEvents() }, { hangs: [], recoveries: [] });
+	});
+
+	test('keeps watching a turn after the user answers a confirmation it had hung on', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-answered');
+			fire({
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-answered',
+				toolCallId: 'tc-answered',
+				toolName: 'write',
+				displayName: 'write',
+			});
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-answered',
+				toolCallId: 'tc-answered',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+			await timeout(TURN_HANG_THRESHOLD_MS);
+
+			const confirmed: ChatAction = {
+				type: ActionType.ChatToolCallConfirmed,
+				turnId: 'turn-answered',
+				toolCallId: 'tc-answered',
+				approved: true,
+				confirmed: ToolCallConfirmationReason.UserAction,
+			};
+			stateManager.dispatchClientAction(defaultChatUri, confirmed, { clientId: 'test', clientSeq: 2 });
+			sideEffects.handleAction(defaultChatUri, confirmed);
+			fire({ type: ActionType.ChatToolCallComplete, turnId: 'turn-answered', toolCallId: 'tc-answered', result: { success: true, pastTenseMessage: 'wrote file' } });
+
+			// The tool is done and nothing is blocking, but the agent loop
+			// never picks the turn back up.
+			await timeout(TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual(hangEvents().map(e => ({ hangReason: e.data.hangReason, isExpected: e.data.isExpected })), [
+			{ hangReason: 'waitingOnUser', isExpected: true },
+			{ hangReason: 'stalledAfterProgress', isExpected: false },
+		]);
+	});
+
+	test('does not report after a turn is cancelled or its session is torn down', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-cancelled');
+			fire({ type: ActionType.ChatTurnCancelled, turnId: 'turn-cancelled', duration: 1000 });
+
+			startTurn('turn-cleared');
+			sideEffects.clearChannelTelemetry(defaultChatUri);
+
+			await timeout(10 * TURN_HANG_THRESHOLD_MS);
+		});
+
+		assert.deepStrictEqual({ hangs: hangEvents(), recoveries: hangRecoveryEvents() }, { hangs: [], recoveries: [] });
+	});
+});


### PR DESCRIPTION
## Why

Today a hung agent turn is only detectable as the **absence** of telemetry — an `agentHost.userMessageSent` with no matching `agentHost.turnCompleted`. Absences don't show up on dashboards, which is why several session-hang bugs shipped undetected. This adds a positive signal.

The motivating case: a session config change caused the Agent Host to destroy its Copilot SDK session and immediately resume the same session ID; a runtime race then dropped the resumed session's native callback registration. `session.send()` returned normally, but no `user.message` was persisted, no model turn ever started, and no error or terminal event was ever emitted. `turnStarted` fired; `turnCompleted` never did. The UI sat on "Working…" forever. This change surfaces exactly that as `hangReason: 'noProgress'` / `hadAnyProgress: false`.

## What

`AgentHostTurnTracker` arms a `disposableTimeout` watchdog per in-flight turn, **debounced by activity** — any turn-scoped protocol action re-arms it. On expiry it classifies the quiet state and emits `agentHost.turnHung`.

The threshold is `5 * 60 * 1000`, matching the existing `TOOL_CALL_STALL_THRESHOLD_MS` so the two hang signals line up on dashboards.

### Expected vs unexpected

Rather than excluding legitimate waits, all four states are reported and tagged, with a derived `isExpected` boolean so queries can split the populations with a single predicate. Silence is only interpretable with the reason attached.

| `hangReason` | `isExpected` | meaning |
| --- | --- | --- |
| `noProgress` | `false` | turn started, **zero** activity ever observed, never completed — the lost-turn signature above |
| `stalledAfterProgress` | `false` | streamed, then went silent with nothing outstanding to explain it |
| `waitingOnUser` | `true` | a request that blocks on a **human** is outstanding — confirmation, tool auth, or elicitation |
| `runningTool` | `true` | a tool call is in flight; covers long builds, **client-executed tools**, and subagents (whose progress is reported on their own chat channel) |

This is documented on the `AgentHostTurnHangReason` type and in `_deriveHangReason`. A blocker outranks an in-flight tool call, since a tool awaiting confirmation is both and the human is the real reason for the silence.

Client tool execution is deliberately **not** a user blocker. The protocol defines `SessionInputRequestKind.ToolClientExecution` as delegated running work rather than a prompt, and the session reducer's `awaitsUser` predicate excludes it for the same reason; counting it would report every long-running client tool as waiting on a human. It is represented by the in-flight tool set instead, yielding `runningTool`.

### Bounded volume

Each reason fires **at most once per turn**, and the watchdog re-arms for at most 6 quiet windows. Re-arming exists so a turn that moves from `waitingOnUser` to genuinely stuck still gets reported; the cap keeps live timers and event volume bounded for a permanently dead turn.

### Recovery event

`agentHost.hungTurnCompleted` fires when a previously-hung turn later completes, carrying `hangReportCount`, `totalTimeMs` and `timeAfterHangMs` — so permanent hangs can be separated from merely slow ones. Modelled on the existing `stalledToolCallCompleted`.

### Leak fix

`_turnTimings` previously kept entries for turns that never completed, forever. Turn tracking is now also cleared on channel teardown (`clearChannelTelemetry`, renamed from `clearToolCallTelemetry` since it now clears both trackers) and on truncation, closing that gap for the whole class of lost-turn bugs.

## Decision: kept `toolCallStalled` alongside, not subsumed

`agentHost.toolCallStalled` carries tool identity (`toolId`, `toolSourceKind`) and only covers tool-specific blockers; the new event is turn-scoped. Subsuming it would mean either losing that tool detail or bloating the generic event with fields that are null for most hangs — and it would break existing queries. Keeping both also keeps this diff smaller and lower-risk.

## Reviewer notes

A review pass caught four issues; three are fixed here, one is deliberately left alone:

1. **`turnUnblocked` didn't restart the quiet clock** — a user answering a confirmation at 4:59 would have been misreported as an unexplained stall one second later. Both blocking and unblocking now reset the quiet period and re-arm.
2. **Synthesized `ChatToolCallReady`** bypasses `_dispatchActionForSession`, so it never reached the watchdog. Now fed explicitly.
3. **Truncation left ghost turns** whose watchdogs could later report a hang for a turn no longer in state. Now cleared via `clearTurnsExcept`.
4. **Client tool execution was misclassified as `waitingOnUser`** (review feedback) — now excluded from user blockers, matching the protocol's `awaitsUser` semantics.
5. **A denied tool confirmation leaked its in-flight entry** (review feedback) — a denial is terminal and no completion follows, so a later hang reported `runningTool` for a tool that would never run. Cleared on both the client and agent dispatch paths.
6. **Not addressed (pre-existing):** subagent turns never call `turnTracker.turnStarted`, so the existing `turnCompleted(subagent.chatUri, …)` calls are already dead code today. Wiring that up would start emitting `agentHost.turnCompleted` for subagent turns and visibly shift turn-count volume on existing dashboards — out of scope here. Subagent hangs are still caught via `runningTool` on the parent turn.

Activity is gated to turn-scoped actions (`hasKey(action, { turnId: true })`). Session-scoped actions like MCP server state changes can arrive while a turn is genuinely stuck and would otherwise mask the hang.

## Testing

11 new tests in `agentHostTurnHangTelemetry.test.ts` using `runWithFakedTimers`, driven through `AgentSideEffects` so the real wiring is exercised rather than the tracker in isolation:

- fires `noProgress` after the threshold for a turn that starts and is never heard from again (the motivating case)
- fires `stalledAfterProgress` after streaming stops
- does **not** fire across 10 windows of elapsed time while deltas keep arriving (debounce)
- tags a confirmation-blocked turn `waitingOnUser`, and a silent long-running tool `runningTool`
- keeps watching after the user answers, then reports the real stall
- paired recovery event; no recovery event for a turn that never hung
- no reports after cancellation, session teardown, or truncation (timer disposal)

`npm run typecheck-client` clean, eslint clean, hygiene clean, and all 4404 `src/vs/platform/agentHost` tests pass — including the two existing telemetry suites, which are unmodified.

(Written by Copilot)

