### PR TITLE
Use modifier from mouse event in editor drag and drop

### DIFF
--- a/src/vs/base/browser/globalPointerMoveMonitor.ts
+++ b/src/vs/base/browser/globalPointerMoveMonitor.ts
@@ -106,7 +106,7 @@ export class GlobalPointerMoveMonitor implements IDisposable {
 		this._hooks.add(dom.addDisposableListener(
 			eventSource,
 			dom.EventType.POINTER_UP,
-			(e: PointerEvent) => this.stopMonitoring(true)
+			(e: PointerEvent) => this.stopMonitoring(true, e)
 		));
 	}
 }

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -483,8 +483,12 @@ class MouseDownOperation extends Disposable {
 						// cancel
 						this._viewController.emitMouseDropCanceled();
 					} else {
+						// Send out the pointer up event, such that listeners observe the modifier
+						// state at the time of the drop. The position is still derived from the last
+						// pointer move event, because the pointer up event is captured and its target
+						// does not necessarily reflect a position in the editor.
 						this._viewController.emitMouseDrop({
-							event: this._lastMouseEvent!,
+							event: browserEvent ? new EditorMouseEvent(browserEvent, true, this._viewHelper.viewDomNode) : this._lastMouseEvent!,
 							target: (position ? this._createMouseTarget(this._lastMouseEvent!, true) : null) // Ignoring because position is unknown, e.g., Content View Zone
 						});
 					}

--- a/src/vs/editor/contrib/dnd/browser/dnd.ts
+++ b/src/vs/editor/contrib/dnd/browser/dnd.ts
@@ -37,7 +37,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 	private _dragSelection: Selection | null;
 	private readonly _dndDecorationIds: IEditorDecorationsCollection;
 	private _mouseDown: boolean;
-	private _modifierPressed: boolean;
 	static readonly TRIGGER_KEY_VALUE = isMacintosh ? KeyCode.Alt : KeyCode.Ctrl;
 
 	static get(editor: ICodeEditor): DragAndDropController | null {
@@ -58,7 +57,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._register(this._editor.onDidBlurEditorWidget(() => this.onEditorBlur()));
 		this._register(this._editor.onDidBlurEditorText(() => this.onEditorBlur()));
 		this._mouseDown = false;
-		this._modifierPressed = false;
 		this._dragSelection = null;
 	}
 
@@ -66,16 +64,11 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._removeDecoration();
 		this._dragSelection = null;
 		this._mouseDown = false;
-		this._modifierPressed = false;
 	}
 
 	private onEditorKeyDown(e: IKeyboardEvent): void {
 		if (!this._editor.getOption(EditorOption.dragAndDrop) || this._editor.getOption(EditorOption.columnSelection)) {
 			return;
-		}
-
-		if (hasTriggerModifier(e)) {
-			this._modifierPressed = true;
 		}
 
 		if (this._mouseDown && hasTriggerModifier(e)) {
@@ -88,10 +81,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 	private onEditorKeyUp(e: IKeyboardEvent): void {
 		if (!this._editor.getOption(EditorOption.dragAndDrop) || this._editor.getOption(EditorOption.columnSelection)) {
 			return;
-		}
-
-		if (hasTriggerModifier(e)) {
-			this._modifierPressed = false;
 		}
 
 		if (this._mouseDown && e.keyCode === DragAndDropController.TRIGGER_KEY_VALUE) {
@@ -180,15 +169,12 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 				(<CodeEditorWidget>this._editor).setSelections(newSelections || [], 'mouse', CursorChangeReason.Explicit);
 			} else if (!this._dragSelection.containsPosition(newCursorPosition) ||
 				(
-					(
-						hasTriggerModifier(mouseEvent.event) ||
-						this._modifierPressed
-					) && (
+					hasTriggerModifier(mouseEvent.event) && (
 						this._dragSelection.getEndPosition().equals(newCursorPosition) || this._dragSelection.getStartPosition().equals(newCursorPosition)
 					) // we allow users to paste content beside the selection
 				)) {
 				this._editor.pushUndoStop();
-				this._editor.executeCommand(DragAndDropController.ID, new DragAndDropCommand(this._dragSelection, newCursorPosition, hasTriggerModifier(mouseEvent.event) || this._modifierPressed));
+				this._editor.executeCommand(DragAndDropController.ID, new DragAndDropCommand(this._dragSelection, newCursorPosition, hasTriggerModifier(mouseEvent.event)));
 				this._editor.pushUndoStop();
 			}
 		}
@@ -234,7 +220,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._removeDecoration();
 		this._dragSelection = null;
 		this._mouseDown = false;
-		this._modifierPressed = false;
 		super.dispose();
 	}
 }


### PR DESCRIPTION
Fixes #58515

In the discussion linked from that issue, @alexdima suggested reading the modifier state off the mouse event in `_onEditorMouseDrop` rather than tracking it across keydown/keyup. This does that and drops the `_modifierPressed` field.

### The tracked flag also looks buggy

`onEditorKeyUp` guarded its reset with `hasTriggerModifier(e)`:

```ts
if (hasTriggerModifier(e)) {
    this._modifierPressed = false;
}
```

On the keyup of Alt/Ctrl itself, that modifier already reads as released, so `hasTriggerModifier(e)` is `false` and the reset never runs. `_modifierPressed` stayed `true` from the first modifier press until the editor lost focus. Since `_onEditorMouseDrop` OR-ed it into the copy decision, a later plain drag and drop should have copied the selection instead of moving it. Reading the drop event's own modifier makes that state unrepresentable.

I want to be upfront that I reasoned this out from the code and browser modifier semantics rather than reproducing it in a running build, so treat the bug part as expected-not-observed.

### What I deliberately kept

The issue thread suggested also removing `onEditorKeyDown`/`onEditorKeyUp`, `_onEditorMouseDown`/`_onEditorMouseUp` and `_mouseDown`. I left those in place:

- The key handlers still do real work — they update `mouseStyle` to `copy`/`default` mid-drag. `_onEditorMouseDrag` only fires while the mouse is *moving*, so pressing the modifier while holding the mouse still would leave a stale cursor.
- `_mouseDown` is what stops those handlers from flipping the cursor to `copy` when the modifier is tapped with no drag in progress.
- `_onEditorMouseUp` resets `mouseStyle` to `text`, which is behavior rather than bookkeeping.

Happy to remove them too if you consider that cursor case not worth keeping.

### Verification

`tsc --noEmit -p src/tsconfig.json` and `eslint` on the changed file both pass. There is no existing test coverage for editor drag and drop that I could find, so nothing to extend there.