### PR TITLE
Filter pre-existing PRs from folder sessions

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/common/agentHostGitStateService.ts
@@ -47,12 +47,6 @@ export interface IAgentHostGitStateService {
 	 */
 	attachSessionGitHubPullRequest(sessionKey: string, workingDirectory?: URI): Promise<void>;
 
-	/**
-	 * Detect GitHub issues referenced in a user message and add them to the
-	 * session's GitHub state. Already-known issues are kept, so the session
-	 * accumulates every issue referenced over its lifetime.
-	 * @param sessionKey The key of the session the message was sent to.
-	 * @param text The user message to scan for issue references.
-	 */
-	attachSessionGitHubIssues(sessionKey: string, text: string): Promise<void>;
+	/** Adds GitHub issues and pull requests referenced in a user message to the session. */
+	attachSessionGitHubReferences(sessionKey: string, text: string): Promise<void>;
 }

--- a/src/vs/platform/agentHost/common/githubPullRequestReferences.ts
+++ b/src/vs/platform/agentHost/common/githubPullRequestReferences.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** A GitHub pull request referenced from a user message. */
+export interface IGitHubPullRequestReference {
+	readonly owner: string;
+	readonly repo: string;
+	readonly number: number;
+}
+
+const PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?github\.com\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/pull\/(?<number>\d+)\b/gi;
+const PULL_REQUEST_SHORTHAND_PATTERN = /\b(?:PR|pull request)\s*#(?<number>\d+)\b/gi;
+
+/** Extracts unambiguous GitHub pull request references without duplicates. */
+export function parseGitHubPullRequestReferences(text: string, defaultRepository?: { readonly owner: string; readonly repo: string }): IGitHubPullRequestReference[] {
+	const candidates: (IGitHubPullRequestReference & { readonly index: number })[] = [];
+	const references: IGitHubPullRequestReference[] = [];
+	const seen = new Set<string>();
+
+	const addCandidate = (index: number, owner: string, repo: string, rawNumber: string): void => {
+		const number = Number(rawNumber);
+		if (!Number.isSafeInteger(number) || number <= 0) {
+			return;
+		}
+		candidates.push({ index, owner, repo, number });
+	};
+
+	for (const match of text.matchAll(PULL_REQUEST_URL_PATTERN)) {
+		if (match.groups) {
+			addCandidate(match.index, match.groups.owner, match.groups.repo, match.groups.number);
+		}
+	}
+	if (defaultRepository) {
+		for (const match of text.matchAll(PULL_REQUEST_SHORTHAND_PATTERN)) {
+			if (match.groups) {
+				addCandidate(match.index, defaultRepository.owner, defaultRepository.repo, match.groups.number);
+			}
+		}
+	}
+
+	for (const candidate of candidates.sort((a, b) => a.index - b.index)) {
+		const { owner, repo, number } = candidate;
+		const reference = { owner, repo, number };
+		const url = toGitHubPullRequestUrl(reference).toLowerCase();
+		if (!seen.has(url)) {
+			seen.add(url);
+			references.push(reference);
+		}
+	}
+
+	return references;
+}
+
+/** Builds the canonical `github.com` URL for a pull request reference. */
+export function toGitHubPullRequestUrl(reference: IGitHubPullRequestReference): string {
+	return `https://github.com/${reference.owner}/${reference.repo}/pull/${reference.number}`;
+}

--- a/src/vs/platform/agentHost/common/githubPullRequestReferences.ts
+++ b/src/vs/platform/agentHost/common/githubPullRequestReferences.ts
@@ -10,14 +10,15 @@ export interface IGitHubPullRequestReference {
 	readonly number: number;
 }
 
-const PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?:www\.)?github\.com\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/pull\/(?<number>\d+)\b/gi;
+const PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?<host>[\w.-]+)\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/pull\/(?<number>\d+)\b/gi;
 const PULL_REQUEST_SHORTHAND_PATTERN = /\b(?:PR|pull request)\s*#(?<number>\d+)\b/gi;
 
 /** Extracts unambiguous GitHub pull request references without duplicates. */
-export function parseGitHubPullRequestReferences(text: string, defaultRepository?: { readonly owner: string; readonly repo: string }): IGitHubPullRequestReference[] {
+export function parseGitHubPullRequestReferences(text: string, defaultRepository?: { readonly owner: string; readonly repo: string }, gitHubHost = 'github.com'): IGitHubPullRequestReference[] {
 	const candidates: (IGitHubPullRequestReference & { readonly index: number })[] = [];
 	const references: IGitHubPullRequestReference[] = [];
 	const seen = new Set<string>();
+	const normalizedGitHubHost = normalizeGitHubHost(gitHubHost);
 
 	const addCandidate = (index: number, owner: string, repo: string, rawNumber: string): void => {
 		const number = Number(rawNumber);
@@ -28,7 +29,7 @@ export function parseGitHubPullRequestReferences(text: string, defaultRepository
 	};
 
 	for (const match of text.matchAll(PULL_REQUEST_URL_PATTERN)) {
-		if (match.groups) {
+		if (match.groups && normalizeGitHubHost(match.groups.host) === normalizedGitHubHost) {
 			addCandidate(match.index, match.groups.owner, match.groups.repo, match.groups.number);
 		}
 	}
@@ -43,7 +44,7 @@ export function parseGitHubPullRequestReferences(text: string, defaultRepository
 	for (const candidate of candidates.sort((a, b) => a.index - b.index)) {
 		const { owner, repo, number } = candidate;
 		const reference = { owner, repo, number };
-		const url = toGitHubPullRequestUrl(reference).toLowerCase();
+		const url = toGitHubPullRequestUrl(reference, gitHubHost).toLowerCase();
 		if (!seen.has(url)) {
 			seen.add(url);
 			references.push(reference);
@@ -53,7 +54,11 @@ export function parseGitHubPullRequestReferences(text: string, defaultRepository
 	return references;
 }
 
-/** Builds the canonical `github.com` URL for a pull request reference. */
-export function toGitHubPullRequestUrl(reference: IGitHubPullRequestReference): string {
-	return `https://github.com/${reference.owner}/${reference.repo}/pull/${reference.number}`;
+function normalizeGitHubHost(host: string): string {
+	return host.toLowerCase().replace(/^www\./, '');
+}
+
+/** Builds the canonical URL for a pull request reference on the configured GitHub host. */
+export function toGitHubPullRequestUrl(reference: IGitHubPullRequestReference, gitHubHost = 'github.com'): string {
+	return `https://${normalizeGitHubHost(gitHubHost)}/${reference.owner}/${reference.repo}/pull/${reference.number}`;
 }

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1336,10 +1336,10 @@ export const MAX_SESSION_PULL_REQUEST_REFERENCES = 10;
 
 function normalizeSessionPullRequestUrls(urls: readonly string[]): string[] {
 	const normalizedUrls = urls.map(url => {
-		const match = /^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/pull\/(?<number>\d+)\/?$/.exec(url);
+		const match = /^https:\/\/(?<host>[^/]+)\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/pull\/(?<number>\d+)\/?$/.exec(url);
 		const groups = match?.groups;
 		return groups
-			? `https://github.com/${groups['owner']}/${groups['repo']}/pull/${groups['number']}`
+			? `https://${groups['host'].toLowerCase()}/${groups['owner']}/${groups['repo']}/pull/${groups['number']}`
 			: url;
 	});
 	return distinct(normalizedUrls, url => url.toLowerCase()).slice(0, MAX_SESSION_PULL_REQUEST_REFERENCES);

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1286,8 +1286,12 @@ export interface ISessionGitHubState {
 	readonly owner?: string;
 	/** The name of the GitHub repository. */
 	readonly repo?: string;
-	/** GitHub pull request URLs associated with the session, most recent first. */
+	/** GitHub pull request URLs found for the session's checkouts, most recent first. */
 	readonly pullRequestUrls?: readonly string[];
+	/** Pull requests that predate a folder-isolated session. An empty array is a captured baseline. */
+	readonly initialPullRequestUrls?: readonly string[];
+	/** Pull requests explicitly associated through user intent, most recent first. */
+	readonly associatedPullRequestUrls?: readonly string[];
 	/**
 	 * URLs of the GitHub issues referenced by the session's user messages, in
 	 * order of first appearance.
@@ -1318,6 +1322,15 @@ export function hasSessionPullRequestForBranch(gitHubState: ISessionGitHubState 
 	return gitHubState.pullRequestBranchName === undefined || gitHubState.pullRequestBranchName === branchName;
 }
 
+/** Returns pull requests related to the session rather than inherited from its folder checkout. */
+export function getSessionRelatedPullRequestUrls(gitHubState: ISessionGitHubState | undefined): readonly string[] {
+	const pullRequestUrls = gitHubState?.pullRequestUrls ?? [];
+	const initialPullRequestUrls = gitHubState?.initialPullRequestUrls;
+	const initialUrls = new Set(initialPullRequestUrls?.map(url => url.toLowerCase()) ?? []);
+	const associatedUrls = new Set(gitHubState?.associatedPullRequestUrls?.map(url => url.toLowerCase()) ?? []);
+	return pullRequestUrls.filter(url => !initialUrls.has(url.toLowerCase()) || associatedUrls.has(url.toLowerCase()));
+}
+
 /** Maximum pull requests retained for a session. */
 export const MAX_SESSION_PULL_REQUEST_REFERENCES = 10;
 
@@ -1342,6 +1355,45 @@ export function withMostRecentSessionPullRequest(gitHubState: ISessionGitHubStat
 	return {
 		pullRequestUrls,
 		pullRequestBranchName: branchName,
+	};
+}
+
+/** Returns state that promotes a pull request from the folder baseline into the session. */
+export function withMostRecentRelatedSessionPullRequest(gitHubState: ISessionGitHubState | undefined, pullRequestUrl: string, branchName: string): ISessionGitHubState {
+	const next = withMostRecentSessionPullRequest(gitHubState, pullRequestUrl, branchName);
+	const promotedUrl = normalizeSessionPullRequestUrls([pullRequestUrl])[0]?.toLowerCase();
+	const initialPullRequestUrls = gitHubState?.initialPullRequestUrls;
+	const associatedPullRequestUrls = normalizeSessionPullRequestUrls([
+		pullRequestUrl,
+		...(gitHubState?.associatedPullRequestUrls ?? [])
+	]);
+	return {
+		...next,
+		associatedPullRequestUrls,
+		...(initialPullRequestUrls !== undefined ? {
+			initialPullRequestUrls: initialPullRequestUrls.filter(url => url.toLowerCase() !== promotedUrl)
+		} : {}),
+	};
+}
+
+/** Returns state that records a pull request in the folder-session baseline. */
+export function withInitialSessionPullRequest(gitHubState: ISessionGitHubState | undefined, pullRequestUrl?: string): ISessionGitHubState {
+	return {
+		initialPullRequestUrls: normalizeSessionPullRequestUrls([
+			...(pullRequestUrl ? [pullRequestUrl] : []),
+			...(gitHubState?.initialPullRequestUrls ?? [])
+		])
+	};
+}
+
+/** Returns state that records a user-referenced pull request without changing checkout PR state. */
+export function withMostRecentReferencedSessionPullRequest(gitHubState: ISessionGitHubState | undefined, pullRequestUrl: string): ISessionGitHubState {
+	const associatedPullRequestUrls = normalizeSessionPullRequestUrls([
+		pullRequestUrl,
+		...(gitHubState?.associatedPullRequestUrls ?? [])
+	]);
+	return {
+		associatedPullRequestUrls,
 	};
 }
 
@@ -1423,6 +1475,8 @@ export function readSessionGitHubState(meta: SessionSummaryMeta | undefined): IS
 		owner?: string;
 		repo?: string;
 		pullRequestUrls?: readonly string[];
+		initialPullRequestUrls?: readonly string[];
+		associatedPullRequestUrls?: readonly string[];
 		issueUrls?: readonly string[];
 		pullRequestBranchName?: string;
 	} = {};
@@ -1436,6 +1490,15 @@ export function readSessionGitHubState(meta: SessionSummaryMeta | undefined): IS
 			: [];
 	if (pullRequestUrls.length > 0) {
 		result.pullRequestUrls = normalizeSessionPullRequestUrls(pullRequestUrls);
+	}
+	if (Array.isArray(raw['initialPullRequestUrls'])) {
+		result.initialPullRequestUrls = normalizeSessionPullRequestUrls(raw['initialPullRequestUrls'].filter((url): url is string => typeof url === 'string'));
+	}
+	if (Array.isArray(raw['associatedPullRequestUrls'])) {
+		const associatedPullRequestUrls = normalizeSessionPullRequestUrls(raw['associatedPullRequestUrls'].filter((url): url is string => typeof url === 'string'));
+		if (associatedPullRequestUrls.length > 0) {
+			result.associatedPullRequestUrls = associatedPullRequestUrls;
+		}
 	}
 	if (Array.isArray(raw['issueUrls'])) { result.issueUrls = raw['issueUrls'].filter((url): url is string => typeof url === 'string'); }
 	if (typeof raw['pullRequestBranchName'] === 'string') { result.pullRequestBranchName = raw['pullRequestBranchName']; }

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -201,7 +201,8 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		const currentState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
 		const issueReferences = parseGitHubIssueReferences(text);
 		const repository = currentState?.owner && currentState.repo ? { owner: currentState.owner, repo: currentState.repo } : undefined;
-		const pullRequestReferences = parseGitHubPullRequestReferences(text, repository)
+		const gitHubHost = this._gitHubEndpointService.getEnterpriseHost() ?? 'github.com';
+		const pullRequestReferences = parseGitHubPullRequestReferences(text, repository, gitHubHost)
 			.filter(reference => !repository || reference.owner.toLowerCase() === repository.owner.toLowerCase() && reference.repo.toLowerCase() === repository.repo.toLowerCase());
 		if (issueReferences.length === 0 && pullRequestReferences.length === 0) {
 			return;
@@ -221,7 +222,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 			: {};
 		for (let index = pullRequestReferences.length - 1; index >= 0; index--) {
 			const reference = pullRequestReferences[index];
-			const url = toGitHubPullRequestUrl(reference);
+			const url = toGitHubPullRequestUrl(reference, gitHubHost);
 			nextState = {
 				...nextState,
 				...withMostRecentReferencedSessionPullRequest({ ...currentState, ...nextState }, url)

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -8,8 +8,9 @@ import { URI } from '../../../base/common/uri.js';
 import { Emitter } from '../../../base/common/event.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostGitStateService, META_GIT_STATE, META_GITHUB_STATE } from '../common/agentHostGitStateService.js';
-import { ISessionGitHubState, ISessionWithDefaultChat, readSessionGitHubState, readSessionGitState, SessionLifecycle, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, type ISessionGitState } from '../common/state/sessionState.js';
+import { getSessionRelatedPullRequestUrls, ISessionGitHubState, ISessionWithDefaultChat, readSessionGitHubState, readSessionGitState, SessionLifecycle, withInitialSessionPullRequest, withMostRecentReferencedSessionPullRequest, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, type ISessionGitState } from '../common/state/sessionState.js';
 import { MAX_SESSION_ISSUE_REFERENCES, parseGitHubIssueReferences, toGitHubIssueUrl } from '../common/githubIssueReferences.js';
+import { parseGitHubPullRequestReferences, toGitHubPullRequestUrl } from '../common/githubPullRequestReferences.js';
 import { IAgentHostGitService, parseUpstreamBranchName } from '../common/agentHostGitService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
@@ -20,6 +21,9 @@ import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { ThrottlerByKey, SequencerByKey, timeout } from '../../../base/common/async.js';
 import { isCancellationError } from '../../../base/common/errors.js';
+import { SessionConfigKey } from '../common/sessionConfigKeys.js';
+
+const PULL_REQUEST_CREATION_CLOCK_SKEW_MS = 5 * 60_000;
 
 export class AgentHostGitStateService extends Disposable implements IAgentHostGitStateService {
 	declare readonly _serviceBrand: undefined;
@@ -111,27 +115,56 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 			}
 
 			const pr = await this._findPullRequestForCheckout(state, gitHubState.owner, gitHubState.repo, gitState, branchName, authToken);
-			if (!pr?.url) {
-				// No pull request for this branch (yet). The previously known
-				// pull request, if any, keeps being reported and the lookup is
-				// retried on the next refresh.
-				this._logService.trace(`[AgentHostGitStateService][attachSessionGitHubPullRequest] No pull request found for ${sessionKey} on branch ${branchName}`);
-				return;
-			}
-
-			// The working copy may have moved to another branch while the
-			// request was in flight; discard the now stale result so it cannot
-			// overwrite the pull request of the branch that is checked out now.
 			const currentBranchName = readSessionGitState(this._stateManager.getSessionState(sessionKey)?._meta)?.branchName;
 			if (currentBranchName !== branchName) {
 				return;
 			}
 
-			const currentGitHubState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
-			await this.setSessionGitHubState(sessionKey, withMostRecentSessionPullRequest(currentGitHubState, pr.url, branchName));
+			const currentState = this._stateManager.getSessionState(sessionKey);
+			if (!currentState) {
+				return;
+			}
+			const currentGitHubState = readSessionGitHubState(currentState._meta);
+			if (!pr?.url) {
+				if (this._isFolderSession(currentState, currentGitHubState) && currentGitHubState?.initialPullRequestUrls === undefined) {
+					await this.setSessionGitHubState(sessionKey, withInitialSessionPullRequest(currentGitHubState));
+				}
+				this._logService.trace(`[AgentHostGitStateService][attachSessionGitHubPullRequest] No pull request found for ${sessionKey} on branch ${branchName}`);
+				return;
+			}
+
+			let nextGitHubState = withMostRecentSessionPullRequest(currentGitHubState, pr.url, branchName);
+			if (this._shouldAddToFolderBaseline(sessionKey, currentState, currentGitHubState, pr)) {
+				nextGitHubState = {
+					...nextGitHubState,
+					...withInitialSessionPullRequest(currentGitHubState, pr.url),
+				};
+			} else if (this._isFolderSession(currentState, currentGitHubState) && currentGitHubState?.initialPullRequestUrls === undefined) {
+				nextGitHubState = {
+					...nextGitHubState,
+					...withInitialSessionPullRequest(currentGitHubState),
+				};
+			}
+			await this.setSessionGitHubState(sessionKey, nextGitHubState);
 		} catch (error) {
 			this._logService.warn(`[AgentHostGitStateService][attachSessionGitHubPullRequest] Failed to find pull request for ${sessionKey}`, error);
 		}
+	}
+
+	private _shouldAddToFolderBaseline(sessionKey: string, state: ISessionWithDefaultChat, gitHubState: ISessionGitHubState | undefined, pullRequest: CreatedPullRequest): boolean {
+		if (!this._isFolderSession(state, gitHubState) || getSessionRelatedPullRequestUrls(gitHubState).some(url => url.toLowerCase() === pullRequest.url.toLowerCase())) {
+			return false;
+		}
+		if (pullRequest.createdAt !== undefined) {
+			const sessionStart = Date.parse(this._stateManager.getSessionSummary(sessionKey)?.createdAt ?? '');
+			return Number.isNaN(sessionStart) || pullRequest.createdAt < sessionStart - PULL_REQUEST_CREATION_CLOCK_SKEW_MS;
+		}
+		return gitHubState?.initialPullRequestUrls === undefined;
+	}
+
+	private _isFolderSession(state: ISessionWithDefaultChat, gitHubState: ISessionGitHubState | undefined): boolean {
+		return state.config?.values[SessionConfigKey.Isolation] === 'folder'
+			|| gitHubState?.initialPullRequestUrls !== undefined;
 	}
 
 	/**
@@ -164,34 +197,37 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 			: undefined;
 	}
 
-	/**
-	 * Scans a user message for GitHub issue references and merges them into the
-	 * session's GitHub state. References already recorded are preserved and keep
-	 * their position, so the list reflects the order in which the session first
-	 * mentioned each issue.
-	 */
-	async attachSessionGitHubIssues(sessionKey: string, text: string): Promise<void> {
-		const references = parseGitHubIssueReferences(text);
-		if (references.length === 0) {
+	async attachSessionGitHubReferences(sessionKey: string, text: string): Promise<void> {
+		const currentState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
+		const issueReferences = parseGitHubIssueReferences(text);
+		const repository = currentState?.owner && currentState.repo ? { owner: currentState.owner, repo: currentState.repo } : undefined;
+		const pullRequestReferences = parseGitHubPullRequestReferences(text, repository)
+			.filter(reference => !repository || reference.owner.toLowerCase() === repository.owner.toLowerCase() && reference.repo.toLowerCase() === repository.repo.toLowerCase());
+		if (issueReferences.length === 0 && pullRequestReferences.length === 0) {
 			return;
 		}
 
-		const currentUrls = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta)?.issueUrls ?? [];
-		const nextUrls = [...currentUrls];
-		for (const reference of references) {
+		const currentIssueUrls = currentState?.issueUrls ?? [];
+		const nextIssueUrls = [...currentIssueUrls];
+		for (const reference of issueReferences) {
 			const url = toGitHubIssueUrl(reference);
-			if (!nextUrls.includes(url)) {
-				nextUrls.push(url);
+			if (!nextIssueUrls.includes(url)) {
+				nextIssueUrls.push(url);
 			}
 		}
 
-		if (nextUrls.length === currentUrls.length) {
-			return;
+		let nextState: ISessionGitHubState = issueReferences.length > 0
+			? { issueUrls: nextIssueUrls.slice(0, MAX_SESSION_ISSUE_REFERENCES) }
+			: {};
+		for (let index = pullRequestReferences.length - 1; index >= 0; index--) {
+			const reference = pullRequestReferences[index];
+			const url = toGitHubPullRequestUrl(reference);
+			nextState = {
+				...nextState,
+				...withMostRecentReferencedSessionPullRequest({ ...currentState, ...nextState }, url)
+			};
 		}
-
-		await this.setSessionGitHubState(sessionKey, {
-			issueUrls: nextUrls.slice(0, MAX_SESSION_ISSUE_REFERENCES)
-		} satisfies ISessionGitHubState);
+		await this.setSessionGitHubState(sessionKey, nextState);
 	}
 
 	async refreshSessionGitState(sessionKey: string, workingDirectory: URI | undefined): Promise<void> {

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationProvider.ts
@@ -8,7 +8,7 @@ import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import type { IChangesetOperationContribution, IChangesetOperationContext, IChangesetOperationRegistry } from '../common/agentHostChangesetOperationService.js';
 import { IAgentHostGitStateService } from '../common/agentHostGitStateService.js';
-import { ChangesetOperationScope, ChangesetOperationStatus, hasSessionPullRequestForBranch, readSessionGitHubState, SessionLifecycle, withMostRecentSessionPullRequest, type ChangesetOperation } from '../common/state/sessionState.js';
+import { ChangesetOperationScope, ChangesetOperationStatus, hasSessionPullRequestForBranch, readSessionGitHubState, SessionLifecycle, withMostRecentRelatedSessionPullRequest, type ChangesetOperation } from '../common/state/sessionState.js';
 import { AgentHostPullRequestOperationHandler, type PullRequestCreatedEvent } from './agentHostPullRequestOperationHandler.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 
@@ -111,6 +111,6 @@ export class AgentHostPullRequestOperationContribution extends Disposable implem
 		this._registry?.refreshSessionGitState(sessionKey);
 
 		const gitHubState = readSessionGitHubState(this._stateManager.getSessionState(sessionKey)?._meta);
-		this._gitStateService.setSessionGitHubState(sessionKey, withMostRecentSessionPullRequest(gitHubState, event.pullRequestUrl, event.branchName));
+		this._gitStateService.setSessionGitHubState(sessionKey, withMostRecentRelatedSessionPullRequest(gitHubState, event.pullRequestUrl, event.branchName));
 	}
 }

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -581,8 +581,7 @@ export class AgentService extends Disposable implements IAgentService {
 				void this._gitStateService.attachSessionGitHubPullRequest(session, workingDirStr ? URI.parse(workingDirStr) : undefined);
 			},
 			onUserMessage: (session, text) => {
-				// Record the GitHub issues the message references on the session.
-				void this._gitStateService.attachSessionGitHubIssues(session.toString(), text);
+				void this._gitStateService.attachSessionGitHubReferences(session.toString(), text);
 			},
 		}));
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -121,11 +121,7 @@ export interface IAgentSideEffectsOptions {
 	 * excluded — only the parent session URI is passed.
 	 */
 	readonly onTurnComplete: (session: ProtocolURI) => void;
-	/**
-	 * Called with the text of every user message that is forwarded to an agent,
-	 * so the host can derive session state from what the user wrote (e.g. the
-	 * GitHub issues the message references).
-	 */
+	/** Called for user messages so the host can record referenced GitHub work. */
 	readonly onUserMessage?: (session: ProtocolURI, text: string) => void;
 	/** Process launcher used when client-origin metadata is unavailable. */
 	readonly hostLaunchKind?: AgentHostLaunchKind;

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -21,6 +21,7 @@ export interface CreatedPullRequest {
 	readonly url: string;
 	readonly number: number;
 	readonly nodeId?: string;
+	readonly createdAt?: number;
 }
 
 /**
@@ -33,6 +34,7 @@ interface GitHubPullRequestResponseItem {
 	readonly number?: unknown;
 	readonly html_url?: unknown;
 	readonly node_id?: unknown;
+	readonly created_at?: unknown;
 	readonly state?: unknown;
 	readonly head?: { readonly sha?: unknown };
 }
@@ -41,8 +43,15 @@ function toCreatedPullRequest(item: GitHubPullRequestResponseItem | undefined): 
 	const html_url = item?.html_url;
 	const number = item?.number;
 	const node_id = item?.node_id;
+	const created_at = item?.created_at;
+	const createdAt = typeof created_at === 'string' ? Date.parse(created_at) : undefined;
 	return typeof html_url === 'string' && typeof number === 'number'
-		? { number, url: html_url, nodeId: typeof node_id === 'string' ? node_id : undefined }
+		? {
+			number,
+			url: html_url,
+			nodeId: typeof node_id === 'string' ? node_id : undefined,
+			...(createdAt !== undefined && Number.isFinite(createdAt) ? { createdAt } : {}),
+		}
 		: undefined;
 }
 

--- a/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/sessionServerTools.ts
@@ -8,7 +8,7 @@ import type { Mutable } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
 import { AgentSession, type AgentProvider, type IAgentCreateSessionConfig, type IAgentModelInfo, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { SessionStatus } from '../../common/state/protocol/channels-session/state.js';
-import { buildChatUri, buildDefaultChatUri, getInlineToolInput, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionGitState, readSessionGitHubState, ResponsePartKind, ToolCallStatus, TurnState, type Message, type ModelSelection, type ResponsePart, type ToolCallState, type ToolDefinition, type StringOrMarkdown, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, getInlineToolInput, getSessionRelatedPullRequestUrls, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionGitState, readSessionGitHubState, ResponsePartKind, ToolCallStatus, TurnState, type Message, type ModelSelection, type ResponsePart, type ToolCallState, type ToolDefinition, type StringOrMarkdown, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { buildOpenSessionLinkUri, parseOpenSessionLinkChatId, parseOpenSessionLinkUri } from '../../common/openSessionLink.js';
 import { SessionServerToolName } from '../../common/serverToolNames.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -498,7 +498,7 @@ export function filterSessions(sessions: readonly IAgentSessionMetadata[], args:
 		if (args.unread && !sessionIsUnread(session)) {
 			return false;
 		}
-		if (args.withPullRequest && !readSessionGitHubState(session._meta)?.pullRequestUrls?.length) {
+		if (args.withPullRequest && getSessionRelatedPullRequestUrls(readSessionGitHubState(session._meta)).length === 0) {
 			return false;
 		}
 		// Archived sessions are hidden unless explicitly requested, either via
@@ -539,7 +539,8 @@ function serializeGitHubState(session: IAgentSessionMetadata): ISerializedGitHub
 	const result: Mutable<ISerializedGitHubState> = {};
 	if (github.owner !== undefined) { result.owner = github.owner; }
 	if (github.repo !== undefined) { result.repo = github.repo; }
-	if (github.pullRequestUrls?.[0] !== undefined) { result.pullRequestUrl = github.pullRequestUrls[0]; }
+	const pullRequestUrl = getSessionRelatedPullRequestUrls(github)[0];
+	if (pullRequestUrl !== undefined) { result.pullRequestUrl = pullRequestUrl; }
 	return Object.keys(result).length > 0 ? result : undefined;
 }
 

--- a/src/vs/platform/agentHost/test/common/githubPullRequestReferences.test.ts
+++ b/src/vs/platform/agentHost/test/common/githubPullRequestReferences.test.ts
@@ -23,4 +23,15 @@ suite('GitHub pull request references', () => {
 	test('ignores shorthand without repository context', () => {
 		assert.deepStrictEqual(parseGitHubPullRequestReferences('Check PR #42, issue #7, and #9.'), []);
 	});
+
+	test('uses the configured GitHub Enterprise host', () => {
+		assert.deepStrictEqual(parseGitHubPullRequestReferences(
+			'Compare https://github.com/o/r/pull/1 with https://ghe.example.com/o/r/pull/2 and PR #3.',
+			{ owner: 'o', repo: 'r' },
+			'ghe.example.com'
+		), [
+			{ owner: 'o', repo: 'r', number: 2 },
+			{ owner: 'o', repo: 'r', number: 3 },
+		]);
+	});
 });

--- a/src/vs/platform/agentHost/test/common/githubPullRequestReferences.test.ts
+++ b/src/vs/platform/agentHost/test/common/githubPullRequestReferences.test.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { parseGitHubPullRequestReferences } from '../../common/githubPullRequestReferences.js';
+
+suite('GitHub pull request references', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('extracts URLs and repository-scoped shorthand without duplicates', () => {
+		assert.deepStrictEqual(parseGitHubPullRequestReferences(
+			'Compare pull request #43 with https://github.com/microsoft/vscode/pull/42, then check PR #42.',
+			{ owner: 'microsoft', repo: 'vscode' }
+		), [
+			{ owner: 'microsoft', repo: 'vscode', number: 43 },
+			{ owner: 'microsoft', repo: 'vscode', number: 42 },
+		]);
+	});
+
+	test('ignores shorthand without repository context', () => {
+		assert.deepStrictEqual(parseGitHubPullRequestReferences('Check PR #42, issue #7, and #9.'), []);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
@@ -375,7 +375,7 @@ class TestGitStateService extends Disposable implements IAgentHostGitStateServic
 	}
 	async setSessionGitHubState(_sessionKey: string, _state: ISessionGitHubState): Promise<void> { }
 	async attachSessionGitHubPullRequest(_sessionKey: string): Promise<void> { }
-	async attachSessionGitHubIssues(_sessionKey: string, _text: string): Promise<void> { }
+	async attachSessionGitHubReferences(_sessionKey: string, _text: string): Promise<void> { }
 }
 
 class TestFileMonitorService extends Disposable implements IAgentHostFileMonitorService {

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetOperationService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetOperationService.test.ts
@@ -75,7 +75,7 @@ class TestGitStateService implements IAgentHostGitStateService {
 	async setSessionGitHubState(_sessionKey: string, _state: ISessionGitHubState): Promise<void> { }
 
 	async attachSessionGitHubPullRequest(_sessionKey: string): Promise<void> { }
-	async attachSessionGitHubIssues(_sessionKey: string, _text: string): Promise<void> { }
+	async attachSessionGitHubReferences(_sessionKey: string, _text: string): Promise<void> { }
 }
 
 suite('AgentHostChangesetOperationService', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -10,13 +10,14 @@ import { runWithFakedTimers } from '../../../../base/test/common/timeTravelSched
 import { NullLogService } from '../../../log/common/log.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import type { IAgentService } from '../../common/agentService.js';
-import { readSessionGitHubState, readSessionGitState, SESSION_META_GITHUB_KEY, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, SessionStatus, type ISessionGitHubState, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
+import { getSessionRelatedPullRequestUrls, hasSessionPullRequestForBranch, readSessionGitHubState, readSessionGitState, SESSION_META_GITHUB_KEY, withInitialSessionPullRequest, withMostRecentRelatedSessionPullRequest, withMostRecentSessionPullRequest, withSessionGitHubState, withSessionGitState, SessionStatus, type ISessionGitHubState, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
 import { META_GIT_STATE, META_GITHUB_STATE } from '../../common/agentHostGitStateService.js';
 import { AgentHostGitStateService } from '../../node/agentHostGitStateService.js';
 import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import type { CreatedPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../common/sessionTestHelpers.js';
+import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 
 const SESSION = 'mock:/session-1';
 const WORKING_DIRECTORY = 'file:///wd';
@@ -80,6 +81,58 @@ suite('AgentHostGitStateService', () => {
 			],
 			pullRequestBranchName: 'feature-5',
 		});
+	});
+
+	test('promotes an initial pull request into the session', () => {
+		const initial = 'https://github.com/microsoft/vscode/pull/1';
+		const state = withMostRecentRelatedSessionPullRequest({
+			pullRequestUrls: [initial],
+			initialPullRequestUrls: [initial],
+		}, initial, 'feature');
+
+		assert.deepStrictEqual({
+			state,
+			related: getSessionRelatedPullRequestUrls(state),
+		}, {
+			state: {
+				pullRequestUrls: [initial],
+				associatedPullRequestUrls: [initial],
+				pullRequestBranchName: 'feature',
+				initialPullRequestUrls: [],
+			},
+			related: [initial],
+		});
+	});
+
+	test('keeps checkout recency when combining discovered and associated pull requests', () => {
+		const current = 'https://github.com/microsoft/vscode/pull/2';
+		const referenced = 'https://github.com/microsoft/vscode/pull/1';
+
+		assert.deepStrictEqual(getSessionRelatedPullRequestUrls({
+			pullRequestUrls: [current, referenced],
+			initialPullRequestUrls: [referenced],
+			associatedPullRequestUrls: [referenced],
+		}), [current, referenced]);
+	});
+
+	test('keeps the most recently discovered pull requests in the bounded baseline', () => {
+		let state: ISessionGitHubState | undefined;
+		for (let number = 1; number <= 11; number++) {
+			state = { ...state, ...withInitialSessionPullRequest(state, `https://github.com/microsoft/vscode/pull/${number}`) };
+		}
+
+		assert.deepStrictEqual(state?.initialPullRequestUrls, [
+			'https://github.com/microsoft/vscode/pull/11',
+			'https://github.com/microsoft/vscode/pull/10',
+			'https://github.com/microsoft/vscode/pull/9',
+			'https://github.com/microsoft/vscode/pull/8',
+			'https://github.com/microsoft/vscode/pull/7',
+			'https://github.com/microsoft/vscode/pull/6',
+			'https://github.com/microsoft/vscode/pull/5',
+			'https://github.com/microsoft/vscode/pull/4',
+			'https://github.com/microsoft/vscode/pull/3',
+			'https://github.com/microsoft/vscode/pull/2',
+		]);
 	});
 
 	function createHarness(options?: { octoKitService?: IAgentHostOctoKitService; agentService?: IAgentService }) {
@@ -151,19 +204,25 @@ suite('AgentHostGitStateService', () => {
 		};
 	}
 
-	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState; gitHubState?: ISessionGitHubState }): void {
+	function seedSession(stateManager: AgentHostStateManager, options?: { workingDirectory?: string; gitState?: ISessionGitState; gitHubState?: ISessionGitHubState; isolation?: 'folder' | 'worktree'; createdAt?: number }): void {
 		const summary: SessionSummary = {
 			resource: SESSION,
 			provider: 'mock',
 			title: 'Test',
 			status: SessionStatus.Idle,
-			createdAt: new Date(0).toISOString(),
+			createdAt: new Date(options?.createdAt ?? 0).toISOString(),
 			modifiedAt: new Date(0).toISOString(),
 			workingDirectories: options?.workingDirectory ? [options.workingDirectory] : undefined,
 		};
 		// `restoreSession` materializes the session in `ready` lifecycle so the
 		// persistence path (which skips `creating` sessions) actually runs.
 		stateManager.restoreSession(summary, []);
+		if (options?.isolation) {
+			stateManager.setSessionConfig(SESSION, {
+				schema: { type: 'object', properties: {} },
+				values: { [SessionConfigKey.Isolation]: options.isolation },
+			});
+		}
 		if (options?.gitState) {
 			stateManager.setSessionMeta(SESSION, withSessionGitState(undefined, options.gitState));
 		}
@@ -426,13 +485,307 @@ suite('AgentHostGitStateService', () => {
 		});
 	});
 
+	test('keeps a pre-existing folder-session pull request out of the related set', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+				isolation: 'folder',
+				createdAt: 600_000,
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', {
+				url: 'https://github.com/microsoft/vscode/pull/1',
+				number: 1,
+				createdAt: 1_000,
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			assert.deepStrictEqual({
+				github,
+				related: [...getSessionRelatedPullRequestUrls(github)],
+				persistedGitHub: JSON.parse((await h.db.getMetadata(META_GITHUB_STATE))!),
+			}, {
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'],
+					initialPullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'],
+					pullRequestBranchName: 'feature',
+				},
+				related: [],
+				persistedGitHub: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'],
+					initialPullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'],
+					pullRequestBranchName: 'feature',
+				},
+			});
+		});
+	});
+
+	test('uses folder isolation that resolves while a pull request lookup is in flight', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const pullRequestUrl = 'https://github.com/microsoft/vscode/pull/1';
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+				createdAt: 600_000,
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', { url: pullRequestUrl, number: 1, createdAt: 1_000 });
+			h.setOnPullRequestLookup(async () => {
+				h.stateManager.setSessionConfig(SESSION, {
+					schema: { type: 'object', properties: {} },
+					values: { [SessionConfigKey.Isolation]: 'folder' },
+				});
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			assert.deepStrictEqual({
+				github,
+				related: [...getSessionRelatedPullRequestUrls(github)],
+			}, {
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: [pullRequestUrl],
+					initialPullRequestUrls: [pullRequestUrl],
+					pullRequestBranchName: 'feature',
+				},
+				related: [],
+			});
+		});
+	});
+
+	test('relates a pull request created after a folder session began', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+				isolation: 'folder',
+				createdAt: 600_000,
+			});
+			h.setGitResult(gitState);
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+			h.setPullRequest('feature', {
+				url: 'https://github.com/microsoft/vscode/pull/2',
+				number: 2,
+				createdAt: 600_500,
+			});
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			assert.deepStrictEqual({
+				github,
+				related: [...getSessionRelatedPullRequestUrls(github)],
+			}, {
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: ['https://github.com/microsoft/vscode/pull/2'],
+					initialPullRequestUrls: [],
+					pullRequestBranchName: 'feature',
+				},
+				related: ['https://github.com/microsoft/vscode/pull/2'],
+			});
+		});
+	});
+
+	test('keeps worktree pull request behavior unchanged', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+				isolation: 'worktree',
+				createdAt: 2_000,
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', {
+				url: 'https://github.com/microsoft/vscode/pull/1',
+				number: 1,
+				createdAt: 1_000,
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			assert.deepStrictEqual({
+				github,
+				related: [...getSessionRelatedPullRequestUrls(github)],
+			}, {
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: ['https://github.com/microsoft/vscode/pull/1'],
+					pullRequestBranchName: 'feature',
+				},
+				related: ['https://github.com/microsoft/vscode/pull/1'],
+			});
+		});
+	});
+
+	test('promotes a referenced baseline pull request', async () => {
+		const h = createHarness();
+		const pullRequestUrl = 'https://github.com/microsoft/vscode/pull/1';
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrls: [pullRequestUrl],
+				initialPullRequestUrls: [pullRequestUrl],
+				pullRequestBranchName: 'feature',
+			},
+			isolation: 'folder',
+		});
+
+		await h.service.attachSessionGitHubReferences(SESSION, 'Please unblock PR #1. Ignore https://github.com/octo/repo/pull/9.');
+
+		const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+		assert.deepStrictEqual({
+			github,
+			related: [...getSessionRelatedPullRequestUrls(github)],
+		}, {
+			github: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrls: [pullRequestUrl],
+				initialPullRequestUrls: [pullRequestUrl],
+				associatedPullRequestUrls: [pullRequestUrl],
+				pullRequestBranchName: 'feature',
+			},
+			related: [pullRequestUrl],
+		});
+	});
+
+	test('records an unrelated PR mention without changing checkout PR state', async () => {
+		const h = createHarness();
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitHubState: { owner: 'microsoft', repo: 'vscode', initialPullRequestUrls: [] },
+			isolation: 'folder',
+		});
+
+		await h.service.attachSessionGitHubReferences(SESSION, 'Compare this with PR #99.');
+
+		const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+		assert.deepStrictEqual({
+			github,
+			related: [...getSessionRelatedPullRequestUrls(github)],
+			hasCheckoutPullRequest: hasSessionPullRequestForBranch(github, 'feature'),
+		}, {
+			github: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				initialPullRequestUrls: [],
+				associatedPullRequestUrls: ['https://github.com/microsoft/vscode/pull/99'],
+			},
+			related: [],
+			hasCheckoutPullRequest: false,
+		});
+	});
+
+	test('retains a full PR URL mentioned before repository discovery', async () => {
+		const h = createHarness();
+		const pullRequestUrl = 'https://github.com/microsoft/vscode/pull/1';
+		seedSession(h.stateManager, { workingDirectory: WORKING_DIRECTORY, isolation: 'folder' });
+
+		await h.service.attachSessionGitHubReferences(SESSION, `Please unblock ${pullRequestUrl}.`);
+		await h.service.setSessionGitHubState(SESSION, {
+			owner: 'microsoft',
+			repo: 'vscode',
+			pullRequestUrls: [pullRequestUrl],
+			initialPullRequestUrls: [pullRequestUrl],
+		});
+
+		const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+		assert.deepStrictEqual({
+			github,
+			related: [...getSessionRelatedPullRequestUrls(github)],
+		}, {
+			github: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrls: [pullRequestUrl],
+				initialPullRequestUrls: [pullRequestUrl],
+				associatedPullRequestUrls: [pullRequestUrl],
+			},
+			related: [pullRequestUrl],
+		});
+	});
+
+	test('preserves an explicit PR reference while its baseline lookup is in flight', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const pullRequestUrl = 'https://github.com/microsoft/vscode/pull/1';
+			const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+				isolation: 'folder',
+				createdAt: 600_000,
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature', { url: pullRequestUrl, number: 1, createdAt: 1_000 });
+			h.setOnPullRequestLookup(async () => {
+				await h.service.attachSessionGitHubReferences(SESSION, 'Please unblock PR #1.');
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+			assert.deepStrictEqual({
+				github,
+				related: [...getSessionRelatedPullRequestUrls(github)],
+			}, {
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: [pullRequestUrl],
+					initialPullRequestUrls: [pullRequestUrl],
+					associatedPullRequestUrls: [pullRequestUrl],
+					pullRequestBranchName: 'feature',
+				},
+				related: [pullRequestUrl],
+			});
+		});
+	});
+
+	test('round-trips an empty folder-session baseline through persisted metadata', () => {
+		const persisted = JSON.parse(JSON.stringify({ initialPullRequestUrls: [] }));
+
+		assert.deepStrictEqual(readSessionGitHubState({ [SESSION_META_GITHUB_KEY]: persisted }), {
+			initialPullRequestUrls: [],
+		});
+	});
+
 	test('accumulates the GitHub issues referenced across user messages', async () => {
 		const h = createHarness();
 		seedSession(h.stateManager, { workingDirectory: WORKING_DIRECTORY });
 
-		await h.service.attachSessionGitHubIssues(SESSION, 'Fix https://github.com/microsoft/vscode/issues/1 please');
-		await h.service.attachSessionGitHubIssues(SESSION, 'Also microsoft/vscode#1 and octo/repo#2, but not #3');
-		await h.service.attachSessionGitHubIssues(SESSION, 'Nothing to see here');
+		await h.service.attachSessionGitHubReferences(SESSION, 'Fix https://github.com/microsoft/vscode/issues/1 please');
+		await h.service.attachSessionGitHubReferences(SESSION, 'Also microsoft/vscode#1 and octo/repo#2, but not #3');
+		await h.service.attachSessionGitHubReferences(SESSION, 'Nothing to see here');
 
 		assert.deepStrictEqual({
 			github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
@@ -555,7 +908,7 @@ suite('AgentHostGitStateService', () => {
 				h.setGitResult(gitState);
 				h.setPullRequest('feature', { url: 'https://github.com/microsoft/vscode/pull/1', number: 1 });
 				h.setOnPullRequestLookup(async () => {
-					await h.service.attachSessionGitHubIssues(SESSION, 'See microsoft/vscode#42');
+					await h.service.attachSessionGitHubReferences(SESSION, 'See microsoft/vscode#42');
 					const currentState = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
 					await h.service.setSessionGitHubState(SESSION, withMostRecentSessionPullRequest(currentState, 'https://github.com/microsoft/vscode/pull/2', 'feature-2'));
 				});
@@ -648,6 +1001,30 @@ suite('AgentHostGitStateService', () => {
 			}, {
 				pullRequestCalls: ['feature'],
 				github: { owner: 'microsoft', repo: 'vscode' },
+			});
+		});
+
+		test('does not capture an empty baseline for a stale branch lookup', async () => {
+			await runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const gitState: ISessionGitState = { branchName: 'feature', baseBranchName: 'main' };
+				const h = createHarness();
+				seedSession(h.stateManager, {
+					workingDirectory: WORKING_DIRECTORY,
+					gitState,
+					gitHubState: { owner: 'microsoft', repo: 'vscode' },
+					isolation: 'folder',
+				});
+				h.setGitResult(gitState);
+				h.setOnPullRequestLookup(async () => {
+					h.stateManager.setSessionMeta(SESSION, withSessionGitState(h.stateManager.getSessionState(SESSION)?._meta, { branchName: 'feature-2', baseBranchName: 'main' }));
+				});
+
+				await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+				assert.deepStrictEqual(readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta), {
+					owner: 'microsoft',
+					repo: 'vscode',
+				});
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -135,7 +135,7 @@ suite('AgentHostGitStateService', () => {
 		]);
 	});
 
-	function createHarness(options?: { octoKitService?: IAgentHostOctoKitService; agentService?: IAgentService }) {
+	function createHarness(options?: { octoKitService?: IAgentHostOctoKitService; agentService?: IAgentService; enterpriseUri?: string }) {
 		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		const db = new TestSessionDatabase();
 		const sessionDataService = createSessionDataService(db);
@@ -179,7 +179,7 @@ suite('AgentHostGitStateService', () => {
 			gitService,
 			options?.octoKitService ?? octoKitService,
 			options?.agentService ?? agentService,
-			createTestGitHubEndpointService(),
+			createTestGitHubEndpointService(options?.enterpriseUri),
 			new NullLogService(),
 			sessionDataService,
 		));
@@ -659,6 +659,40 @@ suite('AgentHostGitStateService', () => {
 		});
 
 		await h.service.attachSessionGitHubReferences(SESSION, 'Please unblock PR #1. Ignore https://github.com/octo/repo/pull/9.');
+
+		const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
+		assert.deepStrictEqual({
+			github,
+			related: [...getSessionRelatedPullRequestUrls(github)],
+		}, {
+			github: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrls: [pullRequestUrl],
+				initialPullRequestUrls: [pullRequestUrl],
+				associatedPullRequestUrls: [pullRequestUrl],
+				pullRequestBranchName: 'feature',
+			},
+			related: [pullRequestUrl],
+		});
+	});
+
+	test('promotes a referenced GitHub Enterprise baseline pull request', async () => {
+		const h = createHarness({ enterpriseUri: 'https://ghe.example.com' });
+		const pullRequestUrl = 'https://ghe.example.com/microsoft/vscode/pull/1';
+		seedSession(h.stateManager, {
+			workingDirectory: WORKING_DIRECTORY,
+			gitHubState: {
+				owner: 'microsoft',
+				repo: 'vscode',
+				pullRequestUrls: [pullRequestUrl],
+				initialPullRequestUrls: [pullRequestUrl],
+				pullRequestBranchName: 'feature',
+			},
+			isolation: 'folder',
+		});
+
+		await h.service.attachSessionGitHubReferences(SESSION, 'Please unblock PR #1.');
 
 		const github = readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta);
 		assert.deepStrictEqual({

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationProvider.test.ts
@@ -21,7 +21,7 @@ const nullGitStateService = new class implements IAgentHostGitStateService {
 	async getSessionGitHubState(): Promise<ISessionGitHubState | undefined> { return undefined; }
 	async setSessionGitHubState(): Promise<void> { }
 	async attachSessionGitHubPullRequest(): Promise<void> { }
-	async attachSessionGitHubIssues(): Promise<void> { }
+	async attachSessionGitHubReferences(): Promise<void> { }
 };
 
 const githubBranchWithUncommittedChanges: ISessionGitState = {

--- a/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionServerTools.test.ts
@@ -269,7 +269,8 @@ suite('SessionServerTools', () => {
 		const elsewhere = { ...sessionMeta('elsewhere', SessionStatus.Idle, other), startTime: 5000 };
 		const archived = { ...sessionMeta('archived', SessionStatus.Idle | SessionStatus.IsArchived, workspace), startTime: 2000 };
 		const withPr = { ...sessionMeta('withPr', SessionStatus.Idle, workspace), startTime: 4000, _meta: withSessionGitHubState(undefined, { pullRequestUrls: ['https://github.com/o/r/pull/2'] }) };
-		const sessions = [idle, needsInput, elsewhere, archived, withPr];
+		const inheritedPr = { ...sessionMeta('inheritedPr', SessionStatus.Idle, workspace), startTime: 4500, _meta: withSessionGitHubState(undefined, { pullRequestUrls: ['https://github.com/o/r/pull/3'], initialPullRequestUrls: ['https://github.com/o/r/pull/3'] }) };
+		const sessions = [idle, needsInput, elsewhere, archived, withPr, inheritedPr];
 		const group = createSessionServerToolGroup(createAccessor({ listSessions: async () => sessions }));
 
 		const ids = async (args: object) => JSON.parse(await group.execute(stateManager, 'copilot:/caller', SessionServerToolName.ListSessions, args)).sessions.map((s: { session: string }) => s.session);
@@ -289,15 +290,15 @@ suite('SessionServerTools', () => {
 		}, {
 			byStatus: ['copilot:/needsInput'],
 			byArchivedStatus: ['copilot:/archived'],
-			byWorkspace: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/withPr'],
+			byWorkspace: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/withPr', 'copilot:/inheritedPr'],
 			withChanges: ['copilot:/idle'],
 			unread: ['copilot:/needsInput'],
 			withPullRequest: ['copilot:/withPr'],
-			withArchived: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/archived', 'copilot:/withPr'],
-			createdAfter: ['copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/withPr'],
+			withArchived: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/archived', 'copilot:/withPr', 'copilot:/inheritedPr'],
+			createdAfter: ['copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/withPr', 'copilot:/inheritedPr'],
 			createdBefore: ['copilot:/idle', 'copilot:/needsInput'],
 			combined: ['copilot:/idle'],
-			all: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/withPr'],
+			all: ['copilot:/idle', 'copilot:/needsInput', 'copilot:/elsewhere', 'copilot:/withPr', 'copilot:/inheritedPr'],
 		});
 		store.dispose();
 	});

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -93,7 +93,7 @@ suite('AgentHostOctoKitService', () => {
 	});
 
 	test('findPullRequestByHeadBranch fetches the latest matching pull request', async () => {
-		const { fetch, captured } = capturingFetch(jsonResponse([{ html_url: 'https://github.com/o/r/pull/9', number: 9, node_id: 'PR_node_9' }]));
+		const { fetch, captured } = capturingFetch(jsonResponse([{ html_url: 'https://github.com/o/r/pull/9', number: 9, node_id: 'PR_node_9', created_at: '2026-08-09T12:00:00.000Z' }]));
 		const service = makeService(fetch);
 
 		const result = await service.findPullRequestByHeadBranch('o', 'r', 'feature/test', 'tok', signal());
@@ -103,7 +103,7 @@ suite('AgentHostOctoKitService', () => {
 			url: captured().url,
 			method: captured().init?.method,
 		}, {
-			result: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: 'PR_node_9' },
+			result: { url: 'https://github.com/o/r/pull/9', number: 9, nodeId: 'PR_node_9', createdAt: Date.parse('2026-08-09T12:00:00.000Z') },
 			url: 'https://api.github.com/repos/o/r/pulls?head=o%3Afeature%2Ftest&state=all&sort=updated&direction=desc&per_page=1',
 			method: 'GET',
 		});

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -57,6 +57,12 @@ The Electron-only `electron-browser/agentHost.contribution.ts` adds desktop-only
 
 These session-type icons are specific to the Agents window provider. In the editor window, `agentSessions.ts` maps local Agent Host Copilot to the Local harness's `Codicon.vm` picker icon, while `agentSessionsViewer.ts` uses the same session-list status dot as the Local harness.
 
+## Pull Request Provenance
+
+Agent Host metadata keeps the complete pull-request history discovered for a checkout so branch operations can detect an existing PR. Folder-isolated sessions additionally persist `initialPullRequestUrls`; the provider filters those pre-existing PRs from session presentation and `withPullRequest` queries.
+
+A baseline PR becomes session-related when the user references it in a message or deliberately invokes a create-PR operation that resolves to it. Explicit references are stored separately from checkout PRs and only surface after checkout discovery confirms the same PR, so an unrelated mention cannot change branch operations or session presentation. Pull requests created after the session began are related automatically. Worktree and legacy sessions have no baseline and retain the complete discovered history.
+
 ## IDs and URI Schemes
 
 A single agent host session uses several distinct identifiers:

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -63,6 +63,8 @@ Agent Host metadata keeps the complete pull-request history discovered for a che
 
 A baseline PR becomes session-related when the user references it in a message or deliberately invokes a create-PR operation that resolves to it. Explicit references are stored separately from checkout PRs and only surface after checkout discovery confirms the same PR, so an unrelated mention cannot change branch operations or session presentation. Pull requests created after the session began are related automatically. Worktree and legacy sessions have no baseline and retain the complete discovered history.
 
+Pull-request identity uses the Agent Host's configured GitHub host. Never canonicalize references to `github.com`: Enterprise checkout URLs and explicit references must remain comparable by host, owner, repository, and number.
+
 ## IDs and URI Schemes
 
 A single agent host session uses several distinct identifiers:

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -27,7 +27,7 @@ import type { IAgentSubscription } from '../../../../../platform/agentHost/commo
 import { ResolveSessionConfigResult, type SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { AgentCustomization, ChangesSummary, ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, type ClientPluginCustomization, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionActiveClient, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isChatAction, isSessionAction, NotificationType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
-import { AgentCapabilities, AgentInfo, buildChatUri, buildDefaultChatUri, isDefaultChatUri, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionWorkspaceless, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionMeta, StateComponents, withSessionMultiRootMetadata, withSessionStatusFlag, withSessionWorkspaceless, type ChatSummary, type ISessionGitState, type ISessionMultiRootMetadata } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentCapabilities, AgentInfo, buildChatUri, buildDefaultChatUri, getSessionRelatedPullRequestUrls, isDefaultChatUri, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionWorkspaceless, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionMeta, StateComponents, withSessionMultiRootMetadata, withSessionStatusFlag, withSessionWorkspaceless, type ChatSummary, type ISessionGitState, type ISessionMultiRootMetadata } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -251,7 +251,7 @@ function toGitHubPullRequestRefs(pullRequestUrls: readonly string[] | undefined)
 function toGitHubInfo(meta: SessionMeta | undefined): IGitHubInfo | undefined {
 	const state = readSessionGitHubState(meta);
 	const gitState = readSessionGitState(meta);
-	const pullRequests = toGitHubPullRequestRefs(state?.pullRequestUrls);
+	const pullRequests = toGitHubPullRequestRefs(getSessionRelatedPullRequestUrls(state));
 	const pullRequest = pullRequests?.[0];
 	const repository = state?.owner && state.repo
 		? { owner: state.owner, repo: state.repo }

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -5025,6 +5025,48 @@ suite('LocalAgentHostSessionsProvider', () => {
 		sub.dispose();
 	}));
 
+	test('filters folder-session baseline pull requests from GitHub info', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const gitHubService = new class extends mock<IGitHubService>() {
+			private readonly _model = { pullRequest: constObservable(undefined) } as unknown as GitHubPullRequestModel;
+			override createPullRequestModelReference = () => new ImmortalReference(this._model);
+		}();
+
+		agentHost.addSession(createSession('pr-baseline', { summary: 'PR Session', project: { uri: URI.parse('file:///repo'), displayName: 'repo' } }));
+		const provider = createProvider(disposables, agentHost, undefined, { gitHubService });
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'PR Session');
+		assert.ok(session);
+
+		provider.getSessionConfig(session.sessionId);
+		agentHost.setSessionState('pr-baseline', 'copilotcli', {
+			provider: 'copilotcli', title: 'PR Session', status: ProtocolSessionStatus.Idle,
+			lifecycle: SessionLifecycle.Ready,
+			activeClients: [],
+			chats: [],
+			_meta: {
+				github: {
+					owner: 'owner',
+					repo: 'repo',
+					pullRequestUrls: [
+						'https://github.com/owner/repo/pull/42',
+						'https://github.com/owner/repo/pull/41',
+					],
+					initialPullRequestUrls: ['https://github.com/owner/repo/pull/42'],
+				}
+			},
+		});
+
+		const gitHubInfo = session.workspace.get()!.folders[0]!.gitRepository!.gitHubInfo.get();
+		assert.deepStrictEqual({
+			activePullRequest: gitHubInfo?.pullRequest?.number,
+			pullRequests: gitHubInfo?.pullRequests?.map(pullRequest => pullRequest.number),
+		}, {
+			activePullRequest: 41,
+			pullRequests: [41],
+		});
+	}));
+
 	// ---- replaceSessionConfig -------
 
 	test('replaceSessionConfig only replaces sessionMutable, non-readOnly values and preserves everything else', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {


### PR DESCRIPTION
## Summary
- distinguish checkout pull requests from session-related pull requests for folder-isolated sessions
- promote pre-existing pull requests when user intent or Create PR associates them with the session
- preserve branch operation behavior, legacy/worktree behavior, and durable restore metadata

## Testing
- `npm run typecheck-client`
- `npm run valid-layers-check`
- focused unit suites: 264 passing, 11 pending