### PR TITLE
Enhance modern UI with uppercase view headers

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -818,6 +818,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('modernUI', "Controls whether the experimental Modern UI Update is enabled. When on, the side bars and bottom panel are shown as floating cards with rounded corners and gaps, and a set of refreshed workbench styles is applied, matching the Agents window design."),
 				experiment: { mode: 'auto' },
 			},
+			[LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS]: {
+				'type': 'boolean',
+				'default': false,
+				'tags': ['experimental'],
+				'markdownDescription': localize({ key: 'modernUIUppercaseViewHeaders', comment: ['{0} is a placeholder for a setting identifier.'] }, "Controls whether view headers and Explorer workspace titles use uppercase text when {0} is enabled.", '`#workbench.experimental.modernUI#`'),
+			},
 		}
 	});
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -822,7 +822,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'boolean',
 				'default': false,
 				'tags': ['experimental'],
-				'markdownDescription': localize({ key: 'modernUIUppercaseViewHeaders', comment: ['{0} is a placeholder for a setting identifier.'] }, "Controls whether view headers and Explorer workspace titles use uppercase text when {0} is enabled.", '`#workbench.experimental.modernUI#`'),
+				'markdownDescription': localize({ key: 'modernUIUppercaseViewHeaders', comment: ['{0} is a placeholder for a setting identifier.'] }, "Controls whether view headers, side bar titles, and panel tabs use uppercase text when {0} is enabled.", '`#workbench.experimental.modernUI#`'),
 			},
 		}
 	});

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -150,6 +150,13 @@
 	text-transform: none;
 }
 
+/* Restore the legacy casing for view headers and Explorer titles when requested. */
+.style-override.modern-ui-uppercase-view-headers .monaco-pane-view .pane > .pane-header > .title,
+.style-override.modern-ui-uppercase-view-headers.monaco-workbench .part:not(.editor)[data-active-composite="workbench.view.explorer"] > .title > .title-label h2,
+.style-override.modern-ui-uppercase-view-headers .monaco-pane-view .pane > .pane-header > .icon.codicon-explorer-view-icon + .title {
+	text-transform: uppercase;
+}
+
 /*
  * Chat view title — the conversation title (e.g. "hello") shown in the chat
  * view header. It is dynamic text (user / model generated), so respect its real

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -150,9 +150,11 @@
 	text-transform: none;
 }
 
-/* Restore the legacy casing for view headers and Explorer titles when requested. */
+/* Restore the legacy casing for view, part, and composite tab headers when requested. */
 .style-override.modern-ui-uppercase-view-headers .monaco-pane-view .pane > .pane-header > .title,
-.style-override.modern-ui-uppercase-view-headers.monaco-workbench .part:not(.editor)[data-active-composite="workbench.view.explorer"] > .title > .title-label h2,
+.style-override.modern-ui-uppercase-view-headers.monaco-workbench .part:not(.editor) > .title > .title-label h2,
+.style-override.modern-ui-uppercase-view-headers.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.style-override.modern-ui-uppercase-view-headers.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
 .style-override.modern-ui-uppercase-view-headers .monaco-pane-view .pane > .pane-header > .icon.codicon-explorer-view-icon + .title {
 	text-transform: uppercase;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -55,6 +55,7 @@ interface IStyleOverrideModule {
  */
 const STYLE_OVERRIDE_CLASS = 'style-override';
 const MODERN_UI_TABS_CLASS = 'modern-ui-tabs';
+const MODERN_UI_UPPERCASE_VIEW_HEADERS_CLASS = 'modern-ui-uppercase-view-headers';
 
 /**
  * The fixed catalog of built-in style-override modules. The CSS for each module
@@ -108,7 +109,7 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		// A config change re-applies to every container (the global `update()`
 		// covers all windows, including auxiliary ones).
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
+			if (e.affectsConfiguration(LayoutSettings.MODERN_UI) || e.affectsConfiguration(LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS)) {
 				this.update();
 				// Some modules change layout metrics, so a relayout is required once
 				// their classes and corresponding layout values are updated.
@@ -123,7 +124,8 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		// Apply the current selection to windows opened after startup (e.g.
 		// auxiliary windows). Subsequent config changes are handled by `update()`.
 		this._register(this.layoutService.onDidAddContainer(({ container }) => {
-			this.applyTo(container, this.isEnabled());
+			const enabled = this.isEnabled();
+			this.applyTo(container, enabled, enabled && this.useUppercaseViewHeaders());
 		}));
 
 		this.update();
@@ -133,23 +135,29 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		return this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI) === true;
 	}
 
+	private useUppercaseViewHeaders(): boolean {
+		return this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS) === true;
+	}
+
 	private hasActiveLayoutAffectingModule(): boolean {
 		return this.isEnabled() && this.hasLayoutAffectingModule;
 	}
 
 	private update(): void {
 		const enabled = this.isEnabled();
+		const useUppercaseViewHeaders = enabled && this.useUppercaseViewHeaders();
 		this.applyPaneHeaderSize(enabled);
 		for (const container of this.layoutService.containers) {
-			this.applyTo(container, enabled);
+			this.applyTo(container, enabled, useUppercaseViewHeaders);
 		}
 		this.applyScrollbarSize(enabled);
 		this.applyNotificationRowHeight(enabled);
 	}
 
-	private applyTo(container: HTMLElement, enabled: boolean): void {
+	private applyTo(container: HTMLElement, enabled: boolean, useUppercaseViewHeaders: boolean): void {
 		container.classList.toggle(STYLE_OVERRIDE_CLASS, enabled);
 		container.classList.toggle(MODERN_UI_TABS_CLASS, enabled);
+		container.classList.toggle(MODERN_UI_UPPERCASE_VIEW_HEADERS_CLASS, useUppercaseViewHeaders);
 	}
 
 	private applyScrollbarSize(enabled: boolean): void {
@@ -169,6 +177,7 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		for (const container of this.layoutService.containers) {
 			container.classList.remove(STYLE_OVERRIDE_CLASS);
 			container.classList.remove(MODERN_UI_TABS_CLASS);
+			container.classList.remove(MODERN_UI_UPPERCASE_VIEW_HEADERS_CLASS);
 		}
 		setGlobalDefaultScrollbarSize(DEFAULT_SCROLLBAR_SIZE);
 		setNotificationRowHeight(DEFAULT_NOTIFICATION_ROW_HEIGHT);

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -80,7 +80,10 @@ suite('StyleOverridesContribution', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('applies startup values without relayout and relayouts once when toggled', async () => {
-		const configurationService = new TestConfigurationService({ [LayoutSettings.MODERN_UI]: true });
+		const configurationService = new TestConfigurationService({
+			[LayoutSettings.MODERN_UI]: true,
+			[LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS]: true,
+		});
 		store.add(configurationService.onDidChangeConfigurationEmitter);
 		const layoutService = new StyleOverridesTestLayoutService();
 		store.add(layoutService.onDidAddContainerEmitter);
@@ -100,8 +103,10 @@ suite('StyleOverridesContribution', () => {
 		const startupState = {
 			mainEnabled: layoutService.mainContainer.classList.contains('style-override'),
 			mainTabsEnabled: layoutService.mainContainer.classList.contains('modern-ui-tabs'),
+			mainUppercaseViewHeaders: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			auxiliaryEnabled: auxiliaryContainer.classList.contains('style-override'),
 			auxiliaryTabsEnabled: auxiliaryContainer.classList.contains('modern-ui-tabs'),
+			auxiliaryUppercaseViewHeaders: auxiliaryContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			paneHeaderSize: pane.minimumSize,
 			paneHeaderLineHeight: getWindow(pane.draggableElement!).getComputedStyle(pane.draggableElement!).lineHeight,
 			paneHeaderInlineLineHeight: pane.draggableElement!.style.lineHeight,
@@ -120,8 +125,10 @@ suite('StyleOverridesContribution', () => {
 			startupState,
 			mainEnabledAfterToggle: layoutService.mainContainer.classList.contains('style-override'),
 			mainTabsEnabledAfterToggle: layoutService.mainContainer.classList.contains('modern-ui-tabs'),
+			mainUppercaseViewHeadersAfterToggle: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			auxiliaryEnabledAfterToggle: auxiliaryContainer.classList.contains('style-override'),
 			auxiliaryTabsEnabledAfterToggle: auxiliaryContainer.classList.contains('modern-ui-tabs'),
+			auxiliaryUppercaseViewHeadersAfterToggle: auxiliaryContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			paneHeaderSizeAfterToggle: pane.minimumSize,
 			paneHeaderLineHeightAfterToggle: getWindow(pane.draggableElement!).getComputedStyle(pane.draggableElement!).lineHeight,
 			paneHeaderInlineLineHeightAfterToggle: pane.draggableElement!.style.lineHeight,
@@ -130,8 +137,10 @@ suite('StyleOverridesContribution', () => {
 			startupState: {
 				mainEnabled: true,
 				mainTabsEnabled: true,
+				mainUppercaseViewHeaders: true,
 				auxiliaryEnabled: true,
 				auxiliaryTabsEnabled: true,
+				auxiliaryUppercaseViewHeaders: true,
 				paneHeaderSize: 28,
 				paneHeaderLineHeight: '28px',
 				paneHeaderInlineLineHeight: '',
@@ -139,12 +148,73 @@ suite('StyleOverridesContribution', () => {
 			},
 			mainEnabledAfterToggle: false,
 			mainTabsEnabledAfterToggle: false,
+			mainUppercaseViewHeadersAfterToggle: false,
 			auxiliaryEnabledAfterToggle: false,
 			auxiliaryTabsEnabledAfterToggle: false,
+			auxiliaryUppercaseViewHeadersAfterToggle: false,
 			paneHeaderSizeAfterToggle: 22,
 			paneHeaderLineHeightAfterToggle: '22px',
 			paneHeaderInlineLineHeightAfterToggle: '',
 			layoutCountAfterToggle: 1,
+		});
+	});
+
+	test('toggles uppercase view headers without relayout', async () => {
+		const configurationService = new TestConfigurationService({
+			[LayoutSettings.MODERN_UI]: true,
+			[LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS]: false,
+		});
+		store.add(configurationService.onDidChangeConfigurationEmitter);
+		const layoutService = new StyleOverridesTestLayoutService();
+		store.add(layoutService.onDidAddContainerEmitter);
+		store.add(new StyleOverridesContribution(configurationService, layoutService));
+
+		layoutService.mainContainer.classList.add('monaco-workbench');
+		const paneView = appendElement(layoutService.mainContainer, 'monaco-pane-view');
+		const paneHeader = appendElement(appendElement(paneView, 'pane'), 'pane-header');
+		const paneTitle = appendElement(paneHeader, 'title');
+
+		const explorerPart = appendElement(layoutService.mainContainer, 'part');
+		explorerPart.dataset.activeComposite = 'workbench.view.explorer';
+		const explorerTitleLabel = appendElement(appendElement(explorerPart, 'title'), 'title-label');
+		const explorerTitle = document.createElement('h2');
+		explorerTitleLabel.appendChild(explorerTitle);
+
+		document.body.appendChild(layoutService.mainContainer);
+		store.add(toDisposable(() => layoutService.mainContainer.remove()));
+		const targetWindow = getWindow(layoutService.mainContainer);
+		const beforeToggle = {
+			classApplied: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
+			paneTitleTransform: targetWindow.getComputedStyle(paneTitle).textTransform,
+			explorerTitleTransform: targetWindow.getComputedStyle(explorerTitle).textTransform,
+			layoutCount: layoutService.layoutCount,
+		};
+
+		await configurationService.setUserConfiguration(LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS, true);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: key => key === LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS,
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS]),
+			change: { keys: [LayoutSettings.MODERN_UI_UPPERCASE_VIEW_HEADERS], overrides: [] }
+		});
+
+		assert.deepStrictEqual({
+			beforeToggle,
+			classApplied: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
+			paneTitleTransform: targetWindow.getComputedStyle(paneTitle).textTransform,
+			explorerTitleTransform: targetWindow.getComputedStyle(explorerTitle).textTransform,
+			layoutCount: layoutService.layoutCount,
+		}, {
+			beforeToggle: {
+				classApplied: false,
+				paneTitleTransform: 'capitalize',
+				explorerTitleTransform: 'none',
+				layoutCount: 0,
+			},
+			classApplied: true,
+			paneTitleTransform: 'uppercase',
+			explorerTitleTransform: 'uppercase',
+			layoutCount: 0,
 		});
 	});
 

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -56,7 +56,7 @@ function appendElement(parent: HTMLElement, className: string): HTMLElement {
 	return element;
 }
 
-function createCompositeAction(root: HTMLElement, titleHeight: number, checked: boolean, icon = false): { actionItem: HTMLElement; indicator: HTMLElement } {
+function createCompositeAction(root: HTMLElement, titleHeight: number, checked: boolean, icon = false): { actionItem: HTMLElement; actionLabel: HTMLElement; indicator: HTMLElement } {
 	root.style.setProperty('--vscode-spacing-size20', '2px');
 	root.style.setProperty('--vscode-spacing-size40', '4px');
 	root.style.setProperty('--vscode-spacing-size240', '24px');
@@ -70,9 +70,9 @@ function createCompositeAction(root: HTMLElement, titleHeight: number, checked: 
 	const actionsContainer = appendElement(actionBar, 'actions-container');
 	const actionItem = appendElement(actionsContainer, `action-item${checked ? ' checked' : ''}${icon ? ' icon' : ''}`);
 	actionItem.tabIndex = 0;
-	appendElement(actionItem, 'action-label');
+	const actionLabel = appendElement(actionItem, 'action-label');
 	const indicator = appendElement(actionItem, 'active-item-indicator');
-	return { actionItem, indicator };
+	return { actionItem, actionLabel, indicator };
 }
 
 suite('StyleOverridesContribution', () => {
@@ -179,6 +179,11 @@ suite('StyleOverridesContribution', () => {
 		const explorerTitleLabel = appendElement(appendElement(explorerPart, 'title'), 'title-label');
 		const explorerTitle = document.createElement('h2');
 		explorerTitleLabel.appendChild(explorerTitle);
+		const extensionsPart = appendElement(layoutService.mainContainer, 'part');
+		const extensionsTitleLabel = appendElement(appendElement(extensionsPart, 'title'), 'title-label');
+		const extensionsTitle = document.createElement('h2');
+		extensionsTitleLabel.appendChild(extensionsTitle);
+		const panelTab = createCompositeAction(layoutService.mainContainer, 35, true).actionLabel;
 
 		document.body.appendChild(layoutService.mainContainer);
 		store.add(toDisposable(() => layoutService.mainContainer.remove()));
@@ -187,6 +192,8 @@ suite('StyleOverridesContribution', () => {
 			classApplied: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			paneTitleTransform: targetWindow.getComputedStyle(paneTitle).textTransform,
 			explorerTitleTransform: targetWindow.getComputedStyle(explorerTitle).textTransform,
+			extensionsTitleTransform: targetWindow.getComputedStyle(extensionsTitle).textTransform,
+			panelTabTransform: targetWindow.getComputedStyle(panelTab).textTransform,
 			layoutCount: layoutService.layoutCount,
 		};
 
@@ -203,17 +210,23 @@ suite('StyleOverridesContribution', () => {
 			classApplied: layoutService.mainContainer.classList.contains('modern-ui-uppercase-view-headers'),
 			paneTitleTransform: targetWindow.getComputedStyle(paneTitle).textTransform,
 			explorerTitleTransform: targetWindow.getComputedStyle(explorerTitle).textTransform,
+			extensionsTitleTransform: targetWindow.getComputedStyle(extensionsTitle).textTransform,
+			panelTabTransform: targetWindow.getComputedStyle(panelTab).textTransform,
 			layoutCount: layoutService.layoutCount,
 		}, {
 			beforeToggle: {
 				classApplied: false,
 				paneTitleTransform: 'capitalize',
 				explorerTitleTransform: 'none',
+				extensionsTitleTransform: 'capitalize',
+				panelTabTransform: 'capitalize',
 				layoutCount: 0,
 			},
 			classApplied: true,
 			paneTitleTransform: 'uppercase',
 			explorerTitleTransform: 'uppercase',
+			extensionsTitleTransform: 'uppercase',
+			panelTabTransform: 'uppercase',
 			layoutCount: 0,
 		});
 	});

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -51,7 +51,8 @@ export const enum LayoutSettings {
 	COMMAND_CENTER = 'window.commandCenter',
 	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
 	SHADOWS = 'workbench.shadows',
-	MODERN_UI = 'workbench.experimental.modernUI'
+	MODERN_UI = 'workbench.experimental.modernUI',
+	MODERN_UI_UPPERCASE_VIEW_HEADERS = 'workbench.experimental.modernUIUppercaseViewHeaders'
 }
 
 /**


### PR DESCRIPTION
Update descriptions and restore legacy casing for view headers and tabs in the modern UI. Add support for uppercase view headers, allowing users to customize the appearance of view headers, side bar titles, and panel tabs. Test the changes by enabling the experimental settings in the configuration.

Resolves https://github.com/microsoft/vscode

