### PR TITLE
Fix modal editor tab model rebuilds

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -538,6 +538,9 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 	private _updateTabsModel(changeEvent: IEditorsChangeEvent): void {
 		const event = changeEvent.event;
 		const groupId = changeEvent.groupId;
+		if (this._editorGroupsService.activeModalEditorPart?.groups.some(group => group.id === groupId)) {
+			return;
+		}
 		switch (event.kind) {
 			case GroupModelChangeKind.GROUP_ACTIVE:
 				if (groupId === this._editorGroupsService.activeGroup.id) {

--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -274,6 +274,9 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 				kind: TabModelOperationKind.TAB_UPDATE
 			});
 		} else {
+			if (this._editorGroupsService.activeModalEditorPart?.groups.some(group => group.id === groupId)) {
+				return;
+			}
 			this._logService.error('Invalid model for label change, rebuilding');
 			this._createTabsModel();
 		}
@@ -538,9 +541,6 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 	private _updateTabsModel(changeEvent: IEditorsChangeEvent): void {
 		const event = changeEvent.event;
 		const groupId = changeEvent.groupId;
-		if (this._editorGroupsService.activeModalEditorPart?.groups.some(group => group.id === groupId)) {
-			return;
-		}
 		switch (event.kind) {
 			case GroupModelChangeKind.GROUP_ACTIVE:
 				if (groupId === this._editorGroupsService.activeGroup.id) {

--- a/src/vs/workbench/api/test/browser/mainThreadEditorTabs.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadEditorTabs.test.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../platform/configuration/test/common/testConfigurationService.js';
+import { NullLogService } from '../../../../platform/log/common/log.js';
+import { GroupModelChangeKind } from '../../../common/editor.js';
+import { IEditorGroup, IEditorGroupsService, IModalEditorPart } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorsChangeEvent, IEditorService } from '../../../services/editor/common/editorService.js';
+import { TestEditorInput } from '../../../test/browser/workbenchTestServices.js';
+import { MainThreadEditorTabs } from '../../browser/mainThreadEditorTabs.js';
+import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
+
+suite('MainThreadEditorTabs', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('ignores modal editor group changes', async () => {
+		const modalGroup = new class extends mock<IEditorGroup>() {
+			override readonly id = 2;
+		}();
+		const modalEditorPart = new class extends mock<IModalEditorPart>() {
+			override readonly groups = [modalGroup];
+		}();
+		let groupsReadCount = 0;
+		const editorGroupsService = new class extends mock<IEditorGroupsService>() {
+			override readonly activeModalEditorPart = modalEditorPart;
+			override readonly onDidAddGroup = Event.None;
+			override readonly onDidRemoveGroup = Event.None;
+			override readonly whenReady = Promise.resolve();
+			override get groups(): readonly IEditorGroup[] {
+				groupsReadCount++;
+				return [];
+			}
+		}();
+		const editorChanges = disposables.add(new Emitter<IEditorsChangeEvent>());
+		const editorService = new class extends mock<IEditorService>() {
+			override readonly onDidEditorsChange = editorChanges.event;
+		}();
+		const input = disposables.add(new TestEditorInput(URI.parse('test:modal'), 'testEditor'));
+		disposables.add(new MainThreadEditorTabs(
+			SingleProxyRPCProtocol({}),
+			editorGroupsService,
+			new TestConfigurationService(),
+			new NullLogService(),
+			editorService,
+		));
+		await Promise.resolve();
+		groupsReadCount = 0;
+
+		editorChanges.fire({
+			groupId: modalGroup.id,
+			event: {
+				kind: GroupModelChangeKind.EDITOR_LABEL,
+				editor: input,
+				editorIndex: 0,
+			},
+		});
+
+		assert.strictEqual(groupsReadCount, 0);
+	});
+});

--- a/src/vs/workbench/api/test/browser/mainThreadEditorTabs.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadEditorTabs.test.ts
@@ -21,7 +21,7 @@ suite('MainThreadEditorTabs', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('ignores modal editor group changes', async () => {
+	test('ignores only missing modal editor label changes', async () => {
 		const modalGroup = new class extends mock<IEditorGroup>() {
 			override readonly id = 2;
 		}();
@@ -34,6 +34,9 @@ suite('MainThreadEditorTabs', () => {
 			override readonly onDidAddGroup = Event.None;
 			override readonly onDidRemoveGroup = Event.None;
 			override readonly whenReady = Promise.resolve();
+			override getGroup(): IEditorGroup | undefined {
+				return undefined;
+			}
 			override get groups(): readonly IEditorGroup[] {
 				groupsReadCount++;
 				return [];
@@ -62,7 +65,22 @@ suite('MainThreadEditorTabs', () => {
 				editorIndex: 0,
 			},
 		});
+		const rebuildsAfterLabelChange = groupsReadCount;
+		editorChanges.fire({
+			groupId: modalGroup.id,
+			event: {
+				kind: GroupModelChangeKind.EDITOR_OPEN,
+				editor: input,
+				editorIndex: 0,
+			},
+		});
 
-		assert.strictEqual(groupsReadCount, 0);
+		assert.deepStrictEqual({
+			rebuildsAfterLabelChange,
+			rebuildsAfterOpen: groupsReadCount,
+		}, {
+			rebuildsAfterLabelChange: 0,
+			rebuildsAfterOpen: 1,
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- ignore modal editor group events in the extension-host tabs model
- prevent reactive modal multi-diff title changes from triggering full tab-model rebuilds
- add regression coverage for modal label changes

## Testing
- `scripts\test.bat --run src\vs\workbench\api\test\browser\mainThreadEditorTabs.test.ts`
- `npm run typecheck-client`
- ESLint on changed files