### PR TITLE
sessions: allow providers to resolve agent auth requirements

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -2482,7 +2482,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			.map((agent): ISessionType => ({
 				id: agent.provider,
 				supportsWorktreeConfiguration: agent.provider === CopilotCLISessionType.id,
-				authRequirement: resolveAgentAuthRequirement(agent),
+				authRequirement: this._resolveAgentAuthRequirement(agent),
 				// The chat session contribution and language models for an agent-host
 				// agent are registered under its resource scheme (`agent-host-<provider>`),
 				// not the bare provider id, so carry it for availability lookups.
@@ -2497,6 +2497,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		}
 		this._sessionTypes = next;
 		this._onDidChangeSessionTypes.fire();
+	}
+
+	protected _resolveAgentAuthRequirement(agent: AgentInfo): SessionTypeAuthRequirement {
+		return resolveAgentAuthRequirement(agent);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -35,7 +35,7 @@ import { ChatModeKind } from '../../../../../../workbench/contrib/chat/common/co
 import { ILanguageModelsService, type ILanguageModelChatMetadata } from '../../../../../../workbench/contrib/chat/common/languageModels.js';
 import type { IChatModel, IChatModelInputState, IInputModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ISessionChangeEvent } from '../../../../../services/sessions/common/sessionsProvider.js';
-import { ChatInteractivity, ChatOriginKind, getChatCapabilities, ISession, SessionStatus } from '../../../../../services/sessions/common/session.js';
+import { ChatInteractivity, ChatOriginKind, getChatCapabilities, ISession, SessionStatus, SessionTypeAuthRequirement } from '../../../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../../services/sessions/browser/sessionsService.js';
 import { IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
@@ -598,6 +598,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		// local and remote hosts and the standalone Copilot CLI provider.
 		assert.strictEqual(provider.sessionTypes[0].id, 'copilotcli');
 		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot');
+		assert.strictEqual(provider.sessionTypes[0].authRequirement, SessionTypeAuthRequirement.GitHub);
 	});
 
 	test('session types update when the local host advertises additional agents', () => {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -35,7 +35,7 @@ import { IChatResponseModel } from '../../../../../../workbench/contrib/chat/com
 import { IChatAgentData } from '../../../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { IGitService } from '../../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionChangeEvent } from '../../../../../services/sessions/common/sessionsProvider.js';
-import { GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../../services/sessions/common/session.js';
+import { GITHUB_REMOTE_FILE_SCHEME, SessionStatus, SessionTypeAuthRequirement } from '../../../../../services/sessions/common/session.js';
 import { ChatConfiguration, ChatPermissionLevel } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { CopilotChatSessionsProvider, COPILOT_PROVIDER_ID, CopilotCloudSessionType, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -406,6 +406,16 @@ suite('CopilotChatSessionsProvider', () => {
 		const provider = createProvider(disposables, model);
 		assert.strictEqual(provider.id, COPILOT_PROVIDER_ID);
 		assert.strictEqual(provider.sessionTypes.length, 1);
+	});
+
+	test('legacy session types remain GitHub-gated', () => {
+		assert.deepStrictEqual(
+			[CopilotCLISessionType, CopilotCloudSessionType].map(type => type.authRequirement),
+			[
+				SessionTypeAuthRequirement.GitHub,
+				SessionTypeAuthRequirement.GitHub,
+			],
+		);
 	});
 
 	test('sessionTypes excludes Local', () => {


### PR DESCRIPTION
## Summary

- Adds an override point for session providers to resolve an advertised agent's authentication requirement.
- Preserves the existing authentication requirements for local Agent Host, Copilot Cloud, and Copilot CLI session types.
- Keeps provider-specific policy out of the shared session-type construction path.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

The base Agent Host sessions provider derived every advertised session type's authentication requirement directly from its agent metadata. Subclasses could filter advertised agents but could not specialize this part of the session-type descriptor.

### Implementation

Session-type construction now calls a protected resolution method. Its default implementation delegates to the existing shared resolver, so current providers retain the same behavior. Provider tests assert the resulting requirements for the local Agent Host and Copilot Chat session types.

### Behavior and constraints

- The default path remains behaviorally unchanged.
- The hook receives the complete advertised agent metadata and returns the existing session authentication requirement type.
- No provider overrides the hook in this change; it establishes the narrow extension point for provider-specific authentication policy.

</details>
