### PR TITLE
MCP: Recognize MCP Configuration in Workspace Files

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -910,7 +910,7 @@ class McpSettingsRenderer extends Disposable implements languages.CodeActionProv
 }
 
 class WorkspaceConfigurationRenderer extends Disposable {
-	private static readonly supportedKeys = ['folders', 'tasks', 'launch', 'extensions', 'settings', 'remoteAuthority', 'transient'];
+	private static readonly supportedKeys = ['folders', 'tasks', 'launch', mcpConfigurationSection, 'extensions', 'settings', 'remoteAuthority', 'transient'];
 
 	private readonly decorations: editorCommon.IEditorDecorationsCollection;
 	private renderingDelayer = this._register(new Delayer<void>(200));


### PR DESCRIPTION
Fixes #268286

This adds the MCP configuration section to the supported top-level keys in the workspace configuration renderer. Valid `mcp` configuration in `.code-workspace` files is no longer marked as unsupported or dimmed.

Validation:
- `npm run transpile-client`
- `npx eslint src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts`
- Opened a `.code-workspace` file containing a top-level `mcp` section in Code OSS and verified it has no unsupported-property marker or dimmed decoration