### PR TITLE
Git: remove repos when workspace folders are removed

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -472,15 +472,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			const possibleRepositoryFolders = added
 				.filter(folder => !this.getOpenRepository(folder.uri));
 
-			const activeRepositoriesList = window.visibleTextEditors
-				.map(editor => this.getRepository(editor.document.uri))
-				.filter(repository => !!repository) as Repository[];
-
-			const activeRepositories = new Set<Repository>(activeRepositoriesList);
 			const openRepositoriesToDispose = removed
 				.map(folder => this.getOpenRepository(folder.uri))
 				.filter(r => !!r)
-				.filter(r => !activeRepositories.has(r!.repository))
 				.filter(r => !(workspace.workspaceFolders || []).some(f => isDescendant(f.uri.fsPath, r!.repository.root))) as OpenRepository[];
 
 			openRepositoriesToDispose.forEach(r => r.dispose());


### PR DESCRIPTION
## Summary
- dispose Git repositories when their workspace folder is removed, even if an editor from that folder is still visible
- keep the existing guard that preserves repositories still covered by another workspace folder

## Why
Removing a folder from a multi-root workspace should also remove its repository from SCM. The current implementation keeps that repository open whenever a visible editor still belongs to it, which matches the stale-repository behavior reported in #108757.

## Testing
- `git diff --check`
- full extension tests were not run in this environment
