### PR TITLE
Escape backslashes in trusted domains

### DIFF
--- a/src/vs/platform/url/common/trustedDomains.ts
+++ b/src/vs/platform/url/common/trustedDomains.ts
@@ -15,7 +15,7 @@ import { testUrlMatchesGlob } from './urlGlob.js';
  * - Star matches all subdomains. For example https://*.microsoft.com matches https://www.microsoft.com and https://foo.bar.microsoft.com
  */
 export function isURLDomainTrusted(url: URI, trustedDomains: string[]): boolean {
-	url = URI.parse(normalizeURL(url));
+	url = URI.parse(normalizeURL(url).replace(/\\/g, '/'));
 	trustedDomains = trustedDomains.map(normalizeURL);
 
 	if (isLocalhostAuthority(url.authority)) {

--- a/src/vs/platform/url/common/trustedDomains.ts
+++ b/src/vs/platform/url/common/trustedDomains.ts
@@ -15,8 +15,8 @@ import { testUrlMatchesGlob } from './urlGlob.js';
  * - Star matches all subdomains. For example https://*.microsoft.com matches https://www.microsoft.com and https://foo.bar.microsoft.com
  */
 export function isURLDomainTrusted(url: URI, trustedDomains: string[]): boolean {
-	url = URI.parse(normalizeURL(url).replace(/\\/g, '/'));
-	trustedDomains = trustedDomains.map(normalizeURL);
+	url = URI.parse(normalizeURL(url.toString(true).replace(/\\/g, '/')));
+	trustedDomains = trustedDomains.map(domain => normalizeURL(domain.replace(/\\/g, '/')));
 
 	if (isLocalhostAuthority(url.authority)) {
 		return true;

--- a/src/vs/platform/url/test/common/trustedDomains.test.ts
+++ b/src/vs/platform/url/test/common/trustedDomains.test.ts
@@ -22,6 +22,11 @@ suite('trustedDomains', () => {
 			assert.strictEqual(isURLDomainTrusted(URI.parse('http://[::1]:3000'), []), true);
 		});
 
+		test('backslashes are treated as URL path separators', () => {
+			assert.strictEqual(isURLDomainTrusted(URI.parse('https://example.com\\.localhost'), []), false);
+			assert.strictEqual(isURLDomainTrusted(URI.parse('https://example.com\\.github.com'), ['https://*.github.com']), false);
+		});
+
 		test('wildcard (*) matches everything', () => {
 			assert.strictEqual(isURLDomainTrusted(URI.parse('https://example.com'), ['*']), true);
 			assert.strictEqual(isURLDomainTrusted(URI.parse('http://anything.org'), ['*']), true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This aligns both the chromium parsing and the trusted domain node parsing so a link that has backslashes in it doesn't appear different in the opener prompt to what is actually opened