### PR TITLE
Forward VS Code experiment context to Copilot CLI telemetry

### DIFF
--- a/src/vs/platform/agentHost/common/copilotCliConfig.ts
+++ b/src/vs/platform/agentHost/common/copilotCliConfig.ts
@@ -31,6 +31,8 @@ export const enum CopilotCliConfigKey {
 	ModelCapabilityOverrides = 'modelCapabilityOverrides',
 }
 
+export const CopilotCliVSCodeAssignmentContextKey = 'copilotCliVSCodeAssignmentContext';
+
 // VS Code `chat.agentHost.*` setting IDs that feed the root-config keys above,
 // kept beside the keys they forward to. Registered in `chat.shared.contribution.ts`
 // and forwarded into the host's root config by `AgentHostCopilotCliSettingsContribution`

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -36,7 +36,7 @@ import { IAgentHostReviewService } from '../../common/agentHostReviewService.js'
 import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, DEFAULT_SESSION_CUSTOMIZATION_DISCOVERY_MODE, toContainerCustomization } from '../../common/agentHostCustomizationConfig.js';
-import { CopilotCliConfigKey, copilotCliConfigSchema, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
+import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey, copilotCliConfigSchema, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
 import { AgentHostMcpServersConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, prepareSideChatPrompt, stripSideChatContext, type IPersistedChat } from '../agentPeerChats.js';
@@ -635,6 +635,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private readonly _plugins: PluginController;
 	private readonly _sessionLauncher: CopilotSessionLauncher;
 	private readonly _gitHubTelemetryForwarder: CopilotGitHubTelemetryForwarder;
+	private _vscodeAssignmentContext: string | undefined;
 	private readonly _githubTelemetryRouter: AgentHostGitHubTelemetryRouter | undefined;
 	readonly onDidCustomizationsChange: Event<void>;
 	/** Per-session active client state for tools + plugin snapshot tracking. */
@@ -662,7 +663,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 		super();
 		this._plugins = this._register(this._instantiationService.createInstance(PluginController, () => this._ensureClient()));
 		this._sessionLauncher = this._instantiationService.createInstance(CopilotSessionLauncher);
-		this._gitHubTelemetryForwarder = this._instantiationService.createInstance(CopilotGitHubTelemetryForwarder, () => this._restrictedTelemetryEnabled);
+		this._configurationService.publishRootTransientValues?.({ [CopilotCliVSCodeAssignmentContextKey]: undefined });
+		this._gitHubTelemetryForwarder = this._instantiationService.createInstance(CopilotGitHubTelemetryForwarder, () => this._restrictedTelemetryEnabled, () => this._vscodeAssignmentContext);
+		this._register(this._configurationService.onDidRootConfigChange(() => this._updateVSCodeAssignmentContext()));
+		this._updateVSCodeAssignmentContext();
 		this._slashCommandProvider = new CopilotSlashCommandProvider(() => this._ensureClient().then(c => c.rpc.commands.list().then(c => c.commands)), this._logService);
 		this._githubTelemetryRouter = isAgentHostTelemetryService(this._telemetryService)
 			? new AgentHostGitHubTelemetryRouter(this._telemetryService)
@@ -784,6 +788,18 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _isMigrateLegacyCopilotCliEnabled(): boolean {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostMigrateLegacyCopilotCliEnabledConfigKey) === true;
+	}
+
+	/**
+	 * A key absent from root config (e.g. dropped by a schema-filtered replace)
+	 * keeps the last-known context sticky; an explicit empty-string dispatch
+	 * from the workbench clears it.
+	 */
+	private _updateVSCodeAssignmentContext(): void {
+		const value = this._configurationService.getRootConfigValues?.()[CopilotCliVSCodeAssignmentContextKey];
+		if (typeof value === 'string') {
+			this._vscodeAssignmentContext = value || undefined;
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -127,6 +127,7 @@ export class CopilotGitHubTelemetryForwarder {
 
 	constructor(
 		private readonly _isRestrictedTelemetryEnabled: () => boolean,
+		private readonly _getVSCodeAssignmentContext: () => string | undefined,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) { }
 
@@ -149,6 +150,14 @@ export class CopilotGitHubTelemetryForwarder {
 			kind: event.kind,
 			restricted: notification.restricted,
 		};
+
+		// VS Code's TAS assignment context, scoped to forwarded Copilot CLI
+		// events only — deliberately not a telemetry-service-wide experiment
+		// property, so Claude/Codex/host events stay unstamped.
+		const assignmentContext = this._getVSCodeAssignmentContext();
+		if (assignmentContext) {
+			data['abexp.assignmentcontext'] = assignmentContext;
+		}
 
 		if (event.features) {
 			for (const [key, value] of Object.entries(event.features)) {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -32,7 +32,7 @@ import type { IByokLmBridgeConnection, IByokLmModelInfo } from '../../common/age
 import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService, NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
-import { CopilotCliConfigKey } from '../../common/copilotCliConfig.js';
+import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey } from '../../common/copilotCliConfig.js';
 import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
 import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
@@ -417,6 +417,11 @@ class TestCopilotClient implements ITestCopilotClient {
 class RecordingTelemetryService extends NullTelemetryServiceShape {
 	readonly events: Array<{ eventName: string; data: unknown }> = [];
 	readonly errorEvents: Array<{ eventName: string; data: unknown }> = [];
+	readonly experimentProperties: Record<string, string> = {};
+
+	override setExperimentProperty(name?: string, value?: string): void {
+		this.experimentProperties[name ?? ''] = value ?? '';
+	}
 
 	override publicLog2(eventName?: string, data?: unknown): void {
 		this.events.push({ eventName: eventName ?? '', data });
@@ -752,6 +757,55 @@ suite('CopilotAgent', () => {
 		try {
 			await agent.listSessions();
 			assert.strictEqual(typeof getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry, 'function');
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('threads the assignment context from root config into forwarded CLI telemetry, sticky across a wipe', async () => {
+		const client = new TestCopilotClient([]);
+		const telemetryService = new class extends RecordingTelemetryService {
+			override publicLog(eventName?: string, data?: unknown): void {
+				this.events.push({ eventName: eventName ?? '', data });
+			}
+		}();
+		const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client, telemetryService });
+		try {
+			await agent.listSessions();
+			const forward = getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry;
+			assert.ok(forward);
+
+			const notification = (sessionId: string): GitHubTelemetryNotification => ({
+				sessionId,
+				restricted: false,
+				event: { kind: 'response.success', properties: {}, metrics: {} },
+			});
+			configurationService.updateRootConfig({ [CopilotCliVSCodeAssignmentContextKey]: 'experiment:1' });
+			await forward(notification('set'));
+			configurationService.updateRootConfig({}, true);
+			await forward(notification('wiped-sticky'));
+			configurationService.updateRootConfig({ [CopilotCliVSCodeAssignmentContextKey]: '' });
+			await forward(notification('cleared'));
+
+			const expectedData = (sessionId: string, assignmentContext?: string) => ({
+				created_at: undefined,
+				model_call_id: undefined,
+				exp_assignment_context: undefined,
+				session_id: sessionId,
+				sdk_session_id: sessionId,
+				copilot_tracking_id: undefined,
+				kind: 'response.success',
+				restricted: false,
+				...(assignmentContext ? { 'abexp.assignmentcontext': assignmentContext } : {}),
+			});
+			assert.deepStrictEqual({ events: telemetryService.events, experimentProperties: telemetryService.experimentProperties }, {
+				events: [
+					{ eventName: 'copilotCli/response.success', data: expectedData('set', 'experiment:1') },
+					{ eventName: 'copilotCli/response.success', data: expectedData('wiped-sticky', 'experiment:1') },
+					{ eventName: 'copilotCli/response.success', data: expectedData('cleared') },
+				],
+				experimentProperties: {},
+			});
 		} finally {
 			await disposeAgent(agent);
 		}

--- a/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
@@ -41,7 +41,7 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 
 	test('forwards a standard event to VS Code telemetry', () => {
 		const telemetryService = new TestTelemetryService();
-		const forwarder = new CopilotGitHubTelemetryForwarder(() => false, telemetryService);
+		const forwarder = new CopilotGitHubTelemetryForwarder(() => false, () => undefined, telemetryService);
 
 		forwarder.forward({
 			sessionId: 'notification-session',
@@ -93,7 +93,7 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 	test('gates restricted events on the restricted telemetry option', () => {
 		const telemetryService = new TestTelemetryService();
 		let restrictedTelemetryEnabled = false;
-		const forwarder = new CopilotGitHubTelemetryForwarder(() => restrictedTelemetryEnabled, telemetryService);
+		const forwarder = new CopilotGitHubTelemetryForwarder(() => restrictedTelemetryEnabled, () => undefined, telemetryService);
 		const notification: GitHubTelemetryNotification = {
 			sessionId: 'session',
 			restricted: true,
@@ -119,6 +119,37 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 				copilot_tracking_id: undefined,
 				kind: 'restricted_event',
 				restricted: true,
+			},
+		}]);
+	});
+
+	test('stamps VS Code assignment context independently of the runtime context', () => {
+		const telemetryService = new TestTelemetryService();
+		const forwarder = new CopilotGitHubTelemetryForwarder(() => false, () => 'experiment:1;experiment:2', telemetryService);
+
+		forwarder.forward({
+			sessionId: 'session',
+			restricted: false,
+			event: {
+				kind: 'response.success',
+				properties: {},
+				metrics: {},
+				exp_assignment_context: 'runtime-context',
+			},
+		});
+
+		assert.deepStrictEqual(telemetryService.events, [{
+			eventName: 'copilotCli/response.success',
+			data: {
+				created_at: undefined,
+				model_call_id: undefined,
+				exp_assignment_context: 'runtime-context',
+				session_id: 'session',
+				sdk_session_id: 'session',
+				copilot_tracking_id: undefined,
+				kind: 'response.success',
+				restricted: false,
+				'abexp.assignmentcontext': 'experiment:1;experiment:2',
 			},
 		}]);
 	});

--- a/src/vs/workbench/services/agentHost/electron-browser/agentHostService.ts
+++ b/src/vs/workbench/services/agentHost/electron-browser/agentHostService.ts
@@ -17,7 +17,12 @@ import { IAgentHostService } from '../../../../platform/agentHost/common/agentSe
 import { LocalAgentHostServiceClient } from '../../../../platform/agentHost/electron-browser/localAgentHostService.js';
 import { IAgentHostEnablementService } from '../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { agentsWindowAgentHostClientInfo, editorWindowAgentHostClientInfo } from '../../../../platform/agentHost/common/agentHostClientInfo.js';
+import { CopilotCliVSCodeAssignmentContextKey } from '../../../../platform/agentHost/common/copilotCliConfig.js';
+import { ActionType } from '../../../../platform/agentHost/common/state/sessionActions.js';
+import { ROOT_STATE_URI } from '../../../../platform/agentHost/common/state/sessionState.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IWorkbenchAssignmentService } from '../../assignment/common/assignmentService.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { EditorRemoteAgentHostServiceClient } from '../browser/editorRemoteAgentHostServiceClient.js';
 
@@ -45,18 +50,43 @@ class WorkbenchAgentHostService {
 	}
 }
 
-class AgentHostPrewarmer {
+class AgentHostPrewarmer extends Disposable {
+
+	private _assignmentContextRequest = 0;
 
 	constructor(
-		@IAgentHostService agentHostService: IAgentHostService,
+		@IAgentHostService private readonly agentHostService: IAgentHostService,
+		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
+		@ILogService private readonly logService: ILogService,
 	) {
-		agentHostService.startAgentHost();
+		super();
+		this._register(this.agentHostService.onAgentHostStart(() => this.updateAssignmentContext()));
+		this._register(this.assignmentService.onDidRefetchAssignments(() => this.updateAssignmentContext()));
+		this.agentHostService.startAgentHost();
+		this.updateAssignmentContext();
+	}
+
+	private updateAssignmentContext(): void {
+		void this.doUpdateAssignmentContext().catch(error => this.logService.error('Failed to forward Agent Host assignment context', error));
+	}
+
+	private async doUpdateAssignmentContext(): Promise<void> {
+		const request = ++this._assignmentContextRequest;
+		const context = (await this.assignmentService.getCurrentExperiments())?.join(';') ?? '';
+		if (request !== this._assignmentContextRequest) {
+			return;
+		}
+		this.agentHostService.dispatch(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [CopilotCliVSCodeAssignmentContextKey]: context },
+		});
 	}
 }
 
 export class AgentHostPrewarmContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.agentHostPrewarm';
+	private prewarmer: AgentHostPrewarmer | undefined;
 
 	constructor(
 		@IAgentHostEnablementService agentHostEnablementService: IAgentHostEnablementService,
@@ -75,7 +105,7 @@ export class AgentHostPrewarmContribution extends Disposable implements IWorkben
 	}
 
 	private start(): void {
-		this.instantiationService.createInstance(AgentHostPrewarmer);
+		this.prewarmer ??= this._register(this.instantiationService.createInstance(AgentHostPrewarmer));
 	}
 }
 

--- a/src/vs/workbench/services/agentHost/test/electron-browser/agentHostService.test.ts
+++ b/src/vs/workbench/services/agentHost/test/electron-browser/agentHostService.test.ts
@@ -4,21 +4,62 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullAgentHostService } from '../../../../../platform/agentHost/browser/nullAgentHostService.js';
 import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { CopilotCliVSCodeAssignmentContextKey } from '../../../../../platform/agentHost/common/copilotCliConfig.js';
+import { ActionType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ROOT_STATE_URI } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { AgentHostPrewarmContribution } from '../../electron-browser/agentHostService.js';
+import { IWorkbenchAssignmentService } from '../../../assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../assignment/test/common/nullAssignmentService.js';
 import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
 
 class TestAgentHostService extends NullAgentHostService {
 	startCount = 0;
+	readonly dispatches: Parameters<IAgentHostService['dispatch']>[] = [];
+	override readonly onAgentHostStart: Event<void>;
+
+	constructor(private readonly _onAgentHostStart: Emitter<void>) {
+		super();
+		this.onAgentHostStart = _onAgentHostStart.event;
+	}
 
 	override startAgentHost(): void {
 		this.startCount++;
+	}
+
+	override dispatch(...args: Parameters<IAgentHostService['dispatch']>): void {
+		this.dispatches.push(args);
+	}
+
+	fireAgentHostStart(): void {
+		this._onAgentHostStart.fire();
+	}
+}
+
+class TestWorkbenchAssignmentService extends NullWorkbenchAssignmentService {
+	override readonly onDidRefetchAssignments: Event<void>;
+	experiments: string[] | undefined = ['experiment:1'];
+
+	constructor(private readonly _onDidRefetchAssignments: Emitter<void>) {
+		super();
+		this.onDidRefetchAssignments = _onDidRefetchAssignments.event;
+	}
+
+	override async getCurrentExperiments(): Promise<string[] | undefined> {
+		return this.experiments;
+	}
+
+	setExperiments(experiments: string[] | undefined): void {
+		this.experiments = experiments;
+		this._onDidRefetchAssignments.fire();
 	}
 }
 
@@ -48,17 +89,27 @@ suite('AgentHostPrewarmContribution', () => {
 		readonly contribution: AgentHostPrewarmContribution;
 		readonly agentHostEnablementService: TestAgentHostEnablementService;
 		readonly agentHostService: TestAgentHostService;
+		readonly assignmentService: TestWorkbenchAssignmentService;
 	} {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		const agentHostEnablementService = disposables.add(new TestAgentHostEnablementService(enabled));
-		const agentHostService = new TestAgentHostService();
+		const onAgentHostStart = new Emitter<void>();
+		const onDidRefetchAssignments = new Emitter<void>();
+		const agentHostService = new TestAgentHostService(onAgentHostStart);
+		const assignmentService = new TestWorkbenchAssignmentService(onDidRefetchAssignments);
 
 		instantiationService.stub(IAgentHostEnablementService, agentHostEnablementService);
 		instantiationService.stub(IAgentHostService, agentHostService);
+		instantiationService.stub(IWorkbenchAssignmentService, assignmentService);
+		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IWorkbenchEnvironmentService, { remoteAuthority });
 
+		// Register the contribution before the emitters so its listeners are
+		// disposed before the emitters they are attached to.
 		const contribution = disposables.add(instantiationService.createInstance(AgentHostPrewarmContribution));
-		return { contribution, agentHostEnablementService, agentHostService };
+		disposables.add(onAgentHostStart);
+		disposables.add(onDidRefetchAssignments);
+		return { contribution, agentHostEnablementService, agentHostService, assignmentService };
 	}
 
 	test('starts immediately when enabled', () => {
@@ -95,5 +146,44 @@ suite('AgentHostPrewarmContribution', () => {
 		agentHostEnablementService.setEnabled(false);
 		agentHostEnablementService.setEnabled(true);
 		assert.strictEqual(agentHostService.startCount, 1);
+	});
+
+	test('forwards assignment context and clears it when unavailable', async () => {
+		const { agentHostService, assignmentService } = createContribution(true);
+		await Promise.resolve();
+
+		assignmentService.setExperiments(undefined);
+		await Promise.resolve();
+
+		assert.deepStrictEqual(agentHostService.dispatches, [
+			[ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [CopilotCliVSCodeAssignmentContextKey]: 'experiment:1' },
+			}],
+			[ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [CopilotCliVSCodeAssignmentContextKey]: '' },
+			}],
+		]);
+	});
+
+	test('refreshes assignment context when the agent host starts', async () => {
+		const { agentHostService, assignmentService } = createContribution(true);
+		await Promise.resolve();
+
+		assignmentService.experiments = ['experiment:2'];
+		agentHostService.fireAgentHostStart();
+		await Promise.resolve();
+
+		assert.deepStrictEqual(agentHostService.dispatches, [
+			[ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [CopilotCliVSCodeAssignmentContextKey]: 'experiment:1' },
+			}],
+			[ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [CopilotCliVSCodeAssignmentContextKey]: 'experiment:2' },
+			}],
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

- forward the filtered VS Code TAS assignment context to the local agent host through a Copilot CLI-specific transient root value
- attach the context as `abexp.assignmentcontext` only to `copilotCli/*` events emitted by `CopilotGitHubTelemetryForwarder`
- refresh the value when assignments or the local agent-host process change, preserving the last-known context across schema-filtered replacement while supporting explicit clearing

## Testing

- focused Copilot agent, GitHub telemetry forwarder, and local agent-host service tests (11 passing)
- `npm run typecheck-client` (only the unrelated existing `SinonFakeTimersConfig` local dependency/type mismatch remains)