### PR TITLE
Show specific optional editors in the editor type picker

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -51,7 +51,7 @@ import { BreadcrumbsConfig, IBreadcrumbsService } from './breadcrumbs.js';
 import { BreadcrumbsModel, FileElement, OutlineElement2 } from './breadcrumbsModel.js';
 import { BreadcrumbsFilePicker, BreadcrumbsOutlinePicker } from './breadcrumbsPicker.js';
 import { IEditorGroupView } from './editor.js';
-import { createEditorTypeActions, editorTypeDisplayLabel, getAvailableEditorTypes, hasDefaultEditorAssociation } from './editorTypePicker.js';
+import { createEditorTypeActions, editorTypeDisplayLabel, getAvailableEditorTypes } from './editorTypePicker.js';
 import './media/breadcrumbscontrol.css';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
@@ -521,8 +521,7 @@ export class BreadcrumbsControl {
 		const previousWidth = this._editorTypeNode?.offsetWidth ?? 0;
 
 		const available = (this._options.showEditorTypePicker && this._cfShowEditorType.getValue()) ? getAvailableEditorTypes(this._editorGroup.activeEditor, this._editorResolverService) : undefined;
-		const configuredDefaultEditor = available ? this._editorResolverService.getConfiguredDefaultEditor(available.resource, available.isDiffEditor) : undefined;
-		if (!available || !hasDefaultEditorAssociation(available, configuredDefaultEditor)) {
+		if (!available) {
 			this._hideEditorTypeControl();
 		} else {
 			const { label: editorTypeLabel, hover: editorTypeHover } = this._createEditorTypeControl();

--- a/src/vs/workbench/browser/parts/editor/editorTypePicker.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTypePicker.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { DEFAULT_EDITOR_ASSOCIATION, EditorResourceAccessor, SideBySideEditor, isDiffEditorInput, isEditorInputWithDiffResources } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
-import { IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority, priorityToRank } from '../../../services/editor/common/editorResolverService.js';
+import { IEditorResolverService, RegisteredEditorInfo } from '../../../services/editor/common/editorResolverService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { REOPEN_ACTIVE_EDITOR_WITH_COMMAND_ID } from './editorCommands.js';
 
@@ -42,7 +42,12 @@ export function getAvailableEditorTypes(activeEditor: EditorInput | null | undef
 	if (!resource) {
 		return undefined;
 	}
-	const editors = editorResolverService.getEditors(resource);
+	const currentId = activeEditor?.editorId ?? DEFAULT_EDITOR_ASSOCIATION.id;
+	const editors = editorResolverService.getEditors(resource, {
+		excludeUnconfiguredUniversalOptionalEditors: true,
+		currentEditorId: currentId,
+		isDiffEditor: !!diffResources,
+	});
 	if (editors.length <= 1) {
 		return undefined;
 	}
@@ -51,25 +56,9 @@ export function getAvailableEditorTypes(activeEditor: EditorInput | null | undef
 		isDiffEditor: !!diffResources,
 		originalResource: diffResources?.original,
 		modifiedResource: diffResources?.modified,
-		currentId: activeEditor?.editorId ?? DEFAULT_EDITOR_ASSOCIATION.id,
+		currentId,
 		editors
 	};
-}
-
-/** Whether a custom editor can be selected by default for the resource. */
-export function hasDefaultEditorAssociation(available: IAvailableEditorTypes, configuredDefaultEditor: string | undefined): boolean {
-	if (configuredDefaultEditor !== undefined && configuredDefaultEditor !== DEFAULT_EDITOR_ASSOCIATION.id) {
-		return true;
-	}
-
-	return available.editors.some(editor => {
-		if (editor.id === DEFAULT_EDITOR_ASSOCIATION.id) {
-			return false;
-		}
-
-		const priority = available.isDiffEditor ? editor.priority.diff : editor.priority.editor;
-		return priorityToRank(priority) >= priorityToRank(RegisteredEditorPriority.builtin);
-	});
 }
 
 /**

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -25,7 +25,7 @@ import { SideBySideEditorInput } from '../../../common/editor/sideBySideEditorIn
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { findGroup } from '../common/editorGroupFinder.js';
 import { IEditorGroup, IEditorGroupsService } from '../common/editorGroupsService.js';
-import { diffEditorsAssociationsSettingId, EditorAssociation, EditorAssociations, EditorInputFactoryObject, editorsAssociationsSettingId, globMatchesResource, IEditorResolverService, priorityToRank, RegisteredEditorInfo, RegisteredEditorOptions, RegisteredEditorPriority, RegisteredEditorRegistrationInfo, ResolvedEditor, ResolvedStatus, toRegisteredEditorPriorityInfo } from '../common/editorResolverService.js';
+import { diffEditorsAssociationsSettingId, EditorAssociation, EditorAssociations, EditorInputFactoryObject, editorsAssociationsSettingId, globMatchesResource, IEditorResolverService, IEditorResolverServiceGetEditorsOptions, priorityToRank, RegisteredEditorInfo, RegisteredEditorOptions, RegisteredEditorPriority, RegisteredEditorRegistrationInfo, ResolvedEditor, ResolvedStatus, toRegisteredEditorPriorityInfo } from '../common/editorResolverService.js';
 import { PreferredGroup } from '../common/editorService.js';
 
 interface RegisteredEditor {
@@ -473,14 +473,26 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		});
 	}
 
-	public getEditors(resource?: URI): RegisteredEditorInfo[] {
+	public getEditors(resource?: URI, options?: IEditorResolverServiceGetEditorsOptions): RegisteredEditorInfo[] {
 		this._flattenedEditors = this._flattenEditorsMap();
 
 		// By resource
 		if (URI.isUri(resource)) {
-			const editors = this.findMatchingEditors(resource);
-			if (editors.find(e => e.editorInfo.priority.editor === RegisteredEditorPriority.exclusive)) {
+			const associationType = options?.isDiffEditor ? EditorAssociationType.DiffEditor : EditorAssociationType.Editor;
+			let editors = this.findMatchingEditors(resource, associationType);
+			if (editors.find(editor => this.getEffectivePriority(editor.editorInfo, associationType) === RegisteredEditorPriority.exclusive)) {
 				return [];
+			}
+			if (options?.excludeUnconfiguredUniversalOptionalEditors) {
+				const configuredEditorIds = new Set(this.getAssociationsForResourceByType(resource, associationType).map(association => association.viewType));
+				editors = editors.filter(editor => {
+					const priority = this.getEffectivePriority(editor.editorInfo, associationType);
+					return editor.globPattern !== '*'
+						|| priority !== RegisteredEditorPriority.option
+						|| editor.editorInfo.id === options.currentEditorId
+						|| configuredEditorIds.has(editor.editorInfo.id);
+				});
+				return distinct(editors.map(editor => editor.editorInfo), editor => editor.id);
 			}
 			return editors.map(editor => editor.editorInfo);
 		}

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -145,6 +145,15 @@ export type RegisteredEditorOptions = {
 	canSupportResource?: (resource: URI) => boolean;
 };
 
+export interface IEditorResolverServiceGetEditorsOptions {
+	/**
+	 * Excludes optional editors registered for `*`, unless they are configured or currently active.
+	 */
+	readonly excludeUnconfiguredUniversalOptionalEditors?: boolean;
+	readonly currentEditorId?: string;
+	readonly isDiffEditor?: boolean;
+}
+
 export type RegisteredEditorPriorityInfo = {
 	readonly editor: RegisteredEditorPriority;
 	readonly diff: RegisteredEditorPriority;
@@ -268,7 +277,7 @@ export interface IEditorResolverService {
 	 * @param resource The resource
 	 * @returns A list of editor ids
 	 */
-	getEditors(resource: URI): RegisteredEditorInfo[];
+	getEditors(resource: URI, options?: IEditorResolverServiceGetEditorsOptions): RegisteredEditorInfo[];
 
 	/**
 	 * A set of all the editors that are registered to the editor resolver.

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -12,7 +12,7 @@ import { EditorPart } from '../../../../browser/parts/editor/editorPart.js';
 import { DiffEditorInput } from '../../../../common/editor/diffEditorInput.js';
 import { EditorResolverService } from '../../browser/editorResolverService.js';
 import { IEditorGroupsService } from '../../common/editorGroupsService.js';
-import { diffEditorsAssociationsAgentsWindowDefault, IEditorResolverService, ResolvedStatus, RegisteredEditorPriority, diffEditorsAssociationsSettingId, editorsAssociationsSettingId } from '../../common/editorResolverService.js';
+import { diffEditorsAssociationsAgentsWindowDefault, EditorInputFactoryObject, IEditorResolverService, ResolvedStatus, RegisteredEditorPriority, diffEditorsAssociationsSettingId, editorsAssociationsSettingId } from '../../common/editorResolverService.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { createEditorPart, ITestInstantiationService, TestFileEditorInput, TestServiceAccessor, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 
@@ -747,6 +747,92 @@ suite('EditorResolverService', () => {
 		assert.strictEqual(eventCounter, 2);
 		assert.strictEqual(service.getEditors().length, editors.length);
 		assert.strictEqual(service.getEditors().some(editor => editor.id === 'TEST_EDITOR'), false);
+	});
+
+	test('getEditors excludes inactive universal optional editors when requested', async () => {
+		const [, service] = await createEditorResolverService();
+		const resource = URI.file('/workspace/index.html');
+		const factory: EditorInputFactoryObject = {
+			createEditorInput: ({ resource }) => ({ editor: new TestFileEditorInput(resource, TEST_EDITOR_INPUT_ID) })
+		};
+		disposables.add(service.registerEditor('*', {
+			id: 'test.universalOptional',
+			label: 'Universal Optional',
+			priority: RegisteredEditorPriority.option
+		}, {}, factory));
+		disposables.add(service.registerEditor('*.html', {
+			id: 'test.specificOptional',
+			label: 'Specific Optional',
+			priority: RegisteredEditorPriority.option
+		}, {}, factory));
+
+		const relevantIds = (currentEditorId?: string) => service.getEditors(resource, {
+			excludeUnconfiguredUniversalOptionalEditors: true,
+			currentEditorId
+		}).map(editor => editor.id).filter(id => id.startsWith('test.'));
+
+		assert.deepStrictEqual({
+			all: service.getEditors(resource).map(editor => editor.id).filter(id => id.startsWith('test.')),
+			filtered: relevantIds(),
+			currentUniversal: relevantIds('test.universalOptional'),
+			diff: service.getEditors(resource, {
+				excludeUnconfiguredUniversalOptionalEditors: true,
+				isDiffEditor: true
+			}).map(editor => editor.id).filter(id => id.startsWith('test.'))
+		}, {
+			all: ['test.specificOptional', 'test.universalOptional'],
+			filtered: ['test.specificOptional'],
+			currentUniversal: ['test.specificOptional', 'test.universalOptional'],
+			diff: []
+		});
+	});
+
+	test('getEditors uses the effective diff priority', async () => {
+		const [, service] = await createEditorResolverService();
+		const resource = URI.file('/workspace/index.html');
+		disposables.add(service.registerEditor('*.html', {
+			id: 'test.exclusiveDiff',
+			label: 'Exclusive Diff',
+			priority: {
+				editor: RegisteredEditorPriority.option,
+				diff: RegisteredEditorPriority.exclusive
+			}
+		}, {}, {
+			createEditorInput: ({ resource }) => ({ editor: new TestFileEditorInput(resource, TEST_EDITOR_INPUT_ID) }),
+			createDiffEditorInput: () => { throw new Error('Unexpected diff editor creation.'); }
+		}));
+
+		assert.deepStrictEqual({
+			editor: service.getEditors(resource).map(editor => editor.id).filter(id => id.startsWith('test.')),
+			diff: service.getEditors(resource, { isDiffEditor: true }).map(editor => editor.id).filter(id => id.startsWith('test.'))
+		}, {
+			editor: ['test.exclusiveDiff'],
+			diff: []
+		});
+	});
+
+	test('getEditors preserves configured universal optional editors', async () => {
+		const instantiationService = workbenchInstantiationService({
+			configurationService: () => new TestConfigurationService({
+				[editorsAssociationsSettingId]: {
+					'*.html': 'test.universalOptional'
+				}
+			})
+		}, disposables);
+		const [, service] = await createEditorResolverService(instantiationService);
+		const resource = URI.file('/workspace/index.html');
+		disposables.add(service.registerEditor('*', {
+			id: 'test.universalOptional',
+			label: 'Universal Optional',
+			priority: RegisteredEditorPriority.option
+		}, {}, {
+			createEditorInput: ({ resource }) => ({ editor: new TestFileEditorInput(resource, TEST_EDITOR_INPUT_ID) })
+		}));
+
+		assert.deepStrictEqual(
+			service.getEditors(resource, { excludeUnconfiguredUniversalOptionalEditors: true }).map(editor => editor.id).filter(id => id.startsWith('test.')),
+			['test.universalOptional']
+		);
 	});
 
 	test('Multiple registrations to same glob and id #155859', async () => {

--- a/src/vs/workbench/test/browser/parts/editor/editorTypePicker.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorTypePicker.test.ts
@@ -9,8 +9,8 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { DEFAULT_EDITOR_ASSOCIATION, IEditorInputWithDiffResources } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
-import { getAvailableEditorTypes, IAvailableEditorTypes, hasDefaultEditorAssociation } from '../../../../browser/parts/editor/editorTypePicker.js';
-import { IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
+import { getAvailableEditorTypes } from '../../../../browser/parts/editor/editorTypePicker.js';
+import { IEditorResolverService, IEditorResolverServiceGetEditorsOptions, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../../services/editor/common/editorResolverService.js';
 
 suite('Editor Type Picker', () => {
 
@@ -28,42 +28,6 @@ suite('Editor Type Picker', () => {
 		};
 	}
 
-	function available(customEditor: RegisteredEditorInfo, isDiffEditor = false): IAvailableEditorTypes {
-		return {
-			resource: URI.file('/test.txt'),
-			isDiffEditor,
-			currentId: DEFAULT_EDITOR_ASSOCIATION.id,
-			editors: [
-				editor(DEFAULT_EDITOR_ASSOCIATION.id, RegisteredEditorPriority.builtin),
-				customEditor,
-			]
-		};
-	}
-
-	test('default editor association visibility', () => {
-		const optionalEditor = available(editor('test.optionalEditor', RegisteredEditorPriority.option));
-		const defaultEditor = available(editor('test.defaultEditor', RegisteredEditorPriority.default));
-		const builtinEditor = available(editor('test.builtinEditor', RegisteredEditorPriority.builtin));
-		const diffDefaultEditor = available(editor('test.diffDefaultEditor', RegisteredEditorPriority.option, RegisteredEditorPriority.default), true);
-
-		assert.deepStrictEqual({
-			optionalEditor: hasDefaultEditorAssociation(optionalEditor, undefined),
-			configuredOptionalEditor: hasDefaultEditorAssociation(optionalEditor, 'test.optionalEditor'),
-			configuredTextEditor: hasDefaultEditorAssociation(optionalEditor, DEFAULT_EDITOR_ASSOCIATION.id),
-			defaultEditor: hasDefaultEditorAssociation(defaultEditor, undefined),
-			defaultEditorOverriddenWithText: hasDefaultEditorAssociation(defaultEditor, DEFAULT_EDITOR_ASSOCIATION.id),
-			builtinEditor: hasDefaultEditorAssociation(builtinEditor, undefined),
-			diffDefaultEditor: hasDefaultEditorAssociation(diffDefaultEditor, undefined),
-		}, {
-			optionalEditor: false,
-			configuredOptionalEditor: true,
-			configuredTextEditor: false,
-			defaultEditor: true,
-			defaultEditorOverriddenWithText: true,
-			builtinEditor: true,
-			diffDefaultEditor: true,
-		});
-	});
 	test('inline custom diff editor is classified as a diff editor', () => {
 		const original = URI.file('/original/test.md');
 		const modified = URI.file('/modified/test.md');
@@ -79,19 +43,26 @@ suite('Editor Type Picker', () => {
 			override getName(): string { return 'test'; }
 		}());
 		const requestedResources: URI[] = [];
+		const requestedOptions: (IEditorResolverServiceGetEditorsOptions | undefined)[] = [];
 		const editorResolverService = new class extends mock<IEditorResolverService>() {
-			override getEditors(resource?: URI): RegisteredEditorInfo[] {
+			override getEditors(resource?: URI, options?: IEditorResolverServiceGetEditorsOptions): RegisteredEditorInfo[] {
 				if (resource) {
 					requestedResources.push(resource);
 				}
+				requestedOptions.push(options);
 				return registeredEditors;
 			}
 		};
 
 		const result = getAvailableEditorTypes(input, editorResolverService);
 
-		assert.deepStrictEqual({ requestedResources, result }, {
+		assert.deepStrictEqual({ requestedResources, requestedOptions, result }, {
 			requestedResources: [modified],
+			requestedOptions: [{
+				excludeUnconfiguredUniversalOptionalEditors: true,
+				currentEditorId: 'test.markdownEditor',
+				isDiffEditor: true,
+			}],
 			result: {
 				resource: modified,
 				isDiffEditor: true,


### PR DESCRIPTION
## Summary
- show resource-specific optional editors in the breadcrumbs editor type picker
- exclude inactive, unconfigured optional editors registered for all resources while preserving configured and current editors
- query diff editor registrations so the picker only offers editors that can open the diff

## Testing
- editor resolver and editor type picker unit tests (20 passed)
- pre-commit hygiene