### PR TITLE
Prevent Agents titlebar control collisions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -128,7 +128,7 @@ The titlebar is a standalone implementation (`TitlebarPart`) — not extending `
 
 No menubar or `WindowTitle` dependency. Editor-specific actions remain in the editor header, while session-level actions are placed on the right of the title bar.
 
-The Update indicator occupies its own trailing toolbar immediately before native window controls. It keeps the shared Update tooltip behavior and hides when the titlebar cannot fit it without overflowing.
+The Update indicator occupies its own trailing toolbar immediately before native window controls. At constrained widths, the titlebar measures each of its three sections so content that overflows inside the center grid cannot collide with the right controls. Optional toolbars yield as complete groups: center-adjacent actions and navigation first, then global layout/account actions, active-session actions, and finally Update. The session picker, left toolbar, and native window controls remain stable.
 
 The account widget shows overlapping provider identities only for accounts that are currently verified as signed in. Its panel keeps provider and status groups in a stable order: Copilot, ChatGPT (or its sign-in action), then contributed account status such as Codebase Semantic Index, with dividers between groups. Subscription usage uses a two-row metric layout with the plan and percentage first, followed by reset timing and the usage label.
 

--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -108,7 +108,8 @@
 	margin-left: 4px;
 }
 
-.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right > .titlebar-update-container.overflowing {
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-actions-container.overflowing,
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right > .titlebar-actions-container.overflowing {
 	display: none;
 }
 

--- a/src/vs/sessions/browser/parts/titlebarPart.ts
+++ b/src/vs/sessions/browser/parts/titlebarPart.ts
@@ -83,7 +83,7 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 	private leftToolbarContainer!: HTMLElement;
 	private centerContent!: HTMLElement;
 	private rightContent!: HTMLElement;
-	private updateToolBarElement: HTMLElement | undefined;
+	private readonly overflowManagedToolBarElements: HTMLElement[] = [];
 
 	get leftContainer(): HTMLElement { return this.leftContent; }
 	get rightContainer(): HTMLElement { return this.rightContent; }
@@ -216,7 +216,7 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 
 		// Navigation toolbar (Back/Forward), rendered left of the command center.
 		const centerNavContainer = append(this.centerContent, $('div.titlebar-actions-container.titlebar-center-nav-container'));
-		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerNavContainer, Menus.TitleBarCenterLeft, {
+		const centerNavToolBar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerNavContainer, Menus.TitleBarCenterLeft, {
 			contextMenu: Menus.TitleBarContext,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'titlePart.centerLeft',
@@ -241,7 +241,7 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 
 		// Actions toolbar (Open in VS Code), rendered right of the command center.
 		const centerActionsContainer = append(this.centerContent, $('div.titlebar-actions-container.titlebar-center-actions-container'));
-		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerActionsContainer, Menus.TitleBarCenterRight, {
+		const centerActionsToolBar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerActionsContainer, Menus.TitleBarCenterRight, {
 			contextMenu: Menus.TitleBarContext,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'titlePart.centerRight',
@@ -250,7 +250,7 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 
 		// Right toolbar (driven by Menus.TitleBarRightLayout - includes layout actions)
 		const rightToolbarContainer = prepend(this.rightContent, $('div.titlebar-actions-container.titlebar-right-layout-container'));
-		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, rightToolbarContainer, Menus.TitleBarRightLayout, {
+		const rightToolBar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, rightToolbarContainer, Menus.TitleBarRightLayout, {
 			contextMenu: Menus.TitleBarContext,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'titlePart.right',
@@ -259,7 +259,7 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 
 		// Session title actions toolbar (before right toolbar)
 		const sessionActionsContainer = prepend(this.rightContent, $('div.titlebar-actions-container.titlebar-session-actions-container'));
-		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, sessionActionsContainer, Menus.TitleBarSessionMenu, {
+		const sessionActionsToolBar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, sessionActionsContainer, Menus.TitleBarSessionMenu, {
 			contextMenu: Menus.TitleBarContext,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'titlePart.sessionActions',
@@ -269,14 +269,18 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 		// Update toolbar (rightmost, immediately before native window controls)
 		const updateToolBarElement = $('div.titlebar-actions-container.titlebar-update-container');
 		this.rightContent.insertBefore(updateToolBarElement, rightWindowControlsContainer ?? null);
-		this.updateToolBarElement = updateToolBarElement;
 		const updateToolBar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, updateToolBarElement, Menus.TitleBarUpdate, {
 			contextMenu: Menus.TitleBarContext,
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'titlePart.update',
 			toolbarOptions: { primaryGroup: () => true },
 		}));
-		this._register(updateToolBar.onDidChangeMenuItems(() => this.updateUpdateToolBarOverflow()));
+
+		this.registerOverflowManagedToolBar(centerActionsContainer, centerActionsToolBar);
+		this.registerOverflowManagedToolBar(centerNavContainer, centerNavToolBar);
+		this.registerOverflowManagedToolBar(rightToolbarContainer, rightToolBar);
+		this.registerOverflowManagedToolBar(sessionActionsContainer, sessionActionsToolBar);
+		this.registerOverflowManagedToolBar(updateToolBarElement, updateToolBar);
 
 		// Context menu on the titlebar
 		this._register(addDisposableListener(this.rootContainer, EventType.CONTEXT_MENU, e => {
@@ -327,22 +331,37 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 	override layout(width: number, height: number): void {
 		this.updateLayout();
 		super.layoutContents(width, height);
-		this.updateUpdateToolBarOverflow();
+		this.updateTitleBarToolBarOverflow();
 	}
 
-	private updateUpdateToolBarOverflow(): void {
-		const element = this.updateToolBarElement;
-		if (!element) {
-			return;
-		}
+	private registerOverflowManagedToolBar(element: HTMLElement, toolBar: MenuWorkbenchToolBar): void {
+		this.overflowManagedToolBarElements.push(element);
+		this._register(toolBar.onDidChangeMenuItems(() => this.updateTitleBarToolBarOverflow()));
+	}
 
-		if (element.classList.contains('has-no-actions')) {
+	private updateTitleBarToolBarOverflow(): void {
+		for (const element of this.overflowManagedToolBarElements) {
 			element.classList.remove('overflowing');
+		}
+
+		if (this.rootContainer.clientWidth === 0) {
 			return;
 		}
 
-		element.classList.remove('overflowing');
-		element.classList.toggle('overflowing', this.rootContainer.scrollWidth > this.rootContainer.clientWidth);
+		for (const element of this.overflowManagedToolBarElements) {
+			if (!this.isTitleBarOverflowing()) {
+				return;
+			}
+
+			if (!element.classList.contains('has-no-actions')) {
+				element.classList.add('overflowing');
+			}
+		}
+	}
+
+	private isTitleBarOverflowing(): boolean {
+		return [this.rootContainer, this.leftContent, this.centerContent, this.rightContent]
+			.some(element => element.scrollWidth > element.clientWidth);
 	}
 
 	private updateLayout(): void {

--- a/src/vs/sessions/test/browser/titlebarPart.test.ts
+++ b/src/vs/sessions/test/browser/titlebarPart.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mainWindow } from '../../../base/browser/window.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { TitlebarPart } from '../../browser/parts/titlebarPart.js';
+
+suite('Sessions - Titlebar Part', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const updateTitleBarToolBarOverflow = Reflect.get(TitlebarPart.prototype, 'updateTitleBarToolBarOverflow') as (this: TitlebarPart) => void;
+
+	test('hides optional toolbar groups when a titlebar section overflows', () => {
+		let centerClientWidth = 60;
+		let rightClientWidth = 60;
+		const root = createMeasuredElement(() => 100, () => 100);
+		const left = createMeasuredElement(() => 20, () => 20);
+		const toolBars = [20, 20, 20, 20, 20].map(() => mainWindow.document.createElement('div'));
+		const center = createMeasuredElement(
+			() => centerClientWidth,
+			() => 40 + visibleWidth(toolBars[0], 20) + visibleWidth(toolBars[1], 20)
+		);
+		const right = createMeasuredElement(
+			() => rightClientWidth,
+			() => 40 + visibleWidth(toolBars[2], 20) + visibleWidth(toolBars[3], 20) + visibleWidth(toolBars[4], 20)
+		);
+		const titlebarPart = Object.create(TitlebarPart.prototype) as TitlebarPart;
+		Reflect.set(titlebarPart, 'rootContainer', root);
+		Reflect.set(titlebarPart, 'leftContent', left);
+		Reflect.set(titlebarPart, 'centerContent', center);
+		Reflect.set(titlebarPart, 'rightContent', right);
+		Reflect.set(titlebarPart, 'overflowManagedToolBarElements', toolBars);
+
+		updateTitleBarToolBarOverflow.call(titlebarPart);
+		const constrained = toolBars.map(element => element.classList.contains('overflowing'));
+
+		centerClientWidth = 100;
+		rightClientWidth = 100;
+		updateTitleBarToolBarOverflow.call(titlebarPart);
+		const expanded = toolBars.map(element => element.classList.contains('overflowing'));
+
+		assert.deepStrictEqual({ constrained, expanded }, {
+			constrained: [true, true, true, true, false],
+			expanded: [false, false, false, false, false],
+		});
+	});
+});
+
+function createMeasuredElement(clientWidth: () => number, scrollWidth: () => number): HTMLElement {
+	const element = mainWindow.document.createElement('div');
+	Object.defineProperties(element, {
+		clientWidth: { get: clientWidth },
+		scrollWidth: { get: scrollWidth },
+	});
+	return element;
+}
+
+function visibleWidth(element: HTMLElement, width: number): number {
+	return element.classList.contains('overflowing') || element.classList.contains('has-no-actions') ? 0 : width;
+}


### PR DESCRIPTION
## Summary

- measure overflow in each Agents titlebar section instead of relying only on root-container overflow
- progressively hide optional toolbar groups before they can collide with neighboring groups or native window controls
- restore hidden groups when width becomes available again
- document the titlebar overflow priority and add focused regression coverage

## Verification

- `scripts\test.bat --run src\vs\sessions\test\browser\titlebarPart.test.ts`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- targeted ESLint and Stylelint
- launched the Agents window at zoom level 2 and verified zero titlebar-control intersections at narrow widths, including the final Update-to-window-controls fallback

Fixes #330043