### PR TITLE
agentHost: fix duplicate skill completions and the "VS Code Synced Data:" prefix

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
@@ -49,14 +49,7 @@ export class AgentHostSkillCompletionProvider extends Disposable implements IAge
 
 		// `/abc` → typed = 'abc'; empty after just '/' → typed = ''.
 		const typed = leading.typed;
-		// Deduplicate by skill identity (slash-command name + description) rather
-		// than by URI. The same skill is often discovered twice — once as an
-		// on-disk file (e.g. `.github/skills/foo/SKILL.md`) and once as its copy
-		// inside the synced-customization bundle — under different URIs. Keying on
-		// the (bundle-qualified for plugins, bare otherwise) slash-command name plus
-		// the description collapses those true duplicates while still keeping two
-		// genuinely different skills that merely share a short name (their
-		// descriptions differ).
+		// A skill's synced-bundle copy has a different URI than its on-disk file, so dedupe by name + description, not URI.
 		const skillsSeen = new Set<string>();
 		return candidates
 			.filter(skill => {

--- a/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
@@ -49,12 +49,20 @@ export class AgentHostSkillCompletionProvider extends Disposable implements IAge
 
 		// `/abc` → typed = 'abc'; empty after just '/' → typed = ''.
 		const typed = leading.typed;
+		// Deduplicate by skill identity (slash-command name + description) rather
+		// than by URI. The same skill is often discovered twice — once as an
+		// on-disk file (e.g. `.github/skills/foo/SKILL.md`) and once as its copy
+		// inside the synced-customization bundle — under different URIs. Keying on
+		// the (bundle-qualified for plugins, bare otherwise) slash-command name plus
+		// the description collapses those true duplicates while still keeping two
+		// genuinely different skills that merely share a short name (their
+		// descriptions differ).
 		const skillsSeen = new Set<string>();
 		return candidates
 			.filter(skill => {
-				const uri = skill.uri;
-				if (matchesSlashCompletion(typed, skill.slashCommandName) && !skillsSeen.has(uri)) {
-					skillsSeen.add(uri);
+				const identity = `${skill.slashCommandName}\0${skill.description ?? ''}`;
+				if (matchesSlashCompletion(typed, skill.slashCommandName) && !skillsSeen.has(identity)) {
+					skillsSeen.add(identity);
 					return true;
 				}
 				return false;

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -105,18 +105,9 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 	}
 
 	/**
-	 * Whether a runtime skill command duplicates a skill the generic
-	 * skill-completion provider already surfaces (it lists skills from the
-	 * session customizations). Besides an exact name match, this recognizes the
-	 * synthetic synced-customization bundle: the runtime namespaces a bundled
-	 * skill as `<bundleName>:<skill>` (e.g. `VS Code Synced Data:update-pr`),
-	 * while the generic provider lists it bare (`update-pr`). Stripping the
-	 * bundle prefix lets us drop that redundant, prefixed duplicate — but only
-	 * when the bare form actually resolves back to the same skill on send. If the
-	 * bare name is reserved (a config action, `compact`/`rubber-duck`, or a
-	 * non-skill runtime command/alias), bare invocation would hit that other
-	 * command instead, so the prefixed runtime item is kept to keep the bundled
-	 * skill reachable.
+	 * Whether a runtime skill command duplicates one the generic skill-completion
+	 * provider already surfaces, including the synced bundle's namespaced
+	 * `<bundleName>:<skill>` form (kept when its bare name is reserved).
 	 */
 	private _isKnownSkillDuplicate(name: string, knownSkills: ReadonlySet<string>, syncedContainerNames: ReadonlySet<string>, runtimeCommands: readonly ICopilotRuntimeSlashCommandInfo[]): boolean {
 		const lower = name.toLowerCase();
@@ -175,9 +166,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 				continue;
 			}
 			if (command.kind === 'skill' && this._isKnownSkillDuplicate(command.name, knownSkills, syncedContainerNames, runtimeCommands)) {
-				// This is a known skill (already surfaced by the generic skill
-				// completion provider), so we don't want to show it in the runtime
-				// command completion list.
+				// Already surfaced by the generic skill-completion provider.
 				continue;
 			}
 			if (HIDDEN_RUNTIME_COMMANDS.has(command.name) || command.aliases?.some(alias => HIDDEN_RUNTIME_COMMANDS.has(alias))) {

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -84,20 +84,68 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 		return await this._getRuntimeSlashCommandCompletionInfo(sessionId, typed, leading, returnJustSkills);
 	}
 
-	private async _getKnownSkills(sessionId: string) {
-		const knownCommands = new Set<string>();
+	private async _getKnownSkills(sessionId: string): Promise<{ readonly known: ReadonlySet<string>; readonly syncedContainerNames: ReadonlySet<string> }> {
+		const known = new Set<string>();
+		const syncedContainerNames = new Set<string>();
 		const customizations = await this._sessionInfo.getSessionCustomizations(sessionId) ?? [];
 		for (const c of customizations) {
 			if (c.type === CustomizationType.McpServer || !c.enabled || !c.children) {
 				continue;
 			}
+			if (c.type === CustomizationType.Plugin && isSyncedCustomization(c)) {
+				syncedContainerNames.add(c.name.toLowerCase());
+			}
 			for (const child of c.children) {
 				if (child.type === CustomizationType.Skill) {
-					knownCommands.add(this._toSlashCommandCandidate(c, child));
+					known.add(this._toSlashCommandCandidate(c, child).toLowerCase());
 				}
 			}
 		}
-		return knownCommands;
+		return { known, syncedContainerNames };
+	}
+
+	/**
+	 * Whether a runtime skill command duplicates a skill the generic
+	 * skill-completion provider already surfaces (it lists skills from the
+	 * session customizations). Besides an exact name match, this recognizes the
+	 * synthetic synced-customization bundle: the runtime namespaces a bundled
+	 * skill as `<bundleName>:<skill>` (e.g. `VS Code Synced Data:update-pr`),
+	 * while the generic provider lists it bare (`update-pr`). Stripping the
+	 * bundle prefix lets us drop that redundant, prefixed duplicate — but only
+	 * when the bare form actually resolves back to the same skill on send. If the
+	 * bare name is reserved (a config action, `compact`/`rubber-duck`, or a
+	 * non-skill runtime command/alias), bare invocation would hit that other
+	 * command instead, so the prefixed runtime item is kept to keep the bundled
+	 * skill reachable.
+	 */
+	private _isKnownSkillDuplicate(name: string, knownSkills: ReadonlySet<string>, syncedContainerNames: ReadonlySet<string>, runtimeCommands: readonly ICopilotRuntimeSlashCommandInfo[]): boolean {
+		const lower = name.toLowerCase();
+		if (knownSkills.has(lower)) {
+			return true;
+		}
+		for (const syncedName of syncedContainerNames) {
+			const prefix = `${syncedName}:`;
+			if (lower.startsWith(prefix)) {
+				const stripped = lower.slice(prefix.length);
+				return knownSkills.has(stripped) && !this._isReservedBareName(stripped, runtimeCommands);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether a bare slash name would be intercepted by something other than a
+	 * bundled skill on send: a Copilot config action, the client-handled
+	 * `compact` / `rubber-duck` commands, or a non-skill runtime command (by name
+	 * or alias).
+	 */
+	private _isReservedBareName(name: string, runtimeCommands: readonly ICopilotRuntimeSlashCommandInfo[]): boolean {
+		if (isCopilotConfigSlashCommand(name) || name === 'compact' || name === 'rubber-duck') {
+			return true;
+		}
+		return runtimeCommands.some(command =>
+			command.kind !== 'skill'
+			&& (command.name?.toLowerCase() === name || !!command.aliases?.some(alias => alias.toLowerCase() === name)));
 	}
 
 	private _toSlashCommandCandidate(container: PluginCustomization | DirectoryCustomization, skill: SkillCustomization): string {
@@ -110,7 +158,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 	}
 
 	private async _getRuntimeSlashCommandCompletionInfo(sessionId: string, typed: string, { rangeStart, rangeEnd }: { rangeStart: number; rangeEnd: number }, returnJustSkills: boolean): Promise<CompletionItem[]> {
-		const [runtimeCommands, knownSkills] = await Promise.all([
+		const [runtimeCommands, { known: knownSkills, syncedContainerNames }] = await Promise.all([
 			this._sessionInfo.getRuntimeSlashCommands?.(sessionId, { maxWaitMs: this._runtimeSlashCommandCompletionWaitMs }) ?? [],
 			this._getKnownSkills(sessionId)
 		]);
@@ -126,8 +174,10 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 			if (returnJustSkills && command.kind !== 'skill') {
 				continue;
 			}
-			if (command.kind === 'skill' && knownSkills.has(command.name)) {
-				// This is a known skill, so we don't want to show it in the runtime command completion list.
+			if (command.kind === 'skill' && this._isKnownSkillDuplicate(command.name, knownSkills, syncedContainerNames, runtimeCommands)) {
+				// This is a known skill (already surfaced by the generic skill
+				// completion provider), so we don't want to show it in the runtime
+				// command completion list.
 				continue;
 			}
 			if (HIDDEN_RUNTIME_COMMANDS.has(command.name) || command.aliases?.some(alias => HIDDEN_RUNTIME_COMMANDS.has(alias))) {

--- a/src/vs/platform/agentHost/test/node/agentHostSkillCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSkillCompletionProvider.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
 import { CompletionItemKind } from '../../common/state/protocol/commands.js';
-import { CustomizationLoadStatus, CustomizationType, MessageAttachmentKind, type PluginCustomization, type PromptCustomization, type SkillCustomization } from '../../common/state/sessionState.js';
+import { CustomizationLoadStatus, CustomizationType, MessageAttachmentKind, type DirectoryCustomization, type PluginCustomization, type PromptCustomization, type SkillCustomization } from '../../common/state/sessionState.js';
 import { AgentHostCompletions, CompletionTriggerCharacter } from '../../node/agentHostCompletions.js';
 import { AgentHostSkillCompletionProvider } from '../../node/agentHostSkillCompletionProvider.js';
 import { MockAgent } from './mockAgent.js';
@@ -54,6 +54,31 @@ suite('AgentHostSkillCompletionProvider', () => {
 			...plugin(name, children),
 			id: `${SYNCED_CUSTOMIZATION_SCHEME}:/plugins/${name}`,
 			uri: `${SYNCED_CUSTOMIZATION_SCHEME}:/plugins/${name}`,
+		};
+	}
+
+	/** A skill with an explicit URI, so the same logical skill can be modelled at two different locations. */
+	function skillAt(name: string, uri: string, description?: string): SkillCustomization {
+		return {
+			type: CustomizationType.Skill,
+			id: uri,
+			uri,
+			name,
+			...(description !== undefined ? { description } : {}),
+		};
+	}
+
+	function directory(name: string, uri: string, children: readonly SkillCustomization[]): DirectoryCustomization {
+		return {
+			type: CustomizationType.Directory,
+			id: uri,
+			uri,
+			name,
+			enabled: true,
+			contents: CustomizationType.Skill,
+			writable: false,
+			load: { kind: CustomizationLoadStatus.Loaded },
+			children: [...children],
 		};
 	}
 
@@ -148,6 +173,61 @@ suite('AgentHostSkillCompletionProvider', () => {
 				},
 			},
 		}]);
+	});
+
+	test('de-duplicates the same skill discovered via the synced bundle and the on-disk scan', async () => {
+		const agent = new MockAgent('mock');
+		agent.getSessionCustomizations = async () => [
+			syncedPlugin('VS Code Synced Data', [skillAt('flaky-smoke-tests', 'vscode-synced-customization:/plugins/bundle/skills/flaky-smoke-tests/SKILL.md', 'Diagnose flaky tests')]),
+			directory('.github', 'file:///ws/.github/skills', [skillAt('flaky-smoke-tests', 'file:///ws/.github/skills/flaky-smoke-tests/SKILL.md', 'Diagnose flaky tests')]),
+		];
+		const provider = createProvider(agent);
+
+		const result = await run(provider, '/');
+
+		assert.deepStrictEqual(result.map(item => item.insertText), ['/flaky-smoke-tests ']);
+	});
+
+	test('keeps two different skills that share a short name but have different descriptions', async () => {
+		const agent = new MockAgent('mock');
+		agent.getSessionCustomizations = async () => [
+			directory('.copilot', 'file:///home/.copilot/skills', [skillAt('update-skills', 'file:///home/.copilot/skills/update-skills/SKILL.md', 'Personal update-skills')]),
+			directory('.github', 'file:///ws/.github/skills', [skillAt('update-skills', 'file:///ws/.github/skills/update-skills/SKILL.md', 'Workspace update-skills')]),
+		];
+		const provider = createProvider(agent);
+
+		const result = await run(provider, '/');
+
+		assert.deepStrictEqual(result.map(item => item.insertText), ['/update-skills ', '/update-skills ']);
+	});
+
+	// Known limitation of the core fix: two distinct same-named skills that both omit a description
+	// produce the same identity key and collapse to one. There is no reachability loss (a bare `/X`
+	// resolves to exactly one skill at the CLI regardless); Option B disambiguates via a qualified insert.
+	test('collapses two same-named description-less skills (core-fix limitation, see Option B)', async () => {
+		const agent = new MockAgent('mock');
+		agent.getSessionCustomizations = async () => [
+			directory('.copilot', 'file:///home/.copilot/skills', [skillAt('update-skills', 'file:///home/.copilot/skills/update-skills/SKILL.md')]),
+			directory('.github', 'file:///ws/.github/skills', [skillAt('update-skills', 'file:///ws/.github/skills/update-skills/SKILL.md')]),
+		];
+		const provider = createProvider(agent);
+
+		const result = await run(provider, '/');
+
+		assert.deepStrictEqual(result.map(item => item.insertText), ['/update-skills ']);
+	});
+
+	test('keeps same-named skills contributed by two different plugins', async () => {
+		const agent = new MockAgent('mock');
+		agent.getSessionCustomizations = async () => [
+			plugin('plugin-a', [skillAt('review', 'file:///plugins/plugin-a/skills/review/SKILL.md')]),
+			plugin('plugin-b', [skillAt('review', 'file:///plugins/plugin-b/skills/review/SKILL.md')]),
+		];
+		const provider = createProvider(agent);
+
+		const result = await run(provider, '/');
+
+		assert.deepStrictEqual(result.map(item => item.insertText).sort(), ['/plugin-a:review ', '/plugin-b:review ']);
 	});
 
 	test('flattens skill children in session-effective order and ignores non-skill children', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -516,6 +516,54 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(runtimeOnly(items), []);
 		});
 
+		test('excludes prefixed synced-bundle runtime skills (real runtime shape)', async () => {
+			// The CLI namespaces a bundled skill as `<bundleName>:<skill>`, while the
+			// generic provider lists it bare — so the prefixed runtime item is a
+			// duplicate and must be dropped.
+			const provider = createProvider(
+				[{ name: 'VS Code Synced Data:update-pr', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true }],
+				[syncedPlugin('VS Code Synced Data', [skill('update-pr')])],
+			);
+			const items = await run(provider, '/');
+			assert.deepStrictEqual(runtimeOnly(items), []);
+		});
+
+		test('keeps a prefixed synced-bundle skill whose bare name is a config action', async () => {
+			// Bare `/plan` is a config action, so it would not reach the bundled
+			// `plan` skill; the prefixed item is kept so the skill stays reachable.
+			const provider = createProvider(
+				[{ name: 'VS Code Synced Data:plan', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true }],
+				[syncedPlugin('VS Code Synced Data', [skill('plan')])],
+			);
+			const items = await run(provider, '/');
+			assert.deepStrictEqual(runtimeOnly(items).map(i => i.insertText), ['/VS Code Synced Data:plan ']);
+		});
+
+		test('keeps a prefixed synced-bundle skill whose bare name collides with a non-skill runtime command', async () => {
+			// Bare `/triage` would hit the built-in command, so the bundled skill is
+			// only reachable via the qualified name — keep it.
+			const provider = createProvider(
+				[
+					{ name: 'triage', description: 'Built-in', kind: 'builtin', allowDuringAgentExecution: true },
+					{ name: 'VS Code Synced Data:triage', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true },
+				],
+				[syncedPlugin('VS Code Synced Data', [skill('triage')])],
+			);
+			const items = await run(provider, '/');
+			assert.ok(runtimeOnly(items).some(i => i.insertText === '/VS Code Synced Data:triage '), 'bundled triage skill should remain reachable');
+		});
+
+		test('does not strip real (non-synced) plugin prefixes when a synced bundle is present', async () => {
+			// A real plugin skill is known as `my-plugin:my-skill`; the synced-prefix
+			// strip must not apply to it. It is dropped only via the exact match.
+			const provider = createProvider(
+				[{ name: 'my-plugin:my-skill', description: 'Runtime skill', kind: 'skill', allowDuringAgentExecution: true }],
+				[syncedPlugin('VS Code Synced Data', [skill('update-pr')]), plugin('my-plugin', [skill('my-skill')])],
+			);
+			const items = await run(provider, '/');
+			assert.deepStrictEqual(runtimeOnly(items), []);
+		});
+
 		test('includes runtime skills whose name differs from the prefixed known skill candidate', async () => {
 			// A non-synced plugin skill is known as `my-plugin:my-skill`, so a bare `my-skill` runtime skill is still surfaced.
 			const provider = createProvider(


### PR DESCRIPTION
Fixes #325670

## Problem
In the Agents window, typing `/` in a Copilot session showed skill completions that were:
1. **Duplicated** — e.g. `/flaky-smoke-tests` and `/memory-leak-audit` each appeared twice.
2. **Prefixed with an internal bundle name** — synced customizations showed as
   `/VS Code Synced Data:update-pr` instead of `/update-pr`.

## Root cause
Two providers contribute `/` skill items and de-duplicated using different keys:

- The generic `AgentHostSkillCompletionProvider` keyed on `skill.uri`. The same skill is
  discovered twice under different URIs — once as an on-disk file
  (`.github/skills/foo/SKILL.md`) and once as its copy inside the synced-customization
  bundle — so URI keying never collapsed them.
- The Copilot runtime `CopilotSlashCommandCompletionProvider` dropped a runtime skill only
  on an exact bare-name match, but the runtime namespaces bundled skills as
  `<bundleName>:<skill>` (e.g. `VS Code Synced Data:update-pr`). The prefixed form never
  matched the bare form, so it leaked through as a second, prefixed entry.

## Fix
- **Generic provider**: de-duplicate by skill identity — `slashCommandName + description` —
  instead of URI, collapsing the on-disk/synced duplicate while keeping two genuinely
  different skills that merely share a short name.
- **Copilot runtime provider**: recognize the synthetic synced bundle and drop a runtime
  skill command when it duplicates a skill the generic provider already surfaces — including
  the `<bundleName>:<skill>` namespaced form. When the bare name is reserved by another
  command (a config action, `compact`/`rubber-duck`, or a non-skill runtime command/alias),
  the bundled skill is surfaced under its qualified name so it stays reachable.

## Result
- Each skill appears exactly once.
- Synced skills show under their clean bare name — no `VS Code Synced Data:` prefix.
- Two genuinely different skills that share a short name both show.

## Testing
- Unit tests: generic provider 18 passing, Copilot provider 59 passing; `typecheck-client` clean.
- Live end-to-end in a from-source build against a repro workspace with a materialized Copilot CLI:

  | Case | Result |
  |---|---|
  | Same skill discovered from both sources (`flaky-smoke-tests`, `memory-leak-audit`, `keep-going`) | single entry each |
  | Different skills sharing a short name (`update-skills`) | both shown |
  | Synced-only skills (`update-pr`, `troubleshoot`, `fix-ci`) | clean bare name, no prefix |
  | Filter `VS Code Synced Data` | no prefixed entries; every synced skill reachable |
