### PR TITLE
Gate the Agents window sign-in requirement behind the signed-out opt-in

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -276,7 +276,7 @@
 				"--disable-features=CalculateNativeWinOcclusion",
 				"--disable-extension=vscode.vscode-api-tests"
 			],
-			"userDataDir": "${userHome}/.vscode-oss-dev",
+			"userDataDir": "${userHome}/.vscode-oss-dev-5",
 			"webRoot": "${workspaceFolder}",
 			"cascadeTerminateToConfigurations": [
 				"Attach to Extension Host"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -276,7 +276,7 @@
 				"--disable-features=CalculateNativeWinOcclusion",
 				"--disable-extension=vscode.vscode-api-tests"
 			],
-			"userDataDir": "${userHome}/.vscode-oss-dev-5",
+			"userDataDir": "${userHome}/.vscode-oss-dev",
 			"webRoot": "${workspaceFolder}",
 			"cascadeTerminateToConfigurations": [
 				"Attach to Extension Host"

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -86,9 +86,10 @@ export const AgentHostCodexMultiRootEnabledSettingId = 'chat.agentHost.codexAgen
 
 /**
  * Experimentation setting id gating the conditional agent-window auth feature.
- * When `true`, a session type that is usable without GitHub (e.g. Claude in
- * native mode with an existing local setup) lets the agent window open for a
- * signed-out user instead of forcing GitHub sign-in.
+ * When `true`, the agent window opens for a signed-out user instead of forcing
+ * GitHub sign-in; each session type then gates on its own GitHub requirement, so
+ * a type usable without GitHub (e.g. Claude in native mode with an existing local
+ * setup) works signed out while types that need GitHub prompt for it on demand.
  *
  * This is the **workbench** VS Code setting id. The workbench registers the
  * configuration schema and forwards the value into the agent-host root config

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -65,13 +65,12 @@ export interface IAccountTitleBarStateContext {
 		readonly completions?: IQuotaSnapshot;
 	};
 	/**
-	 * Whether at least one registered session type is usable without GitHub
-	 * right now (the conditional-auth opt-in is on and a usable type exists).
+	 * Whether the conditional-auth opt-in permits signed-out operation.
 	 * When true, a signed-out account shows a calm opt-in sign-in instead of the
 	 * alarming "Agents Signed Out". Defaults to `false`, so the opt-in being off
 	 * keeps today's behavior.
 	 */
-	readonly usableWithoutGitHub: boolean;
+	readonly allowSignedOutWhenUsable: boolean;
 }
 
 export interface IAccountTitleBarState {
@@ -113,7 +112,7 @@ export function getAccountTitleBarState(context: IAccountTitleBarStateContext): 
 		};
 	}
 
-	const copilotState = getCopilotPresentation(context.entitlement, context.sentiment, context.quotas, context.usableWithoutGitHub);
+	const copilotState = getCopilotPresentation(context.entitlement, context.sentiment, context.quotas, context.allowSignedOutWhenUsable);
 	if (copilotState) {
 		return copilotState;
 	}
@@ -144,16 +143,15 @@ function getCopilotPresentation(
 	entitlement: ChatEntitlement,
 	sentiment: IChatSentiment,
 	quotas: { readonly chat?: IQuotaSnapshot; readonly completions?: IQuotaSnapshot },
-	usableWithoutGitHub: boolean
+	allowSignedOutWhenUsable: boolean
 ): IAccountTitleBarState | undefined {
 	if (sentiment.hidden) {
 		return undefined;
 	}
 
 	if (entitlement === ChatEntitlement.Unknown) {
-		if (usableWithoutGitHub) {
-			// A session type is usable without GitHub, so signing in is optional:
-			// present a calm opt-in affordance rather than alarming the user.
+		if (allowSignedOutWhenUsable) {
+			// Signing in is optional, so present a calm affordance.
 			return {
 				source: 'copilot',
 				kind: 'default',

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -151,9 +151,7 @@ function getCopilotPresentation(
 
 	if (entitlement === ChatEntitlement.Unknown) {
 		if (allowSignedOutWhenUsable) {
-			// The user can work while signed out, so this is an invitation, not a
-			// problem to fix: stay at the `default` tier rather than escalating to
-			// the `prominent` "Agents Signed Out" below.
+			// Signing in is optional, so present a calm affordance.
 			return {
 				source: 'copilot',
 				kind: 'default',

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -151,7 +151,9 @@ function getCopilotPresentation(
 
 	if (entitlement === ChatEntitlement.Unknown) {
 		if (allowSignedOutWhenUsable) {
-			// Signing in is optional, so present a calm affordance.
+			// The user can work while signed out, so this is an invitation, not a
+			// problem to fix: stay at the `default` tier rather than escalating to
+			// the `prominent` "Agents Signed Out" below.
 			return {
 				source: 'copilot',
 				kind: 'default',

--- a/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
@@ -343,9 +343,9 @@ export class MobileTitlebarPart extends Disposable {
 			entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
-			// The conditional-auth opt-in is desktop-only (the native agent host
-			// that makes a type usable without GitHub does not run on mobile/web).
-			usableWithoutGitHub: false,
+			// The conditional-auth opt-in is desktop-only (the native agent host it
+			// lets in does not run on mobile/web).
+			allowSignedOutWhenUsable: false,
 		});
 
 		// Avatar
@@ -432,7 +432,7 @@ export class MobileTitlebarPart extends Disposable {
 			entitlement: this.chatEntitlementService.entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
-			usableWithoutGitHub: false,
+			allowSignedOutWhenUsable: false,
 		}));
 		if (badgeKey) {
 			this.dismissedBadgeKey = badgeKey;

--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -7,8 +7,6 @@ import { Event } from '../../base/common/event.js';
 import { IObservable, observableFromEvent } from '../../base/common/observable.js';
 import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../platform/agentHost/common/agentService.js';
 import type { IConfigurationService } from '../../platform/configuration/common/configuration.js';
-import { SessionTypeAuthRequirement } from '../services/sessions/common/session.js';
-import type { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
 
 /**
  * Predicates behind the Agents window's conditional authentication — when the
@@ -18,20 +16,22 @@ import type { ISessionsManagementService } from '../services/sessions/common/ses
  *
  * - The **window gate** is the last-resort, window-level block that forces
  *   sign-in before *any* of the sessions UI is shown (backed by
- *   `SessionsWelcomeVisibleContext`). Historically unconditional; it now lifts as
- *   soon as some session type can work without GitHub. Note the *editor* window
- *   is untouched by all of this — its chat-setup modal already offers a "Don't
- *   sign in" escape hatch, and it is that missing escape hatch in the Agents
- *   window (a non-dismissible modal) that this machinery restores conditionally.
+ *   `SessionsWelcomeVisibleContext`). Historically unconditional; it now lifts on
+ *   the opt-in alone. Note the *editor* window is untouched by all of this — its
+ *   chat-setup modal already offers a "Don't sign in" escape hatch, and it is
+ *   that missing escape hatch in the Agents window (a non-dismissible modal) that
+ *   this machinery restores conditionally.
  * - The **per-type gate** is the on-demand sign-in surfaced when the user selects
  *   a specific session type that needs GitHub. It already existed
- *   (`getSessionTypeAvailability()` → `SignInRequired`) and still carries most of
- *   the work: once the window is open, each type answers for itself.
+ *   (`getSessionTypeAvailability()` → `SignInRequired`) and carries the actual
+ *   work: once the window is open, each type answers for itself.
  *
- * "Requires GitHub auth" is a property of a session type *at a moment in time*,
- * not a fixed trait — Claude and Codex both move as their own credentials come
- * and go. It is resolved by each provider into
- * {@link SessionTypeAuthRequirement} and read here provider-agnostically.
+ * The window gate deliberately does *not* consult per-type readiness. "Requires
+ * GitHub auth" is a property of a session type *at a moment in time* — Claude and
+ * Codex both move as their own credentials come and go, and providers resolve it
+ * asynchronously — so a gate that waited on it would race the modal it is meant
+ * to suppress. The per-type gate observes those changes and is the right altitude
+ * for them.
  */
 
 /**
@@ -41,6 +41,15 @@ import type { ISessionsManagementService } from '../services/sessions/common/ses
  */
 export function isAllowSignedOutWhenUsableEnabled(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true;
+}
+
+/**
+ * The **window gate**: whether the Agents window must force GitHub sign-in before
+ * showing any of the sessions UI. Callers are always on a signed-out path, so this
+ * is simply the inverse of the opt-in.
+ */
+export function shouldForceGitHubSignIn(allowSignedOutWhenUsable: boolean): boolean {
+	return !allowSignedOutWhenUsable;
 }
 
 /**
@@ -76,41 +85,13 @@ export function conditionalAuthState(accountResolved: boolean, signedIn: boolean
 }
 
 /**
- * Whether a signed-out user can work without GitHub right now: the opt-in is on
- * and some registered session type reports that it runs without a GitHub
- * account (e.g. an agent-host agent that discovered an existing native
- * configuration).
- *
- * The per-type fact is resolved by each provider into
- * {@link ISessionType.authRequirement}, so this stays provider-agnostic. A type
- * that cannot run at all ({@link SessionTypeAuthRequirement.Unusable}) does not
- * count, so a broken agent never holds the window open.
- * The opt-in is re-checked here as well as on the agent host so the setting
- * remains an authoritative kill switch even if a host is still running in a
- * mode it resolved before the setting changed.
- *
- * TODO: this deliberately does NOT reuse `getSessionTypeAvailability`, which the
- * per-type pickers use to answer a related question. Two reasons: that helper
- * lives in `vs/workbench/contrib` and is unreachable from this layer, and its
- * model check cannot detect a credential-less native agent (the Claude SDK's
- * `supportedModels()` is a static catalog). The cost is two predicates that can
- * drift — they already differ over `chatEntitlementService.anonymous`, which the
- * pickers honour and this gate ignores. That divergence is pre-existing (with
- * the opt-in off this collapses to today's always-force-sign-in) but should be
- * converged: have providers resolve availability the same way the pickers do, so
- * both read one derivation.
+ * Observe the setting that permits the Agents window to proceed without forcing
+ * GitHub sign-in. Provider readiness is deliberately not part of this gate.
  */
-export function observeUsableWithoutGitHub(
-	sessionsManagementService: ISessionsManagementService,
-	configurationService: IConfigurationService,
-): IObservable<boolean> {
+export function observeAllowSignedOutWhenUsable(configurationService: IConfigurationService): IObservable<boolean> {
 	return observableFromEvent(
-		Event.any(
-			Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(AgentHostAllowSignedOutWhenUsableSettingId)),
-			sessionsManagementService.onDidChangeSessionTypes,
-		),
-		() => isAllowSignedOutWhenUsableEnabled(configurationService)
-			&& sessionsManagementService.getAllProviderSessionTypes().some(type => type.sessionType.authRequirement === SessionTypeAuthRequirement.None));
+		Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(AgentHostAllowSignedOutWhenUsableSettingId)),
+		() => isAllowSignedOutWhenUsableEnabled(configurationService));
 }
 
 /**

--- a/src/vs/sessions/browser/sessionsSetUpService.ts
+++ b/src/vs/sessions/browser/sessionsSetUpService.ts
@@ -26,8 +26,7 @@ import { IHostService } from '../../workbench/services/host/browser/host.js';
 import { IMarkdownRendererService } from '../../platform/markdown/browser/markdownRenderer.js';
 import { WELCOME_COMPLETE_KEY } from '../common/welcome.js';
 import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
-import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
-import { ConditionalAuthState, conditionalAuthState, observeUsableWithoutGitHub } from './sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, observeAllowSignedOutWhenUsable, shouldForceGitHubSignIn } from './sessionsAuthGate.js';
 
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { Codicon } from '../../base/common/codicons.js';
@@ -86,8 +85,8 @@ class SessionsSetUpWidget extends Disposable {
 	 * startup gap — one nothing can retire, since the account resolves silently.
 	 */
 	private _accountResolved = false;
-	/** Whether a signed-out user can work without GitHub right now. */
-	private readonly _usableWithoutGitHub: IObservable<boolean>;
+	/** Whether the window may proceed without GitHub sign-in. */
+	private readonly _allowSignedOutWhenUsable: IObservable<boolean>;
 
 	// Non-service params must come before @-decorated service params
 	constructor(
@@ -108,35 +107,29 @@ class SessionsSetUpWidget extends Disposable {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHostService private readonly hostService: IHostService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
-		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
-		this._usableWithoutGitHub = observeUsableWithoutGitHub(this.sessionsManagementService, this.configurationService);
-		// The gate's inputs resolve asynchronously: the local agent host advertises
-		// Claude at `AfterRestored`, i.e. after this widget has already decided. So
-		// this subscription is lifetime-scoped rather than installed once setup
-		// completes — otherwise a signed-out startup shows the non-dismissible
-		// modal before Claude resolves and never reconsiders.
-		this._register(runOnChange(this._usableWithoutGitHub, usable => this._onUsableWithoutGitHubChanged(usable)));
+		this._allowSignedOutWhenUsable = observeAllowSignedOutWhenUsable(this.configurationService);
+		this._register(runOnChange(this._allowSignedOutWhenUsable, allow => this._onAllowSignedOutWhenUsableChanged(allow)));
 		this._start();
 	}
 
 	/**
-	 * The last-resort gate's answer changed while the window is open. Ignored
-	 * until the account has resolved (see {@link _accountResolved}) and for
-	 * signed-in users. For a signed-out user, becoming usable retires an
-	 * already-open sign-in modal (it was raised before the answer resolved);
-	 * becoming unusable falls back to demanding sign-in.
+	 * The opt-in was toggled while the window is open. Ignored until the account
+	 * has resolved (see {@link _accountResolved}) and for signed-in users. For a
+	 * signed-out user, turning it on retires an already-open sign-in modal (it was
+	 * raised before the account resolved); turning it off falls back to demanding
+	 * sign-in.
 	 */
-	private _onUsableWithoutGitHubChanged(usable: boolean): void {
+	private _onAllowSignedOutWhenUsableChanged(allow: boolean): void {
 		// Only act once the account has resolved AND the user is signed out; while
 		// unresolved or signed in, the sign-in watch owns the decision.
 		const signedIn = this.defaultAccountService.currentDefaultAccount !== null;
 		if (conditionalAuthState(this._accountResolved, signedIn) !== ConditionalAuthState.SignedOut) {
 			return;
 		}
-		if (!usable) {
+		if (!allow) {
 			this._proceedingSignedOut = false;
 			void this._showWelcome(false);
 			return;
@@ -165,15 +158,14 @@ class SessionsSetUpWidget extends Disposable {
 				return;
 			}
 			this._accountResolved = true;
-			// A `_usableWithoutGitHub` change during the unresolved window was
-			// ignored above. If the agent ended up usable, replay it now so a
-			// signed-out user is let in rather than stranded on a sign-in dialog
-			// nothing else retires — the web path has no post-resolution re-check
-			// of its own (the native paths re-read usability after they await the
-			// account). While not usable, the initial setup flow still owns the
-			// dialog, so there is nothing to replay.
-			if (this._usableWithoutGitHub.get()) {
-				this._onUsableWithoutGitHubChanged(true);
+			// A setting change during the unresolved window was ignored above. If
+			// the opt-in is on, replay it now so a signed-out user is let in rather
+			// than stranded on a sign-in dialog nothing else retires — the web path
+			// has no post-resolution re-check of its own (the native paths re-read
+			// the opt-in after they await the account). With the opt-in off, the
+			// initial setup flow still owns the dialog, so there is nothing to replay.
+			if (this._allowSignedOutWhenUsable.get()) {
+				this._onAllowSignedOutWhenUsableChanged(true);
 			}
 		});
 
@@ -273,18 +265,16 @@ class SessionsSetUpWidget extends Disposable {
 	/**
 	 * The **window gate**: whether the Agents window must fall back to forcing
 	 * GitHub sign-in before showing any of the sessions UI. Every caller is on a
-	 * signed-out path, so this is simply the inverse of "can work without GitHub"
-	 * — always true while the opt-in is off, which is today's mandatory-sign-in
-	 * behavior.
+	 * signed-out path, so this is simply the inverse of the opt-in — always true
+	 * while the opt-in is off, which is today's mandatory-sign-in behavior.
 	 *
-	 * Deliberately a *last resort*, not the primary gate. The moment any session
-	 * type is usable without GitHub the window opens, and per-type on-demand
-	 * sign-in carries the rest — so this never blocks a user who has their own
-	 * credentials. See `sessionsAuthGate.ts` for the window-gate vs per-type-gate
-	 * distinction.
+	 * Deliberately a *last resort*, not the primary gate. With the opt-in on the
+	 * window opens immediately and per-type on-demand sign-in carries the rest —
+	 * so this never blocks a user who has their own credentials. See
+	 * `sessionsAuthGate.ts` for the window-gate vs per-type-gate distinction.
 	 */
 	private _mustForceGitHubSignIn(): boolean {
-		return !this._usableWithoutGitHub.get();
+		return shouldForceGitHubSignIn(this._allowSignedOutWhenUsable.get());
 	}
 
 	/**
@@ -305,17 +295,17 @@ class SessionsSetUpWidget extends Disposable {
 	}
 
 	/**
-	 * Open the Agents window for a signed-out user because at least one session
-	 * type is usable without GitHub. Mirrors the signed-in completion path, but
-	 * keeps watching so a later change (a usable type disappears, or the user
-	 * signs in) re-drives the decision. Idempotent while already proceeding.
+	 * Open the Agents window for a signed-out user because the opt-in permits it.
+	 * Mirrors the signed-in completion path, but keeps watching so a later change
+	 * (the opt-in is turned off, or the user signs in) re-drives the decision.
+	 * Idempotent while already proceeding.
 	 */
 	private async _proceedWithoutGitHub(): Promise<void> {
 		if (this._proceedingSignedOut) {
 			return;
 		}
 		this._proceedingSignedOut = true;
-		this.logService.info('[sessions welcome] Proceeding without GitHub sign-in; a session type is usable while signed out');
+		this.logService.info('[sessions welcome] Proceeding without GitHub sign-in; signed-out operation is enabled');
 		await this._ensureAIFeaturesEnabled();
 		if (this._store.isDisposed) {
 			return;
@@ -377,8 +367,8 @@ class SessionsSetUpWidget extends Disposable {
 		}
 
 		// A non-first-launch _showWelcome means the user is signed out. Consult the
-		// last-resort GitHub gate before forcing sign-in: when a session type is
-		// usable without GitHub (and the opt-in is on), open the window instead.
+		// last-resort GitHub gate before forcing sign-in: with the opt-in on, open
+		// the window instead.
 		if (!isFirstLaunch && !this._mustForceGitHubSignIn()) {
 			await this._proceedWithoutGitHub();
 			return;
@@ -420,7 +410,7 @@ class SessionsSetUpWidget extends Disposable {
 			} else if (this._mustForceGitHubSignIn()) {
 				await this._showSignInDialog();
 			} else {
-				// Signed-out first launch, but a session type is usable without GitHub.
+				// Signed-out first launch, but the opt-in permits proceeding.
 				this.dialogRef.clear();
 				await this._proceedWithoutGitHub();
 				return;

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -35,8 +35,7 @@ import { ChatStatusDashboard, IChatStatusDashboardOptions } from '../../../../wo
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, IAccountTitleBarState, resolveAccountInfo } from '../../../browser/accountTitleBarState.js';
-import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { observeUsableWithoutGitHub } from '../../../browser/sessionsAuthGate.js';
+import { observeAllowSignedOutWhenUsable } from '../../../browser/sessionsAuthGate.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IAuthenticationAccessService } from '../../../../workbench/services/authentication/browser/authenticationAccessService.js';
@@ -183,8 +182,8 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 	private readonly copilotDashboardStore = this._register(new MutableDisposable<DisposableStore>());
 	private readonly clickPanelDisposable = this._register(new MutableDisposable<DisposableStore>());
 	private readonly avatarLoadDisposable = this._register(new MutableDisposable());
-	/** Whether a signed-out user can work without GitHub right now. */
-	private readonly usableWithoutGitHub: IObservable<boolean>;
+	/** Whether the conditional-auth opt-in permits signed-out operation. */
+	private readonly allowSignedOutWhenUsable: IObservable<boolean>;
 
 	constructor(
 		action: IAction,
@@ -197,18 +196,17 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
 		@ICodexAccountService private readonly codexAccountService: ICodexAccountService,
-		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super(undefined, action, options);
-		this.usableWithoutGitHub = observeUsableWithoutGitHub(sessionsManagementService, configurationService);
+		this.allowSignedOutWhenUsable = observeAllowSignedOutWhenUsable(configurationService);
 		this.lastState = getAccountTitleBarState({
 			isAccountLoading: true,
 			entitlement: this.chatEntitlementService.entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
-			usableWithoutGitHub: false,
+			allowSignedOutWhenUsable: false,
 		});
 
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.refreshAccount()));
@@ -227,9 +225,8 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				this.renderState();
 			}
 		}));
-		// A type becoming usable/unusable without GitHub, or toggling the opt-in,
-		// can flip the signed-out affordance between the calm and alarming states.
-		this._register(runOnChange(this.usableWithoutGitHub, () => this.renderState()));
+		// Toggling the opt-in flips the signed-out affordance between calm and alarming states.
+		this._register(runOnChange(this.allowSignedOutWhenUsable, () => this.renderState()));
 		this.refreshAccount();
 	}
 
@@ -306,7 +303,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			entitlement,
 			sentiment: this.chatEntitlementService.sentiment,
 			quotas: this.chatEntitlementService.quotas,
-			usableWithoutGitHub: this.usableWithoutGitHub.get(),
+			allowSignedOutWhenUsable: this.allowSignedOutWhenUsable.get(),
 		});
 		this.lastState = state;
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -225,7 +225,9 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				this.renderState();
 			}
 		}));
-		// Toggling the opt-in flips the signed-out affordance between calm and alarming states.
+		// A signed-out user sees either a quiet "Sign In" (the opt-in is on, so signing
+		// in is optional) or a prominent "Agents Signed Out". Re-render so toggling the
+		// setting switches between them while the window is open.
 		this._register(runOnChange(this.allowSignedOutWhenUsable, () => this.renderState()));
 		this.refreshAccount();
 	}

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
@@ -20,7 +20,7 @@ suite('Sessions - Account Title Bar State', () => {
 			entitlement: ChatEntitlement.Pro,
 			sentiment: {},
 			quotas: {},
-			usableWithoutGitHub: false,
+			allowSignedOutWhenUsable: false,
 			...overrides,
 		};
 	}
@@ -145,12 +145,12 @@ suite('Sessions - Account Title Bar State', () => {
 		});
 	});
 
-	test('offers a calm opt-in sign-in instead of "Agents Signed Out" when a type is usable without GitHub', () => {
+	test('offers a calm opt-in sign-in when signed-out operation is enabled', () => {
 		const state = getAccountTitleBarState(createState({
 			accountName: undefined,
 			accountProviderLabel: undefined,
 			entitlement: ChatEntitlement.Unknown,
-			usableWithoutGitHub: true,
+			allowSignedOutWhenUsable: true,
 		}));
 
 		assert.deepStrictEqual({

--- a/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
+++ b/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
@@ -5,11 +5,21 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
-import { ConditionalAuthState, conditionalAuthState, shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, shouldForceGitHubSignIn, shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
 
 suite('Sessions - Auth Gate', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('blocking sign-in follows the signed-out opt-in only', () => {
+		assert.deepStrictEqual({
+			featureDisabled: shouldForceGitHubSignIn(false),
+			featureEnabled: shouldForceGitHubSignIn(true),
+		}, {
+			featureDisabled: true,
+			featureEnabled: false,
+		});
+	});
 
 	test('conditionalAuthState treats an unresolved account as unknown, never signed out', () => {
 		// The root-cause distinction: before the account resolves, its snapshot is

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1565,7 +1565,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[AgentHostAllowSignedOutWhenUsableSettingId]: {
 			type: 'boolean',
-			markdownDescription: nls.localize('chat.agentHost.allowSignedOutWhenUsable', "When enabled, the Agents window opens without forcing GitHub sign-in as long as at least one agent is usable without GitHub (for example Claude in native mode with your own Anthropic credentials). When disabled (the default), GitHub sign-in is required."),
+			markdownDescription: nls.localize('chat.agentHost.allowSignedOutWhenUsable', "When enabled, the Agents window opens without forcing GitHub sign-in. Agents usable without GitHub (for example Claude in native mode with your own Anthropic credentials) work while signed out; agents that require GitHub still prompt for sign-in when selected. When disabled (the default), GitHub sign-in is required before the window opens."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],


### PR DESCRIPTION
The Agents window can force a GitHub sign-in modal before showing any of its UI. That gate used to ask two questions — and only one of them can be answered in time.

- **The gate combined two inputs**: is the `chat.agentHost.allowSignedOutWhenUsable` opt-in on, *and* does some session type currently report that it runs without GitHub?
- **The second input lands too late.** The local agent host advertises its agents at `AfterRestored`, long after the setup widget has decided — so the gate raced the very modal it was meant to suppress.
- **Every consumer paid for the race**, needing a lifetime-scoped subscription just to retire a dialog it had already raised.

```mermaid
flowchart LR
  subgraph before ["Before"]
    direction LR
    O1["opt-in"] --> W1["window gate"] --> S1["force sign-in?"]
    R1["provider readiness"] -. "lands at AfterRestored" .-> W1
  end

  subgraph after ["After"]
    direction LR
    O2["opt-in"] --> W2["window gate"] --> S2["force sign-in?"]
    R2["provider readiness"] --> P2["per-type gate"] --> S3["SignInRequired, per type"]
  end
```

- **Drop the second input.** The window gate now reads the opt-in alone. Whether a session type needs GitHub isn't fixed — it flips as Claude and Codex credentials appear and disappear — so it belongs in the per-type gate, which re-runs every time the picker opens, not in a window gate that decides once at startup and never revisits.
- **No behavior change while the opt-in is off**, which is the default and is today's mandatory-sign-in behavior. With it on, a signed-out user gets the window immediately.

<details>
<summary>Details</summary>

### Changes

- `observeUsableWithoutGitHub()` → `observeAllowSignedOutWhenUsable()`, no longer taking `ISessionsManagementService`. Both `SessionsSetUpWidget` and `TitleBarAccountWidget` lose that dependency.
- Extracted `shouldForceGitHubSignIn()` so the window gate is one named, unit-testable predicate rather than an inline negation.
- Renamed `IAccountTitleBarStateContext.usableWithoutGitHub` → `allowSignedOutWhenUsable`. It carries the opt-in now, not a usability fact. This touches two one-line call sites in `mobileTitlebarPart.ts`.
- `IDiscoveredConfigNudgeContext.usableWithoutGitHub` is deliberately **not** renamed — that one really is provider-derived (the agent found an existing native config). Keeping the names distinct is the point.
- Refreshed the comments in `sessionsSetUpService.ts` that still narrated per-type readiness, including an `is does not require` typo.

### The TODO this removes

`sessionsAuthGate.ts` carried a ~20-line TODO acknowledging that this gate duplicated a judgement the per-type gate already makes (`getSessionTypeAvailability()` → `SignInRequired`), that the two predicates could drift, and that they already disagreed over `chatEntitlementService.anonymous` — the pickers honour it, the window gate ignored it. Removing the second input removes the duplication, so the TODO goes with it.

### Files

| File | Δ |
|---|---|
| `src/vs/sessions/browser/sessionsAuthGate.ts` | +26/−47 |
| `src/vs/sessions/browser/sessionsSetUpService.ts` | +33/−42 |
| `src/vs/sessions/browser/accountTitleBarState.ts` | +6/−8 |
| `src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts` | +8/−11 |
| `src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts` | +4/−4 |
| `src/vs/sessions/test/browser/sessionsAuthGate.test.ts` | +11/−1 |
| `src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts` | +3/−3 |

Net −23 lines. First of a stack splitting up the signed-out Copilot BYOK work in the Agents window; this one has no dependencies on the rest.

### Validation

- `npm run typecheck-client` — clean.
- `Sessions - Auth Gate` and `Sessions - Account Title Bar State` — 12 passing. Added a case covering `shouldForceGitHubSignIn` directly.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

