### PR TITLE
Let piece tree's nodeAt and nodeAt2 return null

### DIFF
--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CharCode } from '../../../../base/common/charCode.js';
+import { assertReturnsDefined } from '../../../../base/common/types.js';
 import { Position } from '../../core/position.js';
 import { Range } from '../../core/range.js';
 import { FindMatch, ITextSnapshot, SearchData } from '../../model.js';
@@ -383,6 +384,10 @@ export class PieceTreeBase {
 			const len = str.length;
 			const startPosition = other.nodeAt(offset);
 			const endPosition = other.nodeAt(offset + len);
+			if (!startPosition || !endPosition) {
+				// the other buffer is shorter than this one
+				return false;
+			}
 			const val = other.getValueInRange2(startPosition, endPosition);
 
 			offset += len;
@@ -463,6 +468,9 @@ export class PieceTreeBase {
 
 		const startPosition = this.nodeAt2(range.startLineNumber, range.startColumn);
 		const endPosition = this.nodeAt2(range.endLineNumber, range.endColumn);
+		if (!startPosition || !endPosition) {
+			return '';
+		}
 
 		const value = this.getValueInRange2(startPosition, endPosition);
 		if (eol) {
@@ -650,6 +658,9 @@ export class PieceTreeBase {
 
 	public getLineCharCode(lineNumber: number, index: number): number {
 		const nodePos = this.nodeAt2(lineNumber, index + 1);
+		if (!nodePos) {
+			return 0;
+		}
 		return this._getCharCode(nodePos);
 	}
 
@@ -663,11 +674,17 @@ export class PieceTreeBase {
 
 	public getCharCode(offset: number): number {
 		const nodePos = this.nodeAt(offset);
+		if (!nodePos) {
+			return 0;
+		}
 		return this._getCharCode(nodePos);
 	}
 
 	public getNearestChunk(offset: number): string {
 		const nodePos = this.nodeAt(offset);
+		if (!nodePos) {
+			return '';
+		}
 		if (nodePos.remainder === nodePos.node.piece.length) {
 			// the offset is at the head of next node.
 			const matchingNode = nodePos.node.next();
@@ -793,6 +810,9 @@ export class PieceTreeBase {
 
 			startLineNumber++;
 			startPosition = this.nodeAt2(startLineNumber, 1);
+			if (!startPosition) {
+				return result;
+			}
 			currentNode = startPosition.node;
 			start = this.positionInBuffer(startPosition.node, startPosition.remainder);
 		}
@@ -852,7 +872,9 @@ export class PieceTreeBase {
 		this._lastVisitedLine.value = '';
 
 		if (this.root !== SENTINEL) {
-			const { node, remainder, nodeStartOffset } = this.nodeAt(offset);
+			// the offset is expected to be inside the tree, and silently skipping the
+			// insertion would leave the buffer out of sync with the model
+			const { node, remainder, nodeStartOffset } = assertReturnsDefined(this.nodeAt(offset));
 			const piece = node.piece;
 			const bufferIndex = piece.bufferIndex;
 			const insertPosInBuffer = this.positionInBuffer(node, remainder);
@@ -952,8 +974,10 @@ export class PieceTreeBase {
 			return;
 		}
 
-		const startPosition = this.nodeAt(offset);
-		const endPosition = this.nodeAt(offset + cnt);
+		// the range is expected to be inside the tree, and silently skipping the
+		// deletion would leave the buffer out of sync with the model
+		const startPosition = assertReturnsDefined(this.nodeAt(offset));
+		const endPosition = assertReturnsDefined(this.nodeAt(offset + cnt));
 		const startNode = startPosition.node;
 		const endNode = endPosition.node;
 
@@ -1492,7 +1516,7 @@ export class PieceTreeBase {
 		updateTreeMetadata(this, node, value.length, lf_delta);
 	}
 
-	private nodeAt(offset: number): NodePosition {
+	private nodeAt(offset: number): NodePosition | null {
 		let x = this.root;
 		const cache = this._searchCache.get(offset);
 		if (cache) {
@@ -1524,10 +1548,10 @@ export class PieceTreeBase {
 			}
 		}
 
-		return null!;
+		return null;
 	}
 
-	private nodeAt2(lineNumber: number, column: number): NodePosition {
+	private nodeAt2(lineNumber: number, column: number): NodePosition | null {
 		let x = this.root;
 		let nodeStartOffset = 0;
 
@@ -1591,7 +1615,7 @@ export class PieceTreeBase {
 			x = x.next();
 		}
 
-		return null!;
+		return null;
 	}
 
 	private nodeCharCodeAt(node: TreeNode, offset: number): number {

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -385,7 +385,7 @@ export class PieceTreeBase {
 			const startPosition = other.nodeAt(offset);
 			const endPosition = other.nodeAt(offset + len);
 			if (!startPosition || !endPosition) {
-				// the other buffer is shorter than this one
+				// defensive, the lengths are compared above
 				return false;
 			}
 			const val = other.getValueInRange2(startPosition, endPosition);
@@ -872,8 +872,7 @@ export class PieceTreeBase {
 		this._lastVisitedLine.value = '';
 
 		if (this.root !== SENTINEL) {
-			// the offset is expected to be inside the tree, and silently skipping the
-			// insertion would leave the buffer out of sync with the model
+			// fail rather than silently leaving the buffer out of sync with the model
 			const { node, remainder, nodeStartOffset } = assertReturnsDefined(this.nodeAt(offset));
 			const piece = node.piece;
 			const bufferIndex = piece.bufferIndex;
@@ -974,8 +973,7 @@ export class PieceTreeBase {
 			return;
 		}
 
-		// the range is expected to be inside the tree, and silently skipping the
-		// deletion would leave the buffer out of sync with the model
+		// fail rather than silently leaving the buffer out of sync with the model
 		const startPosition = assertReturnsDefined(this.nodeAt(offset));
 		const endPosition = assertReturnsDefined(this.nodeAt(offset + cnt));
 		const startNode = startPosition.node;

--- a/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
+++ b/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
@@ -1833,6 +1833,16 @@ suite('buffer api', () => {
 		assert.equal(pt.getNearestChunk(6), '345');
 		assert.equal(pt.getNearestChunk(9), '78');
 	});
+
+	test('offsets past the end of the buffer', () => {
+		const pieceTree = createTextBuffer(['012345678']);
+		ds.add(pieceTree);
+		const pt = pieceTree.getPieceTree();
+
+		// `nodeAt` finds no node, so these fall back instead of throwing
+		assert.strictEqual(pt.getCharCode(100), 0);
+		assert.strictEqual(pt.getNearestChunk(100), '');
+	});
 });
 
 suite('search offset cache', () => {


### PR DESCRIPTION
Fixes #228362

`nodeAt` and `nodeAt2` can both fall out of their search loops and end with `return null!`, so every caller was typed as receiving a `NodePosition` while actually being handed `null`.

This is not hypothetical. `findMatchesLineByLine` already guards with explicit `=== null` checks, which the current types make look like unreachable code:

```ts
let startPosition = this.nodeAt2(searchRange.startLineNumber, searchRange.startColumn);
if (startPosition === null) {
    return [];
}
```

This changes the return type to `NodePosition | null` and handles it at each of the call sites.

### Read paths

Chosen to match what the surrounding code already does for the equivalent "nothing there" case:

| Call site | Behaviour when `null` |
| --- | --- |
| `getCharCode`, `getLineCharCode` | return `0`, which is what `_getCharCode` already returns when there is no adjacent node |
| `getValueInRange`, `getNearestChunk` | return the empty string |
| `equal` | report the buffers as different — a missing node means the other buffer ended early |
| `findMatchesLineByLine` | return the matches collected so far |

### Mutation paths

`insert` and `delete` use `assertReturnsDefined` rather than a graceful fallback. Silently skipping a mutation would leave the piece tree out of sync with the model, which is worse than failing, so these keep throwing — just with a meaningful error instead of a property access on `null`.

### Risk

Every one of these sites previously dereferenced `null` and threw a `TypeError`, so behaviour is unchanged whenever a node is found, which is to say in all normal operation. The change only affects what happens on a path that already crashed.

### Verification

I reviewed the types by hand and did not run a local compile or the piece tree test suite, so please let CI be the judge. The existing `pieceTreeTextBuffer` tests cover these methods heavily and should exercise the read paths.