### PR TITLE
copilot: scope the BYOK utility model hint to local sessions

### DIFF
--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
@@ -13,7 +13,9 @@ const NOTIFICATION_ID = 'copilot.byokUtilityModelHint';
 const UTILITY_MODEL_SETTING = 'chat.utilityModel';
 const UTILITY_SMALL_MODEL_SETTING = 'chat.utilitySmallModel';
 const BYOK_UTILITY_MODEL_DEFAULT_SETTING = 'chat.byokUtilityModelDefault';
+const ALLOW_SIGNED_OUT_WHEN_USABLE_SETTING = 'chat.agentHost.allowSignedOutWhenUsable';
 const MAIN_AGENT_BYOK_UTILITY_MODEL_DEFAULT = 'mainAgent';
+const LOCAL_CHAT_SESSION_TYPE = 'local';
 
 /**
  * Shows a chat input notification in air-gapped BYOK scenarios (no GitHub
@@ -48,6 +50,7 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 				e.affectsConfiguration(UTILITY_MODEL_SETTING)
 				|| e.affectsConfiguration(UTILITY_SMALL_MODEL_SETTING)
 				|| e.affectsConfiguration(BYOK_UTILITY_MODEL_DEFAULT_SETTING)
+				|| e.affectsConfiguration(ALLOW_SIGNED_OUT_WHEN_USABLE_SETTING)
 			) {
 				this._update();
 			}
@@ -97,6 +100,9 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 		notification.severity = vscode.ChatInputNotificationSeverity.Info;
 		notification.dismissible = true;
 		notification.autoDismissOnMessage = false;
+		notification.sessionTypes = this._configService.getNonExtensionConfig<boolean>(ALLOW_SIGNED_OUT_WHEN_USABLE_SETTING)
+			? [LOCAL_CHAT_SESSION_TYPE]
+			: undefined;
 
 		if (utilityUnset && utilitySmallUnset) {
 			notification.message = vscode.l10n.t('Set BYOK utility models');

--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
@@ -18,6 +18,7 @@ const mockNotification = {
 	message: '',
 	description: '',
 	actions: [] as { label: string; commandId: string; commandArgs?: unknown[] }[],
+	sessionTypes: undefined as readonly string[] | undefined,
 	show: vi.fn(),
 	hide: vi.fn(),
 	dispose: vi.fn(),
@@ -99,6 +100,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		mockNotification.message = '';
 		mockNotification.description = '';
 		mockNotification.actions = [];
+		mockNotification.sessionTypes = undefined;
 		mockWorkspace.isAgentSessionsWorkspace = false;
 		selectChatModelsMock.mockResolvedValue([{ vendor: 'ollama', id: 'llama3' }]);
 	});
@@ -110,7 +112,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 
 	test('shows notification when signed out + BYOK + both utility settings unset', async () => {
 		const { authService } = createAuthService({ anyGitHubSession: undefined });
-		const { configService } = createConfigService();
+		const { configService } = createConfigService({ 'chat.agentHost.allowSignedOutWhenUsable': true });
 		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
 
 		await flushAsync();
@@ -120,6 +122,18 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.actions).toHaveLength(1);
 		expect(mockNotification.actions[0].commandId).toBe('workbench.action.openSettings');
 		expect(mockNotification.actions[0].commandArgs).toEqual(['chat.byokUtilityModelDefault']);
+		expect(mockNotification.sessionTypes).toEqual(['local']);
+	});
+
+	test('keeps the notification global when signed-out operation is disabled', async () => {
+		const { authService } = createAuthService({ anyGitHubSession: undefined });
+		const { configService } = createConfigService();
+		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
+
+		await flushAsync();
+
+		expect(mockNotification.show).toHaveBeenCalled();
+		expect(mockNotification.sessionTypes).toBeUndefined();
 	});
 
 	test('does not show notification in the Agents window', async () => {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #330002 (base is `vritant24/chat-input-notification-session-types`). Review only the second commit; retarget to `main` once #330002 merges.

The "Set BYOK utility models" hint is about the local chat session's utility models, but it renders in every session type because it had no way to scope itself.

With `chat.agentHost.allowSignedOutWhenUsable` on, the Agents window shows harness sessions where this hint is noise — and where a harness-specific notification is the right guidance instead. This pins it to the `local` session type using the `sessionTypes` field added in #330002.

With the setting off, `sessionTypes` stays `undefined` and the hint remains global, so nothing changes today.

### Validation
- `vitest --run --pool=forks byokUtilityModel` — 12 passing, including a new case asserting the hint stays global when the setting is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)