### PR TITLE
Fix Find matching text that was already deleted

### DIFF
--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -717,12 +717,7 @@ export class PieceTreeBase {
 					return resultLen;
 				}
 				if (offsetInBuffer(m.index) + m[0].length > end) {
-					// The match starts within this piece's valid text but runs past
-					// its logical end. Deletions only move `end` backward without
-					// erasing the underlying buffer, so text past `end` is stale
-					// data that no longer exists in the document, and since matches
-					// are found in increasing order, nothing later in this piece can
-					// be fully in bounds either.
+					// Deletions only move `end` backward without erasing the buffer, so text past `end` is stale and no longer part of the document.
 					return resultLen;
 				}
 				this.positionInBuffer(node, offsetInBuffer(m.index) - startOffsetInBuffer, ret);

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -716,6 +716,15 @@ export class PieceTreeBase {
 				if (offsetInBuffer(m.index) >= end) {
 					return resultLen;
 				}
+				if (offsetInBuffer(m.index) + m[0].length > end) {
+					// The match starts within this piece's valid text but runs past
+					// its logical end. Deletions only move `end` backward without
+					// erasing the underlying buffer, so text past `end` is stale
+					// data that no longer exists in the document, and since matches
+					// are found in increasing order, nothing later in this piece can
+					// be fully in bounds either.
+					return resultLen;
+				}
 				this.positionInBuffer(node, offsetInBuffer(m.index) - startOffsetInBuffer, ret);
 				const lineFeedCnt = this.getLineFeedCnt(node.piece.bufferIndex, startCursor, ret);
 				const retStartColumn = ret.line === startCursor.line ? ret.column - startCursor.column + startColumn : ret.column + 1;

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -820,4 +820,15 @@ suite('TextModelSearch', () => {
 			]
 		);
 	});
+
+	test('issue #220139. Find does not match text that has been deleted', () => {
+		const model = createTextModel('foo bar baz');
+		model.applyEdits([{ range: new Range(1, 8, 1, 12), text: '' }]); // delete " baz"
+		assert.strictEqual(model.getLineContent(1), 'foo bar');
+
+		const matches = model.findMatches('foo bar baz', false, false, false, null, false);
+		assert.deepStrictEqual(matches, []);
+
+		model.dispose();
+	});
 });


### PR DESCRIPTION
## Overview

Find could report a match for text you had already deleted, as long as the search string started inside text that still exists and continued into text you deleted from the end of it. Fixes #220139.

## Approach

VS Code's text buffer is a piece table. Deleting text only moves an internal end marker back, it never erases the old characters from the underlying buffer string. Find's plain text search, with Whole Word off, searched that raw buffer directly instead of the trimmed text. It only checked that a match started before the marker, never that it ended before it too. So a search string that began inside real text and ran into the deleted tail could still register as a match.

This adds one check in findMatchesInNode that rejects a match once it runs past the real end of the text, right next to the existing check for where a match starts. Nothing else in the function changes, and the branch used when Whole Word is on, which already slices the buffer correctly, is untouched.

## Testing & validation

Added a test named issue #220139, using the exact steps from the issue: type foo bar baz, delete baz, search for foo bar baz.

textModelSearch.test.ts: 44 passing. pieceTreeTextBuffer.test.ts: 88 passing, including the existing boundary test right next to this code. findModel.test.ts: 45 passing. ESLint clean on both changed files.

- [x] Verified the fix works
- [x] Added a regression test
