### PR TITLE
Avoid logging canceled prompt discovery as an error

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -558,7 +558,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 				const userInvocable = parsedPromptFile?.header?.userInvocable;
 				return { status: 'loaded', promptPath: this.withPromptPathMetadata(promptPath, name, description), argumentHint, userInvocable } satisfies ISlashCommandDiscoveryResult;
 			} catch (e) {
-				this.logger.error(`[computeSlashCommandDiscoveryInfo] Failed to parse prompt file for slash command: ${promptPath.uri}`, e instanceof Error ? e.message : String(e));
+				if (!isCancellationError(e)) {
+					this.logger.error(`[computeSlashCommandDiscoveryInfo] Failed to parse prompt file for slash command: ${promptPath.uri}`, e instanceof Error ? e.message : String(e));
+				}
 				return { status: 'skipped', skipReason: 'parse-error', errorMessage: e instanceof Error ? e.message : String(e), promptPath } satisfies ISlashCommandDiscoveryResult;
 			}
 		}));

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -3720,6 +3720,34 @@ suite('PromptsService', () => {
 		});
 	});
 
+	suite('getPromptSlashCommands - prompt discovery', () => {
+		teardown(() => {
+			sinon.restore();
+		});
+
+		test('CancellationError from parseNew is skipped without logging', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, false);
+
+			const promptUri = URI.parse('file://extensions/my-extension/cancelled.prompt.md');
+			const logErrorSpy = sinon.spy(logService, 'error');
+			sinon.stub(service, 'listPromptFiles').callsFake(async (type: PromptsType) => {
+				return type === PromptsType.prompt
+					? [{ uri: promptUri, storage: PromptsStorage.local, type: PromptsType.prompt } as IPromptPath]
+					: [];
+			});
+			sinon.stub(service, 'parseNew').rejects(new CancellationError());
+
+			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
+			const discoveryInfo = await service.getDiscoveryInfo(PromptsType.prompt, CancellationToken.None);
+
+			assert.deepStrictEqual(slashCommands, []);
+			assert.strictEqual(logErrorSpy.called, false);
+			assert.strictEqual(discoveryInfo.files.length, 1);
+			assert.strictEqual(discoveryInfo.files[0].status, 'skipped');
+			assert.strictEqual(discoveryInfo.files[0].skipReason, 'parse-error');
+		});
+	});
+
 	suite('getPromptSlashCommands - skills', () => {
 		teardown(() => {
 			sinon.restore();
@@ -3771,28 +3799,6 @@ suite('PromptsService', () => {
 			assert.ok(anotherSkillCommand, 'Should find another skill as slash command');
 			assert.strictEqual(anotherSkillCommand.description, 'Another skill from workspace');
 			assert.strictEqual(anotherSkillCommand.storage, PromptsStorage.local);
-		});
-
-		test('CancellationError from parseNew is skipped without logging', async () => {
-			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, false);
-
-			const promptUri = URI.parse('file://extensions/my-extension/cancelled.prompt.md');
-			const logErrorSpy = sinon.spy(logService, 'error');
-			sinon.stub(service, 'listPromptFiles').callsFake(async (type: PromptsType) => {
-				return type === PromptsType.prompt
-					? [{ uri: promptUri, storage: PromptsStorage.local, type: PromptsType.prompt } as IPromptPath]
-					: [];
-			});
-			sinon.stub(service, 'parseNew').rejects(new CancellationError());
-
-			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
-			const discoveryInfo = await service.getDiscoveryInfo(PromptsType.prompt, CancellationToken.None);
-
-			assert.deepStrictEqual(slashCommands, []);
-			assert.strictEqual(logErrorSpy.called, false);
-			assert.strictEqual(discoveryInfo.files.length, 1);
-			assert.strictEqual(discoveryInfo.files[0].status, 'skipped');
-			assert.strictEqual(discoveryInfo.files[0].skipReason, 'parse-error');
 		});
 
 		test('should deduplicate skills with the same name from symlinked locations', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -43,7 +43,7 @@ import { ComputeAutomaticInstructions, newInstructionsCollectionEvent, newInstru
 import { PromptsConfig } from '../../../../common/promptSyntax/config/config.js';
 import { AGENTS_SOURCE_FOLDER, CLAUDE_CONFIG_FOLDER, HOOKS_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../../../../common/promptSyntax/config/promptFileLocations.js';
 import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID, PromptFileSource, PromptsType, Target } from '../../../../common/promptSyntax/promptTypes.js';
-import { IAgentDiscoveryResult, IAgentSource, ICustomAgent, IPromptFileContext, IPromptsService, PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
+import { IAgentDiscoveryResult, IAgentSource, ICustomAgent, IPromptFileContext, IPromptPath, IPromptsService, PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
 import { PromptsService } from '../../../../common/promptSyntax/service/promptsServiceImpl.js';
 import { mockFiles } from '../testUtils/mockFilesystem.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../../../platform/storage/common/storage.js';
@@ -100,10 +100,12 @@ suite('PromptsService', () => {
 	let fileService: IFileService;
 	let testPluginsObservable: ISettableObservable<readonly IAgentPlugin[]>;
 	let workspaceTrustService: TestWorkspaceTrustManagementService;
+	let logService: NullLogService;
 
 	setup(async () => {
 		instaService = disposables.add(new TestInstantiationService());
-		instaService.stub(ILogService, new NullLogService());
+		logService = new NullLogService();
+		instaService.stub(ILogService, logService);
 
 		workspaceContextService = new TestContextService();
 		instaService.stub(IWorkspaceContextService, workspaceContextService);
@@ -3769,6 +3771,28 @@ suite('PromptsService', () => {
 			assert.ok(anotherSkillCommand, 'Should find another skill as slash command');
 			assert.strictEqual(anotherSkillCommand.description, 'Another skill from workspace');
 			assert.strictEqual(anotherSkillCommand.storage, PromptsStorage.local);
+		});
+
+		test('CancellationError from parseNew is skipped without logging', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, false);
+
+			const promptUri = URI.parse('file://extensions/my-extension/cancelled.prompt.md');
+			const logErrorSpy = sinon.spy(logService, 'error');
+			sinon.stub(service, 'listPromptFiles').callsFake(async (type: PromptsType) => {
+				return type === PromptsType.prompt
+					? [{ uri: promptUri, storage: PromptsStorage.local, type: PromptsType.prompt } as IPromptPath]
+					: [];
+			});
+			sinon.stub(service, 'parseNew').rejects(new CancellationError());
+
+			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
+			const discoveryInfo = await service.getDiscoveryInfo(PromptsType.prompt, CancellationToken.None);
+
+			assert.deepStrictEqual(slashCommands, []);
+			assert.strictEqual(logErrorSpy.called, false);
+			assert.strictEqual(discoveryInfo.files.length, 1);
+			assert.strictEqual(discoveryInfo.files[0].status, 'skipped');
+			assert.strictEqual(discoveryInfo.files[0].skipReason, 'parse-error');
 		});
 
 		test('should deduplicate skills with the same name from symlinked locations', async () => {


### PR DESCRIPTION
## Summary

Avoid logging expected prompt slash-command discovery cancellations as parse errors while preserving the skipped discovery result for diagnostics.

This was found by running `/vscode-dev:scan-logs`: one Insiders startup session emitted 309 identical cancellation errors in 169 ms while prompt and skill files were being discovered.

- skip error logging for `CancellationError`, matching adjacent agent discovery behavior
- add regression coverage for canceled prompt parsing

Fixes #330168

## Testing

- `scripts\test.bat --run src\vs\workbench\contrib\chat\test\common\promptSyntax\service\promptsService.test.ts --grep "CancellationError from parseNew is skipped without logging"`
- `npm run typecheck-client`