### PR TITLE
chat: preserve streamed response text when tool_calls delta is empty

### DIFF
--- a/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
@@ -150,6 +150,28 @@ data: [DONE]
 		});
 	});
 
+	// Regression for https://github.com/microsoft/vscode/issues/329963
+	test('delta content is preserved when tool_calls is empty', async function () {
+		const response = `data: {"choices":[{"delta":{"content":" I","tool_calls":[]},"index":0,"finish_reason":null}]}
+data: {"choices":[{"delta":{"content":" am","tool_calls":[]},"index":0,"finish_reason":null}]}
+data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
+data: [DONE]
+`;
+		const processor = await SSEProcessor.create(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assertSimplifiedResultsEqual(results, {
+			0: {
+				finishReason: FinishedCompletionReason.Stop,
+				chunks: [' I', ' am'],
+			},
+		});
+	});
+
 	test('response with text and without finish_reason yields "DONE" result', async function () {
 		// This is not an expected case, since the OpenAI API should always
 		// include a finish_reason, but we handle it anyway.

--- a/extensions/copilot/src/platform/networking/node/stream.ts
+++ b/extensions/copilot/src/platform/networking/node/stream.ts
@@ -470,7 +470,7 @@ export class SSEProcessor {
 					};
 
 					let handled = true;
-					if (choice.delta?.tool_calls) {
+					if (choice.delta?.tool_calls?.length) {
 						const hadExistingToolCalls = this.toolCalls.hasToolCalls();
 						if (!hadExistingToolCalls) {
 							const firstToolCall = choice.delta.tool_calls.at(0);


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/329963

- Streamed assistant text is no longer dropped when a chat-completions response attaches an empty `tool_calls: []` array to content chunks.
- Fixes Custom Endpoint / BYOK models (for example vLLM-backed) where the model answered correctly and was billed, but the chat showed "Sorry, no response was returned".
- Scope is limited to the streaming chat-completions parser. The Responses API, Anthropic Messages API, and non-streaming paths are unaffected.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

`SSEProcessor` routed each streamed delta through a chain of mutually exclusive branches gated by a shared `handled` flag. The first branch tested `if (choice.delta?.tool_calls)`, which only checks truthiness. An empty array is truthy, so a delta like `{"content":" I","tool_calls":[]}` entered the tool-call branch, iterated zero tool calls, and left `handled` set to `true`. That skipped the terminal `if (!handled) { solution.append(choice); … }` path — the only place `delta.content` is read — so the visible text was discarded. Backends that attach `tool_calls: []` to every content delta (observed with vLLM 0.22.1) therefore lost the entire response, chunk by chunk, while the stream still finished with `stop` and tokens were still counted.

### Implementation

Guard the branch on `choice.delta?.tool_calls?.length` so an empty array is treated as "no tool calls" and falls through to normal content handling. This mirrors how OpenAI-compatible streaming clients handle the same payload: they iterate `tool_calls` and no-op on an empty array instead of gating the content path on its mere presence.

### Behavior and constraints

- Non-empty tool-call streaming (begin-tool-call emission, argument accumulation, finish handling) is unchanged.
- Empty `tool_calls: []` deltas now behave exactly like a plain content delta.
- Out of scope: a delta that carries visible text together with a non-empty `tool_calls` array in the same chunk. That is a rarer backend behavior and is intentionally not addressed by this minimal fix.
- Only the streaming chat-completions processor is touched; Responses, Messages, and non-streaming response processors use separate paths.

### Review context

- Fixes #329963.
- A focused regression test drives content deltas carrying `tool_calls: []` through to a `stop` completion and asserts the text survives.

</details>
