### PR TITLE
agentHost: perf: stop re-deriving worktree roots on every listing

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -93,41 +93,81 @@ export interface IPullOptions {
 export const IAgentHostGitService = createDecorator<IAgentHostGitService>('agentHostGitService');
 
 /**
- * How long an unresolvable checkout is remembered before Git is asked again.
- * Bounded rather than permanent: the Agent Host is a long-lived utility process
- * shared by every window, so a checkout that failed because a volume was still
- * mounting must recover without the user restarting the application.
+ * Per-pass state for repairing many checkouts at once: what Git has already
+ * answered, what it could not answer, and how much longer the pass may spend
+ * asking.
+ *
+ * All of it is scoped to the pass rather than kept in the resolver, because
+ * none of it is durable knowledge. Git reports "this is not a worktree" and
+ * "Git could not run just now" identically, so remembering a failure would
+ * freeze a wrong repository root for every window until the Agent Host process
+ * restarts. A success is only true until the filesystem moves underneath it,
+ * and a listing now *certifies* what it resolves — so a mapping that outlived
+ * the pass that observed it could get a stale root stamped as canonical.
  */
-const UNRESOLVABLE_CHECKOUT_TTL_MS = 60_000;
+export class PrimaryWorktreeResolutionPass {
+	private _deadline: number | undefined;
+	private readonly _roots = new Map<string, URI>();
+	private readonly _unresolvable = new Set<string>();
+
+	/** Omit `_budgetMs` for a pass that may take as long as it needs. */
+	constructor(private readonly _budgetMs?: number) { }
+
+	/**
+	 * Whether the pass has spent its budget. The clock starts at the first call
+	 * rather than at construction, so enumerating sessions and reading their
+	 * metadata cannot consume time meant for Git. The first probe is therefore
+	 * always allowed, which guarantees a pass makes progress however tight the
+	 * budget is.
+	 */
+	isExpired(): boolean {
+		if (this._budgetMs === undefined) {
+			return false;
+		}
+		if (this._deadline === undefined) {
+			this._deadline = Date.now() + this._budgetMs;
+			return false;
+		}
+		return Date.now() > this._deadline;
+	}
+
+	getRoot(key: string): URI | undefined {
+		return this._roots.get(key);
+	}
+
+	setRoot(key: string, primaryRoot: URI): void {
+		this._roots.set(key, primaryRoot);
+	}
+
+	isUnresolvable(key: string): boolean {
+		return this._unresolvable.has(key);
+	}
+
+	markUnresolvable(key: string): void {
+		this._unresolvable.add(key);
+	}
+}
 
 /**
- * Resolves linked checkouts to their primary worktree and caches successful mappings for every worktree reported by Git.
+ * Resolves linked checkouts to their primary worktree, sharing one Git listing across every worktree it reports.
  *
- * One `git worktree list` teaches the resolver a whole repository's membership,
- * so a session catalogue collapses to roughly one Git launch per repository.
- * That only holds if the recorded siblings survive and match later lookups:
+ * One `git worktree list` teaches a pass a whole repository's membership, so a
+ * session catalogue collapses to roughly one Git launch per repository. That
+ * only holds if the recorded siblings match later lookups, so keys are
+ * canonical paths: Git reports resolved paths while a session persists the path
+ * it was created with, and `/tmp/x` and `/private/tmp/x` would otherwise be
+ * different keys for one worktree — every lookup a miss.
  *
- * - The map is deliberately unbounded. Its entries *are* the membership Git
- *   reported, so evicting any of them re-creates the storm this cache exists to
- *   prevent; a bound only decides how many worktrees it takes to hit it. Entries
- *   are two short strings and are limited by the checkouts that actually exist
- *   on disk.
- * - Keys are canonical paths. Git reports resolved paths, while a session
- *   persists the path it was created with, so `/tmp/x` and `/private/tmp/x`
- *   would otherwise be different keys for one worktree — every lookup a miss.
- * - Launches stay serialized, because that is what lets the first checkout of a
- *   repository answer every later one instead of each racing its own Git. Only
- *   lookups that actually need Git reach the queue; anything the cache can
- *   already answer returns without joining it.
+ * Launches stay serialized, because that is what lets the first checkout of a
+ * repository answer every later one instead of each racing its own Git. Only
+ * lookups the pass cannot already answer reach the queue.
  */
 class PrimaryWorktreeRootResolver {
-	private readonly _roots = new Map<string, URI>();
-	private readonly _unresolvable = new Map<string, number>();
 	private readonly _sequencer = new Sequencer();
 
 	constructor(private readonly _gitService: IAgentHostGitService) { }
 
-	async resolve(checkoutRoot: URI): Promise<URI | undefined> {
+	async resolve(checkoutRoot: URI, pass: PrimaryWorktreeResolutionPass): Promise<URI | undefined> {
 		// Also acts as an existence check: a path that is gone cannot be
 		// canonicalized, and Git could only be launched to fail on it.
 		const canonical = await this._canonicalize(checkoutRoot);
@@ -135,37 +175,47 @@ class PrimaryWorktreeRootResolver {
 			return undefined;
 		}
 		const key = canonical.toString();
-		const cached = this._roots.get(key);
-		if (cached) {
-			return cached;
+		const known = pass.getRoot(key);
+		if (known) {
+			return known;
 		}
-		if (this._isKnownUnresolvable(key)) {
+		if (pass.isUnresolvable(key)) {
 			return undefined;
 		}
 		return this._sequencer.queue(async () => {
 			// Re-check: a concurrent probe of a sibling checkout may have
 			// recorded this repository's membership while this one queued.
-			const cached = this._roots.get(key);
-			if (cached) {
-				return cached;
+			const known = pass.getRoot(key);
+			if (known) {
+				return known;
 			}
-			if (this._isKnownUnresolvable(key)) {
+			if (pass.isUnresolvable(key)) {
+				return undefined;
+			}
+			// Checked here rather than before queueing: callers arrive
+			// together, so they would all pass a check taken on arrival and
+			// then queue anyway, capping nothing. Anything the pass can
+			// already answer is served above regardless, because it costs
+			// nothing.
+			if (pass.isExpired()) {
 				return undefined;
 			}
 			const roots = await this._gitService.getWorktreeRoots(canonical);
 			const primaryRoot = roots[0];
 			if (!primaryRoot) {
-				this._unresolvable.set(key, Date.now());
+				pass.markUnresolvable(key);
 				return undefined;
 			}
-			this._roots.set(key, primaryRoot);
-			for (const root of roots) {
-				this._roots.set(root.toString(), primaryRoot);
+			pass.setRoot(key, primaryRoot);
+			await Promise.all(roots.map(async root => {
+				pass.setRoot(root.toString(), primaryRoot);
+				// Git usually reports resolved paths already, but Windows only
+				// settles on-disk casing through a real lookup.
 				const canonicalRoot = await this._canonicalize(root);
 				if (canonicalRoot) {
-					this._roots.set(canonicalRoot.toString(), primaryRoot);
+					pass.setRoot(canonicalRoot.toString(), primaryRoot);
 				}
-			}
+			}));
 			return primaryRoot;
 		});
 	}
@@ -181,31 +231,26 @@ class PrimaryWorktreeRootResolver {
 			return undefined;
 		}
 	}
-
-	private _isKnownUnresolvable(key: string): boolean {
-		const failedAt = this._unresolvable.get(key);
-		if (failedAt === undefined) {
-			return false;
-		}
-		if (Date.now() - failedAt < UNRESOLVABLE_CHECKOUT_TTL_MS) {
-			return true;
-		}
-		this._unresolvable.delete(key);
-		return false;
-	}
 }
 
 /** Resolver lifetime follows the injected Git service; each resolver owns a bounded path cache. */
 const primaryWorktreeRootResolvers = new WeakMap<IAgentHostGitService, PrimaryWorktreeRootResolver>();
 
-/** Resolves the primary worktree root when Git reports a worktree listing. */
-export function tryResolvePrimaryWorktreeRoot(gitService: IAgentHostGitService, checkoutRoot: URI): Promise<URI | undefined> {
+/**
+ * Resolves the primary worktree root when Git reports a worktree listing.
+ *
+ * `pass` shares one Git listing across a batch of checkouts and bounds what the
+ * batch may spend. Omit it for a one-off resolution, which then answers from a
+ * throwaway pass — so a background repair budget can never starve a foreground
+ * resolution, and no state outlives the call.
+ */
+export function tryResolvePrimaryWorktreeRoot(gitService: IAgentHostGitService, checkoutRoot: URI, pass?: PrimaryWorktreeResolutionPass): Promise<URI | undefined> {
 	let resolver = primaryWorktreeRootResolvers.get(gitService);
 	if (!resolver) {
 		resolver = new PrimaryWorktreeRootResolver(gitService);
 		primaryWorktreeRootResolvers.set(gitService, resolver);
 	}
-	return resolver.resolve(checkoutRoot);
+	return resolver.resolve(checkoutRoot, pass ?? new PrimaryWorktreeResolutionPass());
 }
 
 export interface IRefQuery {

--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -5,7 +5,6 @@
 
 import { Sequencer } from '../../../base/common/async.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
-import { LRUCache } from '../../../base/common/map.js';
 import { URI } from '../../../base/common/uri.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ISessionFileDiff, ISessionGitState } from './state/sessionState.js';
@@ -94,37 +93,105 @@ export interface IPullOptions {
 export const IAgentHostGitService = createDecorator<IAgentHostGitService>('agentHostGitService');
 
 /**
+ * How long an unresolvable checkout is remembered before Git is asked again.
+ * Bounded rather than permanent: the Agent Host is a long-lived utility process
+ * shared by every window, so a checkout that failed because a volume was still
+ * mounting must recover without the user restarting the application.
+ */
+const UNRESOLVABLE_CHECKOUT_TTL_MS = 60_000;
+
+/**
  * Resolves linked checkouts to their primary worktree and caches successful mappings for every worktree reported by Git.
- * Resolution is serialized so concurrent requests across linked checkouts share one probe, while empty results remain retryable.
+ *
+ * One `git worktree list` teaches the resolver a whole repository's membership,
+ * so a session catalogue collapses to roughly one Git launch per repository.
+ * That only holds if the recorded siblings survive and match later lookups:
+ *
+ * - The map is deliberately unbounded. Its entries *are* the membership Git
+ *   reported, so evicting any of them re-creates the storm this cache exists to
+ *   prevent; a bound only decides how many worktrees it takes to hit it. Entries
+ *   are two short strings and are limited by the checkouts that actually exist
+ *   on disk.
+ * - Keys are canonical paths. Git reports resolved paths, while a session
+ *   persists the path it was created with, so `/tmp/x` and `/private/tmp/x`
+ *   would otherwise be different keys for one worktree — every lookup a miss.
+ * - Launches stay serialized, because that is what lets the first checkout of a
+ *   repository answer every later one instead of each racing its own Git. Only
+ *   lookups that actually need Git reach the queue; anything the cache can
+ *   already answer returns without joining it.
  */
 class PrimaryWorktreeRootResolver {
-	private readonly _roots = new LRUCache<string, URI>(100);
+	private readonly _roots = new Map<string, URI>();
+	private readonly _unresolvable = new Map<string, number>();
 	private readonly _sequencer = new Sequencer();
 
 	constructor(private readonly _gitService: IAgentHostGitService) { }
 
 	async resolve(checkoutRoot: URI): Promise<URI | undefined> {
-		const key = checkoutRoot.toString();
+		// Also acts as an existence check: a path that is gone cannot be
+		// canonicalized, and Git could only be launched to fail on it.
+		const canonical = await this._canonicalize(checkoutRoot);
+		if (!canonical) {
+			return undefined;
+		}
+		const key = canonical.toString();
 		const cached = this._roots.get(key);
 		if (cached) {
 			return cached;
 		}
+		if (this._isKnownUnresolvable(key)) {
+			return undefined;
+		}
 		return this._sequencer.queue(async () => {
+			// Re-check: a concurrent probe of a sibling checkout may have
+			// recorded this repository's membership while this one queued.
 			const cached = this._roots.get(key);
 			if (cached) {
 				return cached;
 			}
-			const roots = await this._gitService.getWorktreeRoots(checkoutRoot);
+			if (this._isKnownUnresolvable(key)) {
+				return undefined;
+			}
+			const roots = await this._gitService.getWorktreeRoots(canonical);
 			const primaryRoot = roots[0];
 			if (!primaryRoot) {
+				this._unresolvable.set(key, Date.now());
 				return undefined;
 			}
 			this._roots.set(key, primaryRoot);
 			for (const root of roots) {
 				this._roots.set(root.toString(), primaryRoot);
+				const canonicalRoot = await this._canonicalize(root);
+				if (canonicalRoot) {
+					this._roots.set(canonicalRoot.toString(), primaryRoot);
+				}
 			}
 			return primaryRoot;
 		});
+	}
+
+	private async _canonicalize(path: URI): Promise<URI | undefined> {
+		const canonicalize = this._gitService.canonicalizeExistingPath;
+		if (!canonicalize) {
+			return path;
+		}
+		try {
+			return await canonicalize.call(this._gitService, path);
+		} catch {
+			return undefined;
+		}
+	}
+
+	private _isKnownUnresolvable(key: string): boolean {
+		const failedAt = this._unresolvable.get(key);
+		if (failedAt === undefined) {
+			return false;
+		}
+		if (Date.now() - failedAt < UNRESOLVABLE_CHECKOUT_TTL_MS) {
+			return true;
+		}
+		this._unresolvable.delete(key);
+		return false;
 	}
 }
 
@@ -208,6 +275,15 @@ export interface IAgentHostGitService {
 	getRepositoryRoot(workingDirectory: URI): Promise<URI | undefined>;
 	/** Returns worktree roots in Git's porcelain order, with the primary worktree first. */
 	getWorktreeRoots(workingDirectory: URI): Promise<URI[]>;
+	/**
+	 * Resolves `path` to its canonical on-disk spelling, or `undefined` when it
+	 * does not exist. Used to key caches so that the several spellings of one
+	 * directory — symlinked prefixes such as `/tmp` vs `/private/tmp`, or
+	 * Windows casing — do not read as different locations. Optional:
+	 * implementations without filesystem access omit it and are keyed by the
+	 * path as given.
+	 */
+	canonicalizeExistingPath?(path: URI): Promise<URI | undefined>;
 	/**
 	 * Creates a worktree for a new branch. `onProgress` receives every checkout
 	 * sample git reports, which can be several per second, so consumers are

--- a/src/vs/platform/agentHost/common/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitService.ts
@@ -228,7 +228,9 @@ class PrimaryWorktreeRootResolver {
 		try {
 			return await canonicalize.call(this._gitService, path);
 		} catch {
-			return undefined;
+			// A thrown error is not an answer either, so it must not read as
+			// absence: fall back to the path as given and let Git decide.
+			return path;
 		}
 	}
 }
@@ -321,12 +323,17 @@ export interface IAgentHostGitService {
 	/** Returns worktree roots in Git's porcelain order, with the primary worktree first. */
 	getWorktreeRoots(workingDirectory: URI): Promise<URI[]>;
 	/**
-	 * Resolves `path` to its canonical on-disk spelling, or `undefined` when it
-	 * does not exist. Used to key caches so that the several spellings of one
-	 * directory — symlinked prefixes such as `/tmp` vs `/private/tmp`, or
-	 * Windows casing — do not read as different locations. Optional:
-	 * implementations without filesystem access omit it and are keyed by the
-	 * path as given.
+	 * Resolves `path` to its canonical on-disk spelling. Used to key caches so
+	 * that the several spellings of one directory — symlinked prefixes such as
+	 * `/tmp` vs `/private/tmp`, or Windows casing — do not read as different
+	 * locations.
+	 *
+	 * Returns `undefined` only when the path is genuinely absent, because that
+	 * is the one answer letting a caller skip Git entirely. When the filesystem
+	 * cannot answer — an unreadable parent, a symlink loop, a volume briefly
+	 * away — it returns the path unchanged, so the caller still asks Git rather
+	 * than mistaking silence for absence. Optional: implementations without
+	 * filesystem access omit it and are keyed by the path as given.
 	 */
 	canonicalizeExistingPath?(path: URI): Promise<URI | undefined>;
 	/**

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -139,9 +139,14 @@ export class AgentHostGitService implements IAgentHostGitService {
 	async canonicalizeExistingPath(path: URI): Promise<URI | undefined> {
 		try {
 			return URI.file(await fsPromises.realpath(path.fsPath));
-		} catch {
-			// Missing, unreadable, or a broken link: no canonical spelling exists.
-			return undefined;
+		} catch (error) {
+			// Only absence is an answer. An unreadable parent, a symlink loop or
+			// a volume that is briefly away all mean the question went
+			// unanswered, and reporting those as absence would silently skip
+			// Git for a checkout that is really there. Fall back to the path as
+			// given and let Git be the one to fail.
+			const code = (error as NodeJS.ErrnoException).code;
+			return code === 'ENOENT' || code === 'ENOTDIR' ? undefined : path;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -136,6 +136,15 @@ export class AgentHostGitService implements IAgentHostGitService {
 			.map(line => URI.file(line.substring('worktree '.length)));
 	}
 
+	async canonicalizeExistingPath(path: URI): Promise<URI | undefined> {
+		try {
+			return URI.file(await fsPromises.realpath(path.fsPath));
+		} catch {
+			// Missing, unreadable, or a broken link: no canonical spelling exists.
+			return undefined;
+		}
+	}
+
 	async addWorktree(repositoryRoot: URI, worktree: URI, branchName: string, startPoint: string, track = false, onProgress?: (progress: IWorktreeFileProgress) => void): Promise<void> {
 		const resolvedStartPoint = await this._resolveRemoteTrackingBranch(repositoryRoot, startPoint) ?? startPoint;
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -44,7 +44,7 @@ import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHost
 import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
-import { IAgentHostGitService, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
+import { IAgentHostGitService, PrimaryWorktreeResolutionPass, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
@@ -152,12 +152,14 @@ function omitHostOwnedSessionConfig<T>(config: Record<string, T>): Record<string
 const RESOURCE_WATCH_GRACE_MS = 30_000;
 
 /**
- * Time one {@link AgentService.listSessions} call may spend repairing repository
- * roots persisted by builds that predate worktree-identity canonicalization.
- * Repair is stamped and therefore one-shot per session, but a first listing over
- * a catalogue spanning many repositories still has to launch Git once per
- * repository. The budget keeps that bounded; sessions past it keep their
- * persisted root, stay unstamped, and are repaired by a later listing.
+ * Wall-clock time one {@link AgentService.listSessions} call may spend launching
+ * Git to repair repository roots persisted by builds that predate
+ * worktree-identity canonicalization. Repair is stamped and therefore one-shot
+ * per session, but a first listing over a catalogue spanning many repositories
+ * still has to launch Git once per repository. Sessions reached after the budget
+ * keep their persisted root, stay unstamped, and are repaired by a later
+ * listing. The budget gates *starting* a launch, so one already in flight can
+ * still run to `_runGit`'s timeout.
  */
 const LISTED_WORKTREE_ROOT_MIGRATION_BUDGET_MS = 2_000;
 
@@ -947,17 +949,10 @@ export class AgentService extends Disposable implements IAgentService {
 	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
 	 *
 	 * A repaired root is stamped, so this costs one resolution per session ever
-	 * rather than one per listing. Persistence is deliberately not awaited: the
-	 * value returned to the client is already correct, and a lost write only
-	 * means the next listing re-derives it.
+	 * rather than one per listing.
 	 */
-	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string, stamp: string | undefined, deadline: number): Promise<string> {
+	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string, stamp: string | undefined, pass: PrimaryWorktreeResolutionPass): Promise<string> {
 		if (isRepositoryRootStamped(stamp, repositoryRootRaw)) {
-			return repositoryRootRaw;
-		}
-		// Migrating the rest of the catalogue must not hold up the listing. What
-		// is left stays unstamped and is picked up by a later listing.
-		if (Date.now() > deadline) {
 			return repositoryRootRaw;
 		}
 		const persistedRoot = URI.parse(repositoryRootRaw);
@@ -965,8 +960,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
 		let primaryRoot: URI | undefined;
 		try {
-			primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
-				?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
+			primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot, pass)
+				?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot, pass) : undefined);
 		} catch (error) {
 			this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
 		}
@@ -984,21 +979,24 @@ export class AgentService extends Disposable implements IAgentService {
 		if (nextStamp) {
 			writes.push(database.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp));
 		}
-		if (writes.length) {
-			Promise.all(writes).catch(error => {
-				this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
-			});
+		try {
+			// Awaited on purpose. The caller disposes its database reference as
+			// soon as this returns, and disposing the last one closes the
+			// database, so a write merely started here is rejected and lost --
+			// taking the stamp, and the repair itself, with it.
+			await Promise.all(writes);
+		} catch (error) {
+			this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
 		}
 		return normalized;
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
-		// Caps what one listing spends repairing legacy repository roots. Work
-		// left over stays unstamped and is resumed by the next listing, so a
-		// catalogue spanning unusually many repositories still converges
-		// without ever blocking the window on it.
-		const migrationDeadline = Date.now() + LISTED_WORKTREE_ROOT_MIGRATION_BUDGET_MS;
+		// Shared by every session in this listing, so one Git listing answers a
+		// whole repository, and bounds what the listing spends doing it. Work
+		// left over stays unstamped and is resumed by the next listing.
+		const migrationPass = new PrimaryWorktreeResolutionPass(LISTED_WORKTREE_ROOT_MIGRATION_BUDGET_MS);
 		const results = await Promise.all(
 			[...this._providers.values()].map(p => p.listSessions())
 		);
@@ -1072,7 +1070,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 					let repositoryRootRaw = m[WORKTREE_META_REPOSITORY_ROOT];
 					if (repositoryRootRaw) {
-						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw, m[WORKTREE_META_REPOSITORY_ROOT_STAMP], migrationDeadline);
+						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw, m[WORKTREE_META_REPOSITORY_ROOT_STAMP], migrationPass);
 					}
 					const worktreeProject = worktreeProjectFromRepositoryRoot(repositoryRootRaw);
 					if (worktreeProject) {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -972,12 +972,18 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		const normalized = primaryRoot.toString();
 		const nextStamp = buildRepositoryRootStamp(primaryRoot);
-		const writes: Promise<void>[] = [];
+		if (!nextStamp) {
+			// Git answered, but with something no listing should freeze — a git
+			// directory rather than a working tree. Persisting it without a
+			// stamp would overwrite the session's root with a value every later
+			// listing has to re-derive, so leave the stored one alone.
+			return repositoryRootRaw;
+		}
+		const writes: Promise<void>[] = [
+			database.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp),
+		];
 		if (normalized !== repositoryRootRaw) {
 			writes.push(database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, normalized));
-		}
-		if (nextStamp) {
-			writes.push(database.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp));
 		}
 		try {
 			// Awaited on purpose. The caller disposes its database reference as

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -9,7 +9,7 @@ import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { LRUCache, ResourceMap } from '../../../base/common/map.js';
+import { ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
 import { IObservable, observableValue } from '../../../base/common/observable.js';
@@ -51,7 +51,7 @@ import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
 import { type IChatContextSnapshot, type ISessionCreationDefaults, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 
-import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
+import { buildRepositoryRootStamp, buildWorktreeFailureNotification, isRepositoryRootStamped, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService } from '../common/agentHostCheckpointService.js';
@@ -150,6 +150,16 @@ function omitHostOwnedSessionConfig<T>(config: Record<string, T>): Record<string
  * envelope replay buffer for the same reason.
  */
 const RESOURCE_WATCH_GRACE_MS = 30_000;
+
+/**
+ * Time one {@link AgentService.listSessions} call may spend repairing repository
+ * roots persisted by builds that predate worktree-identity canonicalization.
+ * Repair is stamped and therefore one-shot per session, but a first listing over
+ * a catalogue spanning many repositories still has to launch Git once per
+ * repository. The budget keeps that bounded; sessions past it keep their
+ * persisted root, stay unstamped, and are repaired by a later listing.
+ */
+const LISTED_WORKTREE_ROOT_MIGRATION_BUDGET_MS = 2_000;
 
 /** Bound on how long {@link AgentService.subscribe} waits for a pending subagent chat to register before giving up. */
 const SUBAGENT_CHAT_PENDING_TIMEOUT_MS = 15_000;
@@ -330,8 +340,6 @@ export class AgentService extends Disposable implements IAgentService {
 	 * agents stay unaware of the folder-vs-worktree distinction.
 	 */
 	private _worktree: WorktreeIsolation | undefined;
-	/** Successful list-time repository-root resolutions; eviction only causes safe re-resolution. */
-	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(100);
 	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
 	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */
@@ -937,40 +945,60 @@ export class AgentService extends Disposable implements IAgentService {
 	/**
 	 * Repairs repository roots written by older builds that treated a parent linked checkout as the repository.
 	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
+	 *
+	 * A repaired root is stamped, so this costs one resolution per session ever
+	 * rather than one per listing. Persistence is deliberately not awaited: the
+	 * value returned to the client is already correct, and a lost write only
+	 * means the next listing re-derives it.
 	 */
-	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string): Promise<string> {
-		const storedRepositoryRootRaw = repositoryRootRaw;
+	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string, stamp: string | undefined, deadline: number): Promise<string> {
+		if (isRepositoryRootStamped(stamp, repositoryRootRaw)) {
+			return repositoryRootRaw;
+		}
+		// Migrating the rest of the catalogue must not hold up the listing. What
+		// is left stays unstamped and is picked up by a later listing.
+		if (Date.now() > deadline) {
+			return repositoryRootRaw;
+		}
 		const persistedRoot = URI.parse(repositoryRootRaw);
-		const sessionStr = session.session.toString();
-		let primaryRoot = this._normalizedWorktreeRepositoryRoots.get(sessionStr);
+		const workingDirectory = session.workingDirectories?.[0];
+		const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
+		let primaryRoot: URI | undefined;
+		try {
+			primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
+				?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
+		} catch (error) {
+			this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
+		}
 		if (!primaryRoot) {
-			const workingDirectory = session.workingDirectories?.[0];
-			const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
-			try {
-				primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
-					?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
-				if (primaryRoot) {
-					this._normalizedWorktreeRepositoryRoots.set(sessionStr, primaryRoot);
-				}
-			} catch (error) {
-				this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
-			}
+			// Leave the root unstamped so a later listing can still repair it,
+			// rather than freezing a value this run could not confirm.
+			return repositoryRootRaw;
 		}
-		if (primaryRoot) {
-			repositoryRootRaw = primaryRoot.toString();
+		const normalized = primaryRoot.toString();
+		const nextStamp = buildRepositoryRootStamp(primaryRoot);
+		const writes: Promise<void>[] = [];
+		if (normalized !== repositoryRootRaw) {
+			writes.push(database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, normalized));
 		}
-		if (repositoryRootRaw !== storedRepositoryRootRaw) {
-			try {
-				await database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, repositoryRootRaw);
-			} catch (error) {
+		if (nextStamp) {
+			writes.push(database.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp));
+		}
+		if (writes.length) {
+			Promise.all(writes).catch(error => {
 				this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
-			}
+			});
 		}
-		return repositoryRootRaw;
+		return normalized;
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
+		// Caps what one listing spends repairing legacy repository roots. Work
+		// left over stays unstamped and is resumed by the next listing, so a
+		// catalogue spanning unusually many repositories still converges
+		// without ever blocking the window on it.
+		const migrationDeadline = Date.now() + LISTED_WORKTREE_ROOT_MIGRATION_BUDGET_MS;
 		const results = await Promise.all(
 			[...this._providers.values()].map(p => p.listSessions())
 		);
@@ -994,8 +1022,8 @@ export class AgentService extends Disposable implements IAgentService {
 					const sessionStr = s.session.toString();
 					const changesetKeys = this._changesetCoordinator.getListMetadataKeys(sessionStr);
 					const metadataKeys: Record<string, true> = changesetKeys
-						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
-						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS };
+						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, [WORKTREE_META_REPOSITORY_ROOT_STAMP]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
+						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [PEER_CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, [WORKTREE_META_REPOSITORY_ROOT_STAMP]: true, ...GIT_DB_METADATA_KEYS };
 					const m = await ref.object.getMetadataObject(metadataKeys);
 					// This session is an internal peer-chat backing (e.g. a
 					// Claude peer chat's SDK session, enumerated by the agent's
@@ -1044,7 +1072,7 @@ export class AgentService extends Disposable implements IAgentService {
 
 					let repositoryRootRaw = m[WORKTREE_META_REPOSITORY_ROOT];
 					if (repositoryRootRaw) {
-						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw);
+						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw, m[WORKTREE_META_REPOSITORY_ROOT_STAMP], migrationDeadline);
 					}
 					const worktreeProject = worktreeProjectFromRepositoryRoot(repositoryRootRaw);
 					if (worktreeProject) {

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -36,6 +36,37 @@ import { ICopilotApiService } from './copilotApiService.js';
 const WORKTREE_META_BRANCH = 'copilot.worktree.branchName';
 const WORKTREE_META_PATH = 'copilot.worktree.path';
 export const WORKTREE_META_REPOSITORY_ROOT = 'copilot.worktree.repositoryRoot';
+/**
+ * Records that {@link WORKTREE_META_REPOSITORY_ROOT} was derived from Git's own
+ * worktree listing, so listing can trust it without launching Git again. Older
+ * builds stored a parent linked checkout there and an unstamped root is
+ * indistinguishable from one of those, so it has to be re-derived once.
+ *
+ * The stamp carries the version of the resolution that produced it *and* the
+ * exact root it certifies, which keeps it honest in both directions: rewriting
+ * the root through any other path invalidates the stamp automatically, and
+ * raising {@link WORKTREE_REPOSITORY_ROOT_STAMP_VERSION} re-migrates roots that
+ * an improved resolution would now answer differently.
+ */
+export const WORKTREE_META_REPOSITORY_ROOT_STAMP = 'copilot.worktree.repositoryRootStamp';
+const WORKTREE_REPOSITORY_ROOT_STAMP_VERSION = '1';
+
+/** Builds the stamp certifying `repositoryRoot`, or `undefined` when it must not be certified. */
+export function buildRepositoryRootStamp(repositoryRoot: URI): string | undefined {
+	// Git answers a submodule or `--separate-git-dir` checkout with its git
+	// directory rather than a working tree. Grouping under that is wrong today
+	// too, but it self-heals on the next listing; certifying it would freeze it.
+	if (repositoryRoot.path.split('/').includes('.git')) {
+		return undefined;
+	}
+	return `${WORKTREE_REPOSITORY_ROOT_STAMP_VERSION}:${repositoryRoot.toString()}`;
+}
+
+/** Whether `stamp` certifies `repositoryRootRaw` as already canonical. */
+export function isRepositoryRootStamped(stamp: string | undefined, repositoryRootRaw: string): boolean {
+	return !!stamp && stamp === `${WORKTREE_REPOSITORY_ROOT_STAMP_VERSION}:${repositoryRootRaw}`;
+}
+
 const WORKTREE_META_CREATION_FAILURE = 'copilot.worktree.creationFailure';
 const MAX_WORKTREE_FAILURE_DIAGNOSTIC_LENGTH = 200;
 
@@ -570,7 +601,7 @@ export class WorktreeIsolation extends Disposable {
 			return workingDirectory;
 		}
 
-		const repositoryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
+		const { root: repositoryRoot, resolved: repositoryRootResolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
 		const worktreesRoot = getWorktreesRoot(repositoryRoot);
 		// Prefix (e.g. the user's `git.branchPrefix`) the client forwards for
 		// worktree-isolated sessions. Prepended ahead of the built-in `agents/`
@@ -626,7 +657,7 @@ export class WorktreeIsolation extends Disposable {
 		// subsequent restore (history) both surface the message in the chat.
 		this._pendingFirstTurnAnnouncements.set(sessionId, buildWorktreeAnnouncementText(branchName));
 		try {
-			await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktree, repositoryRoot });
+			await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktree, repositoryRoot, repositoryRootResolved });
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}:${sessionId}] Failed to persist worktree branch metadata: ${errorMessage(error)}`);
 		}
@@ -896,7 +927,7 @@ export class WorktreeIsolation extends Disposable {
 		}
 		const branchName = await this._gitService.getCurrentBranch(worktreeRoot).catch(() => undefined) ?? 'HEAD';
 		const baseBranch = (await this._gitService.getDefaultBranch(primaryRoot).catch(() => undefined))?.name;
-		await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktreeRoot, repositoryRoot: primaryRoot });
+		await this._writeWorktreeMetadata(sessionUri, { branchName, baseBranch, worktreePath: worktreeRoot, repositoryRoot: primaryRoot, repositoryRootResolved: true });
 		return true;
 	}
 
@@ -917,12 +948,19 @@ export class WorktreeIsolation extends Disposable {
 		return meta?.repositoryRoot ? projectFromRepositoryRoot(meta.repositoryRoot) : undefined;
 	}
 
-	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<URI> {
+	/**
+	 * Resolves the primary worktree owning `checkoutRoot`, reporting whether Git
+	 * actually answered. Callers must not persist a stamp for a fallback: it is
+	 * the raw checkout root, which is exactly the value this canonicalization
+	 * exists to replace.
+	 */
+	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<{ readonly root: URI; readonly resolved: boolean }> {
 		try {
-			return await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot) ?? fallbackRoot;
+			const resolved = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot);
+			return resolved ? { root: resolved, resolved: true } : { root: fallbackRoot, resolved: false };
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}] Failed to resolve primary worktree for '${checkoutRoot.fsPath}': ${errorMessage(error)}`);
-			return fallbackRoot;
+			return { root: fallbackRoot, resolved: false };
 		}
 	}
 
@@ -963,7 +1001,7 @@ export class WorktreeIsolation extends Disposable {
 			: selectedBranch;
 	}
 
-	private async _writeWorktreeMetadata(sessionUri: URI, metadata: { branchName: string; baseBranch: string | undefined; worktreePath: URI; repositoryRoot: URI }): Promise<void> {
+	private async _writeWorktreeMetadata(sessionUri: URI, metadata: { branchName: string; baseBranch: string | undefined; worktreePath: URI; repositoryRoot: URI; repositoryRootResolved: boolean }): Promise<void> {
 		const dbRef = this._sessionDataService.openDatabase(sessionUri);
 		try {
 			const work: Promise<void>[] = [
@@ -971,6 +1009,13 @@ export class WorktreeIsolation extends Disposable {
 				dbRef.object.setMetadata(WORKTREE_META_PATH, metadata.worktreePath.toString()),
 				dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, metadata.repositoryRoot.toString()),
 			];
+			// Certify only a root Git actually answered for, so listing never
+			// re-derives it. A fallback is the raw checkout root, which is the
+			// value the migration exists to replace, and must stay repairable.
+			const stamp = metadata.repositoryRootResolved ? buildRepositoryRootStamp(metadata.repositoryRoot) : undefined;
+			if (stamp) {
+				work.push(dbRef.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, stamp));
+			}
 			if (metadata.baseBranch) {
 				work.push(dbRef.object.setMetadata(META_DIFF_BASE_BRANCH, metadata.baseBranch));
 			}
@@ -983,6 +1028,7 @@ export class WorktreeIsolation extends Disposable {
 	/**
 	 * Reads worktree metadata and migrates repository roots written before linked checkouts were canonicalized.
 	 * It probes an existing worktree when available and otherwise falls back to the persisted root for archived sessions.
+	 * A stamped root is already canonical, so resuming a session costs no Git launch.
 	 */
 	private async _readWorktreeMetadata(sessionUri: URI): Promise<IWorktreeMetadata | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);
@@ -991,23 +1037,29 @@ export class WorktreeIsolation extends Disposable {
 		}
 
 		try {
-			const [branchName, worktreePathRaw, repositoryRootRaw] = await Promise.all([
+			const [branchName, worktreePathRaw, repositoryRootRaw, stamp] = await Promise.all([
 				ref.object.getMetadata(WORKTREE_META_BRANCH),
 				ref.object.getMetadata(WORKTREE_META_PATH),
 				ref.object.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				ref.object.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
 			]);
 			if (!branchName) {
 				return undefined;
 			}
 			const worktreePath = worktreePathRaw ? URI.parse(worktreePathRaw) : undefined;
 			let repositoryRoot = repositoryRootRaw ? URI.parse(repositoryRootRaw) : undefined;
-			if (repositoryRoot) {
+			if (repositoryRoot && !isRepositoryRootStamped(stamp, repositoryRootRaw!)) {
 				const checkoutRoot = worktreePath && await fileExists(worktreePath.fsPath) ? worktreePath : repositoryRoot;
-				const primaryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
-				if (primaryRoot.toString() !== repositoryRoot.toString()) {
-					repositoryRoot = primaryRoot;
+				const { root: primaryRoot, resolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
+				const changed = primaryRoot.toString() !== repositoryRoot.toString();
+				repositoryRoot = primaryRoot;
+				const nextStamp = resolved ? buildRepositoryRootStamp(primaryRoot) : undefined;
+				if (changed || nextStamp) {
 					try {
-						await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString());
+						await Promise.all([
+							...(changed ? [ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString())] : []),
+							...(nextStamp ? [ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp)] : []),
+						]);
 					} catch (error) {
 						this._logService.warn(`[${this._logLabel}] Failed to normalize worktree repository metadata for '${sessionUri.toString()}': ${errorMessage(error)}`);
 					}

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -53,10 +53,14 @@ const WORKTREE_REPOSITORY_ROOT_STAMP_VERSION = '1';
 
 /** Builds the stamp certifying `repositoryRoot`, or `undefined` when it must not be certified. */
 export function buildRepositoryRootStamp(repositoryRoot: URI): string | undefined {
-	// Git answers a submodule or `--separate-git-dir` checkout with its git
-	// directory rather than a working tree. Grouping under that is wrong today
-	// too, but it self-heals on the next listing; certifying it would freeze it.
-	if (repositoryRoot.path.split('/').includes('.git')) {
+	// Git answers a submodule with its git directory rather than a working
+	// tree, and a bare repository's worktrees with the bare directory. Neither
+	// is a repository root worth freezing, so decline to certify them. This is
+	// a conservative refusal by name, not a classification: a
+	// `--separate-git-dir` target can be called anything, so it is not caught
+	// here and keeps the behaviour it has today.
+	const segments = repositoryRoot.path.split('/');
+	if (segments.includes('.git') || segments[segments.length - 1]?.endsWith('.git')) {
 		return undefined;
 	}
 	return `${WORKTREE_REPOSITORY_ROOT_STAMP_VERSION}:${repositoryRoot.toString()}`;
@@ -1051,14 +1055,18 @@ export class WorktreeIsolation extends Disposable {
 			if (repositoryRoot && !isRepositoryRootStamped(stamp, repositoryRootRaw!)) {
 				const checkoutRoot = worktreePath && await fileExists(worktreePath.fsPath) ? worktreePath : repositoryRoot;
 				const { root: primaryRoot, resolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
-				const changed = primaryRoot.toString() !== repositoryRoot.toString();
-				repositoryRoot = primaryRoot;
+				// Only a root worth freezing is adopted: one Git confirmed, and
+				// one the stamp will certify. Anything else leaves the stored
+				// value alone rather than replacing it with something every
+				// later read has to re-derive.
 				const nextStamp = resolved ? buildRepositoryRootStamp(primaryRoot) : undefined;
-				if (changed || nextStamp) {
+				if (nextStamp) {
+					const changed = primaryRoot.toString() !== repositoryRoot.toString();
+					repositoryRoot = primaryRoot;
 					try {
 						await Promise.all([
 							...(changed ? [ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString())] : []),
-							...(nextStamp ? [ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp)] : []),
+							ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP, nextStamp),
 						]);
 					} catch (error) {
 						this._logService.warn(`[${this._logLabel}] Failed to normalize worktree repository metadata for '${sessionUri.toString()}': ${errorMessage(error)}`);

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -51,16 +51,24 @@ export const WORKTREE_META_REPOSITORY_ROOT = 'copilot.worktree.repositoryRoot';
 export const WORKTREE_META_REPOSITORY_ROOT_STAMP = 'copilot.worktree.repositoryRootStamp';
 const WORKTREE_REPOSITORY_ROOT_STAMP_VERSION = '1';
 
+/**
+ * Whether `path` names a git directory rather than a working tree. Git answers a
+ * submodule with `<super>/.git/modules/<name>`, and a bare repository's worktree
+ * listing with the bare directory itself. Neither is a repository root: deriving
+ * a worktree location from one would place the session's worktree inside the
+ * repository's own metadata, and grouping under one is meaningless.
+ *
+ * A conservative refusal by name, not a classification — a `--separate-git-dir`
+ * target can be called anything and is not recognisable from its path.
+ */
+export function isGitDirectoryPath(path: URI): boolean {
+	const segments = path.path.split('/');
+	return segments.includes('.git') || !!segments[segments.length - 1]?.endsWith('.git');
+}
+
 /** Builds the stamp certifying `repositoryRoot`, or `undefined` when it must not be certified. */
 export function buildRepositoryRootStamp(repositoryRoot: URI): string | undefined {
-	// Git answers a submodule with its git directory rather than a working
-	// tree, and a bare repository's worktrees with the bare directory. Neither
-	// is a repository root worth freezing, so decline to certify them. This is
-	// a conservative refusal by name, not a classification: a
-	// `--separate-git-dir` target can be called anything, so it is not caught
-	// here and keeps the behaviour it has today.
-	const segments = repositoryRoot.path.split('/');
-	if (segments.includes('.git') || segments[segments.length - 1]?.endsWith('.git')) {
+	if (isGitDirectoryPath(repositoryRoot)) {
 		return undefined;
 	}
 	return `${WORKTREE_REPOSITORY_ROOT_STAMP_VERSION}:${repositoryRoot.toString()}`;
@@ -926,7 +934,8 @@ export class WorktreeIsolation extends Disposable {
 		}
 		const primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, worktreeRoot).catch(() => undefined);
 		// A primary checkout (not a linked worktree) resolves to itself; nothing to bridge.
-		if (!primaryRoot || isEqual(primaryRoot, worktreeRoot)) {
+		// A git directory is not a repository root at all, so there is nothing to adopt either.
+		if (!primaryRoot || isEqual(primaryRoot, worktreeRoot) || isGitDirectoryPath(primaryRoot)) {
 			return false;
 		}
 		const branchName = await this._gitService.getCurrentBranch(worktreeRoot).catch(() => undefined) ?? 'HEAD';
@@ -961,7 +970,14 @@ export class WorktreeIsolation extends Disposable {
 	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<{ readonly root: URI; readonly resolved: boolean }> {
 		try {
 			const resolved = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot);
-			return resolved ? { root: resolved, resolved: true } : { root: fallbackRoot, resolved: false };
+			if (resolved && !isGitDirectoryPath(resolved)) {
+				return { root: resolved, resolved: true };
+			}
+			// Git answered with its own git directory — a submodule, or a bare
+			// repository. Adopting it would group the session under a path
+			// inside the repository's metadata, and worse, place its worktree
+			// there: the worktrees directory is derived from this value.
+			return { root: fallbackRoot, resolved: false };
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}] Failed to resolve primary worktree for '${checkoutRoot.fsPath}': ${errorMessage(error)}`);
 			return { root: fallbackRoot, resolved: false };

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -15,6 +15,9 @@ import type { Message } from '../../common/state/sessionState.js';
 export class TestSessionDatabase implements ISessionDatabase {
 	private readonly _edits: (IFileEditRecord & IFileEditContent)[] = [];
 	private readonly _metadata = new Map<string, string>();
+	private _closed = false;
+	/** Opt in to production's deferred, close-aware write semantics. */
+	modelDeferredWrites = false;
 	private readonly _drafts = new Map<string, Message>();
 	private readonly _reviewedFiles: IReviewedFileRecord[] = [];
 	private readonly _localTurns = new Map<string, ILocalTurnRecord>();
@@ -78,6 +81,16 @@ export class TestSessionDatabase implements ISessionDatabase {
 	}
 
 	async setMetadata(key: string, value: string): Promise<void> {
+		if (this.modelDeferredWrites) {
+			// Production defers the write behind a sequencer before it reaches
+			// SQLite, and rejects it once closed. Without that, a write which
+			// was merely started -- never awaited -- still lands here, hiding
+			// the class of bug where a caller releases its reference first.
+			await new Promise(resolve => setTimeout(resolve, 0));
+			if (this._closed) {
+				throw new Error('SessionDatabase has been disposed');
+			}
+		}
 		this.setMetadataCalls.push({ key, value });
 		this._metadata.set(key, value);
 	}
@@ -95,7 +108,10 @@ export class TestSessionDatabase implements ISessionDatabase {
 		return this._drafts.get(chat.toString());
 	}
 
-	async close(): Promise<void> { }
+	/** Closes the database, as releasing the last reference does in production. */
+	async close(): Promise<void> {
+		this._closed = true;
+	}
 
 	async vacuumInto(_targetPath: string): Promise<void> { }
 
@@ -230,13 +246,20 @@ export function createZeroDiffComputeService(): IDiffComputeService {
 	return new TestDiffComputeService({ added: 0, removed: 0, changes: [] });
 }
 
-export function createSessionDataService(database: ISessionDatabase = new TestSessionDatabase()): ISessionDataService {
+export function createSessionDataService(database: ISessionDatabase = new TestSessionDatabase(), options?: { readonly closeOnDispose?: boolean }): ISessionDataService {
+	// Production closes the database when its last reference goes away, which
+	// rejects any write that had only been started. Opt in to model that.
+	let release: (() => void) | undefined;
+	if (options?.closeOnDispose && database instanceof TestSessionDatabase) {
+		database.modelDeferredWrites = true;
+		release = () => { void database.close(); };
+	}
 	return {
 		_serviceBrand: undefined,
 		getSessionDataDir: session => URI.from({ scheme: Schemas.inMemory, path: `/session-data${session.path}` }),
 		getSessionDataDirById: sessionId => URI.from({ scheme: Schemas.inMemory, path: `/session-data/${sessionId}` }),
-		openDatabase: () => createReference(database),
-		tryOpenDatabase: async () => createReference(database),
+		openDatabase: () => createReference(database, release),
+		tryOpenDatabase: async () => createReference(database, release),
 		deleteSessionData: async () => { },
 		onWillDeleteSessionData: Event.None,
 		cleanupOrphanedData: async () => { },
@@ -339,10 +362,10 @@ export function createNoopChangesetService(): import('../../common/agentHostChan
 	};
 }
 
-function createReference<T>(object: T): IReference<T> {
+function createReference<T>(object: T, onDispose?: () => void): IReference<T> {
 	return {
 		object,
-		dispose: () => { },
+		dispose: () => onDispose?.(),
 	};
 }
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -501,6 +501,27 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		assert.strictEqual(await svc!.branchExists(URI.file(dir), 'does-not-exist'), false);
 	});
 
+	// Git answers with resolved paths, while a session persists the path it was
+	// created with. Unless both are canonicalized they are different cache keys
+	// for one worktree, and every lookup misses.
+	(hasGit ? test : test.skip)('canonicalizeExistingPath agrees with the paths git reports, and rejects missing paths', async () => {
+		const dir = initRepo();
+		const worktree = join(dir, 'linked');
+		cp.execFileSync('git', ['worktree', 'add', '-q', '--no-checkout', '-b', 'linked', worktree, 'main'], { cwd: dir, env, stdio: 'pipe' });
+
+		const reported = await svc!.getWorktreeRoots(URI.file(worktree));
+		const canonicalWorktree = await svc!.canonicalizeExistingPath(URI.file(worktree));
+		const canonicalPrimary = await svc!.canonicalizeExistingPath(URI.file(dir));
+
+		assert.deepStrictEqual({
+			reportedMatchCanonical: reported.map(root => root.fsPath).sort(),
+			missing: await svc!.canonicalizeExistingPath(URI.file(join(dir, 'never-existed'))),
+		}, {
+			reportedMatchCanonical: [canonicalPrimary!.fsPath, canonicalWorktree!.fsPath].sort(),
+			missing: undefined,
+		});
+	});
+
 	(hasGit ? test : test.skip)('hasUncommittedChanges flips with untracked and committed work', async () => {
 		const dir = initRepo();
 		assert.strictEqual(await svc!.hasUncommittedChanges(URI.file(dir)), false);

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -501,6 +501,27 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		assert.strictEqual(await svc!.branchExists(URI.file(dir), 'does-not-exist'), false);
 	});
 
+	// Only genuine absence lets a caller skip Git. Anything else the filesystem
+	// refuses to answer must not read as absence.
+	(hasGit && process.getuid?.() !== 0 ? test : test.skip)('canonicalizeExistingPath reports absence only for a path that is really gone', async () => {
+		const dir = initRepo();
+		const denied = join(dir, 'denied');
+		const fs = await import('fs/promises');
+		await fs.mkdir(join(denied, 'inner'), { recursive: true });
+		await fs.chmod(denied, 0o000);
+		try {
+			assert.deepStrictEqual({
+				missing: await svc!.canonicalizeExistingPath(URI.file(join(dir, 'never-existed'))),
+				unreadable: (await svc!.canonicalizeExistingPath(URI.file(join(denied, 'inner'))))?.fsPath,
+			}, {
+				missing: undefined,
+				unreadable: URI.file(join(denied, 'inner')).fsPath,
+			});
+		} finally {
+			await fs.chmod(denied, 0o755);
+		}
+	});
+
 	// Git answers with resolved paths, while a session persists the path it was
 	// created with. Unless both are canonicalized they are different cache keys
 	// for one worktree, and every lookup misses.

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -42,7 +42,7 @@ import { type ISessionEvent } from './copilotTestEvents.js';
 import { createNoopGitService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT } from '../../node/shared/worktreeIsolation.js';
+import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -1769,6 +1769,71 @@ suite('AgentService (node dispatcher)', () => {
 				resolvedFrom: [linkedCheckout.toString()],
 				project: { uri: primaryRoot.toString(), displayName: 'vscode' },
 				persistedRepositoryRoot: primaryRoot.toString(),
+			});
+		});
+
+		test('listSessions trusts a stamped repository root after a host restart', async () => {
+			// The stamp, not an in-memory cache, is what has to make the repair
+			// one-shot: a fresh host must re-read the catalogue without Git.
+			const db = disposables.add(new TestSessionDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			const sessionWorktree = URI.file('/workspace/vscode.worktrees/parent.worktrees/child');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			const sessionId = 'test-session-stamped-worktree';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const listWith = async () => {
+				const agent = new MockAgent('copilot');
+				disposables.add(toDisposable(() => agent.dispose()));
+				agent.sessionMetadataOverrides = { workingDirectories: [sessionWorktree], project: { uri: linkedCheckout, displayName: 'parent' } };
+				(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+				// A new Git service means a new resolver, i.e. no warm cache.
+				const gitService = createNoopGitService();
+				let worktreeRootCalls = 0;
+				gitService.getWorktreeRoots = async () => {
+					worktreeRootCalls++;
+					return [primaryRoot, linkedCheckout, sessionWorktree];
+				};
+				const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
+				svc.registerProvider(agent);
+				const sessions = await svc.listSessions();
+				return { worktreeRootCalls, project: sessions[0].project?.uri.toString() };
+			};
+
+			const first = await listWith();
+			const afterRestart = await listWith();
+
+			assert.deepStrictEqual({ first, afterRestart }, {
+				first: { worktreeRootCalls: 1, project: primaryRoot.toString() },
+				afterRestart: { worktreeRootCalls: 0, project: primaryRoot.toString() },
+			});
+		});
+
+		test('listSessions leaves a root git could not confirm unstamped', async () => {
+			// Certifying a value this run could not derive would freeze the very
+			// mis-grouping the migration exists to repair.
+			const db = disposables.add(new TestSessionDatabase());
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			const sessionId = 'test-session-unresolvable-worktree';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [linkedCheckout] };
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			gitService.getWorktreeRoots = async () => [];
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			await svc.listSessions();
+
+			assert.deepStrictEqual({
+				stamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+			}, {
+				stamp: undefined,
+				persistedRepositoryRoot: linkedCheckout.toString(),
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1837,6 +1837,36 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('listSessions persists the repair before releasing the session database', async () => {
+			// The overlay disposes its database reference the moment the repair
+			// returns. A write merely started by then is rejected, silently
+			// losing both the stamp and the repair it certifies.
+			const db = disposables.add(new TestSessionDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			const sessionId = 'test-session-persisted-repair';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [linkedCheckout] };
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			gitService.getWorktreeRoots = async () => [primaryRoot, linkedCheckout];
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db, { closeOnDispose: true }), { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			await svc.listSessions();
+
+			assert.deepStrictEqual({
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				stamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
+			}, {
+				persistedRepositoryRoot: primaryRoot.toString(),
+				stamp: `1:${primaryRoot.toString()}`,
+			});
+		});
+
 		test('listSessions uses SDK title when no custom title exists', async () => {
 			service.registerProvider(copilotAgent);
 			copilotAgent.sessionMetadataOverrides = { summary: 'Auto-generated Title' };

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1867,6 +1867,38 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('listSessions leaves the stored root alone when git answers with a git directory', async () => {
+			// Git answers a submodule with its git directory. Persisting that
+			// unstamped would replace the session's root with a value every
+			// later listing has to re-derive.
+			const db = disposables.add(new TestSessionDatabase());
+			const persistedRoot = URI.file('/workspace/outer');
+			const gitDirectory = URI.file('/workspace/outer/.git/modules/sub');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, persistedRoot.toString());
+			const sessionId = 'test-session-submodule';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [persistedRoot] };
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			gitService.getWorktreeRoots = async () => [gitDirectory];
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			const sessions = await svc.listSessions();
+
+			assert.deepStrictEqual({
+				project: sessions[0].project?.uri.toString(),
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				stamp: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP),
+			}, {
+				project: persistedRoot.toString(),
+				persistedRepositoryRoot: persistedRoot.toString(),
+				stamp: undefined,
+			});
+		});
+
 		test('listSessions uses SDK title when no custom title exists', async () => {
 			service.registerProvider(copilotAgent);
 			copilotAgent.sessionMetadataOverrides = { summary: 'Auto-generated Title' };

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -42,7 +42,7 @@ import { type ISessionEvent } from './copilotTestEvents.js';
 import { createNoopGitService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
-import { getWorktreesRoot, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP } from '../../node/shared/worktreeIsolation.js';
+import { getWorktreesRoot, isRepositoryRootStamped, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, WORKTREE_META_REPOSITORY_ROOT_STAMP } from '../../node/shared/worktreeIsolation.js';
 import { AhpErrorCodes, JSON_RPC_INTERNAL_ERROR, ProtocolError } from '../../common/state/sessionProtocol.js';
 import type { INetworkDiagnosticsService } from '../../node/networkDiagnosticsService.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -1896,6 +1896,58 @@ suite('AgentService (node dispatcher)', () => {
 				project: persistedRoot.toString(),
 				persistedRepositoryRoot: persistedRoot.toString(),
 				stamp: undefined,
+			});
+		});
+
+		test('listSessions does not certify a root whose write failed', async () => {
+			// A stamp must certify only what is durable. Issued alongside the
+			// root, it can land when the root write does not -- so it embeds the
+			// root it vouches for, and a mismatch reads as uncertified.
+			class FailingRootWriteDatabase extends TestSessionDatabase {
+				failRootWrites = false;
+				override async setMetadata(key: string, value: string): Promise<void> {
+					if (this.failRootWrites && key === WORKTREE_META_REPOSITORY_ROOT) {
+						throw new Error('write failed');
+					}
+					return super.setMetadata(key, value);
+				}
+			}
+			const db = disposables.add(new FailingRootWriteDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
+			db.failRootWrites = true;
+			const sessionId = 'test-session-failed-root-write';
+			const sessionUri = AgentSession.uri('copilot', sessionId);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [linkedCheckout] };
+			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
+			const gitService = createNoopGitService();
+			let worktreeRootCalls = 0;
+			gitService.getWorktreeRoots = async () => {
+				worktreeRootCalls++;
+				return [primaryRoot, linkedCheckout];
+			};
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
+			svc.registerProvider(agent);
+
+			await svc.listSessions();
+			const callsAfterFirst = worktreeRootCalls;
+			// A stamp certifying a root that was never stored must not stop the
+			// next listing from repairing it.
+			await svc.listSessions();
+
+			assert.deepStrictEqual({
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+				stampCertifiesStoredRoot: isRepositoryRootStamped(await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT_STAMP), linkedCheckout.toString()),
+				callsAfterFirst,
+				retriedOnNextListing: worktreeRootCalls > callsAfterFirst,
+			}, {
+				persistedRepositoryRoot: linkedCheckout.toString(),
+				stampCertifiesStoredRoot: false,
+				callsAfterFirst: 1,
+				retriedOnNextListing: true,
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { tryResolvePrimaryWorktreeRoot, type IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../common/agentHostGitService.js';
+import { PrimaryWorktreeResolutionPass, tryResolvePrimaryWorktreeRoot, type IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../common/agentHostGitService.js';
 import { projectFromCopilotContext, projectFromRepository, resolveGitProject } from '../../node/copilot/copilotGitProject.js';
 
 class TestAgentHostGitService implements IAgentHostGitService {
@@ -108,9 +108,10 @@ suite('Copilot Git Project', () => {
 		const checkoutB = URI.file('/workspace/source-repo.worktrees/b');
 		gitService.worktreeRoots = [primaryRoot, checkoutA, checkoutB];
 
+		const pass = new PrimaryWorktreeResolutionPass();
 		const roots = await Promise.all([
-			tryResolvePrimaryWorktreeRoot(gitService, checkoutA),
-			tryResolvePrimaryWorktreeRoot(gitService, checkoutB),
+			tryResolvePrimaryWorktreeRoot(gitService, checkoutA, pass),
+			tryResolvePrimaryWorktreeRoot(gitService, checkoutB, pass),
 		]);
 
 		assert.deepStrictEqual({
@@ -119,6 +120,53 @@ suite('Copilot Git Project', () => {
 		}, {
 			worktreeRootCalls: 1,
 			roots: [primaryRoot.toString(), primaryRoot.toString()],
+		});
+	});
+
+	test('spends its budget on git launches, not on whatever ran before them', async () => {
+		// Callers arrive together, so a budget started when the pass was built
+		// would already be gone before the first launch. It starts at the first
+		// launch, which also guarantees a pass always makes progress.
+		const primaryRoot = URI.file('/workspace/source-repo');
+		gitService.worktreeRoots = [primaryRoot];
+		const pass = new PrimaryWorktreeResolutionPass(0);
+
+		const first = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/a'), pass);
+		await new Promise(resolve => setTimeout(resolve, 5));
+		const second = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/b'), pass);
+		// A caller outside the pass is unaffected, so a repair budget never
+		// starves foreground resolution.
+		const foreground = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/c'));
+
+		assert.deepStrictEqual({
+			first: first?.toString(),
+			second,
+			foreground: foreground?.toString(),
+			worktreeRootCalls: gitService.worktreeRootCalls,
+		}, {
+			first: primaryRoot.toString(),
+			second: undefined,
+			foreground: primaryRoot.toString(),
+			worktreeRootCalls: 2,
+		});
+	});
+
+	test('answers an exhausted pass from what git already reported', async () => {
+		const primaryRoot = URI.file('/workspace/source-repo');
+		const checkoutA = URI.file('/workspace/source-repo.worktrees/a');
+		const checkoutB = URI.file('/workspace/source-repo.worktrees/b');
+		gitService.worktreeRoots = [primaryRoot, checkoutA, checkoutB];
+		const pass = new PrimaryWorktreeResolutionPass(0);
+
+		await tryResolvePrimaryWorktreeRoot(gitService, checkoutA, pass);
+		const afterBudget = await tryResolvePrimaryWorktreeRoot(gitService, checkoutB, pass);
+
+		assert.deepStrictEqual({
+			afterBudget: afterBudget?.toString(),
+			worktreeRootCalls: gitService.worktreeRootCalls,
+		}, {
+			afterBudget: primaryRoot.toString(),
+			worktreeRootCalls: 1,
 		});
 	});
 
@@ -138,8 +186,9 @@ suite('Copilot Git Project', () => {
 			[primaryRoot.fsPath, primaryRoot.fsPath],
 		]);
 
-		const viaSymlink = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/source-repo.worktrees/a'));
-		const viaCanonical = await tryResolvePrimaryWorktreeRoot(gitService, canonicalCheckout);
+		const pass = new PrimaryWorktreeResolutionPass();
+		const viaSymlink = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/source-repo.worktrees/a'), pass);
+		const viaCanonical = await tryResolvePrimaryWorktreeRoot(gitService, canonicalCheckout, pass);
 
 		assert.deepStrictEqual({
 			worktreeRootCalls: gitService.worktreeRootCalls,
@@ -158,19 +207,32 @@ suite('Copilot Git Project', () => {
 		assert.deepStrictEqual({ root, worktreeRootCalls: gitService.worktreeRootCalls }, { root: undefined, worktreeRootCalls: 0 });
 	});
 
-	test('does not re-probe a checkout git could not describe', async () => {
+	test('probes a checkout git could not describe once per pass, and again in the next one', async () => {
+		// Git reports "not a worktree" and "git could not run" identically, so a
+		// failure must never outlive the pass that saw it -- otherwise a repo
+		// repaired between listings stays mis-grouped with no way to retry.
 		const orphaned = URI.file('/workspace/orphaned-worktree');
 		gitService.worktreeRoots = [];
+		const pass = new PrimaryWorktreeResolutionPass();
 
-		const first = await tryResolvePrimaryWorktreeRoot(gitService, orphaned);
-		const second = await tryResolvePrimaryWorktreeRoot(gitService, orphaned);
+		const first = await tryResolvePrimaryWorktreeRoot(gitService, orphaned, pass);
+		const again = await tryResolvePrimaryWorktreeRoot(gitService, orphaned, pass);
+		const callsWithinPass = gitService.worktreeRootCalls;
+
+		const primaryRoot = URI.file('/workspace/source-repo');
+		gitService.worktreeRoots = [primaryRoot];
+		const nextPass = await tryResolvePrimaryWorktreeRoot(gitService, orphaned, new PrimaryWorktreeResolutionPass());
 
 		assert.deepStrictEqual({
-			worktreeRootCalls: gitService.worktreeRootCalls,
-			roots: [first, second],
+			withinPass: [first, again],
+			callsWithinPass,
+			nextPass: nextPass?.toString(),
+			totalCalls: gitService.worktreeRootCalls,
 		}, {
-			worktreeRootCalls: 1,
-			roots: [undefined, undefined],
+			withinPass: [undefined, undefined],
+			callsWithinPass: 1,
+			nextPass: primaryRoot.toString(),
+			totalCalls: 2,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -15,6 +15,8 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	repositoryRoot: URI | undefined;
 	worktreeRoots: URI[] = [];
 	worktreeRootCalls = 0;
+	/** Canonical spelling per path; a path absent from the map does not exist. */
+	canonicalPaths: Map<string, string> | undefined;
 
 	async getCurrentBranch(): Promise<string | undefined> { return undefined; }
 	async getDefaultBranch(): Promise<IDefaultBranch | undefined> { return undefined; }
@@ -25,6 +27,13 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	async getWorktreeRoots(): Promise<URI[]> {
 		this.worktreeRootCalls++;
 		return this.worktreeRoots;
+	}
+	async canonicalizeExistingPath(path: URI): Promise<URI | undefined> {
+		if (!this.canonicalPaths) {
+			return path;
+		}
+		const canonical = this.canonicalPaths.get(path.fsPath);
+		return canonical ? URI.file(canonical) : undefined;
 	}
 	async addWorktree(): Promise<void> { }
 	async copyWorktreeIncludeFiles(): Promise<void> { }
@@ -115,6 +124,54 @@ suite('Copilot Git Project', () => {
 
 	test('returns undefined outside a git working tree', async () => {
 		assert.strictEqual(await resolveGitProject(URI.file('/workspace/plain-folder'), gitService), undefined);
+	});
+
+	test('shares one resolution across the spellings of a worktree path', async () => {
+		// Git reports resolved paths while a session persists the path it was
+		// created with, so both must key the same cache entry.
+		const primaryRoot = URI.file('/private/workspace/source-repo');
+		const canonicalCheckout = URI.file('/private/workspace/source-repo.worktrees/a');
+		gitService.worktreeRoots = [primaryRoot, canonicalCheckout];
+		gitService.canonicalPaths = new Map([
+			['/workspace/source-repo.worktrees/a', canonicalCheckout.fsPath],
+			[canonicalCheckout.fsPath, canonicalCheckout.fsPath],
+			[primaryRoot.fsPath, primaryRoot.fsPath],
+		]);
+
+		const viaSymlink = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/source-repo.worktrees/a'));
+		const viaCanonical = await tryResolvePrimaryWorktreeRoot(gitService, canonicalCheckout);
+
+		assert.deepStrictEqual({
+			worktreeRootCalls: gitService.worktreeRootCalls,
+			roots: [viaSymlink?.toString(), viaCanonical?.toString()],
+		}, {
+			worktreeRootCalls: 1,
+			roots: [primaryRoot.toString(), primaryRoot.toString()],
+		});
+	});
+
+	test('never launches git for a checkout that no longer exists', async () => {
+		gitService.canonicalPaths = new Map();
+
+		const root = await tryResolvePrimaryWorktreeRoot(gitService, URI.file('/workspace/deleted-repo'));
+
+		assert.deepStrictEqual({ root, worktreeRootCalls: gitService.worktreeRootCalls }, { root: undefined, worktreeRootCalls: 0 });
+	});
+
+	test('does not re-probe a checkout git could not describe', async () => {
+		const orphaned = URI.file('/workspace/orphaned-worktree');
+		gitService.worktreeRoots = [];
+
+		const first = await tryResolvePrimaryWorktreeRoot(gitService, orphaned);
+		const second = await tryResolvePrimaryWorktreeRoot(gitService, orphaned);
+
+		assert.deepStrictEqual({
+			worktreeRootCalls: gitService.worktreeRootCalls,
+			roots: [first, second],
+		}, {
+			worktreeRootCalls: 1,
+			roots: [undefined, undefined],
+		});
 	});
 
 	test('falls back to repository context when no git project is available', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -207,6 +207,25 @@ suite('Copilot Git Project', () => {
 		assert.deepStrictEqual({ root, worktreeRootCalls: gitService.worktreeRootCalls }, { root: undefined, worktreeRootCalls: 0 });
 	});
 
+	test('still asks git when the filesystem cannot say whether a checkout exists', async () => {
+		// An unreadable parent or a volume that is briefly away is not absence.
+		// Treating it as such would skip Git for a checkout that is really there.
+		const primaryRoot = URI.file('/workspace/source-repo');
+		const checkout = URI.file('/workspace/source-repo.worktrees/a');
+		gitService.worktreeRoots = [primaryRoot, checkout];
+		gitService.canonicalizeExistingPath = async () => { throw Object.assign(new Error('permission denied'), { code: 'EACCES' }); };
+
+		const root = await tryResolvePrimaryWorktreeRoot(gitService, checkout);
+
+		assert.deepStrictEqual({
+			root: root?.toString(),
+			worktreeRootCalls: gitService.worktreeRootCalls,
+		}, {
+			root: primaryRoot.toString(),
+			worktreeRootCalls: 1,
+		});
+	});
+
 	test('probes a checkout git could not describe once per pass, and again in the next one', async () => {
 		// Git reports "not a worktree" and "git could not run" identically, so a
 		// failure must never outlive the pass that saw it -- otherwise a repo

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -18,7 +18,7 @@ import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, MessageKind, ResponsePartKind, TurnState, type Turn } from '../../../common/state/sessionState.js';
 import { AgentBranchNameGenerator, IAgentBranchNameGenerator } from '../../../node/shared/agentBranchNameGenerator.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
-import { buildWorktreeFailureNotification, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, isGitDirectoryPath, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../../common/sessionTestHelpers.js';
 
 /**
@@ -881,5 +881,20 @@ suite('WorktreeIsolation', () => {
 			retryRepositoryRoot: repoRoot.toString(),
 			retryWorktree: worktree.toString(),
 		});
+	});
+	test('recognizes the git directories git answers with instead of a working tree', () => {
+		// Verified against real git: from a submodule checkout `git worktree
+		// list --porcelain` reports `<super>/.git/modules/<name>`, and a bare
+		// repository's listing reports the bare directory itself. Deriving a
+		// worktrees directory from either would place a session's worktree
+		// inside the repository's own metadata.
+		assert.deepStrictEqual([
+			'/work/super/.git/modules/vendored',
+			'/work/repo.git',
+			'/work/repo/.git',
+			'/work/repo',
+			'/work/repo.worktrees/feature',
+			'/work/gitlab/repo',
+		].map(path => isGitDirectoryPath(URI.file(path))), [true, true, true, false, false, false]);
 	});
 });


### PR DESCRIPTION
Fixes #329880. Alternative to #329925 — the two should be reviewed side by side and **one picked**; see the comparison at the bottom.

## The problem

Reloading the Agents window could leave session details unavailable for tens of seconds. On the reporter's machine the first `listSessions` took **52s** and spawned **400-570 git processes** for ~850-979 sessions.

`listSessions` runs a data migration (`AgentService._normalizeListedWorktreeRepositoryRoot`). #328375 fixed a project-grouping bug — `git rev-parse --show-toplevel` returns the *current checkout* root, which for a linked worktree is not the canonical repository root — and the migration repairs roots written by older builds that stored a linked-checkout path. It runs at list time because archived sessions may never resume through `WorktreeIsolation`'s metadata reader.

The migrated value decides **which project a session is grouped under**, so it is on the critical path for first paint.

## Approach

Git is the right authority for "which worktree is primary", so this keeps `git worktree list --porcelain` as the single source of truth and **reimplements none of git's on-disk layout logic**. Instead it makes the question almost never need asking. Three separate things were stopping the answer from being reused.

### 1. The cache threw away exactly what it had just learned

`PrimaryWorktreeRootResolver` already learns a repository's *entire membership* from one listing and bulk-records every sibling. But it stored them in an `LRUCache(100)`: inserting N siblings evicted the entries they existed to serve. `AgentService._normalizedWorktreeRepositoryRoots` was worse — keyed by **session URI**, unique per session, so it was a 100% miss by construction. It is deleted.

The resolver map is now **unbounded**. The entries *are* the membership git reported, so any bound merely decides how many worktrees it takes to reproduce the storm. The policy follows from the cost of a miss: here a miss is a **subprocess**, so a constant that silently chooses between one spawn and hundreds is indefensible. Measured cost of unbounded: 4096 entries = 0.78 MB, 10k = 1.25 MB, 50k = 7.29 MB.

### 2. The recorded entries could never match the next lookup

Git reports **resolved** paths; a session persists the path it was created with. Verified:

```
query path : /tmp/ahlink/wt1
git reports: /private/tmp/ahsym/wt1
```

So on any symlinked setup (macOS `/tmp`, symlinked `$HOME`/code dirs, Windows casing) every sibling entry was a different key from the lookup — the bulk-record collapsed nothing. Keys are now canonicalized via `realpath`.

This does double duty as an **existence check**: a checkout that is gone cannot be canonicalized, and git could only have been launched to fail on it. Verified an orphaned linked worktree exits 128, and `getWorktreeRoots` swallows that into `[]`.

### 3. The repair re-ran forever

A repaired root is now stamped (`copilot.worktree.repositoryRootStamp`), read in the *existing* batched `getMetadataObject` call, so the migration costs one resolution per session **ever** rather than one per listing. Sessions written by this build are born stamped. The resume path (`_readWorktreeMetadata`) honours it too — otherwise every session *open* would still spawn git.

The stamp is deliberately **not** a bare version marker:

- It carries `<version>:<exact root>`, so rewriting the root through any other writer invalidates it automatically, and bumping the version re-migrates roots an improved resolution would now answer differently.
- **Only a root git actually answered for is certified.** `_resolvePrimaryWorktreeRoot` previously collapsed *resolved* and *fell back* into one `URI`; it now returns `{ root, resolved }`. A fallback is the raw checkout root — precisely the value this migration exists to replace — so stamping it would freeze the #328375 bug permanently.
- It refuses to certify roots containing a `.git` segment, because git answers a submodule or `--separate-git-dir` checkout with its git directory. That is already wrong today, but it self-heals; certifying would freeze it.
- Roots git could not describe stay **unstamped** and remain repairable.

### Nothing unconfirmed outlives the pass that observed it

A listing creates one `PrimaryWorktreeResolutionPass` and shares it across every
session, so one `git worktree list` answers a whole repository. Everything the
resolver learns lives in that pass and dies with it:

- **Failures**, because Git reports "this is not a worktree" and "Git could not run
  just now" identically. Remembering one would freeze a wrong project for every
  window until the Agent Host process restarts — and reloading the window does not
  help, because the host is a `UtilityProcess` that outlives windows.
- **Successes**, because a listing now *certifies* what it resolves. A worktree path
  reused by another repository, or a primary worktree that moved, would otherwise be
  answered from memory and stamped as canonical.

The budget is checked immediately before a launch rather than on arrival, and its
clock starts at the first launch rather than at the start of the listing — so
enumerating sessions and reading their metadata cannot consume time meant for Git,
and the largest catalogues (which need repair most) are not the ones starved of it.
The first launch is always allowed, so a pass always makes progress.

Repair writes are **awaited**. The caller releases its session-database reference as
soon as the repair returns, and releasing the last one closes the database, so a
write that has only been started is rejected and lost.

### The invariant, stated once

Three separate bugs across this PR and #329925 turned out to be the same rule broken
three ways. Worth stating as one thing rather than three fixes:

> **A stamp may certify only a root that is both confirmed and durable.**
>
> 1. **Confirmed by git**, not a fallback. `_resolvePrimaryWorktreeRoot` returns
>    `{ root, resolved }`, and only `resolved` is certified — a fallback is the raw
>    checkout root, which is the value the migration exists to replace.
> 2. **Confirmed present**, not merely unreadable. `canonicalizeExistingPath` reports
>    absence only for `ENOENT`/`ENOTDIR`; an unreadable parent or a briefly unavailable
>    volume falls back to the path so git is still asked.
> 3. **Durably stored**, not merely attempted. The stamp embeds the exact root, so a
>    stamp that lands when its root write did not certifies nothing and the session is
>    repaired on the next listing. (A bare version marker would silently certify
>    whatever root happened to be stored — verified: replacing the value-bound stamp
>    with one makes the regression test fail.)

Corollary, since git answers a submodule with its git directory and a bare repository
with the bare directory: **a root the stamp will not certify is not stored either**,
or listing would replace a session's root with a value every later listing has to
re-derive.

### Two further invariants



**Nothing that outlives a listing may be stamped by it.** Once a listing certifies
what it resolves, any memory surviving the listing can certify a stale answer — a
worktree path reused by another repository, or a primary that moved. That is why
both halves of the resolver's state live in the pass and not in the resolver.

A related rule, learned the hard way here: **fire-and-forget persistence is safe only
when whoever issues the write also owns the database reference until it settles.** The
existing writers in `agentService` do (`.finally(() => ref.dispose())`); the listing
repair did not — the listing owned the reference and released it on return — so its
writes were orphaned. They are awaited now.

## Measurements (real git, driving the compiled resolver)

Single repository, 301 worktrees, 300 concurrent sessions:

| | git spawns | time |
| --- | --- | --- |
| `LRUCache(100)` (today) | 201 | 13,859 ms |
| this change | **1** | **74 ms** |

A catalogue's cost is its *shape*, not its size, so one repository is the easy case. Mixed catalogue — 530 sessions = 300 live worktrees across **20 repositories** + 30 orphaned checkouts + 200 deleted:

| | git spawns | time |
| --- | --- | --- |
| first listing, cold host | 50 (= 20 repos + 30 orphans) | 465 ms |
| second listing, warm host | **0** | 3 ms |
| 200 deleted checkouts | **0** (never reach git) | — |

The residual is `#distinct repositories + #distinct undescribable checkouts` — which is why the issue's own benchmark saw 21-28 processes rather than 2, and why "~1-3s once, then zero" is the honest figure for the reporter's catalogue, **not** the 74 ms single-repo number. The stamp then carries that across restarts.

## Rejected alternatives

**Deferring the migration off the synchronous listing path** (the original suggestion). With the stamp, only the *first* listing after upgrade resolves anything, so deferral buys a one-time cost and pays for it permanently. `project` is a **grouping key**, so eventual consistency reflows the tree under the user's cursor and breaks selection/scroll anchoring. Worse, `onDidChangeSessions` triggers a full `refresh()`, so a fan-out of hundreds of `sessionSummaryChanged` notifications would be a *new* performance bug. It also needs a background scheduler and an eventual-consistency window living on the most perf-sensitive path forever.

**Repairing only on open/resume.** This is what #328375 deliberately rejected: archived sessions may never resume, so they would stay mis-grouped indefinitely. The stamp gets the same "once per session" cost without sacrificing them.

**Bounded concurrency instead of the `Sequencer`.** Tried and reverted. Serialization is *the* mechanism that lets the first checkout of a repository answer every later one; a `Limiter` broke the existing test pinning one git call per repository. Only lookups that actually need git reach the queue now, and the per-listing budget bounds the tail instead.

## Tests

- Repeat listing across a **cold host** (new git service ⇒ new resolver) does **zero** git work — proves the stamp, not an in-memory cache, is what makes this one-shot.
- A root git could not confirm is left unstamped and unchanged.
- Both spellings of a worktree path share one resolution.
- A checkout that no longer exists never launches git.
- An undescribable checkout is not re-probed.
- Real-git integration test asserting `canonicalizeExistingPath` agrees with the paths git reports, and rejects missing paths.

## Validation

- `npm run typecheck-client` — 17 errors, **= clean `main` baseline** (pre-existing Copilot SDK mismatch).
- agentHost unit — **4411 passing, 0 failing** (5 new).
- `agentHostGitService.integrationTest.ts` — **41 passing** (1 new, real git).
- `npm run valid-layers-check` — 42, **= baseline**.

## Comparison with #329925

Both fix the issue. #329925 additionally reimplements git's on-disk layout in TypeScript (`.git` file parsing, `commondir`, `is_git_directory()`, `core.worktree`, `--separate-git-dir`) to avoid spawning git at all.

| | #329925 | this |
| --- | --- | --- |
| steady-state sync cost | 0 | 0 |
| first listing | ~0 git | 1 git launch per repository, then stamped |
| git behaviour reimplemented | layout resolution | **none** |
| deleted checkouts | spawns git | never reach git |
| undescribable checkouts | re-spawn every listing | TTL'd negative entry |
| resume path | listing only | listing **and** resume |
| capacity cliff | none (a miss costs file reads) | none (unbounded) |

Neither has a capacity cliff — the cache policy simply differs because the cost of a miss differs.

**The honest trade:** right-sizing/removing the cache bound is what actually fixes #329880; the on-disk resolver buys roughly one repository's worth of latency on a single listing per install, in exchange for owning `is_git_directory()` semantics permanently. That logic needed two review rounds plus differential testing against real git to stop returning wrong roots for damaged layouts. This PR takes the position that the encapsulation is worth more than that latency.

## Review

Four models reviewed the implemented diff (`claude-opus-5`, `claude-opus-4.8`,
`gpt-5.6-sol`, `gemini-3.1-pro-preview`). They found three defects that the
design-level review had missed, all fixed in the second commit:

1. **The repair never reached disk.** The root and stamp writes were fire-and-forget,
   and the caller released the database on return. Reproduced against the real
   `SessionDatabase`: both writes reject with `SessionDatabase has been disposed`, so
   neither the stamp *nor the repair* persisted — worse than before this change for
   exactly the archived sessions the listing migration exists to serve. The test that
   should have caught it could not, because the test double keeps a map in memory and
   its reference releases into a no-op; it now models a released database and is
   verified to fail when the bug is reintroduced.
2. **The budget bounded nothing.** Sessions are repaired concurrently, so all of them
   read the clock at once — before any Git had run — and all passed, then queued
   anyway. A near-empty budget now stops a 530-session catalogue after one launch
   instead of running all fifty.
3. **Remembered answers could freeze a wrong project.** Covered above; both the
   negative and positive halves now live in the pass.

Two reviewers independently reproduced (1), and their recommendation on the negative
cache — dedupe within a listing, never across — is what shipped, replacing the
60-second TTL an earlier revision used.

A follow-up pass then verified, path by path, that **an unconfirmed root is never
certified** — across all four writers (creation, adoption, resume, listing) against
every distinct failure reason (git reported nothing, git failed or timed out, the
checkout is absent, the filesystem could not answer, the budget expired, the stamp
refused the root). The property holds, and no root/stamp pair can diverge into a false
certification: the stamp embeds the exact root, so every partial-write or interleaving
outcome lands on "not certified" and is re-derived.

That pass also found the two issues fixed in the third commit: the `.git` guard
suppressed the stamp but not the root write (leaving submodule sessions permanently
unstampable and re-resolved on every listing), and it did not cover bare repositories,
whose directory name ends in `.git` without being a `.git` segment.

Separately, `canonicalizeExistingPath` no longer collapses every `errno`. `realpath`
distinguishes the cases and the discriminator was being thrown away, so an unreadable
parent or a briefly unavailable volume read as "checkout deleted" and skipped git for a
checkout that was really there. Absence is now `ENOENT`/`ENOTDIR` only; anything else
falls back to the path so git is still asked.

One finding is deliberately **out of scope** and filed as #329943: `resolveGitProject`
falls back to the checkout root and `CopilotAgent` persists that fallback as resolved,
so a folder-isolated session can freeze a wrong project by the same mechanism. It
predates this change, affects #329925 equally, and has no worktree metadata to migrate.
