### PR TITLE
sessions: allow BYOK Agent Host use while signed out

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostByokLm.ts
+++ b/src/vs/platform/agentHost/common/agentHostByokLm.ts
@@ -171,6 +171,11 @@ export function getByokLmSelectionModelId(model: IByokLmModelInfo): string {
 		: model.id;
 }
 
+/** Returns the provider-qualified model id advertised by the agent host. */
+export function getByokLmAgentModelId(model: IByokLmModelInfo): string {
+	return `${model.vendor}/${getByokLmSelectionModelId(model)}`;
+}
+
 export const IAgentHostByokLmHandler = createDecorator<IAgentHostByokLmHandler>('agentHostByokLmHandler');
 
 /**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -691,6 +691,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// startup changes, disposing any active sessions. These values are applied in
 		// `_ensureClient`, so they only take effect on the next client start.
 		this._register(this._configurationService.onDidRootConfigChange(() => {
+			// Protected-resource optionality depends on the signed-out opt-in.
+			this._publishModels();
 			this._restartClientIfStartupConfigChanged().catch(err =>
 				this._logService.error('[Copilot] Failed to apply root config change', err)
 			);
@@ -1019,8 +1021,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
+		const allowSignedOutWhenUsable = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.AllowSignedOutWhenUsable) === true;
+		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		return [
-			this._gitHubEndpointService.getCopilotResource(),
+			allowSignedOutWhenUsable && this._byokModels.length > 0 ? { ...copilotResource, required: false } : copilotResource,
 			this._gitHubEndpointService.getRepoResource(),
 		];
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -55,7 +55,7 @@ import { ProtectedResourceMetadata, type AgentSelection, type ChildCustomization
 import { ActionType, type SessionAction } from '../../common/state/sessionActions.js';
 import { areAdditionalWorkingDirectoriesEqual } from '../../common/state/sessionWorkingDirectories.js';
 import { AgentCustomization, CustomizationLoadStatus, CustomizationType, RuleCustomization, ChatInputResponseKind, SkillCustomization, customizationId, buildChatUri, buildDefaultChatUri, isDefaultChatUri, parseChatUri, parseRequiredSessionUriFromChatUri, parseSubagentSessionUri, AH_META_WORKSPACELESS_DB_KEY, withSessionEhcliAdoptable, type ChildCustomization, type ClientPluginCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type MessageAttachment, type PendingMessage, type PluginCustomization, type PolicyState, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
-import { getByokLmSelectionModelId } from '../../common/agentHostByokLm.js';
+import { getByokLmAgentModelId } from '../../common/agentHostByokLm.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
@@ -1436,7 +1436,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const thinkingLevel = this._createThinkingLevelConfigSchemaProperty(m.supportedReasoningEfforts, m.defaultReasoningEffort, m.id);
 			return {
 				provider: this.id,
-				id: `${m.vendor}/${getByokLmSelectionModelId(m)}`,
+				id: getByokLmAgentModelId(m),
 				name: m.name ?? m.id,
 				maxContextWindow: m.maxContextWindowTokens,
 				supportsVision: m.supportsVision ?? false,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -691,8 +691,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// startup changes, disposing any active sessions. These values are applied in
 		// `_ensureClient`, so they only take effect on the next client start.
 		this._register(this._configurationService.onDidRootConfigChange(() => {
-			// Protected-resource optionality depends on the signed-out opt-in.
-			this._publishModels();
 			this._restartClientIfStartupConfigChanged().catch(err =>
 				this._logService.error('[Copilot] Failed to apply root config change', err)
 			);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -2694,6 +2694,9 @@ suite('CopilotAgent', () => {
 			modelSnapshots.fire([{ vendor: 'gemini', id: 'gemini-2.5-pro', modelIdentifier: 'gemini/Gemini/gemini-2.5-pro' }]);
 			await waitForState(agent.models, models => models.length === 1);
 			const optionalWithByok = copilotRequired();
+			modelSnapshots.fire([]);
+			await waitForState(agent.models, models => models.length === 0);
+			const requiredAfterHide = copilotRequired();
 			configurationService.updateRootConfig({ [AgentHostConfigKey.AllowSignedOutWhenUsable]: false });
 			const requiredAfterDisable = copilotRequired();
 
@@ -2701,11 +2704,13 @@ suite('CopilotAgent', () => {
 				initiallyRequired,
 				requiredWithoutByok,
 				optionalWithByok,
+				requiredAfterHide,
 				requiredAfterDisable,
 			}, {
 				initiallyRequired: true,
 				requiredWithoutByok: true,
 				optionalWithByok: false,
+				requiredAfterHide: true,
 				requiredAfterDisable: true,
 			});
 		} finally {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -33,6 +33,7 @@ import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService, NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
+import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
 import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
@@ -2669,6 +2670,44 @@ suite('CopilotAgent', () => {
 				{ id: 'acme/valid-default', thinkingLevel: { enum: ['low', 'medium', 'high'], default: 'medium' } },
 				{ id: 'acme/minimal-only', thinkingLevel: { enum: ['minimal'], default: 'minimal' } },
 			]);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('BYOK models make Copilot authentication optional only while signed-out operation is enabled', async () => {
+		const byokBridgeRegistry = new ByokLmBridgeRegistry();
+		const { agent, configurationService } = createTestAgentContext(disposables, { byokBridgeRegistry });
+		const modelSnapshots = disposables.add(new Emitter<IByokLmModelInfo[]>());
+		const connection: IByokLmBridgeConnection = {
+			chat: async () => ({ output: [] }),
+			onDidChangeModels: modelSnapshots.event,
+		};
+		disposables.add(byokBridgeRegistry.register('renderer', connection));
+		const copilotRequired = () => agent.getProtectedResources()
+			.find(resource => resource.resource === GITHUB_COPILOT_PROTECTED_RESOURCE.resource)?.required !== false;
+
+		try {
+			const initiallyRequired = copilotRequired();
+			configurationService.updateRootConfig({ [AgentHostConfigKey.AllowSignedOutWhenUsable]: true });
+			const requiredWithoutByok = copilotRequired();
+			modelSnapshots.fire([{ vendor: 'gemini', id: 'gemini-2.5-pro', modelIdentifier: 'gemini/Gemini/gemini-2.5-pro' }]);
+			await waitForState(agent.models, models => models.length === 1);
+			const optionalWithByok = copilotRequired();
+			configurationService.updateRootConfig({ [AgentHostConfigKey.AllowSignedOutWhenUsable]: false });
+			const requiredAfterDisable = copilotRequired();
+
+			assert.deepStrictEqual({
+				initiallyRequired,
+				requiredWithoutByok,
+				optionalWithByok,
+				requiredAfterDisable,
+			}, {
+				initiallyRequired: true,
+				requiredWithoutByok: true,
+				optionalWithByok: false,
+				requiredAfterDisable: true,
+			});
 		} finally {
 			await disposeAgent(agent);
 		}

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -20,6 +20,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { SessionTypePicker, ISessionTypePickerOptions } from '../sessionTypePicker.js';
 import { isPhoneLayout } from '../../../../browser/parts/mobile/mobileLayout.js';
 import { IMobilePickerSheetItem, showMobilePickerSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 /**
  * Phone variant of {@link SessionTypePicker} that renders the picker as
@@ -45,10 +46,11 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@IChatEntitlementService chatEntitlementService: IChatEntitlementService,
 		@ILanguageModelsService languageModelsService: ILanguageModelsService,
+		@IConfigurationService configurationService: IConfigurationService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
-		super(session, options, actionWidgetService, sessionsManagementService, _sessionsProvidersService, storageService, telemetryService, chatSessionsService, chatEntitlementService, languageModelsService, contextKeyService);
+		super(session, options, actionWidgetService, sessionsManagementService, _sessionsProvidersService, storageService, telemetryService, chatSessionsService, chatEntitlementService, languageModelsService, configurationService, contextKeyService);
 	}
 
 	override render(container: HTMLElement, options?: { className?: string }): void {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -10,6 +10,7 @@ import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '..
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { IProviderSessionType, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -24,11 +25,12 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
-import { getSessionTypeAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../../../workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability.js';
+import { getSessionTypeAvailability, getSessionTypePickerAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../../../workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability.js';
 import { IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { markOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 import { SessionHarnessPickerVisibleContext } from '../../../common/contextkeys.js';
+import { isAllowSignedOutWhenUsableEnabled } from '../../../browser/sessionsAuthGate.js';
 
 const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.userSelectedSessionType';
 
@@ -164,6 +166,7 @@ export class SessionTypePicker extends Disposable {
 		@IChatSessionsService protected readonly chatSessionsService: IChatSessionsService,
 		@IChatEntitlementService protected readonly chatEntitlementService: IChatEntitlementService,
 		@ILanguageModelsService protected readonly languageModelsService: ILanguageModelsService,
+		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
@@ -453,7 +456,13 @@ export class SessionTypePicker extends Disposable {
 			}
 			for (const { providerId, sessionType } of types) {
 				const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
-				const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
+				const modelTarget = sessionType.chatSessionType ?? sessionType.id;
+				const allowSignedOutWhenUsable = isAllowSignedOutWhenUsableEnabled(this.configurationService);
+				const availability = getSessionTypePickerAvailability(
+					modelTarget,
+					getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, modelTarget, allowSignedOutWhenUsable),
+					allowSignedOutWhenUsable,
+				);
 				const unavailable = availability !== SessionTypeAvailability.Available;
 				const item: ISessionTypePickerItem = {
 					providerId,

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -11,6 +11,8 @@ import { autorun, constObservable, ISettableObservable, observableValue } from '
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -134,6 +136,7 @@ function createPicker(
 		getLanguageModelIds: () => [],
 		lookupLanguageModel: () => undefined,
 	});
+	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
 	return disposables.add(instantiationService.createInstance(TestSessionTypePicker, session, options));
 }
@@ -143,6 +146,7 @@ function createPicker(
 suite('SessionTypePicker', () => {
 
 	const disposables = new DisposableStore();
+
 	const folder = URI.file('/project');
 
 	let management: MockSessionsManagementService;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostByokLmHandler.ts
@@ -9,6 +9,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { decodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import {
 	ByokLmImageMimeType,
+	getByokLmAgentModelId,
 	IAgentHostByokLmHandler,
 	IByokLmChatRequest,
 	IByokLmChatResult,
@@ -29,6 +30,7 @@ import {
 	ILanguageModelChatRequestOptions,
 	ILanguageModelsService,
 } from '../../../common/languageModels.js';
+import { SessionType } from '../../../common/chatSessionsService.js';
 
 const STATEFUL_MARKER_MIME_TYPE = 'stateful_marker';
 const USAGE_MIME_TYPE = 'usage';
@@ -62,6 +64,9 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 		// agent host can refresh its BYOK model list — extension-provided BYOK models
 		// often register shortly after the bridge connects.
 		this._register(Event.debounce(this._languageModelsService.onDidChangeLanguageModels, () => undefined, 500)(() => {
+			this._onDidChangeModels.fire();
+		}));
+		this._register(this._languageModelsService.onDidChangeModelVisibility(() => {
 			this._onDidChangeModels.fire();
 		}));
 		this._register(Event.filter(contextKeyService.onDidChangeContext, event => event.affectsSome(CLIENT_BYOK_CONTEXT_KEYS))(() => {
@@ -159,7 +164,7 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 				const reasoningEffortSchema = metadata.configurationSchema?.properties?.reasoningEffort;
 				const supportedReasoningEfforts = reasoningEffortSchema?.enum?.filter((value): value is string => typeof value === 'string');
 				const defaultReasoningEffort = typeof reasoningEffortSchema?.default === 'string' ? reasoningEffortSchema.default : undefined;
-				models.push({
+				const model: IByokLmModelInfo = {
 					vendor: metadata.vendor,
 					id: metadata.id,
 					name: metadata.name,
@@ -168,7 +173,11 @@ export class AgentHostByokLmHandler extends Disposable implements IAgentHostByok
 					supportsVision: !!metadata.capabilities?.vision,
 					...(supportedReasoningEfforts?.length ? { supportedReasoningEfforts } : {}),
 					...(defaultReasoningEffort !== undefined ? { defaultReasoningEffort } : {}),
-				});
+				};
+				const agentHostModelIdentifier = `${SessionType.AgentHostCopilot}:${getByokLmAgentModelId(model)}`;
+				if (!this._languageModelsService.isModelHidden(identifier) && !this._languageModelsService.isModelHidden(agentHostModelIdentifier)) {
+					models.push(model);
+				}
 			}
 		}
 		return models;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability.ts
@@ -6,7 +6,7 @@
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { localize } from '../../../../../nls.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
-import { IChatSessionsService } from '../../common/chatSessionsService.js';
+import { IChatSessionsService, SessionType } from '../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 
 /**
@@ -16,12 +16,18 @@ import { ILanguageModelsService } from '../../common/languageModels.js';
 export enum SessionTypeAvailability {
 	/** Selectable — has an Auto fallback or at least one targeted/BYOK model. */
 	Available,
-	/** Unusable until the user signs in (the type needs a Copilot account; BYOK is not supported here). */
+	/** Unusable until the user signs in (the type needs a Copilot account and has no visible Agent Host BYOK model). */
 	SignInRequired,
 	/** Unusable, but the user can resolve it by upgrading (Copilot Free / Student). */
 	UpgradeRequired,
 	/** Unusable with no upgrade path — no models target it and the user is already on a paid plan. */
 	NoModels,
+}
+
+export function getSessionTypePickerAvailability(type: string, availability: SessionTypeAvailability, allowSignedOutWhenUsable: boolean): SessionTypeAvailability {
+	return allowSignedOutWhenUsable && type === SessionType.AgentHostCopilot && availability === SessionTypeAvailability.SignInRequired
+		? SessionTypeAvailability.Available
+		: availability;
 }
 
 /**
@@ -39,8 +45,9 @@ export enum SessionTypeAvailability {
  * explanation with no upgrade button. A signed-out user gets a Sign-in
  * affordance ({@link SessionTypeAvailability.SignInRequired}) for Copilot-backed
  * types ({@link IChatSessionsService.requiresCopilotSignInForSessionType}), unless
- * anonymous access is enabled; types that don't depend on Copilot stay usable
- * while signed out. Unavailable types are greyed out in the picker either way.
+ * anonymous access is enabled or a visible Agent Host BYOK model targets the type.
+ * Types that don't depend on Copilot stay usable while signed out. Unavailable
+ * types are greyed out in the picker either way.
  *
  * While the type's contribution isn't registered yet (e.g. during a window
  * reload before the extension host re-registers), this returns
@@ -56,21 +63,23 @@ export function getSessionTypeAvailability(
 	chatEntitlementService: IChatEntitlementService,
 	languageModelsService: ILanguageModelsService,
 	type: string,
+	allowSignedOutWhenUsable = false,
 ): SessionTypeAvailability {
 	// Contribution loads asynchronously; while missing (e.g. during a reload) we
 	// can't judge the type, so stay selectable to avoid locking it prematurely.
 	if (!chatSessionsService.getChatSessionContribution(type)) {
 		return SessionTypeAvailability.Available;
 	}
-	// Copilot-backed types need a Copilot account (BYOK isn't supported here), so a signed-out user can't use them —
-	// unless anonymous access is enabled, which grants access without signing in.
 	const entitlement = chatEntitlementService.entitlement;
-	if (entitlement === ChatEntitlement.Unknown && !chatEntitlementService.anonymous && chatSessionsService.requiresCopilotSignInForSessionType(type)) {
+	const hasTargetedModels = hasModelsTargetingSessionType(languageModelsService, type);
+	const hasVisibleByokModels = allowSignedOutWhenUsable && chatEntitlementService.clientByokEnabled && hasVisibleByokModelsTargetingSessionType(languageModelsService, type);
+	// A visible Agent Host BYOK model can run without a Copilot account.
+	if (entitlement === ChatEntitlement.Unknown && !chatEntitlementService.anonymous && chatSessionsService.requiresCopilotSignInForSessionType(type) && !hasVisibleByokModels) {
 		return SessionTypeAvailability.SignInRequired;
 	}
 	// Signed in: a model targeting the type (e.g. BYOK) or an "Auto" fallback
 	// (e.g. the Copilot CLI harness) makes it usable.
-	if (hasModelsTargetingSessionType(languageModelsService, type) || chatSessionsService.supportsAutoModelForSessionType(type)) {
+	if (hasTargetedModels || chatSessionsService.supportsAutoModelForSessionType(type)) {
 		return SessionTypeAvailability.Available;
 	}
 	// No Auto fallback and no targeted models: Free / Student users must upgrade
@@ -95,6 +104,19 @@ function hasModelsTargetingSessionType(languageModelsService: ILanguageModelsSer
 	return languageModelsService.getLanguageModelIds().some(id => {
 		const metadata = languageModelsService.lookupLanguageModel(id);
 		return metadata?.targetChatSessionType === type;
+	});
+}
+
+export function hasVisibleByokModelsTargetingSessionType(languageModelsService: ILanguageModelsService, type: string): boolean {
+	return languageModelsService.getLanguageModelIds().some(id => {
+		const metadata = languageModelsService.lookupLanguageModel(id);
+		const byokIdentifier = metadata?.byokModelIdentifier;
+		const byokSource = byokIdentifier ? languageModelsService.lookupLanguageModel(byokIdentifier) : undefined;
+		return metadata?.targetChatSessionType === type
+			&& byokIdentifier !== undefined
+			&& byokSource?.isBYOK === true
+			&& !languageModelsService.isModelHidden(id)
+			&& !languageModelsService.isModelHidden(byokIdentifier);
 	});
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -24,12 +24,13 @@ import { IStorageService } from '../../../../../../platform/storage/common/stora
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IAgentHostEnablementService } from '../../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { AgentSessionProviders, AgentSessionTarget, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
-import { getSessionTypeAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../agentSessions/sessionTypeAvailability.js';
+import { getSessionTypeAvailability, getSessionTypePickerAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../agentSessions/sessionTypeAvailability.js';
 import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../../common/constants.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { ISessionTypePickerDelegate } from '../../chat.js';
@@ -114,7 +115,12 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 				const actions: IActionWidgetDropdownAction[] = [...this._getAdditionalActions().map(a => ({ ...action, ...a }))];
 				for (const sessionTypeItem of this._sessionTypeItems) {
-					const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionTypeItem.type);
+					const allowSignedOutWhenUsable = this._isSessionsWindow && this.configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true;
+					const availability = getSessionTypePickerAvailability(
+						sessionTypeItem.type,
+						getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionTypeItem.type, allowSignedOutWhenUsable),
+						allowSignedOutWhenUsable,
+					);
 					actions.push(createSessionTypePickerAction(
 						action,
 						sessionTypeItem,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostByokLmHandler.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { Event } from '../../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
@@ -17,6 +17,7 @@ import { ContextKeyService } from '../../../../../../platform/contextkey/browser
 import { IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ChatEntitlementContextKeys, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { AgentHostByokLmHandler } from '../../../browser/agentSessions/agentHost/agentHostByokLmHandler.js';
+import { SessionType } from '../../../common/chatSessionsService.js';
 import { ChatMessageRole, IChatMessage, IChatResponsePart, ILanguageModelChatMetadata, ILanguageModelChatRequestOptions, ILanguageModelChatResponse, ILanguageModelsService } from '../../../common/languageModels.js';
 
 interface ICapturedRequest {
@@ -36,12 +37,16 @@ class TestLanguageModelsService extends mock<ILanguageModelsService>() {
 	captured: ICapturedRequest | undefined;
 
 	override readonly onDidChangeLanguageModels = Event.None;
+	override readonly onDidChangeModelVisibility: Event<void>;
 
 	constructor(
 		private readonly _models: ReadonlyMap<string, ILanguageModelChatMetadata>,
 		private readonly _respond: (request: ICapturedRequest) => ILanguageModelChatResponse,
+		onDidChangeModelVisibility = Event.None,
+		private readonly _isModelHidden: (identifier: string) => boolean = () => false,
 	) {
 		super();
+		this.onDidChangeModelVisibility = onDidChangeModelVisibility;
 	}
 
 	override getLanguageModelIds(): string[] {
@@ -50,6 +55,10 @@ class TestLanguageModelsService extends mock<ILanguageModelsService>() {
 
 	override lookupLanguageModel(modelId: string): ILanguageModelChatMetadata | undefined {
 		return this._models.get(modelId);
+	}
+
+	override isModelHidden(identifier: string): boolean {
+		return this._isModelHidden(identifier);
 	}
 
 	override async sendChatRequest(modelId: string, _from: ExtensionIdentifier | undefined, messages: IChatMessage[], options: ILanguageModelChatRequestOptions, _token: CancellationToken): Promise<ILanguageModelChatResponse> {
@@ -186,6 +195,62 @@ suite('AgentHostByokLmHandler', () => {
 			{ vendor: 'openrouter', id: 'ai21/jamba-large-1.7', name: 'openrouter ai21/jamba-large-1.7', modelIdentifier: groupedId, maxContextWindowTokens: 2000, supportsVision: false },
 			{ vendor: 'openrouter', id: 'gpt-4', name: 'openrouter gpt-4', modelIdentifier: 'openrouter/gpt-4', maxContextWindowTokens: 2000, supportsVision: false },
 		]);
+	});
+
+	test('listModels excludes hidden BYOK sources and Agent Host copies', async () => {
+		const sourceIdentifier = 'openrouter/OpenRouter 2/ai21/jamba-large-1.7';
+		const agentHostIdentifier = `${SessionType.AgentHostCopilot}:openrouter/OpenRouter 2/ai21/jamba-large-1.7`;
+		const hidden = new Set<string>();
+		const visibilityChanges = store.add(new Emitter<void>());
+		const service = new TestLanguageModelsService(
+			new Map([[sourceIdentifier, byokModel('openrouter', 'ai21/jamba-large-1.7')]]),
+			() => responseOf([]),
+			visibilityChanges.event,
+			identifier => hidden.has(identifier),
+		);
+		const handler = createHandler(service);
+		let modelChangeCount = 0;
+		store.add(handler.onDidChangeModels(() => modelChangeCount++));
+
+		const visibleModels = await handler.listModels(CancellationToken.None);
+		hidden.add(sourceIdentifier);
+		visibilityChanges.fire();
+		const sourceHiddenModels = await handler.listModels(CancellationToken.None);
+		hidden.delete(sourceIdentifier);
+		hidden.add(agentHostIdentifier);
+		visibilityChanges.fire();
+		const copyHiddenModels = await handler.listModels(CancellationToken.None);
+		hidden.clear();
+		visibilityChanges.fire();
+		const restoredModels = await handler.listModels(CancellationToken.None);
+
+		assert.deepStrictEqual({
+			modelChangeCount,
+			visibleModels,
+			sourceHiddenModels,
+			copyHiddenModels,
+			restoredModels,
+		}, {
+			modelChangeCount: 3,
+			visibleModels: [{
+				vendor: 'openrouter',
+				id: 'ai21/jamba-large-1.7',
+				name: 'openrouter ai21/jamba-large-1.7',
+				modelIdentifier: sourceIdentifier,
+				maxContextWindowTokens: 2000,
+				supportsVision: false,
+			}],
+			sourceHiddenModels: [],
+			copyHiddenModels: [],
+			restoredModels: [{
+				vendor: 'openrouter',
+				id: 'ai21/jamba-large-1.7',
+				name: 'openrouter ai21/jamba-large-1.7',
+				modelIdentifier: sourceIdentifier,
+				maxContextWindowTokens: 2000,
+				supportsVision: false,
+			}],
+		});
 	});
 
 	test('listModels carries string reasoning effort metadata from renderer BYOK schemas', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/sessionTypeAvailability.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/sessionTypeAvailability.test.ts
@@ -7,8 +7,8 @@ import assert from 'assert';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
-import { getSessionTypeAvailability, SessionTypeAvailability } from '../../../browser/agentSessions/sessionTypeAvailability.js';
-import { IChatSessionsService, ResolvedChatSessionsExtensionPoint } from '../../../common/chatSessionsService.js';
+import { getSessionTypeAvailability, getSessionTypePickerAvailability, SessionTypeAvailability } from '../../../browser/agentSessions/sessionTypeAvailability.js';
+import { IChatSessionsService, ResolvedChatSessionsExtensionPoint, SessionType } from '../../../common/chatSessionsService.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../common/languageModels.js';
 
 interface ITypeConfig {
@@ -24,33 +24,36 @@ interface ITypeConfig {
 
 const TYPE = 'agent-host-test';
 
-function createChatSessionsService(config: ITypeConfig): IChatSessionsService {
+function createChatSessionsService(config: ITypeConfig, sessionType = TYPE): IChatSessionsService {
 	return new class extends mock<IChatSessionsService>() {
 		override supportsAutoModelForSessionType(type: string): boolean {
-			return type === TYPE ? config.supportsAutoModel : false;
+			return type === sessionType ? config.supportsAutoModel : false;
 		}
 		override requiresCustomModelsForSessionType(type: string): boolean {
-			return type === TYPE ? config.requiresCustomModels : false;
+			return type === sessionType ? config.requiresCustomModels : false;
 		}
 		override requiresCopilotSignInForSessionType(type: string): boolean {
-			return type === TYPE ? !!config.requiresCopilotSignIn : false;
+			return type === sessionType ? !!config.requiresCopilotSignIn : false;
 		}
 		override getChatSessionContribution(type: string): ResolvedChatSessionsExtensionPoint | undefined {
-			if (type === TYPE && config.registered) {
-				return { type: TYPE, name: TYPE, displayName: TYPE, description: '', icon: undefined };
+			if (type === sessionType && config.registered) {
+				return { type: sessionType, name: sessionType, displayName: sessionType, description: '', icon: undefined };
 			}
 			return undefined;
 		}
 	}();
 }
 
-function createEntitlementService(entitlement: ChatEntitlement, anonymous = false): IChatEntitlementService {
+function createEntitlementService(entitlement: ChatEntitlement, anonymous = false, clientByokEnabled = true): IChatEntitlementService {
 	return new class extends mock<IChatEntitlementService>() {
 		override get entitlement(): ChatEntitlement {
 			return entitlement;
 		}
 		override get anonymous(): boolean {
 			return anonymous;
+		}
+		override get clientByokEnabled(): boolean {
+			return clientByokEnabled;
 		}
 	}();
 }
@@ -69,12 +72,51 @@ function createLanguageModelsService(targets: readonly (string | undefined)[]): 
 			}
 			return { targetChatSessionType: targets[index] } as ILanguageModelChatMetadata;
 		}
+		override isModelHidden(): boolean {
+			return false;
+		}
+	}();
+}
+
+function createByokLanguageModelsService(type: string, hidden: readonly string[] = [], sourceRegistered = true): ILanguageModelsService {
+	const sourceIdentifier = 'gemini/gemini-2.5-flash';
+	return new class extends mock<ILanguageModelsService>() {
+		override getLanguageModelIds(): string[] {
+			return sourceRegistered ? ['agent-host-byok', sourceIdentifier] : ['agent-host-byok'];
+		}
+		override lookupLanguageModel(identifier: string): ILanguageModelChatMetadata | undefined {
+			if (identifier === 'agent-host-byok') {
+				return { targetChatSessionType: type, byokModelIdentifier: sourceIdentifier } as ILanguageModelChatMetadata;
+			}
+			if (identifier === sourceIdentifier && sourceRegistered) {
+				return { isBYOK: true } as ILanguageModelChatMetadata;
+			}
+			return undefined;
+		}
+		override isModelHidden(identifier: string): boolean {
+			return hidden.includes(identifier);
+		}
 	}();
 }
 
 suite('getSessionTypeAvailability', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Copilot Agent Host remains setup-selectable when signed-out operation is enabled', () => {
+		const pickerAvailability = (type: string, allowSignedOutWhenUsable: boolean) => getSessionTypePickerAvailability(type, SessionTypeAvailability.SignInRequired, allowSignedOutWhenUsable);
+		assert.deepStrictEqual({
+			localCopilot: pickerAvailability(SessionType.AgentHostCopilot, true),
+			localClaude: pickerAvailability(SessionType.AgentHostClaude, true),
+			localDisabled: pickerAvailability(SessionType.AgentHostCopilot, false),
+			legacyCopilot: pickerAvailability(SessionType.CopilotCLI, true),
+		}, {
+			localCopilot: SessionTypeAvailability.Available,
+			localClaude: SessionTypeAvailability.SignInRequired,
+			localDisabled: SessionTypeAvailability.SignInRequired,
+			legacyCopilot: SessionTypeAvailability.SignInRequired,
+		});
+	});
 
 	function availability(config: ITypeConfig, entitlement: ChatEntitlement, modelTargets: readonly (string | undefined)[] = [], anonymous = false): SessionTypeAvailability {
 		return getSessionTypeAvailability(
@@ -102,6 +144,28 @@ suite('getSessionTypeAvailability', () => {
 		// e.g. an agent host Claude harness: supportsAutoModel=false, requiresCustomModels=true.
 		const config: ITypeConfig = { registered: true, supportsAutoModel: false, requiresCustomModels: true, requiresCopilotSignIn: true };
 		assert.strictEqual(availability(config, ChatEntitlement.Unknown), SessionTypeAvailability.SignInRequired);
+	});
+
+	test('local Agent Host Copilot and Claude require sign-in without a usable BYOK model', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: false, requiresCustomModels: true, requiresCopilotSignIn: true };
+		const getAvailability = (type: string, entitlement: ChatEntitlement) => getSessionTypeAvailability(
+			createChatSessionsService(config, type),
+			createEntitlementService(entitlement),
+			createLanguageModelsService([]),
+			type,
+		);
+
+		assert.deepStrictEqual({
+			signedOutCopilot: getAvailability(SessionType.AgentHostCopilot, ChatEntitlement.Unknown),
+			signedOutClaude: getAvailability(SessionType.AgentHostClaude, ChatEntitlement.Unknown),
+			freeClaude: getAvailability(SessionType.AgentHostClaude, ChatEntitlement.Free),
+			proClaude: getAvailability(SessionType.AgentHostClaude, ChatEntitlement.Pro),
+		}, {
+			signedOutCopilot: SessionTypeAvailability.SignInRequired,
+			signedOutClaude: SessionTypeAvailability.SignInRequired,
+			freeClaude: SessionTypeAvailability.UpgradeRequired,
+			proClaude: SessionTypeAvailability.NoModels,
+		});
 	});
 
 	test('signed-out user must sign in for a delegation type (e.g. Cloud)', () => {
@@ -134,10 +198,71 @@ suite('getSessionTypeAvailability', () => {
 	});
 
 	test('a targeting model does NOT override sign-in for a Copilot-backed type', () => {
-		// BYOK is not supported in the agent host / Copilot CLI, so a stale/cached
-		// Copilot model still targeting the type must not unlock it when signed out.
+		// A native/CAPI model also targets the harness, but still needs Copilot auth.
 		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
 		assert.strictEqual(availability(config, ChatEntitlement.Unknown, [TYPE]), SessionTypeAvailability.SignInRequired);
+	});
+
+	test('a visible Agent Host BYOK model overrides sign-in for a Copilot-backed type', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
+		assert.strictEqual(getSessionTypeAvailability(
+			createChatSessionsService(config),
+			createEntitlementService(ChatEntitlement.Unknown),
+			createByokLanguageModelsService(TYPE),
+			TYPE,
+			true,
+		), SessionTypeAvailability.Available);
+	});
+
+	test('an Agent Host BYOK model does not override sign-in when signed-out operation is disabled', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
+		assert.strictEqual(getSessionTypeAvailability(
+			createChatSessionsService(config),
+			createEntitlementService(ChatEntitlement.Unknown),
+			createByokLanguageModelsService(TYPE),
+			TYPE,
+			false,
+		), SessionTypeAvailability.SignInRequired);
+	});
+
+	test('an Agent Host BYOK model does not override sign-in when client BYOK is disabled', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
+		assert.strictEqual(getSessionTypeAvailability(
+			createChatSessionsService(config),
+			createEntitlementService(ChatEntitlement.Unknown, false, false),
+			createByokLanguageModelsService(TYPE),
+			TYPE,
+			true,
+		), SessionTypeAvailability.SignInRequired);
+	});
+
+	test('a hidden Agent Host BYOK copy or source model does not override sign-in', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
+		const availabilityForHidden = (hidden: readonly string[]) => getSessionTypeAvailability(
+			createChatSessionsService(config),
+			createEntitlementService(ChatEntitlement.Unknown),
+			createByokLanguageModelsService(TYPE, hidden),
+			TYPE,
+			true,
+		);
+		assert.deepStrictEqual({
+			copyHidden: availabilityForHidden(['agent-host-byok']),
+			sourceHidden: availabilityForHidden(['gemini/gemini-2.5-flash']),
+		}, {
+			copyHidden: SessionTypeAvailability.SignInRequired,
+			sourceHidden: SessionTypeAvailability.SignInRequired,
+		});
+	});
+
+	test('a stale Agent Host BYOK copy does not override sign-in after its source is removed', () => {
+		const config: ITypeConfig = { registered: true, supportsAutoModel: true, requiresCustomModels: true, requiresCopilotSignIn: true };
+		assert.strictEqual(getSessionTypeAvailability(
+			createChatSessionsService(config),
+			createEntitlementService(ChatEntitlement.Unknown),
+			createByokLanguageModelsService(TYPE, [], false),
+			TYPE,
+			true,
+		), SessionTypeAvailability.SignInRequired);
 	});
 
 	test('a targeting model keeps the type available on a paid plan', () => {


### PR DESCRIPTION
## Summary

- Opens the Agents window for signed-out users when the existing experimental opt-in is enabled, then asks for GitHub sign-in only when the selected session type needs it.
- Lets visible client BYOK models keep Copilot-backed Agent Host types usable without a Copilot account.
- Preserves mandatory sign-in when the opt-in is disabled and ignores hidden, disabled, or stale BYOK models.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

The window-level authentication gate combined the opt-in setting with asynchronously discovered session-type readiness. Agent Host types register after restoration, so a signed-out startup could show the non-dismissible sign-in flow before a usable provider appeared. The gate also duplicated the per-type availability decision already used by session pickers.

The intended split is for the window gate to follow the opt-in alone and for each session type to enforce its own authentication requirements when selected.

### Implementation

The Sessions window observes only `chat.agentHost.allowSignedOutWhenUsable` when deciding whether to force GitHub sign-in. Account presentation follows the same setting, while mobile keeps the signed-out path disabled because the native Agent Host is unavailable there.

Session-type availability now recognizes a visible Agent Host model backed by a visible client BYOK source. This exception applies only when signed-out operation and client BYOK are both enabled. Picker-specific handling keeps the Copilot Agent Host setup entry selectable while signed out so users can reach BYOK configuration.

The Copilot Agent Host marks its Copilot protected resource optional when the opt-in is enabled and renderer BYOK models are present. Root configuration changes republish models so protected-resource metadata tracks setting changes without restarting the window.

### Behavior and constraints

- The default setting remains off, preserving the existing mandatory GitHub sign-in flow.
- Copilot-backed types without a qualifying BYOK model still require sign-in.
- Hidden model copies, hidden BYOK sources, removed sources, and disabled client BYOK do not unlock a type.
- Non-Copilot session types and anonymous access retain their existing availability behavior.
- The window-level decision no longer waits for provider readiness; provider-specific usability remains an on-demand picker decision.

### Review context

The main review boundary is consistency between the window gate, picker availability, and Agent Host protected-resource metadata as the setting and model catalog change at runtime.

</details>