### PR TITLE
Update @vscode/codicons to version 0.0.46-36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.6.1",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-35",
+        "@vscode/codicons": "^0.0.46-36",
         "@vscode/copilot-api": "^0.5.1",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "0.0.2-7",
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-35",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-35.tgz",
-      "integrity": "sha512-qw/P7P3gLUnlzQCYgUHtpDLWcdNTEXbeH+L8LUBjaACHSTrXRlUbml7z0zM7zIDhqccTLEbL8vgwy8FBVsB+XQ==",
+      "version": "0.0.46-36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-36.tgz",
+      "integrity": "sha512-K030Z2AGo4P1gIZfT8X6dNyjficRhA3mDbBfuTObHY4M8+QdyIocc7c2nLfLhZC629oUVVPflJery0CjSfrrUw==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@microsoft/mxc-sdk": "0.6.1",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-35",
+    "@vscode/codicons": "^0.0.46-36",
     "@vscode/copilot-api": "^0.5.1",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "0.0.2-7",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-35",
+        "@vscode/codicons": "^0.0.46-36",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-35",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-35.tgz",
-      "integrity": "sha512-qw/P7P3gLUnlzQCYgUHtpDLWcdNTEXbeH+L8LUBjaACHSTrXRlUbml7z0zM7zIDhqccTLEbL8vgwy8FBVsB+XQ==",
+      "version": "0.0.46-36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-36.tgz",
+      "integrity": "sha512-K030Z2AGo4P1gIZfT8X6dNyjficRhA3mDbBfuTObHY4M8+QdyIocc7c2nLfLhZC629oUVVPflJery0CjSfrrUw==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-35",
+    "@vscode/codicons": "^0.0.46-36",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",


### PR DESCRIPTION
Upgrade the @vscode/codicons package to the latest version to ensure compatibility and access to the latest features and fixes. No issues are associated with this update. Testing can be done by verifying the appearance and functionality of icons in the application.

