### PR TITLE
[cherry-pick] Remove fake prompt discount probe

### DIFF
--- a/build/azure-pipelines/common/validatePackageLocks.ts
+++ b/build/azure-pipelines/common/validatePackageLocks.ts
@@ -59,10 +59,10 @@ function isRecord(value: JsonValue | undefined): value is { [key: string]: JsonV
 const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies'] as const;
 
 /**
- * Rewrites the declared range of every changed dependency to the exact version the lockfile commits,
- * so regeneration resolves what the pull request submitted instead of whatever the registry has
- * published since. npm rejects `overrides` for direct dependencies (EOVERRIDE), so the range itself
- * has to carry the pin.
+ * Rewrites the declared range of every changed direct dependency to the exact version the lockfile
+ * commits, so regeneration resolves what the pull request submitted instead of whatever the registry
+ * has published since. npm rejects `overrides` for direct dependencies (EOVERRIDE), so the range
+ * itself has to carry the pin.
  */
 export function pinChangedPackages(packageJson: JsonValue, changedKeys: readonly string[], submitted: IPackageLock): JsonValue {
 	if (!isRecord(packageJson)) {
@@ -74,7 +74,7 @@ export function pinChangedPackages(packageJson: JsonValue, changedKeys: readonly
 	for (const packageKey of changedKeys) {
 		const record = submittedPackages[packageKey];
 		const name = packageKey.slice(packageKey.lastIndexOf('node_modules/') + 'node_modules/'.length);
-		if (isRecord(record) && typeof record.version === 'string' && record.link !== true && name) {
+		if (packageKey === `node_modules/${name}` && isRecord(record) && typeof record.version === 'string' && record.link !== true && name) {
 			pinnedVersions.set(name, record.version);
 		}
 	}
@@ -200,7 +200,8 @@ function regenerateLockfile(lockPath: string, seed: IPackageLock, pinnedPackageJ
 function main(): void {
 	const args = process.argv.slice(2);
 	const baseRef = args.find(arg => !arg.startsWith('--')) ?? 'origin/main';
-	const changedFiles = new Set(git('diff', '--name-only', `${baseRef}...HEAD`).split('\n'));
+	const baseCommit = git('merge-base', baseRef, 'HEAD');
+	const changedFiles = new Set(git('diff', '--name-only', baseCommit, 'HEAD').split('\n'));
 	if (args.includes('--include-working-tree')) {
 		for (const file of git('diff', '--name-only').split('\n')) {
 			changedFiles.add(file);
@@ -222,7 +223,7 @@ function main(): void {
 
 		console.log(`Regenerating ${relativeLockPath} with npm ${process.env.npm_config_user_agent ?? ''}...`);
 		const submitted = readLockfile(fs.readFileSync(lockPath, 'utf8'), lockPath);
-		const base = getBaseLockfile(baseRef, relativeLockPath);
+		const base = getBaseLockfile(baseCommit, relativeLockPath);
 		const changedKeys = findChangedPackageKeys(base, submitted);
 		const seed = createLockfileRegenerationSeed(base, submitted);
 		const packageJsonPath = path.join(path.dirname(lockPath), 'package.json');

--- a/build/lib/test/validatePackageLocks.test.ts
+++ b/build/lib/test/validatePackageLocks.test.ts
@@ -97,6 +97,27 @@ suite('validatePackageLocks', () => {
 		});
 	});
 
+	test('does not use a nested package version to pin a direct dependency', () => {
+		const base = {
+			packages: {
+				'': { dependencies: { shared: '^2.0.0' } },
+				'node_modules/shared': { version: '2.0.0' },
+			}
+		};
+		const submitted = {
+			packages: {
+				'': { dependencies: { shared: '^2.0.0' } },
+				'node_modules/shared': { version: '2.1.0' },
+				'node_modules/sdk/node_modules/shared': { version: '1.0.0' },
+			}
+		};
+		const packageJson = { dependencies: { shared: '^2.0.0' } };
+
+		assert.deepStrictEqual(pinChangedPackages(packageJson, findChangedPackageKeys(base, submitted), submitted), {
+			dependencies: { shared: '2.1.0' }
+		});
+	});
+
 	test('restores declared dependency ranges after regeneration', () => {
 		const regenerated = {
 			packages: {

--- a/extensions/copilot/chat-lib/package-lock.json
+++ b/extensions/copilot/chat-lib/package-lock.json
@@ -12,7 +12,7 @@
 			"dependencies": {
 				"@microsoft/tiktokenizer": "^1.0.10",
 				"@sinclair/typebox": "^0.34.41",
-				"@vscode/copilot-api": "^0.5.1",
+				"@vscode/copilot-api": "^0.5.2",
 				"@vscode/l10n": "^0.0.18",
 				"@vscode/prompt-tsx": "^0.4.0-alpha.8",
 				"@vscode/tree-sitter-wasm": "0.0.5-php.2",
@@ -1420,9 +1420,9 @@
 			}
 		},
 		"node_modules/@vscode/copilot-api": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.1.tgz",
-			"integrity": "sha512-J+pxNXbkhIdzJ0Tx2nW+mxQSfnjPbHu7CSrOnRA814bmVsVjGvgqtVmRtZkWRGNs43kd4fvckXVbvqQzZ78hqw==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.2.tgz",
+			"integrity": "sha512-U+2jyi0/Hpum2ZnED47cVFKgx5+p+thRhOPDKc1+t2PVAzsKlr3aJPKxMeMLOIXGWyLuQcng5BuFvj1vxD1d8w==",
 			"license": "SEE LICENSE"
 		},
 		"node_modules/@vscode/l10n": {

--- a/extensions/copilot/chat-lib/package.json
+++ b/extensions/copilot/chat-lib/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@microsoft/tiktokenizer": "^1.0.10",
 		"@sinclair/typebox": "^0.34.41",
-		"@vscode/copilot-api": "^0.5.1",
+		"@vscode/copilot-api": "^0.5.2",
 		"@vscode/l10n": "^0.0.18",
 		"@vscode/prompt-tsx": "^0.4.0-alpha.8",
 		"@vscode/tree-sitter-wasm": "0.0.5-php.2",

--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -34,7 +34,7 @@
         "@opentelemetry/sdk-trace-node": "^2.5.1",
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@sinclair/typebox": "^0.34.41",
-        "@vscode/copilot-api": "^0.5.1",
+        "@vscode/copilot-api": "^0.5.2",
         "@vscode/extension-telemetry": "^1.5.1",
         "@vscode/l10n": "^0.0.18",
         "@vscode/prompt-tsx": "^0.4.0-alpha.8",
@@ -6804,9 +6804,9 @@
       }
     },
     "node_modules/@vscode/copilot-api": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.1.tgz",
-      "integrity": "sha512-J+pxNXbkhIdzJ0Tx2nW+mxQSfnjPbHu7CSrOnRA814bmVsVjGvgqtVmRtZkWRGNs43kd4fvckXVbvqQzZ78hqw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.2.tgz",
+      "integrity": "sha512-U+2jyi0/Hpum2ZnED47cVFKgx5+p+thRhOPDKc1+t2PVAzsKlr3aJPKxMeMLOIXGWyLuQcng5BuFvj1vxD1d8w==",
       "license": "SEE LICENSE"
     },
     "node_modules/@vscode/debugadapter": {

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -7093,7 +7093,7 @@
     "@opentelemetry/sdk-trace-node": "^2.5.1",
     "@opentelemetry/semantic-conventions": "^1.39.0",
     "@sinclair/typebox": "^0.34.41",
-    "@vscode/copilot-api": "^0.5.1",
+    "@vscode/copilot-api": "^0.5.2",
     "@vscode/extension-telemetry": "^1.5.1",
     "@vscode/l10n": "^0.0.18",
     "@vscode/prompt-tsx": "^0.4.0-alpha.8",

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -212,7 +212,7 @@ suite('LanguageModelAccess model info', () => {
 			_serviceBrand: undefined,
 			resolveAutoModeEndpoint: async () => endpoint,
 			resolveAutoModePickerEndpoint: async () => endpoint,
-			getAutoPickerMetadata: async () => undefined,
+			getAutoPickerMetadata: () => ({ discountRange: { low: 0, high: 0 } }),
 			areAutoModeTiersSupported: () => false,
 			onDidChangeAutoModeTierSupport: Event.None,
 			consumeLastRoutingDecision: () => undefined,

--- a/extensions/copilot/src/extension/test/node/services.ts
+++ b/extensions/copilot/src/extension/test/node/services.ts
@@ -17,7 +17,7 @@ import { DiffServiceImpl } from '../../../platform/diff/node/diffServiceImpl';
 import { EmbeddingType, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
 import { RemoteEmbeddingsComputer } from '../../../platform/embeddings/common/remoteEmbeddingsComputer';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
-import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
+import { AutoModePickerMetadata, IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { IModelConfig } from '../../../platform/endpoint/test/node/openaiCompatibleEndpoint';
 import { TestEndpointProvider } from '../../../platform/endpoint/test/node/testEndpointProvider';
 import { IGitCommitMessageService, NoopGitCommitMessageService } from '../../../platform/git/common/gitCommitMessageService';
@@ -188,8 +188,8 @@ class NullAutomodeService implements IAutomodeService {
 		return undefined;
 	}
 
-	async getAutoPickerMetadata(): Promise<undefined> {
-		return undefined;
+	getAutoPickerMetadata(): AutoModePickerMetadata {
+		return { discountRange: { low: 0, high: 0 } };
 	}
 
 	areAutoModeTiersSupported(): boolean {

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -116,6 +116,11 @@ export interface IModelBilling {
 	restricted_to?: string[];
 	token_prices?: IModelTokenPrices;
 	promo?: IModelPromo;
+	/**
+	 * Discount applied when this model is reached through Auto, as a fraction
+	 * (e.g. `0.1` for 10% off). Only set on models Auto can route to.
+	 */
+	auto_discount?: number;
 }
 
 export interface IModelAPIResponse {

--- a/extensions/copilot/src/platform/endpoint/node/autoV2Fetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/autoV2Fetcher.ts
@@ -75,11 +75,6 @@ export class AutoV2Fetcher {
 			vscodeRequestId?: string;
 			/** Routing profile for the session. Omitted lets the server pick its own default. */
 			tier?: AutoModeTier;
-			/**
-			 * Set when the call only reads `discounted_costs` for the picker.
-			 * Keeps the placeholder prompt out of telemetry and the request log.
-			 */
-			isDiscountProbe?: boolean;
 		} = {},
 	): Promise<AutoV2Response> {
 		const startTime = Date.now();
@@ -123,11 +118,6 @@ export class AutoV2Fetcher {
 
 		const result = await response.json() as AutoV2Response;
 		const e2eLatencyMs = Date.now() - startTime;
-		if (options.isDiscountProbe) {
-			// Only `discounted_costs` is consumed; the selection is discarded.
-			this._logService.trace(`[AutoV2Fetcher] Discount probe resolved in ${e2eLatencyMs}ms`);
-			return result;
-		}
 		if (!result.selected_model?.id) {
 			throw new AutoV2Error('Auto response did not contain a selected model', response.status);
 		}

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -8,13 +8,12 @@ import type { ChatRequest } from 'vscode';
 import { FetchedValue } from '../../../shared-fetch-utils/common/fetchedValue';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Emitter, type Event } from '../../../util/vs/base/common/event';
-import { Disposable, DisposableMap, MutableDisposable } from '../../../util/vs/base/common/lifecycle';
+import { Disposable, DisposableMap } from '../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation } from '../../../vscodeTypes';
 import { IAuthenticationService } from '../../authentication/common/authentication';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { IEnvService } from '../../env/common/envService';
-import { IVSCodeExtensionContext } from '../../extContext/common/extensionContext';
 import { getImageTelemetryEventMeasurements, getImageTelemetryMeasurementsFromReferences, type ImageTelemetryMeasurements } from '../../image/common/imageTelemetry';
 import { ILogService } from '../../log/common/logService';
 import { createCapiClientFetchedValue } from '../../networking/common/capiClientFetchedValue';
@@ -166,17 +165,15 @@ export interface IAutomodeService {
 
 	/**
 	 * Resolves the endpoint backing the "Auto" model picker entry. The picker
-	 * has no prompt, so this only carries display metadata; it may perform the
-	 * discount probe described on {@link getAutoPickerMetadata}.
+	 * has no prompt, so this only carries display metadata.
 	 */
 	resolveAutoModePickerEndpoint(knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint>;
 
 	/**
-	 * Discount metadata for the "Auto" picker entry, persisted across windows.
-	 * `/auto` has no prompt-free variant, so if no discount has ever been seen
-	 * this issues a one-time probe with a placeholder prompt.
+	 * Discount metadata for the "Auto" picker entry, derived from the
+	 * `billing.auto_discount` each model advertises in `/models`.
 	 */
-	getAutoPickerMetadata(): Promise<AutoModePickerMetadata | undefined>;
+	getAutoPickerMetadata(knownEndpoints: IChatEndpoint[]): AutoModePickerMetadata;
 
 	/**
 	 * Whether the Auto model should offer the tier picker. Tiers are a `POST /auto`
@@ -216,18 +213,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 	private _lastRoutingDecision: AutoModeRoutingDecision | undefined;
 	/** Set on a 404 (API-version or feature-flag gate); pins us to V1. */
 	private _autoV2Unavailable = false;
-	/** Discounts from the most recent `POST /auto` response. */
-	private _lastAutoV2Discounts: Record<string, number> | undefined;
-	/** Persists discounts so the picker label survives a restart. */
-	private static readonly AUTO_V2_DISCOUNTS_STORAGE_KEY = 'copilot.autoMode.v2.lastDiscountedCosts';
-	/** Placeholder prompt used to read discounts. See {@link _probeAutoV2Discounts}. */
-	private static readonly DISCOUNT_PROBE_PROMPT = 'MODEL_PICKER_DISCOUNT_RESOLUTION - REPLACE ME';
 	/** Upper bound on live V2 sessions. See {@link _pruneAutoV2Cache}. */
 	private static readonly AUTO_V2_CACHE_MAX_ENTRIES = 50;
-	/** In-flight discount probe, so concurrent picker refreshes share one call. */
-	private _autoV2DiscountProbe: Promise<void> | undefined;
-	/** Session used only to read discounts for the picker on the legacy flow. */
-	private readonly _pickerTokenBank = this._register(new MutableDisposable<AutoModeTokenBank>());
 	private readonly _onDidChangeAutoModeTierSupport = this._register(new Emitter<void>());
 	readonly onDidChangeAutoModeTierSupport = this._onDidChangeAutoModeTierSupport.event;
 	/** Last announced {@link areAutoModeTiersSupported}. See {@link _updateAutoModeTierSupport}. */
@@ -243,10 +230,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IRequestLogger private readonly _requestLogger: IRequestLogger,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IVSCodeExtensionContext private readonly _extensionContext: IVSCodeExtensionContext,
 	) {
 		super();
-		this._lastAutoV2Discounts = this._extensionContext.globalState.get<Record<string, number>>(AutomodeService.AUTO_V2_DISCOUNTS_STORAGE_KEY);
 		this._tierSupportAnnounced = this.areAutoModeTiersSupported();
 		// Covers both settings and their experiment treatments: a treatment
 		// refresh is published as a configuration change.
@@ -260,11 +245,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			// All of this is scoped to the signed-in account. Tier support can come
 			// back with the latch, but LanguageModelAccess already republishes
 			// models on this same event, so there is nothing to announce here.
-			this._setLastAutoV2Discounts(undefined);
 			this._autoV2Unavailable = false;
 			this._tierSupportAnnounced = this.areAutoModeTiersSupported();
-			this._autoV2DiscountProbe = undefined;
-			this._pickerTokenBank.clear();
 			const keys = Array.from(this._reserveTokens.keys());
 			this._reserveTokens.clearAndDisposeAll();
 			for (const location of keys) {
@@ -292,56 +274,6 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		return decision;
 	}
 
-	/**
-	 * Records the discounts shown on the Auto row in the picker. `tier` is the
-	 * profile the discounts came from: tiers route to different model pools and
-	 * so carry different discounts, while the picker has a single Auto row and no
-	 * tier context to qualify it with. Scope the label to the profile the picker
-	 * represents, so neither the internal `fast` tier (inline chat) nor another
-	 * tier's routing pass overwrites it.
-	 */
-	private _setLastAutoV2Discounts(discounts: Record<string, number> | undefined, tier?: AutoModeTier): void {
-		if (tier !== undefined && tier !== defaultAutoModeTier) {
-			return;
-		}
-		if (JSON.stringify(this._lastAutoV2Discounts) === JSON.stringify(discounts)) {
-			return;
-		}
-		this._lastAutoV2Discounts = discounts;
-		// Persisted so the next window shows the discount immediately.
-		this._extensionContext.globalState.update(AutomodeService.AUTO_V2_DISCOUNTS_STORAGE_KEY, discounts)
-			.then(undefined, (e: Error) => this._logService.warn(`[AutomodeService] Failed to persist auto discounts: ${e.message}`));
-	}
-
-	/**
-	 * TEMPORARY: reads discounts via `POST /auto` with a placeholder prompt,
-	 * since the endpoint has no prompt-free variant. Only `discounted_costs` is
-	 * used. Runs at most once per session. Remove once CAPI can return discounts
-	 * without classifying a prompt.
-	 */
-	private async _probeAutoV2Discounts(): Promise<void> {
-		if (!this._autoV2DiscountProbe) {
-			this._autoV2DiscountProbe = (async () => {
-				try {
-					const result = await this._autoV2Fetcher.getAutoDecision(AutomodeService.DISCOUNT_PROBE_PROMPT, {
-						isDiscountProbe: true,
-						// Read the same profile the label represents; see `_setLastAutoV2Discounts`.
-						tier: this.areAutoModeTiersSupported() ? defaultAutoModeTier : undefined,
-					});
-					this._setLastAutoV2Discounts(result.discounted_costs);
-				} catch (e) {
-					// A 404 is a capability result, not a metadata failure: the
-					// routing path treats it the same way.
-					if (e instanceof AutoV2Error && e.status === 404) {
-						this._markAutoV2Unavailable();
-					}
-					this._logService.warn(`[AutomodeService] Failed to probe auto discounts: ${(e as Error).message}`);
-				}
-			})();
-		}
-		return this._autoV2DiscountProbe;
-	}
-
 	async resolveAutoModePickerEndpoint(knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint> {
 		if (!knownEndpoints.length) {
 			throw new Error('No auto mode endpoints provided.');
@@ -352,40 +284,12 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		// Nothing to route without a prompt: wrap a representative endpoint for
 		// its display metadata only. The picker hides per-model pricing for
 		// Auto, so the wrapped model is not user-visible.
-		const metadata = await this.getAutoPickerMetadata();
-		// The probe above can latch V2 off (404), which changes what the picker
-		// may advertise.
-		if (!this.isAutoV2Enabled()) {
-			return this.resolveAutoModeEndpoint(undefined, knownEndpoints);
-		}
-		const discountRange = metadata?.discountRange ?? { low: 0, high: 0 };
 		const base = knownEndpoints.find(e => e.showInModelPicker) ?? knownEndpoints[0];
-		return this._instantiationService.createInstance(AutoChatEndpoint, base, '', 0, discountRange);
+		return this._instantiationService.createInstance(AutoChatEndpoint, base, '', 0, this.getAutoPickerMetadata(knownEndpoints).discountRange);
 	}
 
-	async getAutoPickerMetadata(): Promise<AutoModePickerMetadata | undefined> {
-		if (this.isAutoV2Enabled()) {
-			// `/auto` requires a prompt, which the picker does not have. Prefer
-			// the discounts observed on a real request; only when none have been
-			// seen yet (first ever run) probe with a placeholder prompt.
-			if (!this._lastAutoV2Discounts) {
-				await this._probeAutoV2Discounts();
-			}
-			return this._lastAutoV2Discounts
-				? { discountRange: this._calculateDiscountRange(this._lastAutoV2Discounts) }
-				: undefined;
-		}
-		// The legacy session endpoint returns discounts without a prompt.
-		try {
-			if (!this._pickerTokenBank.value) {
-				this._pickerTokenBank.value = new AutoModeTokenBank('auto-picker-metadata', ChatLocation.Panel, this._capiClientService, this._authService, this._logService, this._expService, this._envService);
-			}
-			const token = await this._pickerTokenBank.value.getToken();
-			return { discountRange: this._calculateDiscountRange(token.discounted_costs) };
-		} catch (e) {
-			this._logService.warn(`[AutomodeService] Failed to resolve auto picker metadata: ${(e as Error).message}`);
-			return undefined;
-		}
+	getAutoPickerMetadata(knownEndpoints: IChatEndpoint[]): AutoModePickerMetadata {
+		return { discountRange: this._calculateDiscountRange(knownEndpoints) };
 	}
 
 	/**
@@ -534,7 +438,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		// Reuse the cached endpoint if the session token and model haven't changed
 		const autoEndpoint = (entry?.endpoint && entry.lastSessionToken === token.session_token && entry.endpoint.model === selectedModel.model)
 			? entry.endpoint
-			: this._instantiationService.createInstance(AutoChatEndpoint, selectedModel, token.session_token, token.discounted_costs?.[selectedModel.model] || 0, this._calculateDiscountRange(token.discounted_costs));
+			: this._instantiationService.createInstance(AutoChatEndpoint, selectedModel, token.session_token, token.discounted_costs?.[selectedModel.model] ?? selectedModel.autoDiscount ?? 0, this._calculateDiscountRange(knownEndpoints));
 
 		const isNewTurn = !entry || lastRoutedPrompt !== entry.lastRoutedPrompt;
 		this._autoModelCache.set(conversationId, {
@@ -659,7 +563,6 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				vscodeRequestId: chatRequest?.id,
 				tier,
 			});
-			this._setLastAutoV2Discounts(result.discounted_costs, tier);
 
 			// Prefer local `/models` metadata: it carries fields `/auto` leaves
 			// unset (token pricing, promos, SKU restrictions, thinking budgets).
@@ -687,7 +590,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 			const endpoint = (entry?.endpoint && entry.sessionToken === result.session_token && entry.endpoint.model === selectedModel.model && entry.tier === tier)
 				? entry.endpoint
-				: this._instantiationService.createInstance(AutoChatEndpoint, selectedModel, result.session_token, result.discounted_costs?.[selectedModel.model] || 0, this._calculateDiscountRange(result.discounted_costs));
+				: this._instantiationService.createInstance(AutoChatEndpoint, selectedModel, result.session_token, result.discounted_costs?.[selectedModel.model] ?? selectedModel.autoDiscount ?? 0, this._calculateDiscountRange(knownEndpoints));
 
 			// Only a genuinely new conversation needs room made for it; the `set`
 			// below otherwise replaces an entry, and evicting would cost an
@@ -1010,21 +913,27 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		return selectedModel;
 	}
 
-	private _calculateDiscountRange(discounts: Record<string, number> | undefined): { low: number; high: number } {
-		if (!discounts) {
-			return { low: 0, high: 0 };
-		}
+	/**
+	 * The span of Auto discounts across the models Auto can route to, as
+	 * fractions (e.g. `0.1` for 10% off). Models without an `auto_discount` are
+	 * outside the Auto pool and do not contribute.
+	 */
+	private _calculateDiscountRange(knownEndpoints: IChatEndpoint[]): { low: number; high: number } {
 		let low = Infinity;
 		let high = -Infinity;
 		let hasValues = false;
 
-		for (const value of Object.values(discounts)) {
-			hasValues = true;
-			if (value < low) {
-				low = value;
+		for (const endpoint of knownEndpoints) {
+			const discount = endpoint.autoDiscount;
+			if (discount === undefined) {
+				continue;
 			}
-			if (value > high) {
-				high = value;
+			hasValues = true;
+			if (discount < low) {
+				low = discount;
+			}
+			if (discount > high) {
+				high = discount;
 			}
 		}
 		return hasValues ? { low, high } : { low: 0, high: 0 };

--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -175,6 +175,7 @@ export class ChatEndpoint implements IChatEndpoint {
 	public readonly isPremium?: boolean | undefined;
 	public readonly multiplier?: number | undefined;
 	public readonly restrictedToSkus?: string[] | undefined;
+	public readonly autoDiscount?: number | undefined;
 	public readonly tokenPricing?: IChatEndpointTokenPricing | undefined;
 	public readonly priceCategory?: string | undefined;
 	public readonly modelPickerCategory?: string | undefined;
@@ -211,6 +212,7 @@ export class ChatEndpoint implements IChatEndpoint {
 		this.isPremium = modelMetadata.billing?.is_premium;
 		this.multiplier = modelMetadata.billing?.multiplier;
 		this.restrictedToSkus = modelMetadata.billing?.restricted_to;
+		this.autoDiscount = modelMetadata.billing?.auto_discount;
 		const normalized = normalizeTokenPrices(modelMetadata.billing?.token_prices);
 		this.tokenPricing = normalized ? {
 			default: { inputPrice: normalized.default.inputPrice, outputPrice: normalized.default.outputPrice, cacheReadTokenPrice: normalized.default.cachePrice, cacheWriteTokenPrice: normalized.default.cacheWritePrice, contextMax: normalized.default.contextMax },

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -11,7 +11,6 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { ChatLocation } from '../../../../vscodeTypes';
 import { IAuthenticationService } from '../../../authentication/common/authentication';
 import { NullEnvService } from '../../../env/common/nullEnvService';
-import { IVSCodeExtensionContext } from '../../../extContext/common/extensionContext';
 import { ILogService } from '../../../log/common/logService';
 import { IChatEndpoint } from '../../../networking/common/networking';
 import { NullRequestLogger } from '../../../requestLogger/node/nullRequestLogger';
@@ -64,8 +63,6 @@ describe('AutomodeService', () => {
 	let mockChatEndpoint: IChatEndpoint;
 	let envService: NullEnvService;
 	let configurationService: IConfigurationService;
-	let globalStateStore: Map<string, unknown>;
-	let mockExtensionContext: IVSCodeExtensionContext;
 	let onDidAuthenticationChangeEmitter: Emitter<void>;
 	let mockTelemetryService: ITelemetryService & { sendEnhancedGHTelemetryEvent: ReturnType<typeof vi.fn>; sendMSFTTelemetryEvent: ReturnType<typeof vi.fn> };
 
@@ -96,8 +93,7 @@ describe('AutomodeService', () => {
 			envService,
 			mockTelemetryService,
 			new NullRequestLogger(),
-			configurationService,
-			mockExtensionContext
+			configurationService
 		);
 	}
 
@@ -161,13 +157,6 @@ describe('AutomodeService', () => {
 		mockExpService = new NullExperimentationService();
 
 		envService = new NullEnvService();
-		globalStateStore = new Map<string, unknown>();
-		mockExtensionContext = {
-			globalState: {
-				get: (key: string) => globalStateStore.get(key),
-				update: async (key: string, value: unknown) => { globalStateStore.set(key, value); },
-			},
-		} as unknown as IVSCodeExtensionContext;
 		// These tests cover the legacy session + intent flow; the single-call
 		// Auto endpoint is exercised separately below.
 		configurationService = new InMemoryConfigurationService(
@@ -2056,38 +2045,6 @@ describe('AutomodeService', () => {
 			expect(autoCallCount()).toBe(callsBefore);
 		});
 
-		it('keeps inline requests from overwriting the discount shown in the picker', async () => {
-			enableAutoV2WithTiers();
-			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.2 },
-			});
-
-			automodeService = createService();
-			await automodeService.resolveAutoModeEndpoint({
-				location: ChatLocation.Panel,
-				prompt: 'panel turn',
-				sessionId: 'session-discount-panel',
-			} as ChatRequest, [mockChatEndpoint, gpt4oEndpoint]);
-
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.9 },
-			});
-			await automodeService.resolveAutoModeEndpoint({
-				location: ChatLocation.Editor,
-				prompt: 'inline turn',
-				sessionId: 'session-discount-inline',
-			} as ChatRequest, [mockChatEndpoint, gpt4oEndpoint]);
-
-			expect(await automodeService.getAutoPickerMetadata()).toEqual({ discountRange: { low: 0.2, high: 0.2 } });
-		});
-
 		// Tiers are experiment-gated, so until the experiment reaches a user the
 		// request must look exactly as it did before tiers existed.
 		it('omits the tier and hides the picker while tiers are disabled', async () => {
@@ -2142,7 +2099,7 @@ describe('AutomodeService', () => {
 			expect(JSON.parse(autoCall![0].body)).toEqual({ prompt: 'panel turn', tier: 'max' });
 		});
 
-		it('resolves the picker endpoint without touching the legacy session under V2', async () => {
+		it('resolves the picker endpoint without any request under V2', async () => {
 			enableAutoV2();
 			mockAuto({
 				session_token: 'auto-v2-token',
@@ -2154,145 +2111,55 @@ describe('AutomodeService', () => {
 			const result = await automodeService.resolveAutoModePickerEndpoint([mockChatEndpoint]);
 
 			expect(result).toBeDefined();
-			const requestTypes = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.map(c => c[1]?.type);
-			expect(requestTypes).not.toContain(RequestType.AutoModels);
-		});
-
-		it('surfaces the discounts from the last /auto response in the picker metadata', async () => {
-			enableAutoV2();
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.1, 'gpt-4o-mini': 0.25 },
-			});
-
-			automodeService = createService();
-			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
-			await automodeService.resolveAutoModeEndpoint({
-				location: ChatLocation.Panel,
-				prompt: 'test prompt',
-				sessionId: 'session-auto-v2-discounts'
-			} as ChatRequest, [gpt4oEndpoint]);
-
-			expect(await automodeService.getAutoPickerMetadata()).toEqual({ discountRange: { low: 0.1, high: 0.25 } });
-		});
-
-		it('probes /auto with the placeholder prompt when no discount is known yet', async () => {
-			enableAutoV2();
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.15 },
-			});
-
-			automodeService = createService();
-			const metadata = await automodeService.getAutoPickerMetadata();
-
-			expect(metadata).toEqual({ discountRange: { low: 0.15, high: 0.15 } });
-			const autoCall = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.find(c => c[1]?.type === RequestType.Auto);
-			expect(JSON.parse(autoCall![0].body)).toEqual({ prompt: 'MODEL_PICKER_DISCOUNT_RESOLUTION - REPLACE ME' });
-		});
-
-		it('withdraws the tier picker when the discount probe is gated with a 404', async () => {
-			enableAutoV2WithTiers();
-			mockAuto({ error: 'not_found' }, 404);
-			const gpt4oMiniEndpoint = createEndpoint('gpt-4o-mini', 'OpenAI');
-
-			automodeService = createService();
-			const endpoint = await automodeService.resolveAutoModePickerEndpoint([gpt4oMiniEndpoint]);
-
-			const requestTypes = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.map(c => c[1]?.type);
-			expect({
-				model: endpoint.model,
-				tiersSupported: automodeService.areAutoModeTiersSupported(),
-				usedLegacySession: requestTypes.includes(RequestType.AutoModels),
-			}).toEqual({ model: 'gpt-4o-mini', tiersSupported: false, usedLegacySession: true });
-		});
-
-		it('probes at most once even across concurrent picker refreshes', async () => {
-			enableAutoV2();
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.15 },
-			});
-
-			automodeService = createService();
-			await Promise.all([
-				automodeService.getAutoPickerMetadata(),
-				automodeService.getAutoPickerMetadata(),
-			]);
-			await automodeService.getAutoPickerMetadata();
-
-			const autoCalls = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.filter(c => c[1]?.type === RequestType.Auto);
-			expect(autoCalls).toHaveLength(1);
-		});
-
-		it('does not probe when a discount is already known', async () => {
-			enableAutoV2();
-			globalStateStore.set('copilot.autoMode.v2.lastDiscountedCosts', { 'gpt-4o': 0.3 });
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-			});
-
-			automodeService = createService();
-			const metadata = await automodeService.getAutoPickerMetadata();
-
-			expect(metadata).toEqual({ discountRange: { low: 0.3, high: 0.3 } });
 			expect(mockCAPIClientService.makeRequest).not.toHaveBeenCalled();
 		});
 
-		it('shows the persisted discount on a cold start before any /auto call', async () => {
+		// The picker has no prompt, so the discount label is read off the model
+		// metadata rather than being resolved through a routing request.
+		it('derives the picker discount range from the models auto_discount', async () => {
+			enableAutoV2();
+
+			automodeService = createService();
+			const metadata = automodeService.getAutoPickerMetadata([
+				createEndpoint('gpt-4o', 'OpenAI', { autoDiscount: 0.1 }),
+				createEndpoint('gpt-4o-mini', 'OpenAI', { autoDiscount: 0.25 }),
+				// Outside the Auto pool: must not drag the range down to zero.
+				createEndpoint('byok-model', 'Anthropic'),
+			]);
+
+			expect({ metadata, requests: (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.length })
+				.toEqual({ metadata: { discountRange: { low: 0.1, high: 0.25 } }, requests: 0 });
+		});
+
+		it('reports no discount when no model advertises one', async () => {
+			enableAutoV2();
+
+			automodeService = createService();
+
+			expect(automodeService.getAutoPickerMetadata([mockChatEndpoint])).toEqual({ discountRange: { low: 0, high: 0 } });
+		});
+
+		it('falls back to the model auto_discount when /auto omits the discounted costs', async () => {
 			enableAutoV2();
 			mockAuto({
 				session_token: 'auto-v2-token',
 				expires_at: Math.floor(Date.now() / 1000) + 86400,
 				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.1, 'gpt-4o-mini': 0.25 },
 			});
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI', { autoDiscount: 0.15 });
 
 			automodeService = createService();
 			await automodeService.resolveAutoModeEndpoint({
 				location: ChatLocation.Panel,
 				prompt: 'test prompt',
-				sessionId: 'session-auto-v2-persist'
-			} as ChatRequest, [createEndpoint('gpt-4o', 'OpenAI')]);
+				sessionId: 'session-auto-v2-discount-fallback'
+			} as ChatRequest, [gpt4oEndpoint]);
 
-			// A new service instance simulates a window reload: the discounts
-			// come back from storage without any request having been made.
-			const restarted = createService();
-			expect(await restarted.getAutoPickerMetadata()).toEqual({ discountRange: { low: 0.1, high: 0.25 } });
+			const autoCall = (mockInstantiationService.createInstance as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+			expect({ discount: autoCall![3], range: autoCall![4] }).toEqual({ discount: 0.15, range: { low: 0.15, high: 0.15 } });
 		});
 
-		it('clears the persisted discount when authentication changes', async () => {
-			enableAutoV2();
-			mockAuto({
-				session_token: 'auto-v2-token',
-				expires_at: Math.floor(Date.now() / 1000) + 86400,
-				selected_model: { id: 'gpt-4o' },
-				discounted_costs: { 'gpt-4o': 0.1 },
-			});
-
-			automodeService = createService();
-			await automodeService.resolveAutoModeEndpoint({
-				location: ChatLocation.Panel,
-				prompt: 'test prompt',
-				sessionId: 'session-auto-v2-auth-change'
-			} as ChatRequest, [createEndpoint('gpt-4o', 'OpenAI')]);
-			expect(await automodeService.getAutoPickerMetadata()).toBeDefined();
-
-			onDidAuthenticationChangeEmitter.fire();
-
-			// The previous account's discount must not survive the switch.
-			expect(globalStateStore.get('copilot.autoMode.v2.lastDiscountedCosts')).toBeUndefined();
-		});
-
-		it('resets the 404 latch and discount probe when authentication changes', async () => {
+		it('resets the 404 latch when authentication changes', async () => {
 			enableAutoV2();
 			mockAuto({ error: 'not_found' }, 404);
 
@@ -2312,23 +2179,12 @@ describe('AutomodeService', () => {
 			expect((mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.filter(c => c[1]?.type === RequestType.Auto)).toHaveLength(2);
 		});
 
-		it('resolves picker metadata via the legacy session call when the setting is disabled', async () => {
-			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue(
-				makeMockTokenResponse({
-					available_models: ['gpt-4o-mini'],
-					expires_at: Math.floor(Date.now() / 1000) + 3600,
-					session_token: 'legacy-token',
-					discounted_costs: { 'gpt-4o-mini': 0.2 },
-				})
-			);
-
+		it('resolves picker metadata from the model metadata when the setting is disabled', async () => {
 			automodeService = createService();
-			const metadata = await automodeService.getAutoPickerMetadata();
+			const metadata = automodeService.getAutoPickerMetadata([createEndpoint('gpt-4o-mini', 'OpenAI', { autoDiscount: 0.2 })]);
 
 			expect(metadata).toEqual({ discountRange: { low: 0.2, high: 0.2 } });
-			const requestTypes = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls.map(c => c[1]?.type);
-			expect(requestTypes).toContain(RequestType.AutoModels);
-			expect(requestTypes).not.toContain(RequestType.Auto);
+			expect(mockCAPIClientService.makeRequest).not.toHaveBeenCalled();
 		});
 
 		it('can be remotely disabled via the experiment treatment variable', async () => {

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -346,6 +346,11 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly multiplier?: number;
 	readonly restrictedToSkus?: string[];
 	/**
+	 * Discount applied when this model is reached through Auto, as a fraction
+	 * (e.g. `0.1` for 10% off). Only set on models Auto can route to.
+	 */
+	readonly autoDiscount?: number;
+	/**
 	 * Normalized token pricing in AICs per million tokens.
 	 * Computed from the raw billing token_prices and normalized
 	 * to per-million-token rates based on batch_size.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
         "@vscode/codicons": "^0.0.46-30",
-        "@vscode/copilot-api": "^0.5.1",
+        "@vscode/copilot-api": "^0.5.2",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "0.0.2-7",
         "@vscode/fs-copyfile": "2.0.0",
@@ -4365,9 +4365,9 @@
       }
     },
     "node_modules/@vscode/copilot-api": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.1.tgz",
-      "integrity": "sha512-J+pxNXbkhIdzJ0Tx2nW+mxQSfnjPbHu7CSrOnRA814bmVsVjGvgqtVmRtZkWRGNs43kd4fvckXVbvqQzZ78hqw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.2.tgz",
+      "integrity": "sha512-U+2jyi0/Hpum2ZnED47cVFKgx5+p+thRhOPDKc1+t2PVAzsKlr3aJPKxMeMLOIXGWyLuQcng5BuFvj1vxD1d8w==",
       "license": "SEE LICENSE"
     },
     "node_modules/@vscode/deviceid": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
     "@vscode/codicons": "^0.0.46-30",
-    "@vscode/copilot-api": "^0.5.1",
+    "@vscode/copilot-api": "^0.5.2",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "0.0.2-7",
     "@vscode/fs-copyfile": "2.0.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@microsoft/mxc-sdk": "0.6.1",
         "@parcel/watcher": "^2.5.6",
-        "@vscode/copilot-api": "^0.5.1",
+        "@vscode/copilot-api": "^0.5.2",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/fs-copyfile": "2.0.0",
         "@vscode/iconv-lite-umd": "0.7.1",
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/@vscode/copilot-api": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.1.tgz",
-      "integrity": "sha512-J+pxNXbkhIdzJ0Tx2nW+mxQSfnjPbHu7CSrOnRA814bmVsVjGvgqtVmRtZkWRGNs43kd4fvckXVbvqQzZ78hqw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/copilot-api/-/copilot-api-0.5.2.tgz",
+      "integrity": "sha512-U+2jyi0/Hpum2ZnED47cVFKgx5+p+thRhOPDKc1+t2PVAzsKlr3aJPKxMeMLOIXGWyLuQcng5BuFvj1vxD1d8w==",
       "license": "SEE LICENSE"
     },
     "node_modules/@vscode/deviceid": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -9,7 +9,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@microsoft/mxc-sdk": "0.6.1",
     "@parcel/watcher": "^2.5.6",
-    "@vscode/copilot-api": "^0.5.1",
+    "@vscode/copilot-api": "^0.5.2",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/fs-copyfile": "2.0.0",
     "@vscode/iconv-lite-umd": "0.7.1",


### PR DESCRIPTION
Cherry-pick of #330058 from `main`.

Merge conflicts in `package.json` / `package-lock.json` have been resolved.

Replaces #330076 (that PR was bot-authored, which tripped the Community PR Approvals check).