### PR TITLE
Update spacing for notifications center and toasts

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -211,8 +211,8 @@
  * `activitybar-compact` is mirrored onto the workbench root by activitybarPart.ts;
  * the `:not` keeps a hidden compact bar resolving to the hidden inset below. */
 .monaco-workbench.floating-panels.activitybar-compact:not(.noactivitybar) .part.statusbar {
-	padding-left: var(--vscode-spacing-size20);
-	padding-right: var(--vscode-spacing-size20);
+	padding-left: var(--vscode-spacing-size40);
+	padding-right: var(--vscode-spacing-size40);
 }
 
 /* When the activity bar is hidden (`noactivitybar`, toggled by layout.ts like

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -40,13 +40,13 @@
  */
 .style-override.monaco-workbench > .notifications-center {
 	right: var(--vscode-spacing-size80);
-	bottom: var(--vscode-spacing-size320);
+	bottom: var(--vscode-spacing-size360);
 }
 
 .style-override.monaco-workbench > .notifications-center.bottom-left {
 	right: auto;
 	left: var(--vscode-spacing-size80);
-	bottom: var(--vscode-spacing-size320);
+	bottom: var(--vscode-spacing-size360);
 }
 
 .style-override.monaco-workbench > .notifications-center.top-right {
@@ -61,13 +61,13 @@
  */
 .style-override.monaco-workbench > .notifications-toasts {
 	right: var(--vscode-spacing-size40);
-	bottom: var(--vscode-spacing-size280);
+	bottom: var(--vscode-spacing-size320);
 }
 
 .style-override.monaco-workbench > .notifications-toasts.bottom-left {
 	right: auto;
 	left: var(--vscode-spacing-size40);
-	bottom: var(--vscode-spacing-size280);
+	bottom: var(--vscode-spacing-size320);
 }
 
 .style-override.monaco-workbench > .notifications-toasts.top-right {


### PR DESCRIPTION
Adjust the bottom spacing for the notifications center and toasts to improve layout consistency. Test the changes by verifying the positioning of notifications in the UI.

