### PR TITLE
[cherry-pick] agentHost: avoid deprecated URL parsing

### DIFF
--- a/src/vs/platform/agentHost/node/webSocketTransport.ts
+++ b/src/vs/platform/agentHost/node/webSocketTransport.ts
@@ -19,7 +19,6 @@ import { JSON_RPC_PARSE_ERROR, type AhpServerNotification, type JsonRpcNotificat
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
 import type * as wsTypes from 'ws';
 import type * as httpTypes from 'http';
-import type * as urlTypes from 'url';
 
 /**
  * Options for creating a {@link WebSocketProtocolServer}.
@@ -106,7 +105,7 @@ export class WebSocketProtocolTransport extends Disposable implements IProtocolT
  * as an {@link IProtocolTransport}.
  *
  * Use the static {@link create} method to construct — it dynamically imports
- * `ws` and `http`/`url` so the modules are only loaded when needed.
+ * `ws` and `http` so the modules are only loaded when needed.
  */
 export class WebSocketProtocolServer extends Disposable implements IProtocolServer {
 
@@ -148,20 +147,19 @@ export class WebSocketProtocolServer extends Disposable implements IProtocolServ
 	}
 
 	/**
-	 * Creates a new WebSocket protocol server. Dynamically imports `ws`,
-	 * `http`, and `url` so callers don't pay the cost when unused.
+	 * Creates a new WebSocket protocol server. Dynamically imports `ws` and
+	 * `http` so callers don't pay the cost when unused.
 	 */
 	static async create(
 		options: IWebSocketServerOptions | number,
 		logService: ILogService,
 		ahpLogOptions?: { readonly instantiationService: IInstantiationService; readonly logsHome: URI },
 	): Promise<WebSocketProtocolServer> {
-		const [ws, http, url] = await Promise.all([
+		const [ws, http] = await Promise.all([
 			import('ws'),
 			import('http'),
-			import('url'),
 		]);
-		return new WebSocketProtocolServer(options, logService, ahpLogOptions, ws, http, url);
+		return new WebSocketProtocolServer(options, logService, ahpLogOptions, ws, http);
 	}
 
 	private constructor(
@@ -170,7 +168,6 @@ export class WebSocketProtocolServer extends Disposable implements IProtocolServ
 		private readonly _ahpLogOptions: { readonly instantiationService: IInstantiationService; readonly logsHome: URI } | undefined,
 		ws: typeof wsTypes,
 		http: typeof httpTypes,
-		url: typeof urlTypes,
 	) {
 		super();
 
@@ -182,8 +179,8 @@ export class WebSocketProtocolServer extends Disposable implements IProtocolServ
 
 		const verifyClient = opts.connectionTokenValidate
 			? (info: { req: httpTypes.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void) => {
-				const parsedUrl = url.parse(info.req.url ?? '', true);
-				const token = parsedUrl.query[connectionTokenQueryName];
+				const tokens = new URL(info.req.url ?? '', 'http://localhost').searchParams.getAll(connectionTokenQueryName);
+				const token = tokens.length > 1 ? tokens : tokens[0];
 				if (!opts.connectionTokenValidate!(token)) {
 					this._logService.warn('[WebSocketProtocol] Connection rejected: invalid connection token');
 					cb(false, 403, 'Forbidden');

--- a/src/vs/platform/agentHost/node/webSocketTransport.ts
+++ b/src/vs/platform/agentHost/node/webSocketTransport.ts
@@ -179,7 +179,14 @@ export class WebSocketProtocolServer extends Disposable implements IProtocolServ
 
 		const verifyClient = opts.connectionTokenValidate
 			? (info: { req: httpTypes.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void) => {
-				const tokens = new URL(info.req.url ?? '', 'http://localhost').searchParams.getAll(connectionTokenQueryName);
+				let tokens: string[];
+				try {
+					tokens = new URL(info.req.url ?? '', 'http://localhost').searchParams.getAll(connectionTokenQueryName);
+				} catch {
+					this._logService.warn('[WebSocketProtocol] Connection rejected: invalid request URL');
+					cb(false, 400, 'Bad Request');
+					return;
+				}
 				const token = tokens.length > 1 ? tokens : tokens[0];
 				if (!opts.connectionTokenValidate!(token)) {
 					this._logService.warn('[WebSocketProtocol] Connection rejected: invalid connection token');

--- a/src/vs/platform/agentHost/test/node/webSocketTransport.test.ts
+++ b/src/vs/platform/agentHost/test/node/webSocketTransport.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as net from 'net';
 import type * as wsTypes from 'ws';
 import { Event } from '../../../../base/common/event.js';
 import { toDisposable } from '../../../../base/common/lifecycle.js';
@@ -33,6 +34,22 @@ suite('WebSocketProtocolServer', () => {
 
 		assert.deepStrictEqual(validatedTokens, ['valid token']);
 	});
+
+	test('rejects a malformed request URL without stopping the server', async () => {
+		const server = store.add(await WebSocketProtocolServer.create({
+			port: 0,
+			connectionTokenValidate: token => token === 'valid',
+		}, new NullLogService()));
+		await server.whenListening;
+
+		const response = await sendUpgradeRequest(server.boundPort!, 'http://[invalid');
+		const transport = Event.toPromise(server.onConnection);
+		const socket = await connect(`ws://127.0.0.1:${server.boundPort}/?${connectionTokenQueryName}=valid`);
+		store.add(toDisposable(() => socket.close()));
+		store.add(await transport);
+
+		assert.strictEqual(response.split('\r\n', 1)[0], 'HTTP/1.1 400 Bad Request');
+	});
 });
 
 async function connect(url: string): Promise<wsTypes.WebSocket> {
@@ -41,5 +58,26 @@ async function connect(url: string): Promise<wsTypes.WebSocket> {
 		const socket = new WebSocket(url);
 		socket.once('open', () => resolve(socket));
 		socket.once('error', reject);
+	});
+}
+
+function sendUpgradeRequest(port: number, requestTarget: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+			socket.end([
+				`GET ${requestTarget} HTTP/1.1`,
+				'Host: localhost',
+				'Connection: Upgrade',
+				'Upgrade: websocket',
+				'Sec-WebSocket-Version: 13',
+				'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+				'',
+				'',
+			].join('\r\n'));
+		});
+		const chunks: Buffer[] = [];
+		socket.on('data', chunk => chunks.push(Buffer.from(chunk)));
+		socket.on('end', () => resolve(Buffer.concat(chunks).toString()));
+		socket.on('error', reject);
 	});
 }

--- a/src/vs/platform/agentHost/test/node/webSocketTransport.test.ts
+++ b/src/vs/platform/agentHost/test/node/webSocketTransport.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type * as wsTypes from 'ws';
+import { Event } from '../../../../base/common/event.js';
+import { toDisposable } from '../../../../base/common/lifecycle.js';
+import { connectionTokenQueryName } from '../../../../base/common/network.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { WebSocketProtocolServer } from '../../node/webSocketTransport.js';
+
+suite('WebSocketProtocolServer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('validates the decoded connection token', async () => {
+		const validatedTokens: unknown[] = [];
+		const server = store.add(await WebSocketProtocolServer.create({
+			port: 0,
+			connectionTokenValidate: token => {
+				validatedTokens.push(token);
+				return token === 'valid token';
+			},
+		}, new NullLogService()));
+		await server.whenListening;
+
+		const transport = Event.toPromise(server.onConnection);
+		const socket = await connect(`ws://127.0.0.1:${server.boundPort}/?${connectionTokenQueryName}=valid+token`);
+		store.add(toDisposable(() => socket.close()));
+		store.add(await transport);
+
+		assert.deepStrictEqual(validatedTokens, ['valid token']);
+	});
+});
+
+async function connect(url: string): Promise<wsTypes.WebSocket> {
+	const { WebSocket } = await import('ws');
+	return new Promise((resolve, reject) => {
+		const socket = new WebSocket(url);
+		socket.once('open', () => resolve(socket));
+		socket.once('error', reject);
+	});
+}


### PR DESCRIPTION
Cherry-pick of #330083 for release/1.133.

This prevents Node's DEP0169 warning from failing browser-capable product sanity tests when the remote server starts the Agent Host.

Validation:
- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/webSocketTransport.test.ts`
