### PR TITLE
chat: expose model management while signed out

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections.ts
@@ -61,7 +61,7 @@ export function buildUnavailableStateItems(options: IBuildModelPickerItemsOption
 	}
 	if (setupRequired) {
 		const enabled = !!options.actions.onRequestSetup;
-		return [
+		const items: IActionListItem<IActionWidgetDropdownAction>[] = [
 			{ kind: ActionListItemKind.Header, label: localize('chat.modelPicker.setupRequired', "Sign in to use Copilot") },
 			{
 				item: {
@@ -80,6 +80,20 @@ export function buildUnavailableStateItems(options: IBuildModelPickerItemsOption
 				hideIcon: false,
 			},
 		];
+		if (options.presentation.showManageModelsInSetupRequired && options.manageModelsAction) {
+			items.push(
+				{ kind: ActionListItemKind.Separator },
+				{
+					item: options.manageModelsAction,
+					kind: ActionListItemKind.Action,
+					label: options.manageModelsAction.label,
+					group: { title: '', icon: Codicon.blank },
+					hideIcon: false,
+					showAlways: true,
+				}
+			);
+		}
+		return items;
 	}
 	if (options.models.length > 0) {
 		return undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemTypes.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemTypes.ts
@@ -30,6 +30,7 @@ export interface IBuildModelPickerItemsOptions {
 		readonly showAutoModel: boolean;
 		readonly restrictedMode: boolean;
 		readonly setupRequired: boolean;
+		readonly showManageModelsInSetupRequired: boolean;
 		readonly isUBB: boolean;
 	};
 	readonly actions: {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget.ts
@@ -23,7 +23,9 @@ import { localize } from '../../../../../../../nls.js';
 import { IActionListHeaderLink } from '../../../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../../../../../../platform/agentHost/common/agentService.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IOpenerService } from '../../../../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../../../platform/telemetry/common/telemetry.js';
@@ -143,6 +145,7 @@ export class ModelPickerWidget extends Disposable {
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
@@ -501,6 +504,7 @@ export class ModelPickerWidget extends Disposable {
 				...presentation,
 				restrictedMode: this.isRestrictedMode(),
 				setupRequired: this.isSetupRequired(),
+				showManageModelsInSetupRequired: this._configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true,
 				isUBB: !!this._entitlementService.quotas.usageBasedBilling,
 			},
 			actions: {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/modelPicker/modelPickerItems.test.ts
@@ -142,6 +142,7 @@ function callBuild(
 		restrictedMode?: boolean;
 		onRequestTrust?: () => void;
 		setupRequired?: boolean;
+		showManageModelsInSetupRequired?: boolean;
 		onRequestSetup?: () => void;
 		onSelect?: (model: ILanguageModelChatMetadataAndIdentifier) => void;
 		entitlementService?: IChatEntitlementService;
@@ -172,6 +173,7 @@ function callBuild(
 			showAutoModel: opts.showAutoModel ?? true,
 			restrictedMode: opts.restrictedMode ?? false,
 			setupRequired: opts.setupRequired ?? false,
+			showManageModelsInSetupRequired: opts.showManageModelsInSetupRequired ?? false,
 			isUBB: false,
 		},
 		actions: {
@@ -339,21 +341,23 @@ suite('buildModelPickerItems', () => {
 	});
 
 	test('setupRequired shows an explanatory header and a Sign In action instead of auto', () => {
-		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { } });
+		const items = callBuild([], { setupRequired: true, showManageModelsInSetupRequired: true, onRequestSetup: () => { } });
 		const actions = getActionItems(items);
 		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Sign in to use Copilot'));
-		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions.length, 2);
 		assert.strictEqual(actions[0].item?.id, 'setupRequiredSignIn');
 		assert.strictEqual(actions[0].item?.enabled, true);
 		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
-		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+		assert.strictEqual(actions[1].item?.id, 'manageModels');
 	});
 
 	test('setupRequired Sign In action is disabled without a setup callback', () => {
 		const items = callBuild([], { setupRequired: true });
-		const signIn = getActionItems(items).find(a => a.item?.id === 'setupRequiredSignIn');
+		const actions = getActionItems(items);
+		const signIn = actions.find(a => a.item?.id === 'setupRequiredSignIn');
 		assert.strictEqual(signIn?.item?.enabled, false);
 		assert.strictEqual(signIn?.disabled, true);
+		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
 	});
 
 	test('setupRequired Sign In action invokes the setup callback', () => {


### PR DESCRIPTION
## Summary

- Keeps the model picker available in the signed-out Copilot Agent Host welcome state when signed-out use is enabled.
- Adds **Manage Models** beside the setup sign-in action so users can configure a BYOK model without authenticating first.
- Limits the additional affordance to the existing signed-out Agent Host opt-in.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

The setup-required model picker only offered sign-in. In the Agents window welcome state, the picker button was also hidden for Copilot Agent Host unless targeted models were already available. A signed-out user therefore had no direct path from the empty state to model configuration.

### Implementation

The model-picker menu condition now keeps the action visible for the Copilot Agent Host session type in the Agents window when the signed-out-use setting is enabled.

The picker presentation reads that same setting and, in the setup-required state, appends the existing model-management action after the sign-in action. The item builder remains generic: callers opt into the extra action through presentation state and must supply the action itself.

### Behavior and constraints

- Other session types and normal editor-window chat surfaces retain their existing picker visibility.
- Disabling signed-out Agent Host use removes both the welcome-state entry path and the setup-state model-management affordance.
- The sign-in action remains the primary setup action and preserves its enabled and disabled behavior.
- The existing model-management command and action rendering are reused, including their keyboard and accessibility behavior.

</details>
