### PR TITLE
Enable Mermaid Legacy Tool Reference Proposal

### DIFF
--- a/extensions/mermaid-markdown-features/package.json
+++ b/extensions/mermaid-markdown-features/package.json
@@ -14,7 +14,8 @@
     "vscode": "^1.104.0"
   },
   "enabledApiProposals": [
-    "chatOutputRenderer"
+    "chatOutputRenderer",
+    "chatParticipantPrivate"
   ],
   "capabilities": {
     "virtualWorkspaces": true,


### PR DESCRIPTION
Fixes #330188

The built-in Mermaid extension contributes `legacyToolReferenceFullNames` for the renamed `renderMermaidDiagram` tool. That manifest property is gated by `chatParticipantPrivate`, but the extension did not enable the proposal, so extension-point validation rejected the complete tool contribution on every startup.

This enables `chatParticipantPrivate` for the built-in extension so the tool and its compatibility alias register successfully.

### Verification

- Parsed `extensions/mermaid-markdown-features/package.json` as JSON.
- Confirmed the extension-point gate requires `chatParticipantPrivate` when `legacyToolReferenceFullNames` is present.