### PR TITLE
Fix chat editing keybindings to respect input focus

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -22,6 +22,7 @@ import { Action2, IAction2Options, MenuId, registerAction2 } from '../../../../.
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { InputFocusedContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { EditorActivation } from '../../../../../platform/editor/common/editor.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -448,7 +449,13 @@ registerAction2(class RemoveAction extends Action2 {
 				mac: {
 					primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 				},
-				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, EditorContextKeys.textInputFocus.negate(), ChatContextKeys.inChatQuestionCarousel.negate(), ChatContextKeys.readOnly.negate()),
+				when: ContextKeyExpr.and(
+					ChatContextKeys.inChatSession,
+					EditorContextKeys.textInputFocus.negate(),
+					InputFocusedContext.toNegated(),
+					ChatContextKeys.inChatQuestionCarousel.negate(),
+					ChatContextKeys.readOnly.negate()
+				),
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
 			menu: [
@@ -503,7 +510,13 @@ registerAction2(class RestoreCheckpointAction extends Action2 {
 				mac: {
 					primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 				},
-				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, EditorContextKeys.textInputFocus.negate(), ChatContextKeys.inChatQuestionCarousel.negate(), ChatContextKeys.readOnly.negate()),
+				when: ContextKeyExpr.and(
+					ChatContextKeys.inChatSession,
+					EditorContextKeys.textInputFocus.negate(),
+					InputFocusedContext.toNegated(),
+					ChatContextKeys.inChatQuestionCarousel.negate(),
+					ChatContextKeys.readOnly.negate()
+				),
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
 			menu: [
@@ -641,7 +654,12 @@ registerAction2(class EditAction extends Action2 {
 			icon: Codicon.edit,
 			keybinding: {
 				primary: KeyCode.Enter,
-				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, EditorContextKeys.textInputFocus.negate(), ChatContextKeys.readOnly.negate()),
+				when: ContextKeyExpr.and(
+					ChatContextKeys.inChatSession,
+					EditorContextKeys.textInputFocus.negate(),
+					InputFocusedContext.toNegated(),
+					ChatContextKeys.readOnly.negate()
+				),
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
 			menu: [

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatEditingActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatEditingActions.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { OS } from '../../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { EditorContextKeys } from '../../../../../../editor/common/editorContextKeys.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { InputFocusedContext } from '../../../../../../platform/contextkey/common/contextkeys.js';
+import { KeybindingsRegistry } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeybindingResolver } from '../../../../../../platform/keybinding/common/keybindingResolver.js';
+import { ResolvedKeybindingItem } from '../../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { USLayoutResolvedKeybinding } from '../../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
+import '../../../browser/chatEditing/chatEditingActions.js';
+
+suite('Chat editing keybinding resolution', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function buildResolverForCommands(commandIds: string[]): KeybindingResolver {
+		const items: ResolvedKeybindingItem[] = [];
+		for (const item of KeybindingsRegistry.getDefaultKeybindingsForOS(OS)) {
+			if (!item.command || !commandIds.includes(item.command) || !item.keybinding) {
+				continue;
+			}
+			const resolved = USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding, OS)[0];
+			items.push(new ResolvedKeybindingItem(resolved, item.command, item.commandArgs, item.when ?? undefined, true, null, false));
+		}
+		return new KeybindingResolver(items, [], () => { });
+	}
+
+	function hasPrimaryKeybinding(commandId: string, inputFocused: boolean, textInputFocused: boolean = false): boolean {
+		const contextKeyService = new ContextKeyService(new TestConfigurationService());
+		try {
+			const overlay = contextKeyService.createOverlay([
+				[ChatContextKeys.inChatSession.key, true],
+				[ChatContextKeys.inChatQuestionCarousel.key, false],
+				[ChatContextKeys.readOnly.key, false],
+				[EditorContextKeys.textInputFocus.key, textInputFocused],
+				[InputFocusedContext.key, inputFocused],
+			]);
+			const resolver = buildResolverForCommands([commandId]);
+			return !!resolver.lookupPrimaryKeybinding(commandId, overlay, true);
+		} finally {
+			contextKeyService.dispose();
+		}
+	}
+
+	test('undo-requests and restore-checkpoint keybindings are disabled while any input is focused', () => {
+		const commandIds = [
+			'workbench.action.chat.undoEdits',
+			'workbench.action.chat.editRequests',
+			'workbench.action.chat.restoreCheckpoint',
+		];
+
+		for (const commandId of commandIds) {
+			assert.strictEqual(hasPrimaryKeybinding(commandId, false), true, `${commandId} should be available when inputFocus=false`);
+			assert.strictEqual(hasPrimaryKeybinding(commandId, true), false, `${commandId} should be disabled when inputFocus=true`);
+			assert.strictEqual(hasPrimaryKeybinding(commandId, false, true), false, `${commandId} should be disabled when textInputFocus=true`);
+		}
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Prevent destructive chat editing keybindings from propagating when focus is in a text input, including the editor input. This keeps Undo Requests / Restore Checkpoint from triggering while the user is typing.

Closes #328266

You can test this by using the Agents window, selecting some text in a reply from a model, entering text into the "Ask Question" input, and confirming that cmd+delete – and I assume ctrl+backspace on windows too – no longer deletes the prompt exchange behind the "Ask Question" popup. 

<img width="373" height="168" alt="image" src="https://github.com/user-attachments/assets/9f6f8a4f-15ac-44c0-a1bb-0005df557160" />
