### PR TITLE
agentHost: make worktree removal idempotent for archived session deletion

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -7,6 +7,7 @@ import * as cp from 'child_process';
 import * as fsPromises from 'fs/promises';
 import { cp as copyFile } from '@vscode/fs-copyfile';
 import * as path from '../../../base/common/path.js';
+import { extUriBiasedIgnorePathCase } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { parse } from '../../../base/common/glob.js';
@@ -18,7 +19,7 @@ import { FileEditKind, type ISessionFileDiff, type ISessionGitState } from '../c
 import { buildGitBlobUri } from './gitDiffContent.js';
 import { EMPTY_TREE_OBJECT, IAgentHostGitService, IBranch, IBranchDiffSafetyInfo, IRefQuery, IComputeSessionFileDiffsOptions, IDefaultBranch, IPullOptions, IPushOptions, GitRefType, IRemoteBranch, GitRef, ITag, Branch, IWorktreeFileProgress } from '../common/agentHostGitService.js';
 import { LRUCache } from '../../../base/common/map.js';
-import { Limiter, SequencerByKey } from '../../../base/common/async.js';
+import { firstParallel, Limiter, SequencerByKey } from '../../../base/common/async.js';
 
 export class AgentHostGitService implements IAgentHostGitService {
 	declare readonly _serviceBrand: undefined;
@@ -211,7 +212,54 @@ export class AgentHostGitService implements IAgentHostGitService {
 			args.push('--force');
 		}
 		args.push(worktree.fsPath);
-		await this._runGit(repositoryRoot, args, { timeout: 60_000, throwOnError: true });
+		try {
+			await this._runGit(repositoryRoot, args, { timeout: 60_000, throwOnError: true });
+		} catch (error) {
+			// Worktree removal is idempotent: archiving a session removes and
+			// de-registers its worktree, so deleting the archived session later
+			// finds nothing to remove and git fails with "'<path>' is not a
+			// working tree". When git no longer tracks the worktree the removal
+			// goal is already met, so treat it as success. Checked against git's
+			// own registry rather than the (truncatable, localizable) error text.
+			// Genuine failures (e.g. a dirty tree needing --force) leave the
+			// worktree registered and still propagate.
+			if (!await this._isWorktreeRegistered(repositoryRoot, worktree)) {
+				return;
+			}
+			throw error;
+		}
+	}
+
+	/** Whether `worktree` is still registered with git (its admin entry survives). */
+	private async _isWorktreeRegistered(repositoryRoot: URI, worktree: URI): Promise<boolean> {
+		const registered = await this.getWorktreeRoots(repositoryRoot);
+		if (registered.length === 0) {
+			return false;
+		}
+		const target = await this._canonicalizeWorktreePath(worktree);
+		// Check every registered worktree in parallel and resolve as soon as one matches.
+		const matched = await firstParallel(
+			registered.map(async entry =>
+				extUriBiasedIgnorePathCase.isEqual(entry, worktree)
+				|| extUriBiasedIgnorePathCase.isEqual(await this._canonicalizeWorktreePath(entry), target)),
+			isMatch => isMatch,
+			false,
+		);
+		return matched ?? false;
+	}
+
+	/**
+	 * Resolves symlinks on the worktree's parent (which persists even after the
+	 * worktree directory itself is deleted) so a path we passed to git (e.g.
+	 * `/var/...`) matches the realpath'd form git reports (`/private/var/...`).
+	 */
+	private async _canonicalizeWorktreePath(worktree: URI): Promise<URI> {
+		try {
+			const parentReal = await fsPromises.realpath(path.dirname(worktree.fsPath));
+			return URI.file(path.join(parentReal, path.basename(worktree.fsPath)));
+		} catch {
+			return worktree;
+		}
 	}
 
 	async branchExists(repositoryRoot: URI, branchName: string): Promise<boolean> {

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -128,11 +128,14 @@ export class AgentHostGitService implements IAgentHostGitService {
 	}
 
 	async getWorktreeRoots(workingDirectory: URI): Promise<URI[]> {
-		const output = await this._runGit(workingDirectory, ['worktree', 'list', '--porcelain']);
-		if (!output) {
+		return this._parseWorktreeRoots(await this._runGit(workingDirectory, ['worktree', 'list', '--porcelain']));
+	}
+
+	private _parseWorktreeRoots(porcelainOutput: string | undefined): URI[] {
+		if (!porcelainOutput) {
 			return [];
 		}
-		return output.split(/\r?\n/g)
+		return porcelainOutput.split(/\r?\n/g)
 			.filter(line => line.startsWith('worktree '))
 			.map(line => URI.file(line.substring('worktree '.length)));
 	}
@@ -215,29 +218,25 @@ export class AgentHostGitService implements IAgentHostGitService {
 		try {
 			await this._runGit(repositoryRoot, args, { timeout: 60_000, throwOnError: true });
 		} catch (error) {
-			// Worktree removal is idempotent: archiving a session removes and
-			// de-registers its worktree, so deleting the archived session later
-			// finds nothing to remove and git fails with "'<path>' is not a
-			// working tree". When git no longer tracks the worktree the removal
-			// goal is already met, so treat it as success. Checked against git's
-			// own registry rather than the (truncatable, localizable) error text.
-			// Genuine failures (e.g. a dirty tree needing --force) leave the
-			// worktree registered and still propagate.
-			if (!await this._isWorktreeRegistered(repositoryRoot, worktree)) {
-				return;
+			// Idempotent: a worktree git no longer tracks is already gone (e.g. an archived session removed it earlier).
+			if (await this._isWorktreeRegistered(repositoryRoot, worktree)) {
+				throw error;
 			}
-			throw error;
 		}
 	}
 
-	/** Whether `worktree` is still registered with git (its admin entry survives). */
+	/** Whether git still tracks `worktree`; fails closed (returns `true`) if the registry cannot be read. */
 	private async _isWorktreeRegistered(repositoryRoot: URI, worktree: URI): Promise<boolean> {
-		const registered = await this.getWorktreeRoots(repositoryRoot);
+		let registered: URI[];
+		try {
+			registered = this._parseWorktreeRoots(await this._runGit(repositoryRoot, ['worktree', 'list', '--porcelain'], { throwOnError: true }));
+		} catch {
+			return true;
+		}
 		if (registered.length === 0) {
 			return false;
 		}
 		const target = await this._canonicalizeWorktreePath(worktree);
-		// Check every registered worktree in parallel and resolve as soon as one matches.
 		const matched = await firstParallel(
 			registered.map(async entry =>
 				extUriBiasedIgnorePathCase.isEqual(entry, worktree)
@@ -248,11 +247,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 		return matched ?? false;
 	}
 
-	/**
-	 * Resolves symlinks on the worktree's parent (which persists even after the
-	 * worktree directory itself is deleted) so a path we passed to git (e.g.
-	 * `/var/...`) matches the realpath'd form git reports (`/private/var/...`).
-	 */
+	/** Resolves symlinks on the worktree's parent so our path matches the realpath'd form git reports. */
 	private async _canonicalizeWorktreePath(worktree: URI): Promise<URI> {
 		try {
 			const parentReal = await fsPromises.realpath(path.dirname(worktree.fsPath));

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -15,7 +15,7 @@
 
 import assert from 'assert';
 import * as cp from 'child_process';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
@@ -582,6 +582,51 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
 			rmDirWithRetry(wtPath);
 			try { cp.execFileSync('git', ['branch', '-D', 'agents/dirty-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
+		}
+	});
+
+	// Regression for #329982: deleting an archived session removed its worktree
+	// twice — archiving removes/de-registers it, then deleting the archived
+	// session removes it again. The second removal must not fail with
+	// "'<path>' is not a working tree".
+	(hasGit ? test : test.skip)('removeWorktree is idempotent when the worktree was already removed', async () => {
+		const dir = initRepo();
+		const wtPath = join(dir, '..', `wt-idem-${Date.now()}`);
+		try {
+			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/idempotent-worktree', 'main');
+			// First removal succeeds and de-registers the worktree (mirrors archive).
+			await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true });
+			assert.strictEqual(existsSync(wtPath), false, 'worktree directory should be gone after the first removal');
+			// Second removal (mirrors deleting the already-archived session) must
+			// not throw even though git no longer tracks the worktree.
+			await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true });
+		} finally {
+			try { await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true }); } catch { /* best-effort cleanup */ }
+			rmDirWithRetry(wtPath);
+			try { cp.execFileSync('git', ['branch', '-D', 'agents/idempotent-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
+		}
+	});
+
+	// Residual case of #329982: a partial removal (e.g. an undeletable file) can
+	// de-register the worktree while leaving its directory on disk. Removal must
+	// still succeed because git no longer tracks the path.
+	(hasGit ? test : test.skip)('removeWorktree succeeds when git no longer tracks a still-present worktree directory', async () => {
+		const dir = initRepo();
+		const wtPath = join(dir, '..', `wt-orphan-${Date.now()}`);
+		try {
+			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/orphan-worktree', 'main');
+			// De-register the worktree (delete git's admin entries) while leaving
+			// the working-tree directory in place.
+			const adminRoot = join(dir, '.git', 'worktrees');
+			for (const entry of readdirSync(adminRoot)) {
+				rmSync(join(adminRoot, entry), { recursive: true, force: true });
+			}
+			assert.strictEqual(existsSync(wtPath), true, 'worktree directory should still exist');
+			// Removal must treat an already-de-registered worktree as success.
+			await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true });
+		} finally {
+			rmDirWithRetry(wtPath);
+			try { cp.execFileSync('git', ['branch', '-D', 'agents/orphan-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 		}
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -630,6 +630,14 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
+	// Fail-closed guard flagged in review: when git cannot confirm the worktree is
+	// unregistered (e.g. the repository is gone), a failed removal must propagate
+	// rather than be silently reported as success.
+	(hasGit ? test : test.skip)('removeWorktree rethrows when git cannot confirm removal', async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'agent-host-git-nonrepo-'));
+		await assert.rejects(svc!.removeWorktree(URI.file(tmpRoot), URI.file(join(tmpRoot, 'missing-worktree')), { force: true }));
+	});
+
 	(hasGit ? test : test.skip)('addWorktree prefers origin start point when local branch is stale', async () => {
 		const dir = initRepo();
 		const fs = await import('fs/promises');


### PR DESCRIPTION
### Issue
Refs #329982

Deleting an **archived** agent session throws:

> Failed to delete the sessions: Error: git worktree exited with code 128: fatal: '<path>' is not a working tree

### Root cause
Archiving a session already removes and **de-registers** its worktree (`AgentSessionWorktreeIsolation._cleanupWorktreeOnArchive` → `IAgentHostGitService.removeWorktree`). Deleting the archived session later calls `removeWorktree(..., { force: true })` again. On `release/1.133`, `removeWorktree` runs `git worktree remove` and rethrows **every** non-zero exit. Because git no longer tracks that path, it exits `128` with `fatal: '<path>' is not a working tree` — which actually means the removal goal (de-registration) is already met, but the code surfaces it as a fatal error.

### Fix
Make `removeWorktree` **idempotent**: when the git command fails, treat it as success **iff git no longer registers the worktree** (checked against `git worktree list` via the same `_isWorktreeRegistered` / `_canonicalizeWorktreePath` helpers used on `main`), otherwise rethrow. This is checked against git's own registry rather than the error text, so it is immune to message truncation (long paths) and localization. Genuine failures (e.g. a dirty tree needing `--force`) leave the worktree registered and still propagate.

This also covers the residual case where a partial removal leaves the directory on disk but de-registers it.

### Tests
Adds two real-git integration tests to `AgentHostGitService - worktree helpers (real git)`:
- `removeWorktree is idempotent when the worktree was already removed` (the reported archived-delete flow)
- `removeWorktree succeeds when git no longer tracks a still-present worktree directory` (residual case)

Both fail on the current `release/1.133` code and pass with the fix.

### Verification (executed locally in a `release/1.133` worktree)
- `npm ci` ✅
- `npm run transpile-client` ✅
- `./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts --grep removeWorktree` → **3 passing** (2 new + existing, no regression) ✅
- `npm run typecheck-client` ✅ (exit 0, no errors)

### Notes
- Scope is `release/1.133` only. `main` already handles the common case via its retry/`prune` loop, but still throws in the residual dir-exists+de-registered case; a separate follow-up PR will harden `main` with the same registration check.