### PR TITLE
agentHost: make worktree prune failure test cross-platform

### DIFF
--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -15,7 +15,7 @@
 
 import assert from 'assert';
 import * as cp from 'child_process';
-import { chmodSync, existsSync, mkdtempSync, readdirSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
@@ -635,28 +635,17 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
-	// Windows is excluded like the other chmod-based tests above: `chmod` does not
-	// convey POSIX directory permissions there, so prune's delete still succeeds
-	// and the masking scenario cannot be reproduced.
-	(hasGit && !isWindows ? test : test.skip)('removeWorktree rejects instead of falsely succeeding when the admin entry cannot be deleted', async function () {
-		// Root bypasses the directory permission that makes prune fail, so this
-		// masking scenario cannot be reproduced there.
-		if (typeof process.getuid === 'function' && process.getuid() === 0) {
-			this.skip();
-		}
+	(hasGit ? test : test.skip)('removeWorktree rejects instead of falsely succeeding when the admin entry cannot be deleted', async () => {
 		const dir = initRepo();
 		const suffix = `wt-leak-${Date.now()}`;
 		const wtPath = join(dir, '..', suffix);
-		const adminParent = join(dir, '.git', 'worktrees');
-		let adminDir: string | undefined;
+		let worktreeLocked = false;
 		try {
 			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/leak-worktree', 'main');
-			adminDir = join(adminParent, readdirSync(adminParent)[0]);
-			// Working tree gone → removeWorktree takes the prune path. Making the
-			// admin dir read-only forces prune's recursive delete to fail; git
-			// can exit 0 while leaving the entry registered (the masking bug).
+			cp.execFileSync('git', ['worktree', 'lock', wtPath], { cwd: dir, env, stdio: 'pipe' });
+			worktreeLocked = true;
+			// A locked missing worktree makes prune exit 0 while retaining the admin entry on every OS.
 			rmSync(wtPath, { recursive: true, force: true });
-			chmodSync(adminDir, 0o500);
 
 			await assert.rejects(
 				svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }),
@@ -666,8 +655,8 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 			const listed = cp.execFileSync('git', ['worktree', 'list', '--porcelain'], { cwd: dir, env, encoding: 'utf8' });
 			assert.ok(listed.includes(suffix), 'the still-registered worktree must surface as a leak, not be masked');
 		} finally {
-			if (adminDir) {
-				try { chmodSync(adminDir, 0o700); } catch { /* best-effort cleanup */ }
+			if (worktreeLocked) {
+				try { cp.execFileSync('git', ['worktree', 'unlock', wtPath], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 			}
 			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
 			rmDirWithRetry(wtPath);


### PR DESCRIPTION
Fixes the platform-specific coverage gap left by the worktree removal regression test from [#329531](https://github.com/microsoft/vscode/pull/329531).

The production retry/prune/verification behavior is correct and remains unchanged. The test now uses Git's native `worktree lock` state to make `git worktree prune` exit successfully while retaining the admin entry. This deterministically exercises the false-success guard on Windows, Unix, and root-run environments without relying on POSIX directory permissions.

Validation:
- Exact regression integration test: 1 passing
- All `removeWorktree` integration tests: 3 passing
- `git diff --check`

(Written by Copilot)