### PR TITLE
Fix title bar update indicator badge shape

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -518,3 +518,17 @@
 	border-radius: 16px;
 	text-align: center;
 }
+
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content {
+	width: 12px;
+	padding: 0;
+	border-radius: var(--vscode-cornerRadius-circle);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
+	width: 12px;
+	height: 12px;
+}


### PR DESCRIPTION
## Summary

- keep the compact title bar progress badge square and fully circular
- size and center the progress glyph within the `12px` badge

## Regression

This regressed in [#291241](https://github.com/microsoft/vscode/pull/291241), which moved the shared progress glyph into normal flow to fix refresh-arrow alignment. That commit added a square, zero-padding override for activity bar progress badges, but the equivalent title bar override was missed. As a result, the `13px` glyph plus horizontal padding widened the `12px`-high badge into an oval.

## Validation

- `npm run stylelint -- src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css`
- no editor diagnostics
- `git diff --check`

Fixes #329900