### PR TITLE
agentHost: Normalize StrictHostKeyChecking output

### DIFF
--- a/src/vs/platform/agentHost/common/sshConfigParsing.ts
+++ b/src/vs/platform/agentHost/common/sshConfigParsing.ts
@@ -72,7 +72,12 @@ export function parseSSHGOutput(stdout: string): ISSHResolvedConfig {
 		}
 	}
 
-	const strictHostKeyChecking = map.get('stricthostkeychecking')?.toLowerCase();
+	const strictHostKeyCheckingValue = map.get('stricthostkeychecking')?.toLowerCase();
+	const strictHostKeyChecking = strictHostKeyCheckingValue === 'true'
+		? 'yes'
+		: strictHostKeyCheckingValue === 'false'
+			? 'no'
+			: strictHostKeyCheckingValue;
 
 	return {
 		hostname: map.get('hostname') ?? '',

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -255,10 +255,9 @@ export interface ISSHConnectResult {
 }
 
 /**
- * How OpenSSH should react to an unknown or changed host key, as reported by
- * `ssh -G` (`stricthostkeychecking`). We honor the user's real SSH config here
- * rather than introducing a parallel VS Code setting, so the escape hatch for
- * users who genuinely cannot use verification stays where they expect it.
+ * How OpenSSH should react to an unknown or changed host key. `ssh -G`
+ * canonicalizes `yes` to `true` and `no`/`off` to `false`, which the resolved
+ * config parser normalizes back to this policy representation.
  */
 export type SSHStrictHostKeyChecking = 'ask' | 'accept-new' | 'yes' | 'no' | 'off';
 
@@ -285,7 +284,7 @@ export interface ISSHResolvedConfig {
 	readonly userKnownHostsFiles: string[];
 	/** `GlobalKnownHostsFile` paths, e.g. `/etc/ssh/ssh_known_hosts`. */
 	readonly globalKnownHostsFiles: string[];
-	/** Resolved `StrictHostKeyChecking`, when it is a value we recognize. */
+	/** Resolved and normalized `StrictHostKeyChecking`, when recognized. */
 	readonly strictHostKeyChecking: SSHStrictHostKeyChecking | undefined;
 }
 

--- a/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
@@ -259,28 +259,40 @@ suite('SSH Config Parsing', () => {
 				['/home/my user/.ssh/known_hosts', '/home/u/other']);
 		});
 
-		test('parses recognized StrictHostKeyChecking values and ignores others', () => {
+		test('normalizes effective StrictHostKeyChecking values and ignores others', () => {
 			const parse = (value: string) => parseSSHGOutput(`stricthostkeychecking ${value}`).strictHostKeyChecking;
 			assert.deepStrictEqual(
 				{
-					ask: parse('ask'),
-					acceptNew: parse('accept-new'),
-					yes: parse('yes'),
-					no: parse('no'),
-					off: parse('off'),
-					uppercase: parse('ASK'),
+					effective: {
+						ask: parse('ask'),
+						acceptNew: parse('accept-new'),
+						yes: parse('true'),
+						noOrOff: parse('false'),
+					},
+					acceptedAliases: {
+						yes: parse('yes'),
+						no: parse('no'),
+						off: parse('off'),
+						uppercase: parse('TRUE'),
+					},
 					// An unrecognized value must not be passed through as if it
 					// were a policy we understand.
 					bogus: parse('maybe'),
 					absent: parseSSHGOutput('').strictHostKeyChecking,
 				},
 				{
-					ask: 'ask',
-					acceptNew: 'accept-new',
-					yes: 'yes',
-					no: 'no',
-					off: 'off',
-					uppercase: 'ask',
+					effective: {
+						ask: 'ask',
+						acceptNew: 'accept-new',
+						yes: 'yes',
+						noOrOff: 'no',
+					},
+					acceptedAliases: {
+						yes: 'yes',
+						no: 'no',
+						off: 'off',
+						uppercase: 'yes',
+					},
 					bogus: undefined,
 					absent: undefined,
 				});


### PR DESCRIPTION
Fixes #329938

Normalize the `true` and `false` values emitted by `ssh -G` for `StrictHostKeyChecking` before applying the Agent Host SSH host-key policy.

This preserves the configured behavior for `yes`, `no`, and `off`, while retaining support for the existing recognized aliases.

Tests:
- `./scripts/test.sh --run src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts` (26 passing)

(Written by Copilot)