### PR TITLE
sessions: reopen the last closed chat or session with cmd+shift+t

### DIFF
--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -614,7 +614,10 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
-	(hasGit ? test : test.skip)('removeWorktree rejects instead of falsely succeeding when the admin entry cannot be deleted', async function () {
+	// Windows is excluded like the other chmod-based tests above: `chmod` does not
+	// convey POSIX directory permissions there, so prune's delete still succeeds
+	// and the masking scenario cannot be reproduced.
+	(hasGit && !isWindows ? test : test.skip)('removeWorktree rejects instead of falsely succeeding when the admin entry cannot be deleted', async function () {
 		// Root bypasses the directory permission that makes prune fail, so this
 		// masking scenario cannot be reproduced there.
 		if (typeof process.getuid === 'function' && process.getuid() === 0) {

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -183,7 +183,7 @@ A second producer sits **outside** the protocol: `IAgentHostAdapterOptions.readO
 - `applyChatCatalog` (`baseAgentHostSessionsProvider.ts`) surfaces a non-default chat as a peer when the session supports multiple chats (`copilotcli`) **or** the chat is a subagent (`origin.kind === Tool`). So subagent chats exist in the peer-chat catalog even in single-chat session types (e.g. `claude`), while ordinary user/fork/side-chat peers still require the usual session support.
 - `VisibleSession` keeps tool-origin chats out of `visibleChatTabs` until the user explicitly opens one (for example from the transcript pill or the **Conversations** menu). `chatCompositeBar` renders whatever is in `visibleChatTabs`, so user-created peers such as side chats behave like ordinary tabs while subagents stay hidden/read-only by default. The trailing **New Chat** action remains gated to `capabilities.supportsMultipleChats`, so single-chat sessions that merely host a subagent don't expose chat creation.
 
-Non-main chat tabs close from their close button, the active-chat close keybinding, or a middle click anywhere on the tab. Closing a committed chat hides it until it is reopened from the **Chats** menu; closing an untitled draft deletes it.
+Non-main chat tabs close from their close button, the active-chat close keybinding, or a middle click anywhere on the tab. Closing a committed chat hides it until it is reopened from the **Chats** menu, from the palette (**Reopen Last Closed Chat**), or with `Ctrl/Cmd+Shift+T` (**Reopen Closed Chat or Session**, which restores whichever chat or session was closed most recently); closing an untitled draft deletes it.
 
 Subagent chats **persist** in the session catalog after the subagent completes (completion only marks the chat's turn complete; the chat is removed only when the whole session is disposed), so the read-only tab stays reviewable for the lifetime of the session.
 
@@ -515,6 +515,38 @@ action itself rather than derived from the `closedChats` observable (which
 intersects with the session's _loaded_ chats), so it never depends on chats
 having loaded or on autorun timing. Stale URIs for chats that were later deleted
 are harmless: restore intersects the persisted set with the live chat list.
+
+`ClosedItemHistory` (`services/sessions/browser/closedItemHistory.ts`) owns
+reopening entirely: an **in-memory, single-entry** memo of the most recently
+closed chat or session, plus the logic to put it back. It backs
+`SessionsService.reopenLastClosedItem()` (`Ctrl/Cmd+Shift+T`, "Reopen Closed
+Chat or Session"), which is a one-line delegation, as are the three recording
+call sites. It deliberately holds one entry only: reopening consumes it, so
+pressing the chord repeatedly cannot walk further back through history, and a
+reload starts empty. Exactly three things record into it —
+`recordClosedChat` (from `closeChat`), `recordClosedSession` (from
+`closeSession`, which reads the session's current grid slot itself), and
+`recordReplacedSlot`, which `VisibleSessions.setActive` reports through a
+constructor callback when a newly opened slot pushes a non-sticky session out.
+An untitled draft is discarded rather than hidden, so it never records;
+close-all commands, deletions, and grid restores never record either.
+`reopenLast()` re-resolves the session by id (the recorded one may be a
+disposed wrapper) and reopens a chat with the service's `openChat`; a session
+that was closed explicitly returns via `insertAtIndex` to the grid index it
+occupied, while a session that was pushed out uses `replaceSlot` to take its
+slot back, removing whatever replaced it (including the empty new-session
+slot). It runs inside an internal suspension so its own activations cannot
+re-record, and the entry is dropped when its session is deleted
+(`onDidDeleteSession`). The class also binds `SessionsHasClosedItemContext`,
+which drives command-palette visibility; the keybinding itself is not
+gated on it, so outside the editor scope the chord always belongs to the
+sessions area. "Editor scope" is `SessionsEditorScopeContext`
+(`common/contextkeys.ts`) — `editorAreaFocus || auxiliaryBarFocus`, i.e. an
+editor part or the auxiliary bar, which the single-pane layout docks into the
+side pane as the detail panel. While it holds, `Ctrl/Cmd+Shift+T` falls through
+to VS Code's own **Reopen Closed Editor**. The other chat-tab chords
+(`Ctrl/Cmd+W`, `Ctrl/Cmd+T`, `Ctrl+Tab`, …) remain scoped on `editorAreaFocus`
+alone.
 
 `sendNewChatRequest(session, options)` accepts a `background` flag: a background
 new-session send returns the agents window to a fresh new-session view (via

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -529,9 +529,15 @@ reload starts empty. Exactly three things record into it —
 `recordReplacedSlot`, which `VisibleSessions.setActive` reports through a
 constructor callback when a newly opened slot pushes a non-sticky session out.
 An untitled draft is discarded rather than hidden, so it never records;
-close-all commands, deletions, and grid restores never record either.
-`reopenLast()` re-resolves the session by id (the recorded one may be a
-disposed wrapper) and reopens a chat with the service's `openChat`; a session
+deletions and grid restores never record either. **Close All Chats** closes
+each chat through the same `closeChat` path, so it passes
+`{ skipHistory: true }` — remembering only the final chat of a batch would make
+one arbitrary member of it reopenable. `reopenLast()` consumes the entry
+**before** acting, then re-resolves the session by id (the recorded one may be
+a disposed wrapper, and a provider can drop a session from its catalog without
+firing `onDidDeleteSession`); consuming first means a no-longer-resolvable
+entry cannot linger and leave the command enabled but permanently inert. A
+chat is reopened with the service's `openChat`; a session
 that was closed explicitly returns via `insertAtIndex` to the grid index it
 occupied, while a session that was pushed out uses `replaceSlot` to take its
 slot back, removing whatever replaced it (including the empty new-session

--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../nls.js';
-import { RawContextKey } from '../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, RawContextKey } from '../../platform/contextkey/common/contextkey.js';
+import { AuxiliaryBarFocusContext, EditorAreaFocusContext } from '../../workbench/common/contextkeys.js';
 
 //#region < --- Active Session --- >
 
@@ -51,6 +52,15 @@ export const ActiveSessionsContext = new RawContextKey<string>('activeSessions',
 export const SessionsFocusContext = new RawContextKey<boolean>('sessionsFocus', false, localize('sessionsFocus', "Whether the sessions part has keyboard focus"));
 export const SessionsVisibleContext = new RawContextKey<boolean>('sessionsVisible', false, localize('sessionsVisible', "Whether the sessions part is visible"));
 export const MultipleSessionsVisibleContext = new RawContextKey<boolean>('multipleSessionsVisible', false, localize('multipleSessionsVisible', "Whether more than one session is visible in the sessions part's grid"));
+export const SessionsHasClosedItemContext = new RawContextKey<boolean>('sessionsHasClosedItem', false, localize('sessionsHasClosedItem', "Whether a chat or session was closed recently and can be reopened with the Reopen Closed Chat or Session command"));
+
+/**
+ * Focus is inside the Agents window's editor surface: an editor part, or the
+ * auxiliary bar, which the single-pane layout docks into the side pane as the
+ * detail panel (Files/Changes). Shortcuts shared with VS Code's editor
+ * commands defer to those commands while this holds.
+ */
+export const SessionsEditorScopeContext = ContextKeyExpr.or(EditorAreaFocusContext, AuxiliaryBarFocusContext)!;
 
 //#endregion
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -27,7 +27,7 @@ import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/l
 import { getQuickNavigateHandler, inQuickPickContext } from '../../../../workbench/browser/quickaccess.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
-import { CanGoBackContext, CanGoForwardContext, SessionProviderIdContext, MultipleSessionsVisibleContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext, SessionIdContext, SessionHasMultipleCommittedChatsContext, SessionShouldShowChatTabsContext, SessionHasMultipleOpenChatsContext, SessionsPickerVisibleContext, SessionActiveChatIsClosableContext, SessionActiveChatIsDeletableContext, SessionChatsPickerVisibleContext, SessionActiveChatHasSubagentsContext, SessionsTitleBarNewSessionEnabledContext } from '../../../common/contextkeys.js';
+import { CanGoBackContext, CanGoForwardContext, SessionProviderIdContext, MultipleSessionsVisibleContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext, SessionIdContext, SessionHasMultipleCommittedChatsContext, SessionShouldShowChatTabsContext, SessionHasMultipleOpenChatsContext, SessionsPickerVisibleContext, SessionActiveChatIsClosableContext, SessionActiveChatIsDeletableContext, SessionChatsPickerVisibleContext, SessionActiveChatHasSubagentsContext, SessionsTitleBarNewSessionEnabledContext, SessionsEditorScopeContext, SessionsHasClosedItemContext } from '../../../common/contextkeys.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 import { CLOSE_CHAT_COMMAND_ID } from '../../../common/sessionCommands.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -671,13 +671,6 @@ registerAction2(class ReopenLastClosedChatAction extends Action2 {
 			f1: true,
 			category: SessionsCategories.Sessions,
 			precondition: SessionSupportsMultipleChatsContext,
-			keybinding: {
-				weight: CHAT_TAB_KEYBINDING_WEIGHT,
-				// Like Cmd/Ctrl+Shift+T in a browser — reopens the most recently
-				// closed chat tab. Scoped to the agents window, outside editor area.
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionIsCreatedContext, SessionSupportsMultipleChatsContext),
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT,
-			},
 		});
 	}
 
@@ -694,6 +687,33 @@ registerAction2(class ReopenLastClosedChatAction extends Action2 {
 		}
 		await sessionsService.openChat(session, lastClosed.resource);
 		sessionsPartService.focusSession(session);
+	}
+});
+
+registerAction2(class ReopenLastClosedItemAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.reopenLastClosedItem',
+			title: localize2('reopenLastClosedItem', "Reopen Closed Chat or Session"),
+			category: SessionsCategories.Sessions,
+			keybinding: {
+				weight: CHAT_TAB_KEYBINDING_WEIGHT,
+				// Like Ctrl/Cmd+Shift+T in a browser. Outside the editor scope the
+				// chord always belongs to the sessions area (it is a no-op when
+				// nothing was closed); inside it, VS Code's own Reopen Closed
+				// Editor takes over.
+				when: ContextKeyExpr.and(IsSessionsWindowContext, SessionsEditorScopeContext.negate()),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT,
+			},
+			menu: {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, SessionsHasClosedItemContext),
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		await accessor.get(ISessionsService).reopenLastClosedItem();
 	}
 });
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -619,7 +619,10 @@ registerAction2(class CloseAllChatsAction extends Action2 {
 			if (chat.status.get() === SessionStatus.Untitled) {
 				await sessionsManagementService.deleteChat(session, chat.resource, { skipConfirmation: true });
 			} else {
-				await sessionsService.closeChat(session, chat);
+				// Closing the whole batch is one gesture, so it is not offered to
+				// Reopen Closed Chat or Session — that would reopen only the last
+				// chat of the batch.
+				await sessionsService.closeChat(session, chat, { skipHistory: true });
 			}
 		}
 	}

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsReopenKeybinding.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsReopenKeybinding.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { decodeKeybinding } from '../../../../../base/common/keybindings.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { OS } from '../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IContext } from '../../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import '../../browser/sessionsActions.js';
+
+const REOPEN_CLOSED_ITEM_ID = 'sessions.reopenLastClosedItem';
+const REOPEN_CLOSED_CHAT_ID = 'sessions.chatCompositeBar.reopenLastClosedChat';
+const CTRL_SHIFT_T = decodeKeybinding(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT, OS)!.getHashCode();
+
+/** Minimal {@link IContext} over a plain record of context key values. */
+function context(values: Record<string, boolean>): IContext {
+	return { getValue: <T>(key: string) => values[key] as T | undefined };
+}
+
+suite('Sessions - Reopen Closed Chat or Session keybinding', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const boundToChord = () => KeybindingsRegistry.getDefaultKeybindings()
+		.filter(item => item.keybinding?.getHashCode() === CTRL_SHIFT_T);
+
+	test('takes Ctrl/Cmd+Shift+T from VS Code\'s Reopen Closed Editor only outside the editor scope', () => {
+		const rule = boundToChord().find(item => item.command === REOPEN_CLOSED_ITEM_ID)!;
+		const evaluate = (values: Record<string, boolean>) => rule.when?.evaluate(context(values)) ?? true;
+
+		assert.deepStrictEqual({
+			// A higher weight than Reopen Closed Editor, so the sessions rule is
+			// consulted first and that command runs only when it does not match.
+			winsOverReopenClosedEditor: rule.weight1 > KeybindingWeight.WorkbenchContrib,
+			normalWindow: evaluate({}),
+			sessionsList: evaluate({ isSessionsWindow: true }),
+			editorArea: evaluate({ isSessionsWindow: true, editorAreaFocus: true }),
+			sidePaneDetail: evaluate({ isSessionsWindow: true, auxiliaryBarFocus: true }),
+		}, {
+			winsOverReopenClosedEditor: true,
+			normalWindow: false,
+			sessionsList: true,
+			editorArea: false,
+			sidePaneDetail: false,
+		});
+	});
+
+	test('supersedes the chord that Reopen Last Closed Chat used to own', () => {
+		const commands = boundToChord().map(item => item.command);
+
+		assert.deepStrictEqual({
+			reopenClosedItem: commands.includes(REOPEN_CLOSED_ITEM_ID),
+			reopenClosedChat: commands.includes(REOPEN_CLOSED_CHAT_ID),
+		}, {
+			reopenClosedItem: true,
+			reopenClosedChat: false,
+		});
+	});
+});

--- a/src/vs/sessions/services/sessions/browser/closedItemHistory.ts
+++ b/src/vs/sessions/services/sessions/browser/closedItemHistory.ts
@@ -106,13 +106,20 @@ export class ClosedItemHistory extends Disposable {
 	 */
 	async reopenLast(): Promise<void> {
 		const item = this._item.get();
-		// The recorded session may be a wrapper that was disposed along with its
-		// grid slot, and it may have disappeared entirely since.
-		const session = item && this._sessionsManagementService.getSessions().find(s => s.sessionId === item.session.sessionId);
-		if (!item || !session) {
+		if (!item) {
 			return;
 		}
+		// Consume up front: a stale entry must not survive a failed reopen, or
+		// the command would stay enabled while permanently doing nothing.
 		this._item.set(undefined, undefined);
+
+		// The recorded session may be a wrapper that was disposed along with its
+		// grid slot, and a provider can drop it from its catalog without ever
+		// firing `onDidDeleteSession`.
+		const session = this._sessionsManagementService.getSessions().find(s => s.sessionId === item.session.sessionId);
+		if (!session) {
+			return;
+		}
 
 		// Reopening re-activates sessions and can evict grid slots itself; keep
 		// its own side effects out of the history.

--- a/src/vs/sessions/services/sessions/browser/closedItemHistory.ts
+++ b/src/vs/sessions/services/sessions/browser/closedItemHistory.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { SessionsHasClosedItemContext } from '../../../common/contextkeys.js';
+import { ISession, SessionStatus } from '../common/session.js';
+import { ISessionsManagementService } from '../common/sessionsManagement.js';
+import { ISessionsPartService } from './sessionsPartService.js';
+import { VisibleSessions } from './visibleSessions.js';
+
+export const enum ClosedItemKind {
+	Chat = 'chat',
+	Session = 'session',
+}
+
+/** A chat tab that was closed (hidden) within a session. */
+export interface IClosedChatItem {
+	readonly kind: ClosedItemKind.Chat;
+	readonly session: ISession;
+	readonly chatResource: URI;
+}
+
+/** A session slot that left the sessions grid. */
+export interface IClosedSessionItem {
+	readonly kind: ClosedItemKind.Session;
+	readonly session: ISession;
+	/** Grid index the slot occupied when the session left the grid. */
+	readonly index: number;
+	readonly sticky: boolean;
+	/**
+	 * Set when the session left the grid because a newly opened slot took its
+	 * place, holding the id of that slot (`undefined` for the empty
+	 * new-session slot). Absent when the user closed the slot explicitly.
+	 */
+	readonly replacedBy?: { readonly sessionId: string | undefined };
+}
+
+export type ClosedItem = IClosedChatItem | IClosedSessionItem;
+
+/**
+ * Remembers the single most recently closed chat or session and reopens it
+ * (`Ctrl/Cmd+Shift+T`). Deliberately holds one entry only: reopening consumes
+ * it, so pressing the chord repeatedly cannot walk further back through
+ * history. In-memory only — a window reload starts empty.
+ */
+export class ClosedItemHistory extends Disposable {
+
+	private readonly _item: ISettableObservable<ClosedItem | undefined> = observableValue(this, undefined);
+
+	private _suspendDepth = 0;
+
+	constructor(
+		private readonly _visibility: VisibleSessions,
+		private readonly _openChat: (session: ISession, chatResource: URI) => Promise<void>,
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@ISessionsPartService private readonly _sessionsPartService: ISessionsPartService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+	) {
+		super();
+
+		const hasClosedItem = SessionsHasClosedItemContext.bindTo(contextKeyService);
+		this._register(autorun(reader => hasClosedItem.set(this._item.read(reader) !== undefined)));
+
+		// A deleted session has nothing left to reopen.
+		this._register(this._sessionsManagementService.onDidDeleteSession(session => {
+			if (this._item.get()?.session.sessionId === session.sessionId) {
+				this._item.set(undefined, undefined);
+			}
+		}));
+	}
+
+	/** Remember a chat that was hidden from its session's tab strip. */
+	recordClosedChat(session: ISession, chatResource: URI): void {
+		this._record({ kind: ClosedItemKind.Chat, session, chatResource });
+	}
+
+	/**
+	 * Remember a session the user closed, together with the grid slot it holds
+	 * right now, so it can return to exactly that position. Must be called
+	 * before the session leaves the grid; a session that is not visible is
+	 * ignored.
+	 */
+	recordClosedSession(session: ISession): void {
+		const slot = this._visibility.getSlot(session.sessionId);
+		if (slot) {
+			this._recordSession(session, slot.index, slot.sticky);
+		}
+	}
+
+	/**
+	 * Remember a session that lost its grid slot to a newly opened one, so it
+	 * can take that slot back.
+	 */
+	recordReplacedSlot(replaced: ISession, index: number, sticky: boolean, replacedBySessionId: string | undefined): void {
+		this._recordSession(replaced, index, sticky, { sessionId: replacedBySessionId });
+	}
+
+	/**
+	 * Reopen the remembered chat or session and focus it, consuming the entry.
+	 * No-op when nothing is remembered or the session is gone.
+	 */
+	async reopenLast(): Promise<void> {
+		const item = this._item.get();
+		// The recorded session may be a wrapper that was disposed along with its
+		// grid slot, and it may have disappeared entirely since.
+		const session = item && this._sessionsManagementService.getSessions().find(s => s.sessionId === item.session.sessionId);
+		if (!item || !session) {
+			return;
+		}
+		this._item.set(undefined, undefined);
+
+		// Reopening re-activates sessions and can evict grid slots itself; keep
+		// its own side effects out of the history.
+		const suspension = this._suspend();
+		try {
+			if (item.kind === ClosedItemKind.Chat) {
+				await this._openChat(session, item.chatResource);
+			} else {
+				this._reopenSession(item, session);
+			}
+		} finally {
+			suspension.dispose();
+		}
+
+		this._sessionsPartService.focusSession(this._visibility.activeSession.get());
+	}
+
+	private _reopenSession(item: IClosedSessionItem, session: ISession): void {
+		// A session pushed out by a newly opened slot takes that slot back, so
+		// the grid returns to what it looked like before. If the replacement has
+		// meanwhile moved or left the grid, fall back to the recorded index.
+		if (item.replacedBy && this._visibility.getSlot(item.replacedBy.sessionId)) {
+			this._sessionsManagementService.discardNewSession(this._visibility.getSession(item.replacedBy.sessionId));
+			if (this._visibility.replaceSlot(item.replacedBy.sessionId, session, item.sticky)) {
+				return;
+			}
+		}
+
+		this._visibility.insertAtIndex(session, item.index, item.sticky);
+	}
+
+	private _recordSession(session: ISession, index: number, sticky: boolean, replacedBy?: { readonly sessionId: string | undefined }): void {
+		// An untitled draft is discarded rather than hidden when it leaves the
+		// grid, so there is nothing meaningful to restore.
+		if (session.status.get() !== SessionStatus.Untitled) {
+			this._record({ kind: ClosedItemKind.Session, session, index, sticky, replacedBy });
+		}
+	}
+
+	private _record(item: ClosedItem): void {
+		if (this._suspendDepth === 0) {
+			this._item.set(item, undefined);
+		}
+	}
+
+	private _suspend(): IDisposable {
+		this._suspendDepth++;
+		return toDisposable(() => this._suspendDepth--);
+	}
+}

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -68,6 +68,16 @@ export interface IOpenNewSessionResult {
 	readonly trustDeclined: boolean;
 }
 
+/** Options for {@link ISessionsService.closeChat}. */
+export interface ICloseChatOptions {
+	/**
+	 * Do not remember the chat as the most recently closed item. Used by batch
+	 * closes (e.g. "Close All Chats"), where remembering just the final chat of
+	 * the batch would make one arbitrary member of it reopenable.
+	 */
+	readonly skipHistory?: boolean;
+}
+
 /**
  * Persisted state for a session.
  * Extend this interface to store additional per-session state that should be
@@ -170,7 +180,7 @@ export interface ISessionsService {
 	 * Close a chat from the session view. The chat is hidden from the tab strip
 	 * and can be reopened from the session header's chats dropdown.
 	 */
-	closeChat(session: IActiveSession, chat: IChat): Promise<void>;
+	closeChat(session: IActiveSession, chat: IChat, options?: ICloseChatOptions): Promise<void>;
 
 	/**
 	 * Reopen the single most recently closed chat or session and focus it.
@@ -688,12 +698,14 @@ export class SessionsService extends Disposable implements ISessionsService {
 		this.logService.trace(`[SessionsView] openChat done total=${Date.now() - t0}ms uri=${chatUri.toString()}`);
 	}
 
-	async closeChat(session: IActiveSession, chat: IChat): Promise<void> {
+	async closeChat(session: IActiveSession, chat: IChat, options?: ICloseChatOptions): Promise<void> {
 		// Closing hides the chat from the tab strip; it stays reopenable from the
 		// session header's chats dropdown.
 		this._visibility.closeChat(session, chat);
 		this._setChatClosedState(session, chat, true);
-		this._closedItems.recordClosedChat(session, chat.resource);
+		if (!options?.skipHistory) {
+			this._closedItems.recordClosedChat(session, chat.resource);
+		}
 	}
 
 	reopenLastClosedItem(): Promise<void> {

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -20,6 +20,7 @@ import { localize } from '../../../../nls.js';
 import { ChatInteractivity, ChatOriginKind, IChat, ISession, SessionStatus } from '../common/session.js';
 import { IActiveSession, ICreateNewChatInSessionOptions, ICreateNewSessionOptions, inheritableSessionTarget, IRecentlyOpenedSessions, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
+import { ClosedItemHistory } from './closedItemHistory.js';
 import { SessionsNavigation } from './sessionNavigation.js';
 import { SessionsRecencyHistory } from './sessionsRecencyHistory.js';
 import { VisibleSessions } from './visibleSessions.js';
@@ -172,6 +173,19 @@ export interface ISessionsService {
 	closeChat(session: IActiveSession, chat: IChat): Promise<void>;
 
 	/**
+	 * Reopen the single most recently closed chat or session and focus it.
+	 *
+	 * A closed chat is un-hidden in its session. A session that was closed
+	 * explicitly returns to the grid at the index it occupied; a session that
+	 * was pushed out of the grid by a newly opened one takes its slot back,
+	 * removing the session that replaced it.
+	 *
+	 * The entry is consumed, so pressing the shortcut repeatedly does not walk
+	 * further back through history. No-op when nothing is remembered.
+	 */
+	reopenLastClosedItem(): Promise<void>;
+
+	/**
 	 * Open the new-session composer.
 	 *
 	 * - Without `options.folderUri`: switch to the new-session view, restoring
@@ -274,6 +288,9 @@ export class SessionsService extends Disposable implements ISessionsService {
 	private readonly _visibility: VisibleSessions;
 	readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>;
 
+	/** Remembers the single most recently closed chat or session for {@link reopenLastClosedItem}. */
+	private readonly _closedItems: ClosedItemHistory;
+
 	/** The canonical active session — the visible active slot. */
 	readonly activeSession: IObservable<IActiveSession | undefined>;
 	private readonly _initialRestoreComplete = observableValue<boolean>(this, false);
@@ -335,9 +352,16 @@ export class SessionsService extends Disposable implements ISessionsService {
 			VisibleSessions,
 			session => this._restoreInitialChat(session),
 			session => this._restoreClosedChats(session),
+			(replaced, index, sticky, replacedBySessionId) => this._closedItems.recordReplacedSlot(replaced, index, sticky, replacedBySessionId),
 		));
 		this.visibleSessions = this._visibility.visibleSessions;
 		this.activeSession = this._visibility.activeSession;
+
+		this._closedItems = this._register(this.instantiationService.createInstance(
+			ClosedItemHistory,
+			this._visibility,
+			(session, chatResource) => this.openChat(session, chatResource),
+		));
 
 		// Bind active-session context keys. These reflect the visible active
 		// slot (the view's `activeSession`); `isNewChatSession` also consults
@@ -669,6 +693,11 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// session header's chats dropdown.
 		this._visibility.closeChat(session, chat);
 		this._setChatClosedState(session, chat, true);
+		this._closedItems.recordClosedChat(session, chat.resource);
+	}
+
+	reopenLastClosedItem(): Promise<void> {
+		return this._closedItems.reopenLast();
 	}
 
 	/**
@@ -885,6 +914,12 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// here means the empty slot is active.
 		const activeSessionId = this._visibility.activeSession.get()?.sessionId;
 		const wasActive = activeSessionId === sessionId;
+
+		// Remember the slot so Reopen Closed Chat or Session can put it back
+		// exactly where it was.
+		if (session) {
+			this._closedItems.recordClosedSession(session);
+		}
 
 		// Discard the in-progress new session when its slot (or the empty slot)
 		// is the one being closed; closing an unrelated session leaves it intact.

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -257,6 +257,9 @@ export class VisibleSession extends Disposable implements IActiveSession {
 	get chats() { return this._session.chats; }
 	get mainChat() { return this._session.mainChat; }
 	get capabilities() { return this._session.capabilities; }
+
+	/** The wrapped session, which outlives this wrapper. */
+	get session(): ISession { return this._session; }
 }
 
 /**
@@ -362,9 +365,15 @@ export class VisibleSessions extends Disposable {
 	 */
 	private _mostRecentNonStickySlot: string | undefined | typeof NO_RECENT = NO_RECENT;
 
+	/**
+	 * @param _onSlotReplaced Reports a session that left the grid because a
+	 * newly opened slot took its place, with the slot state it lost. Explicit
+	 * removals ({@link removeMany}) and grid restores are not reported.
+	 */
 	constructor(
 		private readonly _resolveInitialChat: (session: ISession) => IChat,
 		private readonly _resolveInitialClosedChats: (session: ISession) => Iterable<string>,
+		private readonly _onSlotReplaced: (replaced: ISession, index: number, sticky: boolean, replacedBySessionId: string | undefined) => void,
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
 	) {
 		super();
@@ -421,7 +430,12 @@ export class VisibleSessions extends Disposable {
 				const idx = this._visibleList.indexOf(replaceSlot);
 				this._visibleList.splice(idx, 1, targetId);
 				if (replaceSlot !== undefined) {
+					const replaced = this._wrappers.get(replaceSlot)?.session;
+					const sticky = this._stickyIds.has(replaceSlot);
 					this._wrappers.deleteAndDispose(replaceSlot);
+					if (replaced) {
+						this._onSlotReplaced(replaced, idx, sticky, targetId);
+					}
 				}
 			} else {
 				this._visibleList.push(targetId);
@@ -563,6 +577,84 @@ export class VisibleSessions extends Disposable {
 			this._setActiveSession(activeWrapper, false, tsx);
 			this._refresh(tsx);
 		});
+	}
+
+	/**
+	 * The grid slot state of a currently visible session (or of the empty slot
+	 * when `sessionId` is `undefined`), or `undefined` when it is not visible.
+	 */
+	getSlot(sessionId: string | undefined): { readonly index: number; readonly sticky: boolean } | undefined {
+		const index = this._visibleList.indexOf(sessionId);
+		return index < 0 ? undefined : { index, sticky: this._isStickySlot(sessionId) };
+	}
+
+	/** The session behind a visible slot, or `undefined` for the empty slot / an unknown id. */
+	getSession(sessionId: string | undefined): ISession | undefined {
+		return sessionId === undefined ? undefined : this._wrappers.get(sessionId)?.session;
+	}
+
+	/**
+	 * Put a session (back) into the grid at `index`, shifting the slots at and
+	 * after it to the right, and make it active. The index is clamped to the
+	 * current grid size, so a stale index appends instead of failing. No-op
+	 * when the session is already visible.
+	 */
+	insertAtIndex(session: ISession, index: number, sticky: boolean): VisibleSession | undefined {
+		const id = session.sessionId;
+		if (this._visibleList.includes(id)) {
+			const existing = this._wrappers.get(id);
+			transaction(tsx => this._setActiveSession(existing, false, tsx));
+			return existing;
+		}
+
+		const destIdx = Math.max(0, Math.min(index, this._visibleList.length));
+		const wrapper = this._getOrCreateVisibleSession(session);
+		this._visibleList.splice(destIdx, 0, id);
+		if (sticky) {
+			this._stickyIds.add(id);
+		} else {
+			this._mostRecentNonStickySlot = id;
+		}
+
+		transaction((tsx) => {
+			this._setActiveSession(wrapper, false, tsx);
+			this._refresh(tsx);
+		});
+		return wrapper;
+	}
+
+	/**
+	 * Replace the slot currently held by `slotId` (`undefined` for the empty
+	 * slot) with `session`, and make it active. Used to undo a grid
+	 * replacement, so the restored session lands exactly where it was and the
+	 * session that took its place leaves the grid. No-op when the slot is not
+	 * visible or the session is already visible elsewhere.
+	 */
+	replaceSlot(slotId: string | undefined, session: ISession, sticky: boolean): VisibleSession | undefined {
+		const id = session.sessionId;
+		const idx = this._visibleList.indexOf(slotId);
+		if (idx < 0 || this._visibleList.includes(id)) {
+			return undefined;
+		}
+
+		this._visibleList.splice(idx, 1, id);
+		if (slotId !== undefined) {
+			this._stickyIds.delete(slotId);
+			this._wrappers.deleteAndDispose(slotId);
+		}
+		if (sticky) {
+			this._stickyIds.add(id);
+		}
+		if (this._mostRecentNonStickySlot === slotId) {
+			this._mostRecentNonStickySlot = sticky ? this._findLastNonSticky() : id;
+		}
+
+		const wrapper = this._getOrCreateVisibleSession(session);
+		transaction((tsx) => {
+			this._setActiveSession(wrapper, false, tsx);
+			this._refresh(tsx);
+		});
+		return wrapper;
 	}
 
 	/**

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -2770,6 +2770,50 @@ suite('SessionsManagementService', () => {
 				closedChats: ['b'],
 			});
 		});
+
+		test('a batch close is not offered for reopening', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b'), chat('c')]);
+			const { view, canReopen } = setup([sessionA]);
+
+			await view.openSession(sessionA.resource);
+			const active = view.activeSession.get()!;
+			// Mirrors "Close All Chats", which closes every non-main chat.
+			for (const target of ['b', 'c']) {
+				await view.closeChat(active, sessionA.chats.get().find(c => c.title.get() === target)!, { skipHistory: true });
+			}
+
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({
+				canReopen: canReopen(),
+				closed: view.activeSession.get()!.closedChats.get().map(c => c.title.get()),
+			}, {
+				canReopen: false,
+				closed: ['b', 'c'],
+			});
+		});
+
+		test('a stale entry is dropped when its session vanished without a delete event', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const sessions = [sessionA, sessionB];
+			const provider = new class extends TestSessionsProvider {
+				constructor() { super(sessionA); }
+				override getSessions(): ISession[] { return sessions; }
+			};
+			const { view, contextKeyService } = createSessionsManagementService(sessionA, disposables, provider);
+			const canReopen = () => contextKeyService.getContextKeyValue(SessionsHasClosedItemContext.key) === true;
+
+			await view.openSession(sessionA.resource);
+			await view.closeChat(view.activeSession.get()!, sessionA.chats.get().find(c => c.title.get() === 'b')!);
+
+			// The provider drops the session from its catalog without firing
+			// onDidDeleteSession, so the recorded entry can never be reopened.
+			sessions.splice(0, 1);
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({ canReopen: canReopen() }, { canReopen: false });
+		});
 	});
 
 	suite('createQuickChat', () => {

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -39,6 +39,7 @@ import { ISessionsPartService } from '../../browser/sessionsPartService.js';
 import { CustomViewService, ICustomViewService } from '../../../customView/browser/customViewService.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
+import { SessionsHasClosedItemContext } from '../../../../common/contextkeys.js';
 import { COPILOT_CLI_EH_SCHEME, COPILOT_CLI_LOCAL_AH_SCHEME } from '../../../../../workbench/contrib/chat/browser/copilotCliEventsUri.js';
 
 const stubChat = {
@@ -196,15 +197,16 @@ function createSessionsManagementService(
 	provider: ISessionsProvider | readonly ISessionsProvider[] = new TestSessionsProvider(session),
 	workspaceTrustManagementService = new TestWorkspaceTrustManagementService(),
 	workspaceTrustRequestService?: IWorkspaceTrustRequestService,
-): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService } {
+): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService; contextKeyService: MockContextKeyService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const chatWidgetService = new TestChatWidgetService();
 	const chatService = new TestChatService();
 	const providers = Array.isArray(provider) ? provider : [provider];
+	const contextKeyService = disposables.add(new MockContextKeyService());
 
 	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
 	instantiationService.stub(ILogService, new NullLogService());
-	instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
+	instantiationService.stub(IContextKeyService, contextKeyService);
 	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService(providers));
 	instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
@@ -220,7 +222,7 @@ function createSessionsManagementService(
 
 	const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
 	const view = createView(instantiationService, service, disposables);
-	return { service, view, chatWidgetService, chatService };
+	return { service, view, chatWidgetService, chatService, contextKeyService };
 }
 
 /**
@@ -2638,6 +2640,135 @@ suite('SessionsManagementService', () => {
 			await second.restoreVisibleSessions();
 			await second.openSession(sessionB.resource);
 			assert.deepStrictEqual((second.activeSession.get()?.closedChats.get() ?? []).map(c => c.title.get()), ['b2']);
+		});
+	});
+
+	suite('reopenLastClosedItem', () => {
+
+		function chat(title: string): IChat {
+			return {
+				...stubChat,
+				resource: URI.parse(`test:///chat/${title}`),
+				title: constObservable(title),
+				status: constObservable(SessionStatus.Completed),
+			};
+		}
+
+		function multiChatSession(id: string, chats: IChat[]): ISession {
+			return stubSession({
+				sessionId: id,
+				providerId: 'test',
+				status: constObservable(SessionStatus.Completed),
+				chats: constObservable(chats),
+				mainChat: constObservable(chats[0]),
+				capabilities: constObservable({ supportsMultipleChats: true }),
+			});
+		}
+
+		function setup(sessions: ISession[]) {
+			const provider = new class extends TestSessionsProvider {
+				constructor() { super(sessions[0]); }
+				override getSessions(): ISession[] { return sessions; }
+			};
+			const { view, contextKeyService } = createSessionsManagementService(sessions[0], disposables, provider);
+			// The context key drives the command's palette visibility, and is the
+			// only external signal of whether an entry is remembered.
+			return { view, canReopen: () => contextKeyService.getContextKeyValue(SessionsHasClosedItemContext.key) === true };
+		}
+
+		const grid = (view: SessionsService) => ({
+			visible: view.visibleSessions.get().map(s => s?.sessionId ?? null),
+			sticky: view.visibleSessions.get().map(s => s?.sticky.get() ?? false),
+			active: view.activeSession.get()?.sessionId ?? null,
+		});
+
+		test('reopens a closed chat, consuming the entry', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const { view, canReopen } = setup([sessionA]);
+
+			await view.openSession(sessionA.resource);
+			const chatB = sessionA.chats.get().find(c => c.title.get() === 'b')!;
+			await view.closeChat(view.activeSession.get()!, chatB);
+			const afterClose = canReopen();
+
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({
+				afterClose,
+				closed: view.activeSession.get()!.closedChats.get().map(c => c.title.get()),
+				open: view.activeSession.get()!.openChats.get().map(c => c.title.get()),
+				canReopenAgain: canReopen(),
+			}, {
+				afterClose: true,
+				closed: [],
+				open: ['mainA', 'b'],
+				canReopenAgain: false,
+			});
+		});
+
+		test('an explicitly closed session returns to its grid index', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			// Pin A so opening B adds a second slot instead of replacing it.
+			await view.openSession(sessionA.resource);
+			view.toggleSessionStickiness(sessionA);
+			await view.openSession(sessionB.resource);
+
+			view.closeSession(sessionA);
+			const afterClose = grid(view);
+
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({ afterClose, afterReopen: grid(view) }, {
+				afterClose: { visible: ['B'], sticky: [false], active: 'B' },
+				afterReopen: { visible: ['A', 'B'], sticky: [true, false], active: 'A' },
+			});
+		});
+
+		test('a session pushed out of the grid takes its slot back', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			await view.openSession(sessionB.resource);
+			const afterReplace = grid(view);
+
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({ afterReplace, afterReopen: grid(view) }, {
+				afterReplace: { visible: ['B'], sticky: [false], active: 'B' },
+				afterReopen: { visible: ['A'], sticky: [false], active: 'A' },
+			});
+		});
+
+		test('remembers only the most recently closed item', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			const chatB = sessionA.chats.get().find(c => c.title.get() === 'b')!;
+			await view.closeChat(view.activeSession.get()!, chatB);
+			// Opening B pushes A out of the grid, superseding the closed-chat entry.
+			await view.openSession(sessionB.resource);
+
+			await view.reopenLastClosedItem();
+			// The entry is consumed, so pressing again must not walk back to the
+			// superseded closed chat.
+			await view.reopenLastClosedItem();
+
+			assert.deepStrictEqual({
+				...grid(view),
+				closedChats: view.activeSession.get()!.closedChats.get().map(c => c.title.get()),
+			}, {
+				visible: ['A'],
+				sticky: [false],
+				active: 'A',
+				closedChats: ['b'],
+			});
 		});
 	});
 

--- a/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
@@ -62,13 +62,14 @@ suite('VisibleSessions', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createModel() {
+	function createModel(onSlotReplaced: (replaced: ISession, index: number, sticky: boolean, replacedBySessionId: string | undefined) => void = () => { }) {
 		const uriIdentity = new class extends mock<IUriIdentityService>() {
 			override readonly extUri = extUriBiasedIgnorePathCase;
 		};
 		const model = disposables.add(new VisibleSessions(
 			session => session.mainChat.get(),
 			() => [],
+			onSlotReplaced,
 			uriIdentity,
 		));
 		return model;
@@ -1349,6 +1350,7 @@ suite('VisibleSessions - active chat removal fallback', () => {
 		return disposables.add(new VisibleSessions(
 			session => session.mainChat.get(),
 			() => [],
+			() => { },
 			uriIdentity,
 		));
 	}


### PR DESCRIPTION
Fixes #329184

Adds a single **Reopen Closed Chat or Session** command (`sessions.reopenLastClosedItem`) on `Ctrl/Cmd+Shift+T`, and makes that chord focus-aware in the Agents window.

### Scoping

| Focus | `Ctrl/Cmd+Shift+T` |
| --- | --- |
| Editor area, or the docked detail panel (Files/Changes) | VS Code's own **Reopen Closed Editor** |
| Anywhere else in the Agents window | **Reopen Closed Chat or Session** |

"Editor scope" is the new `SessionsEditorScopeContext` = `editorAreaFocus \|\| auxiliaryBarFocus`. The auxiliary bar is included because the single-pane layout docks it into the side pane as the detail panel, where `editorAreaFocus` is `false`. Outside that scope the sessions command always owns the chord (a no-op when nothing was closed), so it never reopens an editor from the chat side.

### Behaviour

`ClosedItemHistory` remembers the **single** most recently closed chat or session and reopens it. Reopening consumes the entry, so pressing the chord repeatedly cannot walk further back through history. It is in-memory only, so a reload starts empty.

Exactly three things record into it:

- **closing a chat tab** → the chat is un-hidden in its session
- **closing a session slot** → the session returns to the grid index it occupied
- **a grid replacement** (opening a session pushes a non-sticky one out) → the session takes its slot back, removing whatever replaced it

So with two sessions in the grid, closing one and pressing the chord brings it back beside the other; opening a session that replaced the current one and pressing the chord puts the previous session back where it was.

Untitled drafts are discarded rather than hidden, so they never record. Close-all commands, deletions, and grid restores never record either, and an entry is dropped if its session is deleted.

### Notes

- The existing **Reopen Last Closed Chat** keeps its command-palette entry but no longer binds the chord.
- All recording/restore logic lives in `ClosedItemHistory`; `SessionsService` only delegates.
- The other chat-tab chords (`Ctrl/Cmd+W`, `Ctrl/Cmd+T`, `Ctrl+Tab`, …) are unchanged and remain scoped on `editorAreaFocus` alone.

### Validation

`npm run typecheck-client`, `npm run valid-layers-check`, and eslint all pass. 2057 sessions unit tests pass, including 6 new ones covering the reopen semantics and the keybinding scoping. Two failures in the suite (`ResponseSelectionSideChatController` float rounding, `MobileMultiDiffView` timeout) reproduce on a clean tree and are unrelated.
