### PR TITLE
Fix Policy Diagnostics Command to Prevent Indefinite Wait

### DIFF
--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -225,6 +225,10 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			}
 		}
 
+		return this._getAvailableManagementService();
+	}
+
+	private _getAvailableManagementService(): IAgentHostManagementService {
 		if (!this._messagePortClient) {
 			throw new Error('Local agent host management connection is not available.');
 		}
@@ -419,7 +423,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	}
 
 	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> {
-		return this._callManagement(management => management.getManagedSettingsDiagnostics());
+		return this._getAvailableManagementService().getManagedSettingsDiagnostics();
 	}
 
 	diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -7,7 +7,7 @@ import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHu
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { pathToFileURL } from 'url';
-import { CancelablePromise, createCancelablePromise, DeferredPromise, Delayer, disposableTimeout, Limiter, Sequencer, SequencerByKey } from '../../../../base/common/async.js';
+import { CancelablePromise, createCancelablePromise, DeferredPromise, Delayer, disposableTimeout, Limiter, raceTimeout, Sequencer, SequencerByKey } from '../../../../base/common/async.js';
 import { type CancellationToken } from '../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -64,13 +64,39 @@ import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { applyMcpServerEnablement, findMcpChildId, type IMcpServerRuntimeState } from '../shared/mcpCustomizationController.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
 
-interface ICopilotRuntimeManagedSettingsSdk {
-	getManagedSettings(input?: { token?: string; host?: string }): Promise<{ account?: string; resolved: ManagedSettingsResolvedData }>;
+interface ICopilotRuntimeManagedSettingsInput {
+	authInfo?: { type: 'token'; host: string; token: string };
+	token?: string;
+	signal?: AbortSignal;
 }
+
+interface ICopilotRuntimeManagedSettingsSdk {
+	getManagedSettings(input?: ICopilotRuntimeManagedSettingsInput): Promise<{ account?: string; resolved: ManagedSettingsResolvedData }>;
+}
+
+const COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS = 3500;
+const COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS = 4500;
 
 function isCopilotRuntimeManagedSettingsSdk(value: unknown): value is ICopilotRuntimeManagedSettingsSdk {
 	return typeof value === 'object' && value !== null && 'getManagedSettings' in value
 		&& typeof (value as { getManagedSettings?: unknown }).getManagedSettings === 'function';
+}
+
+export async function getCopilotManagedSettingsDiagnostics(
+	runtimeSdk: ICopilotRuntimeManagedSettingsSdk,
+	token: string | undefined,
+	host: string,
+	signal: AbortSignal,
+	timeoutMs = COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS,
+): Promise<{ account?: string; resolved: ManagedSettingsResolvedData }> {
+	const result = await raceTimeout(runtimeSdk.getManagedSettings({
+		...(token ? { authInfo: { type: 'token', host, token } as const, token } : {}),
+		signal,
+	}), timeoutMs);
+	if (!result) {
+		throw new Error(`Copilot runtime managed-settings query exceeded ${timeoutMs / 1000} seconds while waiting for native MDM or GitHub policy resolution.`);
+	}
+	return result;
 }
 import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
 import { SessionWorkingDirectoryMissingError } from '../shared/worktreeIsolation.js';
@@ -1021,22 +1047,36 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	async getManagedSettingsDiagnostics(): Promise<IAgentHostManagedSettingsSnapshot> {
-		const nodeModulesUri = FileAccess.asFileUri(getAppNodeModulesPath());
-		const cliPath = await resolveCopilotCliPath(nodeModulesUri);
-		const runtimeSdkPath = join(dirname(cliPath), 'sdk', 'index.js');
-		if (!await fileExists(runtimeSdkPath)) {
-			throw new Error(`Copilot runtime SDK not found at ${runtimeSdkPath}`);
-		}
-		const runtimeSdk: unknown = await import(pathToFileURL(runtimeSdkPath).href);
-		if (!isCopilotRuntimeManagedSettingsSdk(runtimeSdk)) {
-			throw new Error('Copilot runtime SDK does not expose getManagedSettings()');
-		}
+		this._logService.debug('[Copilot] Collecting runtime managed-settings diagnostics');
+		let stage = 'resolving the Copilot CLI path';
+		const diagnostics = (async () => {
+			const nodeModulesUri = FileAccess.asFileUri(getAppNodeModulesPath());
+			const cliPath = await resolveCopilotCliPath(nodeModulesUri);
+			const runtimeSdkPath = join(dirname(cliPath), 'sdk', 'index.js');
+			stage = 'checking the Copilot runtime SDK';
+			if (!await fileExists(runtimeSdkPath)) {
+				throw new Error(`Copilot runtime SDK not found at ${runtimeSdkPath}`);
+			}
+			stage = 'loading the Copilot runtime SDK';
+			const runtimeSdk: unknown = await import(pathToFileURL(runtimeSdkPath).href);
+			if (!isCopilotRuntimeManagedSettingsSdk(runtimeSdk)) {
+				throw new Error('Copilot runtime SDK does not expose getManagedSettings()');
+			}
 
-		const enterpriseHost = this._getEnterpriseHost();
-		const result = await runtimeSdk.getManagedSettings({
-			...(this._githubToken ? { token: this._githubToken } : {}),
-			...(enterpriseHost ? { host: enterpriseHost } : {}),
-		});
+			stage = 'querying native MDM and GitHub managed settings';
+			return getCopilotManagedSettingsDiagnostics(
+				runtimeSdk,
+				this._githubToken,
+				this._gitHubEndpointService.getEnterpriseUri() ?? 'https://github.com',
+				AbortSignal.timeout(COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS),
+			);
+		})();
+		const result = await raceTimeout(diagnostics, COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS);
+		if (!result) {
+			this._logService.warn(`[Copilot] Runtime managed-settings diagnostics timed out while ${stage}`);
+			throw new Error(`Copilot runtime diagnostics exceeded 4.5 seconds while ${stage}.`);
+		}
+		this._logService.debug('[Copilot] Runtime managed-settings diagnostics collected');
 		return {
 			...result.resolved,
 			...(result.account ? { account: result.account } : {}),

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -63,6 +63,26 @@ import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { applyMcpServerEnablement, findMcpChildId, type IMcpServerRuntimeState } from '../shared/mcpCustomizationController.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
+import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
+import { SessionWorkingDirectoryMissingError } from '../shared/worktreeIsolation.js';
+import { buildSessionEventLogFromTurns } from './buildSessionEvents.js';
+import { CopilotAgentSession } from './copilotAgentSession.js';
+import { createCopilotCliEnvironment } from './copilotCliEnvironment.js';
+import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitProject.js';
+import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
+import { CopilotGitHubTelemetryForwarder } from './copilotGitHubTelemetryForwarder.js';
+import { CopilotSessionLauncher, ContextSizeConfigKey, ThinkingLevelConfigKey, getCopilotContextTier, isCopilotReasoningEffort, resolveCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
+import { ShellManager } from './copilotShellTools.js';
+import { isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
+import { ICopilotApiService, type IRestrictedTelemetryContext } from '../shared/copilotApiService.js';
+import { AgentHostGitHubTelemetryRouter } from '../agentHostGitHubTelemetryRouter.js';
+import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
+import { CopilotSlashCommandCompletionProvider, ICopilotRuntimeSlashCommandQueryOptions } from './copilotSlashCommandCompletionProvider.js';
+import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
+import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
+import { getAppNodeModulesPath } from '../appNodeModules.js';
+import { CopilotSlashCommandProvider } from './copilotSlashCommandProvider.js';
+import { classifyCopilotClientFailure, createCopilotFailureCorrelation, reportCopilotClientFailure, reportCopilotClientRecovery, reportCopilotClientRecoveryTurn, type CopilotClientFailureKind, type CopilotClientFailureOperation, type ICopilotFailureCorrelation } from './copilotFailureTelemetry.js';
 
 interface ICopilotRuntimeManagedSettingsInput {
 	authInfo?: { type: 'token'; host: string; token: string };
@@ -98,26 +118,6 @@ export async function getCopilotManagedSettingsDiagnostics(
 	}
 	return result;
 }
-import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
-import { SessionWorkingDirectoryMissingError } from '../shared/worktreeIsolation.js';
-import { buildSessionEventLogFromTurns } from './buildSessionEvents.js';
-import { CopilotAgentSession } from './copilotAgentSession.js';
-import { createCopilotCliEnvironment } from './copilotCliEnvironment.js';
-import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitProject.js';
-import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
-import { CopilotGitHubTelemetryForwarder } from './copilotGitHubTelemetryForwarder.js';
-import { CopilotSessionLauncher, ContextSizeConfigKey, ThinkingLevelConfigKey, getCopilotContextTier, isCopilotReasoningEffort, resolveCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
-import { ShellManager } from './copilotShellTools.js';
-import { isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
-import { ICopilotApiService, type IRestrictedTelemetryContext } from '../shared/copilotApiService.js';
-import { AgentHostGitHubTelemetryRouter } from '../agentHostGitHubTelemetryRouter.js';
-import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
-import { CopilotSlashCommandCompletionProvider, ICopilotRuntimeSlashCommandQueryOptions } from './copilotSlashCommandCompletionProvider.js';
-import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
-import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
-import { getAppNodeModulesPath } from '../appNodeModules.js';
-import { CopilotSlashCommandProvider } from './copilotSlashCommandProvider.js';
-import { classifyCopilotClientFailure, createCopilotFailureCorrelation, reportCopilotClientFailure, reportCopilotClientRecovery, reportCopilotClientRecoveryTurn, type CopilotClientFailureKind, type CopilotClientFailureOperation, type ICopilotFailureCorrelation } from './copilotFailureTelemetry.js';
 
 const RUNTIME_SLASH_COMMAND_COMPLETION_WAIT_MS = 300;
 const COPILOT_CAPI_URL = 'https://api.githubcopilot.com';
@@ -1068,7 +1068,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				runtimeSdk,
 				this._githubToken,
 				this._gitHubEndpointService.getEnterpriseUri() ?? 'https://github.com',
-				AbortSignal.timeout(COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS),
+				AbortSignal.timeout(COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS),
 			);
 		})();
 		const result = await raceTimeout(diagnostics, COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -48,7 +48,7 @@ import { IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../c
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentHostCompletions, IAgentHostCompletions } from '../../node/agentHostCompletions.js';
-import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, rebaseUnder, REFRESH_DEBOUNCE_MS, resolveCopilotOtlpMetricsEndpoint } from '../../node/copilot/copilotAgent.js';
+import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, getCopilotManagedSettingsDiagnostics, rebaseUnder, REFRESH_DEBOUNCE_MS, resolveCopilotOtlpMetricsEndpoint } from '../../node/copilot/copilotAgent.js';
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS } from '../../node/copilot/prompts/systemMessage.js';
 import { COPILOT_AGENT_HOST_LARGE_OUTPUT_TOOL_INSTRUCTION } from '../../node/copilot/prompts/toolInstructions.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
@@ -1169,6 +1169,40 @@ suite('CopilotAgent', () => {
 		} finally {
 			await disposeAgent(agent);
 		}
+	});
+
+	test('queries managed settings with pre-resolved token authentication', async () => {
+		let receivedInput: { authInfo?: { type: 'token'; host: string; token: string }; token?: string; signal?: AbortSignal } | undefined;
+		const runtimeSdk = {
+			getManagedSettings: async (input?: typeof receivedInput) => {
+				receivedInput = input;
+				return { resolved: { source: 'none' as const, serverManaged: false, deviceManaged: false, clientManaged: false, failClosed: false, bypassPermissionsDisabled: false, managedKeys: [] } };
+			},
+		};
+		const signal = new AbortController().signal;
+
+		await getCopilotManagedSettingsDiagnostics(runtimeSdk, 'token', 'https://github.example.com', signal);
+
+		assert.deepStrictEqual({
+			authInfo: receivedInput?.authInfo,
+			token: receivedInput?.token,
+			signalForwarded: receivedInput?.signal === signal,
+		}, {
+			authInfo: { type: 'token', host: 'https://github.example.com', token: 'token' },
+			token: 'token',
+			signalForwarded: true,
+		});
+	});
+
+	test('identifies a stalled managed settings query', async () => {
+		const runtimeSdk = {
+			getManagedSettings: () => new Promise<never>(() => { }),
+		};
+
+		await assert.rejects(
+			getCopilotManagedSettingsDiagnostics(runtimeSdk, 'token', 'https://github.com', new AbortController().signal, 10),
+			/Copilot runtime managed-settings query exceeded 0.01 seconds while waiting for native MDM or GitHub policy resolution/,
+		);
 	});
 
 	test('returns empty models and lists sessions before authentication', async () => {

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -17,7 +17,7 @@ import { IConfigurationService } from '../../../platform/configuration/common/co
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../platform/contextkey/common/contextkey.js';
 import { Context } from '../../../platform/contextkey/browser/contextKeyService.js';
 import { StandardKeyboardEvent } from '../../../base/browser/keyboardEvent.js';
-import { RunOnceScheduler } from '../../../base/common/async.js';
+import { raceTimeout, RunOnceScheduler } from '../../../base/common/async.js';
 import { ILayoutService } from '../../../platform/layout/browser/layoutService.js';
 import { Registry } from '../../../platform/registry/common/platform.js';
 import { registerAction2, Action2, MenuRegistry } from '../../../platform/actions/common/actions.js';
@@ -55,6 +55,7 @@ import * as json from '../../../base/common/json.js';
 import { getParseErrorMessage } from '../../../base/common/jsonErrorMessages.js';
 import { IAgentHostService } from '../../../platform/agentHost/common/agentService.js';
 import { IAgentHostEnablementService } from '../../../platform/agentHost/common/agentHostEnablementService.js';
+import { IProgressService, ProgressLocation } from '../../../platform/progress/common/progress.js';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -731,6 +732,22 @@ function managedValueCell(value: ManagedSettingValue | undefined): string {
 
 /** Header row + separator for the report's two-column `Property | Value` tables. */
 const PROPERTY_VALUE_TABLE_HEADER = '| Property | Value |\n|----------|-------|\n';
+const AGENT_RUNTIME_DIAGNOSTICS_TIMEOUT = 6000;
+
+interface IPolicyDiagnosticsServices {
+	editorService: IEditorService;
+	configurationService: IConfigurationService;
+	productService: IProductService;
+	defaultAccountService: IDefaultAccountService;
+	authenticationService: IAuthenticationService;
+	authenticationAccessService: IAuthenticationAccessService;
+	policyService: IPolicyService;
+	accountPolicyGateService: IAccountPolicyGateService;
+	agentHostService: IAgentHostService;
+	agentHostEnablementService: IAgentHostEnablementService;
+	nativeManagedSettingsService: INativeManagedSettingsService | undefined;
+	fileManagedSettingsService: IFileManagedSettingsService | undefined;
+}
 
 class PolicyDiagnosticsAction extends Action2 {
 
@@ -754,6 +771,7 @@ class PolicyDiagnosticsAction extends Action2 {
 		const accountPolicyGateService = accessor.get(IAccountPolicyGateService);
 		const agentHostService = accessor.get(IAgentHostService);
 		const agentHostEnablementService = accessor.get(IAgentHostEnablementService);
+		const progressService = accessor.get(IProgressService);
 		// Native MDM is a desktop-only channel, registered in the renderer service collection on
 		// desktop and Agents windows but absent in web. Resolve it now, synchronously, because the
 		// accessor is only valid before the first `await` below.
@@ -772,6 +790,41 @@ class PolicyDiagnosticsAction extends Action2 {
 			// no file channel in this window (e.g. web)
 		}
 
+		return progressService.withProgress({
+			location: ProgressLocation.Notification,
+			title: localize('policyDiagnostics.progress', "Generating policy diagnostics..."),
+			type: 'loading',
+		}, () => this.openPolicyDiagnostics({
+			editorService,
+			configurationService,
+			productService,
+			defaultAccountService,
+			authenticationService,
+			authenticationAccessService,
+			policyService,
+			accountPolicyGateService,
+			agentHostService,
+			agentHostEnablementService,
+			nativeManagedSettingsService,
+			fileManagedSettingsService,
+		}));
+	}
+
+	private async openPolicyDiagnostics(services: IPolicyDiagnosticsServices): Promise<void> {
+		const {
+			editorService,
+			configurationService,
+			productService,
+			defaultAccountService,
+			authenticationService,
+			authenticationAccessService,
+			policyService,
+			accountPolicyGateService,
+			agentHostService,
+			agentHostEnablementService,
+			nativeManagedSettingsService,
+			fileManagedSettingsService,
+		} = services;
 		const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
 		let content = '# VS Code Policy Diagnostics\n\n';
@@ -987,16 +1040,19 @@ class PolicyDiagnosticsAction extends Action2 {
 				content += '*Agent Host is disabled; runtime managed-settings diagnostics were not queried.*\n\n';
 			} else {
 				try {
-					const runtimeDiagnostics = await agentHostService.getManagedSettingsDiagnostics();
-					if (runtimeDiagnostics.length === 0) {
+					const runtimeDiagnostics = await raceTimeout(agentHostService.getManagedSettingsDiagnostics(), AGENT_RUNTIME_DIAGNOSTICS_TIMEOUT);
+					if (!runtimeDiagnostics) {
+						content += '*The Agent Host did not return provider diagnostics within 6 seconds. The report continued without a runtime snapshot; check the Agent Host log for a stalled provider.*\n\n';
+					} else if (runtimeDiagnostics.length === 0) {
 						content += '*No agent provider exposes managed-settings diagnostics.*\n\n';
-					}
-					for (const diagnostic of runtimeDiagnostics) {
-						content += `#### ${diagnostic.provider}\n\n`;
-						if (diagnostic.error) {
-							content += `*Probe failed: ${diagnostic.error}*\n\n`;
-						} else {
-							content += jsonBlock(diagnostic.snapshot);
+					} else {
+						for (const diagnostic of runtimeDiagnostics) {
+							content += `#### ${diagnostic.provider}\n\n`;
+							if (diagnostic.error) {
+								content += `*Probe failed: ${diagnostic.error}*\n\n`;
+							} else {
+								content += jsonBlock(diagnostic.snapshot);
+							}
 						}
 					}
 				} catch (error) {


### PR DESCRIPTION
This pull request addresses the issue where the `Developer: Policy Diagnostics` command fails to open the editor due to an indefinite wait caused by the Agent Host managed-settings probe. 

### Changes Made:
- **Timeout Implementation**: Introduced a five-second timeout for the managed-settings probe to prevent it from blocking indefinitely.
- **SDK Delay Resolution**: Bypassed a redundant five-minute authentication check in the SDK, allowing for quicker access to managed settings.
- **Error Reporting**: Enhanced error reporting to specify which stage of the process is slow, rather than providing a generic timeout message.
- **Progress Notification**: Wrapped the entire diagnostics generation process in a VS Code loading notification to improve user experience.

### Validation:
- Conducted live tests confirming that the report opens promptly after the timeout.
- Passed all validation checks including ESLint, type-checking, and unit tests.

This fix resolves the issue reported in [issue #329973](https://github.com/microsoft/vscode/issues/329973) and improves the overall responsiveness of the Policy Diagnostics feature.