### PR TITLE
Apply Copilot harness preference consistently

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -444,7 +444,7 @@
             "localization": {
                 "description": {
                     "key": "chat.editor.preferCopilotHarness.policy",
-                    "value": "Configure whether VS Code uses the Agent Host Copilot CLI instead of the local harness for new editor chat sessions."
+                    "value": "Configure whether VS Code uses the Agent Host Copilot SDK instead of the local harness for new editor chat sessions."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -437,6 +437,21 @@
             "included": true
         },
         {
+            "key": "chat.editor.preferCopilotHarness",
+            "name": "ChatEditorPreferCopilotHarness",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.134",
+            "localization": {
+                "description": {
+                    "key": "chat.editor.preferCopilotHarness.policy",
+                    "value": "Configure whether VS Code uses the Agent Host Copilot CLI instead of the local harness for new editor chat sessions."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true
+        },
+        {
             "key": "chat.extensionTools.enabled",
             "name": "ChatAgentExtensionTools",
             "category": "InteractiveSession",

--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IObservable } from '../../../base/common/observable.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import { RawContextKey } from '../../contextkey/common/contextkey.js';
@@ -32,10 +33,21 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		'chat.editor.preferCopilotHarness': {
 			type: 'boolean',
-			description: nls.localize('chat.editor.preferCopilotHarness', "When enabled, prefers the Agent Host Copilot CLI for new editor chat sessions. If the local harness is selected, it is replaced with Copilot once."),
+			description: nls.localize('chat.editor.preferCopilotHarness', "When enabled, uses the Agent Host Copilot CLI whenever the local harness would otherwise be selected for a new editor chat session. Claude and Codex selections are unaffected."),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
+			policy: {
+				name: 'ChatEditorPreferCopilotHarness',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.134',
+				localization: {
+					description: {
+						key: 'chat.editor.preferCopilotHarness.policy',
+						value: nls.localize('chat.editor.preferCopilotHarness.policy', "Configure whether VS Code uses the Agent Host Copilot CLI instead of the local harness for new editor chat sessions."),
+					},
+				},
+			},
 		},
 		'chat.defaultToCopilotHarness': {
 			type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentHostEnablementService.ts
+++ b/src/vs/platform/agentHost/common/agentHostEnablementService.ts
@@ -33,7 +33,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		'chat.editor.preferCopilotHarness': {
 			type: 'boolean',
-			description: nls.localize('chat.editor.preferCopilotHarness', "When enabled, uses the Agent Host Copilot CLI whenever the local harness would otherwise be selected for a new editor chat session. Claude and Codex selections are unaffected."),
+			description: nls.localize('chat.editor.preferCopilotHarness', "When enabled, uses the Agent Host Copilot SDK whenever the local harness would otherwise be selected for a new editor chat session. Claude and Codex selections are unaffected."),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
@@ -44,14 +44,14 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.editor.preferCopilotHarness.policy',
-						value: nls.localize('chat.editor.preferCopilotHarness.policy', "Configure whether VS Code uses the Agent Host Copilot CLI instead of the local harness for new editor chat sessions."),
+						value: nls.localize('chat.editor.preferCopilotHarness.policy', "Configure whether VS Code uses the Agent Host Copilot SDK instead of the local harness for new editor chat sessions."),
 					},
 				},
 			},
 		},
 		'chat.defaultToCopilotHarness': {
 			type: 'boolean',
-			description: nls.localize('chat.defaultToCopilotHarness', "When enabled, new editor and panel chat sessions default to the Agent Host Copilot CLI instead of the local harness."),
+			description: nls.localize('chat.defaultToCopilotHarness', "When enabled, new editor and panel chat sessions default to the Agent Host Copilot SDK instead of the local harness."),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -60,7 +60,6 @@ import { ISCMHistoryItemChangeRangeVariableEntry, ISCMHistoryItemChangeVariableE
 import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetHistoryService } from '../../common/widget/chatWidgetHistoryService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, resolveDefaultNewChatSessionType } from '../../common/constants.js';
-import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { AICustomizationManagementCommands } from '../aiCustomization/aiCustomizationManagement.js';
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
@@ -1785,19 +1784,14 @@ export interface IClearEditingSessionConfirmationOptions {
  */
 export async function clearChatSessionPreservingType(accessor: ServicesAccessor, widget: IChatWidget, sessionType: string | undefined): Promise<void> {
 	const viewsService = accessor.get(IViewsService);
-	const storageService = accessor.get(IStorageService);
 	const currentResource = widget.viewModel?.model.sessionResource;
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const { sessionType: newSessionType, isPreferCopilotHarnessSwap } = resolveDefaultNewChatSessionType(accessor, { explicitOverride: sessionType, currentSessionType });
+	const { sessionType: newSessionType } = resolveDefaultNewChatSessionType(accessor, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext)) {
 		const view = await viewsService.openView(ChatViewId) as ChatViewPane;
 		if (newSessionType !== localChatSessionType) {
 			// Load a session of the resolved type in the sidebar.
 			await view.loadSession(URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` }));
-			// Consume the one-time migration only now that the swap has been applied.
-			if (isPreferCopilotHarnessSwap) {
-				markPreferredCopilotHarness(storageService);
-			}
 		} else {
 			// The resolved type is local (an explicit request or session
 			// preservation). A plain `widget.clear()` re-acquires the computed
@@ -1810,9 +1804,6 @@ export async function clearChatSessionPreservingType(accessor: ServicesAccessor,
 		// clearChatEditor opens a session of that type instead of recomputing
 		// the default (which would drop an explicit or preserved local request).
 		await widget.clear(newSessionType);
-		if (isPreferCopilotHarnessSwap) {
-			markPreferredCopilotHarness(storageService);
-		}
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -6,11 +6,9 @@
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { localChatSessionType } from '../../common/chatSessionsService.js';
 import { resolveDefaultNewChatSessionType } from '../../common/constants.js';
-import { markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
 import { getChatSessionType, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
@@ -23,7 +21,6 @@ function getNewChatSessionResource(sessionType: string): URI {
 
 export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInput?: ChatEditorInput, targetSessionType?: string): Promise<void> {
 	const editorService = accessor.get(IEditorService);
-	const storageService = accessor.get(IStorageService);
 
 	if (!chatEditorInput) {
 		const editorInput = editorService.activeEditor;
@@ -37,9 +34,6 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 			explicitOverride: targetSessionType,
 			currentSessionType,
 		});
-		if (resolved.isPreferCopilotHarnessSwap) {
-			markPreferredCopilotHarness(storageService);
-		}
 		const resource = getNewChatSessionResource(resolved.sessionType);
 
 		// A chat editor can only be open in one group

--- a/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
@@ -6,7 +6,6 @@
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
 export const CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY = 'chat.userSelectedSessionType';
-const CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY = 'chat.preferredCopilotHarness';
 
 export function getRememberedSessionType(storageService: IStorageService): string | undefined {
 	return storageService.get(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
@@ -18,12 +17,4 @@ export function storeUserSelectedSessionType(storageService: IStorageService, se
 
 export function clearUserSelectedSessionType(storageService: IStorageService): void {
 	storageService.remove(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
-}
-
-export function hasPreferredCopilotHarness(storageService: IStorageService): boolean {
-	return storageService.getBoolean(CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY, StorageScope.PROFILE, false);
-}
-
-export function markPreferredCopilotHarness(storageService: IStorageService): void {
-	storageService.store(CHAT_PREFERRED_COPILOT_HARNESS_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
 }

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -16,7 +16,7 @@ import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../comm
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
-import { clearUserSelectedSessionType, getRememberedSessionType, hasPreferredCopilotHarness, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
+import { clearUserSelectedSessionType, getRememberedSessionType, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
 import { IAgentHostEnablementService } from '../../../../platform/agentHost/common/agentHostEnablementService.js';
 
 export { ChatAIDisabledSettingId } from '../../../../platform/chat/common/chatSettings.js';
@@ -348,13 +348,6 @@ export interface IDefaultNewChatSessionTypeOptions {
 export interface IResolvedNewChatSessionType {
 	/** The session type to open for the new chat. */
 	readonly sessionType: string;
-	/**
-	 * True when {@link sessionType} is the one-time `chat.editor.preferCopilotHarness`
-	 * swap. The caller must persist the marker (via `markPreferredCopilotHarness`)
-	 * only once it has actually applied this session type, so the migration is not
-	 * consumed by a caller that discards the result.
-	 */
-	readonly isPreferCopilotHarnessSwap: boolean;
 }
 
 export function getDefaultNewChatSessionType(
@@ -396,33 +389,25 @@ export function resolveDefaultNewChatSessionType(
 	const agentHostEnabled = accessor.get(IAgentHostEnablementService).enabled.get();
 
 	if (options?.explicitOverride) {
-		return { sessionType: options.explicitOverride, isPreferCopilotHarnessSwap: false };
+		return { sessionType: options.explicitOverride };
 	}
 
 	if (isVirtualWorkspace(workspace)) {
-		return { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false };
+		return { sessionType: localChatSessionType };
 	}
 
 	const remembered = getUsableRememberedSessionType(storageService, configurationService, chatSessionsService, workspace);
 	if (remembered && remembered !== localChatSessionType) {
-		return { sessionType: remembered, isPreferCopilotHarnessSwap: false };
+		return { sessionType: remembered };
 	}
 
-	// One-time migration: when the agent host is enabled and the user has opted
-	// in via `chat.editor.preferCopilotHarness`, swap an existing local editor
-	// session to Copilot exactly once (guarded by the persisted marker). Never
-	// swap when the agent host is disabled, since the Copilot harness would be
-	// unavailable. This function does not persist the marker itself; the caller
-	// marks it only after applying the swap, so a caller that discards the
-	// result does not consume the one-time migration.
 	if (options?.currentSessionType === localChatSessionType
 		&& agentHostEnabled
-		&& configurationService.getValue<boolean>(ChatConfiguration.EditorPreferCopilotHarness)
-		&& !hasPreferredCopilotHarness(storageService)) {
-		return { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true };
+		&& configurationService.getValue<boolean>(ChatConfiguration.EditorPreferCopilotHarness)) {
+		return { sessionType: SessionType.AgentHostCopilot };
 	}
 
-	return { sessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, options), isPreferCopilotHarnessSwap: false };
+	return { sessionType: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, workspace, agentHostEnabled, options) };
 }
 
 function getUsableRememberedSessionType(

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -17,7 +17,7 @@ import { ChatConfiguration, ChatPermissionLevel, getChatPermissionLevelFromDefau
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint, IChatSessionsService } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 import { TestContextService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
-import { getRememberedSessionType, hasPreferredCopilotHarness, markPreferredCopilotHarness } from '../../common/chatSessionTypePreference.js';
+import { getRememberedSessionType } from '../../common/chatSessionTypePreference.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 
 suite('ChatConfiguration defaults', () => {
@@ -191,7 +191,7 @@ suite('ChatConfiguration defaults', () => {
 
 		assert.deepStrictEqual(
 			resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.CopilotCLI }),
-			{ sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false }
+			{ sessionType: localChatSessionType }
 		);
 	});
 
@@ -229,7 +229,7 @@ suite('ChatConfiguration defaults', () => {
 		}, {
 			computed: SessionType.AgentHostCopilot,
 			remembered: SessionType.AgentHostClaude,
-			rememberedAware: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
+			rememberedAware: { sessionType: SessionType.AgentHostClaude },
 		});
 	});
 
@@ -269,60 +269,62 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('preferCopilotHarness resolves the swap without consuming the marker until applied', () => {
-		// DefaultToCopilotHarness stays unset so this proves the one-time swap
-		// fires solely because EditorPreferCopilotHarness is enabled, independent
-		// of the new default gate.
+	test('preferCopilotHarness replaces local on every new chat', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
 		const storageService = disposables.add(new TestStorageService());
 
-		// Resolving does not consume the marker on its own: repeated resolves keep
-		// returning the swap until the caller applies it and marks it.
-		const firstResolve = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
-		const markerBeforeApply = hasPreferredCopilotHarness(storageService);
-		const secondResolveBeforeApply = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
-
-		// The caller applies the swap and marks it; further resolves no longer swap.
-		markPreferredCopilotHarness(storageService);
-		const afterApply = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
-
 		assert.deepStrictEqual({
-			firstResolve,
-			markerBeforeApply,
-			secondResolveBeforeApply,
-			afterApply,
-			markerAfterApply: hasPreferredCopilotHarness(storageService),
+			firstResolve: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+			secondResolve: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 		}, {
-			firstResolve: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
-			markerBeforeApply: false,
-			secondResolveBeforeApply: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
-			// Once marked, the one-time swap no longer fires; with no remembered
-			// selection the current local session type is returned.
-			afterApply: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			markerAfterApply: true,
+			firstResolve: { sessionType: SessionType.AgentHostCopilot },
+			secondResolve: { sessionType: SessionType.AgentHostCopilot },
 		});
 	});
 
-	test('one-time Copilot swap is skipped and unmarked when the agent host is disabled', () => {
+	test('Copilot preference is skipped when the agent host is disabled', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
 		const storageService = disposables.add(new TestStorageService());
 
-		// With the agent host disabled (e.g. on web) the swap must not fire, so it
-		// neither returns an unresolvable Copilot type nor marks the transition.
+		// With the agent host disabled (e.g. on web), the Copilot harness is unavailable.
 		const resolved = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, false, { currentSessionType: localChatSessionType });
 
 		assert.deepStrictEqual({
 			resolved,
-			preferenceApplied: hasPreferredCopilotHarness(storageService),
 		}, {
-			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			preferenceApplied: false,
+			resolved: { sessionType: localChatSessionType },
+		});
+	});
+
+	test('preferCopilotHarness preserves Claude and Codex selections', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorPreferCopilotHarness]: true,
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude, SessionType.AgentHostCodex);
+		const storageService = disposables.add(new TestStorageService());
+
+		const currentClaude = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.AgentHostClaude });
+		const currentCodex = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: SessionType.AgentHostCodex });
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostClaude, true);
+		const rememberedClaude = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, SessionType.AgentHostCodex, true);
+
+		assert.deepStrictEqual({
+			currentClaude,
+			currentCodex,
+			rememberedClaude,
+			rememberedCodex: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+		}, {
+			currentClaude: { sessionType: SessionType.AgentHostClaude },
+			currentCodex: { sessionType: SessionType.AgentHostCodex },
+			rememberedClaude: { sessionType: SessionType.AgentHostClaude },
+			rememberedCodex: { sessionType: SessionType.AgentHostCodex },
 		});
 	});
 
@@ -367,7 +369,7 @@ suite('ChatConfiguration defaults', () => {
 		});
 	});
 
-	test('one-time Copilot swap overrides a remembered local opt-out and stays redundant when agent host is enabled', () => {
+	test('Copilot preference overrides a remembered local selection every time', () => {
 		const configurationService = new TestConfigurationService({
 			[ChatConfiguration.DefaultToCopilotHarness]: true,
 			[ChatConfiguration.EditorPreferCopilotHarness]: true,
@@ -378,17 +380,12 @@ suite('ChatConfiguration defaults', () => {
 		// Remember local (only reachable because the computed default is Copilot).
 		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, localWorkspace, localChatSessionType, true);
 
-		// The `remembered !== local` guard lets the one-time swap replace the
-		// remembered local, even though the computed default is already Copilot.
-		// The resolver reports the swap but does not mark it (the caller does).
-		const swapped = resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType });
-
 		assert.deepStrictEqual({
-			swapped,
-			preferenceApplied: hasPreferredCopilotHarness(storageService),
+			firstResolve: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
+			secondResolve: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
 		}, {
-			swapped: { sessionType: SessionType.AgentHostCopilot, isPreferCopilotHarnessSwap: true },
-			preferenceApplied: false,
+			firstResolve: { sessionType: SessionType.AgentHostCopilot },
+			secondResolve: { sessionType: SessionType.AgentHostCopilot },
 		});
 	});
 
@@ -403,10 +400,8 @@ suite('ChatConfiguration defaults', () => {
 		// session type wins over the Copilot computed default (session preservation).
 		assert.deepStrictEqual({
 			resolved: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { currentSessionType: localChatSessionType }),
-			preferenceApplied: hasPreferredCopilotHarness(storageService),
 		}, {
-			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			preferenceApplied: false,
+			resolved: { sessionType: localChatSessionType },
 		});
 	});
 
@@ -423,7 +418,7 @@ suite('ChatConfiguration defaults', () => {
 		assert.deepStrictEqual({
 			resolved: resolveSessionType(configurationService, chatSessionsService, storageService, localWorkspace, true, { explicitOverride: localChatSessionType, currentSessionType: SessionType.AgentHostCopilot }),
 		}, {
-			resolved: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
+			resolved: { sessionType: localChatSessionType },
 		});
 	});
 
@@ -475,10 +470,10 @@ suite('ChatConfiguration defaults', () => {
 			remembered: SessionType.AgentHostClaude,
 			rememberedAware: localChatSessionType,
 			currentAware: localChatSessionType,
-			resolvedRemembered: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			resolvedCurrent: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			resolvedPreferMigration: { sessionType: localChatSessionType, isPreferCopilotHarnessSwap: false },
-			explicitOverride: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
+			resolvedRemembered: { sessionType: localChatSessionType },
+			resolvedCurrent: { sessionType: localChatSessionType },
+			resolvedPreferMigration: { sessionType: localChatSessionType },
+			explicitOverride: { sessionType: SessionType.AgentHostClaude },
 			localVisible: true,
 			localRememberedUsable: true,
 		});
@@ -495,7 +490,7 @@ suite('ChatConfiguration defaults', () => {
 			extensionContributed: isNewChatSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService, localWorkspace),
 		}, {
 			agentHost: true,
-			agentHostCurrent: { sessionType: SessionType.AgentHostClaude, isPreferCopilotHarnessSwap: false },
+			agentHostCurrent: { sessionType: SessionType.AgentHostClaude },
 			extensionContributed: false,
 		});
 	});


### PR DESCRIPTION
## Summary

- apply `chat.editor.preferCopilotHarness` every time Local would be selected
- preserve explicit and remembered Claude or Codex selections
- add and export the `ChatEditorPreferCopilotHarness` enterprise policy

## Validation

- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/constants.test.ts`
- `npm run typecheck-client`
- `npm run export-policy-data`

(Written by Copilot)