### PR TITLE
agentHost: use local confirmation for client tools

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2079,12 +2079,26 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const store = new DisposableStore();
 		this._inputNeededWatchers.set(sessionKey, { store, refs: new Set([sessionResource.toString()]) });
 
+		// Requests that we own should be 'invoked' when pending confirmation immediately because
+		// we handle showing their UI directly. For simplicity in later tool call flows, rewrite them.
 		const requests = derivedOpts({ equalsFn: equals }, reader =>
-			(state.read(reader)?.inputNeeded ?? []).filter((request): request is SessionInputRequest =>
-				request.kind === SessionInputRequestKind.ChatInput
-				|| request.kind === SessionInputRequestKind.ToolConfirmation
-				|| request.kind === SessionInputRequestKind.ToolClientExecution
-				|| request.kind === SessionInputRequestKind.ToolAuthentication));
+			(state.read(reader)?.inputNeeded ?? []).map((request): SessionInputRequest => {
+				if (request.kind === SessionInputRequestKind.ToolConfirmation
+					&& request.toolCall.status === ToolCallStatus.PendingConfirmation
+					&& request.toolCall.contributor?.kind === ToolCallContributorKind.Client) {
+					return {
+						...request,
+						kind: SessionInputRequestKind.ToolClientExecution,
+						clientId: request.toolCall.contributor.clientId,
+					};
+				}
+				return request;
+			})
+		);
+
+		const startedClientToolCalls = new Set<string>();
+		const pendingClientToolCts = new CancellationTokenSource();
+		store.add(toDisposable(() => pendingClientToolCts.dispose(true)));
 
 		// This watcher is the single point of truth for how client tools
 		// execute. A turn observer only ever renders the shared invocation; it
@@ -2116,14 +2130,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 
 			const key = this._toolCallKey(chatURI, initial.turnId, initial.toolCall.toolCallId);
-			const cts = new CancellationTokenSource();
-			itemStore.add(toDisposable(() => cts.dispose(true)));
 			itemStore.add(this._retainToolCall(key));
 
 			if (initial.kind === SessionInputRequestKind.ToolClientExecution) {
 				if (initial.clientId !== this._config.connection.clientId) {
 					return; // A different client owns this call.
 				}
+				const cts = new CancellationTokenSource();
+				itemStore.add(toDisposable(() => cts.dispose(true)));
 				let generation = 0;
 				let observedRequest: SessionToolClientExecutionRequest | undefined;
 				let startedRequest: SessionToolClientExecutionRequest | undefined;
@@ -2137,6 +2151,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						observedRequest = undefined;
 						startedRequest = undefined;
 						invocationStarted = false;
+						unobservedTimer.clear();
+						return;
+					}
+					if (startedClientToolCalls.has(key)) {
+						startedRequest = request;
 						unobservedTimer.clear();
 						return;
 					}
@@ -2163,11 +2182,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						void this._executeClientTool(
 							request,
 							contextSessionResource,
-							cts.token,
+							request.toolCall.status === ToolCallStatus.PendingConfirmation ? pendingClientToolCts.token : cts.token,
 							() => requestGeneration === generation && (invocationStarted || equals(request$.read(undefined), request)),
 							() => {
 								if (requestGeneration === generation) {
 									invocationStarted = true;
+									startedClientToolCalls.add(key);
 								}
 							},
 						);
@@ -2181,6 +2201,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						unobservedTimer.value = disposableTimeout(() => {
 							if (requestGeneration === generation && !startedRequest) {
 								startedRequest = request;
+								startedClientToolCalls.add(key);
 								this._denyClientTool(request);
 							}
 						}, UNOBSERVED_CLIENT_TOOL_GRACE_MS);
@@ -2418,7 +2439,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				parameters,
 				context: contextSessionResource ? { sessionResource: contextSessionResource } : undefined,
 				chatStreamToolCallId: toolCall.toolCallId,
-				preApproved: getClientToolPreApproval(toolCall),
+				preApproved: toolCall.status === ToolCallStatus.PendingConfirmation ? undefined : getClientToolPreApproval(toolCall),
 			}, async () => 0, token);
 		} catch (err) {
 			error = err;
@@ -3770,12 +3791,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		store.add(autorun(reader => {
 			const tc = part$.read(reader).toolCall;
-			const state = invocation.state.read(reader);
 			this._tryObserveSubagentToolCall(tc, invocation, store, opts, subagentContext);
-			if (tc.status === ToolCallStatus.PendingConfirmation && state.type === IChatToolInvocation.StateKind.Streaming) {
-				const prepared = toolCallStateToPreparedInvocation(tc, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority);
-				invocation.transitionFromStreaming(prepared, invocation.parameters, getClientToolPreApproval(tc));
-			}
 			if ((tc.status === ToolCallStatus.Cancelled || tc.status === ToolCallStatus.Completed)
 				&& !IChatToolInvocation.isComplete(invocation, reader)) {
 				const fileEdits = finalizeToolInvocation(invocation, tc, opts.backendSession, this._config.connectionAuthority);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -1584,14 +1584,6 @@ suite('AgentHostClientTools', () => {
 			} as ChatAction);
 
 			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
-			await timeout(0);
-			await timeout(0);
-			return chatURI;
-		}
-
-		test('hydrates and confirms a pending client tool before executing it exactly once', async () => {
-			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
-			const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
 			connection.applySessionAction(AgentSession.uri('copilot', 'session-1'), {
 				type: ActionType.SessionInputNeededSet,
 				request: {
@@ -1607,25 +1599,22 @@ suite('AgentHostClientTools', () => {
 						invocationMessage: 'Run Task',
 						toolInput: '{"task":"build"}',
 						confirmationTitle: 'Run Task',
+						contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
 					},
 				},
 			});
 			await timeout(0);
+			await timeout(0);
+			return chatURI;
+		}
+
+		test('invokes a ready client tool and reflects its local confirmation', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
+			await provideSessionWithPendingConfirmationClientTool(handler, connection);
 
 			const invocation = toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1');
 			const stateBeforeApproval = invocation?.state.get().type;
 			const parametersBeforeExecution = invocation?.parameters;
-
-			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
-				toolCallId: 'tool-call-1',
-				toolName: 'runTask',
-				displayName: 'Run Task',
-				invocationMessage: 'Run Task',
-				toolInput: '{"task":"build"}',
-				confirmed: ToolCallConfirmationReason.UserAction,
-			});
-			await timeout(0);
-			await timeout(0);
 
 			const hydratedInvocation = invocation && {
 				state: invocation.state.get().type,
@@ -1661,7 +1650,7 @@ suite('AgentHostClientTools', () => {
 					}),
 			}, {
 				stateBeforeApproval: IChatToolInvocation.StateKind.WaitingForConfirmation,
-				parametersBeforeExecution: undefined,
+				parametersBeforeExecution: { task: 'build' },
 				hydratedInvocation: {
 					state: IChatToolInvocation.StateKind.WaitingForConfirmation,
 					parameters: { task: 'build' },
@@ -1688,50 +1677,34 @@ suite('AgentHostClientTools', () => {
 			});
 		});
 
-		test('dispatches a selected protocol confirmation option with its approval kind', async () => {
-			for (const option of [
-				{ id: 'allow-once', kind: ConfirmationOptionKind.Approve },
-				{ id: 'skip', kind: ConfirmationOptionKind.Deny },
-			]) {
-				const local = disposables.add(new DisposableStore());
-				const { handler, connection, toolsService } = createHandlerWithMocks(local, [testRunTaskTool]);
-				await provideSessionWithPendingConfirmationClientTool(handler, connection);
+		test('ignores protocol confirmation when the client tool does not require it', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool]);
+			await provideSessionWithPendingConfirmationClientTool(handler, connection);
+			await timeout(0);
 
-				const invocation = toolsService.begunToolCalls[0];
-				const state = invocation.state.get();
-				assert.strictEqual(state.type, IChatToolInvocation.StateKind.WaitingForConfirmation);
-				assert.strictEqual(toolsService.invokedToolCalls.length, 0);
-				if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
-					return;
-				}
-				state.confirm({
-					type: ToolConfirmKind.UserAction,
-					selectedButton: option.id,
-					selectedButtonKind: option.kind,
-				});
-				await timeout(0);
-
-				const confirmation = connection.dispatchedActions.find(entry => isChatAction(entry.action)
-					&& entry.action.type === ActionType.ChatToolCallConfirmed
-					&& entry.action.toolCallId === 'tool-call-1');
-				assert.deepStrictEqual(confirmation?.action, option.kind === ConfirmationOptionKind.Approve
-					? {
-						type: ActionType.ChatToolCallConfirmed,
-						turnId: 'turn-1',
-						toolCallId: 'tool-call-1',
-						approved: true,
-						confirmed: ToolCallConfirmationReason.UserAction,
-						selectedOptionId: option.id,
-					}
-					: {
-						type: ActionType.ChatToolCallConfirmed,
-						turnId: 'turn-1',
-						toolCallId: 'tool-call-1',
-						approved: false,
-						reason: ToolCallCancellationReason.Denied,
-						selectedOptionId: option.id,
-					});
-			}
+			const invocation = toolsService.begunToolCalls[0];
+			const confirmation = connection.dispatchedActions.find(entry => isChatAction(entry.action)
+				&& entry.action.type === ActionType.ChatToolCallConfirmed
+				&& entry.action.toolCallId === 'tool-call-1');
+			assert.deepStrictEqual({
+				invocations: toolsService.invokedToolCalls.length,
+				preApproved: toolsService.invokedToolCalls[0]?.preApproved,
+				sawWaitingForConfirmation: (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.WaitingForConfirmation),
+				confirmationMessages: invocation.confirmationMessages,
+				confirmation: confirmation?.action,
+			}, {
+				invocations: 1,
+				preApproved: undefined,
+				sawWaitingForConfirmation: false,
+				confirmationMessages: undefined,
+				confirmation: {
+					type: ActionType.ChatToolCallConfirmed,
+					turnId: 'turn-1',
+					toolCallId: 'tool-call-1',
+					approved: true,
+					confirmed: ToolCallConfirmationReason.NotNeeded,
+				},
+			});
 		});
 
 		test('preserves the client tool confirmation reason through execution', async () => {
@@ -1745,7 +1718,7 @@ suite('AgentHostClientTools', () => {
 			for (const reason of reasons) {
 				const local = disposables.add(new DisposableStore());
 				const { handler, connection, toolsService } = createHandlerWithMocks(local, [testRunTaskTool], { requireConfirmation: true });
-				const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
+				await provideSessionWithPendingConfirmationClientTool(handler, connection);
 				const confirmedReason = reason === ToolCallConfirmationReason.NotNeeded
 					? { type: ToolConfirmKind.ConfirmationNotNeeded as const }
 					: reason === ToolCallConfirmationReason.Setting
@@ -1756,15 +1729,6 @@ suite('AgentHostClientTools', () => {
 					toolsService.begunToolCalls.find(invocation => invocation.toolCallId === 'tool-call-1'),
 					confirmedReason,
 				);
-				await timeout(0);
-				applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
-					toolCallId: 'tool-call-1',
-					toolName: 'runTask',
-					displayName: 'Run Task',
-					invocationMessage: 'Run Task',
-					toolInput: '{"task":"build"}',
-					confirmed: reason,
-				});
 				await timeout(0);
 				await timeout(0);
 
@@ -1792,34 +1756,33 @@ suite('AgentHostClientTools', () => {
 			})));
 		});
 
-		test('does not confirm or execute a pending client tool that completes without ever running', async () => {
-			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
+		test('does not execute again when the protocol advances the locally invoked tool to running', async () => {
+			const invokeResult = new DeferredPromise<IToolResult>();
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { invokeResult });
 			const chatURI = await provideSessionWithPendingConfirmationClientTool(handler, connection);
 
-			// The call completes while still `PendingConfirmation`, with no
-			// running client-execution record. The watcher never runs it, so it
-			// is never confirmed or driven through execution.
-			connection.applySessionAction(chatURI, {
-				type: ActionType.ChatToolCallComplete,
-				turnId: 'turn-1',
+			applyRunningClientExecution(connection, chatURI.toString(), 'turn-1', {
 				toolCallId: 'tool-call-1',
-				result: { success: true, pastTenseMessage: 'Ran task' },
-			} as ChatAction);
-			await timeout(0);
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
 			await timeout(0);
 
 			assert.deepStrictEqual({
 				invoked: toolsService.invokedToolCalls.filter(invocation => invocation.chatStreamToolCallId === 'tool-call-1').length,
-				sawExecuting: (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.Executing),
 				dispatchedApproval: connection.dispatchedActions.some(entry => isChatAction(entry.action)
 					&& entry.action.type === ActionType.ChatToolCallConfirmed
 					&& entry.action.toolCallId === 'tool-call-1'
 					&& entry.action.approved === true),
 			}, {
-				invoked: 0,
-				sawExecuting: false,
-				dispatchedApproval: false,
+				invoked: 1,
+				dispatchedApproval: true,
 			});
+			invokeResult.complete({ content: [{ kind: 'text', value: 'done' }] });
+			await timeout(0);
 		});
 
 		test('reconnecting to an active turn with owned client tool completes the initial snapshot invocation', async () => {


### PR DESCRIPTION
Backport of #330130 to release/1.133.

## Summary

- invoke client-owned tools as soon as their parameters are ready
- let the local tool invocation decide whether confirmation is required
- reflect local confirmation state back to the Agent Host Protocol

## Validation

- npm run transpile-client
- scripts/test.bat --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts (50 passing)

The branch-wide typecheck is currently blocked by a pre-existing managed-settings source type mismatch in copilotAgent.ts.