### PR TITLE
Style overrides: Update font weight for auxiliary bar action labels

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -74,6 +74,10 @@
 	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
+.style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label.codicon {
+	font-weight: var(--vscode-fontWeight-regular);
+}
+
 /* Editor tab labels use Body 1 for comfortable readability at a normal viewing distance. */
 .style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label {
 	font-size: var(--vscode-fontSize-body1);


### PR DESCRIPTION
Adjust the font weight for action labels in the auxiliary bar to enhance readability. This change improves the visual hierarchy and consistency across the interface.

