### PR TITLE
Stabilize incremental rendering and model picker tests

### DIFF
--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { Event } from '../../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -354,13 +355,13 @@ suite('IncrementalDOMMorpher', () => {
 			morpher.setRenderCallback(() => { });
 			let drainCount = 0;
 			disposables.add(morpher.onDidDrain(() => drainCount++));
+			const didDrain = Event.toPromise(morpher.onDidDrain);
 
 			morpher.seed('one two three');
 			morpher.updateStreamRate(2000, true);
 			assert.strictEqual(morpher.isDrained, false);
 
-			await new Promise(r => mainWindow.requestAnimationFrame(r));
-			await new Promise(r => mainWindow.requestAnimationFrame(r));
+			await didDrain;
 
 			assert.deepStrictEqual({
 				isDrained: morpher.isDrained,

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -368,7 +368,9 @@ export class Chat {
 		// There can be a hidden duplicate of the config button (e.g. an overflow
 		// copy); target the visible one.
 		const configButton = page.locator(`${CHAT_MODEL_PICKER_CONFIG}:visible`).first();
-		const anyRow = page.locator(`${ACTION_WIDGET_ROW}:visible`).first();
+		const configWidget = page.locator(`${ACTION_WIDGET}:visible`, {
+			has: page.locator('.monaco-list-row.group-header')
+		}).first();
 		const deadline = Date.now() + timeoutMs;
 		let lastError: unknown;
 
@@ -389,10 +391,7 @@ export class Chat {
 			try {
 				await configButton.waitFor({ state: 'visible', timeout: 15_000 });
 				await configButton.click({ force: true });
-				await this.code.waitForElement(ACTION_WIDGET);
-				// Wait for the option rows to actually render, not just the popup
-				// container, so callers don't race a half-open / tearing-down popup.
-				await anyRow.waitFor({ state: 'visible', timeout: 5_000 });
+				await configWidget.locator('.monaco-list-row.action').first().waitFor({ state: 'visible', timeout: 5_000 });
 				return;
 			} catch (error) {
 				lastError = error;


### PR DESCRIPTION
Fixes #329905
Fixes #329908

Stabilizes two timing-sensitive tests by waiting for the state each assertion depends on:

- wait for the incremental DOM morpher to emit its drain event instead of assuming two animation frames are sufficient
- wait for the visible model configuration widget and its rendered action rows instead of accepting a row from any transient action widget

## Validation

- [Flaky Smoke Tests validation run 463301](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=463301&view=results): **60/60 iteration tasks passed** on macOS (**20/20 Electron unit**, **20/20 Node.js unit**, **20/20 Electron smoke**)

## Original flaky runs

- [Run 463073](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=463073&view=results) for #329905
- [Run 463072](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=463072&view=results) for #329908