### PR TITLE
agentHost: Preserve detached shells during idle eviction

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1738,9 +1738,10 @@ export interface IAgent {
 	 * session database, and worktree are all preserved so the session can be
 	 * transparently resumed later. Used by idle-session eviction to bound
 	 * memory in long-lived host processes. Optional; providers that hold no
-	 * releasable in-memory state simply omit it.
+	 * releasable in-memory state simply omit it. Returns `false` when live
+	 * provider work prevents release; the host will retry later.
 	 */
-	releaseSession?(session: URI): Promise<void>;
+	releaseSession?(session: URI): Promise<boolean>;
 
 	/** Respond to a pending permission request from the SDK. */
 	respondToPermissionRequest(requestId: string, approved: boolean): void;

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2259,6 +2259,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// {@link ProtocolServerHandler} when state is already cached).
 		this.addSubscriber(resource, clientId);
 		try {
+			await this._releaseSessionInFlight.get(this._sessionReleaseKey(resource));
 			// Check for terminal state
 			const terminalState = this._terminalManager.getTerminalState(resourceStr);
 			if (terminalState) {
@@ -2345,6 +2346,18 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 	}
 
+	private _sessionReleaseKey(resource: URI): string {
+		const resourceString = resource.toString();
+		const changesetSession = parseChangesetUri(resourceString)?.sessionUri;
+		const chatSession = parseDefaultChatUri(resourceString);
+		let session = URI.parse(changesetSession ?? chatSession ?? resourceString);
+		let subagent;
+		while ((subagent = parseSubagentSessionUri(session))) {
+			session = subagent.parentSession;
+		}
+		return session.toString();
+	}
+
 	/** Waits for an armed subagent chat to register (or its wait to time out); returns `undefined` if not armed or never registered. */
 	private async _awaitPendingSubagentChat(subagentChatUri: string): Promise<IStateSnapshot | undefined> {
 		const pending = this._pendingSubagentChats.get(subagentChatUri);
@@ -2404,14 +2417,18 @@ export class AgentService extends Disposable implements IAgentService {
 		// and keeps the live provider SDK session, avoiding a disconnect/resume
 		// churn cycle that races concurrent session operations on the shared
 		// provider runtime. A zero grace releases on the next tick.
-		this._pendingSessionRelease.set(resource, disposableTimeout(() => {
-			this._pendingSessionRelease.deleteAndDispose(resource);
-			this._maybeEvictIdleSession(resource);
-		}, SESSION_RELEASE_GRACE_MS));
+		this._scheduleSessionRelease(resource);
 	}
 
 	private _cancelPendingSessionRelease(resource: URI): void {
 		this._pendingSessionRelease.deleteAndDispose(resource);
+	}
+
+	private _scheduleSessionRelease(resource: URI): void {
+		this._pendingSessionRelease.set(resource, disposableTimeout(() => {
+			this._pendingSessionRelease.deleteAndDispose(resource);
+			this._maybeEvictIdleSession(resource);
+		}, SESSION_RELEASE_GRACE_MS));
 	}
 
 	/**
@@ -2519,14 +2536,8 @@ export class AgentService extends Disposable implements IAgentService {
 				evictionTarget = parsed.parentSession;
 			}
 		}
-		// Don't evict if the root or any of its subagent descendants still has subscribers.
-		if (this._resourceSubscribers.has(evictionTarget)) {
+		if (this._hasSessionSubscribers(evictionTarget)) {
 			return;
-		}
-		for (const subscribedUri of this._resourceSubscribers.keys()) {
-			if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
-				return;
-			}
 		}
 		const evictionTargetKey = evictionTarget.toString();
 		// A restore/resume racing this unsubscribe means a client is about to
@@ -2536,36 +2547,71 @@ export class AgentService extends Disposable implements IAgentService {
 			return;
 		}
 		const targetState = this._stateManager.getSessionState(evictionTargetKey);
-		if (!targetState || targetState.activeTurn !== undefined) {
+		if (!targetState) {
 			return;
 		}
-		this._logService.info(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
-		// Also evict any sibling subagent entries cached under the parent: their
-		// authoritative state is the parent's turn tree, and dropping the parent
-		// would leave them orphaned.
+		if (targetState.activeTurn !== undefined) {
+			this._scheduleSessionRelease(evictionTarget);
+			return;
+		}
+		const provider = this._findProviderForSession(evictionTarget);
+		if (!provider?.releaseSession) {
+			this._evictSessionState(evictionTarget, evictionTargetKey, key);
+			return;
+		}
+		const release = provider.releaseSession(evictionTarget);
+		const trackedRelease = (async () => {
+			try {
+				const released = await release;
+				if (released) {
+					const currentState = this._stateManager.getSessionState(evictionTargetKey);
+					if (this._hasSessionSubscribers(evictionTarget)) {
+						return;
+					}
+					if (this._restoreSessionInFlight.has(evictionTargetKey) || currentState?.activeTurn !== undefined) {
+						this._scheduleSessionRelease(evictionTarget);
+						return;
+					}
+					if (currentState) {
+						this._evictSessionState(evictionTarget, evictionTargetKey, key);
+					}
+				} else if (!this._hasSessionSubscribers(evictionTarget)) {
+					this._scheduleSessionRelease(evictionTarget);
+				}
+			} catch (err) {
+				this._logService.error(err, `[AgentService] Failed to release idle session ${evictionTargetKey}`);
+				if (!this._hasSessionSubscribers(evictionTarget)) {
+					this._scheduleSessionRelease(evictionTarget);
+				}
+			}
+		})();
+		this._releaseSessionInFlight.set(evictionTargetKey, trackedRelease);
+		void trackedRelease.then(() => {
+			if (this._releaseSessionInFlight.get(evictionTargetKey) === trackedRelease) {
+				this._releaseSessionInFlight.delete(evictionTargetKey);
+			}
+		});
+	}
+
+	private _hasSessionSubscribers(session: URI): boolean {
+		if (this._resourceSubscribers.has(session)) {
+			return true;
+		}
+		for (const subscribedUri of this._resourceSubscribers.keys()) {
+			if (this._isSubagentDescendantOf(subscribedUri, session)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private _evictSessionState(evictionTarget: URI, evictionTargetKey: string, triggerKey: string): void {
+		this._logService.info(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${triggerKey})`);
 		const subagentPrefix = buildSubagentSessionUriPrefix(evictionTarget);
 		for (const cachedKey of this._stateManager.getSessionUrisWithPrefix(subagentPrefix)) {
 			this._stateManager.removeSession(cachedKey);
 		}
 		this._stateManager.removeSession(evictionTargetKey);
-		// Release the provider's in-memory SDK session in lockstep with the
-		// cached state. Non-destructive: durable data is preserved so the
-		// session resumes transparently on the next access. Fire-and-forget —
-		// the provider sequences the release internally and re-checks its own
-		// invariants (e.g. a turn that started after this call).
-		const provider = this._findProviderForSession(evictionTarget);
-		const release = provider?.releaseSession?.(evictionTarget);
-		if (release) {
-			const trackedRelease = release.catch(err => {
-				this._logService.error(err, `[AgentService] Failed to release idle session ${evictionTargetKey}`);
-			});
-			this._releaseSessionInFlight.set(evictionTargetKey, trackedRelease);
-			void trackedRelease.then(() => {
-				if (this._releaseSessionInFlight.get(evictionTargetKey) === trackedRelease) {
-					this._releaseSessionInFlight.delete(evictionTargetKey);
-				}
-			});
-		}
 	}
 
 	// Returns true when a changeset is safe to drop from the in-memory cache.

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2421,14 +2421,19 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	private _cancelPendingSessionRelease(resource: URI): void {
-		this._pendingSessionRelease.deleteAndDispose(resource);
+		this._pendingSessionRelease.deleteAndDispose(this._sessionReleaseResource(resource));
 	}
 
 	private _scheduleSessionRelease(resource: URI): void {
-		this._pendingSessionRelease.set(resource, disposableTimeout(() => {
-			this._pendingSessionRelease.deleteAndDispose(resource);
-			this._maybeEvictIdleSession(resource);
+		const session = this._sessionReleaseResource(resource);
+		this._pendingSessionRelease.set(session, disposableTimeout(() => {
+			this._pendingSessionRelease.deleteAndDispose(session);
+			this._maybeEvictIdleSession(session);
 		}, SESSION_RELEASE_GRACE_MS));
+	}
+
+	private _sessionReleaseResource(resource: URI): URI {
+		return URI.parse(this._sessionReleaseKey(resource));
 	}
 
 	/**
@@ -2554,6 +2559,9 @@ export class AgentService extends Disposable implements IAgentService {
 			this._scheduleSessionRelease(evictionTarget);
 			return;
 		}
+		if (this._releaseSessionInFlight.has(evictionTargetKey)) {
+			return;
+		}
 		const provider = this._findProviderForSession(evictionTarget);
 		if (!provider?.releaseSession) {
 			this._evictSessionState(evictionTarget, evictionTargetKey, key);
@@ -2594,11 +2602,9 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	private _hasSessionSubscribers(session: URI): boolean {
-		if (this._resourceSubscribers.has(session)) {
-			return true;
-		}
+		const sessionKey = this._sessionReleaseKey(session);
 		for (const subscribedUri of this._resourceSubscribers.keys()) {
-			if (this._isSubagentDescendantOf(subscribedUri, session)) {
+			if (this._sessionReleaseKey(subscribedUri) === sessionKey) {
 				return true;
 			}
 		}

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1322,28 +1322,29 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	 * {@link disposeSession}; the destructive difference (deleting durable data)
 	 * lives in the orchestrator, which only invokes it on dispose.
 	 */
-	releaseSession(session: URI): Promise<void> {
+	releaseSession(session: URI): Promise<boolean> {
 		const sessionId = AgentSession.id(session);
 		return this._disposeSequencer.queue(sessionId, async () => {
 			const entry = this._sessions.get(sessionId);
 			if (!entry) {
-				return;
+				return true;
 			}
 			// Provisional sessions (default chat not materialized) have no
 			// on-disk SDK session to resume from; releasing would lose state.
 			if (!entry.defaultChat?.isPipelineReady) {
-				return;
+				return false;
 			}
 			// Defensive active-turn guard: the orchestrator already skips
 			// eviction while a turn is active, but `disposeSession` and
 			// `sendMessage` run on separate sequencers, so a turn could be in
 			// flight. Never tear the pipeline down under a live turn.
 			if (entry.allChatSessions().some(chatSession => chatSession.hasActiveTurn)) {
-				return;
+				return false;
 			}
 			this._logService.info(`[Claude:${sessionId}] Releasing idle session from memory (durable state preserved)`);
 			await this._teardownEntry(sessionId);
 			this._pruneActiveClientHandles(sessionId);
+			return true;
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -3797,25 +3797,26 @@ export class CodexAgent extends Disposable implements IAgent {
 	 * sessions whose codex thread was never started) and for sessions with a
 	 * turn in flight — `thread/unsubscribe` mid-turn would drop live progress.
 	 */
-	async releaseSession(sessionUri: URI): Promise<void> {
+	async releaseSession(sessionUri: URI): Promise<boolean> {
 		const sessionId = AgentSession.id(sessionUri);
 		const session = this._sessions.get(sessionId);
 		if (!session) {
-			return;
+			return true;
 		}
 		// Provisional sessions have no codex thread on disk to resume from;
 		// releasing them would lose their in-memory state. Leave them in place.
 		if (session.threadId === undefined) {
-			return;
+			return false;
 		}
 		// Defensive active-turn guard: the orchestrator already skips eviction
 		// while a turn is active, but one could have started between that check
 		// and this call.
 		if (session.currentTurnId !== undefined) {
-			return;
+			return false;
 		}
 		this._logService.info(`[Codex:${session.threadId}] Releasing idle session from memory (durable state preserved)`);
 		await this._teardownSessionInMemory(session, sessionId);
+		return true;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -2933,16 +2933,18 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * sessions) or that aren't currently held in memory, and for sessions with a
 	 * running turn — disconnecting mid-turn would strand the SDK session.
 	 */
-	async releaseSession(session: URI): Promise<void> {
+	async releaseSession(session: URI): Promise<boolean> {
 		const sessionId = AgentSession.id(session);
 		const lifetime = this._getOrCreateSessionLifetime(sessionId);
 		if (!lifetime) {
-			return;
+			return true;
 		}
+		let released = true;
 		await lifetime.queueSession(() => lifetime.release(async () => {
 			// Provisional sessions were never persisted, so releasing them would
 			// lose state with no way to resume. Leave them in memory.
 			if (this._provisionalSessions.has(sessionId)) {
+				released = false;
 				return;
 			}
 			const entry = this._sessions.get(sessionId);
@@ -2953,11 +2955,20 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// eviction while a turn is active, but a turn could have started
 			// between that check and this sequenced callback.
 			if (entry.allChatSessions().some(chatSession => chatSession.hasActiveTurn)) {
+				released = false;
 				return;
+			}
+			for (const chatSession of entry.allChatSessions()) {
+				if (await chatSession.hasRunningDetachedShells()) {
+					this._logService.info(`[Copilot:${sessionId}] Deferring idle release while a detached shell is running`);
+					released = false;
+					return;
+				}
 			}
 			this._logService.info(`[Copilot:${sessionId}] Releasing idle session from memory (durable state preserved)`);
 			await this._releaseSessionResources(sessionId);
 		}));
+		return released;
 	}
 
 	private async _abortSession(chat: URI): Promise<void> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1222,6 +1222,19 @@ export class CopilotAgentSession extends Disposable {
 		this._currentTurn = new CopilotTurn(turnId, this._nextTurnOrdinal++, senderClientId, clientType);
 	}
 
+	async hasRunningDetachedShells(): Promise<boolean> {
+		try {
+			await this._wrapper.session.rpc.tasks.refresh();
+			const tasks = await this._wrapper.session.rpc.tasks.list();
+			return tasks.tasks.some(task => task.type === 'shell'
+				&& task.attachmentMode === 'detached'
+				&& (task.status === 'running' || task.status === 'idle'));
+		} catch (err) {
+			this._logService.warn(`[Copilot:${this.sessionId}] Failed to read detached shell state; deferring release: ${getErrorMessage(err)}`);
+			return true;
+		}
+	}
+
 	/** Refreshes prompt-cache state and the session-wide nano-AIU total from the SDK's authoritative usage metrics. */
 	private async _refreshSessionUsageMetrics(): Promise<boolean> {
 		try {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5904,6 +5904,73 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
+		test('chat subscription cancels the root release retry and gets a fresh grace period', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const agent = new DeferringReleaseMockAgent('copilot');
+				service.registerProvider(agent);
+				const { session } = await agent.createSession();
+				const sessionResource = (await agent.listSessions())[0].session;
+				const chatResource = URI.parse(buildDefaultChatUri(sessionResource));
+				agent.sessionMessages = [
+					{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+					{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+				];
+				await service.restoreSession(sessionResource);
+				service.addSubscriber(sessionResource, 'client-session');
+				service.unsubscribe(sessionResource, 'client-session');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.strictEqual(agent.releaseAttempts, 1);
+
+				service.addSubscriber(chatResource, 'client-chat');
+				await new Promise(resolve => setTimeout(resolve, 10_000));
+				service.unsubscribe(chatResource, 'client-chat');
+				await new Promise(resolve => setTimeout(resolve, 20_000));
+				assert.strictEqual(agent.releaseAttempts, 1, 'the cancelled root retry must not fire at its original deadline');
+				await new Promise(resolve => setTimeout(resolve, 9_999));
+				assert.strictEqual(agent.releaseAttempts, 1, 'chat disconnect should receive a fresh release grace');
+				await new Promise(resolve => setTimeout(resolve, 1));
+
+				assert.deepStrictEqual({
+					releaseAttempts: agent.releaseAttempts,
+					hasCachedState: service.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					releaseAttempts: 2,
+					hasCachedState: false,
+				});
+			});
+		});
+
+		test('overlapping root release timers preserve the original in-flight release', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const agent = new DelayedReleaseMockAgent('copilot');
+				service.registerProvider(agent);
+				const { session } = await agent.createSession();
+				const sessionResource = (await agent.listSessions())[0].session;
+				const chatResource = URI.parse(buildDefaultChatUri(sessionResource));
+				agent.sessionMessages = [
+					{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+					{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+				];
+				await service.restoreSession(sessionResource);
+				agent.events.length = 0;
+				service.addSubscriber(sessionResource, 'client-session');
+				service.unsubscribe(sessionResource, 'client-session');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.deepStrictEqual(agent.events, ['release:start']);
+
+				service.addSubscriber(chatResource, 'client-chat');
+				service.unsubscribe(chatResource, 'client-chat');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.deepStrictEqual(agent.events, ['release:start'], 'second timer must not start another provider release');
+
+				await agent.release.complete();
+				await Promise.resolve();
+				assert.deepStrictEqual(agent.events, ['release:start', 'release:end']);
+			});
+		});
+
 		test('a restored idle session is evicted when its last subscriber drops', () => {
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				service.registerProvider(copilotAgent);

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5785,16 +5785,29 @@ suite('AgentService (node dispatcher)', () => {
 			readonly release = new DeferredPromise<void>();
 			readonly events: string[] = [];
 
-			override async releaseSession(session: URI): Promise<void> {
+			override async releaseSession(session: URI): Promise<boolean> {
 				this.events.push('release:start');
-				await super.releaseSession(session);
+				const released = await super.releaseSession(session);
 				await this.release.p;
 				this.events.push('release:end');
+				return released;
 			}
 
 			override async getSessionMetadata(session: URI): Promise<IAgentSessionMetadata | undefined> {
 				this.events.push('metadata');
 				return super.getSessionMetadata(session);
+			}
+		}
+
+		class DeferringReleaseMockAgent extends MockAgent {
+			releaseAttempts = 0;
+
+			override async releaseSession(session: URI): Promise<boolean> {
+				this.releaseAttempts++;
+				if (this.releaseAttempts === 1) {
+					return false;
+				}
+				return super.releaseSession(session);
 			}
 		}
 
@@ -5828,6 +5841,67 @@ suite('AgentService (node dispatcher)', () => {
 			service.unsubscribe(sessionResource, 'client-1');
 
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'active-turn session must not be evicted');
+		});
+
+		test('an unsubscribed session is released after its active turn completes', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				service.registerProvider(copilotAgent);
+				const sessionResource = await service.createSession({ provider: 'copilot' });
+				const chatResource = buildDefaultChatUri(sessionResource.toString());
+				service.addSubscriber(sessionResource, 'client-1');
+				service.dispatchAction(
+					chatResource,
+					{ type: ActionType.ChatTurnStarted, turnId: 'turn-background', startedAt: '2025-01-01T00:00:00.000Z', message: { text: 'hello', origin: { kind: MessageKind.User } } },
+					'client-1', 1,
+				);
+				service.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.strictEqual(copilotAgent.releaseSessionCalls.length, 0, 'active session should re-arm idle release');
+
+				service.dispatchAction(
+					chatResource,
+					{ type: ActionType.ChatTurnComplete, turnId: 'turn-background', duration: 30_000 },
+					'client-1', 2,
+				);
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				assert.deepStrictEqual(copilotAgent.releaseSessionCalls.map(uri => uri.toString()), [sessionResource.toString()]);
+			});
+		});
+
+		test('a provider can defer idle release without losing cached state', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const agent = new DeferringReleaseMockAgent('copilot');
+				service.registerProvider(agent);
+				const { session } = await agent.createSession();
+				const sessionResource = (await agent.listSessions())[0].session;
+				agent.sessionMessages = [
+					{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+					{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+				];
+				await service.restoreSession(sessionResource);
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.deepStrictEqual({
+					releaseAttempts: agent.releaseAttempts,
+					hasCachedState: service.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					releaseAttempts: 1,
+					hasCachedState: true,
+				});
+
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+				assert.deepStrictEqual({
+					releaseAttempts: agent.releaseAttempts,
+					hasCachedState: service.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					releaseAttempts: 2,
+					hasCachedState: false,
+				});
+			});
 		});
 
 		test('a restored idle session is evicted when its last subscriber drops', () => {
@@ -5915,7 +5989,7 @@ suite('AgentService (node dispatcher)', () => {
 			});
 		});
 
-		test('restore waits for provider release to finish', () => {
+		test('subscription waits for provider release and keeps cached state', () => {
 			return runWithFakedTimers({ useFakeTimers: true }, async () => {
 				const agent = new DelayedReleaseMockAgent('copilot');
 				service.registerProvider(agent);
@@ -5933,10 +6007,52 @@ suite('AgentService (node dispatcher)', () => {
 				service.unsubscribe(sessionResource, 'client-1');
 				await new Promise(resolve => setTimeout(resolve, 30_000));
 
-				const restore = service.subscribe(sessionResource, 'client-2');
+				let subscriptionSettled = false;
+				const subscription = service.subscribe(sessionResource, 'client-2').then(result => {
+					subscriptionSettled = true;
+					return result;
+				});
+				await Promise.resolve();
+				assert.strictEqual(subscriptionSettled, false);
 				await agent.release.complete();
-				await restore;
-				assert.deepStrictEqual(agent.events, ['release:start', 'release:end', 'metadata']);
+				await subscription;
+				assert.deepStrictEqual({
+					events: agent.events,
+					hasCachedState: service.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					events: ['release:start', 'release:end'],
+					hasCachedState: true,
+				});
+			});
+		});
+
+		test('initial subscriber added during provider release keeps cached state', () => {
+			return runWithFakedTimers({ useFakeTimers: true }, async () => {
+				const agent = new DelayedReleaseMockAgent('copilot');
+				service.registerProvider(agent);
+				const { session } = await agent.createSession();
+				const sessionResource = (await agent.listSessions())[0].session;
+				agent.sessionMessages = [
+					{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+					{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+				];
+				await service.restoreSession(sessionResource);
+				agent.events.length = 0;
+				service.addSubscriber(sessionResource, 'client-1');
+				service.unsubscribe(sessionResource, 'client-1');
+				await new Promise(resolve => setTimeout(resolve, 30_000));
+
+				service.addSubscriber(sessionResource, 'client-2');
+				await agent.release.complete();
+				await Promise.resolve();
+
+				assert.deepStrictEqual({
+					events: agent.events,
+					hasCachedState: service.stateManager.getSessionState(sessionResource.toString()) !== undefined,
+				}, {
+					events: ['release:start', 'release:end'],
+					hasCachedState: true,
+				});
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -602,6 +602,7 @@ class TestableCopilotAgent extends CopilotAgent {
 			getMessages: fake.getMessages,
 			appliedSnapshot: undefined,
 			dispose: fake.dispose,
+			hasRunningDetachedShells: async () => false,
 			resetTurnState: (newTurnId: string) => { turnId = newTurnId; },
 			emitInitialMarkdown: (content: string) => {
 				emitter.fire({
@@ -4647,6 +4648,7 @@ suite('CopilotAgent', () => {
 				resetTurnState(turnId: string, senderClientId: string | undefined): void { rec.resets.push({ turnId, senderClientId }); },
 				async setModel(id: string): Promise<void> { rec.modelCalls.push({ id }); },
 				async setAgent(name: string | undefined): Promise<void> { rec.agentCalls.push(name); },
+				async hasRunningDetachedShells(): Promise<boolean> { return false; },
 				handleClientToolCallComplete(): void { },
 				async getNextTurnEventId(): Promise<string | undefined> { return undefined; },
 				getMessages: getMessages ?? (async () => []),
@@ -4800,6 +4802,7 @@ suite('CopilotAgent', () => {
 				setDefaultSessionStub(agent, AgentSession.id(session), {
 					workingDirectory: URI.file('/workspace'),
 					hasActiveTurn: false,
+					async hasRunningDetachedShells() { return false; },
 					async destroySession() { },
 					dispose() { },
 				});
@@ -4851,6 +4854,7 @@ suite('CopilotAgent', () => {
 				setDefaultSessionStub(agent, AgentSession.id(session), {
 					workingDirectory: URI.file('/workspace'),
 					hasActiveTurn: false,
+					async hasRunningDetachedShells() { return false; },
 					async destroySession() { },
 					dispose() { },
 				});
@@ -4868,6 +4872,7 @@ suite('CopilotAgent', () => {
 				const internals = agent as unknown as ChatInternals;
 				internals._resumeSession = async () => ({
 					workingDirectory: URI.file('/workspace'),
+					async hasRunningDetachedShells() { return false; },
 					dispose() { },
 				} as unknown as CopilotAgentSession);
 				internals._createAgentSession = (launchPlan, _directory, _activeClient, identity) => {
@@ -4926,6 +4931,7 @@ suite('CopilotAgent', () => {
 				setDefaultSessionStub(agent, AgentSession.id(session), {
 					workingDirectory: URI.file('/workspace'),
 					hasActiveTurn: false,
+					async hasRunningDetachedShells() { return false; },
 					async destroySession() {
 						releaseStarted = true;
 						await releaseGate.p;
@@ -4939,6 +4945,7 @@ suite('CopilotAgent', () => {
 				const internals = agent as unknown as ChatInternals;
 				internals._resumeSession = async () => ({
 					workingDirectory: URI.file('/workspace'),
+					async hasRunningDetachedShells() { return false; },
 					dispose() { },
 				} as unknown as CopilotAgentSession);
 				let initializations = 0;
@@ -4981,6 +4988,7 @@ suite('CopilotAgent', () => {
 				setDefaultSessionStub(agent, sessionId, {
 					workingDirectory: URI.file('/workspace'),
 					hasActiveTurn: false,
+					async hasRunningDetachedShells() { return false; },
 					async destroySession() { },
 					dispose() { },
 				});
@@ -5036,6 +5044,7 @@ suite('CopilotAgent', () => {
 				setDefaultSessionStub(agent, AgentSession.id(session), {
 					workingDirectory: URI.file('/workspace'),
 					hasActiveTurn: false,
+					async hasRunningDetachedShells() { return false; },
 					async destroySession() {
 						releaseStarted = true;
 						await releaseGate.p;

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -128,6 +128,10 @@ class MockCopilotSession {
 	 * Lets a test make an earlier-issued read resolve after a later one.
 	 */
 	readonly usageMetricsGates: Array<Promise<unknown>> = [];
+	backgroundTasks: Awaited<ReturnType<CopilotSession['rpc']['tasks']['list']>>['tasks'] = [];
+	backgroundTaskListCalls = 0;
+	backgroundTaskRefreshCalls = 0;
+	backgroundTaskListError: Error | undefined;
 
 	private readonly _handlers = new Map<string, Set<(event: SessionEvent) => void>>();
 	private readonly _allHandlers = new Set<SessionEventHandler>();
@@ -258,6 +262,22 @@ class MockCopilotSession {
 			invoke: async (params: { name: string; input?: string }) => {
 				this.commandInvokeCalls.push(params);
 				return this.commandInvokeResult;
+			},
+		},
+		tasks: {
+			list: async () => {
+				this.backgroundTaskListCalls++;
+				if (this.backgroundTaskListError) {
+					const error = this.backgroundTaskListError;
+					this.backgroundTaskListError = undefined;
+					throw error;
+				}
+				const tasks = this.backgroundTasks.map(task => ({ ...task }));
+				return { tasks };
+			},
+			refresh: async () => {
+				this.backgroundTaskRefreshCalls++;
+				return {};
 			},
 		},
 		mcp: {
@@ -5493,6 +5513,68 @@ suite('CopilotAgentSession', () => {
 
 			assert.strictEqual(signals.length, 1);
 			assert.ok(isAction(signals[0], ActionType.ChatTurnComplete));
+		});
+
+		test('idle event completes the active turn while a detached shell runs', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			mockSession.backgroundTasks = [{
+				type: 'shell',
+				id: 'shell-1',
+				description: 'Monitor CI',
+				status: 'running',
+				startedAt: new Date(0).toISOString(),
+				command: 'monitor-ci',
+				attachmentMode: 'detached',
+				executionMode: 'background',
+			}];
+			session.resetTurnState('turn-background');
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+
+			assert.deepStrictEqual({
+				hasActiveTurn: session.hasActiveTurn,
+				completedTurns: getActions(signals).filter(action => action.type === ActionType.ChatTurnComplete).length,
+				listCalls: mockSession.backgroundTaskListCalls,
+				refreshCalls: mockSession.backgroundTaskRefreshCalls,
+			}, {
+				hasActiveTurn: false,
+				completedTurns: 1,
+				listCalls: 0,
+				refreshCalls: 0,
+			});
+		});
+
+		test('running detached shell state defers release conservatively', async () => {
+			const { session, mockSession } = await createAgentSession(disposables);
+			const runningShell = {
+				type: 'shell' as const,
+				id: 'shell-running',
+				description: 'Monitor CI',
+				status: 'running' as const,
+				startedAt: new Date(0).toISOString(),
+				command: 'monitor-ci',
+				attachmentMode: 'detached' as const,
+				executionMode: 'background' as const,
+			};
+			mockSession.backgroundTasks = [runningShell];
+			const running = await session.hasRunningDetachedShells();
+			mockSession.backgroundTasks = [{ ...runningShell, status: 'completed', completedAt: new Date().toISOString() }];
+			const completed = await session.hasRunningDetachedShells();
+			mockSession.backgroundTaskListError = new Error('transient tasks.list failure');
+			const failedRead = await session.hasRunningDetachedShells();
+
+			assert.deepStrictEqual({
+				running,
+				completed,
+				failedRead,
+				listCalls: mockSession.backgroundTaskListCalls,
+				refreshCalls: mockSession.backgroundTaskRefreshCalls,
+			}, {
+				running: true,
+				completed: false,
+				failedRead: true,
+				listCalls: 3,
+				refreshCalls: 3,
+			});
 		});
 
 		test('tool-call aggregate emits once with cancelled result across abort and idle', async () => {

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -190,10 +190,11 @@ export class MockAgent implements IAgent {
 		this._sessions.delete(AgentSession.id(session));
 	}
 
-	async releaseSession(session: URI): Promise<void> {
+	async releaseSession(session: URI): Promise<boolean> {
 		// Non-destructive: record the call but keep the session in the catalog
 		// so a later restore/resume still finds its durable data.
 		this.releaseSessionCalls.push(session);
+		return true;
 	}
 
 	async abortSession(session: URI): Promise<void> {

--- a/src/vs/platform/agentHost/test/node/providerIntegration/copilotMockLlm.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/copilotMockLlm.integrationTest.ts
@@ -8,20 +8,32 @@
  */
 
 import assert from 'assert';
-import { mkdtemp, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { timeout } from '../../../../../base/common/async.js';
+import { join } from '../../../../../base/common/path.js';
+import { isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { buildDefaultChatUri, ResponsePartKind, type ISessionWithDefaultChat } from '../../../common/state/sessionState.js';
+import { ActionType, type ChatToolCallCompleteAction, type ChatToolCallReadyAction } from '../../../common/state/sessionActions.js';
+import { buildDefaultChatUri, ResponsePartKind, SessionStatus, type ISessionWithDefaultChat } from '../../../common/state/sessionState.js';
+import { ToolCallConfirmationReason } from '../../../common/state/protocol/channels-chat/state.js';
 import { AgentHostSessionReleaseGraceMsEnvVar } from '../../../common/agentService.js';
 import { createProviderSession, dispatchTurn, type IAgentHostProviderTestConfig } from '../providerIntegrationTestHelpers.js';
-import { fetchSessionWithChat, isActionNotification, IServerHandle, startRealServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
+import { fetchSessionWithChat, getActionEnvelope, isActionNotification, IServerHandle, startRealServer, stopServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 
 const COPILOT_CONFIG: IAgentHostProviderTestConfig = {
 	provider: 'copilotcli',
 	scheme: 'copilotcli',
 	githubToken: 'not-a-real-token',
 };
+
+const DETACHED_SHELL_SCENARIO_ID = 'detached-shell-idle-release';
+const DETACHED_SHELL_DELAY_MS = 6000;
+
+function quoteShellArgument(value: string): string {
+	return isWindows ? `'${value.replace(/'/g, '\'\'')}'` : `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 suite('Agent Host Provider Integration — Copilot with Mock LLM', function () {
 
@@ -104,16 +116,51 @@ suite('Agent Host Provider Integration — Copilot Idle Release', function () {
 
 	let server: IServerHandle;
 	let client: TestProtocolClient;
+	let suiteHome: string;
+	let detachedCompletionMarker: string;
 	const createdSessions: string[] = [];
 	const tempDirs: string[] = [];
 
 	suiteSetup(async function () {
 		this.timeout(120_000);
-		server = await startRealServer({ mockLlm: true, env: { [AgentHostSessionReleaseGraceMsEnvVar]: String(RELEASE_GRACE_MS) } });
+		suiteHome = await mkdtemp(`${tmpdir()}/test-mock-idle-release-home`);
+		detachedCompletionMarker = join(suiteHome, 'detached-shell-complete');
+		const detachedScript = join(suiteHome, 'detached-shell.js');
+		await writeFile(detachedScript, `setTimeout(() => require('fs').writeFileSync(${JSON.stringify(detachedCompletionMarker)}, 'done'), ${DETACHED_SHELL_DELAY_MS});`);
+		const command = `node ${quoteShellArgument(detachedScript)}`;
+		server = await startRealServer({
+			mockLlm: true,
+			homeDir: suiteHome,
+			userDataDir: join(suiteHome, 'user-data'),
+			env: { [AgentHostSessionReleaseGraceMsEnvVar]: String(RELEASE_GRACE_MS) },
+			mockScenarios: [{
+				id: DETACHED_SHELL_SCENARIO_ID,
+				definition: {
+					type: 'multi-turn',
+					turns: [
+						{
+							kind: 'tool-calls',
+							toolCalls: [{
+								toolNamePattern: /^(bash|powershell)$/,
+								arguments: {
+									command,
+									description: 'Run detached shell release probe',
+									mode: 'async',
+									detach: true,
+									initial_wait: 30,
+								},
+							}],
+						},
+						{ kind: 'content', chunks: [{ content: 'Waiting for detached shell completion.', delayMs: 0 }] },
+					],
+				},
+			}],
+		});
 	});
 
-	suiteTeardown(function () {
-		server?.process.kill();
+	suiteTeardown(async function () {
+		await stopServer(server);
+		await rm(suiteHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
 	});
 
 	setup(async function () {
@@ -137,6 +184,59 @@ suite('Agent Host Provider Integration — Copilot Idle Release', function () {
 			} catch { /* best-effort */ }
 		}
 		tempDirs.length = 0;
+	});
+
+	test('keeps a detached shell running after an idle session loses all subscribers (mock LLM)', async function () {
+		this.timeout(180_000);
+
+		const workspaceDir = await mkdtemp(`${tmpdir()}/test-mock-detached-release`);
+		tempDirs.push(workspaceDir);
+		const sessionUri = await createProviderSession(client, COPILOT_CONFIG, 'real-sdk-mock-detached-release', createdSessions, URI.file(workspaceDir));
+		const turnId = 'turn-detached-release';
+
+		dispatchTurn(client, sessionUri, turnId, `[scenario:${DETACHED_SHELL_SCENARIO_ID}] Start the detached shell.`, 1);
+		const readyNotification = await client.waitForNotification(n => {
+			if (!isActionNotification(n, 'chat/toolCallReady')) {
+				return false;
+			}
+			return !(getActionEnvelope(n).action as ChatToolCallReadyAction).confirmed;
+		}, 90_000);
+		const readyEnvelope = getActionEnvelope(readyNotification);
+		const readyAction = readyEnvelope.action as ChatToolCallReadyAction;
+		client.dispatch({
+			channel: readyEnvelope.channel,
+			clientSeq: 2,
+			action: {
+				type: ActionType.ChatToolCallConfirmed,
+				turnId: readyAction.turnId,
+				toolCallId: readyAction.toolCallId,
+				approved: true,
+				confirmed: ToolCallConfirmationReason.UserAction,
+			},
+		});
+		const completeNotification = await client.waitForNotification(n => isActionNotification(n, 'chat/toolCallComplete'), 90_000);
+		const completeAction = getActionEnvelope(completeNotification).action as ChatToolCallCompleteAction;
+		assert.match(JSON.stringify(completeAction.result), /detached background/);
+		await client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 90_000);
+
+		const idle = await fetchSessionWithChat(client, sessionUri);
+		assert.deepStrictEqual({
+			activeTurn: idle.activeTurn,
+			inProgress: (idle.status & SessionStatus.InProgress) !== 0,
+		}, {
+			activeTurn: undefined,
+			inProgress: false,
+		});
+
+		for (const channel of [buildDefaultChatUri(sessionUri), sessionUri]) {
+			client.notify('unsubscribe', { channel });
+		}
+		await timeout(RELEASE_GRACE_MS + 1000);
+
+		for (let attempt = 0; attempt < 150 && !existsSync(detachedCompletionMarker); attempt++) {
+			await timeout(100);
+		}
+		assert.strictEqual(await readFile(detachedCompletionMarker, 'utf8'), 'done');
 	});
 
 	test('releases an idle session and resumes it losslessly on re-subscribe (mock LLM)', async function () {


### PR DESCRIPTION
## Summary

- let Copilot SDK `session.idle` complete the AHP turn and show the session as idle
- defer provider release while authoritative SDK task state reports a running detached shell
- keep cached AHP state until release succeeds, retry deferred release, and preserve reconnect ordering during in-flight release
- cover the lifecycle with focused unit tests and a real bundled-SDK mock-LLM integration test

## Validation

- `npm run hygiene`
- `npm run typecheck-client`
- targeted ESLint for all changed files
- 302 `CopilotAgentSession` tests
- 13 subscriber-refcount eviction tests
- Copilot and Claude release tests
- 4 Copilot mock-LLM provider integration tests
- Opus 5 code review

(Written by Copilot)