### PR TITLE
sessions: make the discovered-config nudge's X the "don't show again"

### DIFF
--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -110,9 +110,9 @@ export interface IDiscoveredConfigNudgeContext {
 	 */
 	readonly usableWithoutGitHub: boolean;
 	/**
-	 * Whether the user has permanently silenced this nudge via its "Don't Show
-	 * Again" affordance. Once muted, the nudge never shows again regardless of
-	 * the other inputs.
+	 * Whether the user has already dismissed this nudge, which silences it for
+	 * good. Once muted, the nudge never shows again regardless of the other
+	 * inputs.
 	 */
 	readonly muted: boolean;
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification.ts
@@ -6,7 +6,6 @@
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
-import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
@@ -23,15 +22,11 @@ const DISCOVERED_CONFIG_NOTIFICATION_ID = 'agentHost.discoveredConfig.claude';
 /** Single entry point for starting GitHub Copilot sign-in from a nudge. */
 const SIGN_IN_COMMAND_ID = 'workbench.action.chat.triggerSetup';
 
-/** Command bound to the nudge's bell-slash "Don't Show Again" button. */
-const MUTE_COMMAND_ID = 'workbench.action.agentHost.discoveredConfig.mute';
-
 /**
- * Persists the user's "Don't Show Again" choice. The discovered config lives on
- * this machine, so the preference is scoped to the machine — {@link
- * StorageScope.APPLICATION} to span profiles and workspaces, and {@link
- * StorageTarget.MACHINE} so settings sync does not carry it to a machine where
- * no such config exists.
+ * Persists the user's dismissal. The discovered config lives on this machine, so
+ * the preference is scoped to the machine — {@link StorageScope.APPLICATION} to
+ * span profiles and workspaces, and {@link StorageTarget.MACHINE} so settings
+ * sync does not carry it to a machine where no such config exists.
  */
 const MUTED_STORAGE_KEY = 'agentHost.discoveredConfig.claude.muted';
 
@@ -45,9 +40,10 @@ const MUTED_STORAGE_KEY = 'agentHost.discoveredConfig.claude.muted';
  *
  * The banner is scoped to the Claude session type (so it only renders when that
  * harness is selected) and clears itself the moment the user signs in or the
- * agent stops advertising native mode. Its bell-slash button persists a
- * machine-wide "Don't Show Again" choice; the X button dismisses it only for the
- * current window.
+ * agent stops advertising native mode. Dismissing it with the X persists a
+ * machine-wide choice not to show it again — the nudge is informational, so a
+ * user who has read it once has read it for good. Sending a message merely hides
+ * it for the current window.
  */
 export class AgentHostDiscoveredConfigNotificationContribution extends Disposable implements IWorkbenchContribution {
 
@@ -71,10 +67,15 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 	) {
 		super();
 
-		// The bell-slash button runs this command, which persists the mute; the
-		// storage listener below then re-drives `_update` to tear the banner down.
-		this._register(CommandsRegistry.registerCommand(MUTE_COMMAND_ID, () => {
-			this._storageService.store(MUTED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		// Dismissing the banner is the user telling us they've read it, so persist
+		// that; the storage listener below then re-drives `_update` to tear it
+		// down. `onDidDismiss` fires only for an explicit dismissal — the
+		// auto-dismiss on send does not, so sending a message still just hides
+		// the nudge for this window.
+		this._register(this._chatInputNotificationService.onDidDismiss(id => {
+			if (id === DISCOVERED_CONFIG_NOTIFICATION_ID) {
+				this._storageService.store(MUTED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			}
 		}));
 
 		// Signing in/out flips the nudge; a session-type change is how the agent
@@ -148,13 +149,13 @@ export class AgentHostDiscoveredConfigNotificationContribution extends Disposabl
 				kind: ChatInputNotificationActionKind.Command,
 				label: localize('agentHost.discoveredConfig.signIn', "Sign in to GitHub"),
 				commandId: SIGN_IN_COMMAND_ID,
+				// Dismissal is permanent now, so a sign-in click — which the user
+				// may still cancel — must not route through it. The banner retires
+				// on its own once the account resolves to signed in.
+				keepOpen: true,
 			}],
 			dismissible: true,
 			autoDismissOnMessage: true,
-			mute: {
-				commandId: MUTE_COMMAND_ID,
-				tooltip: localize('agentHost.discoveredConfig.mute', "Don't Show Again"),
-			},
 			sessionTypes: [SessionType.AgentHostClaude],
 		});
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostDiscoveredConfigNotification.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostDiscoveredConfigNotification.test.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../../base/common/async.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IChatInputNotification, IChatInputNotificationService } from '../../../../../../workbench/contrib/chat/browser/widget/input/chatInputNotificationService.js';
+import { SessionType } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { SessionTypeAuthRequirement } from '../../../../../services/sessions/common/session.js';
+import { IProviderSessionType, ISessionsManagementService } from '../../../../../services/sessions/common/sessionsManagement.js';
+import { AgentHostDiscoveredConfigNotificationContribution } from '../../browser/agentHostDiscoveredConfigNotification.js';
+
+class TestChatInputNotificationService extends Disposable implements IChatInputNotificationService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly onDidChange = Event.None;
+	private readonly _onDidDismiss = this._register(new Emitter<string>());
+	readonly onDidDismiss = this._onDidDismiss.event;
+
+	readonly notifications = new Map<string, IChatInputNotification>();
+
+	setNotification(notification: IChatInputNotification): void {
+		this.notifications.set(notification.id, notification);
+	}
+	deleteNotification(id: string): void {
+		this.notifications.delete(id);
+	}
+	/** Mirrors the real service: a dismissal is remembered, not forgotten. */
+	dismissNotification(id: string): void {
+		if (this.notifications.has(id)) {
+			this._onDidDismiss.fire(id);
+		}
+	}
+	getActiveNotification(): IChatInputNotification | undefined {
+		return [...this.notifications.values()].at(0);
+	}
+	handleMessageSent(): void { }
+	announceRendered(): void { }
+}
+
+/**
+ * A signed-out user who has opted in, with Claude advertising that it runs on the
+ * user's own credentials — the one situation the nudge is written for.
+ */
+function createContribution(store: Pick<DisposableStore, 'add'>, storageService = store.add(new InMemoryStorageService())) {
+	const notificationService = store.add(new TestChatInputNotificationService());
+	const claude: IProviderSessionType = {
+		providerId: 'local-agent-host',
+		sessionType: {
+			id: 'claude',
+			label: 'Claude Code',
+			icon: Codicon.copilot,
+			chatSessionType: SessionType.AgentHostClaude,
+			authRequirement: SessionTypeAuthRequirement.None,
+		},
+	};
+
+	store.add(new AgentHostDiscoveredConfigNotificationContribution(
+		notificationService,
+		new class extends mock<ISessionsManagementService>() {
+			override readonly onDidChangeSessionTypes = Event.None;
+			override getAllProviderSessionTypes(): IProviderSessionType[] { return [claude]; }
+		}(),
+		new class extends mock<IDefaultAccountService>() {
+			override readonly onDidChangeDefaultAccount = Event.None;
+			override readonly currentDefaultAccount = null;
+			override getDefaultAccount() { return Promise.resolve(null); }
+		}(),
+		new TestConfigurationService({ [AgentHostAllowSignedOutWhenUsableSettingId]: true }),
+		storageService,
+	));
+
+	return { notificationService, storageService };
+}
+
+suite('AgentHostDiscoveredConfigNotification', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('nudges the signed-out user, with dismissal as the only off switch', async () => {
+		const { notificationService } = createContribution(store);
+
+		// The account resolves asynchronously; the nudge waits for it.
+		await timeout(0);
+
+		assert.deepStrictEqual([...notificationService.notifications.values()].map(notification => ({
+			message: notification.message,
+			actions: notification.actions.map(action => ({ label: action.label, keepOpen: action.keepOpen })),
+			dismissible: notification.dismissible,
+			mute: notification.mute,
+			sessionTypes: notification.sessionTypes,
+		})), [{
+			message: 'We\'ve discovered your existing Claude Code configuration.',
+			// `keepOpen` so a sign-in the user then cancels doesn't silence the nudge.
+			actions: [{ label: 'Sign in to GitHub', keepOpen: true }],
+			dismissible: true,
+			mute: undefined,
+			sessionTypes: [SessionType.AgentHostClaude],
+		}]);
+	});
+
+	test('dismissing it silences the nudge on this machine for good', async () => {
+		const storageService = store.add(new InMemoryStorageService());
+		const first = createContribution(store, storageService);
+		await timeout(0);
+		const notification = first.notificationService.getActiveNotification();
+
+		first.notificationService.dismissNotification(notification!.id);
+
+		// A fresh contribution stands in for the next window on this machine.
+		const next = createContribution(store, storageService);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			afterDismissal: first.notificationService.notifications.size,
+			nextWindow: next.notificationService.notifications.size,
+		}, {
+			afterDismissal: 0,
+			nextWindow: 0,
+		});
+	});
+});


### PR DESCRIPTION
Fixes #329980.

The signed-out "We've discovered your existing Claude configuration" nudge carried two off switches: an **X** that dismissed it for the window, and a **bell-slash** that persisted a machine-wide mute. As @amunger put it in the issue — if you click the X, it should just not show you again, and you shouldn't need the bell.

So the X now does what the bell did, and the bell is gone.

### What changed

- **The X persists.** Swapped the bell's command registration for a listener on `IChatInputNotificationService.onDidDismiss`, writing the same `MUTED_STORAGE_KEY` (`APPLICATION` scope / `MACHINE` target). Same key, so anyone who already clicked the bell stays muted.
- **Sending a message still only hides it for the window.** `handleMessageSent` marks the dismissal internally without firing `onDidDismiss`, so the auto-dismiss path doesn't leak into the permanent one.
- **The sign-in action gains `keepOpen`.** This is the non-obvious consequence: the widget dismisses a notification after any non-`keepOpen` action, so without this, clicking "Sign in to GitHub" and then *cancelling* the flow would have silenced the nudge forever. It now stays up and retires on its own once the account resolves to signed-in.

### Scope

The shared `IChatInputNotification.mute` affordance stays in the widget for `agentHostPromptCacheNotification`, where X (until the next cache expiration) and bell (forever) mean genuinely different things. Only this notification loses its bell.

### Testing

New unit tests in `agentHostDiscoveredConfigNotification.test.ts` (the contribution had no coverage before): one snapshot asserting the payload shape including `mute: undefined` and `keepOpen: true`, one asserting a dismissal survives into a fresh contribution.

Also verified end-to-end in a real signed-out Agents window (`--use-mock-keychain`, `chat.agentHost.allowSignedOutWhenUsable: true`, Claude in native mode via a local `~/.claude/settings.json`):

1. Banner renders with X only — live DOM `{hasMuteBell: false, hasDismissX: true}`, and the a11y tree goes straight from the title to `button "Dismiss notification"`.
2. X dismisses and writes `agentHost.discoveredConfig.claude.muted|true` through to `state.vscdb`.
3. Killed and relaunched seeded from that profile → no banner.
4. Control: same profile, deleted only the mute key, relaunched → banner returns. (Rules out a false pass where step 3 looked clean because a precondition had broken.)
5. Clicked "Sign in to GitHub" → in-window sign-in modal, banner still present, **no** mute key written; Escape to cancel → still present, still unmuted.

### Note for reviewers

The X's tooltip is still the shared widget's hardcoded "Dismiss notification". Accurate, but it no longer hints that the dismissal is permanent and machine-wide. Giving it a per-notification label means touching the shared `IChatInputNotification` interface — happy to do it if you'd rather, but it seemed out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
