### PR TITLE
Fix session/chat cycling keybindings to respect terminal focus

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -23,6 +23,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { TerminalContextKeys } from '../../../../workbench/contrib/terminal/common/terminalContextKey.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { getQuickNavigateHandler, inQuickPickContext } from '../../../../workbench/browser/quickaccess.js';
 import { Menus } from '../../../browser/menus.js';
@@ -428,7 +429,7 @@ registerAction2(class AddChatToSessionAction extends Action2 {
 				// Like Cmd/Ctrl+T in a browser — opens a new chat tab within the
 				// active session. Scoped so it does not steal the shortcut outside
 				// the agents window or when the session does not support multiple chats.
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionIsCreatedContext, SessionSupportsMultipleChatsContext, SessionIsArchivedContext.negate()),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), TerminalContextKeys.focus.negate(), SessionIsCreatedContext, SessionSupportsMultipleChatsContext, SessionIsArchivedContext.negate()),
 				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
 			},
 			menu: {
@@ -485,7 +486,7 @@ registerAction2(class NavigateNextChatAction extends Action2 {
 			precondition: SessionHasMultipleOpenChatsContext,
 			keybinding: {
 				weight: CHAT_TAB_KEYBINDING_WEIGHT,
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionHasMultipleOpenChatsContext),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), TerminalContextKeys.focus.negate(), SessionHasMultipleOpenChatsContext),
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketRight,
 			},
 		});
@@ -505,7 +506,7 @@ registerAction2(class NavigatePreviousChatAction extends Action2 {
 			precondition: SessionHasMultipleOpenChatsContext,
 			keybinding: {
 				weight: CHAT_TAB_KEYBINDING_WEIGHT,
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionHasMultipleOpenChatsContext),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), TerminalContextKeys.focus.negate(), SessionHasMultipleOpenChatsContext),
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketLeft,
 			},
 		});

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -21,6 +21,7 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/k
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
 import { CLOSE_MOBILE_SIDEBAR_DRAWER_COMMAND_ID } from '../../../../browser/workbench.js';
 import { EditorsVisibleContext, EditorAreaFocusContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { TerminalContextKeys } from '../../../../../workbench/contrib/terminal/common/terminalContextKey.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { RENAME_SESSION_COMMAND_ID, UNARCHIVE_SESSION_COMMAND_ID } from '../../../../common/sessionCommands.js';
 import { SessionSupportsDeleteContext, SessionSupportsRenameContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
@@ -180,7 +181,7 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 			keybinding: {
 				// Mirror core "Previous Editor"; keep Alt+Up as a sessions-only alternate outside the editor area.
 				weight: KeybindingWeight.SessionsContrib,
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), TerminalContextKeys.focus.negate()),
 				primary: KeyMod.CtrlCmd | KeyCode.PageUp,
 				secondary: [KeyMod.Alt | KeyCode.UpArrow],
 				mac: {
@@ -214,7 +215,7 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 			keybinding: {
 				// Mirror core "Next Editor"; keep Alt+Down as a sessions-only alternate outside the editor area.
 				weight: KeybindingWeight.SessionsContrib,
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), TerminalContextKeys.focus.negate()),
 				primary: KeyMod.CtrlCmd | KeyCode.PageDown,
 				secondary: [KeyMod.Alt | KeyCode.DownArrow],
 				mac: {

--- a/src/vs/sessions/test/browser/terminalTabCyclingKeybindings.test.ts
+++ b/src/vs/sessions/test/browser/terminalTabCyclingKeybindings.test.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { OS } from '../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { ContextKeyService } from '../../../platform/contextkey/browser/contextKeyService.js';
+import { IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
+import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
+import { KeybindingsRegistry } from '../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeybindingResolver } from '../../../platform/keybinding/common/keybindingResolver.js';
+import { ResolvedKeybindingItem } from '../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { USLayoutResolvedKeybinding } from '../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { TerminalCommandId } from '../../../workbench/contrib/terminal/common/terminal.js';
+import { TerminalContextKeys } from '../../../workbench/contrib/terminal/common/terminalContextKey.js';
+import { registerTerminalActions } from '../../../workbench/contrib/terminal/browser/terminalActions.js';
+import { EditorAreaFocusContext, IsSessionsWindowContext } from '../../../workbench/common/contextkeys.js';
+import { SessionHasMultipleOpenChatsContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionSupportsMultipleChatsContext } from '../../common/contextkeys.js';
+
+import '../../contrib/sessions/browser/sessionsActions.js';
+import '../../contrib/sessions/browser/views/sessionsViewActions.js';
+
+registerTerminalActions();
+
+suite('Terminal tab cycling keybindings', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createResolver(commandIds: string[]): KeybindingResolver {
+		const items: ResolvedKeybindingItem[] = [];
+		for (const item of KeybindingsRegistry.getDefaultKeybindingsForOS(OS)) {
+			if (!item.command || !commandIds.includes(item.command) || !item.keybinding) {
+				continue;
+			}
+			const resolved = USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding, OS)[0];
+			items.push(new ResolvedKeybindingItem(resolved, item.command, item.commandArgs, item.when ?? undefined, true, null, false));
+		}
+		return new KeybindingResolver(items, [], () => { });
+	}
+
+	function createContext(terminalFocus: boolean): { readonly context: ContextKeyService; readonly overlay: IContextKeyService } {
+		const context = new ContextKeyService(new TestConfigurationService());
+		return {
+			context,
+			overlay: context.createOverlay([
+				[IsSessionsWindowContext.key, true],
+				[EditorAreaFocusContext.key, false],
+				[TerminalContextKeys.processSupported.key, true],
+				[TerminalContextKeys.focus.key, terminalFocus],
+				[TerminalContextKeys.editorFocus.key, false],
+				[SessionIsCreatedContext.key, true],
+				[SessionSupportsMultipleChatsContext.key, true],
+				[SessionHasMultipleOpenChatsContext.key, true],
+				[SessionIsArchivedContext.key, false],
+			]),
+		};
+	}
+
+	test('terminal focus keeps chat/session cycling out of the binding set', () => {
+		const resolver = createResolver([
+			TerminalCommandId.FocusNext,
+			TerminalCommandId.FocusPrevious,
+			'sessions.chatCompositeBar.navigateNextChat',
+			'sessions.chatCompositeBar.navigatePreviousChat',
+			'sessionsViewPane.navigateNextSession',
+			'sessionsViewPane.navigatePreviousSession',
+		]);
+		const { context, overlay } = createContext(true);
+		try {
+			assert.deepStrictEqual({
+				terminalNext: resolver.lookupPrimaryKeybinding(TerminalCommandId.FocusNext, overlay, true) !== null,
+				terminalPrevious: resolver.lookupPrimaryKeybinding(TerminalCommandId.FocusPrevious, overlay, true) !== null,
+				chatNext: resolver.lookupPrimaryKeybinding('sessions.chatCompositeBar.navigateNextChat', overlay, true) !== null,
+				chatPrevious: resolver.lookupPrimaryKeybinding('sessions.chatCompositeBar.navigatePreviousChat', overlay, true) !== null,
+				sessionNext: resolver.lookupPrimaryKeybinding('sessionsViewPane.navigateNextSession', overlay, true) !== null,
+				sessionPrevious: resolver.lookupPrimaryKeybinding('sessionsViewPane.navigatePreviousSession', overlay, true) !== null,
+			}, {
+				terminalNext: true,
+				terminalPrevious: true,
+				chatNext: false,
+				chatPrevious: false,
+				sessionNext: false,
+				sessionPrevious: false,
+			});
+		} finally {
+			context.dispose();
+		}
+	});
+
+	test('non-terminal focus keeps terminal cycling out of the binding set', () => {
+		const resolver = createResolver([
+			TerminalCommandId.FocusNext,
+			TerminalCommandId.FocusPrevious,
+			'sessions.chatCompositeBar.navigateNextChat',
+			'sessions.chatCompositeBar.navigatePreviousChat',
+			'sessionsViewPane.navigateNextSession',
+			'sessionsViewPane.navigatePreviousSession',
+		]);
+		const { context, overlay } = createContext(false);
+		try {
+			assert.deepStrictEqual({
+				terminalNext: resolver.lookupPrimaryKeybinding(TerminalCommandId.FocusNext, overlay, true) !== null,
+				terminalPrevious: resolver.lookupPrimaryKeybinding(TerminalCommandId.FocusPrevious, overlay, true) !== null,
+				chatNext: resolver.lookupPrimaryKeybinding('sessions.chatCompositeBar.navigateNextChat', overlay, true) !== null,
+				chatPrevious: resolver.lookupPrimaryKeybinding('sessions.chatCompositeBar.navigatePreviousChat', overlay, true) !== null,
+				sessionNext: resolver.lookupPrimaryKeybinding('sessionsViewPane.navigateNextSession', overlay, true) !== null,
+				sessionPrevious: resolver.lookupPrimaryKeybinding('sessionsViewPane.navigatePreviousSession', overlay, true) !== null,
+			}, {
+				terminalNext: false,
+				terminalPrevious: false,
+				chatNext: true,
+				chatPrevious: true,
+				sessionNext: true,
+				sessionPrevious: true,
+			});
+		} finally {
+			context.dispose();
+		}
+	});
+});


### PR DESCRIPTION
This fixes Agents-window tab-cycling shortcuts so they respect terminal focus.  
When focus is in terminal, `cmd+shift+[` / `cmd+shift+]` (and platform equivalents) should cycle terminal tabs/groups, not switch chats/sessions.

Is an associated issue a hard requirement for a PR? I can create one if so.

You can test this by opening multiple chats and multiple terminal tabs in the Agents window, then:
- focus the terminal pane and verify the shortcuts cycle terminal tabs/groups
- focus chat/session UI and verify they still cycle chats/sessions there

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
