### PR TITLE
Remove voice file attachment actions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatVoice.ts
@@ -61,8 +61,6 @@ export interface INewChatVoiceComposer {
 	getVoiceModels(): readonly ILanguageModelChatMetadataAndIdentifier[];
 	/** Select a model by its exact frontend identifier. */
 	selectVoiceModel(identifier: string): boolean;
-	/** Attach files to this draft composer. */
-	attach(uris: URI[]): void;
 }
 
 export const INewChatVoiceTargetService = createDecorator<INewChatVoiceTargetService>('newChatVoiceTargetService');

--- a/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/voiceBridge.contribution.ts
@@ -6,14 +6,14 @@
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { basename, isEqual } from '../../../../base/common/resources.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IVoiceSessionController } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceSessionController.js';
 import { combineVoiceInput } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceInputUtils.js';
-import { IVoiceAttachmentResult, IVoiceModelSelectionResult, resolveVoiceModel } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.js';
+import { IVoiceModelSelectionResult, resolveVoiceModel } from '../../../../workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { INewChatVoiceComposer, INewChatVoiceTargetService, NEW_CHAT_VOICE_SENTINEL } from './newChatVoice.js';
@@ -114,25 +114,6 @@ class SessionsVoiceBridgeContribution extends Disposable implements IWorkbenchCo
 				? composer.selectVoiceModel(resolved.identifier)
 				: widget!.inputPart.switchModelByIdentifier(resolved.identifier, true, true);
 			return selected ? resolved : { ok: false, reason: 'selection_failed', available_models: resolved.available_models };
-		}));
-
-		this._commandDisposables.add(CommandsRegistry.registerCommand('_chat.voice.attachFiles', async (_accessor, resourceStrings: readonly string[]): Promise<IVoiceAttachmentResult> => {
-			const composer = this._activeComposerTarget();
-			const widget = composer ? undefined : this._activeSessionWidget() ?? this.chatWidgetService.lastFocusedWidget;
-			if (!composer && !widget) {
-				return { ok: false, reason: 'no_input' };
-			}
-			try {
-				const resources = resourceStrings.map(resource => URI.parse(resource));
-				if (composer) {
-					composer.attach(resources);
-				} else {
-					await Promise.all(resources.map(resource => widget!.attachmentModel.addFile(resource)));
-				}
-				return { ok: true, attached: resources.map(resource => basename(resource)) };
-			} catch {
-				return { ok: false, reason: 'attachment_failed' };
-			}
 		}));
 
 		// Reveal the session that owns the given chat resource.

--- a/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/voiceBridge.test.ts
@@ -28,7 +28,6 @@ suite('SessionsVoiceNewComposerContribution', () => {
 			focus: () => { },
 			getVoiceModels: () => [],
 			selectVoiceModel: () => false,
-			attach: () => { },
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -26,7 +26,7 @@ import { IVoiceAudioResponse, IVoiceBargeIn, IVoiceCheckpointNarrationMetadata, 
 import { getVoiceConfirmationType, isPendingVoiceQuestionnaireInvocation, isVoiceQuestionnaireInvocation } from '../../common/voiceClient/voiceConfirmation.js';
 import { IMicCaptureService, IPttDiagnostic, isMicrophonePermissionDeniedError } from './micCaptureService.js';
 import { ITtsPlaybackService } from './ttsPlaybackService.js';
-import { IVoiceAttachmentResult, IVoiceModelSelectionResult, IVoiceToolDispatchService, VoiceToolDispatchService } from './voiceToolDispatchService.js';
+import { IVoiceModelSelectionResult, IVoiceToolDispatchService, VoiceToolDispatchService } from './voiceToolDispatchService.js';
 import { IVoicePlaybackService } from '../../common/voicePlaybackService.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { AgentSessionStatus } from '../agentSessions/agentSessionsModel.js';
@@ -915,9 +915,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			getTargetSessionResource: (): URI | undefined => this._targetSession.get(),
 			selectModel: async (requestedModel: string): Promise<IVoiceModelSelectionResult> =>
 				(await this.commandService.executeCommand<IVoiceModelSelectionResult>('_chat.voice.selectModel', requestedModel)
-					.catch(() => undefined)) ?? { ok: false, reason: 'no_input' },
-			attachFiles: async (resources: readonly URI[]): Promise<IVoiceAttachmentResult> =>
-				(await this.commandService.executeCommand<IVoiceAttachmentResult>('_chat.voice.attachFiles', resources.map(resource => resource.toString()))
 					.catch(() => undefined)) ?? { ok: false, reason: 'no_input' },
 			getAutoApprovedSessions: (): Set<string> => {
 				return this._autoApprovedSessions;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -5,7 +5,6 @@
 
 import { URI } from '../../../../../base/common/uri.js';
 import { constObservable } from '../../../../../base/common/observable.js';
-import { posix, win32 } from '../../../../../base/common/path.js';
 import { localize } from '../../../../../nls.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
@@ -22,10 +21,6 @@ import { ILanguageModelToolsService } from '../../common/tools/languageModelTool
 import { IVoiceDispatchResult, IVoiceModelReference, IVoiceToolCall, markPendingIdResolved, peekPendingId } from '../../common/voiceClient/voiceClientService.js';
 import { getVoiceConfirmationType } from '../../common/voiceClient/voiceConfirmation.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/editor.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { isExplicitFileOrImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 
 /**
@@ -45,8 +40,6 @@ export interface IVoiceToolDispatchDelegate {
 	getTargetSessionResource(): URI | undefined;
 	/** Select a model in the currently shown voice input. */
 	selectModel(requestedModel: string): Promise<IVoiceModelSelectionResult>;
-	/** Attach files to the currently shown voice input. */
-	attachFiles(resources: readonly URI[]): Promise<IVoiceAttachmentResult>;
 	/** Get the set of auto-approved session resource strings. */
 	getAutoApprovedSessions(): Set<string>;
 	/** Mark all current sessions as auto-approved. */
@@ -62,13 +55,6 @@ export interface IVoiceModelSelectionResult {
 	readonly reason?: 'no_input' | 'model_not_found' | 'ambiguous_model' | 'selection_failed';
 	readonly selected_model?: IVoiceModelReference;
 	readonly available_models?: readonly IVoiceModelReference[];
-}
-
-export interface IVoiceAttachmentResult {
-	readonly ok: boolean;
-	readonly reason?: 'no_input' | 'no_file' | 'file_not_found' | 'ambiguous_file' | 'attachment_failed';
-	readonly attached?: readonly string[];
-	readonly candidates?: readonly string[];
 }
 
 function voiceModelReference(model: ILanguageModelChatMetadataAndIdentifier): IVoiceModelReference {
@@ -150,8 +136,6 @@ const ACTION_LABELS: Record<string, string> = {
 	respond_to_session: localize('agentsVoice.action.respond', "Responding..."),
 	focus_session: localize('agentsVoice.action.focusSession', "Focusing session..."),
 	set_model: localize('agentsVoice.action.setModel', "Changing model..."),
-	attach_file: localize('agentsVoice.action.attachFile', "Attaching file..."),
-	attach_files: localize('agentsVoice.action.attachFiles', "Attaching files..."),
 	auto_approve_session: localize('agentsVoice.action.autoApprove', "Auto-approving session..."),
 	revoke_auto_approve: localize('agentsVoice.action.revokeAutoApprove', "Revoking auto-approve..."),
 };
@@ -166,9 +150,6 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IChatService private readonly chatService: IChatService,
 		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
-		@IEditorService private readonly editorService: IEditorService,
-		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
-		@IFileService private readonly fileService: IFileService,
 	) { }
 
 	setDelegate(delegate: IVoiceToolDispatchDelegate): void {
@@ -278,18 +259,6 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 				}
 				return JSON.stringify(await delegate.selectModel(requestedModel));
 			}
-			case 'attach_file':
-			case 'attach_files': {
-				const target = await this._showActionTarget(argString('coding_session_id'));
-				if (!target.ok) {
-					return JSON.stringify(target);
-				}
-				const resolved = await this._resolveAttachmentResources(args);
-				if (!resolved.ok) {
-					return JSON.stringify(resolved);
-				}
-				return JSON.stringify(await delegate.attachFiles(resolved.resources));
-			}
 			case 'auto_approve_session': {
 				delegate.addAllAutoApprovedSessions();
 				break;
@@ -358,62 +327,6 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 			delegate.setTargetSession(resource);
 		}
 		return { ok: true, resource };
-	}
-
-	private async _resolveAttachmentResources(args: Record<string, unknown>): Promise<
-		{ ok: true; resources: readonly URI[] }
-		| { ok: false; reason: NonNullable<IVoiceAttachmentResult['reason']>; candidates?: readonly string[] }
-	> {
-		const uriValues = [args['uri'], ...(Array.isArray(args['uris']) ? args['uris'] : [])]
-			.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
-		const pathValues = [args['path'], ...(Array.isArray(args['paths']) ? args['paths'] : [])]
-			.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
-		if (uriValues.length === 0 && pathValues.length === 0) {
-			const activeResource = EditorResourceAccessor.getCanonicalUri(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
-			return activeResource ? { ok: true, resources: [activeResource] } : { ok: false, reason: 'no_file' };
-		}
-
-		const resources: URI[] = [];
-		for (const rawValue of uriValues) {
-			const value = rawValue.trim();
-			let resource: URI;
-			try {
-				resource = URI.parse(value, true);
-			} catch {
-				return { ok: false, reason: 'file_not_found', candidates: [value] };
-			}
-			if (!await this.fileService.exists(resource)) {
-				return { ok: false, reason: 'file_not_found', candidates: [value] };
-			}
-			resources.push(resource);
-		}
-
-		for (const rawValue of pathValues) {
-			const value = rawValue.trim();
-			const isWindowsPath = win32.isAbsolute(value);
-			if (isWindowsPath || posix.isAbsolute(value)) {
-				const resource = URI.file(isWindowsPath ? value.replaceAll('\\', '/') : value);
-				if (!await this.fileService.exists(resource)) {
-					return { ok: false, reason: 'file_not_found', candidates: [value] };
-				}
-				resources.push(resource);
-				continue;
-			}
-
-			const relativePath = value.replace(/^\.[\\/]/, '').replaceAll('\\', '/');
-			const candidates = this.workspaceContextService.getWorkspace().folders
-				.map(folder => URI.joinPath(folder.uri, relativePath));
-			const exists = await Promise.all(candidates.map(candidate => this.fileService.exists(candidate)));
-			const matches = candidates.filter((_candidate, index) => exists[index]);
-			if (matches.length === 0) {
-				return { ok: false, reason: 'file_not_found', candidates: [value] };
-			}
-			if (matches.length > 1) {
-				return { ok: false, reason: 'ambiguous_file', candidates: matches.map(match => match.toString()) };
-			}
-			resources.push(matches[0]);
-		}
-		return { ok: true, resources };
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -16,7 +16,7 @@ import { MutableDisposable, toDisposable, DisposableStore, IDisposable } from '.
 import { LRUCache } from '../../../../../../base/common/map.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { autorun, IObservable, IReader, observableFromEvent, observableValue } from '../../../../../../base/common/observable.js';
-import { basename, getComparisonKey, isEqual } from '../../../../../../base/common/resources.js';
+import { getComparisonKey, isEqual } from '../../../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
@@ -82,7 +82,7 @@ import { IVoiceInputModeService, SimulatedVoiceState } from '../../voiceInputMod
 import { isGlowingVoiceState, readVoiceGlowIntensity, resolveVoiceGlowColors, VoiceGlowState } from '../../voiceClient/voiceGlow.js';
 import { createVoiceGlowController } from '../../voiceClient/voiceGlowController.js';
 import { combineVoiceInput } from '../../voiceClient/voiceInputUtils.js';
-import { IVoiceAttachmentResult, IVoiceModelSelectionResult, resolveVoiceModel } from '../../voiceClient/voiceToolDispatchService.js';
+import { IVoiceModelSelectionResult, resolveVoiceModel } from '../../voiceClient/voiceToolDispatchService.js';
 import { IAgentTitleBarStatusService } from '../../agentSessions/experiments/agentTitleBarStatusService.js';
 import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
 import { VOICE_AGENT_PROGRESS_SETTING } from '../../../common/voiceClient/voiceClientService.js';
@@ -470,19 +470,6 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				return widget.inputPart.switchModelByIdentifier(resolved.identifier, true, true)
 					? resolved
 					: { ok: false, reason: 'selection_failed', available_models: resolved.available_models };
-			}));
-			this._voiceBarDisposables.add(CommandsRegistry.registerCommand('_chat.voice.attachFiles', async (_accessor, resourceStrings: readonly string[]): Promise<IVoiceAttachmentResult> => {
-				const widget = this._getVoiceActionWidget();
-				if (!widget) {
-					return { ok: false, reason: 'no_input' };
-				}
-				try {
-					const resources = resourceStrings.map(resource => URI.parse(resource));
-					await Promise.all(resources.map(resource => widget.attachmentModel.addFile(resource)));
-					return { ok: true, attached: resources.map(resource => basename(resource)) };
-				} catch {
-					return { ok: false, reason: 'attachment_failed' };
-				}
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/voiceClient/voiceToolDispatchService.test.ts
@@ -18,9 +18,6 @@ import { ChatQuestionCarouselData } from '../../../common/model/chatProgressType
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { AskQuestionsToolId } from '../../../common/tools/builtinTools/askQuestionsTool.js';
 import { derivePendingId, IVoiceToolCall } from '../../../common/voiceClient/voiceClientService.js';
-import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
 
 suite('VoiceToolDispatchService - model selection', () => {
@@ -64,9 +61,6 @@ suite('VoiceToolDispatchService - session actions', () => {
 		readonly targetResource?: URI;
 		readonly agentSessionResources?: readonly URI[];
 		readonly chatModels?: readonly IChatModel[];
-		readonly activeEditorResource?: URI;
-		readonly workspaceFolders?: readonly URI[];
-		readonly existingResources?: ReadonlySet<string>;
 		readonly selectModelResult?: IVoiceModelSelectionResult;
 		readonly switchSucceeds?: boolean;
 	}
@@ -76,7 +70,6 @@ suite('VoiceToolDispatchService - session actions', () => {
 			switchedTo: [] as URI[],
 			targeted: [] as URI[],
 			selectedModels: [] as string[],
-			attachedResources: [] as Array<readonly URI[]>,
 		};
 		let currentResource = options.currentResource;
 		let targetResource = options.targetResource;
@@ -90,30 +83,10 @@ suite('VoiceToolDispatchService - session actions', () => {
 		const chatService = new class extends mock<IChatService>() {
 			override readonly chatModels = observableValue<readonly IChatModel[]>('chatModels', options.chatModels ?? []);
 		};
-		const editorService = new class extends mock<IEditorService>() {
-			override get activeEditor(): IEditorService['activeEditor'] {
-				return options.activeEditorResource ? { resource: options.activeEditorResource } as IEditorService['activeEditor'] : undefined;
-			}
-		};
-		const workspaceContextService = new class extends mock<IWorkspaceContextService>() {
-			override getWorkspace(): ReturnType<IWorkspaceContextService['getWorkspace']> {
-				return {
-					folders: (options.workspaceFolders ?? []).map((uri, index) => ({ uri, index, name: `folder-${index}` })),
-				} as ReturnType<IWorkspaceContextService['getWorkspace']>;
-			}
-		};
-		const fileService = new class extends mock<IFileService>() {
-			override async exists(resource: URI): Promise<boolean> {
-				return options.existingResources?.has(resource.toString()) ?? false;
-			}
-		};
 		const service = new VoiceToolDispatchService(
 			agentSessionsService,
 			chatService,
 			new class extends mock<ILanguageModelToolsService>() { },
-			editorService,
-			workspaceContextService,
-			fileService,
 		);
 		service.setDelegate(new class extends mock<IVoiceToolDispatchDelegate>() {
 			override async getCurrentSessionResource(): Promise<URI | undefined> { return currentResource; }
@@ -136,10 +109,6 @@ suite('VoiceToolDispatchService - session actions', () => {
 					ok: true,
 					selected_model: { identifier: requestedModel, name: requestedModel, vendor: 'test' },
 				};
-			}
-			override async attachFiles(resources: readonly URI[]) {
-				calls.attachedResources.push(resources);
-				return { ok: true, attached: resources.map(resource => resource.toString()) };
 			}
 		}());
 		return { service, calls };
@@ -213,69 +182,6 @@ suite('VoiceToolDispatchService - session actions', () => {
 		assert.deepStrictEqual(unavailable.calls.targeted, []);
 	});
 
-	test('attaches the active editor when no file argument is supplied', async () => {
-		const currentResource = URI.parse('vscode-chat://test/current');
-		const activeEditorResource = URI.file('/workspace/active.ts');
-		const { service, calls } = createActionHarness({ currentResource, activeEditorResource });
-
-		const result = await dispatch(service, 'attach_file');
-
-		assert.deepStrictEqual(result, { ok: true, attached: [activeEditorResource.toString()] });
-		assert.strictEqual(calls.attachedResources[0]?.[0]?.toString(), activeEditorResource.toString());
-	});
-
-	test('reports no file when an argument and active editor are both absent', async () => {
-		const currentResource = URI.parse('vscode-chat://test/current');
-		const { service, calls } = createActionHarness({ currentResource });
-
-		const result = await dispatch(service, 'attach_file');
-
-		assert.deepStrictEqual(result, { ok: false, reason: 'no_file' });
-		assert.deepStrictEqual(calls.attachedResources, []);
-	});
-
-	test('reports a workspace-relative attachment that does not exist', async () => {
-		const currentResource = URI.parse('vscode-chat://test/current');
-		const { service } = createActionHarness({ currentResource, workspaceFolders: [URI.file('/workspace')] });
-
-		const result = await dispatch(service, 'attach_file', { path: 'src/missing.ts' });
-
-		assert.deepStrictEqual(result, { ok: false, reason: 'file_not_found', candidates: ['src/missing.ts'] });
-	});
-
-	test('reports all matching workspace roots for an ambiguous attachment', async () => {
-		const currentResource = URI.parse('vscode-chat://test/current');
-		const workspaceFolders = [URI.file('/workspace/one'), URI.file('/workspace/two')];
-		const matches = workspaceFolders.map(folder => URI.joinPath(folder, 'src/shared.ts'));
-		const { service } = createActionHarness({
-			currentResource,
-			workspaceFolders,
-			existingResources: new Set(matches.map(resource => resource.toString())),
-		});
-
-		const result = await dispatch(service, 'attach_file', { path: 'src/shared.ts' });
-
-		assert.deepStrictEqual(result, {
-			ok: false,
-			reason: 'ambiguous_file',
-			candidates: matches.map(resource => resource.toString()),
-		});
-	});
-
-	test('treats an absolute Windows path as a file instead of a URI scheme', async () => {
-		const currentResource = URI.parse('vscode-chat://test/current');
-		const file = URI.file('C:/repo/file.ts');
-		const { service, calls } = createActionHarness({
-			currentResource,
-			existingResources: new Set([file.toString()]),
-		});
-
-		const result = await dispatch(service, 'attach_file', { path: 'C:\\repo\\file.ts' });
-
-		assert.strictEqual(result.ok, true);
-		assert.strictEqual(calls.attachedResources[0]?.[0]?.toString(), file.toString());
-	});
-
 	test('includes an active regular chat before its first request', async () => {
 		const resource = URI.parse('vscode-chat://test/empty-active');
 		const model = {
@@ -330,9 +236,6 @@ suite('VoiceToolDispatchService - respondToSession', () => {
 			agentSessionsService,
 			chatService,
 			new class extends mock<ILanguageModelToolsService>() { },
-			new class extends mock<IEditorService>() { },
-			new class extends mock<IWorkspaceContextService>() { },
-			new class extends mock<IFileService>() { },
 		);
 	}
 


### PR DESCRIPTION
We don't plan to support this

## Summary

- remove the frontend \`attach_file\` and \`attach_files\` Voice Mode actions
- remove file resolution and chat/Agents attachment command bridges
- retain attachment metadata in voice session context for session awareness

