### PR TITLE
Update @vscode/codicons to version 0.0.46-35 and add 'close-small' icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.6.1",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-30",
+        "@vscode/codicons": "^0.0.46-35",
         "@vscode/copilot-api": "^0.5.1",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "0.0.2-7",
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-30",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-30.tgz",
-      "integrity": "sha512-LukGa9R2EP3fjHw+hu1QCgne6FIzHG4t/trbv/nxKifJVlJTATKrmcDUTew+O6raRLL5KWso70XpCDJPRkqgaQ==",
+      "version": "0.0.46-35",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-35.tgz",
+      "integrity": "sha512-qw/P7P3gLUnlzQCYgUHtpDLWcdNTEXbeH+L8LUBjaACHSTrXRlUbml7z0zM7zIDhqccTLEbL8vgwy8FBVsB+XQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@microsoft/mxc-sdk": "0.6.1",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-30",
+    "@vscode/codicons": "^0.0.46-35",
     "@vscode/copilot-api": "^0.5.1",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "0.0.2-7",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-30",
+        "@vscode/codicons": "^0.0.46-35",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-30",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-30.tgz",
-      "integrity": "sha512-LukGa9R2EP3fjHw+hu1QCgne6FIzHG4t/trbv/nxKifJVlJTATKrmcDUTew+O6raRLL5KWso70XpCDJPRkqgaQ==",
+      "version": "0.0.46-35",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-35.tgz",
+      "integrity": "sha512-qw/P7P3gLUnlzQCYgUHtpDLWcdNTEXbeH+L8LUBjaACHSTrXRlUbml7z0zM7zIDhqccTLEbL8vgwy8FBVsB+XQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-30",
+    "@vscode/codicons": "^0.0.46-35",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -761,4 +761,5 @@ export const codiconsLibrary = {
 	arrowUpCompact: register('arrow-up-compact', 0xeceb),
 	xai: register('xai', 0xecec),
 	arrowCircleUpSparkle: register('arrow-circle-up-sparkle', 0xeced),
+	closeSmall: register('close-small', 0xecee),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-35 and introduce the 'close-small' icon to the codicons library. This enhances the icon set available for use. Testing can be done by verifying the presence of the new icon in the codicons library.

