### PR TITLE
Fix crash when a tool result text part has an undefined value (fixes #324371)

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -592,71 +592,9 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 		expect(serialized).not.toContain('image_url');
 	});
 
-		test('renders a text part with an undefined value without crashing', async () => {
-		const toolName = 'malformedTextTool';
-		const toolCallId = 'call-undef-text';
+	test('renders a text part with an undefined value without crashing', async () => { 		const toolName = 'malformedTextTool'; 		const toolCallId = 'call-undef-text';  		const toolInfo: vscode.LanguageModelToolInformation = { 			name: toolName, 			description: 'tool returning a malformed text part', 			source: undefined, 			inputSchema: undefined, 			tags: [], 		};  		const testingServiceCollection = createExtensionUnitTestingServices(); 		const toolsService = new CapturingToolsService(toolInfo); 		testingServiceCollection.define(IToolsService, toolsService);  		const accessor = testingServiceCollection.createTestingAccessor(); 		const instantiationService = accessor.get(IInstantiationService); 		const endpointProvider = accessor.get(IEndpointProvider); 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');  		// MCP servers can return a text part without a value; the LanguageModelTextPart 		// constructor does not validate the value, so it can be undefined at runtime (#324371). 		const toolCallResults: Record<string, vscode.LanguageModelToolResult> = { 			[toolCallId]: new LanguageModelToolResult([ 				new LanguageModelTextPart(undefined as unknown as string), 			]), 		};  		const round: IToolCallRound = { 			id: 'round-1', 			response: 'calling tool', 			toolInputRetry: 0, 			toolCalls: [{ name: toolName, arguments: '{}', id: toolCallId }], 		};  		const promptContext: IBuildPromptContext = { 			query: 'test', 			history: [], 			chatVariables: new ChatVariablesCollection(), 			conversation: { sessionId: 'session-undef-text' } as unknown as Conversation, 			request: {} as vscode.ChatRequest, 			tools: { 				toolReferences: [], 				toolInvocationToken: {} as vscode.ChatParticipantToolToken, 				availableTools: [toolInfo], 			}, 		};  		// Rendering must succeed and fall back to the empty text instead of throwing 		// Cannot read properties of undefined (reading 'length') (the pre-fix behavior). 		const { messages } = await renderPromptElement(instantiationService, endpoint, ChatToolCalls, { 			promptContext, 			toolCallRounds: [round], 			toolCallResults, 			isHistorical: true, 		});  		const serialized = JSON.stringify(messages); 		// The undefined text contributes nothing; the tool result renders as empty 		expect(serialized).not.toContain('undefined'); 		expect(serialized).toContain('(empty)'); 	});
 
-		const toolInfo: vscode.LanguageModelToolInformation = {
-			name: toolName,
-			description: 'tool returning a malformed text part',
-			source: undefined,
-			inputSchema: undefined,
-			tags: [],
-		};
-
-		const testingServiceCollection = createExtensionUnitTestingServices();
-		const toolsService = new CapturingToolsService(toolInfo);
-		testingServiceCollection.define(IToolsService, toolsService);
-
-		const accessor = testingServiceCollection.createTestingAccessor();
-		const instantiationService = accessor.get(IInstantiationService);
-		const endpointProvider = accessor.get(IEndpointProvider);
-		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
-
-		// MCP servers can return a text part without a value; the LanguageModelTextPart
-		// constructor does not validate the value, so it can be undefined at runtime (#324371).
-		const toolCallResults: Record<string, vscode.LanguageModelToolResult> = {
-			[toolCallId]: new LanguageModelToolResult([
-				new LanguageModelTextPart(undefined as unknown as string),
-			]),
-		};
-
-		const round: IToolCallRound = {
-			id: 'round-1',
-			response: 'calling tool',
-			toolInputRetry: 0,
-			toolCalls: [{ name: toolName, arguments: '{}', id: toolCallId }],
-		};
-
-		const promptContext: IBuildPromptContext = {
-			query: 'test',
-			history: [],
-			chatVariables: new ChatVariablesCollection(),
-			conversation: { sessionId: 'session-undef-text' } as unknown as Conversation,
-			request: {} as vscode.ChatRequest,
-			tools: {
-				toolReferences: [],
-				toolInvocationToken: {} as vscode.ChatParticipantToolToken,
-				availableTools: [toolInfo],
-			},
-		};
-
-		// Rendering must succeed and fall back to the empty text instead of throwing
-		// Cannot read properties of undefined (reading 'length') (the pre-fix behavior).
-		const { messages } = await renderPromptElement(instantiationService, endpoint, ChatToolCalls, {
-			promptContext,
-			toolCallRounds: [round],
-			toolCallResults,
-			isHistorical: true,
-		});
-
-		const serialized = JSON.stringify(messages);
-		// The undefined text contributes nothing; the tool result renders as empty
-		expect(serialized).not.toContain('undefined');
-		expect(serialized).toContain('(empty)');
-	});
-
-test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
+	test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
 		// Regression test for issue #312813: ensure sendInvokedToolTelemetry uses DI to instantiate
 		// PrimitiveToolResult so that @IPromptEndpoint is properly injected when rendering images.
 		// Previously, it used raw BasePromptRenderer which bypassed DI, causing 'Cannot read properties

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -592,7 +592,71 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 		expect(serialized).not.toContain('image_url');
 	});
 
-	test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
+		test('renders a text part with an undefined value without crashing', async () => {
+		const toolName = 'malformedTextTool';
+		const toolCallId = 'call-undef-text';
+
+		const toolInfo: vscode.LanguageModelToolInformation = {
+			name: toolName,
+			description: 'tool returning a malformed text part',
+			source: undefined,
+			inputSchema: undefined,
+			tags: [],
+		};
+
+		const testingServiceCollection = createExtensionUnitTestingServices();
+		const toolsService = new CapturingToolsService(toolInfo);
+		testingServiceCollection.define(IToolsService, toolsService);
+
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const endpointProvider = accessor.get(IEndpointProvider);
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		// MCP servers can return a text part without a value; the LanguageModelTextPart
+		// constructor does not validate the value, so it can be undefined at runtime (#324371).
+		const toolCallResults: Record<string, vscode.LanguageModelToolResult> = {
+			[toolCallId]: new LanguageModelToolResult([
+				new LanguageModelTextPart(undefined as unknown as string),
+			]),
+		};
+
+		const round: IToolCallRound = {
+			id: 'round-1',
+			response: 'calling tool',
+			toolInputRetry: 0,
+			toolCalls: [{ name: toolName, arguments: '{}', id: toolCallId }],
+		};
+
+		const promptContext: IBuildPromptContext = {
+			query: 'test',
+			history: [],
+			chatVariables: new ChatVariablesCollection(),
+			conversation: { sessionId: 'session-undef-text' } as unknown as Conversation,
+			request: {} as vscode.ChatRequest,
+			tools: {
+				toolReferences: [],
+				toolInvocationToken: {} as vscode.ChatParticipantToolToken,
+				availableTools: [toolInfo],
+			},
+		};
+
+		// Rendering must succeed and fall back to the empty text instead of throwing
+		// Cannot read properties of undefined (reading 'length') (the pre-fix behavior).
+		const { messages } = await renderPromptElement(instantiationService, endpoint, ChatToolCalls, {
+			promptContext,
+			toolCallRounds: [round],
+			toolCallResults,
+			isHistorical: true,
+		});
+
+		const serialized = JSON.stringify(messages);
+		// The undefined text contributes nothing; the tool result renders as empty
+		expect(serialized).not.toContain('undefined');
+		expect(serialized).toContain('(empty)');
+	});
+
+test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
 		// Regression test for issue #312813: ensure sendInvokedToolTelemetry uses DI to instantiate
 		// PrimitiveToolResult so that @IPromptEndpoint is properly injected when rendering images.
 		// Previously, it used raw BasePromptRenderer which bypassed DI, causing 'Cannot read properties

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -592,7 +592,70 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 		expect(serialized).not.toContain('image_url');
 	});
 
-	test('renders a text part with an undefined value without crashing', async () => { 		const toolName = 'malformedTextTool'; 		const toolCallId = 'call-undef-text';  		const toolInfo: vscode.LanguageModelToolInformation = { 			name: toolName, 			description: 'tool returning a malformed text part', 			source: undefined, 			inputSchema: undefined, 			tags: [], 		};  		const testingServiceCollection = createExtensionUnitTestingServices(); 		const toolsService = new CapturingToolsService(toolInfo); 		testingServiceCollection.define(IToolsService, toolsService);  		const accessor = testingServiceCollection.createTestingAccessor(); 		const instantiationService = accessor.get(IInstantiationService); 		const endpointProvider = accessor.get(IEndpointProvider); 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');  		// MCP servers can return a text part without a value; the LanguageModelTextPart 		// constructor does not validate the value, so it can be undefined at runtime (#324371). 		const toolCallResults: Record<string, vscode.LanguageModelToolResult> = { 			[toolCallId]: new LanguageModelToolResult([ 				new LanguageModelTextPart(undefined as unknown as string), 			]), 		};  		const round: IToolCallRound = { 			id: 'round-1', 			response: 'calling tool', 			toolInputRetry: 0, 			toolCalls: [{ name: toolName, arguments: '{}', id: toolCallId }], 		};  		const promptContext: IBuildPromptContext = { 			query: 'test', 			history: [], 			chatVariables: new ChatVariablesCollection(), 			conversation: { sessionId: 'session-undef-text' } as unknown as Conversation, 			request: {} as vscode.ChatRequest, 			tools: { 				toolReferences: [], 				toolInvocationToken: {} as vscode.ChatParticipantToolToken, 				availableTools: [toolInfo], 			}, 		};  		// Rendering must succeed and fall back to the empty text instead of throwing 		// Cannot read properties of undefined (reading 'length') (the pre-fix behavior). 		const { messages } = await renderPromptElement(instantiationService, endpoint, ChatToolCalls, { 			promptContext, 			toolCallRounds: [round], 			toolCallResults, 			isHistorical: true, 		});  		const serialized = JSON.stringify(messages); 		// The undefined text contributes nothing; the tool result renders as empty 		expect(serialized).not.toContain('undefined'); 		expect(serialized).toContain('(empty)'); 	});
+	test('renders a text part with an undefined value without crashing', async () => {
+		const toolName = 'malformedTextTool';
+		const toolCallId = 'call-undef-text';
+
+		const toolInfo: vscode.LanguageModelToolInformation = {
+			name: toolName,
+			description: 'tool returning a malformed text part',
+			source: undefined,
+			inputSchema: undefined,
+			tags: [],
+		};
+
+		const testingServiceCollection = createExtensionUnitTestingServices();
+		const toolsService = new CapturingToolsService(toolInfo);
+		testingServiceCollection.define(IToolsService, toolsService);
+
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const endpointProvider = accessor.get(IEndpointProvider);
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		// MCP servers can return a text part without a value; the LanguageModelTextPart
+		// constructor does not validate the value, so it can be undefined at runtime (#324371).
+		const toolCallResults: Record<string, vscode.LanguageModelToolResult> = {
+			[toolCallId]: new LanguageModelToolResult([
+				new LanguageModelTextPart(undefined as unknown as string),
+			]),
+		};
+
+		const round: IToolCallRound = {
+			id: 'round-1',
+			response: 'calling tool',
+			toolInputRetry: 0,
+			toolCalls: [{ name: toolName, arguments: '{}', id: toolCallId }],
+		};
+
+		const promptContext: IBuildPromptContext = {
+			query: 'test',
+			history: [],
+			chatVariables: new ChatVariablesCollection(),
+			conversation: { sessionId: 'session-undef-text' } as unknown as Conversation,
+			request: {} as vscode.ChatRequest,
+			tools: {
+				toolReferences: [],
+				toolInvocationToken: {} as vscode.ChatParticipantToolToken,
+				availableTools: [toolInfo],
+			},
+		};
+
+		// Rendering must succeed and fall back to the empty text instead of throwing
+		// Cannot read properties of undefined (reading 'length') (the pre-fix behavior).
+		const { messages } = await renderPromptElement(instantiationService, endpoint, ChatToolCalls, {
+			promptContext,
+			toolCallRounds: [round],
+			toolCallResults,
+			isHistorical: true,
+		});
+
+		const serialized = JSON.stringify(messages);
+		// The undefined text contributes nothing; the tool result renders as empty
+		expect(serialized).not.toContain('undefined');
+		expect(serialized).toContain('(empty)');
+	});
+
 
 	test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
 		// Regression test for issue #312813: ensure sendInvokedToolTelemetry uses DI to instantiate

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -768,7 +768,9 @@ class PrimitiveToolResult<T extends IPrimitiveToolResultProps> extends PromptEle
 				<IfEmpty alt='(empty)'>
 					{await Promise.all(this.props.content.filter(part => this.hasAssistantAudience(part)).map(async part => {
 						if (part instanceof LanguageModelTextPart) {
-							return await this.onText(part.value);
+							// Tool results (e.g. from MCP servers) may include text parts with an undefined value;
+							// render them as empty text instead of crashing the renderer (#324371)
+							return await this.onText(part.value ?? '');
 						} else if (part instanceof LanguageModelPromptTsxPart) {
 							return await this.onTSX(part.value as JSONTree.PromptElementJSON);
 						} else if (isImageDataPart(part)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #324371

## Description

The tool-result renderer crashes with `Cannot read properties of undefined (reading 'length')` when a tool result contains a `LanguageModelTextPart` whose `value` is `undefined` (e.g. an MCP server returning a `{ type: 'text' }` part without a `text` field — the `LanguageModelTextPart` constructor in `extHostTypes.ts` performs no validation, so the MCP bridge can produce such a part).

`ToolResult.onText()` reads `content.length` (for both the large-result-to-disk threshold and the truncation budget), so an `undefined` value throws inside the prompt-tsx render. The annotated error (`at tsx element ...`) is then shown as red error text in the chat panel, and the tool result fails to render. This is the same renderer bug previously reported in #260622 (user-authored MCP tool returning `text: undefined`), but the fix belongs in the renderer: any tool — built-in or MCP — can emit such a part, and the user cannot change the emitted shape.

## Change

One line in `PrimitiveToolResult.render()` (`extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx`): coerce an undefined text-part value to `''` before passing it to `onText()`, so malformed tool output renders as empty text instead of crashing the renderer.

## How to test

1. Set up an MCP server (or temporarily use any tool) that returns a content part of the form `{ type: 'text' }` without a `text` field.
2. In Copilot Chat (agent mode), ask the agent to invoke that tool.
3. Before the fix: the chat panel shows `Cannot read properties of undefined (reading 'length')` as red error text and the tool result does not render.
4. After the fix: the tool result renders without error — the malformed part simply contributes no text.