### PR TITLE
Agents window: Update badge positioning and refactor activity bar styling for sessions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -42,6 +42,8 @@ Editors open as modal overlays via `ModalEditorPart`. The main editor part exist
 | Auxiliary Bar | Right side | Visible | Changes view, file tree |
 | Panel | Below Sessions Part + Aux Bar | Hidden | Terminal, debug output |
 
+The Panel and Auxiliary Bar tab strips inherit the shared Modern UI pane-tab presentation from `workbench/contrib/styleOverrides/browser/media/tabs.css` through the workbench root's `modern-ui-tabs` class. Sessions-owned styles define only the part surface and inset; action geometry, active/hover/focus states, and badge placement remain owned by the shared pane-tab stylesheet so the Editor and Agents windows stay aligned.
+
 ### 2.2 Grid Tree
 
 ```

--- a/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
+++ b/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
@@ -3,46 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* ===== Modern action label styling for sessions auxiliary bar ===== */
-
-/* Base label: lowercase text + heavier weight + pill padding */
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
-	text-transform: capitalize;
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
-	border-radius: var(--vscode-cornerRadius-small);
-	padding: 0px 8px;
-	font-size: var(--vscode-agents-fontSize-label1);
-	line-height: 22px;
-}
-
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
-	padding-left: 0;
-	padding-right: 0;
-}
-
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
-	margin-left: -4px;
-	padding-right: 6px;
-}
-
 .agent-sessions-workbench .part.auxiliarybar > .title {
 	padding-left: 4px;
 	padding-right: 2px;
 	background-color: var(--vscode-agentsPanel-background);
-}
-
-/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
-	display: none !important;
-}
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
-	display: block !important;
-}
-
-/* Active/checked state: background container instead of underline */
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
-	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 5%, transparent) !important;
-	border-radius: var(--vscode-cornerRadius-small);
 }
 
 /* Override base workbench monaco editor background in auxiliary bar content */

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -8,46 +8,10 @@
 	border-top-width: 0;
 }
 
-/* ===== Modern action label styling for sessions panel ===== */
-
-/* Base label: lowercase text + heavier weight + pill padding */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
-	text-transform: capitalize;
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
-	border-radius: var(--vscode-cornerRadius-small);
-	padding: 0px 8px;
-	font-size: var(--vscode-agents-fontSize-label1);
-	line-height: 22px;
-}
-
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
-	padding-left: 0;
-	padding-right: 0;
-}
-
-/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
-	display: none !important;
-}
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
-	display: block !important;
-}
-
-/* Make icon action items 24px tall */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon {
-	height: 24px;
-}
-
 .agent-sessions-workbench .part.panel > .title {
 	padding-left: 4px;
 	padding-right: 2px;
 	background-color: var(--vscode-agentsPanel-background);
-}
-
-/* Active/checked state: background container instead of underline */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
-	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 5%, transparent) !important;
-	border-radius: var(--vscode-cornerRadius-small);
 }
 
 /* Override base workbench panel content background for terminal */
@@ -72,10 +36,6 @@
 
 .monaco-workbench.vs.agent-sessions-workbench .part.panel > .content #workbench\.sessions\.panel\.chatDebugContainer .monaco-list-rows {
 	background: var(--vscode-agentsPanel-background) !important;
-}
-
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
-	top: 11px;
 }
 
 /* Terminal body background */

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -282,11 +282,6 @@
 	top: 10px;
 }
 
-.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
-	top: 10px;
-	right: var(--vscode-spacing-size20);
-}
-
 .style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon:not(.checked) .action-label.codicon.codicon-more:hover {
 	background: transparent;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -467,6 +467,11 @@
 	width: auto;
 }
 
+.modern-ui-tabs.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+	top: 13px;
+	right: var(--vscode-spacing-size20);
+}
+
 .modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge) {
 	position: relative;
 	z-index: 1;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -459,6 +459,14 @@
 	transform: translateY(-50%);
 }
 
+.modern-ui-tabs.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon > .active-item-indicator {
+	top: 50%;
+	right: var(--vscode-spacing-size20);
+	bottom: auto;
+	left: var(--vscode-spacing-size20);
+	width: auto;
+}
+
 .modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item > :is(.action-label, .badge) {
 	position: relative;
 	z-index: 1;

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -56,7 +56,7 @@ function appendElement(parent: HTMLElement, className: string): HTMLElement {
 	return element;
 }
 
-function createCompositeAction(root: HTMLElement, titleHeight: number, checked: boolean): { actionItem: HTMLElement; indicator: HTMLElement } {
+function createCompositeAction(root: HTMLElement, titleHeight: number, checked: boolean, icon = false): { actionItem: HTMLElement; indicator: HTMLElement } {
 	root.style.setProperty('--vscode-spacing-size20', '2px');
 	root.style.setProperty('--vscode-spacing-size40', '4px');
 	root.style.setProperty('--vscode-spacing-size240', '24px');
@@ -68,7 +68,7 @@ function createCompositeAction(root: HTMLElement, titleHeight: number, checked: 
 	const compositeBar = appendElement(compositeBarContainer, 'composite-bar');
 	const actionBar = appendElement(compositeBar, 'monaco-action-bar');
 	const actionsContainer = appendElement(actionBar, 'actions-container');
-	const actionItem = appendElement(actionsContainer, `action-item${checked ? ' checked' : ''}`);
+	const actionItem = appendElement(actionsContainer, `action-item${checked ? ' checked' : ''}${icon ? ' icon' : ''}`);
 	actionItem.tabIndex = 0;
 	appendElement(actionItem, 'action-label');
 	const indicator = appendElement(actionItem, 'active-item-indicator');
@@ -161,18 +161,29 @@ suite('StyleOverridesContribution', () => {
 		document.body.appendChild(agentsRoot);
 		store.add(toDisposable(() => agentsRoot.remove()));
 		const agents = createCompositeAction(agentsRoot, 35, false);
+		const agentsIcon = createCompositeAction(agentsRoot, 35, true, true);
 
 		const targetWindow = getWindow(agents.actionItem);
+		const agentsIconTargetBounds = agentsIcon.actionItem.getBoundingClientRect();
+		const agentsIconIndicatorBounds = agentsIcon.indicator.getBoundingClientRect();
 		assert.deepStrictEqual({
 			regularTargetHeight: targetWindow.getComputedStyle(regular.actionItem).height,
 			regularIndicatorHeight: targetWindow.getComputedStyle(regular.indicator).height,
 			agentsTargetHeight: targetWindow.getComputedStyle(agents.actionItem).height,
 			agentsIndicatorHeight: targetWindow.getComputedStyle(agents.indicator).height,
+			agentsIconTargetHeight: targetWindow.getComputedStyle(agentsIcon.actionItem).height,
+			agentsIconIndicatorHeight: targetWindow.getComputedStyle(agentsIcon.indicator).height,
+			agentsIconIndicatorTopInset: agentsIconIndicatorBounds.top - agentsIconTargetBounds.top,
+			agentsIconIndicatorBottomInset: agentsIconTargetBounds.bottom - agentsIconIndicatorBounds.bottom,
 		}, {
 			regularTargetHeight: '32px',
 			regularIndicatorHeight: '24px',
 			agentsTargetHeight: '35px',
 			agentsIndicatorHeight: '24px',
+			agentsIconTargetHeight: '35px',
+			agentsIconIndicatorHeight: '24px',
+			agentsIconIndicatorTopInset: 5.5,
+			agentsIconIndicatorBottomInset: 5.5,
 		});
 	});
 

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -155,6 +155,10 @@ suite('StyleOverridesContribution', () => {
 		store.add(toDisposable(() => regularRoot.remove()));
 		// Taller container than the fixed 32px override, so the override is verified rather than a 100% fallback.
 		const regular = createCompositeAction(regularRoot, 40, true);
+		const regularIcon = createCompositeAction(regularRoot, 40, true, true);
+		const regularIconBadge = appendElement(regularIcon.actionItem, 'badge compact');
+		const regularIconBadgeContent = appendElement(regularIconBadge, 'badge-content');
+		regularIcon.actionItem.insertBefore(regularIconBadge, regularIcon.indicator);
 
 		const agentsRoot = document.createElement('div');
 		agentsRoot.className = 'monaco-workbench modern-ui-tabs';
@@ -162,6 +166,9 @@ suite('StyleOverridesContribution', () => {
 		store.add(toDisposable(() => agentsRoot.remove()));
 		const agents = createCompositeAction(agentsRoot, 35, false);
 		const agentsIcon = createCompositeAction(agentsRoot, 35, true, true);
+		const agentsIconBadge = appendElement(agentsIcon.actionItem, 'badge compact');
+		const agentsIconBadgeContent = appendElement(agentsIconBadge, 'badge-content');
+		agentsIcon.actionItem.insertBefore(agentsIconBadge, agentsIcon.indicator);
 
 		const targetWindow = getWindow(agents.actionItem);
 		const agentsIconTargetBounds = agentsIcon.actionItem.getBoundingClientRect();
@@ -169,21 +176,29 @@ suite('StyleOverridesContribution', () => {
 		assert.deepStrictEqual({
 			regularTargetHeight: targetWindow.getComputedStyle(regular.actionItem).height,
 			regularIndicatorHeight: targetWindow.getComputedStyle(regular.indicator).height,
+			regularIconBadgeTop: targetWindow.getComputedStyle(regularIconBadgeContent).top,
+			regularIconBadgeRight: targetWindow.getComputedStyle(regularIconBadgeContent).right,
 			agentsTargetHeight: targetWindow.getComputedStyle(agents.actionItem).height,
 			agentsIndicatorHeight: targetWindow.getComputedStyle(agents.indicator).height,
 			agentsIconTargetHeight: targetWindow.getComputedStyle(agentsIcon.actionItem).height,
 			agentsIconIndicatorHeight: targetWindow.getComputedStyle(agentsIcon.indicator).height,
 			agentsIconIndicatorTopInset: agentsIconIndicatorBounds.top - agentsIconTargetBounds.top,
 			agentsIconIndicatorBottomInset: agentsIconTargetBounds.bottom - agentsIconIndicatorBounds.bottom,
+			agentsIconBadgeTop: targetWindow.getComputedStyle(agentsIconBadgeContent).top,
+			agentsIconBadgeRight: targetWindow.getComputedStyle(agentsIconBadgeContent).right,
 		}, {
 			regularTargetHeight: '32px',
 			regularIndicatorHeight: '24px',
+			regularIconBadgeTop: '13px',
+			regularIconBadgeRight: '2px',
 			agentsTargetHeight: '35px',
 			agentsIndicatorHeight: '24px',
 			agentsIconTargetHeight: '35px',
 			agentsIconIndicatorHeight: '24px',
 			agentsIconIndicatorTopInset: 5.5,
 			agentsIconIndicatorBottomInset: 5.5,
+			agentsIconBadgeTop: '13px',
+			agentsIconBadgeRight: '2px',
 		});
 	});
 


### PR DESCRIPTION
This pull request refactors how the Sessions panel and auxiliary bar tab strips are styled, consolidating their appearance with the shared Modern UI pane-tab presentation. Custom styles for these areas have been removed in favor of using the centralized stylesheet, ensuring consistency with the main editor and agents windows. The test suite is updated to verify the new shared styles and layout for icon action items and badges.

**Styling consolidation and cleanup:**
- Removed custom action label and badge styling from `panelPart.css` and `auxiliaryBarPart.css`, delegating all action geometry, states, and badge placement to the shared `tabs.css` stylesheet for unified Modern UI tabs appearance. [[1]](diffhunk://#diff-f29d01d169b0227918bc82932099e7fde0c752268542bc4d9666a3de52e017cfL6-L47) [[2]](diffhunk://#diff-41843752963ab333ff46547805cb5c71ac231acbcffc7d7de4a778c39b6abe6dL11-L52) [[3]](diffhunk://#diff-41843752963ab333ff46547805cb5c71ac231acbcffc7d7de4a778c39b6abe6dL77-L80)
- Updated documentation (`LAYOUT.md`) to clarify that Sessions panel and auxiliary bar now inherit their tab strip presentation from the shared Modern UI tabs stylesheet, with only surface and inset styles remaining session-specific.

**Modern UI tabs enhancements:**
- Added new CSS rules in `tabs.css` to style icon action item indicators and badge positioning for the Modern UI tabs, ensuring proper alignment and consistent appearance across all parts.
- Removed redundant or conflicting badge positioning styles from `activityBar.css` now that badge placement is handled by the shared stylesheet.

**Test updates:**
- Enhanced the style override tests to cover icon action items and badges, verifying their layout and positioning under the new shared Modern UI tabs styling. [[1]](diffhunk://#diff-8cd8680ca3e0bfd8608cdaba0861d510089d5b48dc13d9f88ad609aa1763001cL59-R59) [[2]](diffhunk://#diff-8cd8680ca3e0bfd8608cdaba0861d510089d5b48dc13d9f88ad609aa1763001cL71-R71) [[3]](diffhunk://#diff-8cd8680ca3e0bfd8608cdaba0861d510089d5b48dc13d9f88ad609aa1763001cR158-R201)

Resolves https://github.com/microsoft/vscode/issues/329911