### PR TITLE
agentHost: keep GitHub context when refining the first-turn session title

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -50,6 +50,23 @@ interface IGitHubReferenceContext {
 	readonly value: GitHubIssueOrPullRequest;
 }
 
+/** Everything the utility model is told about when asked for a title. */
+interface ITitlePromptContext {
+	/** The request or conversation to title. */
+	readonly content: string;
+	/** Whether {@link content} is a whole conversation rather than a single request. */
+	readonly isConversation: boolean;
+	/**
+	 * Text scanned for GitHub issue / pull request links whose title and body
+	 * are appended to {@link content}. Usually the user's request: links the
+	 * agent merely mentioned in its response should not pull in context.
+	 * Omitted when no enrichment should happen.
+	 */
+	readonly gitHubReferenceSource?: string;
+	/** The title in place already, offered to the model as the incumbent. */
+	readonly currentTitle?: string;
+}
+
 export interface IAgentHostSessionTitleControllerOptions {
 	readonly sessionDataService: ISessionDataService;
 	readonly getGitHubCopilotToken?: () => string | undefined;
@@ -109,8 +126,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		}
 		this._generateTitleSoon(
 			key,
-			userPrompt,
-			false,
+			{ content: userPrompt, isConversation: false, gitHubReferenceSource: userPrompt },
 			fallbackTitle,
 			title => this._applySeedTitle(channel, additionalChat, title),
 			() => this._currentSeedTitle(channel, additionalChat) === this._lastAppliedTitle.get(key),
@@ -209,6 +225,14 @@ export class AgentHostSessionTitleController extends Disposable {
 	 * this controller last applied — a manual `/rename`, a user edit, or a
 	 * forked session's inherited title all suppress it.
 	 *
+	 * The request is re-scanned for GitHub issue / pull request links and the
+	 * referenced titles and bodies are appended, exactly as when the opening
+	 * message was titled: a request that is little more than an issue link
+	 * carries all of its meaning there, and dropping that context made this
+	 * pass regress such titles to a generic restatement of the link. The
+	 * incumbent title is passed along too, so the model only replaces it when
+	 * the completed turn is genuinely more informative.
+	 *
 	 * Only normal text response parts are considered (tool calls, reasoning,
 	 * and other parts are ignored). If the context still exceeds the budget
 	 * the middle is removed (marked with `...`). The user's first request is
@@ -225,15 +249,15 @@ export class AgentHostSessionTitleController extends Disposable {
 			if (lastApplied === undefined || chatState.title !== lastApplied) {
 				return;
 			}
-			const context = this._buildFirstTurnContext(chatState.turns[0]);
+			const turn = chatState.turns[0];
+			const context = this._buildFirstTurnContext(turn);
 			if (!context) {
 				return;
 			}
 			const apply = (title: string) => this._applyTitle(chatChannel, title, t => this._stateManager.updateChatTitle(channel, chatChannel, t));
 			this._generateTitleSoon(
 				chatChannel,
-				context,
-				true,
+				{ content: context, isConversation: true, gitHubReferenceSource: turn.message.text, currentTitle: lastApplied },
 				lastApplied,
 				apply,
 				() => this._stateManager.getChatState(chatChannel)?.title === this._lastAppliedTitle.get(chatChannel),
@@ -250,7 +274,8 @@ export class AgentHostSessionTitleController extends Disposable {
 		if (lastApplied === undefined || state.title !== lastApplied) {
 			return;
 		}
-		const context = this._buildFirstTurnContext(state.turns[0]);
+		const turn = state.turns[0];
+		const context = this._buildFirstTurnContext(turn);
 		if (!context) {
 			return;
 		}
@@ -260,8 +285,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		}));
 		this._generateTitleSoon(
 			channel,
-			context,
-			true,
+			{ content: context, isConversation: true, gitHubReferenceSource: turn.message.text, currentTitle: lastApplied },
 			lastApplied,
 			apply,
 			() => this._stateManager.getSessionState(channel)?.title === this._lastAppliedTitle.get(channel),
@@ -298,8 +322,7 @@ export class AgentHostSessionTitleController extends Disposable {
 			const apply = (title: string) => this._applyTitle(key, title, t => this._stateManager.updateChatTitle(channel, key, t));
 			this._generateTitleSoon(
 				key,
-				context,
-				true,
+				{ content: context, isConversation: true },
 				fallbackTitle,
 				apply,
 				() => this._stateManager.getChatState(key)?.title === this._lastAppliedTitle.get(key),
@@ -315,8 +338,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		}));
 		this._generateTitleSoon(
 			channel,
-			context,
-			true,
+			{ content: context, isConversation: true },
 			fallbackTitle,
 			apply,
 			() => this._stateManager.getSessionState(channel)?.title === this._lastAppliedTitle.get(channel),
@@ -335,8 +357,7 @@ export class AgentHostSessionTitleController extends Disposable {
 
 	private _generateTitleSoon(
 		key: ProtocolURI,
-		promptContent: string,
-		isConversation: boolean,
+		prompt: ITitlePromptContext,
 		fallbackTitle: string,
 		apply: (title: string) => void,
 		currentTitleMatchesFallback: () => boolean,
@@ -345,7 +366,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		this._cancelTitleGeneration(key);
 		const source = new CancellationTokenSource();
 		this._titleGenerationCancellationSources.set(key, source);
-		void this._generateTitle(key, promptContent, isConversation, fallbackTitle, apply, currentTitleMatchesFallback, persist, source.token).catch(err => {
+		void this._generateTitle(key, prompt, fallbackTitle, apply, currentTitleMatchesFallback, persist, source.token).catch(err => {
 			if (!source.token.isCancellationRequested) {
 				this._logService.warn(`[AgentHostSessionTitleController] Failed to apply generated title for ${key}`, err);
 			}
@@ -359,15 +380,14 @@ export class AgentHostSessionTitleController extends Disposable {
 
 	private async _generateTitle(
 		key: ProtocolURI,
-		promptContent: string,
-		isConversation: boolean,
+		prompt: ITitlePromptContext,
 		fallbackTitle: string,
 		apply: (title: string) => void,
 		currentTitleMatchesFallback: () => boolean,
 		persist: (title: string) => void,
 		token: CancellationToken,
 	): Promise<void> {
-		const generatedTitle = await this._generateTitleFromPrompt(promptContent, isConversation, token);
+		const generatedTitle = await this._generateTitleFromPrompt(prompt, token);
 		if (token.isCancellationRequested || !generatedTitle) {
 			return;
 		}
@@ -382,7 +402,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		persist(generatedTitle);
 	}
 
-	private async _generateTitleFromPrompt(promptContent: string, isConversation: boolean, token: CancellationToken): Promise<string | undefined> {
+	private async _generateTitleFromPrompt(prompt: ITitlePromptContext, token: CancellationToken): Promise<string | undefined> {
 		if (token.isCancellationRequested) {
 			return undefined;
 		}
@@ -396,14 +416,14 @@ export class AgentHostSessionTitleController extends Disposable {
 		const abortController = new AbortController();
 		const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 		try {
-			const titlePromptContent = isConversation
-				? promptContent
-				: await this._appendGitHubContext(promptContent, abortController.signal, token);
+			const titlePromptContent = prompt.gitHubReferenceSource === undefined
+				? prompt.content
+				: await this._appendGitHubContext(prompt.content, prompt.gitHubReferenceSource, abortController.signal, token);
 			if (token.isCancellationRequested) {
 				return undefined;
 			}
 			const rawTitle = await copilotApiService.utilityChatCompletion(githubToken, {
-				messages: this._buildTitlePrompt(titlePromptContent, isConversation),
+				messages: this._buildTitlePrompt(titlePromptContent, prompt),
 				maxTokens: MAX_TITLE_TOKENS,
 			}, {
 				signal: abortController.signal,
@@ -420,8 +440,14 @@ export class AgentHostSessionTitleController extends Disposable {
 		}
 	}
 
-	private async _appendGitHubContext(promptContent: string, cancellationSignal: AbortSignal, token: CancellationToken): Promise<string> {
-		const references = this._parseGitHubReferences(promptContent);
+	/**
+	 * Appends the title and body of every GitHub issue / pull request linked
+	 * from `referenceSource` to `promptContent`. The two differ when titling a
+	 * conversation: the links are taken from the user's request alone, while
+	 * the enriched text is the whole conversation.
+	 */
+	private async _appendGitHubContext(promptContent: string, referenceSource: string, cancellationSignal: AbortSignal, token: CancellationToken): Promise<string> {
+		const references = this._parseGitHubReferences(referenceSource);
 		const githubToken = this._options.getGitHubToken?.();
 		const octoKitService = this._options.octoKitService;
 		if (references.length === 0 || !githubToken || !octoKitService) {
@@ -517,10 +543,14 @@ export class AgentHostSessionTitleController extends Disposable {
 		].join('\n');
 	}
 
-	private _buildTitlePrompt(promptContent: string, isConversation: boolean): ICopilotUtilityChatMessage[] {
-		const userInstruction = isConversation
+	private _buildTitlePrompt(promptContent: string, prompt: ITitlePromptContext): ICopilotUtilityChatMessage[] {
+		const request = prompt.isConversation
 			? `Please write a brief title for the following conversation:\n\n${promptContent}`
 			: `Please write a brief title for the following request:\n\n${promptContent}`;
+		const currentTitle = prompt.currentTitle?.trim();
+		const userInstruction = currentTitle
+			? `${request}\n\nIts current title is: ${currentTitle}\nReply with that same title unless the text above supports a clearly more accurate one.`
+			: request;
 		return [
 			{
 				role: 'system',

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -30,11 +30,18 @@ const TRAILING_HAN_SUFFIX = /(?<!\p{sc=Han})\p{sc=Han}{2,3}$/u;
 const GITHUB_ISSUE_OR_PULL_REQUEST_URL_PATTERN = /\bhttps?:\/\/(?<host>[\w.-]+)\/(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)\/(?<kind>issues|pull)\/(?<number>\d+)\b/gi;
 
 /**
- * Soft upper bound, in characters, for the first-turn context fed to the
- * utility model when refining a session title. Sized to stay well within the
- * small model's context window while leaving room for the prompt scaffolding.
+ * Soft upper bound, in characters, for the whole context fed to the utility
+ * model when titling a session, including any appended GitHub context. Sized
+ * to stay well within the small model's context window while leaving room for
+ * the prompt scaffolding.
  */
 const MAX_TITLE_CONTEXT_CHARS = 20000;
+
+/**
+ * Slice of {@link MAX_TITLE_CONTEXT_CHARS} always available to GitHub context,
+ * so a referenced issue title survives even a budget-filling conversation.
+ */
+const MIN_GITHUB_CONTEXT_CHARS = 4_000;
 
 type GitHubReferenceKind = 'issue' | 'pull request';
 
@@ -56,12 +63,7 @@ interface ITitlePromptContext {
 	readonly content: string;
 	/** Whether {@link content} is a whole conversation rather than a single request. */
 	readonly isConversation: boolean;
-	/**
-	 * Text scanned for GitHub issue / pull request links whose title and body
-	 * are appended to {@link content}. Usually the user's request: links the
-	 * agent merely mentioned in its response should not pull in context.
-	 * Omitted when no enrichment should happen.
-	 */
+	/** Text scanned for GitHub links to enrich {@link content} with, or `undefined` to skip enrichment. */
 	readonly gitHubReferenceSource?: string;
 	/** The title in place already, offered to the model as the incumbent. */
 	readonly currentTitle?: string;
@@ -224,14 +226,6 @@ export class AgentHostSessionTitleController extends Disposable {
 	 * for the very first turn and only when the current title is still the one
 	 * this controller last applied — a manual `/rename`, a user edit, or a
 	 * forked session's inherited title all suppress it.
-	 *
-	 * The request is re-scanned for GitHub issue / pull request links and the
-	 * referenced titles and bodies are appended, exactly as when the opening
-	 * message was titled: a request that is little more than an issue link
-	 * carries all of its meaning there, and dropping that context made this
-	 * pass regress such titles to a generic restatement of the link. The
-	 * incumbent title is passed along too, so the model only replaces it when
-	 * the completed turn is genuinely more informative.
 	 *
 	 * Only normal text response parts are considered (tool calls, reasoning,
 	 * and other parts are ignored). If the context still exceeds the budget
@@ -441,10 +435,12 @@ export class AgentHostSessionTitleController extends Disposable {
 	}
 
 	/**
-	 * Appends the title and body of every GitHub issue / pull request linked
-	 * from `referenceSource` to `promptContent`. The two differ when titling a
-	 * conversation: the links are taken from the user's request alone, while
-	 * the enriched text is the whole conversation.
+	 * Appends the GitHub issue / pull requests linked from `referenceSource` to
+	 * `promptContent`, keeping the combined text within
+	 * {@link MAX_TITLE_CONTEXT_CHARS}. Enrichment is guaranteed
+	 * {@link MIN_GITHUB_CONTEXT_CHARS}; whatever it leaves over bounds
+	 * `promptContent`, whose middle is dropped so the request at its head and
+	 * the response tail both survive.
 	 */
 	private async _appendGitHubContext(promptContent: string, referenceSource: string, cancellationSignal: AbortSignal, token: CancellationToken): Promise<string> {
 		const references = this._parseGitHubReferences(referenceSource);
@@ -478,7 +474,12 @@ export class AgentHostSessionTitleController extends Disposable {
 			if (successfulContexts.length === 0) {
 				return promptContent;
 			}
-			return `${promptContent}\n\n${this._formatGitHubContexts(successfulContexts)}`;
+			const separator = '\n\n';
+			const gitHubBudget = Math.max(MIN_GITHUB_CONTEXT_CHARS, MAX_TITLE_CONTEXT_CHARS - promptContent.length - separator.length);
+			const gitHubContext = this._formatGitHubContexts(successfulContexts, gitHubBudget);
+			const contentBudget = Math.max(0, MAX_TITLE_CONTEXT_CHARS - gitHubContext.length - separator.length);
+			const content = promptContent.length > contentBudget ? truncateMiddle(promptContent, contentBudget) : promptContent;
+			return `${content}${separator}${gitHubContext}`;
 		} finally {
 			limiter.dispose();
 		}
@@ -516,12 +517,12 @@ export class AgentHostSessionTitleController extends Disposable {
 		return normalizedHost === 'www.github.com' ? 'github.com' : normalizedHost;
 	}
 
-	private _formatGitHubContexts(contexts: readonly IGitHubReferenceContext[]): string {
+	private _formatGitHubContexts(contexts: readonly IGitHubReferenceContext[], budget: number): string {
 		const heading = 'GitHub issue and pull request context:\n\n';
 		const fixedLength = heading.length + contexts.reduce((length, context, index) => {
 			return length + this._formatGitHubContext(context.reference, context.value, '').length + (index === 0 ? 0 : 2);
 		}, 0);
-		let remainingBodyBudget = Math.max(0, MAX_TITLE_CONTEXT_CHARS - fixedLength);
+		let remainingBodyBudget = Math.max(0, budget - fixedLength);
 		const sections = contexts.map((context, index) => {
 			const bodyBudget = Math.min(
 				MAX_GITHUB_CONTEXT_BODY_CHARS,
@@ -531,7 +532,7 @@ export class AgentHostSessionTitleController extends Disposable {
 			remainingBodyBudget -= body.length;
 			return this._formatGitHubContext(context.reference, context.value, body);
 		});
-		return truncateMiddle(`${heading}${sections.join('\n\n')}`, MAX_TITLE_CONTEXT_CHARS);
+		return truncateMiddle(`${heading}${sections.join('\n\n')}`, budget);
 	}
 
 	private _formatGitHubContext(reference: IGitHubReference, value: GitHubIssueOrPullRequest, body: string): string {

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -351,24 +351,28 @@ suite('AgentHostSessionTitleController', () => {
 		});
 	});
 
-	test('seedTitleFromFirstMessage caps the fully formatted GitHub context', async () => {
+	test('seedTitleFromFirstMessage caps the combined prompt and GitHub context', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		const octoKitService = new TestAgentHostOctoKitService();
 		octoKitService.responses.set('microsoft/vscode#123', { title: `start${'x'.repeat(30_000)}end`, body: '' });
 		const { controller, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const prompt = 'Fix https://github.com/microsoft/vscode/issues/123';
 
-		controller.seedTitleFromFirstMessage(session.toString(), 'Fix https://github.com/microsoft/vscode/issues/123');
+		controller.seedTitleFromFirstMessage(session.toString(), prompt);
 		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
 
 		const userMessage = copilotApiService.utilityCalls[0].request.messages.find(message => message.role === 'user')?.content ?? '';
+		const promptContent = userMessage.slice(userMessage.indexOf(prompt));
 		const context = userMessage.slice(userMessage.indexOf('GitHub issue and pull request context:'));
 		assert.deepStrictEqual({
-			contextLength: context.length,
+			promptContentLength: promptContent.length,
+			keepsRequest: promptContent.startsWith(prompt),
 			hasStart: context.includes('start'),
 			hasTruncationMarker: context.includes('\n...\n'),
 			hasEnd: context.includes('end'),
 		}, {
-			contextLength: 20_000,
+			promptContentLength: 20_000,
+			keepsRequest: true,
 			hasStart: true,
 			hasTruncationMarker: true,
 			hasEnd: true,
@@ -789,6 +793,38 @@ suite('AgentHostSessionTitleController', () => {
 		}, {
 			fetched: [123, 123],
 			includesMentionedIssueContext: false,
+		});
+	});
+
+	test('refineTitleFromFirstTurn keeps the issue title within budget despite an oversized response', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Local commit lookup fails', body: 'C'.repeat(30_000) });
+		const { controller, stateManager, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const request = 'Tackle this issue: https://github.com/microsoft/vscode/issues/123';
+		await seedFirstTitle(controller, copilotApiService, db, session, request, 'First title');
+
+		copilotApiService.response = 'Refined title';
+		const hugeResponse = 'A'.repeat(15_000) + ' MIDDLE_MARKER ' + 'B'.repeat(15_000);
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn(request, [textPart(hugeResponse)])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Refined title', 'refined title should be persisted');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		const promptContent = userMessage.slice(userMessage.indexOf('User request:'), userMessage.indexOf('\n\nIts current title is:'));
+		assert.deepStrictEqual({
+			promptContentLength: promptContent.length,
+			includesUserRequest: promptContent.includes(request),
+			includesIssueTitle: promptContent.includes('The title of the issue is: Local commit lookup fails'),
+			keepsResponseHeadAndTail: promptContent.includes('AAAA') && promptContent.includes('BBBB'),
+			middleTruncated: !promptContent.includes('MIDDLE_MARKER'),
+		}, {
+			promptContentLength: 20_000,
+			includesUserRequest: true,
+			includesIssueTitle: true,
+			keepsResponseHeadAndTail: true,
+			middleTruncated: true,
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -739,6 +739,59 @@ suite('AgentHostSessionTitleController', () => {
 		});
 	});
 
+	test('refineTitleFromFirstTurn appends GitHub context from the request and offers the current title', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Agent Host logs an error when a local commit is not on GitHub', body: 'Issue body' });
+		const { controller, stateManager, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const request = 'Tackle this issue: https://github.com/microsoft/vscode/issues/123';
+		await seedFirstTitle(controller, copilotApiService, db, session, request, 'First title');
+
+		copilotApiService.response = 'Missing commit lookup error';
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn(request, [textPart('Fixed the pull request lookup.')])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Missing commit lookup error', 'refined title should be persisted');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			fetched: octoKitService.calls.map(call => call.number),
+			includesIssueTitle: userMessage.includes('The title of the issue is: Agent Host logs an error when a local commit is not on GitHub'),
+			includesResponse: userMessage.includes('Fixed the pull request lookup.'),
+			includesCurrentTitle: userMessage.includes('Its current title is: First title'),
+		}, {
+			fetched: [123, 123],
+			includesIssueTitle: true,
+			includesResponse: true,
+			includesCurrentTitle: true,
+		});
+	});
+
+	test('refineTitleFromFirstTurn ignores GitHub links the agent only mentioned in its response', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const octoKitService = new TestAgentHostOctoKitService();
+		octoKitService.responses.set('microsoft/vscode#123', { title: 'Requested issue', body: 'Issue body' });
+		octoKitService.responses.set('microsoft/vscode#456', { title: 'Mentioned issue', body: 'Other body' });
+		const { controller, stateManager, session, db } = setup(copilotApiService, '', () => 'gh-token', octoKitService);
+		const request = 'Tackle this issue: https://github.com/microsoft/vscode/issues/123';
+		await seedFirstTitle(controller, copilotApiService, db, session, request, 'First title');
+
+		copilotApiService.response = 'Refined title';
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn(request, [textPart('This also affects https://github.com/microsoft/vscode/issues/456')])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Refined title', 'refined title should be persisted');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			fetched: octoKitService.calls.map(call => call.number),
+			includesMentionedIssueContext: userMessage.includes('The title of the issue is: Mentioned issue'),
+		}, {
+			fetched: [123, 123],
+			includesMentionedIssueContext: false,
+		});
+	});
+
 	function turn(id: string, text: string, responseParts: ResponsePart[]): Turn {
 		return {
 			id,


### PR DESCRIPTION
Fixes the Agents session title being renamed from a good, issue-derived title to a generic one shortly after the first turn completes.

### What was happening

Titles are generated twice: once from the opening message (`seedTitleFromFirstMessage`) and once after the first turn completes (`refineTitleFromFirstTurn`). Only the first pass appended GitHub issue/pull request context, because the enrichment was gated on `isConversation` — the same flag that distinguishes "a single request" from "a whole conversation" in the prompt wording.

So a session started with `Tackle this issue: <link>` was titled well from the issue contents, and then renamed to a generic restatement of the link once the first turn finished. The refine pass only sees the user request plus markdown response parts, and a tool-heavy first turn leaves it with almost no signal — the request itself is just a URL. Observed on a real session: a title derived from *"Agent Host logs an error when a local commit is not on GitHub"* was replaced by `Fix for vscode issue #330072`.

### What changed

- Prompt inputs are now a small `ITitlePromptContext` record, and GitHub enrichment is driven by an explicit `gitHubReferenceSource` instead of `isConversation`. The refine pass passes it, so it sees the same issue/PR titles and bodies the seed pass did.
- Links are parsed from the user's request rather than the enriched content. An issue the agent merely *mentioned* in its response can no longer pull in unrelated context (or extra API calls). For the seed pass both strings are identical, so its prompt is byte-for-byte unchanged.
- The refine pass also passes the incumbent title, and the prompt asks the model to keep it unless the completed turn supports a clearly more accurate one.

`generateForkedTitle` is untouched: it already frames the source title inside its own context and does no GitHub lookups.

### Notes for reviewers

The existing seed tests assert exact equality on the generated user message, so they confirm the first pass is unaffected. Two tests were added covering the refine pass: that it appends the issue context and offers the current title, and that it ignores links that appear only in the agent's response.

Verified with `tsc --noEmit` on `src/tsconfig.json`, ESLint on both files, and the full `AgentHostSessionTitleController` suite (27 passing).
