### PR TITLE
Fall back to the plain tsdk path when the prefixed one does not exist

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionProvider.electron.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionProvider.electron.ts
@@ -108,15 +108,22 @@ export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider
 			];
 		}
 
+		// A setting such as `x/node_modules/typescript/lib` inside a workspace folder
+		// named `x` is ambiguous: it may mean the nested `x/x/node_modules/...` or the
+		// folder-name-prefixed `x/node_modules/...`. Only take the prefixed reading when
+		// it resolves to a real tsserver.js, otherwise fall through to the plain join
+		// below so the nested path still works.
 		const workspacePath = RelativeWorkspacePathResolver.asAbsoluteWorkspacePath(tsdkPathSetting);
 		if (workspacePath !== undefined) {
 			const serverPath = path.join(workspacePath, 'tsserver.js');
-			return [
-				new TypeScriptVersion(source,
-					serverPath,
-					DiskTypeScriptVersionProvider.getApiVersion(serverPath),
-					tsdkPathSetting)
-			];
+			if (fs.existsSync(serverPath)) {
+				return [
+					new TypeScriptVersion(source,
+						serverPath,
+						DiskTypeScriptVersionProvider.getApiVersion(serverPath),
+						tsdkPathSetting)
+				];
+			}
 		}
 
 		return this.loadTypeScriptVersionsFromPath(source, tsdkPathSetting);


### PR DESCRIPTION
Fixes #272761

## What is broken

`RelativeWorkspacePathResolver.asAbsoluteWorkspacePath` strips a leading path segment whenever it equals the workspace folder's name:

```ts
const rootPrefixes = [`./${root.name}/`, `${root.name}/`, `.\\${root.name}\\`, `${root.name}\\`];
for (const rootPrefix of rootPrefixes) {
    if (relativePath.startsWith(rootPrefix)) {
        return path.join(root.uri.fsPath, relativePath.replace(rootPrefix, ''));
    }
}
```

In a workspace folder named `x`, the setting `typescript.tsdk: "x/node_modules/typescript/lib"` is ambiguous. It can mean the nested `<root>/x/node_modules/typescript/lib`, which is what the reporter has, or the folder-name-prefixed `<root>/node_modules/typescript/lib`. The resolver always picks the second, so `loadVersionsFromSetting` returns a `TypeScriptVersion` pointing at a `tsserver.js` that does not exist. `localVersion` returns it anyway, and the workspace TypeScript version silently fails to load.

## Fix

Take the prefix-stripped reading only when it resolves to a real `tsserver.js`. Otherwise fall through to `loadTypeScriptVersionsFromPath`, which already joins the setting onto the workspace root unchanged and produces the nested path correctly.

This keeps the existing prefix behaviour for everyone relying on it, since those paths exist on disk and still match first. It only changes what happens in the case that is currently broken.

`fs` is already imported in this file and `fs.existsSync` is the same probe `getTypeScriptVersion` uses a few lines below.

## Note on multi-root

When the prefixed path does not exist, `loadTypeScriptVersionsFromPath` returns one candidate per workspace folder rather than the single candidate the old branch returned. That matches what already happens for any `tsdk` setting that does not begin with a folder name, so the behaviour is consistent rather than new. `localVersion` still takes the first entry.

## Testing

I was not able to build or run the test suite for this change. My checkout is a sparse clone without `node_modules`, and a full install and build was not practical here. The diff is small and self contained, so I have kept it to the single call site rather than changing the resolver's contract, which has three callers.

Happy to add a regression test under `extensions/typescript-language-features/src/test/unit/` if you can point me at the right harness for stubbing `vscode.workspace.workspaceFolders`, or to restructure the fix if you would prefer it inside the resolver instead.
