### PR TITLE
agentHost: fix: never treat a git directory as a repository root

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -53,7 +53,7 @@ import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { buildServerToolGroups } from './shared/serverToolGroups.js';
 import { type IChatContextSnapshot, type ISessionCreationDefaults, type ISessionServerToolAccessor } from './shared/sessionServerTools.js';
 
-import { buildWorktreeFailureNotification, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, isGitDirectoryPath, WorktreeIsolation, WORKTREE_META_REPOSITORY_ROOT, worktreeProjectFromRepositoryRoot } from './shared/worktreeIsolation.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService } from '../common/agentHostCheckpointService.js';
@@ -939,6 +939,7 @@ export class AgentService extends Disposable implements IAgentService {
 	/**
 	 * Repairs repository roots written by older builds that treated a parent linked checkout as the repository.
 	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
+	 * Leaves the stored value alone when git answers with its own git directory — see {@link isGitDirectoryPath}.
 	 */
 	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string): Promise<string> {
 		const storedRepositoryRootRaw = repositoryRootRaw;
@@ -958,7 +959,7 @@ export class AgentService extends Disposable implements IAgentService {
 				this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
 			}
 		}
-		if (primaryRoot) {
+		if (primaryRoot && !isGitDirectoryPath(primaryRoot)) {
 			repositoryRootRaw = primaryRoot.toString();
 		}
 		if (repositoryRootRaw !== storedRepositoryRootRaw) {

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -65,6 +65,29 @@ interface IWorktreeMetadata {
 }
 
 /**
+ * Whether `path` names a git *directory* rather than a working tree.
+ *
+ * `git worktree list` does not always answer with a working tree: inside a
+ * submodule it reports the superproject's git directory
+ * (`/super/.git/modules/vendored`), and for a worktree of a bare repository it
+ * reports the bare directory (`/work/repo.git`). Adopting either as a session's
+ * repository root is destructive, because {@link getWorktreesRoot} derives the
+ * worktrees directory from it: a worktree-isolated session created from a
+ * submodule would be materialized at
+ * `/super/.git/modules/vendored.worktrees/<name>`, inside the repository's own
+ * metadata.
+ *
+ * This is a conservative refusal by name, not a classification of the path. It
+ * only recognises the conventional `.git` spellings; a `--separate-git-dir`
+ * target can be named anything, so it is deliberately not recognised here and
+ * callers keep whatever fallback they already had for that case.
+ */
+export function isGitDirectoryPath(path: URI): boolean {
+	const segments = path.path.split('/');
+	return segments.includes('.git') || !!segments[segments.length - 1]?.endsWith('.git');
+}
+
+/**
  * The `<repo>.worktrees` sibling directory where per-session isolated
  * worktrees are created, e.g. `/src/vscode` → `/src/vscode.worktrees`.
  */
@@ -570,7 +593,7 @@ export class WorktreeIsolation extends Disposable {
 			return workingDirectory;
 		}
 
-		const repositoryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
+		const { root: repositoryRoot } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, checkoutRoot);
 		const worktreesRoot = getWorktreesRoot(repositoryRoot);
 		// Prefix (e.g. the user's `git.branchPrefix`) the client forwards for
 		// worktree-isolated sessions. Prepended ahead of the built-in `agents/`
@@ -890,8 +913,10 @@ export class WorktreeIsolation extends Disposable {
 			return false;
 		}
 		const primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, worktreeRoot).catch(() => undefined);
-		// A primary checkout (not a linked worktree) resolves to itself; nothing to bridge.
-		if (!primaryRoot || isEqual(primaryRoot, worktreeRoot)) {
+		// A primary checkout (not a linked worktree) resolves to itself; nothing to
+		// bridge. Neither is there when git answers with its own git directory —
+		// see {@link isGitDirectoryPath}.
+		if (!primaryRoot || isGitDirectoryPath(primaryRoot) || isEqual(primaryRoot, worktreeRoot)) {
 			return false;
 		}
 		const branchName = await this._gitService.getCurrentBranch(worktreeRoot).catch(() => undefined) ?? 'HEAD';
@@ -917,12 +942,26 @@ export class WorktreeIsolation extends Disposable {
 		return meta?.repositoryRoot ? projectFromRepositoryRoot(meta.repositoryRoot) : undefined;
 	}
 
-	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<URI> {
+	/**
+	 * Resolves the repository's primary worktree root for `checkoutRoot`, or
+	 * `fallbackRoot` when git has no usable answer. `resolved` distinguishes a
+	 * genuine git answer from the fallback so callers can decide whether the
+	 * value is worth persisting.
+	 */
+	private async _resolvePrimaryWorktreeRoot(checkoutRoot: URI, fallbackRoot: URI): Promise<{ readonly root: URI; readonly resolved: boolean }> {
 		try {
-			return await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot) ?? fallbackRoot;
+			const resolved = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot);
+			if (resolved && !isGitDirectoryPath(resolved)) {
+				return { root: resolved, resolved: true };
+			}
+			// Git answered with its own git directory — a submodule, or a bare
+			// repository. Adopting it would group the session under a path inside
+			// the repository's metadata, and worse, place its worktree there: the
+			// worktrees directory is derived from this value.
+			return { root: fallbackRoot, resolved: false };
 		} catch (error) {
 			this._logService.warn(`[${this._logLabel}] Failed to resolve primary worktree for '${checkoutRoot.fsPath}': ${errorMessage(error)}`);
-			return fallbackRoot;
+			return { root: fallbackRoot, resolved: false };
 		}
 	}
 
@@ -1003,8 +1042,10 @@ export class WorktreeIsolation extends Disposable {
 			let repositoryRoot = repositoryRootRaw ? URI.parse(repositoryRootRaw) : undefined;
 			if (repositoryRoot) {
 				const checkoutRoot = worktreePath && await fileExists(worktreePath.fsPath) ? worktreePath : repositoryRoot;
-				const primaryRoot = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
-				if (primaryRoot.toString() !== repositoryRoot.toString()) {
+				const { root: primaryRoot, resolved } = await this._resolvePrimaryWorktreeRoot(checkoutRoot, repositoryRoot);
+				// Only persist a root that git genuinely resolved; a fallback carries
+				// no new information and must not overwrite what is already stored.
+				if (resolved && primaryRoot.toString() !== repositoryRoot.toString()) {
 					repositoryRoot = primaryRoot;
 					try {
 						await ref.object.setMetadata(WORKTREE_META_REPOSITORY_ROOT, primaryRoot.toString());

--- a/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/worktreeIsolation.test.ts
@@ -18,7 +18,7 @@ import { SessionConfigKey } from '../../../common/sessionConfigKeys.js';
 import { AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, MessageKind, ResponsePartKind, TurnState, type Turn } from '../../../common/state/sessionState.js';
 import { AgentBranchNameGenerator, IAgentBranchNameGenerator } from '../../../node/shared/agentBranchNameGenerator.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
-import { buildWorktreeFailureNotification, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
+import { buildWorktreeFailureNotification, isGitDirectoryPath, normalizeWorktreeFailureDiagnostic, SessionWorkingDirectoryMissingError, WorktreeIsolation, getWorktreeName, getWorktreesRoot } from '../../../node/shared/worktreeIsolation.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../../common/sessionTestHelpers.js';
 
 /**
@@ -138,6 +138,24 @@ suite('WorktreeIsolation', () => {
 			namedFlattened: 'feature-sub-topic',
 			namedNoPrefix: 'plain-branch',
 			namedWithBranchPrefix: 'add-config',
+		});
+	});
+
+	test('isGitDirectoryPath refuses the git directories git reports for submodules and bare repositories', () => {
+		assert.deepStrictEqual({
+			submoduleGitDir: isGitDirectoryPath(URI.file('/work/super/.git/modules/vendored')),
+			bareRepository: isGitDirectoryPath(URI.file('/work/repo.git')),
+			dotGitDirectory: isGitDirectoryPath(URI.file('/work/repo/.git')),
+			workingTree: isGitDirectoryPath(URI.file('/work/repo')),
+			worktreesSibling: isGitDirectoryPath(URI.file('/work/repo.worktrees/feature')),
+			substringLookalike: isGitDirectoryPath(URI.file('/work/gitlab/repo')),
+		}, {
+			submoduleGitDir: true,
+			bareRepository: true,
+			dotGitDirectory: true,
+			workingTree: false,
+			worktreesSibling: false,
+			substringLookalike: false,
 		});
 	});
 
@@ -304,6 +322,35 @@ suite('WorktreeIsolation', () => {
 		}, {
 			worktree: URI.joinPath(fallbackWorktreesRoot, getWorktreeName(branchName)).toString(),
 			metaRepositoryRoot: checkoutRoot.toString(),
+		});
+	});
+
+	test('resolveWorkingDirectory keeps a submodule working tree rather than the git directory git reports', async () => {
+		// Inside a submodule `git worktree list` answers with the superproject's
+		// git directory, so the worktree must not be derived from it.
+		const submoduleCheckout = URI.joinPath(repoRoot, 'vendored');
+		const submoduleGitDir = URI.joinPath(repoRoot, '.git', 'modules', 'vendored');
+		const gitService = createGitService();
+		gitService.getRepositoryRoot = async () => submoduleCheckout;
+		gitService.getWorktreeRoots = async () => [submoduleGitDir];
+		const isolation = createIsolation(disposables, { gitService });
+
+		const worktree = await isolation.resolveWorkingDirectory({
+			sessionUri,
+			sessionId,
+			workingDirectory: submoduleCheckout,
+			config: { [SessionConfigKey.Isolation]: 'worktree', [SessionConfigKey.Branch]: 'main' },
+		});
+		const meta = await isolation.readWorktreeMetadata(sessionUri);
+
+		assert.deepStrictEqual({
+			worktree: worktree?.toString(),
+			metaRepositoryRoot: meta?.repositoryRoot?.toString(),
+			createdInsideGitDirectory: existsSync(getWorktreesRoot(submoduleGitDir).fsPath),
+		}, {
+			worktree: URI.joinPath(getWorktreesRoot(submoduleCheckout), getWorktreeName(branchName)).toString(),
+			metaRepositoryRoot: submoduleCheckout.toString(),
+			createdInsideGitDirectory: false,
 		});
 	});
 


### PR DESCRIPTION
### Worktrees are being created inside `.git/modules/...`

A worktree-isolated session created from a **submodule** checkout has its worktree materialized **inside the repository's own git directory**:

```
/super/.git/modules/vendored.worktrees/agents-my-feature/
```

That is not a labelling problem — the agent host creates a real directory tree, and later deletes it via `removeWorktree`, underneath git's own metadata.

### Why

The Agent Host resolves a session's repository root with `git worktree list --porcelain` and takes the first entry (`PrimaryWorktreeRootResolver`, used via `tryResolvePrimaryWorktreeRoot`). But that command does not always answer with a **working tree**. Verified against real git:

```
inside /super/vendored (a submodule):
  git rev-parse --show-toplevel     -> /super/vendored                  (correct working tree)
  git worktree list --porcelain     -> /super/.git/modules/vendored     (git directory!)
```

For a worktree of a **bare** repository it likewise reports the bare directory, e.g. `/work/repo.git`.

`WorktreeIsolation` persists that value as `copilot.worktree.repositoryRoot`, and the worktrees directory is *derived* from it:

```ts
export function getWorktreesRoot(repositoryRoot: URI): URI {
	return URI.joinPath(repositoryRoot, '..', `${basename(repositoryRoot.fsPath)}.worktrees`);
}
```

So `/super/.git/modules/vendored` → `/super/.git/modules/vendored.worktrees/<name>`. This happens at **session creation**, before any listing.

Secondary consequences of the same bad value: the session groups in the Agents window under that `.git/modules/...` path, and the value feeds `removeWorktree` and archived-session resume.

### The fix

A new `isGitDirectoryPath` predicate, and one guard in `_resolvePrimaryWorktreeRoot` so **every** caller — creation and resume-repair — inherits it from a single place:

- `_resolvePrimaryWorktreeRoot` now returns `{ root, resolved }`. `resolved` distinguishes a genuine git answer from a fallback, so the resume repair no longer persists a fallback over a stored value. On the creation path the fallback is already `checkoutRoot`, i.e. exactly what `rev-parse --show-toplevel` reports for a submodule — the correct working tree.
- `adoptExistingWorktreeMetadata` declines a git-directory primary; there is nothing to bridge to.
- `_normalizeListedWorktreeRepositoryRoot` (the list-time repair in `agentService.ts`) leaves the stored value alone rather than overwriting a session's root with a `.git/...` path.

The predicate is a deliberately **conservative refusal by name**, not a classification of the path — it only recognises the conventional `.git` spellings. A `--separate-git-dir` target can be named anything, cannot be recognised by path, and is explicitly out of scope; callers keep whatever fallback they already had.

### Tests

- `isGitDirectoryPath` over the real shapes git produces: `/work/super/.git/modules/vendored`, `/work/repo.git`, `/work/repo/.git` → refused; `/work/repo`, `/work/repo.worktrees/feature`, `/work/gitlab/repo` (substring lookalike) → accepted.
- A session created from a submodule checkout keeps the working-tree root, and asserts no directory is created under `<gitdir>.worktrees`. Verified to fail without the guard (`createdInsideGitDirectory: true`, root `.../.git/modules/vendored`).

### Validation

- `npm run typecheck-client` — 17 errors, byte-identical to a clean `main` baseline (17). All pre-existing Copilot SDK / `assignmentService` mismatches; none in the touched files.
- `./scripts/test.sh --runGlob "**/vs/platform/agentHost/**/*.test.js"` — 4482 passing, 0 failing.
- `npm run valid-layers-check` — 42 errors, matching the pre-existing baseline.

### Scope

This is **pre-existing on `main`** (introduced with the worktree-identity work in #328375) and independent of the performance issue.

Related: #329880 (not fixed by this PR).

#329932 contains overlapping performance work in `_normalizeListedWorktreeRepositoryRoot`. This fix is deliberately standalone — no caching, budget, or stamp changes — so it can land regardless of how that one resolves.
