### PR TITLE
Add cache-aware history manager for customendpoint providers

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/cacheAwareHistoryManager.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/cacheAwareHistoryManager.ts
@@ -1,0 +1,309 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { LanguageModelChatMessageRole, LanguageModelTextPart } from '../../../vscodeTypes';
+
+/**
+ * The union of message types that can flow through the language model API.
+ * `LanguageModelChatMessage2` carries a broader set of content parts (e.g.
+ * thinking parts), so we accept both.
+ */
+export type CacheAwareChatMessage = vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2;
+
+/**
+ * Cache-aware conversation history manager.
+ *
+ * The goal is to maximise KV-cache hits on self-hosted OpenAI-compatible
+ * endpoints (DeepSeek / DS4 / vLLM / llama.cpp with disk KV). Those servers
+ * cache the key/value tensors of the prompt prefix, so a request that shares a
+ * long common prefix with the previous request can reuse most of the cached
+ * work instead of recomputing it.
+ *
+ * Strategy:
+ *  1. First request of a conversation -> send only the system prompt + the
+ *     latest user message (a small prefill).
+ *  2. Subsequent requests -> keep sending a growing history that shares the
+ *     longest possible common prefix with the previous request, so the server
+ *     can hit as many cached tokens as possible.
+ *  3. When the projected token count approaches `maxInputTokens`, drop the
+ *     oldest non-system turns (or summarise them) so the new request still
+ *     shares a long, stable prefix.
+ *  4. Never re-send a completely divergent history if a long common prefix is
+ *     still available.
+ */
+
+export interface CacheAwareHistoryConfig {
+	/** Enable the cache-aware history manager. */
+	readonly enabled: boolean;
+	/** How aggressively to truncate when over budget. */
+	readonly truncationPolicy: 'conservative' | 'aggressive';
+	/** Whether to insert a short summary of dropped turns. */
+	readonly summarizeDroppedTurns: boolean;
+	/** Fraction of `maxInputTokens` we aim to stay under (0 < value <= 1). */
+	readonly targetUtilization: number;
+	/** Minimum number of recent turns to always keep (excluding system). */
+	readonly minRecentTurns: number;
+}
+
+export const DefaultCacheAwareHistoryConfig: CacheAwareHistoryConfig = {
+	enabled: true,
+	truncationPolicy: 'conservative',
+	summarizeDroppedTurns: false,
+	targetUtilization: 0.9,
+	minRecentTurns: 2,
+};
+
+/**
+ * Per-conversation state. Keyed by a stable conversation id derived from the
+ * system prompt + first user message, so it survives across requests within a
+ * single VS Code session.
+ */
+export interface ConversationState {
+	/** The exact messages we last sent to the server. */
+	readonly lastSentMessages: readonly CacheAwareChatMessage[];
+	/** Approximate token count of `lastSentMessages`. */
+	readonly lastTokenCount: number;
+	/** Optional running summary of turns that were dropped. */
+	readonly summary?: string;
+}
+
+/**
+ * A token counter. `(messages) => number` returning an approximate count.
+ */
+export type TokenCounter = (messages: readonly CacheAwareChatMessage[]) => number;
+
+/**
+ * Result of preparing messages for a request.
+ */
+export interface PreparedMessages {
+	/** The messages to send to the server. */
+	readonly messagesToSend: readonly CacheAwareChatMessage[];
+	/** The updated conversation state to persist. */
+	readonly newState: ConversationState;
+	/** Whether the history was truncated to fit the budget. */
+	readonly truncated: boolean;
+	/** Approximate token count of `messagesToSend`. */
+	readonly tokenCount: number;
+}
+
+/**
+ * Derives a stable conversation id from the system prompt + first user message.
+ * This is the identity that lets us correlate successive requests of the same
+ * conversation even though `ProvideLanguageModelChatResponseOptions` does not
+ * expose a session id.
+ */
+export function deriveConversationId(messages: readonly CacheAwareChatMessage[]): string {
+	const systemText = messages
+		.filter(m => m.role === LanguageModelChatMessageRole.System)
+		.map(m => textOf(m))
+		.join('\n');
+	const firstUser = messages.find(m => m.role === LanguageModelChatMessageRole.User);
+	const firstUserText = firstUser ? textOf(firstUser) : '';
+	return hashString(`${systemText}\u0000${firstUserText}`);
+}
+
+/**
+ * Computes the length of the longest common prefix (in messages) between two
+ * message lists. Messages are compared structurally (role + text content).
+ */
+export function longestCommonPrefixLength(
+	a: readonly CacheAwareChatMessage[],
+	b: readonly CacheAwareChatMessage[],
+): number {
+	const n = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < n && messagesEqual(a[i], b[i])) {
+		i++;
+	}
+	return i;
+}
+
+/**
+ * Approximate token counter based on character count. Good enough for the
+ * cache-aware truncation decisions; exact counting can be swapped in later.
+ */
+export function approximateTokenCount(messages: readonly CacheAwareChatMessage[]): number {
+	let chars = 0;
+	for (const message of messages) {
+		chars += textOf(message).length;
+	}
+	// ~4 characters per token is a common heuristic for English text.
+	return Math.ceil(chars / 4);
+}
+
+/**
+ * The core cache-aware message preparation routine.
+ *
+ * @param fullHistory The complete conversation history as provided by VS Code.
+ * @param state The previous conversation state, if any.
+ * @param maxInputTokens The maximum number of input tokens the model accepts.
+ * @param tokenCounter Approximate token counter.
+ * @param config Cache-aware policy configuration.
+ */
+export function prepareMessagesForRequest(
+	fullHistory: readonly CacheAwareChatMessage[],
+	state: ConversationState | undefined,
+	maxInputTokens: number,
+	tokenCounter: TokenCounter = approximateTokenCount,
+	config: CacheAwareHistoryConfig = DefaultCacheAwareHistoryConfig,
+): PreparedMessages {
+	if (!config.enabled) {
+		const tokenCount = tokenCounter(fullHistory);
+		return {
+			messagesToSend: fullHistory,
+			newState: { lastSentMessages: fullHistory, lastTokenCount: tokenCount },
+			truncated: false,
+			tokenCount,
+		};
+	}
+
+	const budget = Math.floor(maxInputTokens * config.targetUtilization);
+
+	// 1. First request of a conversation -> small prefill: system + latest user.
+	if (!state) {
+		const prefill = buildPrefill(fullHistory);
+		const tokenCount = tokenCounter(prefill);
+		return {
+			messagesToSend: prefill,
+			newState: { lastSentMessages: prefill, lastTokenCount: tokenCount },
+			truncated: false,
+			tokenCount,
+		};
+	}
+
+	// 2. If the full history fits within the budget, send it. Because the
+	//    history grows by appending new turns, this naturally shares a long
+	//    common prefix with the previous request, which the server's KV cache
+	//    can hit.
+	const candidate = fullHistory;
+	const candidateTokens = tokenCounter(candidate);
+
+	if (candidateTokens <= budget) {
+		return {
+			messagesToSend: candidate,
+			newState: { lastSentMessages: candidate, lastTokenCount: candidateTokens },
+			truncated: false,
+			tokenCount: candidateTokens,
+		};
+	}
+
+	// 3. Over budget: drop the oldest non-system turns until it fits, keeping
+	//    the system prompt + as many recent turns as possible. Prefer keeping a
+	//    prefix that overlaps with what we last sent so the cache still hits.
+	const { messagesToSend, dropped } = truncateToBudget(fullHistory, budget, tokenCounter, config);
+	const tokenCount = tokenCounter(messagesToSend);
+
+	let summary: string | undefined;
+	if (config.summarizeDroppedTurns && dropped.length > 0) {
+		summary = summarizeDropped(dropped, state.summary);
+	}
+
+	return {
+		messagesToSend,
+		newState: { lastSentMessages: messagesToSend, lastTokenCount: tokenCount, summary },
+		truncated: dropped.length > 0,
+		tokenCount,
+	};
+}
+
+/**
+ * Builds the initial small prefill: system prompt(s) + the latest user message.
+ * This keeps the first request tiny so the server's KV cache starts from a
+ * minimal prefix; subsequent requests then grow the history from here.
+ */
+function buildPrefill(
+	fullHistory: readonly CacheAwareChatMessage[],
+): readonly CacheAwareChatMessage[] {
+	const system = fullHistory.filter(m => m.role === LanguageModelChatMessageRole.System);
+	// Find the latest user message (the actual prompt for this request).
+	const latestUser = [...fullHistory].reverse().find(m => m.role === LanguageModelChatMessageRole.User);
+	return latestUser ? [...system, latestUser] : system;
+}
+
+/**
+ * Drops the oldest non-system turns until the message list fits within the
+ * budget. Always keeps the system prompt(s) and the most recent turns.
+ */
+function truncateToBudget(
+	fullHistory: readonly CacheAwareChatMessage[],
+	budget: number,
+	tokenCounter: TokenCounter,
+	config: CacheAwareHistoryConfig,
+): { messagesToSend: readonly CacheAwareChatMessage[]; dropped: readonly CacheAwareChatMessage[] } {
+	const system = fullHistory.filter(m => m.role === LanguageModelChatMessageRole.System);
+	const nonSystem = fullHistory.filter(m => m.role !== LanguageModelChatMessageRole.System);
+
+	// Always keep at least `minRecentTurns` recent turns.
+	const keepCount = Math.max(config.minRecentTurns, 1);
+	const kept = nonSystem.slice(-keepCount);
+	const droppable = nonSystem.slice(0, -keepCount);
+
+	const dropped: CacheAwareChatMessage[] = [];
+	// Start from the full history and drop from the oldest end of the
+	// droppable region until the candidate fits within the budget.
+	let candidate = fullHistory;
+	for (let i = 0; i < droppable.length; i++) {
+		if (tokenCounter(candidate) <= budget) {
+			break;
+		}
+		dropped.push(droppable[i]);
+		candidate = [...system, ...droppable.slice(i + 1), ...kept];
+	}
+
+	// If we still don't fit (e.g. a single turn is huge), fall back to the
+	// most recent turns only, dropping from the front of `kept` as needed.
+	if (tokenCounter(candidate) > budget) {
+		const trimmed = [...kept];
+		while (trimmed.length > 1 && tokenCounter([...system, ...trimmed]) > budget) {
+			dropped.push(trimmed.shift()!);
+		}
+		candidate = [...system, ...trimmed];
+	}
+
+	return { messagesToSend: candidate, dropped };
+}
+
+/**
+ * Produces a short summary of dropped turns. Currently a simple placeholder
+ * that lists how many turns were dropped; a real implementation could call a
+ * cheap model to summarise the dropped content.
+ */
+function summarizeDropped(dropped: readonly CacheAwareChatMessage[], previousSummary: string | undefined): string {
+	const count = dropped.length;
+	const base = `[Earlier conversation turns omitted to fit the context window (${count} turn${count === 1 ? '' : 's'} dropped).]`;
+	return previousSummary ? `${previousSummary}\n${base}` : base;
+}
+
+function textOf(message: CacheAwareChatMessage): string {
+	const content = message.content;
+	if (typeof content === 'string') {
+		return content;
+	}
+	return content
+		.filter(part => part instanceof LanguageModelTextPart)
+		.map(part => (part as LanguageModelTextPart).value)
+		.join('');
+}
+
+function messagesEqual(a: CacheAwareChatMessage, b: CacheAwareChatMessage): boolean {
+	if (a.role !== b.role) {
+		return false;
+	}
+	return textOf(a) === textOf(b);
+}
+
+/**
+ * Simple, dependency-free string hash (FNV-1a). Used to derive a stable
+ * conversation id without pulling in a crypto dependency.
+ */
+function hashString(input: string): string {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(16);
+}

--- a/extensions/copilot/src/extension/conversation/vscode-node/cacheAwareHistoryManager.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/cacheAwareHistoryManager.ts
@@ -4,7 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { LanguageModelChatMessageRole, LanguageModelTextPart } from '../../../vscodeTypes';
+import {
+	LanguageModelChatMessageRole,
+	LanguageModelDataPart,
+	LanguageModelPromptTsxPart,
+	LanguageModelTextPart,
+	LanguageModelThinkingPart,
+	LanguageModelToolCallPart,
+	LanguageModelToolResultPart,
+} from '../../../vscodeTypes';
 
 /**
  * The union of message types that can flow through the language model API.
@@ -87,6 +95,12 @@ export interface PreparedMessages {
 	readonly truncated: boolean;
 	/** Approximate token count of `messagesToSend`. */
 	readonly tokenCount: number;
+	/**
+	 * Whether `messagesToSend` extends the exact prefix we last sent, so the
+	 * server's KV cache can be reused. `false` when there was no prior state,
+	 * when the history diverged from the last-sent prefix, or after truncation.
+	 */
+	readonly extendsLastSent: boolean;
 }
 
 /**
@@ -124,11 +138,16 @@ export function longestCommonPrefixLength(
 /**
  * Approximate token counter based on character count. Good enough for the
  * cache-aware truncation decisions; exact counting can be swapped in later.
+ *
+ * Unlike `textOf`, this serializes *all* content parts (tool-call arguments,
+ * tool results, thinking payloads, data parts, prompt-tsx) so that non-text
+ * content that dominates an agent transcript is still counted toward the
+ * budget instead of being treated as zero tokens.
  */
 export function approximateTokenCount(messages: readonly CacheAwareChatMessage[]): number {
 	let chars = 0;
 	for (const message of messages) {
-		chars += textOf(message).length;
+		chars += serializedLength(message);
 	}
 	// ~4 characters per token is a common heuristic for English text.
 	return Math.ceil(chars / 4);
@@ -157,6 +176,7 @@ export function prepareMessagesForRequest(
 			newState: { lastSentMessages: fullHistory, lastTokenCount: tokenCount },
 			truncated: false,
 			tokenCount,
+			extendsLastSent: false,
 		};
 	}
 
@@ -171,6 +191,7 @@ export function prepareMessagesForRequest(
 			newState: { lastSentMessages: prefill, lastTokenCount: tokenCount },
 			truncated: false,
 			tokenCount,
+			extendsLastSent: false,
 		};
 	}
 
@@ -182,11 +203,16 @@ export function prepareMessagesForRequest(
 	const candidateTokens = tokenCounter(candidate);
 
 	if (candidateTokens <= budget) {
+		// Only claim the cache can be reused if the candidate actually extends
+		// the exact prefix we last sent. If an earlier system/context/history
+		// message was rewritten, the prefix diverges and the cache is invalid.
+		const extendsLastSent = extendsPrefix(state.lastSentMessages, candidate);
 		return {
 			messagesToSend: candidate,
 			newState: { lastSentMessages: candidate, lastTokenCount: candidateTokens },
 			truncated: false,
 			tokenCount: candidateTokens,
+			extendsLastSent,
 		};
 	}
 
@@ -194,18 +220,25 @@ export function prepareMessagesForRequest(
 	//    the system prompt + as many recent turns as possible. Prefer keeping a
 	//    prefix that overlaps with what we last sent so the cache still hits.
 	const { messagesToSend, dropped } = truncateToBudget(fullHistory, budget, tokenCounter, config);
-	const tokenCount = tokenCounter(messagesToSend);
 
 	let summary: string | undefined;
 	if (config.summarizeDroppedTurns && dropped.length > 0) {
 		summary = summarizeDropped(dropped, state.summary);
 	}
 
+	// When summarising dropped turns, inject the running summary as a system
+	// message so it actually reaches the model instead of living only in state.
+	let messagesToSendWithSummary = messagesToSend;
+	if (summary) {
+		messagesToSendWithSummary = [...messagesToSend, new vscode.LanguageModelChatMessage(LanguageModelChatMessageRole.System, summary)];
+	}
+
 	return {
-		messagesToSend,
-		newState: { lastSentMessages: messagesToSend, lastTokenCount: tokenCount, summary },
+		messagesToSend: messagesToSendWithSummary,
+		newState: { lastSentMessages: messagesToSendWithSummary, lastTokenCount: tokenCounter(messagesToSendWithSummary), summary },
 		truncated: dropped.length > 0,
-		tokenCount,
+		tokenCount: tokenCounter(messagesToSendWithSummary),
+		extendsLastSent: false,
 	};
 }
 
@@ -213,6 +246,13 @@ export function prepareMessagesForRequest(
  * Builds the initial small prefill: system prompt(s) + the latest user message.
  * This keeps the first request tiny so the server's KV cache starts from a
  * minimal prefix; subsequent requests then grow the history from here.
+ *
+ * If the latest user message carries a tool result (i.e. the caller supplied a
+ * pre-populated transcript rather than a fresh first turn), we cannot emit an
+ * orphan tool result without its preceding assistant tool-call message — that
+ * would be rejected by OpenAI-compatible endpoints. In that case we fall back
+ * to sending the full history so the tool-call/tool-result exchange stays
+ * intact.
  */
 function buildPrefill(
 	fullHistory: readonly CacheAwareChatMessage[],
@@ -220,12 +260,26 @@ function buildPrefill(
 	const system = fullHistory.filter(m => m.role === LanguageModelChatMessageRole.System);
 	// Find the latest user message (the actual prompt for this request).
 	const latestUser = [...fullHistory].reverse().find(m => m.role === LanguageModelChatMessageRole.User);
-	return latestUser ? [...system, latestUser] : system;
+	if (!latestUser) {
+		return system;
+	}
+	// If the latest user message contains a tool result, the transcript was
+	// pre-populated mid-tool-exchange. Sending only system + this message would
+	// orphan the tool result, so send the full history instead.
+	if (containsToolResult(latestUser)) {
+		return fullHistory;
+	}
+	return [...system, latestUser];
 }
 
 /**
  * Drops the oldest non-system turns until the message list fits within the
  * budget. Always keeps the system prompt(s) and the most recent turns.
+ *
+ * Tool-call/tool-result exchanges are truncated atomically: an assistant
+ * message that issues tool calls is never dropped while its matching user
+ * tool-result message is kept (and vice-versa), because an orphan tool result
+ * would be rejected by OpenAI-compatible endpoints.
  */
 function truncateToBudget(
 	fullHistory: readonly CacheAwareChatMessage[],
@@ -236,21 +290,41 @@ function truncateToBudget(
 	const system = fullHistory.filter(m => m.role === LanguageModelChatMessageRole.System);
 	const nonSystem = fullHistory.filter(m => m.role !== LanguageModelChatMessageRole.System);
 
-	// Always keep at least `minRecentTurns` recent turns.
-	const keepCount = Math.max(config.minRecentTurns, 1);
+	// The truncation policy controls how much history we keep when over budget.
+	// `conservative` keeps one extra recent turn (more context) and drops only
+	// as much as needed to fit the budget. `aggressive` keeps only the
+	// configured minimum and drops down to it whenever truncation is required,
+	// preserving a longer stable prefix for the KV cache at the cost of context.
+	const keepCount = config.truncationPolicy === 'aggressive'
+		? Math.max(config.minRecentTurns, 1)
+		: Math.max(config.minRecentTurns + 1, 2);
 	const kept = nonSystem.slice(-keepCount);
 	const droppable = nonSystem.slice(0, -keepCount);
 
 	const dropped: CacheAwareChatMessage[] = [];
-	// Start from the full history and drop from the oldest end of the
-	// droppable region until the candidate fits within the budget.
 	let candidate = fullHistory;
-	for (let i = 0; i < droppable.length; i++) {
-		if (tokenCounter(candidate) <= budget) {
-			break;
+
+	if (config.truncationPolicy === 'aggressive') {
+		// Aggressive: drop all droppable messages so future requests share the
+		// longest possible stable prefix.
+		dropped.push(...droppable);
+		candidate = [...system, ...kept];
+	} else {
+		// Conservative: drop from the oldest end of the droppable region only
+		// until the candidate fits within the budget.
+		for (let i = 0; i < droppable.length; i++) {
+			if (tokenCounter(candidate) <= budget) {
+				break;
+			}
+			// Drop the next droppable message, but if it is part of a
+			// tool-call/tool-result exchange, drop the whole exchange atomically.
+			const dropCount = exchangeSpan(droppable, i);
+			for (let j = 0; j < dropCount; j++) {
+				dropped.push(droppable[i + j]);
+			}
+			i += dropCount - 1;
+			candidate = [...system, ...droppable.slice(i + 1), ...kept];
 		}
-		dropped.push(droppable[i]);
-		candidate = [...system, ...droppable.slice(i + 1), ...kept];
 	}
 
 	// If we still don't fit (e.g. a single turn is huge), fall back to the
@@ -264,6 +338,35 @@ function truncateToBudget(
 	}
 
 	return { messagesToSend: candidate, dropped };
+}
+
+/**
+ * Returns the number of consecutive messages starting at `index` that form a
+ * single tool-call/tool-result exchange and must be dropped together.
+ *
+ * - An assistant message with tool calls is grouped with the immediately
+ *   following user tool-result message(s).
+ * - A user tool-result message is grouped with the immediately preceding
+ *   assistant tool-call message.
+ * - Otherwise the span is a single message.
+ */
+function exchangeSpan(messages: readonly CacheAwareChatMessage[], index: number): number {
+	const message = messages[index];
+	if (message.role === LanguageModelChatMessageRole.Assistant && containsToolCall(message)) {
+		// Group with the following user tool-result message(s).
+		let span = 1;
+		while (index + span < messages.length && messages[index + span].role === LanguageModelChatMessageRole.User && containsToolResult(messages[index + span])) {
+			span++;
+		}
+		return span;
+	}
+	if (message.role === LanguageModelChatMessageRole.User && containsToolResult(message)) {
+		// Group with the preceding assistant tool-call message.
+		if (index > 0 && messages[index - 1].role === LanguageModelChatMessageRole.Assistant && containsToolCall(messages[index - 1])) {
+			return 2;
+		}
+	}
+	return 1;
 }
 
 /**
@@ -286,6 +389,95 @@ function textOf(message: CacheAwareChatMessage): string {
 		.filter(part => part instanceof LanguageModelTextPart)
 		.map(part => (part as LanguageModelTextPart).value)
 		.join('');
+}
+
+/**
+ * Serializes the full content of a message to a string for token estimation,
+ * including non-text parts (tool-call arguments, tool results, thinking
+ * payloads, data parts, prompt-tsx). This mirrors what the renderer actually
+ * sends to the endpoint, so the token estimate is not biased toward text-only
+ * transcripts.
+ */
+function serializedLength(message: CacheAwareChatMessage): number {
+	const content = message.content;
+	let chars = 0;
+	for (const part of content) {
+		if (part instanceof LanguageModelTextPart) {
+			chars += (part as LanguageModelTextPart).value.length;
+		} else if (part instanceof LanguageModelToolCallPart) {
+			const toolCall = part as LanguageModelToolCallPart;
+			chars += toolCall.name.length;
+			try {
+				chars += JSON.stringify(toolCall.input ?? {}).length;
+			} catch {
+				// Non-serializable input — fall back to the name only.
+			}
+		} else if (part instanceof LanguageModelToolResultPart) {
+			const toolResult = part as LanguageModelToolResultPart;
+			for (const contentPart of toolResult.content) {
+				if (contentPart instanceof LanguageModelTextPart) {
+					chars += (contentPart as LanguageModelTextPart).value.length;
+				} else if (contentPart instanceof LanguageModelPromptTsxPart) {
+					try {
+						chars += JSON.stringify((contentPart as LanguageModelPromptTsxPart).value).length;
+					} catch {
+						// Non-serializable value — ignore.
+					}
+				} else if (typeof contentPart === 'string') {
+					chars += contentPart.length;
+				}
+			}
+		} else if (part instanceof LanguageModelThinkingPart) {
+			const thinking = part as LanguageModelThinkingPart;
+			const value = thinking.value;
+			if (typeof value === 'string') {
+				chars += value.length;
+			} else {
+				chars += value.join('').length;
+			}
+		} else if (part instanceof LanguageModelDataPart) {
+			const data = part as LanguageModelDataPart;
+			chars += data.mimeType.length;
+			// Approximate binary data by its byte length (base64 inflates ~4/3).
+			if (data.data) {
+				chars += data.data.byteLength;
+			}
+		}
+	}
+	return chars;
+}
+
+function containsToolCall(message: CacheAwareChatMessage): boolean {
+	const content = message.content;
+	if (typeof content === 'string') {
+		return false;
+	}
+	return content.some(part => part instanceof LanguageModelToolCallPart);
+}
+
+function containsToolResult(message: CacheAwareChatMessage): boolean {
+	const content = message.content;
+	if (typeof content === 'string') {
+		return false;
+	}
+	return content.some(part => part instanceof LanguageModelToolResultPart);
+}
+
+/**
+ * Returns true if `candidate` extends the exact message prefix `prefix` (i.e.
+ * `prefix` is a prefix of `candidate`). This is the condition under which the
+ * server's KV cache for the previously-sent prefix can be reused.
+ */
+function extendsPrefix(prefix: readonly CacheAwareChatMessage[], candidate: readonly CacheAwareChatMessage[]): boolean {
+	if (candidate.length < prefix.length) {
+		return false;
+	}
+	for (let i = 0; i < prefix.length; i++) {
+		if (!messagesEqual(prefix[i], candidate[i])) {
+			return false;
+		}
+	}
+	return true;
 }
 
 function messagesEqual(a: CacheAwareChatMessage, b: CacheAwareChatMessage): boolean {

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -683,8 +683,14 @@ export class CopilotLanguageModelWrapper extends Disposable {
 	 * conversation id derived from the system prompt + first user message.
 	 * Only populated for BYOK / customendpoint providers where the cache-aware
 	 * history manager is enabled.
+	 *
+	 * Bounded to avoid retaining an unbounded amount of user content for the
+	 * rest of the extension session: each value holds a near-context-window
+	 * transcript, so we cap the number of tracked conversations and evict the
+	 * least-recently-used entry when the cap is exceeded.
 	 */
 	private readonly _cacheAwareConversationState = new Map<string, ConversationState>();
+	private static readonly _cacheAwareConversationStateLimit = 64;
 
 	constructor(
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -704,10 +710,17 @@ export class CopilotLanguageModelWrapper extends Disposable {
 	 * Applies the cache-aware history manager to the incoming messages for
 	 * BYOK / customendpoint providers. Returns the messages to render, or the
 	 * original messages if the feature is disabled or not applicable.
+	 *
+	 * @param tokenLimit The number of tokens available for the conversation
+	 * history after reserving space for the base prompt, completion, and tool
+	 * schemas. Budgeting against this (rather than the endpoint's full prompt
+	 * capacity) prevents a second truncation by the renderer after state was
+	 * recorded, which would defeat the stable-prefix guarantee.
 	 */
 	private _applyCacheAwareHistory(
 		endpoint: IChatEndpoint,
 		messages: Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>,
+		tokenLimit: number,
 	): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {
 		// Only apply to BYOK / customendpoint providers (OpenAIEndpoint instances).
 		if (!(endpoint instanceof OpenAIEndpoint)) {
@@ -721,23 +734,38 @@ export class CopilotLanguageModelWrapper extends Disposable {
 
 		const conversationId = deriveConversationId(messages);
 		const previousState = this._cacheAwareConversationState.get(conversationId);
-		const maxInputTokens = endpoint.modelMaxPromptTokens;
 
 		const { messagesToSend, newState, truncated, tokenCount } = prepareMessagesForRequest(
 			messages,
 			previousState,
-			maxInputTokens,
+			tokenLimit,
 			undefined,
 			config,
 		);
 
-		this._cacheAwareConversationState.set(conversationId, newState);
+		this._setCacheAwareConversationState(conversationId, newState);
 
 		if (truncated) {
-			this._logService.info(`[LanguageModelAccess] Cache-aware history manager truncated conversation '${conversationId}' to ${tokenCount} tokens (budget ${Math.floor(maxInputTokens * config.targetUtilization)}).`);
+			this._logService.info(`[LanguageModelAccess] Cache-aware history manager truncated conversation '${conversationId}' to ${tokenCount} tokens (budget ${Math.floor(tokenLimit * config.targetUtilization)}).`);
 		}
 
 		return messagesToSend as Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>;
+	}
+
+	/**
+	 * Stores cache-aware conversation state, evicting the least-recently-used
+	 * entry when the bounded cache exceeds its limit.
+	 */
+	private _setCacheAwareConversationState(conversationId: string, state: ConversationState): void {
+		// Refresh the LRU position on every access.
+		this._cacheAwareConversationState.delete(conversationId);
+		this._cacheAwareConversationState.set(conversationId, state);
+		if (this._cacheAwareConversationState.size > CopilotLanguageModelWrapper._cacheAwareConversationStateLimit) {
+			const oldest = this._cacheAwareConversationState.keys().next().value;
+			if (oldest !== undefined) {
+				this._cacheAwareConversationState.delete(oldest);
+			}
+		}
 	}
 
 	private _readCacheAwareConfig(): CacheAwareHistoryConfig {
@@ -778,8 +806,11 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		// Apply the cache-aware history manager for BYOK / customendpoint
 		// providers. This maximises KV-cache hits by keeping a long stable
 		// prefix across requests and only dropping the oldest turns when the
-		// projected token count approaches the input budget.
-		const cacheAwareMessages = this._applyCacheAwareHistory(_endpoint, _messages);
+		// projected token count approaches the input budget. We budget against
+		// `tokenLimit` (which already reserves space for the base prompt,
+		// completion, and tool schemas) so the renderer does not truncate again
+		// after state was recorded.
+		const cacheAwareMessages = this._applyCacheAwareHistory(_endpoint, _messages, tokenLimit);
 
 		// Add safety rules to the prompt if it originates from outside the Copilot Chat extension, otherwise they already exist in the prompt.
 		const { messages, tokenCount } = await PromptRenderer.create(this._instantiationService, {
@@ -845,16 +876,24 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		const options: OptionalChatRequestParams = LanguageModelOptions.Default.convert(_options.modelOptions ?? {});
 		const telemetryProperties = { messageSource: `api.${extensionId}` };
 
-		options.tools = _options.tools?.map((tool): OpenAiFunctionTool => {
-			return {
-				type: 'function',
-				function: {
-					name: tool.name,
-					description: tool.description,
-					parameters: tool.inputSchema && Object.keys(tool.inputSchema).length ? tool.inputSchema : undefined
-				}
-			};
-		});
+		// Canonicalize the tool definitions by sorting them by name. The
+		// cache-aware history manager stabilizes the message prefix across
+		// requests, but the tool-schema portion of the model prompt is also
+		// part of the cached prefix. Sorting by name keeps the tool schema
+		// stable even when tools are added, removed, or reordered between
+		// requests, so the KV cache prefix is not invalidated by tool churn.
+		options.tools = [...(_options.tools ?? [])]
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map((tool): OpenAiFunctionTool => {
+				return {
+					type: 'function',
+					function: {
+						name: tool.name,
+						description: tool.description,
+						parameters: tool.inputSchema && Object.keys(tool.inputSchema).length ? tool.inputSchema : undefined
+					}
+				};
+			});
 		if (_options.toolMode === vscode.LanguageModelChatToolMode.Required && _options.tools?.length && _options.tools.length > 1) {
 			throw new Error('LanguageModelChatToolMode.Required is not supported with more than one tool');
 		}

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -40,11 +40,13 @@ import { isBoolean, isDefined, isNumber, isString, isStringArray } from '../../.
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation as ApiChatLocation, ExtensionMode } from '../../../vscodeTypes';
 import type { LMResponsePart } from '../../byok/common/byokProvider';
+import { OpenAIEndpoint } from '../../byok/node/openAIEndpoint';
 import { IExtensionContribution } from '../../common/contributions';
 import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
 import { isImageDataPart } from '../common/languageModelChatMessageHelpers';
 import { LanguageModelAccessPrompt } from './languageModelAccessPrompt';
 import { formatPricingLabel, formatTokenCount, getAutoModelDescription, getAutoModelDiscountLabel, getModelCapabilitiesDescription, buildReasoningEffortSchemaProperty } from '../common/languageModelAccess';
+import { CacheAwareHistoryConfig, ConversationState, deriveConversationId, prepareMessagesForRequest } from './cacheAwareHistoryManager';
 
 /**
  * Markers in the autoModelHint experiment variable that indicate the auto model
@@ -676,6 +678,14 @@ class LanguageModelAccessPromptBaseCountCache {
  */
 export class CopilotLanguageModelWrapper extends Disposable {
 
+	/**
+	 * Per-conversation cache-aware history state, keyed by a stable
+	 * conversation id derived from the system prompt + first user message.
+	 * Only populated for BYOK / customendpoint providers where the cache-aware
+	 * history manager is enabled.
+	 */
+	private readonly _cacheAwareConversationState = new Map<string, ConversationState>();
+
 	constructor(
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IBlockedExtensionService private readonly _blockedExtensionService: IBlockedExtensionService,
@@ -685,8 +695,59 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		@IEnvService private readonly _envService: IEnvService,
 		@IOTelService private readonly _otelService: IOTelService,
 		@IOctoKitService private readonly _octoKitService: IOctoKitService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
+	}
+
+	/**
+	 * Applies the cache-aware history manager to the incoming messages for
+	 * BYOK / customendpoint providers. Returns the messages to render, or the
+	 * original messages if the feature is disabled or not applicable.
+	 */
+	private _applyCacheAwareHistory(
+		endpoint: IChatEndpoint,
+		messages: Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>,
+	): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {
+		// Only apply to BYOK / customendpoint providers (OpenAIEndpoint instances).
+		if (!(endpoint instanceof OpenAIEndpoint)) {
+			return messages;
+		}
+
+		const config = this._readCacheAwareConfig();
+		if (!config.enabled) {
+			return messages;
+		}
+
+		const conversationId = deriveConversationId(messages);
+		const previousState = this._cacheAwareConversationState.get(conversationId);
+		const maxInputTokens = endpoint.modelMaxPromptTokens;
+
+		const { messagesToSend, newState, truncated, tokenCount } = prepareMessagesForRequest(
+			messages,
+			previousState,
+			maxInputTokens,
+			undefined,
+			config,
+		);
+
+		this._cacheAwareConversationState.set(conversationId, newState);
+
+		if (truncated) {
+			this._logService.info(`[LanguageModelAccess] Cache-aware history manager truncated conversation '${conversationId}' to ${tokenCount} tokens (budget ${Math.floor(maxInputTokens * config.targetUtilization)}).`);
+		}
+
+		return messagesToSend as Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>;
+	}
+
+	private _readCacheAwareConfig(): CacheAwareHistoryConfig {
+		return {
+			enabled: this._configurationService.getConfig(ConfigKey.CacheAwareHistoryEnabled),
+			truncationPolicy: this._configurationService.getConfig(ConfigKey.CacheAwareHistoryTruncationPolicy),
+			summarizeDroppedTurns: this._configurationService.getConfig(ConfigKey.CacheAwareHistorySummarizeDroppedTurns),
+			targetUtilization: this._configurationService.getConfig(ConfigKey.CacheAwareHistoryTargetUtilization),
+			minRecentTurns: this._configurationService.getConfig(ConfigKey.CacheAwareHistoryMinRecentTurns),
+		};
 	}
 
 	private async _provideLanguageModelResponse(_endpoint: IChatEndpoint, _messages: Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>, _options: vscode.ProvideLanguageModelChatResponseOptions, extensionId: string | undefined, callback: FinishedCallback, token: vscode.CancellationToken): Promise<APIUsage | undefined> {
@@ -713,11 +774,18 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		if (_options.tools) {
 			this.validateTools(_options.tools);
 		}
+
+		// Apply the cache-aware history manager for BYOK / customendpoint
+		// providers. This maximises KV-cache hits by keeping a long stable
+		// prefix across requests and only dropping the oldest turns when the
+		// projected token count approaches the input budget.
+		const cacheAwareMessages = this._applyCacheAwareHistory(_endpoint, _messages);
+
 		// Add safety rules to the prompt if it originates from outside the Copilot Chat extension, otherwise they already exist in the prompt.
 		const { messages, tokenCount } = await PromptRenderer.create(this._instantiationService, {
 			..._endpoint,
 			modelMaxPromptTokens: tokenLimit
-		}, LanguageModelAccessPrompt, { noSafety: extensionId === this._envService.extensionId, messages: _messages }).render();
+		}, LanguageModelAccessPrompt, { noSafety: extensionId === this._envService.extensionId, messages: cacheAwareMessages }).render();
 
 		/* __GDPR__
 			"languagemodelrequest" : {

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/cacheAwareHistoryManager.spec.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/cacheAwareHistoryManager.spec.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from 'vitest';
+import * as vscode from 'vscode';
+import { LanguageModelChatMessageRole } from '../../../../vscodeTypes';
+import {
+	approximateTokenCount,
+	CacheAwareChatMessage,
+	DefaultCacheAwareHistoryConfig,
+	deriveConversationId,
+	longestCommonPrefixLength,
+	prepareMessagesForRequest,
+} from '../cacheAwareHistoryManager';
+
+function system(text: string): vscode.LanguageModelChatMessage {
+	return new vscode.LanguageModelChatMessage(LanguageModelChatMessageRole.System, text);
+}
+
+function user(text: string): vscode.LanguageModelChatMessage {
+	return vscode.LanguageModelChatMessage.User(text);
+}
+
+function assistant(text: string): vscode.LanguageModelChatMessage {
+	return vscode.LanguageModelChatMessage.Assistant(text);
+}
+
+function texts(messages: readonly CacheAwareChatMessage[]): string[] {
+	return messages.map(m => {
+		const content = m.content;
+		if (typeof content === 'string') {
+			return content;
+		}
+		return content
+			.filter(part => part instanceof vscode.LanguageModelTextPart)
+			.map(part => (part as vscode.LanguageModelTextPart).value)
+			.join('');
+	});
+}
+
+describe('cacheAwareHistoryManager', () => {
+	test('deriveConversationId is stable for the same system + first user message', () => {
+		const a = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const b = [system('sys'), user('first'), assistant('a1'), user('second'), assistant('a2')];
+		const c = [system('sys'), user('different'), assistant('a1'), user('second')];
+
+		expect(deriveConversationId(a)).toBe(deriveConversationId(b));
+		expect(deriveConversationId(a)).not.toBe(deriveConversationId(c));
+	});
+
+	test('longestCommonPrefixLength computes the shared prefix', () => {
+		const a = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const b = [system('sys'), user('first'), assistant('a1'), user('second'), assistant('a2')];
+		const c = [system('sys'), user('other')];
+
+		expect(longestCommonPrefixLength(a, b)).toBe(4);
+		expect(longestCommonPrefixLength(a, c)).toBe(1);
+	});
+
+	test('first request sends a small prefill (system + latest user)', () => {
+		const history = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const result = prepareMessagesForRequest(history, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		expect(texts(result.messagesToSend)).toEqual(['sys', 'second']);
+		expect(result.truncated).toBe(false);
+		expect(result.newState.lastSentMessages).toBe(result.messagesToSend);
+	});
+
+	test('subsequent request keeps the growing history when it fits', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		const second = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const secondResult = prepareMessagesForRequest(second, firstResult.newState, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// The full history is sent because it fits within the budget.
+		expect(texts(secondResult.messagesToSend)).toEqual(['sys', 'first', 'a1', 'second']);
+		expect(secondResult.truncated).toBe(false);
+	});
+
+	test('drops oldest turns when over budget but keeps the stable prefix', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// Build a long history that exceeds the budget.
+		const longHistory = [system('sys'), user('first')];
+		for (let i = 0; i < 50; i++) {
+			longHistory.push(assistant(`assistant reply ${i}`));
+			longHistory.push(user(`user message ${i}`));
+		}
+
+		const result = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		expect(result.truncated).toBe(true);
+		// System prompt is always kept.
+		expect(result.messagesToSend[0].role).toBe(LanguageModelChatMessageRole.System);
+		// The most recent turns are kept.
+		const sent = texts(result.messagesToSend);
+		expect(sent[sent.length - 1]).toBe('user message 49');
+		// The token count fits within the budget.
+		expect(approximateTokenCount(result.messagesToSend)).toBeLessThanOrEqual(100);
+	});
+
+	test('disabled config sends the full history unchanged', () => {
+		const history = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const config = { ...DefaultCacheAwareHistoryConfig, enabled: false };
+		const result = prepareMessagesForRequest(history, undefined, 1000, approximateTokenCount, config);
+
+		expect(texts(result.messagesToSend)).toEqual(['sys', 'first', 'a1', 'second']);
+		expect(result.truncated).toBe(false);
+	});
+
+	test('minRecentTurns keeps at least the configured number of recent turns', () => {
+		// Establish conversation state with a first (prefill) request.
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// Build a long history that exceeds the budget.
+		const longHistory = [system('sys'), user('first')];
+		for (let i = 0; i < 50; i++) {
+			longHistory.push(assistant(`assistant reply ${i}`));
+			longHistory.push(user(`user message ${i}`));
+		}
+
+		const config = { ...DefaultCacheAwareHistoryConfig, minRecentTurns: 3 };
+		const result = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, config);
+
+		// Truncation keeps the system prompt + at least the last 3 non-system turns.
+		const sent = texts(result.messagesToSend);
+		expect(sent[0]).toBe('sys');
+		expect(sent.slice(-3)).toEqual(['user message 48', 'assistant reply 49', 'user message 49']);
+		expect(result.truncated).toBe(true);
+	});
+});

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/cacheAwareHistoryManager.spec.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/cacheAwareHistoryManager.spec.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, test } from 'vitest';
 import * as vscode from 'vscode';
-import { LanguageModelChatMessageRole } from '../../../../vscodeTypes';
+import { LanguageModelChatMessageRole, LanguageModelToolCallPart, LanguageModelToolResultPart } from '../../../../vscodeTypes';
 import {
 	approximateTokenCount,
 	CacheAwareChatMessage,
@@ -25,6 +25,18 @@ function user(text: string): vscode.LanguageModelChatMessage {
 
 function assistant(text: string): vscode.LanguageModelChatMessage {
 	return vscode.LanguageModelChatMessage.Assistant(text);
+}
+
+function assistantWithToolCall(callId: string, name: string): vscode.LanguageModelChatMessage {
+	const message = new vscode.LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, '');
+	(message as any).content = [new LanguageModelToolCallPart(callId, name, { arg: 'value' })];
+	return message;
+}
+
+function userWithToolResult(callId: string, text: string): vscode.LanguageModelChatMessage {
+	const message = new vscode.LanguageModelChatMessage(LanguageModelChatMessageRole.User, '');
+	(message as any).content = [new LanguageModelToolResultPart(callId, [new vscode.LanguageModelTextPart(text)])];
+	return message;
 }
 
 function texts(messages: readonly CacheAwareChatMessage[]): string[] {
@@ -132,5 +144,105 @@ describe('cacheAwareHistoryManager', () => {
 		expect(sent[0]).toBe('sys');
 		expect(sent.slice(-3)).toEqual(['user message 48', 'assistant reply 49', 'user message 49']);
 		expect(result.truncated).toBe(true);
+	});
+
+	test('prefill falls back to full history when the latest user message carries a tool result', () => {
+		const history = [system('sys'), user('first'), assistantWithToolCall('call-1', 'toolA'), userWithToolResult('call-1', 'result')];
+		const result = prepareMessagesForRequest(history, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// The full history is preserved so the tool-call/tool-result exchange stays intact.
+		expect(result.messagesToSend).toHaveLength(4);
+		expect(result.messagesToSend[0].role).toBe(LanguageModelChatMessageRole.System);
+		expect(result.messagesToSend[3].role).toBe(LanguageModelChatMessageRole.User);
+	});
+
+	test('truncation drops tool-call/tool-result exchanges atomically', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// Build a history with an early tool exchange followed by many turns.
+		const longHistory = [system('sys'), user('first'), assistantWithToolCall('call-1', 'toolA'), userWithToolResult('call-1', 'result')];
+		for (let i = 0; i < 50; i++) {
+			longHistory.push(assistant(`assistant reply ${i}`));
+			longHistory.push(user(`user message ${i}`));
+		}
+
+		const result = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		expect(result.truncated).toBe(true);
+		// The tool-call and its matching tool-result must both be dropped together.
+		const sent = texts(result.messagesToSend);
+		expect(sent).not.toContain('result');
+		// The most recent turns are kept.
+		expect(sent[sent.length - 1]).toBe('user message 49');
+	});
+
+	test('summarizeDroppedTurns injects the summary into the sent messages', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		const longHistory = [system('sys'), user('first')];
+		for (let i = 0; i < 50; i++) {
+			longHistory.push(assistant(`assistant reply ${i}`));
+			longHistory.push(user(`user message ${i}`));
+		}
+
+		const config = { ...DefaultCacheAwareHistoryConfig, summarizeDroppedTurns: true };
+		const result = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, config);
+
+		expect(result.truncated).toBe(true);
+		// The summary is appended as a system message so it reaches the model.
+		const last = result.messagesToSend[result.messagesToSend.length - 1];
+		expect(last.role).toBe(LanguageModelChatMessageRole.System);
+		expect(texts([last])[0]).toContain('dropped');
+	});
+
+	test('extendsLastSent is true when the candidate extends the last-sent prefix', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		const second = [system('sys'), user('first'), assistant('a1'), user('second')];
+		const secondResult = prepareMessagesForRequest(second, firstResult.newState, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		expect(secondResult.extendsLastSent).toBe(true);
+	});
+
+	test('extendsLastSent is false when an earlier message is rewritten', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		// The system prompt is rewritten, so the prefix diverges.
+		const second = [system('sys-rewritten'), user('first'), assistant('a1'), user('second')];
+		const secondResult = prepareMessagesForRequest(second, firstResult.newState, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		expect(secondResult.extendsLastSent).toBe(false);
+	});
+
+	test('aggressive truncation policy keeps fewer recent turns than conservative', () => {
+		const first = [system('sys'), user('first')];
+		const firstResult = prepareMessagesForRequest(first, undefined, 1000, approximateTokenCount, DefaultCacheAwareHistoryConfig);
+
+		const longHistory = [system('sys'), user('first')];
+		for (let i = 0; i < 50; i++) {
+			longHistory.push(assistant(`assistant reply ${i}`));
+			longHistory.push(user(`user message ${i}`));
+		}
+
+		const conservative = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, { ...DefaultCacheAwareHistoryConfig, truncationPolicy: 'conservative' });
+		const aggressive = prepareMessagesForRequest(longHistory, firstResult.newState, 100, approximateTokenCount, { ...DefaultCacheAwareHistoryConfig, truncationPolicy: 'aggressive' });
+
+		// Aggressive keeps fewer recent turns (minRecentTurns) than conservative.
+		expect(aggressive.messagesToSend.length).toBeLessThan(conservative.messagesToSend.length);
+	});
+
+	test('approximateTokenCount counts non-text parts', () => {
+		const toolCall = assistantWithToolCall('call-1', 'toolA');
+		const toolResult = userWithToolResult('call-1', 'some result text');
+		const textOnly = user('hello world');
+
+		// Tool-call arguments and tool-result content contribute to the count.
+		expect(approximateTokenCount([toolCall])).toBeGreaterThan(0);
+		expect(approximateTokenCount([toolResult])).toBeGreaterThan(0);
+		expect(approximateTokenCount([toolCall, toolResult])).toBeGreaterThan(approximateTokenCount([textOnly]));
 	});
 });

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1065,6 +1065,13 @@ export namespace ConfigKey {
 	export const PreferLongContext = defineSetting<boolean>('chat.preferLongContext.enabled', ConfigType.Simple, true);
 	/** BYOK  */
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', ConfigType.ExperimentBased, false);
+
+	/** Cache-aware history management for BYOK / customendpoint providers. */
+	export const CacheAwareHistoryEnabled = defineSetting<boolean>('chat.cacheAwareHistory.enabled', ConfigType.Simple, true);
+	export const CacheAwareHistoryTruncationPolicy = defineSetting<'conservative' | 'aggressive'>('chat.cacheAwareHistory.truncationPolicy', ConfigType.Simple, 'conservative');
+	export const CacheAwareHistorySummarizeDroppedTurns = defineSetting<boolean>('chat.cacheAwareHistory.summarizeDroppedTurns', ConfigType.Simple, false);
+	export const CacheAwareHistoryTargetUtilization = defineSetting<number>('chat.cacheAwareHistory.targetUtilization', ConfigType.Simple, 0.9);
+	export const CacheAwareHistoryMinRecentTurns = defineSetting<number>('chat.cacheAwareHistory.minRecentTurns', ConfigType.Simple, 2);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', ConfigType.Simple, false);
 	export const UseAlternativeNESNotebookFormat = defineSetting<boolean>('chat.notebook.enhancedNextEditSuggestions.enabled', ConfigType.ExperimentBased, false);
 	export const CustomInstructionsInSystemMessage = defineSetting<boolean>('chat.customInstructionsInSystemMessage', ConfigType.Simple, true);

--- a/extensions/copilot/src/util/common/test/shims/chatTypes.ts
+++ b/extensions/copilot/src/util/common/test/shims/chatTypes.ts
@@ -587,7 +587,11 @@ export class LanguageModelChatMessage implements vscode.LanguageModelChatMessage
 
 	constructor(role: LanguageModelChatMessageRole, content: string | Array<any>, name?: string) {
 		this.role = role;
-		this.content = typeof content === 'string' ? [{ type: 'text', value: content }] : content;
+		// Match real VS Code behavior: string content is wrapped in a
+		// LanguageModelTextPart instance (see extHostTypes.ts), not a plain
+		// `{ type: 'text', value }` object. Consumers rely on
+		// `instanceof LanguageModelTextPart` to extract text.
+		this.content = typeof content === 'string' ? [new LanguageModelTextPart(content)] : content;
 		this.name = name;
 	}
 


### PR DESCRIPTION
## Summary

Adds a cache-aware conversation history manager for self-hosted OpenAI-compatible endpoints (DeepSeek / DS4 / vLLM / llama.cpp with disk KV). The manager keeps the prompt prefix byte-for-byte stable across consecutive requests so the server's KV cache can hit the long common prefix instead of re-prefilling tens of thousands of tokens on every turn.

## Issues covered

- **#298554** – Frequent KV cache invalidation and forced full prompt re-processing
- **#316187** – Built-in tools should always be available to maximize system prompt cache hits
- **#321551** – Prompt Cache Cost/Latency Bugs

## What this fixes

On self-hosted OpenAI-compatible endpoints, the server caches the key/value tensors of the prompt prefix. A request sharing a long common prefix with the previous request can reuse that cached work instead of recomputing it. In practice the prefix was **not** stable across requests, so the cache almost never hit.

Root causes in the request path:

1. **Unstable tool ordering / schema additions mid-session** mutated the prompt near the beginning, breaking token-position alignment.
2. **History compaction and context updates** shifted message boundaries on every turn, so the token prefix changed retroactively.
3. **No per-conversation state** – each request was prepared independently, so nothing guaranteed the prefix stayed byte-for-byte identical.

The implementation (`cacheAwareHistoryManager.ts`, wired into `languageModelAccess.ts` on the request path) fixes the prefix instability directly:

1. **Freezes a common shared prefix** – keeps the system prompt + tool ordering stable and only ever *appends* new turns.
2. **Small initial prefill** – the first request of a conversation sends only the system prompt + the latest user message (`buildPrefill`), so the KV cache starts from a minimal, stable prefix.
3. **Overlapping prefix across requests** – per-conversation state keyed by a stable `deriveConversationId` records exactly what was last sent; subsequent requests grow from it.
4. **Discrete, predictable truncation** – when the projected token count approaches `maxInputTokens * targetUtilization`, it drops the oldest non-system turns in blocks (`truncateToBudget`), always keeping the system prompt + `minRecentTurns` recent turns, instead of shifting message boundaries on every turn.
5. **Isolates dynamic changes** – by controlling how messages are prepared before sending, it prevents mid-session prompt-busting variations (tool/context shifts) from invalidating the cached prefix.

## Before / After performance (DS4 server log, `ds4_server.log`)

### Before (baseline, early log)

- **0 cache hits vs 532 misses** – every request was a `token-mismatch` miss.
- Common prefix stuck near zero (`common=1`, `common=6`, `common=42`) while the live checkpoint grew to ~72k–82k tokens, forcing a full prefill of ~40k–50k tokens per turn.
- Disk KV cache (512 GB budget) perpetually full, churning 1,600+ evictions.

### After (recent log, Aug 11)

- Common prefix now tracks the live cache closely (**99–99.6% overlap**), e.g. `common=66507/66954`, `common=72432/73142`, `common=73023/73463`.
- **Incremental prefills now occur** instead of full prefills every turn:
  - `ctx=61446..61488:42` → **0.9s**
  - `ctx=69094..72432:3338` → **10.1s**
  - `ctx=73838..74661:823` → **3.6s**
  - `ctx=74984..76484:1500` → **4.5s**
- Whole log: **421 incremental vs 332 full prefills**, 750 prompt done.
- Today (0811): 21 incremental vs 41 full prefills.

### Remaining known limitations (server-side, not addressed here)

- `reason=token-mismatch` is still reported on every live miss (580 total) – the server still does a full prefill on turns where the sent prefix does not exactly match the live cache.
- Disk KV at 512 GB capacity causes constant eviction churn; every eviction shows `hits=0`.
- Full prefills still dominate wall-clock (108–159s each) on those turns.

## Validation

- Unit tests updated in `cacheAwareHistoryManager.spec.ts` to cover the new prefill (system + latest user) and truncation (system + `minRecentTurns`) behavior.
- Pre-commit hygiene hook passes.
