### PR TITLE
agentHost: perf: stop repairing worktree roots while listing

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -9,7 +9,7 @@ import { DeferredPromise, disposableTimeout, ResourceQueue } from '../../../base
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { LRUCache, ResourceMap } from '../../../base/common/map.js';
+import { ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
 import { IObservable, observableValue } from '../../../base/common/observable.js';
@@ -23,7 +23,7 @@ import { InstantiationService } from '../../instantiation/common/instantiationSe
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateChatSideChatSelection, IAgentCreateChatSideChatSource, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionAdoptionResult, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
-import { type ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
+import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, parseEditAttributionResource } from '../common/fileEditAttribution.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
@@ -46,7 +46,7 @@ import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { resolveSessionRepositories } from './agentHostSessionRepositories.js';
 import { findDeepestContainingWorkingDirectory, isMultiRootSession } from '../common/agentHostWorkingDirectories.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
-import { IAgentHostGitService, tryResolvePrimaryWorktreeRoot } from '../common/agentHostGitService.js';
+import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
@@ -332,8 +332,6 @@ export class AgentService extends Disposable implements IAgentService {
 	 * agents stay unaware of the folder-vs-worktree distinction.
 	 */
 	private _worktree: WorktreeIsolation | undefined;
-	/** Successful list-time repository-root resolutions; eviction only causes safe re-resolution. */
-	private readonly _normalizedWorktreeRepositoryRoots = new LRUCache<string, URI>(100);
 	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
 	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */
@@ -936,41 +934,6 @@ export class AgentService extends Disposable implements IAgentService {
 		};
 	}
 
-	/**
-	 * Repairs repository roots written by older builds that treated a parent linked checkout as the repository.
-	 * Listing performs this migration because archived sessions may never resume through WorktreeIsolation's metadata reader.
-	 */
-	private async _normalizeListedWorktreeRepositoryRoot(session: IAgentSessionMetadata, database: ISessionDatabase, repositoryRootRaw: string): Promise<string> {
-		const storedRepositoryRootRaw = repositoryRootRaw;
-		const persistedRoot = URI.parse(repositoryRootRaw);
-		const sessionStr = session.session.toString();
-		let primaryRoot = this._normalizedWorktreeRepositoryRoots.get(sessionStr);
-		if (!primaryRoot) {
-			const workingDirectory = session.workingDirectories?.[0];
-			const checkoutRoot = workingDirectory && await this._fileExistsSafe(workingDirectory) ? workingDirectory : persistedRoot;
-			try {
-				primaryRoot = await tryResolvePrimaryWorktreeRoot(this._gitService, checkoutRoot)
-					?? (checkoutRoot.toString() !== persistedRoot.toString() ? await tryResolvePrimaryWorktreeRoot(this._gitService, persistedRoot) : undefined);
-				if (primaryRoot) {
-					this._normalizedWorktreeRepositoryRoots.set(sessionStr, primaryRoot);
-				}
-			} catch (error) {
-				this._logService.warn(`[AgentService][listSessions] Failed to resolve primary worktree for ${session.session}`, error);
-			}
-		}
-		if (primaryRoot) {
-			repositoryRootRaw = primaryRoot.toString();
-		}
-		if (repositoryRootRaw !== storedRepositoryRootRaw) {
-			try {
-				await database.setMetadata(WORKTREE_META_REPOSITORY_ROOT, repositoryRootRaw);
-			} catch (error) {
-				this._logService.warn(`[AgentService][listSessions] Failed to normalize worktree repository metadata for ${session.session}`, error);
-			}
-		}
-		return repositoryRootRaw;
-	}
-
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
 		const results = await Promise.all(
@@ -1044,11 +1007,10 @@ export class AgentService extends Disposable implements IAgentService {
 						updated = { ...updated, _meta: withSessionMultiRootMetadata(updated._meta, multiRoot) };
 					}
 
-					let repositoryRootRaw = m[WORKTREE_META_REPOSITORY_ROOT];
-					if (repositoryRootRaw) {
-						repositoryRootRaw = await this._normalizeListedWorktreeRepositoryRoot(updated, ref.object, repositoryRootRaw);
-					}
-					const worktreeProject = worktreeProjectFromRepositoryRoot(repositoryRootRaw);
+					// The persisted root is used as-is. `WorktreeIsolation`'s metadata
+					// reader canonicalizes and re-persists it whenever a session is
+					// opened, so listing never has to spawn Git to derive the label.
+					const worktreeProject = worktreeProjectFromRepositoryRoot(m[WORKTREE_META_REPOSITORY_ROOT]);
 					if (worktreeProject) {
 						updated = { ...updated, project: worktreeProject };
 					}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1007,9 +1007,7 @@ export class AgentService extends Disposable implements IAgentService {
 						updated = { ...updated, _meta: withSessionMultiRootMetadata(updated._meta, multiRoot) };
 					}
 
-					// The persisted root is used as-is. `WorktreeIsolation`'s metadata
-					// reader canonicalizes and re-persists it whenever a session is
-					// opened, so listing never has to spawn Git to derive the label.
+					// Use the persisted root as-is to keep listing off Git; the metadata reader re-canonicalizes it on open.
 					const worktreeProject = worktreeProjectFromRepositoryRoot(m[WORKTREE_META_REPOSITORY_ROOT]);
 					if (worktreeProject) {
 						updated = { ...updated, project: worktreeProject };

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -983,6 +983,14 @@ export class WorktreeIsolation extends Disposable {
 	/**
 	 * Reads worktree metadata and migrates repository roots written before linked checkouts were canonicalized.
 	 * It probes an existing worktree when available and otherwise falls back to the persisted root for archived sessions.
+	 *
+	 * This is the only place a persisted root is repaired — `listSessions` deliberately
+	 * reads it as-is to stay off Git. The repair is therefore reachable only when
+	 * {@link WORKTREE_META_BRANCH} is also set (see the early return below). Every
+	 * writer of the root key writes the branch alongside it, so that holds in
+	 * practice; note the writes are concurrent rather than transactional, so a
+	 * root persisted without its branch would leave a session whose project label
+	 * could never heal.
 	 */
 	private async _readWorktreeMetadata(sessionUri: URI): Promise<IWorktreeMetadata | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);

--- a/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
+++ b/src/vs/platform/agentHost/node/shared/worktreeIsolation.ts
@@ -981,16 +981,10 @@ export class WorktreeIsolation extends Disposable {
 	}
 
 	/**
-	 * Reads worktree metadata and migrates repository roots written before linked checkouts were canonicalized.
+	 * Reads persisted worktree metadata, canonicalizing, repairing, and persisting the repository root when needed.
 	 * It probes an existing worktree when available and otherwise falls back to the persisted root for archived sessions.
-	 *
-	 * This is the only place a persisted root is repaired — `listSessions` deliberately
-	 * reads it as-is to stay off Git. The repair is therefore reachable only when
-	 * {@link WORKTREE_META_BRANCH} is also set (see the early return below). Every
-	 * writer of the root key writes the branch alongside it, so that holds in
-	 * practice; note the writes are concurrent rather than transactional, so a
-	 * root persisted without its branch would leave a session whose project label
-	 * could never heal.
+	 * The repair is only reachable when {@link WORKTREE_META_BRANCH} is present, so a root
+	 * persisted without its branch will never heal.
 	 */
 	private async _readWorktreeMetadata(sessionUri: URI): Promise<IWorktreeMetadata | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(sessionUri);

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1890,8 +1890,7 @@ suite('AgentService (node dispatcher)', () => {
 			svc.registerProvider(agent);
 
 			const sessions = await svc.listSessions();
-			// Twice: the deleted repair cached per session, so a single listing
-			// could not have distinguished "never resolves" from "resolves once".
+			// Twice, because the deleted repair cached per session: one listing cannot tell "never resolves" from "resolves once".
 			await svc.listSessions();
 
 			assert.deepStrictEqual({
@@ -1935,8 +1934,7 @@ suite('AgentService (node dispatcher)', () => {
 			agent.sessionMessages = [];
 
 			const before = await svc.listSessions();
-			// Opening the session is what heals it: restore resolves the worktree
-			// project, which canonicalizes the persisted root and writes it back.
+			// Restore heals the metadata by resolving the worktree project, canonicalizing the root, and writing it back.
 			await svc.restoreSession(sessionResource);
 			const after = await svc.listSessions();
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1869,9 +1869,8 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(readSessionMultiRootMetadata(sessions[0]._meta), undefined);
 		});
 
-		test('listSessions normalizes a persisted linked-worktree project without probing a missing session worktree', async () => {
+		test('listSessions surfaces the persisted worktree repository root without resolving it', async () => {
 			const db = disposables.add(new TestSessionDatabase());
-			const primaryRoot = URI.file('/workspace/vscode');
 			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
 			const sessionWorktree = URI.file('/workspace/vscode.worktrees/parent.worktrees/child');
 			await db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString());
@@ -1879,30 +1878,75 @@ suite('AgentService (node dispatcher)', () => {
 			const sessionUri = AgentSession.uri('copilot', sessionId);
 			const agent = new MockAgent('copilot');
 			disposables.add(toDisposable(() => agent.dispose()));
-			agent.sessionMetadataOverrides = {
-				workingDirectories: [sessionWorktree],
-				project: { uri: linkedCheckout, displayName: 'parent' },
-			};
+			agent.sessionMetadataOverrides = { workingDirectories: [sessionWorktree] };
 			(agent as unknown as { _sessions: Map<string, URI> })._sessions.set(sessionId, sessionUri);
 			const gitService = createNoopGitService();
-			const resolvedFrom: URI[] = [];
-			gitService.getWorktreeRoots = async workingDirectory => {
-				resolvedFrom.push(workingDirectory);
-				return [primaryRoot, linkedCheckout, sessionWorktree];
+			let worktreeRootResolutions = 0;
+			gitService.getWorktreeRoots = async () => {
+				worktreeRootResolutions++;
+				return [];
 			};
 			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, gitService));
 			svc.registerProvider(agent);
 
 			const sessions = await svc.listSessions();
+			// Twice: the deleted repair cached per session, so a single listing
+			// could not have distinguished "never resolves" from "resolves once".
 			await svc.listSessions();
 
 			assert.deepStrictEqual({
-				resolvedFrom: resolvedFrom.map(uri => uri.toString()),
+				worktreeRootResolutions,
 				project: sessions[0].project && { uri: sessions[0].project.uri.toString(), displayName: sessions[0].project.displayName },
 				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
 			}, {
-				resolvedFrom: [linkedCheckout.toString()],
-				project: { uri: primaryRoot.toString(), displayName: 'vscode' },
+				worktreeRootResolutions: 0,
+				project: { uri: linkedCheckout.toString(), displayName: 'parent' },
+				persistedRepositoryRoot: linkedCheckout.toString(),
+			});
+		});
+
+		test('listSessions reports the repository root once opening the session heals it', async () => {
+			const db = disposables.add(new TestSessionDatabase());
+			const primaryRoot = URI.file('/workspace/vscode');
+			const linkedCheckout = URI.file('/workspace/vscode.worktrees/parent');
+			const sessionWorktree = URI.file('/workspace/vscode.worktrees/parent.worktrees/child');
+			await Promise.all([
+				db.setMetadata('copilot.worktree.branchName', 'agents/child'),
+				db.setMetadata('copilot.worktree.path', sessionWorktree.toString()),
+				db.setMetadata(WORKTREE_META_REPOSITORY_ROOT, linkedCheckout.toString()),
+			]);
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.sessionMetadataOverrides = { workingDirectories: [sessionWorktree] };
+			const gitService = createNoopGitService();
+			gitService.getWorktreeRoots = async () => [primaryRoot, linkedCheckout, sessionWorktree];
+			const sessionDataService = createSessionDataService(db);
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			svc.setWorktreeIsolation(disposables.add(new WorktreeIsolation(
+				{ generateBranchName: async () => 'agents/test' },
+				gitService,
+				new TestCopilotApiService(),
+				sessionDataService,
+				new NullLogService(),
+			)));
+			svc.registerProvider(agent);
+			await agent.createSession();
+			const sessionResource = (await agent.listSessions())[0].session;
+			agent.sessionMessages = [];
+
+			const before = await svc.listSessions();
+			// Opening the session is what heals it: restore resolves the worktree
+			// project, which canonicalizes the persisted root and writes it back.
+			await svc.restoreSession(sessionResource);
+			const after = await svc.listSessions();
+
+			assert.deepStrictEqual({
+				before: before[0].project?.uri.toString(),
+				after: after[0].project?.uri.toString(),
+				persistedRepositoryRoot: await db.getMetadata(WORKTREE_META_REPOSITORY_ROOT),
+			}, {
+				before: linkedCheckout.toString(),
+				after: primaryRoot.toString(),
 				persistedRepositoryRoot: primaryRoot.toString(),
 			});
 		});


### PR DESCRIPTION
Fixes #329880

## What

`listSessions` ran a data migration that re-derived every session's repository root through `git worktree list --porcelain`, to repair roots persisted by builds older than #328375. On a large catalogue that spawned hundreds of Git processes and made the first listing take ~52s — and the Agents window renders nothing until it returns.

This deletes the list-time repair. The listing now uses the persisted `copilot.worktree.repositoryRoot` as-is for the session's project label.

## Why this is safe

`WorktreeIsolation._readWorktreeMetadata` already canonicalizes the persisted root and **writes it back**, and every host-side consumer reads through it: archived resume, worktree removal, archive cleanup, unarchive recreation, and `resolveWorktreeProject`. Within the host, the listing's project label was the only consumer that did not.

Opening a session therefore still heals it: `_withWorktreeProject` resolves the worktree project, which canonicalizes and re-persists the root. `listSessions` also overlays the live summary, so every later listing reports the healed value from two independent sources.

That read-path repair is retained and is now the single repair point — `worktreeIsolation.test.ts` still covers it.

## Tradeoff (not a free removal)

The heal is **deferred rather than immediate**: restore deliberately emits no `sessionAdded`, and the renderer ignores `project` on `sessionSummaryChanged`, so the corrected root reaches the UI on the next `listSessions` refresh — which is turn- or reload-driven rather than periodic.

Until a legacy session is first opened, its sidebar group is named after the linked checkout, and renderer surfaces that read `folders[0].root` ("New Session" on a workspace section, and the customization writes on a just-opened session) can target that checkout. Those surfaces derive a Git root from a *display* field and so never read through the repairing reader — a pre-existing defect this change makes easier to hit, which I'll file separately. The target was a checkout of the same repository when it was persisted, and session creation re-canonicalizes the root, so a new session is still filed under the primary checkout. The merge-into-parent command cannot reach it at all: its only menu is gated on `ContextKeyExpr.false()` and it registers no `f1` entry.

Also accepted: a root persisted without its branch (only reachable via a partial metadata write) used to be repaired by the listing and now never self-heals. The reader's JSDoc records that.

## Measurements

On an 804-session catalogue: **49** sessions carry a worktree root across **4** distinct roots, and **all 4 were already primary checkouts** — the migration re-verified correct data on every listing and repaired nothing.

The issue's "613 sessions with persisted worktree metadata" is the count *with* metadata, not the count *needing repair*.

## Testing

- Replaced the repair-only test with two tests: one asserting the listing performs **zero** worktree-root resolutions and leaves metadata untouched, one asserting a legacy root heals once the session is opened (driving the real `restoreSession` path, so it guards `_withWorktreeProject`).
- Both were verified to **fail** with the production change reverted (0 passing / 2 failing), and the heal test also fails against an injected early-return in `_withWorktreeProject`.
- `npm run typecheck-client`: 17 errors, identical to the clean-`main` baseline (pre-existing Copilot SDK drift).
- `./scripts/test.sh --runGlob "**/vs/platform/agentHost/**/*.test.js"`: 4481 passing.
- `./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts`: 42 passing.
- `npm run valid-layers-check`: 42 errors, all pre-existing baseline.