### PR TITLE
Handle unpushed commits in Agent Host PR lookup

### DIFF
--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -145,11 +145,27 @@ const MAX_ERROR_RESPONSE_BODY_LENGTH = 500;
 /** Page size, and therefore upper bound, for the pull requests read per commit. */
 const MAX_COMMIT_PULL_REQUESTS = 100;
 
+const COMMIT_PULL_REQUESTS_ROUTE = /^repos\/[^/]+\/[^/]+\/commits\/[^/]+\/pulls\?per_page=\d+$/;
+
 const ENABLE_AUTO_MERGE_MUTATION = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
 	enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
 		pullRequest { id }
 	}
 }`;
+
+function isMissingCommitPullRequestsResponse(routeSlug: string, method: 'GET' | 'POST', statusCode: number, responseText: string | undefined): boolean {
+	if (method !== 'GET' || statusCode !== 422 || !COMMIT_PULL_REQUESTS_ROUTE.test(routeSlug) || responseText === undefined) {
+		return false;
+	}
+
+	try {
+		const body: { readonly message?: unknown } | null = JSON.parse(responseText);
+		const message = body?.message;
+		return typeof message === 'string' && message.startsWith('No commit found for SHA: ');
+	} catch {
+		return false;
+	}
+}
 
 export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 
@@ -332,6 +348,9 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 
 		if (!response.ok) {
 			const errorText = await response.text().catch(() => undefined);
+			if (isMissingCommitPullRequestsResponse(routeSlug, method, statusCode, errorText)) {
+				return { data: undefined, statusCode, etag: undefined };
+			}
 			const errorDetail = this._formatErrorResponseBody(errorText);
 			this._logService.error(`[AgentHostOctoKit] ${method} ${url} - Status: ${response.status}${errorDetail ? ` - ${errorDetail}` : ''}`);
 			throw new Error(`GitHub API request failed: ${method} ${routeSlug} - ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -13,6 +13,14 @@ import type { IAgentHostGitHubEndpointService } from '../../../node/agentHostGit
 
 type Captured = { url: string; init: RequestInit | undefined };
 
+class RecordingLogService extends NullLogService {
+	readonly errors: string[] = [];
+
+	override error(message: string | Error, ...args: unknown[]): void {
+		this.errors.push([message, ...args].map(value => value instanceof Error ? value.message : String(value)).join(' '));
+	}
+}
+
 function getUrl(input: string | URL | Request): string {
 	if (typeof input === 'string') {
 		return input;
@@ -20,8 +28,8 @@ function getUrl(input: string | URL | Request): string {
 	return input instanceof URL ? input.href : input.url;
 }
 
-function makeService(fetchImpl: FetchFunction, enterpriseUri?: string): AgentHostOctoKitService {
-	return new AgentHostOctoKitService(fetchImpl, new NullLogService(), createTestGitHubEndpointService(enterpriseUri));
+function makeService(fetchImpl: FetchFunction, enterpriseUri?: string, logService = new NullLogService()): AgentHostOctoKitService {
+	return new AgentHostOctoKitService(fetchImpl, logService, createTestGitHubEndpointService(enterpriseUri));
 }
 
 function signal(): AbortSignal {
@@ -137,6 +145,53 @@ suite('AgentHostOctoKitService', () => {
 			url: 'https://api.github.com/repos/o/r/commits/bbb/pulls?per_page=100',
 			method: 'GET',
 		});
+	});
+
+	test('findPullRequestByHeadSha treats an unpushed commit as no pull request', async () => {
+		const logService = new RecordingLogService();
+		const service = makeService(
+			capturingFetch(jsonResponse({ message: 'No commit found for SHA: bbb' }, 422)).fetch,
+			undefined,
+			logService,
+		);
+
+		const result = await service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal());
+
+		assert.deepStrictEqual({ result, errors: logService.errors }, { result: undefined, errors: [] });
+	});
+
+	test('findPullRequestByHeadSha throws and logs other unprocessable responses', async () => {
+		const logService = new RecordingLogService();
+		const service = makeService(
+			capturingFetch(new Response('{"message":"Validation Failed"}', { status: 422, statusText: 'Unprocessable Entity' })).fetch,
+			undefined,
+			logService,
+		);
+
+		await assert.rejects(
+			() => service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal()),
+			/GitHub API request failed: GET repos\/o\/r\/commits\/bbb\/pulls\?per_page=100 - 422 Unprocessable Entity - {"message":"Validation Failed"}/,
+		);
+		assert.deepStrictEqual(logService.errors, [
+			'[AgentHostOctoKit] GET https://api.github.com/repos/o/r/commits/bbb/pulls?per_page=100 - Status: 422 - {"message":"Validation Failed"}',
+		]);
+	});
+
+	test('findPullRequestByHeadSha throws and logs server errors', async () => {
+		const logService = new RecordingLogService();
+		const service = makeService(
+			capturingFetch(new Response('{"message":"Server Error"}', { status: 500, statusText: 'Server Error' })).fetch,
+			undefined,
+			logService,
+		);
+
+		await assert.rejects(
+			() => service.findPullRequestByHeadSha('o', 'r', 'bbb', 'tok', signal()),
+			/GitHub API request failed: GET repos\/o\/r\/commits\/bbb\/pulls\?per_page=100 - 500 Server Error - {"message":"Server Error"}/,
+		);
+		assert.deepStrictEqual(logService.errors, [
+			'[AgentHostOctoKit] GET https://api.github.com/repos/o/r/commits/bbb/pulls?per_page=100 - Status: 500 - {"message":"Server Error"}',
+		]);
 	});
 
 	test('findPullRequestByHeadSha ignores pull requests that only contain the commit', async () => {


### PR DESCRIPTION
Fixes #330072

Seeded by a VS Code Sweeper review: https://github.com/egamma/vscodesweeper-state/blob/state/records/microsoft/vscode/items/330072.md

Treat GitHub's expected 422 `No commit found for SHA` response as an empty pull-request result only for the commit-pulls GET route. Other 422 responses and server failures continue to log and throw, with regression coverage for each boundary.

Validation:
- `.\scripts\test.bat --run src\vs\platform\agentHost\test\node\shared\agentHostOctoKitService.test.ts`
- `npm run typecheck-client`
- `npm run eslint -- src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts`