### PR TITLE
Style overries: Update sash handle appearance for high contrast themes

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
@@ -57,6 +57,12 @@
 	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
 }
 
+:is(.hc-black, .hc-light).style-override .monaco-sash:not(.disabled)::after {
+	background: var(--vscode-foreground);
+	color: var(--vscode-foreground);
+	opacity: 1;
+}
+
 /* While hovering/dragging, defer to the base full-length highlight. */
 .style-override .monaco-sash.hover:not(.disabled)::after,
 .style-override .monaco-sash.active:not(.disabled)::after {


### PR DESCRIPTION
Enhance the appearance of sash handles to improve visibility in high contrast themes. This change ensures that the sash handles are more distinguishable for users relying on high contrast settings.

