### PR TITLE
Fix Update tooltip keyboard navigation

### DIFF
--- a/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
@@ -97,7 +97,7 @@
 .update-tooltip .release-notes-button {
 	background-color: var(--vscode-button-secondaryBackground);
 	color: var(--vscode-button-secondaryForeground);
-	border: 1px solid var(--vscode-button-border, transparent);
+	border: 1px solid var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent));
 }
 
 .update-tooltip .release-notes-button:hover {

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -249,6 +249,11 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 
 		this.action.run = () => this.runAction();
 		this._register(this.updateService.onStateChange(state => this.onStateChange(state)));
+		this._register(this.commandService.onDidExecuteCommand(event => {
+			if (event.commandId === 'workbench.action.showHover' && this.isFocused()) {
+				this.focusTooltip();
+			}
+		}));
 	}
 
 	public override render(container: HTMLElement) {
@@ -285,12 +290,18 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 			persistence: { sticky: true },
 			appearance: { showPointer: true, compact: true },
 			position: { anchorAlignment: AnchorAlignment.RIGHT },
+			trapFocus: focus,
 		}, focus);
 
 		if (hover) {
 			this.visibleTooltip.value = hover;
 			this.onDidShowTooltip(focus);
 		}
+	}
+
+	private focusTooltip(): void {
+		this.visibleTooltip.clear();
+		this.showTooltip(true);
 	}
 
 	protected override getHoverContents(): IManagedHoverContent {

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -33,8 +33,10 @@ export class UpdateTooltip extends Disposable {
 	private readonly productNameNode: HTMLElement;
 	private readonly currentVersionNode: HTMLElement;
 	private readonly currentVersionCopyValue: { value: string };
+	private readonly currentVersionCopyButton: HTMLElement;
 	private readonly latestVersionNode: HTMLElement;
 	private readonly latestVersionCopyValue: { value: string };
+	private readonly latestVersionCopyButton: HTMLElement;
 	private readonly releaseDateNode: HTMLElement;
 
 	// Progress section
@@ -89,10 +91,12 @@ export class UpdateTooltip extends Disposable {
 		const currentVersionRow = this.createVersionRow(details);
 		this.currentVersionNode = currentVersionRow.label;
 		this.currentVersionCopyValue = currentVersionRow.copyValue;
+		this.currentVersionCopyButton = currentVersionRow.copyButton;
 
 		const latestVersionRow = this.createVersionRow(details);
 		this.latestVersionNode = latestVersionRow.label;
 		this.latestVersionCopyValue = latestVersionRow.copyValue;
+		this.latestVersionCopyButton = latestVersionRow.copyButton;
 
 		this.releaseDateNode = dom.append(details, dom.$('.product-release-date'));
 
@@ -145,8 +149,10 @@ export class UpdateTooltip extends Disposable {
 				: localize('updateTooltip.currentVersionLabel', "Current Version: {0}", productVersion);
 			this.currentVersionCopyValue.value = currentCommitId ? `${productVersion} (${this.productService.commit})` : productVersion;
 			this.currentVersionNode.parentElement!.style.display = '';
+			this.currentVersionCopyButton.tabIndex = 0;
 		} else {
 			this.currentVersionNode.parentElement!.style.display = 'none';
+			this.currentVersionCopyButton.tabIndex = -1;
 		}
 	}
 
@@ -157,6 +163,7 @@ export class UpdateTooltip extends Disposable {
 		this.timeRemainingNode.textContent = '';
 		this.messageNode.style.display = 'none';
 		this.actionButton.style.display = 'none';
+		this.actionButton.tabIndex = -1;
 		this.actionButton.dataset.commandId = '';
 		this.releaseNotesButton.style.marginRight = '';
 	}
@@ -385,8 +392,10 @@ export class UpdateTooltip extends Disposable {
 				: localize('updateTooltip.latestVersionLabel', "Latest Version: {0}", version);
 			this.latestVersionCopyValue.value = updateCommitId ? `${version} (${update.version})` : version;
 			this.latestVersionNode.parentElement!.style.display = '';
+			this.latestVersionCopyButton.tabIndex = 0;
 		} else {
 			this.latestVersionNode.parentElement!.style.display = 'none';
+			this.latestVersionCopyButton.tabIndex = -1;
 		}
 
 		// Release date
@@ -401,6 +410,7 @@ export class UpdateTooltip extends Disposable {
 		// Release notes button
 		this.releaseNotesVersion = version ?? this.productService.version;
 		this.releaseNotesButton.style.display = this.releaseNotesVersion ? '' : 'none';
+		this.releaseNotesButton.tabIndex = this.releaseNotesVersion ? 0 : -1;
 		this.releaseNotesButton.style.marginRight = this.releaseNotesVersion ? 'auto' : '';
 		this.buttonBar.style.display = this.releaseNotesVersion ? '' : 'none';
 	}
@@ -409,6 +419,7 @@ export class UpdateTooltip extends Disposable {
 		this.actionButton.textContent = label;
 		this.actionButton.dataset.commandId = commandId;
 		this.actionButton.style.display = '';
+		this.actionButton.tabIndex = 0;
 	}
 
 	private renderMessage(message: string, icon?: ThemeIcon) {
@@ -421,7 +432,7 @@ export class UpdateTooltip extends Disposable {
 		this.messageNode.style.display = '';
 	}
 
-	private createVersionRow(parent: HTMLElement): { label: HTMLElement; copyValue: { value: string } } {
+	private createVersionRow(parent: HTMLElement): { label: HTMLElement; copyValue: { value: string }; copyButton: HTMLElement } {
 		const row = dom.append(parent, dom.$('.product-version'));
 		const label = dom.append(row, dom.$('span'));
 		const copyValue = { value: '' };
@@ -443,7 +454,7 @@ export class UpdateTooltip extends Disposable {
 			}
 		}));
 
-		return { label, copyValue };
+		return { label, copyValue, copyButton };
 	}
 
 	private runCommandAndClose(command: string, ...args: unknown[]) {

--- a/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { Action } from '../../../../../base/common/actions.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { toDisposable } from '../../../../../base/common/lifecycle.js';
+import { IHoverOptions, IHoverWidget } from '../../../../../base/browser/ui/hover/hover.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandEvent, ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IUpdateService, State } from '../../../../../platform/update/common/update.js';
+import { UpdateTitleBarEntry } from '../../browser/updateTitleBarEntry.js';
+import { UpdateTooltip } from '../../browser/updateTooltip.js';
+
+class TestCommandService extends mock<ICommandService>() {
+	private readonly _onDidExecuteCommand = new Emitter<ICommandEvent>();
+	override readonly onDidExecuteCommand = this._onDidExecuteCommand.event;
+
+	fireDidExecuteCommand(commandId: string): void {
+		this._onDidExecuteCommand.fire({ commandId, args: [] });
+	}
+
+	dispose(): void {
+		this._onDidExecuteCommand.dispose();
+	}
+}
+
+class TestHoverWidget implements IHoverWidget {
+	isDisposed = false;
+
+	dispose(): void {
+		this.isDisposed = true;
+	}
+}
+
+class TestHoverService extends mock<IHoverService>() {
+	readonly showRequests: { readonly focus: boolean; readonly trapFocus: boolean }[] = [];
+
+	override showInstantHover(options: IHoverOptions, focus?: boolean): IHoverWidget {
+		this.showRequests.push({ focus: !!focus, trapFocus: !!options.trapFocus });
+		return new TestHoverWidget();
+	}
+}
+
+suite('UpdateTitleBarEntry', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Show or Focus Hover focuses the tooltip while Tab remains unhandled', () => {
+		const container = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+		store.add(toDisposable(() => container.remove()));
+
+		const commandService = store.add(new TestCommandService());
+		const hoverService = new TestHoverService();
+		const action = store.add(new Action('workbench.actions.updateIndicator', 'Update'));
+		const entry = store.add(new UpdateTitleBarEntry(
+			action,
+			{},
+			new class extends mock<UpdateTooltip>() {
+				override readonly domNode = mainWindow.document.createElement('div');
+			},
+			() => { },
+			() => { },
+			commandService,
+			hoverService,
+			new class extends mock<ITelemetryService>() { },
+			new class extends mock<IUpdateService>() {
+				override readonly onStateChange = Event.None;
+				override readonly state = State.Uninitialized;
+			},
+		));
+		entry.render(container);
+		entry.focus();
+
+		const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', keyCode: 9, bubbles: true, cancelable: true });
+		container.dispatchEvent(tabEvent);
+		commandService.fireDidExecuteCommand('workbench.action.showHover');
+
+		assert.deepStrictEqual({
+			tabDefaultPrevented: tabEvent.defaultPrevented,
+			hoverShowRequests: hoverService.showRequests,
+		}, {
+			tabDefaultPrevented: false,
+			hoverShowRequests: [{ focus: true, trapFocus: true }],
+		});
+	});
+});

--- a/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTitleBarEntry.test.ts
@@ -11,8 +11,12 @@ import { toDisposable } from '../../../../../base/common/lifecycle.js';
 import { IHoverOptions, IHoverWidget } from '../../../../../base/browser/ui/hover/hover.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandEvent, ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IMeteredConnectionService } from '../../../../../platform/meteredConnection/common/meteredConnection.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IUpdateService, State } from '../../../../../platform/update/common/update.js';
 import { UpdateTitleBarEntry } from '../../browser/updateTitleBarEntry.js';
@@ -89,5 +93,44 @@ suite('UpdateTitleBarEntry', () => {
 			tabDefaultPrevented: false,
 			hoverShowRequests: [{ focus: true, trapFocus: true }],
 		});
+	});
+});
+
+suite('UpdateTooltip', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('removes hidden actions from the tab order', () => {
+		const configurationService = new TestConfigurationService({ 'update.mode': 'default' });
+		store.add(configurationService.onDidChangeConfigurationEmitter);
+		const tooltip = store.add(new UpdateTooltip(
+			new class extends mock<IClipboardService>() { },
+			store.add(new TestCommandService()),
+			configurationService,
+			new TestHoverService(),
+			new class extends mock<IMeteredConnectionService>() {
+				override readonly isConnectionMetered = false;
+			},
+			new class extends mock<IProductService>() {
+				override readonly nameLong = 'Code - OSS Dev';
+				override readonly version = '1.134.0';
+				override readonly commit = 'current';
+			},
+		));
+
+		tooltip.renderState(State.Ready({ version: 'next', productVersion: '1.135.0' }, false, false));
+
+		assert.deepStrictEqual(
+			Array.from(tooltip.domNode.querySelectorAll<HTMLElement>('button, [tabindex]')).map(element => ({
+				className: element.className,
+				display: element.style.display,
+				tabIndex: element.tabIndex,
+			})),
+			[
+				{ className: 'copy-version-button', display: '', tabIndex: 0 },
+				{ className: 'copy-version-button', display: '', tabIndex: 0 },
+				{ className: 'release-notes-button', display: '', tabIndex: 0 },
+				{ className: 'action-button', display: 'none', tabIndex: -1 },
+			],
+		);
 	});
 });


### PR DESCRIPTION
Fixes #330046

This keeps normal title-bar Tab navigation unchanged and makes the existing **Show or Focus Hover** command (Ctrl+K Ctrl+I / Cmd+K Cmd+I) focus the Update tooltip when Update is focused. Once focused, Tab traverses the tooltip controls and Escape restores focus to Update.

The Release Notes action now uses the secondary-button border token so its passive state is not visually confused with keyboard focus.

Validation:
- Targeted browser unit test passes
- ESLint and stylelint pass for changed files
- Client transpilation and type checking pass
- Live Code OSS verification covers passive focus, forward Tab navigation, tooltip control traversal, and Escape focus restoration