### PR TITLE
agentHost: resolve primary worktree roots without spawning git

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -94,11 +94,19 @@ export interface IPullOptions {
 export const IAgentHostGitService = createDecorator<IAgentHostGitService>('agentHostGitService');
 
 /**
+ * Sized to cover a full session catalogue: sessions each resolve their own
+ * checkout, and a successful Git listing additionally maps every sibling
+ * worktree of the repository. A cache too small for either set evicts the very
+ * entries it exists to reuse, turning each subsequent lookup back into work.
+ */
+const PRIMARY_WORKTREE_ROOT_CACHE_SIZE = 4096;
+
+/**
  * Resolves linked checkouts to their primary worktree and caches successful mappings for every worktree reported by Git.
  * Resolution is serialized so concurrent requests across linked checkouts share one probe, while empty results remain retryable.
  */
 class PrimaryWorktreeRootResolver {
-	private readonly _roots = new LRUCache<string, URI>(100);
+	private readonly _roots = new LRUCache<string, URI>(PRIMARY_WORKTREE_ROOT_CACHE_SIZE);
 	private readonly _sequencer = new Sequencer();
 
 	constructor(private readonly _gitService: IAgentHostGitService) { }
@@ -108,6 +116,14 @@ class PrimaryWorktreeRootResolver {
 		const cached = this._roots.get(key);
 		if (cached) {
 			return cached;
+		}
+		// Git's own layout answers this for ordinary checkouts, so ask the disk
+		// before paying for a process. These are plain reads, so they neither
+		// need nor deserve the sequencer that exists to collapse Git launches.
+		const fromDisk = await this._gitService.getPrimaryWorktreeRoot?.(checkoutRoot);
+		if (fromDisk) {
+			this._roots.set(key, fromDisk);
+			return fromDisk;
 		}
 		return this._sequencer.queue(async () => {
 			const cached = this._roots.get(key);
@@ -208,6 +224,13 @@ export interface IAgentHostGitService {
 	getRepositoryRoot(workingDirectory: URI): Promise<URI | undefined>;
 	/** Returns worktree roots in Git's porcelain order, with the primary worktree first. */
 	getWorktreeRoots(workingDirectory: URI): Promise<URI[]>;
+	/**
+	 * Returns the primary worktree root owning `workingDirectory` without
+	 * spawning Git, or `undefined` when the repository layout cannot answer it.
+	 * Optional: implementations that cannot inspect the repository on disk omit
+	 * it and are resolved through {@link getWorktreeRoots} instead.
+	 */
+	getPrimaryWorktreeRoot?(workingDirectory: URI): Promise<URI | undefined>;
 	/**
 	 * Creates a worktree for a new branch. `onProgress` receives every checkout
 	 * sample git reports, which can be several per second, so consumers are

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
+import type { Stats } from 'fs';
 import * as fsPromises from 'fs/promises';
 import { cp as copyFile } from '@vscode/fs-copyfile';
 import * as path from '../../../base/common/path.js';
@@ -19,6 +20,16 @@ import { buildGitBlobUri } from './gitDiffContent.js';
 import { EMPTY_TREE_OBJECT, IAgentHostGitService, IBranch, IBranchDiffSafetyInfo, IRefQuery, IComputeSessionFileDiffsOptions, IDefaultBranch, IPullOptions, IPushOptions, GitRefType, IRemoteBranch, GitRef, ITag, Branch, IWorktreeFileProgress } from '../common/agentHostGitService.js';
 import { LRUCache } from '../../../base/common/map.js';
 import { Limiter, SequencerByKey } from '../../../base/common/async.js';
+
+/**
+ * Distinguishes a path that is genuinely absent from one the filesystem merely
+ * refused to describe (permissions, an unmounted volume, an I/O error). Only the
+ * former licenses a caller to keep searching; the latter means "unknown".
+ */
+function isFileNotFound(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return code === 'ENOENT' || code === 'ENOTDIR';
+}
 
 export class AgentHostGitService implements IAgentHostGitService {
 	declare readonly _serviceBrand: undefined;
@@ -154,20 +165,34 @@ export class AgentHostGitService implements IAgentHostGitService {
 	 * are expected to fall back to {@link getWorktreeRoots} in that case.
 	 */
 	async getPrimaryWorktreeRoot(workingDirectory: URI): Promise<URI | undefined> {
+		try {
+			return await this._readPrimaryWorktreeRoot(workingDirectory);
+		} catch (error) {
+			// Reaching here means the filesystem refused to answer rather than
+			// reporting absence. Guessing past that would ascend to an unrelated
+			// enclosing repository, and listing persists what it is told, so a
+			// momentary permission or mount failure would be frozen in. Git can
+			// decide instead.
+			this._logService.trace(`[AgentHostGitService] Could not read the repository layout for '${workingDirectory.fsPath}': ${error}`);
+			return undefined;
+		}
+	}
+
+	private async _readPrimaryWorktreeRoot(workingDirectory: URI): Promise<URI | undefined> {
 		// Git reports canonical paths because it resolves its working directory,
 		// and callers compare this result against roots Git produced. Resolving
 		// symlinks here keeps both sources on one spelling of a path, so the
 		// same repository never presents itself as two different roots.
-		let directory = await fsPromises.realpath(path.resolve(workingDirectory.fsPath)).catch(() => undefined);
+		let directory = await fsPromises.realpath(path.resolve(workingDirectory.fsPath));
 		// Git only searches upwards from a directory that actually exists, and
 		// stopping here keeps a stale session path from adopting an unrelated
 		// ancestor repository.
-		if (!directory || !(await fsPromises.stat(directory).catch(() => undefined))?.isDirectory()) {
+		if (!(await this._statIfPresent(directory))?.isDirectory()) {
 			return undefined;
 		}
 		for (; ;) {
 			const dotGit = path.join(directory, '.git');
-			const stat = await fsPromises.stat(dotGit).catch(() => undefined);
+			const stat = await this._statIfPresent(dotGit);
 			if (stat?.isFile()) {
 				return this._resolvePrimaryWorktreeRootFromLink(dotGit);
 			}
@@ -181,7 +206,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 				// directory, so the enclosing folder is no longer the worktree
 				// Git would report. Parsing the setting properly means honouring
 				// includes, so treat any mention as a reason to defer to Git.
-				const config = await fsPromises.readFile(path.join(dotGit, 'config'), 'utf8').catch(() => undefined);
+				const config = await this._readFileIfPresent(path.join(dotGit, 'config'));
 				return config && /^\s*worktree\s*=/m.test(config) ? undefined : URI.file(directory);
 			}
 			// A bare repository owns no worktree, so climbing out of one would
@@ -197,25 +222,54 @@ export class AgentHostGitService implements IAgentHostGitService {
 		}
 	}
 
+	/**
+	 * Stats `target`, reporting `undefined` only when it is genuinely absent.
+	 * Any other failure is rethrown: "I could not look" must not be mistaken for
+	 * "it is not there", because callers treat absence as a reason to keep
+	 * searching further up the tree.
+	 */
+	private async _statIfPresent(target: string): Promise<Stats | undefined> {
+		try {
+			return await fsPromises.stat(target);
+		} catch (error) {
+			if (isFileNotFound(error)) {
+				return undefined;
+			}
+			throw error;
+		}
+	}
+
+	/** Reads `target`, reporting `undefined` only when it is genuinely absent. */
+	private async _readFileIfPresent(target: string): Promise<string | undefined> {
+		try {
+			return await fsPromises.readFile(target, 'utf8');
+		} catch (error) {
+			if (isFileNotFound(error)) {
+				return undefined;
+			}
+			throw error;
+		}
+	}
+
 	/** Mirrors Git's own repository test: a HEAD alongside the object and ref stores. */
 	private async _isGitDirectory(directory: string): Promise<boolean> {
 		const [head, objects, refs] = await Promise.all([
-			fsPromises.stat(path.join(directory, 'HEAD')).catch(() => undefined),
-			fsPromises.stat(path.join(directory, 'objects')).catch(() => undefined),
-			fsPromises.stat(path.join(directory, 'refs')).catch(() => undefined),
+			this._statIfPresent(path.join(directory, 'HEAD')),
+			this._statIfPresent(path.join(directory, 'objects')),
+			this._statIfPresent(path.join(directory, 'refs')),
 		]);
 		return !!head?.isFile() && !!objects?.isDirectory() && !!refs?.isDirectory();
 	}
 
 	/** Maps a linked worktree's `.git` file to the primary worktree root that owns it. */
 	private async _resolvePrimaryWorktreeRootFromLink(dotGitFile: string): Promise<URI | undefined> {
-		const link = await fsPromises.readFile(dotGitFile, 'utf8').catch(() => undefined);
+		const link = await this._readFileIfPresent(dotGitFile);
 		const gitDirPath = link && /^gitdir:\s*(?<gitDir>.+?)\s*$/m.exec(link)?.groups?.gitDir;
 		if (!gitDirPath) {
 			return undefined;
 		}
 		const gitDir = path.resolve(path.dirname(dotGitFile), gitDirPath);
-		const commonDirPath = (await fsPromises.readFile(path.join(gitDir, 'commondir'), 'utf8').catch(() => undefined))?.trim();
+		const commonDirPath = (await this._readFileIfPresent(path.join(gitDir, 'commondir')))?.trim();
 		if (!commonDirPath) {
 			return undefined;
 		}

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -168,11 +168,26 @@ export class AgentHostGitService implements IAgentHostGitService {
 		for (; ;) {
 			const dotGit = path.join(directory, '.git');
 			const stat = await fsPromises.stat(dotGit).catch(() => undefined);
-			if (stat?.isDirectory()) {
-				return URI.file(directory);
-			}
 			if (stat?.isFile()) {
 				return this._resolvePrimaryWorktreeRootFromLink(dotGit);
+			}
+			// Git accepts a `.git` directory only when it actually holds a
+			// repository and keeps searching upwards otherwise. Skipping that
+			// check would promote a half-written clone, or a checkout whose
+			// worktree link was replaced by an empty directory, into a
+			// repository root — and that answer gets persisted.
+			if (stat?.isDirectory() && await this._isGitDirectory(dotGit)) {
+				// `core.worktree` detaches the working tree from the repository
+				// directory, so the enclosing folder is no longer the worktree
+				// Git would report. Parsing the setting properly means honouring
+				// includes, so treat any mention as a reason to defer to Git.
+				const config = await fsPromises.readFile(path.join(dotGit, 'config'), 'utf8').catch(() => undefined);
+				return config && /^\s*worktree\s*=/m.test(config) ? undefined : URI.file(directory);
+			}
+			// A bare repository owns no worktree, so climbing out of one would
+			// hand back whatever unrelated checkout happens to contain it.
+			if (await this._isGitDirectory(directory)) {
+				return undefined;
 			}
 			const parent = path.dirname(directory);
 			if (parent === directory) {
@@ -180,6 +195,16 @@ export class AgentHostGitService implements IAgentHostGitService {
 			}
 			directory = parent;
 		}
+	}
+
+	/** Mirrors Git's own repository test: a HEAD alongside the object and ref stores. */
+	private async _isGitDirectory(directory: string): Promise<boolean> {
+		const [head, objects, refs] = await Promise.all([
+			fsPromises.stat(path.join(directory, 'HEAD')).catch(() => undefined),
+			fsPromises.stat(path.join(directory, 'objects')).catch(() => undefined),
+			fsPromises.stat(path.join(directory, 'refs')).catch(() => undefined),
+		]);
+		return !!head?.isFile() && !!objects?.isDirectory() && !!refs?.isDirectory();
 	}
 
 	/** Maps a linked worktree's `.git` file to the primary worktree root that owns it. */
@@ -197,7 +222,15 @@ export class AgentHostGitService implements IAgentHostGitService {
 		const commonDir = path.resolve(gitDir, commonDirPath);
 		// Anything but `<primary>/.git` means there is no primary worktree to
 		// point at (bare repository) or the checkout belongs to a submodule.
-		return path.basename(commonDir) === '.git' ? URI.file(path.dirname(commonDir)) : undefined;
+		if (path.basename(commonDir) !== '.git') {
+			return undefined;
+		}
+		// Canonicalize like the checkout branch above: Git records a resolved
+		// path here, but a restored or hand-edited link need not, and Windows
+		// only settles on-disk casing through a real path lookup. One spelling
+		// per repository is what keeps sessions grouped together.
+		const primaryRoot = path.dirname(commonDir);
+		return URI.file(await fsPromises.realpath(primaryRoot).catch(() => primaryRoot));
 	}
 
 	async addWorktree(repositoryRoot: URI, worktree: URI, branchName: string, startPoint: string, track = false, onProgress?: (progress: IWorktreeFileProgress) => void): Promise<void> {

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -136,6 +136,70 @@ export class AgentHostGitService implements IAgentHostGitService {
 			.map(line => URI.file(line.substring('worktree '.length)));
 	}
 
+	/**
+	 * Resolves the primary worktree root that owns `workingDirectory` by reading
+	 * Git's on-disk layout instead of spawning Git.
+	 *
+	 * `git worktree list --porcelain` answers the same question, but a process
+	 * launch per checkout is far too expensive for hot paths such as session
+	 * listing, where every session must resolve its repository identity. The
+	 * layout already encodes the answer: a primary worktree owns a `.git`
+	 * *directory*, while a linked worktree has a `.git` *file* pointing at
+	 * `<primary>/.git/worktrees/<id>`, whose `commondir` resolves back to the
+	 * primary worktree's git directory.
+	 *
+	 * Returns `undefined` when the layout cannot be interpreted — no repository,
+	 * a bare repository (which has no primary worktree), or a submodule, whose
+	 * git directory lives under `modules/` and carries no `commondir`. Callers
+	 * are expected to fall back to {@link getWorktreeRoots} in that case.
+	 */
+	async getPrimaryWorktreeRoot(workingDirectory: URI): Promise<URI | undefined> {
+		// Git reports canonical paths because it resolves its working directory,
+		// and callers compare this result against roots Git produced. Resolving
+		// symlinks here keeps both sources on one spelling of a path, so the
+		// same repository never presents itself as two different roots.
+		let directory = await fsPromises.realpath(path.resolve(workingDirectory.fsPath)).catch(() => undefined);
+		// Git only searches upwards from a directory that actually exists, and
+		// stopping here keeps a stale session path from adopting an unrelated
+		// ancestor repository.
+		if (!directory || !(await fsPromises.stat(directory).catch(() => undefined))?.isDirectory()) {
+			return undefined;
+		}
+		for (; ;) {
+			const dotGit = path.join(directory, '.git');
+			const stat = await fsPromises.stat(dotGit).catch(() => undefined);
+			if (stat?.isDirectory()) {
+				return URI.file(directory);
+			}
+			if (stat?.isFile()) {
+				return this._resolvePrimaryWorktreeRootFromLink(dotGit);
+			}
+			const parent = path.dirname(directory);
+			if (parent === directory) {
+				return undefined;
+			}
+			directory = parent;
+		}
+	}
+
+	/** Maps a linked worktree's `.git` file to the primary worktree root that owns it. */
+	private async _resolvePrimaryWorktreeRootFromLink(dotGitFile: string): Promise<URI | undefined> {
+		const link = await fsPromises.readFile(dotGitFile, 'utf8').catch(() => undefined);
+		const gitDirPath = link && /^gitdir:\s*(?<gitDir>.+?)\s*$/m.exec(link)?.groups?.gitDir;
+		if (!gitDirPath) {
+			return undefined;
+		}
+		const gitDir = path.resolve(path.dirname(dotGitFile), gitDirPath);
+		const commonDirPath = (await fsPromises.readFile(path.join(gitDir, 'commondir'), 'utf8').catch(() => undefined))?.trim();
+		if (!commonDirPath) {
+			return undefined;
+		}
+		const commonDir = path.resolve(gitDir, commonDirPath);
+		// Anything but `<primary>/.git` means there is no primary worktree to
+		// point at (bare repository) or the checkout belongs to a submodule.
+		return path.basename(commonDir) === '.git' ? URI.file(path.dirname(commonDir)) : undefined;
+	}
+
 	async addWorktree(repositoryRoot: URI, worktree: URI, branchName: string, startPoint: string, track = false, onProgress?: (progress: IWorktreeFileProgress) => void): Promise<void> {
 		const resolvedStartPoint = await this._resolveRemoteTrackingBranch(repositoryRoot, startPoint) ?? startPoint;
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -330,8 +330,14 @@ export class AgentService extends Disposable implements IAgentService {
 	 * agents stay unaware of the folder-vs-worktree distinction.
 	 */
 	private _worktree: WorktreeIsolation | undefined;
-	/** Successful list-time repository-root resolutions; eviction only causes safe re-resolution. */
-	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(100);
+	/**
+	 * Successful list-time repository-root resolutions, keyed by session so a
+	 * repeat listing re-reads nothing. Sized to hold a full catalogue: a bound
+	 * below the session count evicts entries before the next listing reaches
+	 * them, so every session would re-resolve on every list. Eviction is
+	 * otherwise harmless — it only causes a safe re-resolution.
+	 */
+	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(4096);
 	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
 	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -9,7 +9,7 @@ import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { LRUCache, ResourceMap } from '../../../base/common/map.js';
+import { ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
 import { IObservable, observableValue } from '../../../base/common/observable.js';
@@ -51,7 +51,7 @@ import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
 import { type IChatContextSnapshot, type ISessionCreationDefaults, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 
-import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService } from '../common/agentHostCheckpointService.js';
@@ -330,14 +330,6 @@ export class AgentService extends Disposable implements IAgentService {
 	 * agents stay unaware of the folder-vs-worktree distinction.
 	 */
 	private _worktree: WorktreeIsolation | undefined;
-	/**
-	 * Successful list-time repository-root resolutions, keyed by session so a
-	 * repeat listing re-reads nothing. Sized to hold a full catalogue: a bound
-	 * below the session count evicts entries before the next listing reaches
-	 * them, so every session would re-resolve on every list. Eviction is
-	 * otherwise harmless — it only causes a safe re-resolution.
-	 */
-	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(4096);
 	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
 	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */
@@ -943,34 +935,36 @@ export class AgentService extends Disposable implements IAgentService {
 	/**
 	 * Repairs repository roots written by older builds that treated a parent linked checkout as the repository.
 	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
+	 * A repaired root is stamped, so this costs one resolution per session ever rather than one per listing.
 	 */
-	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string): Promise<string> {
+	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string, stamp: string | undefined): Promise<string> {
+		if (stamp === WORKTREE_REPOSITORY_ROOT_STAMP) {
+			return repositoryRootRaw;
+		}
 		const storedRepositoryRootRaw = repositoryRootRaw;
 		const persistedRoot = URI.parse(repositoryRootRaw);
-		const sessionStr = session.session.toString();
-		let primaryRoot = this._normalizedWorktreeRepositoryRoots.get(sessionStr);
+		let primaryRoot: URI | undefined;
+		const workingDirectory = session.workingDirectories?.[0];
+		const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
+		try {
+			primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
+				?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
+		} catch (error) {
+			this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
+		}
 		if (!primaryRoot) {
-			const workingDirectory = session.workingDirectories?.[0];
-			const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
-			try {
-				primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
-					?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
-				if (primaryRoot) {
-					this._normalizedWorktreeRepositoryRoots.set(sessionStr, primaryRoot);
-				}
-			} catch (error) {
-				this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
-			}
+			// Leave the root unstamped so a later listing can still repair it,
+			// rather than freezing a value this run could not confirm.
+			return repositoryRootRaw;
 		}
-		if (primaryRoot) {
-			repositoryRootRaw = primaryRoot.toString();
-		}
-		if (repositoryRootRaw !== storedRepositoryRootRaw) {
-			try {
+		repositoryRootRaw = primaryRoot.toString();
+		try {
+			if (repositoryRootRaw !== storedRepositoryRootRaw) {
 				await database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, repositoryRootRaw);
-			} catch (error) {
-				this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
 			}
+			await database.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP);
+		} catch (error) {
+			this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
 		}
 		return repositoryRootRaw;
 	}
@@ -1000,8 +994,8 @@ export class AgentService extends Disposable implements IAgentService {
 					const sessionStr = s.session.toString();
 					const changesetKeys = this._changesetCoordinator.getListMetadataKeys(sessionStr);
 					const metadataKeys: Record<string, true> = changesetKeys
-						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
-						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS };
+						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, [WORKTREE_META_REPOSITORY_ROOT_STAMP]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
+						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, [WORKTREE_META_REPOSITORY_ROOT_STAMP]: true, ...GIT_DB_METADATA_KEYS };
 					const m = await ref.object.getMetadataObject(metadataKeys);
 					// This session is an internal peer-chat backing (e.g. a
 					// Claude peer chat's SDK session, enumerated by the agent's
@@ -1050,7 +1044,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 					let repositoryRootRaw = m[WORKTREE_META_REPOSITORY_ROOT];
 					if (repositoryRootRaw) {
-						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw);
+						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw, m[WORKTREE_META_REPOSITORY_ROOT_STAMP]);
 					}
 					const worktreeProject = worktreeProjectFromRepositoryRoot(repositoryRootRaw);
 					if (worktreeProject) {

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -578,7 +578,7 @@ export class WorktreeIsolation extends Disposable {
 			return workingDirectory;
 		}
 
-		const repositoryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
+		const { root: repositoryRoot, resolved: repositoryRootResolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
 		const worktreesRoot = getWorktreesRoot(repositoryRoot);
 		// Prefix (e.g. the user's `git.branchPrefix`) the client forwards for
 		// worktree-isolated sessions. Prepended ahead of the built-in `agents/`
@@ -634,7 +634,7 @@ export class WorktreeIsolation extends Disposable {
 		// subsequent restore (history) both surface the message in the chat.
 		this._pendingFirstTurnAnnouncements.set(sessionId, buildWorktreeAnnouncementText(branchName));
 		try {
-			await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktree, repositoryRoot });
+			await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktree, repositoryRoot, repositoryRootResolved });
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to persist worktree branch metadata: ${errorMessage(error)}`);
 		}
@@ -904,7 +904,7 @@ export class WorktreeIsolation extends Disposable {
 		}
 		const branchName = await this._gitService.getCurrentBranch(worktreeRoot).catch(() => undefined) ?? 'HEAD';
 		const baseBranch = (await this._gitService.getDefaultBranch(primaryRoot).catch(() => undefined))?.name;
-		await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktreeRoot, repositoryRoot: primaryRoot });
+		await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktreeRoot, repositoryRoot: primaryRoot, repositoryRootResolved: true });
 		return true;
 	}
 
@@ -925,12 +925,18 @@ export class WorktreeIsolation extends Disposable {
 		return meta?.repositoryRoot ? projectFromRepositoryRoot(meta.repositoryRoot) : undefined;
 	}
 
-	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<URI> {
+	/**
+	 * Resolves the repository's primary worktree, reporting whether the answer
+	 * came from the repository or from the caller's fallback. Callers that
+	 * persist the result must not present a fallback as canonical.
+	 */
+	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<{ root: URI; resolved: boolean }> {
 		try {
-			return await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot) ?? fallbackRoot;
+			const primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot);
+			return primaryRoot ? { root: primaryRoot, resolved: true } : { root: fallbackRoot, resolved: false };
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}] Failed to resolve primary worktree for '${checkoutRoot.fsPath}': ${errorMessage(error)}`);
-			return fallbackRoot;
+			return { root: fallbackRoot, resolved: false };
 		}
 	}
 
@@ -971,16 +977,21 @@ export class WorktreeIsolation extends Disposable {
 			: selectedBranch;
 	}
 
-	private async _writeWorktreeMetadata(sessionUri: URI, metadata: { branchName: string; baseBranch: string | undefined; worktreePath: URI; repositoryRoot: URI }): Promise<void> {
+	private async _writeWorktreeMetadata(sessionUri: URI, metadata: { branchName: string; baseBranch: string | undefined; worktreePath: URI; repositoryRoot: URI; repositoryRootResolved: boolean }): Promise<void> {
 		const dbRef = this._sessionDataService.openDatabase(sessionUri);
 		try {
 			const work: Promise<void>[] = [
 				dbRef.object.setMetadata(WORKTREE_META_BRANCH, metadata.branchName),
 				dbRef.object.setMetadata(WORKTREE_META_PATH, metadata.worktreePath.toString()),
 				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, metadata.repositoryRoot.toString()),
-				// Written here already canonical, so listing never re-derives it.
-				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP),
 			];
+			// Only a root the repository actually confirmed may be stamped.
+			// Stamping a fallback would certify the unresolved checkout as
+			// canonical and permanently close the listing repair that exists to
+			// correct it — turning a passing failure into a permanent one.
+			if (metadata.repositoryRootResolved) {
+				work.push(dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP));
+			}
 			if (metadata.baseBranch) {
 				work.push(dbRef.object.setMetadata(META_DIFF_BASE_BRANCH, metadata.baseBranch));
 			}
@@ -1013,14 +1024,19 @@ export class WorktreeIsolation extends Disposable {
 			let repositoryRoot = repositoryRootRaw ? URI.parse(repositoryRootRaw) : undefined;
 			if (repositoryRoot) {
 				const checkoutRoot = worktreePath && await fileExists(worktreePath.fsPath) ? worktreePath : repositoryRoot;
-				const primaryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
-				if (primaryRoot.toString() !== repositoryRoot.toString()) {
-					repositoryRoot = primaryRoot;
+				const { root: primaryRoot, resolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
+				if (resolved) {
 					try {
-						await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString());
+						if (primaryRoot.toString() !== repositoryRoot.toString()) {
+							await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString());
+						}
+						// Certify here too, so a session repaired on resume does
+						// not make listing derive the same answer again.
+						await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP);
 					} catch (error) {
 						this._logService.warn(`[${this._logLabel}] Failed to normalize worktree repository metadata for '${sessionUri.toString()}': ${errorMessage(error)}`);
 					}
+					repositoryRoot = primaryRoot;
 				}
 			}
 			return { branchName, worktreePath, repositoryRoot };

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -985,17 +985,19 @@ export class WorktreeIsolation extends Disposable {
 				dbRef.object.setMetadata(WORKTREE_META_PATH, metadata.worktreePath.toString()),
 				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, metadata.repositoryRoot.toString()),
 			];
-			// Only a root the repository actually confirmed may be stamped.
-			// Stamping a fallback would certify the unresolved checkout as
-			// canonical and permanently close the listing repair that exists to
-			// correct it — turning a passing failure into a permanent one.
-			if (metadata.repositoryRootResolved) {
-				work.push(dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP));
-			}
 			if (metadata.baseBranch) {
 				work.push(dbRef.object.setMetadata(META_DIFF_BASE_BRANCH, metadata.baseBranch));
 			}
 			await Promise.all(work);
+			// Stamped last, and only once the root it vouches for is stored.
+			// Issued alongside the root it would survive a failed root write and
+			// certify whatever value was there before, permanently closing the
+			// listing repair. Only a root the repository actually confirmed may
+			// be stamped at all: certifying a fallback would freeze the
+			// unresolved checkout the repair exists to correct.
+			if (metadata.repositoryRootResolved) {
+				await dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP);
+			}
 		} finally {
 			dbRef.dispose();
 		}

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -36,6 +36,14 @@ import { ICopilotApiService } from './copilotApiService.js';
 const WORKTREE_META_BRANCH = 'copilot.worktree.branchName';
 const WORKTREE_META_PATH = 'copilot.worktree.path';
 export const WORKTREE_META_REPOSITORY_ROOT = 'copilot.worktree.repositoryRoot';
+/**
+ * Stamps the repository root as canonicalized, so listing can trust it without
+ * touching the filesystem. Older builds stored a parent linked checkout here,
+ * and an unstamped root is indistinguishable from one of those, so it has to be
+ * re-derived once. Bump the stamped value if the root's meaning changes again.
+ */
+export const WORKTREE_META_REPOSITORY_ROOT_STAMP = 'copilot.worktree.repositoryRootStamp';
+export const WORKTREE_REPOSITORY_ROOT_STAMP = '1';
 const WORKTREE_META_CREATION_FAILURE = 'copilot.worktree.creationFailure';
 const MAX_WORKTREE_FAILURE_DIAGNOSTIC_LENGTH = 200;
 
@@ -970,6 +978,8 @@ export class WorktreeIsolation extends Disposable {
 				dbRef.object.setMetadata(WORKTREE_META_BRANCH, metadata.branchName),
 				dbRef.object.setMetadata(WORKTREE_META_PATH, metadata.worktreePath.toString()),
 				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, metadata.repositoryRoot.toString()),
+				// Written here already canonical, so listing never re-derives it.
+				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP),
 			];
 			if (metadata.baseBranch) {
 				work.push(dbRef.object.setMetadata(META_DIFF_BASE_BRANCH, metadata.baseBranch));

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -686,6 +686,39 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 			try { cp.execFileSync('git', ['branch', '-D', 'agents/include-files'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 		}
 	});
+
+	(hasGit ? test : test.skip)('getPrimaryWorktreeRoot agrees with git worktree list without spawning git', async () => {
+		const dir = initRepo();
+		const wtPath = join(dir, '..', `wt-primary-${Date.now()}`);
+		const nested = join(dir, 'src', 'nested');
+		try {
+			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/primary-root', 'main');
+			const fs = await import('fs/promises');
+			await fs.mkdir(nested, { recursive: true });
+
+			// `git worktree list --porcelain` reports the primary worktree
+			// first, so its answer is the contract the on-disk resolution must
+			// reproduce for every checkout of the repository.
+			const fromGit = (await svc!.getWorktreeRoots(URI.file(wtPath)))[0];
+
+			assert.deepStrictEqual({
+				expected: fromGit?.fsPath,
+				fromPrimary: (await svc!.getPrimaryWorktreeRoot(URI.file(dir)))?.fsPath,
+				fromLinked: (await svc!.getPrimaryWorktreeRoot(URI.file(wtPath)))?.fsPath,
+				fromNestedDirectory: (await svc!.getPrimaryWorktreeRoot(URI.file(nested)))?.fsPath,
+				fromNonRepository: await svc!.getPrimaryWorktreeRoot(URI.file(join(tmpdir(), `missing-${Date.now()}`))),
+			}, {
+				expected: fromGit?.fsPath,
+				fromPrimary: fromGit?.fsPath,
+				fromLinked: fromGit?.fsPath,
+				fromNestedDirectory: fromGit?.fsPath,
+				fromNonRepository: undefined,
+			});
+		} finally {
+			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
+			rmDirWithRetry(wtPath);
+		}
+	});
 });
 
 suite('AgentHostGitService - restore (real git)', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -687,7 +687,7 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
-	(hasGit ? test : test.skip)('getPrimaryWorktreeRoot agrees with git worktree list without spawning git', async () => {
+	(hasGit ? test : test.skip)('getPrimaryWorktreeRoot agrees with git worktree list', async () => {
 		const dir = initRepo();
 		const wtPath = join(dir, '..', `wt-primary-${Date.now()}`);
 		const nested = join(dir, 'src', 'nested');
@@ -717,6 +717,55 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		} finally {
 			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
 			rmDirWithRetry(wtPath);
+		}
+	});
+
+	(hasGit ? test : test.skip)('getPrimaryWorktreeRoot declines layouts it cannot describe rather than guessing a root', async () => {
+		const dir = initRepo();
+		const fs = await import('fs/promises');
+		// Each of these resolves to a real directory that is NOT the repository
+		// root, so answering from the layout alone would persist a wrong root
+		// and regroup the session under an unrelated project. Declining hands
+		// the question back to git.
+		const strayDotGit = join(dir, 'vendor', 'interrupted-clone');
+		await fs.mkdir(join(strayDotGit, '.git'), { recursive: true });
+
+		const damagedWorktree = join(dir, '..', `wt-damaged-${Date.now()}`);
+		await svc!.addWorktree(URI.file(dir), URI.file(damagedWorktree), 'agents/damaged', 'main');
+		await fs.rm(join(damagedWorktree, '.git'));
+		await fs.mkdir(join(damagedWorktree, '.git'));
+
+		const nestedBare = join(dir, 'nested-bare.git');
+		cp.execFileSync('git', ['clone', '--bare', '-q', dir, nestedBare], { cwd: dir, env, stdio: 'pipe' });
+
+		const detachedWorktree = join(dir, '..', `wt-detached-${Date.now()}`);
+		await fs.mkdir(join(detachedWorktree, '.git'), { recursive: true });
+		for (const entry of ['HEAD', 'config']) {
+			await fs.copyFile(join(dir, '.git', entry), join(detachedWorktree, '.git', entry));
+		}
+		await fs.mkdir(join(detachedWorktree, '.git', 'objects'), { recursive: true });
+		await fs.mkdir(join(detachedWorktree, '.git', 'refs'), { recursive: true });
+		await fs.appendFile(join(detachedWorktree, '.git', 'config'), `\n[core]\n\tworktree = ${dir}\n`);
+
+		try {
+			assert.deepStrictEqual({
+				// A `.git` directory that holds no repository is not a checkout
+				// root; git keeps searching upwards and so must this.
+				strayDotGit: (await svc!.getPrimaryWorktreeRoot(URI.file(strayDotGit)))?.fsPath,
+				damagedWorktree: await svc!.getPrimaryWorktreeRoot(URI.file(damagedWorktree)),
+				nestedBare: await svc!.getPrimaryWorktreeRoot(URI.file(nestedBare)),
+				coreWorktreeRedirect: await svc!.getPrimaryWorktreeRoot(URI.file(detachedWorktree)),
+			}, {
+				strayDotGit: (await svc!.getWorktreeRoots(URI.file(strayDotGit)))[0]?.fsPath,
+				damagedWorktree: undefined,
+				nestedBare: undefined,
+				coreWorktreeRedirect: undefined,
+			});
+		} finally {
+			for (const path of [damagedWorktree, detachedWorktree]) {
+				try { await svc!.removeWorktree(URI.file(dir), URI.file(path), { force: true }); } catch { /* best-effort cleanup */ }
+				rmDirWithRetry(path);
+			}
 		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -738,6 +738,14 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		const nestedBare = join(dir, 'nested-bare.git');
 		cp.execFileSync('git', ['clone', '--bare', '-q', dir, nestedBare], { cwd: dir, env, stdio: 'pipe' });
 
+		// A checkout the filesystem refuses to describe. Ascending past its
+		// unreadable `.git` would answer with the enclosing repository, and
+		// listing certifies what it is told, so a momentary permission failure
+		// would be frozen into a permanent mis-grouping.
+		const unreadable = join(dir, '..', `wt-unreadable-${Date.now()}`);
+		await svc!.addWorktree(URI.file(dir), URI.file(unreadable), 'agents/unreadable', 'main');
+		await fs.chmod(unreadable, 0o000);
+
 		const detachedWorktree = join(dir, '..', `wt-detached-${Date.now()}`);
 		await fs.mkdir(join(detachedWorktree, '.git'), { recursive: true });
 		for (const entry of ['HEAD', 'config']) {
@@ -755,14 +763,17 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 				damagedWorktree: await svc!.getPrimaryWorktreeRoot(URI.file(damagedWorktree)),
 				nestedBare: await svc!.getPrimaryWorktreeRoot(URI.file(nestedBare)),
 				coreWorktreeRedirect: await svc!.getPrimaryWorktreeRoot(URI.file(detachedWorktree)),
+				unreadableCheckout: isWindows ? undefined : await svc!.getPrimaryWorktreeRoot(URI.file(unreadable)),
 			}, {
 				strayDotGit: (await svc!.getWorktreeRoots(URI.file(strayDotGit)))[0]?.fsPath,
 				damagedWorktree: undefined,
 				nestedBare: undefined,
 				coreWorktreeRedirect: undefined,
+				unreadableCheckout: undefined,
 			});
 		} finally {
-			for (const path of [damagedWorktree, detachedWorktree]) {
+			await fs.chmod(unreadable, 0o755).catch(() => { /* best-effort cleanup */ });
+			for (const path of [damagedWorktree, detachedWorktree, unreadable]) {
 				try { await svc!.removeWorktree(URI.file(dir), URI.file(path), { force: true }); } catch { /* best-effort cleanup */ }
 				rmDirWithRetry(path);
 			}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -42,7 +42,7 @@ import { type ISessionEvent } from './copilotTestEvents.js';
 import { createNoopGitService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT } from '../../node/shared/worktreeIsolation.js';
+import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -1765,10 +1765,14 @@ suite('AgentService (node dispatcher)', () => {
 				resolvedFrom: resolvedFrom.map(uri => uri.toString()),
 				project: sessions[0].project && { uri: sessions[0].project.uri.toString(), displayName: sessions[0].project.displayName },
 				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				persistedStamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
 			}, {
+				// Resolved once despite two listings: the stamp records that the
+				// root is already canonical, so later listings never re-derive it.
 				resolvedFrom: [linkedCheckout.toString()],
 				project: { uri: primaryRoot.toString(), displayName: 'vscode' },
 				persistedRepositoryRoot: primaryRoot.toString(),
+				persistedStamp: WORKTREE_REPOSITORY_ROOT_STAMP,
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1776,6 +1776,62 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('listSessions persists the repaired root before the session database is released', async () => {
+			// The real database rejects writes once its last reference is
+			// dropped, and listing drops that reference as soon as the repair
+			// returns. A repair that does not finish inside the reference is
+			// silently discarded, taking the stamp with it, so the session stays
+			// mis-grouped and re-resolves forever. The in-memory helper cannot
+			// show that on its own, so model the release here.
+			class ReleasableSessionDatabase extends TestSessionDatabase {
+				released = false;
+				override async setMetadata(key: string, value: string): Promise<void> {
+					// The real database queues writes behind a sequencer and only
+					// then checks whether it was closed, so a write issued just
+					// before release still fails. Deferring here reproduces that
+					// ordering; checking synchronously would let a discarded
+					// write look like a successful one.
+					await new Promise(resolve => setTimeout(resolve, 0));
+					if (this.released) {
+						throw new Error('SessionDatabase has been disposed');
+					}
+					return super.setMetadata(key, value);
+				}
+			}
+			const db = disposables.add(new ReleasableSessionDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			const sessionId = 'test-session-released-db';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [linkedCheckout] };
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			gitService.getWorktreeRoots = async () => [primaryRoot, linkedCheckout];
+			const reference = () => ({ object: db, dispose: () => { db.released = true; } });
+			const sessionDataService: ISessionDataService = {
+				...createSessionDataService(db),
+				openDatabase: reference,
+				tryOpenDatabase: async () => reference(),
+			};
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			const sessions = await svc.listSessions();
+
+			assert.deepStrictEqual({
+				project: sessions[0].project?.uri.toString(),
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				persistedStamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
+			}, {
+				project: primaryRoot.toString(),
+				persistedRepositoryRoot: primaryRoot.toString(),
+				persistedStamp: WORKTREE_REPOSITORY_ROOT_STAMP,
+			});
+		});
+
 		test('listSessions uses SDK title when no custom title exists', async () => {
 			service.registerProvider(copilotAgent);
 			copilotAgent.sessionMetadataOverrides = { summary: 'Auto-generated Title' };

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -15,6 +15,8 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	repositoryRoot: URI | undefined;
 	worktreeRoots: URI[] = [];
 	worktreeRootCalls = 0;
+	/** Set to emulate a git service that can answer from the repository layout on disk. */
+	primaryWorktreeRootsOnDisk: Map<string, URI> | undefined;
 
 	async getCurrentBranch(): Promise<string | undefined> { return undefined; }
 	async getDefaultBranch(): Promise<IDefaultBranch | undefined> { return undefined; }
@@ -25,6 +27,9 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	async getWorktreeRoots(): Promise<URI[]> {
 		this.worktreeRootCalls++;
 		return this.worktreeRoots;
+	}
+	async getPrimaryWorktreeRoot(workingDirectory: URI): Promise<URI | undefined> {
+		return this.primaryWorktreeRootsOnDisk?.get(workingDirectory.toString());
 	}
 	async addWorktree(): Promise<void> { }
 	async copyWorktreeIncludeFiles(): Promise<void> { }
@@ -109,6 +114,25 @@ suite('Copilot Git Project', () => {
 			roots: roots.map(root => root?.toString()),
 		}, {
 			worktreeRootCalls: 1,
+			roots: [primaryRoot.toString(), primaryRoot.toString()],
+		});
+	});
+
+	test('resolves from the repository layout on disk instead of spawning git', async () => {
+		const primaryRoot = URI.file('/workspace/source-repo');
+		const checkouts = [URI.file('/workspace/source-repo.worktrees/a'), URI.file('/workspace/source-repo.worktrees/b')];
+		gitService.primaryWorktreeRootsOnDisk = new Map(checkouts.map(checkout => [checkout.toString(), primaryRoot]));
+		// A listing this large used to evict the cache faster than it could be
+		// reused, so it must not translate into git process launches.
+		gitService.worktreeRoots = [primaryRoot, ...checkouts];
+
+		const roots = await Promise.all(checkouts.map(checkout => tryResolvePrimaryWorktreeRoot(gitService, checkout)));
+
+		assert.deepStrictEqual({
+			worktreeRootCalls: gitService.worktreeRootCalls,
+			roots: roots.map(root => root?.toString()),
+		}, {
+			worktreeRootCalls: 0,
 			roots: [primaryRoot.toString(), primaryRoot.toString()],
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -316,6 +316,41 @@ suite('WorktreeIsolation', () => {
 		});
 	});
 
+	test('resolveWorkingDirectory leaves the root unstamped when storing it fails', async () => {
+		// A stamp that survived a failed root write would certify whatever value
+		// was already there, and listing skips stamped sessions, so the repair
+		// could never correct it.
+		const failingDb = new class extends TestSessionDatabase {
+			override async setMetadata(key: string, value: string): Promise<void> {
+				if (key === 'copilot.worktree.repositoryRoot') {
+					throw new Error('disk full');
+				}
+				return super.setMetadata(key, value);
+			}
+		}();
+		db = failingDb;
+		const checkoutRoot = URI.joinPath(repoRoot, 'linked-checkout');
+		const gitService = createGitService();
+		gitService.getRepositoryRoot = async () => checkoutRoot;
+		gitService.getWorktreeRoots = async () => [repoRoot, checkoutRoot];
+		const isolation = createIsolation(disposables, { gitService });
+
+		await isolation.resolveWorkingDirectory({
+			sessionUri,
+			sessionId,
+			workingDirectory: checkoutRoot,
+			config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+		});
+
+		assert.deepStrictEqual({
+			metaRepositoryRoot: await failingDb.getMetadata('copilot.worktree.repositoryRoot'),
+			metaRepositoryRootStamp: await failingDb.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
+		}, {
+			metaRepositoryRoot: undefined,
+			metaRepositoryRootStamp: undefined,
+		});
+	});
+
 	test('resolveWorkingDirectory names each creation phase, rounding percentages down and debouncing updates', async () => {
 		const gitService = createGitService();
 		gitService.addWorktree = async (_root, worktree, branch, startPoint, track, onProgress) => {

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -18,7 +18,7 @@ import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, MessageKind, ResponsePartKind, TurnState, type Turn } from '../../../common/state/sessionState.js';
 import { AgentBranchNameGenerator, IAgentBranchNameGenerator } from '../../../node/shared/agentBranchNameGenerator.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
-import { buildWorktreeFailureNotification, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot, WORKTREE_META_REPOSITORY_ROOT_STAMP, WORKTREE_REPOSITORY_ROOT_STAMP } from '../../../node/shared/worktreeIsolation.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../../common/sessionTestHelpers.js';
 
 /**
@@ -272,12 +272,16 @@ suite('WorktreeIsolation', () => {
 			addWorktreeRoot: addWorktreeRoot?.toString(),
 			includeFileRoot: copyIncludeCalls[0]?.repositoryRoot.toString(),
 			metaRepositoryRoot: meta?.repositoryRoot?.toString(),
+			// A genuinely resolved root is certified, so listing trusts it
+			// without deriving it again.
+			metaRepositoryRootStamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
 			project: project && { uri: project.uri.toString(), displayName: project.displayName },
 		}, {
 			worktree: URI.joinPath(worktreesRoot, getWorktreeName(branchName)).toString(),
 			addWorktreeRoot: repoRoot.toString(),
 			includeFileRoot: checkoutRoot.toString(),
 			metaRepositoryRoot: repoRoot.toString(),
+			metaRepositoryRootStamp: WORKTREE_REPOSITORY_ROOT_STAMP,
 			project: { uri: repoRoot.toString(), displayName: basename(repoRoot) },
 		});
 	});
@@ -301,9 +305,14 @@ suite('WorktreeIsolation', () => {
 		assert.deepStrictEqual({
 			worktree: worktree?.toString(),
 			metaRepositoryRoot: meta?.repositoryRoot?.toString(),
+			// The fallback is the linked checkout itself — the very value the
+			// listing repair exists to correct — so it must never be stamped.
+			// Certifying it would make the repair skip this session forever.
+			metaRepositoryRootStamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
 		}, {
 			worktree: URI.joinPath(fallbackWorktreesRoot, getWorktreeName(branchName)).toString(),
 			metaRepositoryRoot: checkoutRoot.toString(),
+			metaRepositoryRootStamp: undefined,
 		});
 	});
 


### PR DESCRIPTION
Fixes #329880

> [!IMPORTANT]
> **A competing implementation exists and may be the better choice.** A parallel effort on `ulugbekna/lazy-worktree-root-migration` keeps `git worktree list --porcelain` as the single source of truth and gets the same steady-state result by fixing the cache keying plus adding the version stamp. Its measurements suggest the cache sizing — not the on-disk resolver — is what actually fixes #329880. See "Comparison with the alternative" at the bottom before reviewing this in depth.

## Summary

Reloading the Agents window could leave session details unavailable for tens of seconds. On the reporter's machine the first `listSessions` took **52s** and spawned **400–570 `git worktree list --porcelain` processes**.

| | before | after |
|---|---:|---:|
| git processes | ~850 | **0** |
| first listing (850 sessions) | ~60s | ~130ms |
| every later listing, and after restart | ~60s | **0 syscalls** |

## Why git was being spawned at all

#328375 fixed a project-grouping bug: `git rev-parse --show-toplevel` returns the *current checkout* root, which for a linked worktree is not the canonical repository root. Alongside it came a **data migration on the `listSessions` path** (`AgentService._normalizeListedWorktreeRepositoryRoot`) to repair roots persisted by older builds, since archived sessions may never reopen through the normal migration path. To find the primary worktree it ran `git worktree list --porcelain`.

Two caches were meant to absorb this. Neither could, for structural reasons:

1. **`AgentService._normalizedWorktreeRepositoryRoots` was keyed by session URI.** Unique per session, so it could never dedupe *within* a listing — a 100% miss rate by construction.
2. **`PrimaryWorktreeRootResolver._roots` is keyed by checkout path**, also unique per session. Its only sharing mechanism was bulk-recording sibling worktree paths from a successful listing — and a 100-entry LRU evicted exactly those entries for a user with hundreds of worktrees.

So nearly every session spawned git, serialized behind the resolver's `Sequencer`. Measured on a real machine: **only 2 distinct primary roots across 850 sessions**, yet all 850 paid a full resolution. The redundancy is in the cache *key*, not the resolution cost.

## The change

### 1. Read the layout instead of spawning git

`AgentHostGitService.getPrimaryWorktreeRoot()` derives the answer from git's on-disk layout:

- `<dir>/.git` is a **directory** holding a real repository → `<dir>` is the primary worktree
- `<dir>/.git` is a **file** → parse `gitdir:`, read `<gitdir>/commondir`, resolve; if its basename is `.git`, the primary root is its dirname
- otherwise `undefined`, and `PrimaryWorktreeRootResolver` falls back to `git worktree list`

Layouts git describes unusually (submodules, bare repos, `--separate-git-dir`) are deliberately declined rather than guessed at, so behaviour there is unchanged — just reached via the fallback. The fallback is **not** dead code.

### 2. Stamp the repair so it stops recurring

Nothing recorded that a root had already been canonicalized, so it was re-derived on **every listing and every restart**. Roots are now stamped (`copilot.worktree.repositoryRootStamp`); a stamped session short-circuits on a value already in the batched metadata read — zero filesystem work. This retires the session-keyed in-memory cache rather than enlarging it.

## Correctness

The resolved value is **written back to persistent metadata** and decides project grouping, so a wrong-but-plausible answer corrupts stored state and does not self-heal. "Returns `undefined` when unsure" was the property to get right.

Differential-tested against real `git worktree list --porcelain` across **17 layouts** — plain repo, linked worktree, worktree-of-worktree, nested subdirectory, non-repo directory under a repo, symlinked repo path, submodule, worktree-of-submodule, bare repo, worktree-of-bare-repo, nested bare repo, `--separate-git-dir`, moved primary, damaged `.git`, stray `.git`, `core.worktree` redirect, nonexistent path. **No divergence.**

Three rounds of review hardening were needed, and each round fixed a bug that only differential testing exposed. Reviewers should weigh that this approach *required* that much hardening:

**Canonicalization.** Git reports realpath'd paths; the initial walk returned the caller's spelling (`/var` vs `/private/var` on macOS). Since this code rewrites persisted metadata, it would have converted correct canonical roots into non-canonical ones and split grouping. Both branches now canonicalize — this matters most on Windows, where `realpath` settles on-disk casing.

**Layouts git would refuse.** Git accepts a `.git` directory only when it holds a repository (`HEAD`+`objects`+`refs`) and keeps searching upwards otherwise; the walk accepted the name alone. A checkout whose worktree link had been replaced by an empty `.git` directory reported *itself* as the repository root — and being truthy, it also consumed the caller's `?? persistedRoot` fallback, so the new code defeated an existing safety net and persisted the wrong value. Bare repos and `core.worktree` redirects failed the same way. All three now validate or decline.

**Certifying an unconfirmed root.** The stamp introduced a subtler failure: materialization resolves the primary worktree with the selected checkout as its *own* fallback — precisely the linked-checkout path the repair exists to correct — and the resolver collapsed "resolved" and "fell back" into one return value. A transient git failure during session creation therefore persisted the wrong root *and stamped it canonical*, so listing would skip that session forever. That converts a passing failure into a permanent one and reinstates the #328375 bug. Resolution now reports whether the repository actually answered, and only a confirmed root is stamped. Verified the regression test fails when the guard is removed.

## Validation

- 4407 agentHost unit tests, 42 real-git integration tests
- `npm run typecheck-client` and `npm run valid-layers-check` at baseline (pre-existing unrelated SDK errors unchanged)
- Integration tests assert parity with `git worktree list` for primary/linked/nested checkouts, and the safe-`undefined` contract for damaged `.git`, nested bare repo, and `core.worktree`
- Unit tests assert the disk path is used with **zero** `getWorktreeRoots` calls; that two listings resolve only once and persist the stamp; and that a fallback root is **never** stamped

## Comparison with the alternative

Honest assessment, since I think it bears directly on whether to merge this:

| | this PR | `lazy-worktree-root-migration` |
|---|---|---|
| steady-state sync cost | 0 | 0 — identical |
| first-run sync cost | ~0 git | 1 git call per repository, then stamped |
| git behaviour reimplemented | `is_git_directory()`, `commondir`, `core.worktree`, `--separate-git-dir` | **none** |
| capacity cliff | none | none |
| broken/orphaned checkouts | still spawn git each listing | never reach git, or TTL'd |
| review rounds to reach correctness | 3 | — |

**The on-disk resolver is not what fixed #329880 — the cache keying was.** Once the cache is right and the stamp lands, reimplementing git's layout logic buys roughly one repository's worth of latency on a single listing per install, in exchange for owning `is_git_directory()` semantics permanently. On that basis the alternative is probably the better trade, and I'd take it.

I originally claimed a capacity cliff as the durable argument for this PR. That was wrong in both directions and is worth recording, because the underlying principle is the interesting part: **the right cache policy follows from the cost of a miss.** The alternative uses an unbounded map, because there a miss costs a subprocess and a fixed bound would silently choose between one process and hundreds. This PR keeps a bounded LRU, because here a miss costs a few `stat`s — measured at 9001 distinct keys against a 4096 bound, i.e. continuous eviction: 4119ms and **zero** git processes. Neither design degrades pathologically.

Known follow-up not addressed here: failures are not cached, so genuinely broken sessions still spawn git on each listing. The alternative fixes that with a TTL'd negative cache.

