### PR TITLE
Prevent omni chat send hover loop

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -3236,6 +3236,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const focusedWidget = observableFromEvent(this, this.chatWidgetService.onDidChangeFocusedSession, () => this.chatWidgetService.lastFocusedWidget);
 		const isVoiceInputActive = derived(this, reader => focusedWidget.read(reader) === widget);
 		const isOmniInput = this.contextKeyService.getContextKeyValue<boolean>(ChatContextKeys.inChatInputWindow.key) === true;
+		hoverDelegate.showNativeHover = isOmniInput;
 		const isVoiceSessionActive = derived(this, reader => {
 			const omniInputActive = this.voiceSessionController.omniInputActive.read(reader);
 			if (omniInputActive) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -3236,7 +3236,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const focusedWidget = observableFromEvent(this, this.chatWidgetService.onDidChangeFocusedSession, () => this.chatWidgetService.lastFocusedWidget);
 		const isVoiceInputActive = derived(this, reader => focusedWidget.read(reader) === widget);
 		const isOmniInput = this.contextKeyService.getContextKeyValue<boolean>(ChatContextKeys.inChatInputWindow.key) === true;
-		hoverDelegate.showNativeHover = isOmniInput;
 		const isVoiceSessionActive = derived(this, reader => {
 			const omniInputActive = this.voiceSessionController.omniInputActive.read(reader);
 			if (omniInputActive) {
@@ -3402,6 +3401,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				}
 				if ((action.id === ChatSubmitAction.ID || action.id === ChatEditingSessionSubmitAction.ID) && action instanceof MenuItemAction) {
 					return this.instantiationService.createInstance(class extends MenuEntryActionViewItem {
+						protected override getHoverContents() {
+							return isOmniInput ? undefined : super.getHoverContents();
+						}
+
 						override render(container: HTMLElement): void {
 							super.render(container);
 							container.classList.add('chat-submit-button');


### PR DESCRIPTION
## Summary
- suppress the visual Send tooltip only in omni chat
- preserve the full accessible label and keyboard shortcut information
- keep managed hovers unchanged in other chat surfaces

Fixes microsoft/vscode-internalbacklog#8795

## Validation
- npm run eslint -- src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
- npm run transpile-client
- git diff --check
- live omni chat verification