### PR TITLE
agentHost: make worktree removal idempotent for the residual de-registered case (#329982)

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -277,6 +277,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 				if (!isRetryableWorktreeRemovalError(error)) {
 					// Idempotent: if git no longer tracks the worktree the removal goal is already met (e.g. an archived session removed it earlier).
 					if (!await this._isWorktreeRegistered(repositoryRoot, worktree)) {
+						this._logService.trace(`[agentHostGitService] worktree '${worktree.fsPath}' already de-registered; treating removal as complete`);
 						return;
 					}
 					throw error;

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -139,11 +139,14 @@ export class AgentHostGitService implements IAgentHostGitService {
 	}
 
 	async getWorktreeRoots(workingDirectory: URI): Promise<URI[]> {
-		const output = await this._runGit(workingDirectory, ['worktree', 'list', '--porcelain']);
-		if (!output) {
+		return this._parseWorktreeRoots(await this._runGit(workingDirectory, ['worktree', 'list', '--porcelain']));
+	}
+
+	private _parseWorktreeRoots(porcelainOutput: string | undefined): URI[] {
+		if (!porcelainOutput) {
 			return [];
 		}
-		return output.split(/\r?\n/g)
+		return porcelainOutput.split(/\r?\n/g)
 			.filter(line => line.startsWith('worktree '))
 			.map(line => URI.file(line.substring('worktree '.length)));
 	}
@@ -240,7 +243,9 @@ export class AgentHostGitService implements IAgentHostGitService {
 	 * So we: retry with a capped exponential backoff to let the racing process
 	 * finish; switch to `prune` once the working tree is already gone; only retry
 	 * transient lock / "directory not empty" failures (a dirty-tree "use --force"
-	 * still fails fast); and verify the worktree is truly de-registered before
+	 * still fails fast); treat a non-retryable failure as success when git no
+	 * longer tracks the worktree (idempotent re-removal of an already-removed or
+	 * archived worktree); and verify the worktree is truly de-registered before
 	 * returning, so a silent `prune` no-op cannot mask a leaked entry.
 	 */
 	async removeWorktree(repositoryRoot: URI, worktree: URI, options?: { readonly force?: boolean }): Promise<void> {
@@ -270,6 +275,10 @@ export class AgentHostGitService implements IAgentHostGitService {
 			} catch (error) {
 				lastError = error;
 				if (!isRetryableWorktreeRemovalError(error)) {
+					// Idempotent: if git no longer tracks the worktree the removal goal is already met (e.g. an archived session removed it earlier).
+					if (!await this._isWorktreeRegistered(repositoryRoot, worktree)) {
+						return;
+					}
 					throw error;
 				}
 			}
@@ -292,9 +301,18 @@ export class AgentHostGitService implements IAgentHostGitService {
 		}
 	}
 
-	/** Whether `worktree` is still registered with git (its admin entry survives). */
+	/**
+	 * Whether `worktree` is still registered with git (its admin entry survives).
+	 * Fails closed (returns `true`) if the registry cannot be read, so an unrelated
+	 * `git worktree list` failure is never mistaken for a completed removal.
+	 */
 	private async _isWorktreeRegistered(repositoryRoot: URI, worktree: URI): Promise<boolean> {
-		const registered = await this.getWorktreeRoots(repositoryRoot);
+		let registered: URI[];
+		try {
+			registered = this._parseWorktreeRoots(await this._runGit(repositoryRoot, ['worktree', 'list', '--porcelain'], { throwOnError: true }));
+		} catch {
+			return true;
+		}
 		if (registered.length === 0) {
 			return false;
 		}

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -664,9 +664,9 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		}
 	});
 
-	// Residual case of #329982: a partial `--force` removal (e.g. an undeletable
-	// file) can de-register the worktree while leaving its directory on disk. A
-	// later removal must still succeed because git no longer tracks the path.
+	// Residual case of #329982: git can de-register a worktree (drop its
+	// `.git/worktrees/<id>` admin entry) while its directory still remains on
+	// disk. A later removal must still succeed because git no longer tracks the path.
 	(hasGit ? test : test.skip)('removeWorktree succeeds when git no longer tracks a still-present worktree directory', async () => {
 		const dir = initRepo();
 		const suffix = `wt-orphan-${Date.now()}`;
@@ -705,7 +705,7 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 		mkdirSync(wtPath); // exists -> deterministic `git worktree remove` branch
 		await assert.rejects(
 			svc!.removeWorktree(URI.file(tmpRoot), URI.file(wtPath), { force: true }),
-			/not a git repository/i,
+			/exited with code 128/,
 		);
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -15,7 +15,7 @@
 
 import assert from 'assert';
 import * as cp from 'child_process';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
@@ -662,6 +662,51 @@ suite('AgentHostGitService - worktree helpers (real git)', () => {
 			rmDirWithRetry(wtPath);
 			try { cp.execFileSync('git', ['branch', '-D', 'agents/leak-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
 		}
+	});
+
+	// Residual case of #329982: a partial `--force` removal (e.g. an undeletable
+	// file) can de-register the worktree while leaving its directory on disk. A
+	// later removal must still succeed because git no longer tracks the path.
+	(hasGit ? test : test.skip)('removeWorktree succeeds when git no longer tracks a still-present worktree directory', async () => {
+		const dir = initRepo();
+		const suffix = `wt-orphan-${Date.now()}`;
+		const wtPath = join(dir, '..', suffix);
+		try {
+			await svc!.addWorktree(URI.file(dir), URI.file(wtPath), 'agents/orphan-worktree', 'main');
+			// De-register the worktree (delete git's admin entries) while leaving the working-tree directory in place.
+			const adminRoot = join(dir, '.git', 'worktrees');
+			for (const entry of readdirSync(adminRoot)) {
+				rmSync(join(adminRoot, entry), { recursive: true, force: true });
+			}
+			// Pin the precondition so the test cannot silently rot into the prune/verify path.
+			const listed = cp.execFileSync('git', ['worktree', 'list', '--porcelain'], { cwd: dir, env, encoding: 'utf8' });
+			assert.deepStrictEqual({
+				dirPresent: existsSync(wtPath),
+				stillRegistered: listed.includes(suffix),
+			}, {
+				dirPresent: true,
+				stillRegistered: false,
+			});
+
+			// Removal must treat an already-de-registered worktree as success.
+			await svc!.removeWorktree(URI.file(dir), URI.file(wtPath), { force: true });
+		} finally {
+			rmDirWithRetry(wtPath);
+			try { cp.execFileSync('git', ['branch', '-D', 'agents/orphan-worktree'], { cwd: dir, env, stdio: 'ignore' }); } catch { /* best-effort cleanup */ }
+		}
+	});
+
+	// Fail-closed guard: when git cannot confirm the worktree is unregistered (e.g.
+	// the repository is gone), a failed removal must propagate rather than be
+	// silently reported as success.
+	(hasGit ? test : test.skip)('removeWorktree rethrows when git cannot confirm removal', async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'agent-host-git-nonrepo-'));
+		const wtPath = join(tmpRoot, 'wt');
+		mkdirSync(wtPath); // exists -> deterministic `git worktree remove` branch
+		await assert.rejects(
+			svc!.removeWorktree(URI.file(tmpRoot), URI.file(wtPath), { force: true }),
+			/not a git repository/i,
+		);
 	});
 
 	(hasGit ? test : test.skip)('addWorktree prefers origin start point when local branch is stale', async () => {


### PR DESCRIPTION
## Summary

Makes `AgentHostGitService.removeWorktree` idempotent for the **residual** worktree state behind #329982, so deleting an archived session no longer throws `git worktree exited with code 128: fatal: '<path>' is not a working tree`.

## Root cause

Archiving a session removes and de-registers its worktree; deleting the archived session removes it again. `main`'s retry loop already handles the common case (working-tree dir gone + de-registered → `prune` → success), but the **residual** case — directory still present + de-registered (a prior `--force` removal de-registered it but left the dir, e.g. an undeletable file or the teardown race) — still fails: `_pathExists`=true → `git worktree remove --force` → `is not a working tree` (exit 128, non-retryable) → rethrow.

## Fix

- **`removeWorktree`**: on a *non-retryable* failure, return success when git no longer registers the worktree (the removal goal is already met); otherwise rethrow. Dirty-tree / still-registered failures continue to fail fast.
- **`_isWorktreeRegistered`**: query the registry with `throwOnError: true` and **fail closed** (return `true` when it can't be read), so an unrelated `git worktree list` failure (repo gone, timeout) is never mistaken for a completed removal. Extracted `_parseWorktreeRoots` so the public `getWorktreeRoots` keeps its swallow-on-error behavior.

## Tests (real git)

- `removeWorktree succeeds when git no longer tracks a still-present worktree directory` — the residual case; **fails on current `main`** (throws "is not a working tree"), passes with the fix. Preconditions pinned (dir present + de-registered) so it can't silently rot.
- `removeWorktree rethrows when git cannot confirm removal` — guards the fail-closed behavior (a vanished repo must not be reported as success).
- Existing behavior preserved: "preserves dirty work unless forced", "prunes a lingering admin entry…", "rejects instead of falsely succeeding…".

## Validation

- `npm run transpile-client`
- targeted integration suite (`AgentHostGitService - worktree helpers (real git)`): **11 passing**
- `npm run typecheck-client`
- Regression proof: the residual test fails on pre-fix `main` with the exact #329982 error; the fail-closed test fails when `_isWorktreeRegistered` is reverted to fail-open — confirming both changes are load-bearing.

## Relationship to other PRs

- Complementary to #329864 (which quiesces background git work to prevent the *race* that can create the residual state); this PR makes removal **idempotent** regardless of how the state arose.
- Mirrors the release/1.133 fix in #330145 (a wrapper, since that branch lacks the retry loop); the shared helper hardening is aligned.

Fixes #329982

(Written by Copilot)

