### PR TITLE
sessions: reserve 5 file rows in changes list, collapse CI checks by default

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -107,6 +107,9 @@ const EMPTY_FILE_CHANGES_MIN_HEIGHT = 140;
 /** Breathing room rendered beneath the last file row when the whole list fits. */
 const TREE_PANE_LIST_BOTTOM_PADDING = 12;
 
+/** The file changes section always reserves room for at least this many file rows. */
+const TREE_PANE_MIN_VISIBLE_ROWS = 5;
+
 // --- ButtonBar widget
 
 /**
@@ -1055,7 +1058,7 @@ export class ChangesViewPane extends ViewPane {
 			return EMPTY_FILE_CHANGES_MIN_HEIGHT;
 		}
 
-		const desiredSize = this.getTreePaneDesiredSize();
+		const desiredSize = Math.max(this.getTreePaneDesiredSize(), this.getTreePaneReservedRowsSize());
 		const availableSize = this.getSplitViewAvailableHeight() - reservedSectionHeight;
 		return Math.min(desiredSize, Math.max(EMPTY_FILE_CHANGES_MIN_HEIGHT, availableSize));
 	}
@@ -1071,8 +1074,18 @@ export class ChangesViewPane extends ViewPane {
 		return filesHeaderHeight + treeContentHeight + bottomPadding;
 	}
 
+	/** Height needed to show {@link TREE_PANE_MIN_VISIBLE_ROWS} file rows, regardless of how many are listed. */
+	private getTreePaneReservedRowsSize(): number {
+		const filesHeaderHeight = this.filesHeaderNode?.offsetHeight ?? 0;
+		return filesHeaderHeight + TREE_PANE_MIN_VISIBLE_ROWS * ChangesTreeDelegate.ROW_HEIGHT + TREE_PANE_LIST_BOTTOM_PADDING;
+	}
+
 	private getTreePaneMaximumSize(): number {
-		return this.getTreePaneDesiredSize();
+		if (this.listContainer?.style.display === 'none') {
+			return EMPTY_FILE_CHANGES_MIN_HEIGHT;
+		}
+
+		return Math.max(this.getTreePaneDesiredSize(), this.getTreePaneReservedRowsSize());
 	}
 
 	private fireTreePaneSizeChange(): void {

--- a/src/vs/sessions/contrib/changes/browser/changesViewService.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewService.ts
@@ -27,7 +27,7 @@ export const ChangesetHasOperationsContext = new RawContextKey<boolean>('session
 
 const DEFAULT_SECTION_COLLAPSE_STATE: IChangesViewSectionCollapseState = Object.freeze({
 	otherFiles: false,
-	checks: false,
+	checks: true,
 });
 
 export class ChangesViewService extends Disposable implements IChangesViewService {
@@ -224,7 +224,7 @@ export class ChangesViewService extends Disposable implements IChangesViewServic
 		}
 
 		const next = { ...current, [section]: collapsed };
-		if (!next.otherFiles && !next.checks) {
+		if (next.otherFiles === DEFAULT_SECTION_COLLAPSE_STATE.otherFiles && next.checks === DEFAULT_SECTION_COLLAPSE_STATE.checks) {
 			this._sectionCollapseStateBySession.delete(sessionResource);
 		} else {
 			this._sectionCollapseStateBySession.set(sessionResource, next);

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewService.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewService.test.ts
@@ -75,21 +75,21 @@ suite('ChangesViewService', () => {
 
 		const states = [service.activeSessionSectionCollapseStateObs.get()];
 		service.setSectionCollapsed(sessionA.resource, 'otherFiles', true);
-		service.setSectionCollapsed(sessionA.resource, 'checks', true);
+		service.setSectionCollapsed(sessionA.resource, 'checks', false);
 		states.push(service.activeSessionSectionCollapseStateObs.get());
 		activeSession.set(sessionB, undefined);
 		states.push(service.activeSessionSectionCollapseStateObs.get());
-		service.setSectionCollapsed(sessionB.resource, 'checks', true);
+		service.setSectionCollapsed(sessionB.resource, 'checks', false);
 		states.push(service.activeSessionSectionCollapseStateObs.get());
 		activeSession.set(sessionA, undefined);
 		states.push(service.activeSessionSectionCollapseStateObs.get());
 
 		assert.deepStrictEqual(states, [
-			{ otherFiles: false, checks: false },
-			{ otherFiles: true, checks: true },
-			{ otherFiles: false, checks: false },
 			{ otherFiles: false, checks: true },
-			{ otherFiles: true, checks: true },
+			{ otherFiles: true, checks: false },
+			{ otherFiles: false, checks: true },
+			{ otherFiles: false, checks: false },
+			{ otherFiles: true, checks: false },
 		]);
 	});
 
@@ -106,8 +106,8 @@ suite('ChangesViewService', () => {
 		const afterDeletion = service.activeSessionSectionCollapseStateObs.get();
 
 		assert.deepStrictEqual({ afterReplacement, afterDeletion }, {
-			afterReplacement: { otherFiles: true, checks: false },
-			afterDeletion: { otherFiles: false, checks: false },
+			afterReplacement: { otherFiles: true, checks: true },
+			afterDeletion: { otherFiles: false, checks: true },
 		});
 	});
 
@@ -116,7 +116,7 @@ suite('ChangesViewService', () => {
 		const secondDraft = createSession('second-draft');
 		const { activeSession, onDidDiscardNewSession, onDidReplaceNewDraftSession, service } = createHarness(firstDraft);
 
-		service.setSectionCollapsed(firstDraft.resource, 'checks', true);
+		service.setSectionCollapsed(firstDraft.resource, 'otherFiles', true);
 		activeSession.set(secondDraft, undefined);
 		onDidReplaceNewDraftSession.fire({ from: firstDraft, to: secondDraft });
 		const afterReplacement = service.activeSessionSectionCollapseStateObs.get();
@@ -125,8 +125,8 @@ suite('ChangesViewService', () => {
 		const afterDiscard = service.activeSessionSectionCollapseStateObs.get();
 
 		assert.deepStrictEqual({ afterReplacement, afterDiscard }, {
-			afterReplacement: { otherFiles: false, checks: false },
-			afterDiscard: { otherFiles: false, checks: false },
+			afterReplacement: { otherFiles: false, checks: true },
+			afterDiscard: { otherFiles: false, checks: true },
 		});
 	});
 });


### PR DESCRIPTION
The changed files section of the Changes view now reserves room for at least five file rows even when fewer files are listed, so the pane no longer shrinks to a sliver for small changesets.

The CI checks section now starts collapsed by default; the per-session collapse state pruning was updated to compare against the defaults instead of assuming both sections default to expanded.