### PR TITLE
Avoid unhandled rejections in cancellable promise races

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -148,9 +148,8 @@ export function raceCancellablePromises<T>(cancellablePromises: (CancelablePromi
 			}
 		});
 	};
-	promise.finally(() => {
-		promise.cancel();
-	});
+	const cancel = () => promise.cancel();
+	promise.then(cancel, cancel);
 	return promise;
 }
 

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -14,6 +14,7 @@ import { runWithFakedTimers } from './timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 import { DisposableStore } from '../../common/lifecycle.js';
 import { Iterable } from '../../common/iterator.js';
+import { isWeb } from '../../common/platform.js';
 
 suite('Async', () => {
 
@@ -169,7 +170,12 @@ suite('Async', () => {
 			let pendingPromiseCancellations = 0;
 			const unhandledRejections: unknown[] = [];
 			const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
-			process.on('unhandledRejection', onUnhandledRejection);
+			const onBrowserUnhandledRejection = (event: PromiseRejectionEvent) => onUnhandledRejection(event.reason);
+			if (isWeb) {
+				globalThis.addEventListener('unhandledrejection', onBrowserUnhandledRejection);
+			} else {
+				process.on('unhandledRejection', onUnhandledRejection);
+			}
 			const rejectingPromise = Object.assign(Promise.reject(expectedError), { cancel: () => rejectingPromiseCancellations++ });
 			const pendingPromise = Object.assign(new Promise<void>(() => { }), { cancel: () => pendingPromiseCancellations++ });
 
@@ -193,7 +199,11 @@ suite('Async', () => {
 					unhandledRejections: []
 				});
 			} finally {
-				process.off('unhandledRejection', onUnhandledRejection);
+				if (isWeb) {
+					globalThis.removeEventListener('unhandledrejection', onBrowserUnhandledRejection);
+				} else {
+					process.off('unhandledRejection', onUnhandledRejection);
+				}
 			}
 		});
 

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -141,6 +141,88 @@ suite('Async', () => {
 		});
 	});
 
+	suite('raceCancellablePromises', function () {
+		test('preserves the result and cancels only the losing promises', async function () {
+			let resolveWinner!: (value: number) => void;
+			let winnerCancellations = 0;
+			let loserCancellations = 0;
+			const winner = Object.assign(new Promise<number>(resolve => resolveWinner = resolve), { cancel: () => winnerCancellations++ });
+			const loser = Object.assign(new Promise<number>(() => { }), { cancel: () => loserCancellations++ });
+			const race = async.raceCancellablePromises([winner, loser]);
+
+			resolveWinner(42);
+
+			assert.deepStrictEqual({
+				result: await race,
+				winnerCancellations,
+				loserCancellations
+			}, {
+				result: 42,
+				winnerCancellations: 0,
+				loserCancellations: 1
+			});
+		});
+
+		test('preserves the error, cancels all promises, and handles cleanup rejection', async function () {
+			const expectedError = new Error('expected');
+			let rejectingPromiseCancellations = 0;
+			let pendingPromiseCancellations = 0;
+			const unhandledRejections: unknown[] = [];
+			const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+			process.on('unhandledRejection', onUnhandledRejection);
+			const rejectingPromise = Object.assign(Promise.reject(expectedError), { cancel: () => rejectingPromiseCancellations++ });
+			const pendingPromise = Object.assign(new Promise<void>(() => { }), { cancel: () => pendingPromiseCancellations++ });
+
+			try {
+				let actualError: unknown;
+				try {
+					await async.raceCancellablePromises([rejectingPromise, pendingPromise]);
+				} catch (error) {
+					actualError = error;
+				}
+				await async.timeout(0);
+				assert.deepStrictEqual({
+					preservesError: actualError === expectedError,
+					rejectingPromiseCancellations,
+					pendingPromiseCancellations,
+					unhandledRejections
+				}, {
+					preservesError: true,
+					rejectingPromiseCancellations: 1,
+					pendingPromiseCancellations: 1,
+					unhandledRejections: []
+				});
+			} finally {
+				process.off('unhandledRejection', onUnhandledRejection);
+			}
+		});
+
+		test('explicit cancellation cancels all pending promises', async function () {
+			const cancellationCounts = [0, 0];
+			const promises = cancellationCounts.map((_, index) => async.createCancelablePromise(token => {
+				store.add(token.onCancellationRequested(() => cancellationCounts[index]++));
+				return new Promise<void>(() => { });
+			}));
+			const race = async.raceCancellablePromises(promises);
+
+			race.cancel();
+			let cancellationError: unknown;
+			try {
+				await race;
+			} catch (error) {
+				cancellationError = error;
+			}
+
+			assert.deepStrictEqual({
+				isCancellationError: isCancellationError(cancellationError),
+				cancellationCounts
+			}, {
+				isCancellationError: true,
+				cancellationCounts: [1, 1]
+			});
+		});
+	});
+
 	suite('Throttler', function () {
 		test('non async', function () {
 			let count = 0;


### PR DESCRIPTION
## Issue

A recent Code Insiders session logged four identical uncaught shared-process exceptions after a deferred integrated-browser action was resumed several times and its page was subsequently closed:

```text
[uncaught exception in sharedProcess]: page.evaluate: Target page, context or browser has been closed
    at PlaywrightTab.runAndWaitForCompletion
    at PlaywrightTab.safeRunAgainstPage
    at PlaywrightSession._runAgainstPage
    at PlaywrightSession._runWithDeferral
```

The page-action rejection itself was handled by the Playwright deferral path. However, `raceCancellablePromises` registered its cleanup through `promise.finally(...)` and discarded the promise returned by `finally`. When the original race rejected, that discarded promise rejected as well, producing the process-level unhandled rejection shown above. Repeated attempts to resume the same deferred action produced repeated copies of the exception.

## Fix

- observe both settlement paths while running the existing cancellation cleanup
- preserve the original race promise, result/error identity, and cancellation timing
- add regression coverage for fulfillment, rejection, loser cleanup, and explicit cancellation

All seven production callers were reviewed. The only behavior change is removal of the secondary unhandled rejection; existing fulfillment, rejection, and cancellation semantics remain unchanged.

## Validation

- `npm run transpile-client`
- Async, CommandService, and AgentHostTerminalManager unit suites: 173 passing, 2 pending
- targeted ESLint for the changed files
- `git diff --check`