### PR TITLE
Fix update tooltip clipping in narrow windows

### DIFF
--- a/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
@@ -8,8 +8,8 @@
 	flex-direction: column;
 	gap: 12px;
 	padding: 6px 6px;
-	min-width: 300px;
-	max-width: 350px;
+	width: 300px;
+	max-width: calc(100% - var(--vscode-spacing-size120));
 	color: var(--vscode-descriptionForeground);
 	font-size: var(--vscode-bodyFontSize-small);
 }


### PR DESCRIPTION
## Summary

- allow the update tooltip to shrink with its hover container in narrow windows
- preserve the existing preferred tooltip width when sufficient space is available

## Testing

- `npm run stylelint -- src/vs/workbench/contrib/update/browser/media/updateTooltip.css`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `scripts/test.bat src/vs/platform/hover/test/browser/hoverService.test.ts` (33 passing, 2 pending, before the generated Electron runtime became externally locked)
- manually verified constrained and unconstrained tooltip widths in the Agents window

Fixes #330033