### PR TITLE
agentHost: detect fork PR heads from push remotes

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1266,7 +1266,7 @@ export interface ISessionGitState {
 	readonly uncommittedChanges?: number;
 	/** GitHub repository owner parsed from the working copy's GitHub remote (preferring `origin`, falling back to the first GitHub remote). */
 	readonly githubOwner?: string;
-	/** GitHub owner parsed from the current branch's upstream remote. */
+	/** GitHub owner parsed from the current branch's upstream or push remote. */
 	readonly githubHeadOwner?: string;
 	/** GitHub repository name parsed from the working copy's GitHub remote (preferring `origin`, falling back to the first GitHub remote). */
 	readonly githubRepo?: string;

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -895,7 +895,15 @@ export class AgentHostGitService implements IAgentHostGitService {
 		const baseBranchName = parseDefaultBranchRef(defaultBranchRef);
 		const githubRepo = parseGitHubRepoFromRemote(remotesOutput);
 		const upstreamRemote = status.upstreamBranchName?.split('/')[0];
-		const githubHeadRepo = upstreamRemote ? parseGitHubRepoFromRemote(remotesOutput, upstreamRemote) : undefined;
+		// `gh pr checkout` can create a local branch whose head lives on a fork but
+		// has no upstream tracking ref; Git still reports the branch's push remote,
+		// which can be a remote name or the literal fork URL.
+		const pushRemote = !upstreamRemote && status.branchName
+			? (await this._runGit(repositoryRoot, ['for-each-ref', '--format=%(push:remotename)', `refs/heads/${status.branchName}`]))?.trim() || undefined
+			: undefined;
+		const githubHeadRepo = upstreamRemote
+			? parseGitHubRepoFromRemote(remotesOutput, upstreamRemote)
+			: parseGitHubHeadRepoFromRemoteSelection(remotesOutput, pushRemote);
 
 		// `git status -b --porcelain=v2` only emits ahead/behind counts when the
 		// branch has an upstream tracking ref. For agent-host worktrees the
@@ -1482,6 +1490,13 @@ export function parseGitHubRepoFromRemote(remotesOutput: string | undefined, rem
 		}
 	}
 	return undefined;
+}
+
+function parseGitHubHeadRepoFromRemoteSelection(remotesOutput: string | undefined, remoteSelection: string | undefined): { owner: string; repo: string } | undefined {
+	if (!remoteSelection) {
+		return undefined;
+	}
+	return parseGitHubRepoFromRemote(remotesOutput, remoteSelection) ?? parseGitHubOwnerRepoFromUrl(remoteSelection);
 }
 
 /**

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -179,7 +179,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		const githubHeadOwner = gitState?.githubHeadOwner;
 		const upstreamBranch = githubHeadOwner ? parseUpstreamBranchName(gitState?.upstreamBranchName) : undefined;
 		const headBranch = upstreamBranch?.branch ?? branchName;
-		const headOwner = upstreamBranch && githubHeadOwner ? githubHeadOwner : owner;
+		const headOwner = githubHeadOwner ?? owner;
 
 		const pullRequestByBranch = await this._octoKitService.findPullRequestByHeadBranch(owner, repo, headBranch, authToken, signal, headOwner);
 		if (pullRequestByBranch) {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -118,6 +118,27 @@ suite('AgentHostGitService - getSessionGitState (real git)', () => {
 		});
 	});
 
+	(hasGit ? test : test.skip)('reports the GitHub owner of a branch push remote without an upstream', async () => {
+		const dir = initRepo({ remote: 'https://github.com/base-owner/repo.git' });
+		cp.execFileSync('git', ['checkout', '-q', '-b', 'feature'], { cwd: dir, stdio: 'pipe' });
+		cp.execFileSync('git', ['config', 'branch.feature.remote', 'https://github.com/fork-owner/repo.git'], { cwd: dir, stdio: 'pipe' });
+		cp.execFileSync('git', ['config', 'branch.feature.pushremote', 'https://github.com/fork-owner/repo.git'], { cwd: dir, stdio: 'pipe' });
+
+		const result = await svc!.getSessionGitState(URI.file(dir));
+
+		assert.deepStrictEqual({
+			githubOwner: result?.githubOwner,
+			githubHeadOwner: result?.githubHeadOwner,
+			githubRepo: result?.githubRepo,
+			upstreamBranchName: result?.upstreamBranchName,
+		}, {
+			githubOwner: 'base-owner',
+			githubHeadOwner: 'fork-owner',
+			githubRepo: 'repo',
+			upstreamBranchName: undefined,
+		});
+	});
+
 	(hasGit ? test : test.skip)('resolves the default branch name and remote-tracking start point', async () => {
 		const dir = initRepo();
 		cp.execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'refs/heads/main'], { cwd: dir, stdio: 'pipe' });

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -442,26 +442,33 @@ suite('AgentHostGitStateService', () => {
 				baseBranchName: 'main',
 				githubHeadOwner: 'jadefr',
 			};
-			const h = createHarness();
+			const calls: Array<{ branch: string; headOwner: string | undefined }> = [];
+			const h = createHarness({
+				octoKitService: {
+					findPullRequestByHeadBranch: async (_owner: string, _repo: string, branch: string, _token: string, _signal: AbortSignal, headOwner?: string) => {
+						calls.push({ branch, headOwner });
+						return {
+							url: 'https://github.com/microsoft/vscode/pull/328975',
+							number: 328975,
+						};
+					},
+				} as unknown as IAgentHostOctoKitService,
+			});
 			seedSession(h.stateManager, {
 				workingDirectory: WORKING_DIRECTORY,
 				gitState,
 				gitHubState: { owner: 'microsoft', repo: 'vscode' },
 			});
 			h.setGitResult(gitState);
-			h.setPullRequest('feature/alt-click-close-other-tabs', {
-				url: 'https://github.com/microsoft/vscode/pull/328975',
-				number: 328975,
-			});
 
 			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
 
 			assert.deepStrictEqual({
-				pullRequestCalls: h.pullRequestCalls,
+				pullRequestCalls: calls,
 				pullRequestShaCalls: h.pullRequestShaCalls,
 				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
 			}, {
-				pullRequestCalls: ['feature/alt-click-close-other-tabs'],
+				pullRequestCalls: [{ branch: 'feature/alt-click-close-other-tabs', headOwner: 'jadefr' }],
 				pullRequestShaCalls: [],
 				github: {
 					owner: 'microsoft',

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -435,6 +435,44 @@ suite('AgentHostGitStateService', () => {
 		});
 	});
 
+	test('looks a fork pull request up by the local branch name when git inferred the fork head owner from the push remote', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = {
+				branchName: 'feature/alt-click-close-other-tabs',
+				baseBranchName: 'main',
+				githubHeadOwner: 'jadefr',
+			};
+			const h = createHarness();
+			seedSession(h.stateManager, {
+				workingDirectory: WORKING_DIRECTORY,
+				gitState,
+				gitHubState: { owner: 'microsoft', repo: 'vscode' },
+			});
+			h.setGitResult(gitState);
+			h.setPullRequest('feature/alt-click-close-other-tabs', {
+				url: 'https://github.com/microsoft/vscode/pull/328975',
+				number: 328975,
+			});
+
+			await h.service.attachSessionGitHubPullRequest(SESSION, URI.parse(WORKING_DIRECTORY));
+
+			assert.deepStrictEqual({
+				pullRequestCalls: h.pullRequestCalls,
+				pullRequestShaCalls: h.pullRequestShaCalls,
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+			}, {
+				pullRequestCalls: ['feature/alt-click-close-other-tabs'],
+				pullRequestShaCalls: [],
+				github: {
+					owner: 'microsoft',
+					repo: 'vscode',
+					pullRequestUrls: ['https://github.com/microsoft/vscode/pull/328975'],
+					pullRequestBranchName: 'feature/alt-click-close-other-tabs',
+				},
+			});
+		});
+	});
+
 	test('falls back to the commit at HEAD when the branch name matches no pull request', async () => {
 		await runWithFakedTimers({ useFakeTimers: true }, async () => {
 			// A branch checked out from a pull request head: no upstream, and a


### PR DESCRIPTION
## Summary
- detect GitHub fork head owners from branch push remotes when a checked out PR branch has no upstream
- use that inferred head owner for Agent Host PR lookup after in-session branch checkouts
- add focused coverage for the git inference path and the PR lookup path

## Why
`gh pr checkout` can leave a local branch without an upstream tracking ref while still configuring a fork push remote. Agent Host previously only inferred the PR head owner from the upstream remote, so it looked up `owner:branch` instead of `forkOwner:branch` and failed to link fork-owned pull requests after checkout.

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- attempted focused unit/integration runs for the touched agentHost tests (environment-specific runner issues prevented completion in this session)