### PR TITLE
agentHost: fix Codex authentication startup race

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -1467,6 +1467,8 @@ export class CodexAgent extends Disposable implements IAgent {
 				try { ready.child.kill('SIGKILL'); } catch { /* already dead */ }
 				throw new Error('Codex app-server was replaced while starting');
 			}
+			// Authentication can complete while the connection is starting; apply the latest token before publishing ready.
+			ready.proxyHandle.setToken(this._githubToken ?? '');
 			this._connection = { kind: 'ready', ...ready };
 			return ready;
 		}).catch(err => {

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -997,7 +997,7 @@ export class CopilotApiService implements ICopilotApiService {
 
 		if (!response.ok) {
 			const text = await response.text().catch(() => '');
-			throw new Error(`Copilot endpoint discovery failed: ${response.status} ${response.statusText} — ${text}`);
+			throw buildCopilotApiHttpError(response.status, response.statusText, text, 'Copilot endpoint discovery failed');
 		}
 
 		const envelope: ICopilotUserResponse = await response.json();

--- a/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexModelRefresh.test.ts
@@ -90,6 +90,31 @@ suite('CodexAgent model refresh', () => {
 		assert.deepStrictEqual(agent.models.get().map(model => model.id), [toCodexModelSelectionId('vscode-proxy', 'gpt-5.5')]);
 	});
 
+	test('applies authentication received while the connection is starting to the proxy', async () => {
+		const agent = createAgent(disposables, async () => []);
+		agent['_queueModelRefresh'] = async () => { };
+		agent['_refreshProviderConfiguration'] = async () => { };
+
+		const appliedTokens: string[] = [];
+		const ready = {
+			client: { dispose() { } },
+			proxyHandle: {
+				setToken: (token: string) => appliedTokens.push(token),
+				dispose() { },
+			},
+			child: { kill: () => true },
+		};
+		let resolveStart!: (value: typeof ready) => void;
+		agent['_startConnection'] = () => new Promise<typeof ready>(resolve => resolveStart = resolve) as never;
+
+		const connection = agent['_ensureConnection']();
+		await agent.authenticate(agent.getProtectedResources()[0].resource, 'token-arriving-during-start');
+		resolveStart(ready);
+		await connection;
+
+		assert.deepStrictEqual(appliedTokens, ['token-arriving-during-start']);
+	});
+
 	test('surfaces current ChatGPT subscription models under the ChatGPT provider', async () => {
 		const agent = createAgent(disposables, async () => []);
 		agent['_connection'] = {

--- a/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
@@ -9,10 +9,12 @@ import type * as http from 'http';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import {
+	CopilotApiError,
 	type ICopilotApiService,
 	type ICopilotApiServiceRequestOptions,
 } from '../../../node/shared/copilotApiService.js';
 import { CodexProxyService, remapCodexReviewerModel } from '../../../node/codex/codexProxyService.js';
+import { extractForwardedErrorInfo } from '../../../node/shared/proxyChatError.js';
 
 // #region Test fakes
 
@@ -30,6 +32,7 @@ class FakeCopilotApiService implements ICopilotApiService {
 
 	readonly responsesCalls: IResponsesCall[] = [];
 	readonly modelsCalls: { githubToken: string; options: ICopilotApiServiceRequestOptions | undefined }[] = [];
+	responsesError: Error | undefined;
 	readonly modelsResult = [
 		{ id: 'gpt-5.5', name: 'GPT-5.5', supported_endpoints: ['/responses'] },
 		{ id: 'claude-sonnet', name: 'Claude Sonnet', supported_endpoints: ['/v1/messages'] },
@@ -50,6 +53,9 @@ class FakeCopilotApiService implements ICopilotApiService {
 
 	async responses(githubToken: string, body: string, options?: ICopilotApiServiceRequestOptions): Promise<Response> {
 		this.responsesCalls.push({ githubToken, body, options });
+		if (this.responsesError) {
+			throw this.responsesError;
+		}
 		const stream = new ReadableStream<Uint8Array>({
 			start(controller) {
 				controller.enqueue(new TextEncoder().encode('event: response.completed\ndata: {}\n\n'));
@@ -146,6 +152,47 @@ suite('CodexProxyService', () => {
 				body: JSON.stringify({ model: 'gpt-5', stream: true, input: [] }),
 			});
 			assert.strictEqual(fake.responsesCalls.at(-1)?.options?.headers?.['User-Agent'], 'vscode_codex/1.2.3');
+		});
+	});
+
+	test('preserves endpoint discovery authentication failures', async () => {
+		await withProxy(async (handle, fake) => {
+			fake.responsesError = new CopilotApiError(401, {
+				type: 'error',
+				error: { type: 'api_error', message: '{"message":"Bad credentials"}' },
+				request_id: null,
+			}, 'Copilot endpoint discovery failed: 401 Unauthorized — {"message":"Bad credentials"}');
+
+			const response = await postResponses(`${handle.baseUrl}/v1/responses`, {
+				headers: { 'Authorization': `Bearer ${handle.nonce}` },
+				body: JSON.stringify({ model: 'gpt-5', stream: true, input: [] }),
+			});
+			const error = JSON.parse(response.body).error as { type: string; message: string };
+
+			assert.deepStrictEqual({
+				status: response.status,
+				type: error.type,
+				error: extractForwardedErrorInfo(error.message),
+			}, {
+				status: 401,
+				type: 'api_error',
+				error: {
+					message: 'Copilot endpoint discovery failed: 401 Unauthorized — {"message":"Bad credentials"}',
+					_meta: {
+						chatError: {
+							fetchError: {
+								type: 'agent_unauthorized',
+								reason: '{"message":"Bad credentials"}',
+								requestId: '',
+								capiError: {
+									code: 'api_error',
+									message: '{"message":"Bad credentials"}',
+								},
+							},
+						},
+					},
+				},
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -345,11 +345,31 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(discoveryUrl, 'https://api.acme.ghe.com/copilot_internal/user');
 		});
 
-		test('throws on 403 from endpoint discovery', async () => {
-			const service = createService(async () => new Response('{"message":"Not authorized"}', { status: 403, statusText: 'Forbidden' }));
+		test('preserves authentication errors from endpoint discovery', async () => {
+			const service = createService(async () => new Response('{"message":"Bad credentials"}', { status: 401, statusText: 'Unauthorized' }));
 			await assert.rejects(
 				() => service.messages('bad-tok', baseRequest),
-				(err: Error) => err.message.includes('Copilot endpoint discovery failed: 403'),
+				(err: Error) => {
+					assert.deepStrictEqual({
+						isCopilotApiError: err instanceof CopilotApiError,
+						status: err instanceof CopilotApiError ? err.status : undefined,
+						message: err.message,
+						envelope: err instanceof CopilotApiError ? err.envelope : undefined,
+					}, {
+						isCopilotApiError: true,
+						status: 401,
+						message: 'Copilot endpoint discovery failed: 401 Unauthorized — {"message":"Bad credentials"}',
+						envelope: {
+							type: 'error',
+							error: {
+								type: 'api_error',
+								message: '{"message":"Bad credentials"}',
+							},
+							request_id: null,
+						},
+					});
+					return true;
+				},
 			);
 		});
 


### PR DESCRIPTION
## Summary

- apply the latest Copilot token to a Codex proxy when authentication completes during connection startup
- preserve endpoint-discovery HTTP failures as `CopilotApiError`s instead of rewriting authentication failures as HTTP 502
- add regression coverage for both the startup race and 401 propagation

## Root cause

PR #328461 made Copilot authentication optional so one Codex process could expose per-session Copilot and ChatGPT model providers. This allowed the proxy to start before the GitHub token arrived. If authentication completed after proxy creation but before the connection became `ready`, `authenticate()` stored the token but did not update the still-starting proxy, leaving it bound to the empty initial token.

## Testing

- `npm run transpile-client`
- `npm run typecheck-client`
- 112 targeted Agent Host unit tests across Codex model refresh, Codex proxy, and Copilot API service suites
- Launch verification: started a `GPT-5.3-Codex` session and received exactly `READY`; Agent Host logged HTTP 200 and `response.completed`, with no endpoint-discovery, bad-credentials, 401, or 502 errors