### PR TITLE
Add editor.border color variable and update related styles for modern UI

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -170,6 +170,7 @@
 		"--vscode-dropdown-foreground",
 		"--vscode-dropdown-listBackground",
 		"--vscode-editor-background",
+		"--vscode-editor-border",
 		"--vscode-editor-compositionBorder",
 		"--vscode-editor-findMatchBackground",
 		"--vscode-editor-findMatchBorder",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -682,6 +682,8 @@ export const SURFACE_BORDER = registerColor('surface.border', {
 	hcLight: contrastBorder
 }, localize('surfaceBorder', "Border color of framed container surfaces (\"cards\"), such as the floating workbench panels in the modern layout."));
 
+export const EDITOR_BORDER = registerColor('editor.border', SURFACE_BORDER, localize('editorBorder', "Border color of the editor surface in the modern layout."));
+
 // < --- Title Bar --- >
 
 export const TITLE_BAR_ACTIVE_FOREGROUND = registerColor('titleBar.activeForeground', {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
@@ -40,9 +40,9 @@
 	box-shadow: none;
 }
 
-/* Keep the editor frame aligned with the shared floating-surface border token. */
+/* Keep the editor frame aligned with the shared floating-surface border by default. */
 .monaco-workbench.style-override.floating-panels .part.editor {
-	border-color: var(--vscode-surface-border, var(--vscode-widget-border, transparent)) !important;
+	border-color: var(--vscode-editor-border, var(--vscode-surface-border, var(--vscode-widget-border, transparent))) !important;
 }
 
 .monaco-workbench.style-override .chat-view-position-left > .voice-agent-controls-wrapper {

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -11,6 +11,9 @@ import { DisposableStore, toDisposable } from '../../../../../base/common/lifecy
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { Extensions as ThemingExtensions, IColorRegistry } from '../../../../../platform/theme/common/colorRegistry.js';
+import { EDITOR_BORDER, SURFACE_BORDER } from '../../../../common/theme.js';
 import { TestLayoutService } from '../../../../test/browser/workbenchTestServices.js';
 import { LayoutSettings } from '../../../../services/layout/browser/layoutService.js';
 import '../../../../browser/parts/activitybar/media/activityaction.css';
@@ -78,6 +81,7 @@ function createCompositeAction(root: HTMLElement, titleHeight: number, checked: 
 suite('StyleOverridesContribution', () => {
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const colorRegistry = Registry.as<IColorRegistry>(ThemingExtensions.ColorContribution);
 
 	test('applies startup values without relayout and relayouts once when toggled', async () => {
 		const configurationService = new TestConfigurationService({ [LayoutSettings.MODERN_UI]: true });
@@ -237,6 +241,27 @@ suite('StyleOverridesContribution', () => {
 			headerBorderWidth: '0px',
 			headerOverflow: 'visible',
 			footerBorderWidth: '0px',
+		});
+	});
+
+	test('uses the editor surface border color', () => {
+		const root = document.createElement('div');
+		root.className = 'monaco-workbench style-override floating-panels';
+		root.style.setProperty('--vscode-editor-border', '#123456');
+		root.style.setProperty('--vscode-surface-border', '#654321');
+		document.body.appendChild(root);
+		store.add(toDisposable(() => root.remove()));
+
+		const grid = appendElement(root, 'monaco-grid-view');
+		const editor = appendElement(grid, 'part editor');
+		const contribution = colorRegistry.getColors().find(color => color.id === EDITOR_BORDER);
+
+		assert.deepStrictEqual({
+			registeredDefault: contribution?.defaults,
+			borderColor: getWindow(editor).getComputedStyle(editor).borderColor,
+		}, {
+			registeredDefault: SURFACE_BORDER,
+			borderColor: 'rgb(18, 52, 86)',
 		});
 	});
 });


### PR DESCRIPTION
Introduce a new color variable for the editor border to enhance the modern UI styling. Update related styles to utilize this new variable, ensuring consistency across the editor's appearance. Include tests to verify the correct application of the editor border color.

