### PR TITLE
Style overrides: Add border styling for inactive tabs in modern UI

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -76,6 +76,16 @@
 	pointer-events: none;
 }
 
+.modern-ui-tabs.monaco-workbench .part.editor .tabs-container > .tab:not(.active):not(.selected):not(.last-in-row):not(:hover) + .tab:not(.active):not(.selected):not(:hover) > .tab-fill::before {
+	content: '';
+	position: absolute;
+	top: var(--vscode-spacing-size40);
+	bottom: var(--vscode-spacing-size40);
+	left: calc(-1 * var(--vscode-spacing-size20));
+	width: var(--vscode-strokeThickness);
+	background-color: var(--vscode-tab-border);
+}
+
 .modern-ui-tabs .part.editor .tabs-container > .tab > .tab-label {
 	position: relative;
 	z-index: 1;


### PR DESCRIPTION
Introduce border styling for inactive tabs in the modern UI to enhance visual distinction. This change improves the overall user experience by clearly differentiating between active and inactive tabs. Testing can be done by observing the appearance of inactive tabs in the editor.

