### PR TITLE
testing: add TestRunProfile priority

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -483,6 +483,9 @@ const _allApiProposals = {
 	testRelatedCode: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.testRelatedCode.d.ts',
 	},
+	testRunProfilePriority: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.testRunProfilePriority.d.ts',
+	},
 	textDocumentChangeReason: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.textDocumentChangeReason.d.ts',
 	},

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -12,7 +12,7 @@ import { createSingleCallFunction } from '../../../base/common/functional.js';
 import { hash } from '../../../base/common/hash.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
-import { isDefined } from '../../../base/common/types.js';
+import { isDefined, isNumber } from '../../../base/common/types.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { IPosition } from '../../../editor/common/core/position.js';
@@ -191,7 +191,7 @@ export class ExtHostTesting extends Disposable implements ExtHostTestingShape {
 					profileId++;
 				}
 
-				return new TestRunProfileImpl(this.proxy, profiles, activeProfiles, this.defaultProfilesChangedEmitter.event, controllerId, profileId, label, group, runHandler, isDefault, tag, supportsContinuousRun);
+				return new TestRunProfileImpl(extension, this.proxy, profiles, activeProfiles, this.defaultProfilesChangedEmitter.event, controllerId, profileId, label, group, runHandler, isDefault, tag, supportsContinuousRun);
 			},
 			createTestItem(id, label, uri) {
 				return new TestItemImpl(controllerId, id, label, uri);
@@ -1219,12 +1219,14 @@ const updateProfile = (impl: TestRunProfileImpl, proxy: MainThreadTestingShape, 
 };
 
 export class TestRunProfileImpl extends TestRunProfileBase implements vscode.TestRunProfile {
+	readonly #extension: IExtensionDescription;
 	readonly #proxy: MainThreadTestingShape;
 	readonly #activeProfiles: Set<number>;
 	readonly #onDidChangeDefaultProfiles: Event<DefaultProfileChangeEvent>;
 	#initialPublish?: ITestRunProfile;
 	#profiles?: Map<number, vscode.TestRunProfile>;
 	private _configureHandler?: (() => void);
+	private _priority = 0;
 
 	public get label() {
 		return this._label;
@@ -1234,6 +1236,20 @@ export class TestRunProfileImpl extends TestRunProfileBase implements vscode.Tes
 		if (label !== this._label) {
 			this._label = label;
 			updateProfile(this, this.#proxy, this.#initialPublish, { label });
+		}
+	}
+
+	public get priority() {
+		checkProposedApiEnabled(this.#extension, 'testRunProfilePriority');
+		return this._priority;
+	}
+
+	public set priority(priority: number) {
+		checkProposedApiEnabled(this.#extension, 'testRunProfilePriority');
+		priority = isNumber(priority) ? Math.max(-Number.MAX_VALUE, Math.min(Number.MAX_VALUE, priority)) : 0;
+		if (priority !== this._priority) {
+			this._priority = priority;
+			updateProfile(this, this.#proxy, this.#initialPublish, { priority });
 		}
 	}
 
@@ -1298,6 +1314,7 @@ export class TestRunProfileImpl extends TestRunProfileBase implements vscode.Tes
 	}
 
 	constructor(
+		extension: IExtensionDescription,
 		proxy: MainThreadTestingShape,
 		profiles: Map<number, vscode.TestRunProfile>,
 		activeProfiles: Set<number>,
@@ -1313,6 +1330,7 @@ export class TestRunProfileImpl extends TestRunProfileBase implements vscode.Tes
 	) {
 		super(controllerId, profileId, kind);
 
+		this.#extension = extension;
 		this.#proxy = proxy;
 		this.#profiles = profiles;
 		this.#activeProfiles = activeProfiles;
@@ -1331,6 +1349,7 @@ export class TestRunProfileImpl extends TestRunProfileBase implements vscode.Tes
 			label: _label,
 			group: groupBitset,
 			isDefault: _isDefault,
+			priority: this._priority,
 			hasConfigurationHandler: false,
 			supportsContinuousRun: _supportsContinuousRun,
 		};

--- a/src/vs/workbench/api/test/browser/extHostTesting.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTesting.test.ts
@@ -651,7 +651,7 @@ suite('ExtHost Testing', () => {
 			cts = new CancellationTokenSource();
 			c = new TestRunCoordinator(proxy, new NullLogService());
 
-			configuration = new TestRunProfileImpl(mockObject<MainThreadTestingShape>()(), new Map(), new Set(), Event.None, 'ctrlId', 42, 'Do Run', TestRunProfileKind.Run, () => { }, false);
+			configuration = new TestRunProfileImpl(ext, mockObject<MainThreadTestingShape>()(), new Map(), new Set(), Event.None, 'ctrlId', 42, 'Do Run', TestRunProfileKind.Run, () => { }, false);
 
 			await single.expand(single.root.id, Infinity);
 			single.collectDiff();
@@ -895,6 +895,29 @@ suite('ExtHost Testing', () => {
 
 			task1.end();
 		});
+	});
+
+	test('guards test run profile priority as proposed API', () => {
+		const profile = ds.add(new TestRunProfileImpl(nullExtensionDescription, mockObject<MainThreadTestingShape>()(), new Map(), new Set(), Event.None, 'ctrlId', 42, 'Run', TestRunProfileKind.Run, () => { }, true));
+		assert.throws(() => profile.priority, /testRunProfilePriority/);
+		assert.throws(() => profile.priority = 1, /testRunProfilePriority/);
+	});
+
+	test('publishes and updates test run profile priority', async () => {
+		const proxy = mockObject<MainThreadTestingShape>()();
+		const extension = { ...nullExtensionDescription, enabledApiProposals: ['testRunProfilePriority'] };
+		const profile = ds.add(new TestRunProfileImpl(extension, proxy, new Map(), new Set(), Event.None, 'ctrlId', 42, 'Run', TestRunProfileKind.Run, () => { }, true));
+
+		assert.strictEqual(profile.priority, 0);
+		profile.priority = 2;
+		await timeout(0);
+		assert.strictEqual(proxy.$publishTestRunProfile.args[0][0].priority, 2);
+
+		profile.priority = Number.POSITIVE_INFINITY;
+		assert.strictEqual(profile.priority, Number.MAX_VALUE);
+
+		profile.priority = 3;
+		assert.deepStrictEqual(proxy.$updateTestRunConfig.args.at(-1), ['ctrlId', 42, { priority: 3 }]);
 	});
 
 	suite('service', () => {

--- a/src/vs/workbench/contrib/testing/common/testProfileService.ts
+++ b/src/vs/workbench/contrib/testing/common/testProfileService.ts
@@ -97,6 +97,14 @@ const sorter = (a: ITestRunProfile, b: ITestRunProfile) => {
 	return a.label.localeCompare(b.label);
 };
 
+const preferredProfileSorter = (a: ITestRunProfile, b: ITestRunProfile) => {
+	if (a.isDefault !== b.isDefault) {
+		return a.isDefault ? -1 : 1;
+	}
+
+	return (b.priority ?? 0) - (a.priority ?? 0) || a.label.localeCompare(b.label);
+};
+
 interface IExtendedTestRunProfile extends ITestRunProfile {
 	wasInitiallyDefault: boolean;
 }
@@ -308,7 +316,14 @@ export class TestProfileService extends Disposable implements ITestProfileServic
 	}
 
 	getDefaultProfileForTest(group: TestRunProfileBitset, test: InternalTestItem): ITestRunProfile | undefined {
-		return this.getControllerProfiles(test.controllerId).find(p => (p.group & group) !== 0 && canUseProfileWithTest(p, test));
+		let preferred: ITestRunProfile | undefined;
+		for (const profile of this.getControllerProfiles(test.controllerId)) {
+			if ((profile.group & group) !== 0 && canUseProfileWithTest(profile, test) && (!preferred || preferredProfileSorter(profile, preferred) < 0)) {
+				preferred = profile;
+			}
+		}
+
+		return preferred;
 	}
 
 	private refreshContextKeys() {

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -80,6 +80,7 @@ export interface ITestRunProfile {
 	label: string;
 	group: TestRunProfileBitset;
 	isDefault: boolean;
+	priority?: number;
 	tag: string | null;
 	hasConfigurationHandler: boolean;
 	supportsContinuousRun: boolean;

--- a/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
@@ -7,13 +7,14 @@
 
 import assert from 'assert';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { upcastDeepPartial, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { TestProfileService } from '../../common/testProfileService.js';
-import { ITestRunProfile, TestRunProfileBitset } from '../../common/testTypes.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
-import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { TestId } from '../../common/testId.js';
+import { TestProfileService } from '../../common/testProfileService.js';
 import { IMainThreadTestController } from '../../common/testService.js';
+import { InternalTestItem, ITestRunProfile, TestRunProfileBitset } from '../../common/testTypes.js';
 
 suite('Workbench - TestProfileService', () => {
 	let t: TestProfileService;
@@ -52,6 +53,18 @@ suite('Workbench - TestProfileService', () => {
 		return p;
 	};
 
+	const makeTest = (...tags: string[]) => upcastDeepPartial<InternalTestItem>({
+		controllerId: 'ctrlId',
+		item: {
+			extId: new TestId(['ctrlId', 'test']).toString(),
+			tags,
+		},
+	});
+	const assertDefaultProfile = (expected: ITestRunProfile, ...tags: string[]) => assert.strictEqual(
+		t.getDefaultProfileForTest(TestRunProfileBitset.Run, makeTest(...tags))?.profileId,
+		expected.profileId,
+	);
+
 	const assertGroupDefaults = (group: TestRunProfileBitset, expected: ITestRunProfile[]) => {
 		assert.deepStrictEqual(t.getGroupDefaultProfiles(group).map(p => p.label), expected.map(e => e.label));
 	};
@@ -70,6 +83,36 @@ suite('Workbench - TestProfileService', () => {
 		addProfile({ isDefault: false, group: TestRunProfileBitset.Run, label: 'e', controllerId: '2' });
 		expectProfiles(t.getGroupDefaultProfiles(TestRunProfileBitset.Run), ['c', 'd']);
 		expectProfiles(t.getGroupDefaultProfiles(TestRunProfileBitset.Debug), ['a']);
+	});
+
+	suite('getDefaultProfileForTest', () => {
+		test('uses priority only for automatic profile selection', () => {
+			const root = addProfile({ label: 'a: root', priority: 0, tag: 'root' });
+			const unrelated = addProfile({ label: 'm: unrelated', priority: 100, tag: 'unrelated' });
+			const nested = addProfile({ label: 'z: nested', priority: 1, tag: 'nested' });
+
+			assertDefaultProfile(nested, 'root', 'nested');
+			assert.deepStrictEqual(t.getControllerProfiles('ctrlId').map(p => p.label), ['a: root', 'm: unrelated', 'z: nested']);
+			expectProfiles([root, unrelated, nested], t.getGroupDefaultProfiles(TestRunProfileBitset.Run, 'ctrlId').map(p => p.label));
+
+			t.updateProfile('ctrlId', nested.profileId, { priority: -1 });
+			assertDefaultProfile(root, 'root', 'nested');
+		});
+
+		test('user-selected default takes precedence over priority', () => {
+			addProfile({ label: 'a: high priority', priority: 100 });
+			const selected = addProfile({ label: 'z: selected', priority: 0 });
+			t.setGroupDefaultProfiles(TestRunProfileBitset.Run, [selected]);
+
+			assertDefaultProfile(selected);
+		});
+
+		test('treats missing and zero priority equally', () => {
+			addProfile({ label: 'z', priority: 0 });
+			const alphabeticallyFirst = addProfile({ label: 'a' });
+
+			assertDefaultProfile(alphabeticallyFirst);
+		});
 	});
 
 	suite('setGroupDefaultProfiles', () => {

--- a/src/vscode-dts/vscode.proposed.testRunProfilePriority.d.ts
+++ b/src/vscode-dts/vscode.proposed.testRunProfilePriority.d.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/330204
+
+	export interface TestRunProfile {
+		/**
+		 * Relative priority used when the editor automatically chooses between
+		 * compatible profiles from the same controller and kind. Higher values
+		 * are preferred. Defaults to `0`.
+		 *
+		 * Profiles currently selected as defaults take precedence over non-default
+		 * profiles regardless of this value.
+		 */
+		priority: number;
+	}
+}


### PR DESCRIPTION
Refs #330204

Adds a proposed `TestRunProfile.priority` API for automatic selection between compatible profiles.

Automatic selection continues to prefer default profiles, then uses the higher priority, with label ordering as the tie-breaker. Compatibility filtering still happens first. This does not change picker order, explicit profile selection, or Run All. Profiles default to priority `0`.

### Testing

- `npm run vscode-dts-compile-check`
- `npm run typecheck-client`
- `npm run hygiene`
- `./scripts/test.sh --run src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts`
- `./scripts/test.sh --run src/vs/workbench/api/test/browser/extHostTesting.test.ts`
