### PR TITLE
agentHost: watch every git repo root for multi-root changeset freshness

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -347,12 +347,19 @@ export class AgentHostChangesetCoordinator extends Disposable {
 	 * already uses the inherited set). `updateOperations` only dispatches for
 	 * subscribed changesets, so refreshing subagents without subscriptions is a
 	 * no-op.
+	 *
+	 * The changed set also determines which repository roots are watched for
+	 * external edits, so re-attach the file monitor for the session (and its
+	 * inheriting subagents) — otherwise a folder added or removed mid-session
+	 * would not start/stop being watched until an unrelated lifecycle event.
 	 */
 	private onDidChangeSessionWorkingDirectories(sessionStr: string): void {
 		this._changesetOperationService.updateOperations(sessionStr);
+		this._changesetFileMonitor.onSessionWorkingDirectoriesChanged(sessionStr);
 		for (const candidate of this._stateManager.getSessionUris()) {
 			if (parseSubagentSessionUri(candidate)?.parentSession.toString() === sessionStr) {
 				this._changesetOperationService.updateOperations(candidate);
+				this._changesetFileMonitor.onSessionWorkingDirectoriesChanged(candidate);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
@@ -11,6 +11,7 @@ import { parseSubagentSessionUri } from '../common/state/sessionState.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { DEFAULT_AGENT_HOST_WATCH_EXCLUDES, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostGitService } from '../common/agentHostGitService.js';
+import { resolveSessionRepositories } from './agentHostSessionRepositories.js';
 import { AgentHostStateManager, IAgentHostStateManager } from './agentHostStateManager.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostGitStateService } from '../common/agentHostGitStateService.js';
@@ -59,10 +60,10 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 	);
 	/** Sessions waiting for materialization before a root watcher can attach. */
 	private readonly _pendingWatchInterest = new Set<string>();
-	/** Session URI string to the working directory that produced the current root attachment. */
-	private readonly _sessionWorkingDirectory = new Map<string, string>();
-	/** Session URI string to repository-root URI string. */
-	private readonly _sessionRoot = new Map<string, string>();
+	/** Session URI string to a stable signature of the working-directory set that produced the current root attachments. */
+	private readonly _sessionWorkingDirectories = new Map<string, string>();
+	/** Session URI string to the set of repository-root URI strings it is watching. */
+	private readonly _sessionRoots = new Map<string, Set<string>>();
 	/** Repository-root URI string to sessions currently fanned out from that root. */
 	private readonly _rootSessions = new Map<string, Set<string>>();
 	/** Repository-root URI string to the shared monitor acquisition. */
@@ -127,7 +128,7 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 
 	private _destroyWatchInterest(sessionStr: string): void {
 		this._pendingWatchInterest.delete(sessionStr);
-		this._releaseSessionRoot(sessionStr);
+		this._releaseSessionRoots(sessionStr);
 	}
 
 	private _retryWatchAttachment(sessionStr: string): void {
@@ -148,67 +149,101 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			if (!this._shouldAttachSession(sessionStr)) {
 				return;
 			}
-			const workingDirectory = this._configurationService.getEffectiveWorkingDirectory(sessionStr);
-			if (!workingDirectory) {
+			const workingDirectories = this._configurationService.getEffectiveWorkingDirectories(sessionStr);
+			if (!workingDirectories || workingDirectories.length === 0) {
 				this._pendingWatchInterest.add(sessionStr);
-				this._releaseSessionRoot(sessionStr);
+				this._releaseSessionRoots(sessionStr);
 				return;
 			}
-			let workingDirectoryUri: URI;
-			try {
-				workingDirectoryUri = URI.parse(workingDirectory);
-			} catch (err) {
-				this._logService.warn(`[ChangesetFileMonitorCoordinator] Failed to parse working directory URI for ${sessionStr}: ${workingDirectory}`, err);
+			const workingDirectoryUris: URI[] = [];
+			for (const workingDirectory of workingDirectories) {
+				try {
+					workingDirectoryUris.push(URI.parse(workingDirectory));
+				} catch (err) {
+					this._logService.warn(`[ChangesetFileMonitorCoordinator] Failed to parse working directory URI for ${sessionStr}: ${workingDirectory}`, err);
+				}
+			}
+			if (workingDirectoryUris.length === 0) {
 				this._pendingWatchInterest.add(sessionStr);
-				this._releaseSessionRoot(sessionStr);
+				this._releaseSessionRoots(sessionStr);
 				return;
 			}
-			if (this._sessionRoot.has(sessionStr) && this._sessionWorkingDirectory.get(sessionStr) === workingDirectory) {
+			const signature = this._workingDirectoriesSignature(workingDirectories);
+			if (this._sessionRoots.has(sessionStr) && this._sessionWorkingDirectories.get(sessionStr) === signature) {
 				this._pendingWatchInterest.delete(sessionStr);
 				return;
 			}
-			const repositoryRoot = await this._gitService.getRepositoryRoot(workingDirectoryUri);
+			const { gitRepositories } = await resolveSessionRepositories(workingDirectoryUris, this._gitService);
 			if (!this._shouldAttachSession(sessionStr)) {
 				return;
 			}
-			if (!repositoryRoot) {
+			if (gitRepositories.length === 0) {
 				this._pendingWatchInterest.delete(sessionStr);
-				this._releaseSessionRoot(sessionStr);
+				this._releaseSessionRoots(sessionStr);
 				return;
 			}
 			this._pendingWatchInterest.delete(sessionStr);
-			this._attachSessionToRoot(sessionStr, repositoryRoot, workingDirectory);
+			this._attachSessionToRoots(sessionStr, gitRepositories, signature);
 		});
 	}
 
-	private _attachSessionToRoot(sessionStr: string, repositoryRoot: URI, workingDirectory: string): void {
-		const rootStr = repositoryRoot.toString();
-		if (this._sessionRoot.get(sessionStr) === rootStr) {
-			this._sessionWorkingDirectory.set(sessionStr, workingDirectory);
+	private _attachSessionToRoots(sessionStr: string, repositoryRoots: readonly URI[], signature: string): void {
+		const desiredRoots = new Map<string, URI>();
+		for (const repositoryRoot of repositoryRoots) {
+			desiredRoots.set(repositoryRoot.toString(), repositoryRoot);
+		}
+
+		// Reconcile the watched set by detaching from roots this session no
+		// longer resolves to. This runs on each re-attach (first subscription,
+		// restore, materialization, or turn end); a bare working-directory-set
+		// change on a live idle session is only reflected at the next such
+		// re-attach (documented follow-up — see the orchestration decisions doc).
+		const current = this._sessionRoots.get(sessionStr);
+		if (current) {
+			for (const rootStr of [...current]) {
+				if (!desiredRoots.has(rootStr)) {
+					current.delete(rootStr);
+					this._detachRootSession(sessionStr, rootStr);
+				}
+			}
+		}
+
+		let sessionRoots = this._sessionRoots.get(sessionStr);
+		if (!sessionRoots) {
+			sessionRoots = new Set<string>();
+			this._sessionRoots.set(sessionStr, sessionRoots);
+		}
+		for (const [rootStr, repositoryRoot] of desiredRoots) {
+			let sessions = this._rootSessions.get(rootStr);
+			if (!sessions) {
+				sessions = new Set<string>();
+				this._rootSessions.set(rootStr, sessions);
+				this._rootUris.set(rootStr, repositoryRoot);
+			}
+			sessions.add(sessionStr);
+			sessionRoots.add(rootStr);
 			this._ensureRootWatcher(rootStr, repositoryRoot);
-			return;
 		}
-		this._releaseSessionRoot(sessionStr);
-		let sessions = this._rootSessions.get(rootStr);
-		if (!sessions) {
-			sessions = new Set<string>();
-			this._rootSessions.set(rootStr, sessions);
-			this._rootUris.set(rootStr, repositoryRoot);
-		}
-		sessions.add(sessionStr);
-		this._sessionRoot.set(sessionStr, rootStr);
-		this._sessionWorkingDirectory.set(sessionStr, workingDirectory);
-		this._ensureRootWatcher(rootStr, repositoryRoot);
+		this._sessionWorkingDirectories.set(sessionStr, signature);
 	}
 
-	private _releaseSessionRoot(sessionStr: string): void {
-		const rootStr = this._sessionRoot.get(sessionStr);
-		if (!rootStr) {
-			this._sessionWorkingDirectory.delete(sessionStr);
+	private _releaseSessionRoots(sessionStr: string): void {
+		this._sessionWorkingDirectories.delete(sessionStr);
+		const rootStrs = this._sessionRoots.get(sessionStr);
+		if (!rootStrs) {
 			return;
 		}
-		this._sessionRoot.delete(sessionStr);
-		this._sessionWorkingDirectory.delete(sessionStr);
+		this._sessionRoots.delete(sessionStr);
+		for (const rootStr of rootStrs) {
+			this._detachRootSession(sessionStr, rootStr);
+		}
+	}
+
+	/**
+	 * Removes a session from one repository root's fan-out set, disposing the
+	 * shared root watcher once the last referencing session drops it.
+	 */
+	private _detachRootSession(sessionStr: string, rootStr: string): void {
 		const sessions = this._rootSessions.get(rootStr);
 		if (!sessions) {
 			return;
@@ -221,6 +256,10 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		}
 	}
 
+	private _workingDirectoriesSignature(workingDirectories: readonly string[]): string {
+		return workingDirectories.join('\u0000');
+	}
+
 	private _onRootChanged(rootStr: string): void {
 		if (this._isRootActive(rootStr)) {
 			return;
@@ -229,24 +268,38 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		if (!sessions || sessions.size === 0) {
 			return;
 		}
-		const activeSessions = [...sessions].filter(session => {
+		const sessionsToRefresh = [...sessions].filter(session => {
 			return this._hasWatchInterest(session)
-				&& this._sessionRoot.get(session) === rootStr
+				&& !!this._sessionRoots.get(session)?.has(rootStr)
 				&& !this._activeSessionRoots.has(session)
 				&& !this._unresolvedActiveSessions.has(session)
 				&& !!this._stateManager.getSessionState(session);
 		});
-		if (activeSessions.length === 0) {
+		if (sessionsToRefresh.length === 0) {
 			return;
 		}
 
-		const workingDirectory = URI.parse(rootStr);
-
-		for (const session of activeSessions) {
-			// Refresh the git state for each active session. If there are multiple
-			// sessions on the same root, trigger the git state refresh for each
-			// individual session as the git state refresh will be throttled downstream.
-			void this._gitStateService.refreshSessionGitState(session, workingDirectory);
+		for (const session of sessionsToRefresh) {
+			// Refresh git state from the session's PRIMARY working directory,
+			// regardless of which of its git roots changed. Git state (branch /
+			// pull request) is a primary-repo concept, while the all-folder
+			// summary recompute triggered downstream re-diffs EVERY repository,
+			// so a change in any watched root is reflected without
+			// mis-attributing a secondary repo's branch/PR to the session. The
+			// refresh is throttled downstream, so multiple roots changing
+			// together coalesce.
+			const primaryWorkingDirectory = this._configurationService.getEffectiveWorkingDirectory(session);
+			if (!primaryWorkingDirectory) {
+				continue;
+			}
+			let primaryWorkingDirectoryUri: URI;
+			try {
+				primaryWorkingDirectoryUri = URI.parse(primaryWorkingDirectory);
+			} catch (err) {
+				this._logService.warn(`[ChangesetFileMonitorCoordinator] Failed to parse primary working directory URI for ${session}: ${primaryWorkingDirectory}`, err);
+				continue;
+			}
+			void this._gitStateService.refreshSessionGitState(session, primaryWorkingDirectoryUri);
 		}
 	}
 
@@ -291,7 +344,7 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		const repositoryRoot = await this._resolveActivityRepositoryRoot(sessionStr);
 		if (!repositoryRoot) {
 			this._unresolvedActiveSessions.add(sessionStr);
-			this._releaseSessionRoot(sessionStr);
+			this._releaseSessionRoots(sessionStr);
 			return;
 		}
 		const rootStr = repositoryRoot.toString();
@@ -304,9 +357,13 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		this._activeSessionRoots.set(sessionStr, rootStr);
 		this._rootUris.set(rootStr, repositoryRoot);
 		this._suspendRootWatcher(rootStr);
-		if (this._sessionRoot.get(sessionStr) !== rootStr) {
-			this._releaseSessionRoot(sessionStr);
-		}
+		// Release ALL idle watch attachments for this session while its turn
+		// runs: turn edits are captured by the turn lifecycle, so neither the
+		// primary nor any secondary root should keep an idle watcher. Primary
+		// active-root tracking above keeps the primary suspended (and blocks
+		// other sessions from watching a shared root); the summary is recomputed
+		// once when the turn completes.
+		this._releaseSessionRoots(sessionStr);
 	}
 
 	private _markSessionInactive(sessionStr: string): void {

--- a/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
@@ -108,6 +108,17 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		this._retryWatchAttachment(sessionStr);
 	}
 
+	/**
+	 * Re-attach a session's root watchers when its effective working-directory
+	 * set changes (a folder added or removed, e.g. in the Editor Window). The
+	 * signature guard in `_attachWatcherIfPossible` makes an unchanged set a
+	 * no-op, so this is cheap; an active (mid-turn) session is instead re-attached
+	 * by the turn lifecycle on turn end.
+	 */
+	onSessionWorkingDirectoriesChanged(sessionStr: string): void {
+		this._retryWatchAttachment(sessionStr);
+	}
+
 	onSessionDisposed(sessionStr: string): void {
 		this.untrackSessionChanges(buildUncommittedChangesetUri(sessionStr));
 		this.untrackSessionChanges(buildSessionChangesetUri(sessionStr));
@@ -194,8 +205,9 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			desiredRoots.set(repositoryRoot.toString(), repositoryRoot);
 		}
 
-		// Detach from roots this session no longer resolves to (runs on each re-attach). A bare
-		// working-dir change on a live idle session reflects only at the next re-attach (documented follow-up).
+		// Detach from roots this session no longer resolves to (runs on each re-attach). An idle
+		// subscribed session re-attaches as soon as its working-directory set changes (via
+		// `onSessionWorkingDirectoriesChanged`); an active session re-attaches at turn end.
 		const current = this._sessionRoots.get(sessionStr);
 		if (current) {
 			for (const rootStr of [...current]) {

--- a/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetFileMonitorCoordinator.ts
@@ -111,6 +111,7 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 	onSessionDisposed(sessionStr: string): void {
 		this.untrackSessionChanges(buildUncommittedChangesetUri(sessionStr));
 		this.untrackSessionChanges(buildSessionChangesetUri(sessionStr));
+		this.untrackSessionChanges(buildBranchChangesetUri(sessionStr));
 		this.untrackSessionChanges(sessionStr);
 		this._removeActiveSession(sessionStr);
 		this._destroyWatchInterest(sessionStr);
@@ -193,11 +194,8 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			desiredRoots.set(repositoryRoot.toString(), repositoryRoot);
 		}
 
-		// Reconcile the watched set by detaching from roots this session no
-		// longer resolves to. This runs on each re-attach (first subscription,
-		// restore, materialization, or turn end); a bare working-directory-set
-		// change on a live idle session is only reflected at the next such
-		// re-attach (documented follow-up — see the orchestration decisions doc).
+		// Detach from roots this session no longer resolves to (runs on each re-attach). A bare
+		// working-dir change on a live idle session reflects only at the next re-attach (documented follow-up).
 		const current = this._sessionRoots.get(sessionStr);
 		if (current) {
 			for (const rootStr of [...current]) {
@@ -213,6 +211,7 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			sessionRoots = new Set<string>();
 			this._sessionRoots.set(sessionStr, sessionRoots);
 		}
+		let allRootsWatched = true;
 		for (const [rootStr, repositoryRoot] of desiredRoots) {
 			let sessions = this._rootSessions.get(rootStr);
 			if (!sessions) {
@@ -222,9 +221,17 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			}
 			sessions.add(sessionStr);
 			sessionRoots.add(rootStr);
-			this._ensureRootWatcher(rootStr, repositoryRoot);
+			if (!this._ensureRootWatcher(rootStr, repositoryRoot)) {
+				allRootsWatched = false;
+			}
 		}
-		this._sessionWorkingDirectories.set(sessionStr, signature);
+		// Cache the signature only when every root was watched; a failed
+		// acquisition is then retried on the next re-attach (not skipped).
+		if (allRootsWatched) {
+			this._sessionWorkingDirectories.set(sessionStr, signature);
+		} else {
+			this._sessionWorkingDirectories.delete(sessionStr);
+		}
 	}
 
 	private _releaseSessionRoots(sessionStr: string): void {
@@ -280,14 +287,9 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		}
 
 		for (const session of sessionsToRefresh) {
-			// Refresh git state from the session's PRIMARY working directory,
-			// regardless of which of its git roots changed. Git state (branch /
-			// pull request) is a primary-repo concept, while the all-folder
-			// summary recompute triggered downstream re-diffs EVERY repository,
-			// so a change in any watched root is reflected without
-			// mis-attributing a secondary repo's branch/PR to the session. The
-			// refresh is throttled downstream, so multiple roots changing
-			// together coalesce.
+			// Always refresh from the PRIMARY working directory, never the changed root: branch/PR is a
+			// primary-repo concept, while the downstream summary recompute re-diffs EVERY repo — so a
+			// secondary change still reflects without mis-attributing its branch/PR. Throttled downstream.
 			const primaryWorkingDirectory = this._configurationService.getEffectiveWorkingDirectory(session);
 			if (!primaryWorkingDirectory) {
 				continue;
@@ -313,13 +315,18 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		return (this._rootActiveSessions.get(rootStr)?.size ?? 0) > 0;
 	}
 
-	private _ensureRootWatcher(rootStr: string, repositoryRoot: URI): void {
+	/**
+	 * Ensures a shared watcher exists for a root. Returns false only when
+	 * acquisition failed (the caller retries that root later); an
+	 * already-watched or turn-suspended active root counts as handled.
+	 */
+	private _ensureRootWatcher(rootStr: string, repositoryRoot: URI): boolean {
 		if (this._isRootActive(rootStr) || this._rootWatchAcquisitions.has(rootStr)) {
-			return;
+			return true;
 		}
 		const sessions = this._rootSessions.get(rootStr);
 		if (!sessions || sessions.size === 0) {
-			return;
+			return true;
 		}
 		const rootWatchAcquisition = this._fileMonitorService.acquire(repositoryRoot, () => this._onRootChanged(rootStr), {
 			excludes: DEFAULT_AGENT_HOST_WATCH_EXCLUDES,
@@ -329,9 +336,10 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 			for (const session of sessions) {
 				this._pendingWatchInterest.add(session);
 			}
-			return;
+			return false;
 		}
 		this._rootWatchAcquisitions.set(rootStr, rootWatchAcquisition);
+		return true;
 	}
 
 	private _suspendRootWatcher(rootStr: string): void {
@@ -357,12 +365,8 @@ export class ChangesetFileMonitorCoordinator extends Disposable {
 		this._activeSessionRoots.set(sessionStr, rootStr);
 		this._rootUris.set(rootStr, repositoryRoot);
 		this._suspendRootWatcher(rootStr);
-		// Release ALL idle watch attachments for this session while its turn
-		// runs: turn edits are captured by the turn lifecycle, so neither the
-		// primary nor any secondary root should keep an idle watcher. Primary
-		// active-root tracking above keeps the primary suspended (and blocks
-		// other sessions from watching a shared root); the summary is recomputed
-		// once when the turn completes.
+		// Release ALL idle attachments during the turn (turn edits are captured by the turn lifecycle).
+		// Primary active-root tracking above keeps the primary suspended; the summary recomputes at turn end.
 		this._releaseSessionRoots(sessionStr);
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
@@ -11,7 +11,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { AgentSession } from '../../common/agentService.js';
-import { buildDefaultChangesetCatalog, buildSessionChangesetUri, buildUncommittedChangesetUri, ChangesetKind, parseChangesetUri } from '../../common/changesetUri.js';
+import { buildBranchChangesetUri, buildDefaultChangesetCatalog, buildSessionChangesetUri, buildUncommittedChangesetUri, ChangesetKind, parseChangesetUri } from '../../common/changesetUri.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { buildSubagentSessionUri, SessionStatus, type ISessionFileDiff, type ISessionGitHubState } from '../../common/state/sessionState.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -581,6 +581,121 @@ suite('ChangesetSessionCoordinator', () => {
 
 		assert.deepStrictEqual(environment.changesets.recomputed, []);
 	});
+
+	test('disposing a session with a live branch subscription clears watch interest', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const environment = createEnvironment();
+		createSession(environment.stateManager, session, 'file:///repo/worktree');
+
+		// Subscribe via the BRANCH changeset URI (tracks the branch subscription key).
+		environment.coordinator.onFirstSubscriber(URI.parse(buildBranchChangesetUri(session)));
+		await environment.monitor.waitForAcquisitions(1);
+
+		// An abrupt dispose (no onLastSubscriber) must clear the branch watch
+		// interest, so a later materialization retry cannot resurrect a watcher.
+		environment.coordinator.onSessionDisposed(session);
+		environment.coordinator.onSessionMaterialized(session);
+		await tick();
+
+		assert.deepStrictEqual({ acquisitions: environment.monitor.acquisitions, disposals: environment.monitor.disposals }, {
+			acquisitions: ['file:///repo'],
+			disposals: ['file:///repo'],
+		});
+	});
+
+	test('detaches a repository root watcher when a session stops resolving to it', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+
+		// repoB drops out of the session's working directories; the next
+		// re-attach must detach and dispose only repoB's watcher.
+		environment.stateManager.dispatchServerAction(session, { type: ActionType.SessionWorkingDirectoryRemoved, directory: rootB.toString() });
+		environment.coordinator.onSessionMaterialized(session);
+		await environment.gitService.waitForRootLookups(3);
+		await tick();
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			disposals: environment.monitor.disposals,
+		}, {
+			acquisitions: [rootA.toString(), rootB.toString()].sort(),
+			disposals: [rootB.toString()],
+		});
+	});
+
+	test('keeps a shared secondary root watched for an idle session while another session runs a turn', async () => {
+		const sessionA = AgentSession.uri('mock', 'session-a').toString();
+		const sessionB = AgentSession.uri('mock', 'session-b').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const sharedRoot = URI.file('/projects/shared');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+			[sharedRoot.toString(), sharedRoot],
+		])));
+		// The shared repo is a SECONDARY root for A (primary repoA) and for B.
+		createMultiRootSession(environment.stateManager, sessionA, [rootA.toString(), sharedRoot.toString()]);
+		createMultiRootSession(environment.stateManager, sessionB, [rootB.toString(), sharedRoot.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(sessionA));
+		environment.coordinator.onFirstSubscriber(URI.parse(sessionB));
+		await environment.monitor.waitForAcquisitions(3);
+		environment.coordinator.onSessionTurnActiveChanged(sessionA, true);
+		await environment.gitService.waitForRootLookups(5);
+		await tick();
+		environment.changesets.clearRefreshes();
+
+		// A's active root is its PRIMARY (repoA); the shared secondary stays
+		// watched for the idle sharer B, so an edit there still refreshes B (D4).
+		environment.monitor.fire(sharedRoot);
+		await tick();
+
+		assert.deepStrictEqual(environment.changesets.recomputed, [sessionB]);
+	});
+
+	test('retries a repository root whose watcher acquisition failed on the next re-attach', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		// repoB's watcher acquisition fails on the first attempt.
+		environment.monitor.failAcquireFor.add(rootB.toString());
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+		await tick();
+
+		// The failure clears; a re-attach must retry repoB (not short-circuit on
+		// a cached signature) so an edit there then refreshes the summary.
+		environment.monitor.failAcquireFor.delete(rootB.toString());
+		environment.coordinator.onSessionMaterialized(session);
+		await environment.monitor.waitForAcquisitions(3);
+		environment.changesets.clearRefreshes();
+		environment.monitor.fire(rootB);
+		await tick();
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			recomputed: environment.changesets.recomputed,
+		}, {
+			acquisitions: [rootA.toString(), rootB.toString(), rootB.toString()].sort(),
+			recomputed: [session],
+		});
+	});
 });
 
 function createGitService(root: URI): IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> } {
@@ -649,13 +764,14 @@ class TestFileMonitorService extends Disposable implements IAgentHostFileMonitor
 	readonly acquisitions: string[] = [];
 	readonly disposals: string[] = [];
 	failAcquire = false;
+	readonly failAcquireFor = new Set<string>();
 	private readonly _callbacks = new Map<string, Set<() => void>>();
 	private readonly _acquisitionWaiters: Array<{ count: number; deferred: DeferredPromise<void> }> = [];
 
 	acquire(folder: URI, callback: () => void, _options?: IAgentHostFileMonitorOptions): IDisposable | undefined {
 		const root = folder.toString();
 		this.acquisitions.push(root);
-		if (this.failAcquire) {
+		if (this.failAcquire || this.failAcquireFor.has(root)) {
 			this._releaseAcquisitionWaiters();
 			return undefined;
 		}

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
@@ -48,7 +48,14 @@ suite('ChangesetSessionCoordinator', () => {
 		stateManager.dispatchServerAction(session, { type: ActionType.SessionReady });
 	}
 
-	function createEnvironment(root: URI = URI.file('/repo')): {
+	function createMultiRootSession(stateManager: AgentHostStateManager, session: string, workingDirectories: readonly string[]): void {
+		createSession(stateManager, session, workingDirectories[0]);
+		for (const workingDirectory of workingDirectories.slice(1)) {
+			stateManager.dispatchServerAction(session, { type: ActionType.SessionWorkingDirectorySet, directory: workingDirectory });
+		}
+	}
+
+	function createEnvironment(root: URI = URI.file('/repo'), gitServiceOverride?: IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> }): {
 		stateManager: AgentHostStateManager;
 		changesets: TestChangesetService;
 		subscriptions: IAgentHostChangesetSubscriptionService;
@@ -64,7 +71,7 @@ suite('ChangesetSessionCoordinator', () => {
 		const subscriptions = new AgentHostChangesetSubscriptionService();
 		const changesets = new TestChangesetService(subscriptions);
 		const monitor = disposables.add(new TestFileMonitorService());
-		const gitService = createGitService(root);
+		const gitService = gitServiceOverride ?? createGitService(root);
 		const gitStateService = disposables.add(new TestGitStateService());
 		const updateOperationsCalls: string[] = [];
 		const operationContributionService: IAgentHostChangesetOperationService = {
@@ -368,9 +375,223 @@ suite('ChangesetSessionCoordinator', () => {
 			disposals: ['file:///repo'],
 		});
 	});
+
+	test('watches every git repository root in a multi-root session', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+
+		assert.deepStrictEqual([...environment.monitor.acquisitions].sort(), [rootA.toString(), rootB.toString()].sort());
+	});
+
+	test('a secondary-root external edit refreshes the summary using the primary working directory', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const primaryRoot = URI.file('/projects/repoA');
+		const secondaryRoot = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[primaryRoot.toString(), primaryRoot],
+			[secondaryRoot.toString(), secondaryRoot],
+		])));
+		createMultiRootSession(environment.stateManager, session, [primaryRoot.toString(), secondaryRoot.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.changesets.clearRefreshes();
+
+		// An external edit in the SECONDARY repo must refresh the all-folder
+		// summary, sourcing git state from the PRIMARY working directory (never
+		// the secondary root that changed).
+		environment.monitor.fire(secondaryRoot);
+		await tick();
+
+		assert.deepStrictEqual({
+			refreshedWith: environment.gitStateService.refreshedWith,
+			recomputed: environment.changesets.recomputed,
+			branchRefreshes: environment.changesets.branchRefreshes,
+		}, {
+			refreshedWith: [{ sessionKey: session, workingDirectory: primaryRoot.toString() }],
+			recomputed: [session],
+			branchRefreshes: [session],
+		});
+	});
+
+	test('a turn suspends and re-attaches every repository root', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.coordinator.onSessionTurnActiveChanged(session, true);
+		await environment.gitService.waitForRootLookups(3);
+		await tick();
+		environment.coordinator.onSessionTurnActiveChanged(session, false);
+		await environment.monitor.waitForAcquisitions(4);
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			disposals: [...environment.monitor.disposals].sort(),
+		}, {
+			acquisitions: [rootA.toString(), rootA.toString(), rootB.toString(), rootB.toString()].sort(),
+			disposals: [rootA.toString(), rootB.toString()].sort(),
+		});
+	});
+
+	test('deduplicates working directories that resolve to the same repository', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const sharedRoot = URI.file('/projects/mono');
+		const dirA = 'file:///projects/mono/packages/a';
+		const dirB = 'file:///projects/mono/packages/b';
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[dirA, sharedRoot],
+			[dirB, sharedRoot],
+		])));
+		createMultiRootSession(environment.stateManager, session, [dirA, dirB]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.gitService.waitForRootLookups(2);
+		await tick();
+
+		assert.deepStrictEqual(environment.monitor.acquisitions, [sharedRoot.toString()]);
+	});
+
+	test('releases every repository root when the last subscriber leaves', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.coordinator.onLastSubscriber(URI.parse(session));
+		await tick();
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			disposals: [...environment.monitor.disposals].sort(),
+		}, {
+			acquisitions: [rootA.toString(), rootB.toString()].sort(),
+			disposals: [rootA.toString(), rootB.toString()].sort(),
+		});
+	});
+
+	test('watches secondary git repositories even when the primary folder is not a git repository', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const nonGitPrimary = 'file:///projects';
+		const secondaryRoot = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map<string, URI | undefined>([
+			[nonGitPrimary, undefined],
+			[secondaryRoot.toString(), secondaryRoot],
+		])));
+		createMultiRootSession(environment.stateManager, session, [nonGitPrimary, secondaryRoot.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(1);
+		environment.changesets.clearRefreshes();
+		environment.monitor.fire(secondaryRoot);
+		await tick();
+
+		assert.deepStrictEqual({
+			acquisitions: environment.monitor.acquisitions,
+			refreshedWith: environment.gitStateService.refreshedWith,
+			recomputed: environment.changesets.recomputed,
+		}, {
+			acquisitions: [secondaryRoot.toString()],
+			refreshedWith: [{ sessionKey: session, workingDirectory: nonGitPrimary }],
+			recomputed: [session],
+		});
+	});
+
+	test('does not refresh from any root while a turn is active', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createMultiRootSession(environment.stateManager, session, [rootA.toString(), rootB.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.coordinator.onSessionTurnActiveChanged(session, true);
+		await environment.gitService.waitForRootLookups(3);
+		await tick();
+		environment.changesets.clearRefreshes();
+
+		// While the turn runs, every root watcher is released; external edits to
+		// any root must not trigger a mid-turn refresh (turn edits are captured
+		// by the turn lifecycle instead).
+		environment.monitor.fire(rootA);
+		environment.monitor.fire(rootB);
+		await tick();
+
+		assert.deepStrictEqual({
+			recomputed: environment.changesets.recomputed,
+			refreshed: environment.gitStateService.refreshed,
+		}, {
+			recomputed: [],
+			refreshed: [],
+		});
+	});
+
+	test('does not refresh an idle session sharing a secondary root while another session runs a turn', async () => {
+		const sessionA = AgentSession.uri('mock', 'session-a').toString();
+		const sessionB = AgentSession.uri('mock', 'session-b').toString();
+		const sharedRoot = URI.file('/projects/shared');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[sharedRoot.toString(), sharedRoot],
+			[rootB.toString(), rootB],
+		])));
+		// A's primary is the shared repo; B watches the shared repo as a secondary.
+		createMultiRootSession(environment.stateManager, sessionA, [sharedRoot.toString()]);
+		createMultiRootSession(environment.stateManager, sessionB, [rootB.toString(), sharedRoot.toString()]);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(sessionA));
+		environment.coordinator.onFirstSubscriber(URI.parse(sessionB));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.coordinator.onSessionTurnActiveChanged(sessionA, true);
+		await environment.gitService.waitForRootLookups(4);
+		await tick();
+		environment.changesets.clearRefreshes();
+
+		// While A runs a turn the shared root is active, so an external edit
+		// there must NOT refresh the idle sharer B (documented, accepted
+		// shared-root suspension — decision D4).
+		environment.monitor.fire(sharedRoot);
+		await tick();
+
+		assert.deepStrictEqual(environment.changesets.recomputed, []);
+	});
 });
 
 function createGitService(root: URI): IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> } {
+	return createGitServiceFromResolver(() => root);
+}
+
+function createRoutingGitService(routes: ReadonlyMap<string, URI | undefined>): IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> } {
+	return createGitServiceFromResolver(workingDirectory => routes.get(workingDirectory.toString()));
+}
+
+function createGitServiceFromResolver(resolveRoot: (workingDirectory: URI) => URI | undefined): IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> } {
 	const rootLookupCalls: string[] = [];
 	const waiters: Array<{ count: number; deferred: DeferredPromise<void> }> = [];
 	const releaseWaiters = () => {
@@ -384,10 +605,10 @@ function createGitService(root: URI): IAgentHostGitService & { readonly rootLook
 	return {
 		...createNoopGitService(),
 		rootLookupCalls,
-		async getRepositoryRoot(workingDirectory: URI): Promise<URI> {
+		async getRepositoryRoot(workingDirectory: URI): Promise<URI | undefined> {
 			rootLookupCalls.push(workingDirectory.toString());
 			releaseWaiters();
-			return root;
+			return resolveRoot(workingDirectory);
 		},
 		waitForRootLookups(count: number): Promise<void> {
 			if (rootLookupCalls.length >= count) {
@@ -407,11 +628,14 @@ class TestGitStateService extends Disposable implements IAgentHostGitStateServic
 	readonly onDidRefreshSessionGitState = this._onDidRefreshSessionGitState.event;
 
 	readonly refreshed: string[] = [];
+	readonly refreshedWith: Array<{ readonly sessionKey: string; readonly workingDirectory: string | undefined }> = [];
 
-	async refreshSessionGitState(sessionKey: string, _workingDirectory?: URI): Promise<void> {
-		// Mirror the production service: record the refresh and notify
-		// listeners so the coordinator recomputes the subscribed changesets.
+	async refreshSessionGitState(sessionKey: string, workingDirectory?: URI): Promise<void> {
+		// Mirror the production service: record the refresh (and the working
+		// directory it was asked to refresh from) and notify listeners so the
+		// coordinator recomputes the subscribed changesets.
 		this.refreshed.push(sessionKey);
+		this.refreshedWith.push({ sessionKey, workingDirectory: workingDirectory?.toString() });
 		this._onDidRefreshSessionGitState.fire(sessionKey);
 	}
 	async setSessionGitHubState(_sessionKey: string, _state: ISessionGitHubState): Promise<void> { }

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetCoordinator.test.ts
@@ -696,6 +696,94 @@ suite('ChangesetSessionCoordinator', () => {
 			recomputed: [session],
 		});
 	});
+
+	test('re-attaches root watchers when a working directory is added or removed mid-session', async () => {
+		const session = AgentSession.uri('mock', 'session-1').toString();
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		createSession(environment.stateManager, session, rootA.toString());
+
+		environment.coordinator.onFirstSubscriber(URI.parse(session));
+		await environment.monitor.waitForAcquisitions(1);
+
+		// Adding a second root mid-session must start watching it (no lifecycle
+		// event required) so external edits there refresh the summary.
+		environment.stateManager.dispatchServerAction(session, { type: ActionType.SessionWorkingDirectorySet, directory: rootB.toString() });
+		await environment.monitor.waitForAcquisitions(2);
+
+		// Removing it again must stop watching that root.
+		environment.stateManager.dispatchServerAction(session, { type: ActionType.SessionWorkingDirectoryRemoved, directory: rootB.toString() });
+		await environment.monitor.waitForDisposals(1);
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			disposals: [...environment.monitor.disposals],
+		}, {
+			acquisitions: [rootA.toString(), rootB.toString()].sort(),
+			disposals: [rootB.toString()],
+		});
+	});
+
+	test('a subagent inheriting a multi-root parent watches every parent root and refreshes via the parent primary', async () => {
+		const parentSession = AgentSession.uri('mock', 'session-parent').toString();
+		const subagentSession = buildSubagentSessionUri(parentSession, 'tool-1');
+		const primaryRoot = URI.file('/projects/repoA');
+		const secondaryRoot = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[primaryRoot.toString(), primaryRoot],
+			[secondaryRoot.toString(), secondaryRoot],
+		])));
+		createMultiRootSession(environment.stateManager, parentSession, [primaryRoot.toString(), secondaryRoot.toString()]);
+		// The subagent has NO own working directories, so it inherits the parent's set.
+		createSession(environment.stateManager, subagentSession);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(subagentSession));
+		await environment.monitor.waitForAcquisitions(2);
+		environment.changesets.clearRefreshes();
+
+		// An external edit in the parent's SECONDARY repo refreshes the subagent,
+		// sourcing git state from the parent's PRIMARY working directory.
+		environment.monitor.fire(secondaryRoot);
+		await tick();
+
+		assert.deepStrictEqual({
+			acquisitions: [...environment.monitor.acquisitions].sort(),
+			refreshedWith: environment.gitStateService.refreshedWith,
+			recomputed: environment.changesets.recomputed,
+		}, {
+			acquisitions: [primaryRoot.toString(), secondaryRoot.toString()].sort(),
+			refreshedWith: [{ sessionKey: subagentSession, workingDirectory: primaryRoot.toString() }],
+			recomputed: [subagentSession],
+		});
+	});
+
+	test('re-attaches an inheriting subagent when the parent gains a working directory mid-session', async () => {
+		const parentSession = AgentSession.uri('mock', 'session-parent').toString();
+		const subagentSession = buildSubagentSessionUri(parentSession, 'tool-1');
+		const rootA = URI.file('/projects/repoA');
+		const rootB = URI.file('/projects/repoB');
+		const environment = createEnvironment(undefined, createRoutingGitService(new Map([
+			[rootA.toString(), rootA],
+			[rootB.toString(), rootB],
+		])));
+		// The parent starts single-root; the subagent inherits its set.
+		createSession(environment.stateManager, parentSession, rootA.toString());
+		createSession(environment.stateManager, subagentSession);
+
+		environment.coordinator.onFirstSubscriber(URI.parse(subagentSession));
+		await environment.monitor.waitForAcquisitions(1);
+
+		// The PARENT gains a second root mid-session: the inheriting subagent must
+		// start watching it too (fan-out to subagents on a parent change).
+		environment.stateManager.dispatchServerAction(parentSession, { type: ActionType.SessionWorkingDirectorySet, directory: rootB.toString() });
+		await environment.monitor.waitForAcquisitions(2);
+
+		assert.deepStrictEqual([...environment.monitor.acquisitions].sort(), [rootA.toString(), rootB.toString()].sort());
+	});
 });
 
 function createGitService(root: URI): IAgentHostGitService & { readonly rootLookupCalls: string[]; waitForRootLookups(count: number): Promise<void> } {
@@ -767,6 +855,7 @@ class TestFileMonitorService extends Disposable implements IAgentHostFileMonitor
 	readonly failAcquireFor = new Set<string>();
 	private readonly _callbacks = new Map<string, Set<() => void>>();
 	private readonly _acquisitionWaiters: Array<{ count: number; deferred: DeferredPromise<void> }> = [];
+	private readonly _disposalWaiters: Array<{ count: number; deferred: DeferredPromise<void> }> = [];
 
 	acquire(folder: URI, callback: () => void, _options?: IAgentHostFileMonitorOptions): IDisposable | undefined {
 		const root = folder.toString();
@@ -785,6 +874,7 @@ class TestFileMonitorService extends Disposable implements IAgentHostFileMonitor
 		return toDisposable(() => {
 			callbacks.delete(callback);
 			this.disposals.push(root);
+			this._releaseDisposalWaiters();
 		});
 	}
 
@@ -807,6 +897,24 @@ class TestFileMonitorService extends Disposable implements IAgentHostFileMonitor
 		for (const waiter of [...this._acquisitionWaiters]) {
 			if (this.acquisitions.length >= waiter.count) {
 				this._acquisitionWaiters.splice(this._acquisitionWaiters.indexOf(waiter), 1);
+				void waiter.deferred.complete(undefined);
+			}
+		}
+	}
+
+	waitForDisposals(count: number): Promise<void> {
+		if (this.disposals.length >= count) {
+			return Promise.resolve();
+		}
+		const deferred = new DeferredPromise<void>();
+		this._disposalWaiters.push({ count, deferred });
+		return deferred.p;
+	}
+
+	private _releaseDisposalWaiters(): void {
+		for (const waiter of [...this._disposalWaiters]) {
+			if (this.disposals.length >= waiter.count) {
+				this._disposalWaiters.splice(this._disposalWaiters.indexOf(waiter), 1);
 				void waiter.deferred.complete(undefined);
 			}
 		}


### PR DESCRIPTION
## What & why

In a multi-root workspace, the Agents session-list "+N −M" changeset chip did not refresh when files were edited in a **secondary** folder: the changeset file monitor attached its watcher only to the **primary** repo root (via the singular `getEffectiveWorkingDirectory`), while the summary computation was already multi-root-aware. This PR makes the trigger multi-root-aware too, so an external edit in **any** git-backed folder refreshes the all-folder chip — matching single-folder freshness.

## What changed

- The changeset file monitor resolves **all** of a session's working directories (`getEffectiveWorkingDirectories` + `resolveSessionRepositories`) and attaches one shared watcher **per unique git repository root** (working directories in the same repo dedup to a single watcher).
- On any watched root changing, git state is refreshed from the **primary** working directory (branch/PR is a primary concept) while the downstream summary re-diffs **every** repo — so a secondary-folder edit refreshes without mis-attributing branch/PR.
- Ref-counted turn suspend/re-attach: a shared root stays watched while another idle session still references it.
- A root whose watcher acquisition fails is retried on the next re-attach (the working-directory signature is cached only when every root was watched).
- Session disposal untracks the branch changeset key, so an abrupt dispose can't leave stale watch interest.
- Re-attach on mid-session working-directory changes (a folder added or removed), including inheriting subagent sessions.

## Tests

`ChangesetSessionCoordinator` node suite: watches every repo root in a multi-root session; a secondary-root external edit refreshes the summary via the primary working directory; turn suspend/re-attach; same-repo dedup; a shared secondary root stays watched for an idle session during another session's turn; failed-acquisition retry; branch-key cleared on dispose; root detach when a session stops resolving to it; mid-session folder add/remove re-attach; and a subagent inheriting a multi-root parent.

Verified locally: with the pre-fix (singular) coordinator the watcher tests fail; with the fix the full suite passes and `typecheck-client` is clean.
