### PR TITLE
chat: let extensions scope input notifications to session types

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatInputNotification.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatInputNotification.ts
@@ -27,6 +27,7 @@ export class MainThreadChatInputNotification extends Disposable implements MainT
 			actions: notification.actions.map<IChatInputNotificationCommandAction>(action => ({ ...action, kind: ChatInputNotificationActionKind.Command })),
 			dismissible: notification.dismissible,
 			autoDismissOnMessage: notification.autoDismissOnMessage,
+			sessionTypes: notification.sessionTypes,
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3858,6 +3858,7 @@ export type ChatInputNotificationDto = {
 	actions: ChatInputNotificationActionDto[];
 	dismissible: boolean;
 	autoDismissOnMessage: boolean;
+	sessionTypes: readonly string[] | undefined;
 };
 
 export interface MainThreadChatInputNotificationShape {

--- a/src/vs/workbench/api/common/extHostChatInputNotification.ts
+++ b/src/vs/workbench/api/common/extHostChatInputNotification.ts
@@ -33,6 +33,7 @@ export class ExtHostChatInputNotification {
 			actions: [],
 			dismissible: true,
 			autoDismissOnMessage: false,
+			sessionTypes: undefined,
 		};
 
 		let disposed = false;
@@ -97,6 +98,14 @@ export class ExtHostChatInputNotification {
 			},
 			set autoDismissOnMessage(value: boolean) {
 				state.autoDismissOnMessage = value;
+				syncState();
+			},
+
+			get sessionTypes(): readonly string[] | undefined {
+				return state.sessionTypes;
+			},
+			set sessionTypes(value: readonly string[] | undefined) {
+				state.sessionTypes = value;
 				syncState();
 			},
 

--- a/src/vs/workbench/api/test/browser/mainThreadChatInputNotification.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatInputNotification.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type * as vscode from 'vscode';
+import { mock } from '../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ChatInputNotificationActionKind, ChatInputNotificationSeverity, IChatInputNotification, IChatInputNotificationService } from '../../../contrib/chat/browser/widget/input/chatInputNotificationService.js';
+import { nullExtensionDescription } from '../../../services/extensions/common/extensions.js';
+import { MainThreadChatInputNotification } from '../../browser/mainThreadChatInputNotification.js';
+import { ExtHostChatInputNotification } from '../../common/extHostChatInputNotification.js';
+import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
+
+suite('MainThreadChatInputNotification', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Wires the extension-facing notification to the real main-thread customer,
+	 * so a test drives the whole ext host -> DTO -> main thread -> service path
+	 * rather than either half in isolation.
+	 */
+	function createBridge(): { notification: vscode.ChatInputNotification; pushed: IChatInputNotification[] } {
+		const pushed: IChatInputNotification[] = [];
+		const notificationService = new class extends mock<IChatInputNotificationService>() {
+			override setNotification(notification: IChatInputNotification): void {
+				pushed.push(notification);
+			}
+			override deleteNotification(): void { }
+		};
+		const mainThread = store.add(new MainThreadChatInputNotification(SingleProxyRPCProtocol(null), notificationService));
+		const extHost = new ExtHostChatInputNotification(SingleProxyRPCProtocol(mainThread));
+		return { notification: extHost.createInputNotification(nullExtensionDescription, 'byokUtilityModelHint'), pushed };
+	}
+
+	test('carries session types across the bridge, defaulting to none', () => {
+		const { notification, pushed } = createBridge();
+
+		notification.message = 'Set BYOK utility models';
+		notification.show();
+		notification.sessionTypes = ['local', 'agent-host-copilotcli'];
+		notification.sessionTypes = undefined;
+
+		assert.deepStrictEqual(pushed.map(entry => entry.sessionTypes), [
+			undefined,
+			['local', 'agent-host-copilotcli'],
+			undefined,
+		]);
+	});
+
+	test('maps the notification onto the internal shape', () => {
+		const { notification, pushed } = createBridge();
+
+		notification.message = 'Set BYOK utility models';
+		notification.description = 'Pick the models used for background work.';
+		notification.actions = [{ label: 'Configure', commandId: 'workbench.action.openSettings', commandArgs: ['chat.byokUtilityModelDefault'] }];
+		notification.sessionTypes = ['local'];
+		notification.show();
+
+		assert.deepStrictEqual(pushed.at(-1), {
+			id: 'nullextensiondescription.byokUtilityModelHint',
+			severity: ChatInputNotificationSeverity.Info,
+			message: 'Set BYOK utility models',
+			description: 'Pick the models used for background work.',
+			actions: [{ kind: ChatInputNotificationActionKind.Command, label: 'Configure', commandId: 'workbench.action.openSettings', commandArgs: ['chat.byokUtilityModelDefault'] }],
+			dismissible: true,
+			autoDismissOnMessage: false,
+			sessionTypes: ['local'],
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
@@ -519,6 +519,32 @@ suite('ChatInputNotificationWidget', () => {
 		assert.strictEqual(widget.domNode.querySelector('.chat-input-notification')?.textContent, 'Agent Host promo');
 	});
 
+	test('matches a notification scoped to both Copilot model targets', () => {
+		const currentSessionType = observableValue<string | undefined>('currentSessionType', SessionType.AgentHostCopilot);
+		const { notificationService, widget } = createWidget({
+			delegate: { modelTargetChatSessionType: currentSessionType },
+		});
+
+		showNotification(notificationService, {
+			id: 'copilot-model-setup',
+			message: 'Choose how you want to use Copilot.',
+			actions: [],
+			sessionTypes: [SessionType.AgentHostCopilot, SessionType.CopilotCLI],
+		});
+		const text = () => widget.domNode.querySelector('.chat-input-notification')?.textContent;
+		const agentHostText = text();
+		currentSessionType.set(SessionType.CopilotCLI, undefined);
+		const copilotCliText = text();
+
+		assert.deepStrictEqual({
+			agentHostText,
+			copilotCliText,
+		}, {
+			agentHostText: 'Choose how you want to use Copilot.',
+			copilotCliText: 'Choose how you want to use Copilot.',
+		});
+	});
+
 	test('announces only the notification rendered in the current session', () => {
 		const currentSessionType = observableValue<string | undefined>('currentSessionType', localChatSessionType);
 		const notificationService = createRecordingNotificationService();

--- a/src/vscode-dts/vscode.proposed.chatInputNotification.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatInputNotification.d.ts
@@ -91,6 +91,12 @@ declare module 'vscode' {
 		autoDismissOnMessage: boolean;
 
 		/**
+		 * Optional chat session types in which this notification is shown.
+		 * When omitted, the notification is shown for every chat session type.
+		 */
+		sessionTypes: readonly string[] | undefined;
+
+		/**
 		 * Shows the notification in the chat input area.
 		 */
 		show(): void;


### PR DESCRIPTION
The chat input notification widget already filters notifications by `sessionTypes` (`chatInputNotificationService.ts` matches on it), but the field was only reachable from the internal service. Extensions had no way to say which sessions their notification is about, so every extension notification renders in every session type.

This surfaces `sessionTypes` on the proposed `ChatInputNotification` API and plumbs it through the ext host → main thread bridge.

- `vscode.proposed.chatInputNotification.d.ts` — new optional `sessionTypes: readonly string[] | undefined`
- `extHostChatInputNotification.ts` — getter/setter that re-syncs state, defaulting to `undefined`
- `extHost.protocol.ts` / `mainThreadChatInputNotification.ts` — carry it across

No behavior change on its own: `undefined` is the default and means "show everywhere", which is what happens today.

Split out of the signed-out Copilot BYOK sessions work (`vritant24/no-auth-agents-window`), where the Copilot extension needs to pin the BYOK utility-model hint to `local` sessions. First consumer stacks on this branch.

### Validation
- `npm run typecheck-client`
- `ChatInputNotificationWidget` suite (17 passing), including a new case covering a notification scoped to two Copilot model targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)