### PR TITLE
agentHost: show Codex download progress during ChatGPT sign-in

### DIFF
--- a/src/vs/platform/agentHost/common/codexAccount.ts
+++ b/src/vs/platform/agentHost/common/codexAccount.ts
@@ -16,7 +16,7 @@ export interface ICodexAccountRateLimitInfo {
 }
 
 export interface ICodexAccountInfo {
-	readonly status: 'unknown' | 'signedIn' | 'signedOut' | 'unavailable' | 'error';
+	readonly status: 'unknown' | 'downloading' | 'signedIn' | 'signedOut' | 'unavailable' | 'error';
 	readonly email?: string;
 	readonly planType?: string;
 	readonly requiresOpenaiAuth?: boolean;
@@ -33,7 +33,7 @@ export function readCodexAccountInfo(state: RootState | undefined): ICodexAccoun
 		return { status: 'unknown' };
 	}
 	const account = value as Partial<ICodexAccountInfo>;
-	if (account.status !== 'unknown' && account.status !== 'signedIn' && account.status !== 'signedOut' && account.status !== 'unavailable' && account.status !== 'error') {
+	if (account.status !== 'unknown' && account.status !== 'downloading' && account.status !== 'signedIn' && account.status !== 'signedOut' && account.status !== 'unavailable' && account.status !== 'error') {
 		return { status: 'unknown' };
 	}
 	const rateLimit = account.rateLimit;

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -296,10 +296,10 @@ async function startAgentHost(): Promise<void> {
 
 	// Surface agent-SDK download progress to clients as generic `progress`
 	// notifications. The downloader fires process-global frames keyed by package
-	// id; the agent service fans each out to the `createSession` progress tokens
-	// of the sessions waiting on that provider's SDK, routed through the state
-	// manager so both the local (IPC) and any external (WebSocket) renderer
-	// receive them via the same path as session updates.
+	// id; the agent service surfaces frames requested by a waiting session or
+	// another user-initiated flow, routed through the state manager so both the
+	// local (IPC) and any external (WebSocket) renderer receive them via the same
+	// path as session updates.
 	if (sdkDownloadProgress) {
 		disposables.add(sdkDownloadProgress(p => agentService.emitDownloadProgress(
 			p.packageId,
@@ -307,6 +307,7 @@ async function startAgentHost(): Promise<void> {
 			p.receivedBytes,
 			p.totalBytes,
 			p.phase === 'completed' || p.phase === 'failed',
+			p.explicitlyRequested,
 		)));
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -362,10 +362,10 @@ async function main(): Promise<void> {
 
 	// Surface agent-SDK download progress to clients as generic `progress`
 	// notifications. The downloader fires process-global frames keyed by package
-	// id; the agent service fans each out to the `createSession` progress tokens
-	// of the sessions waiting on that provider's SDK, routed through the state
-	// manager so both local (IPC) and remote (WebSocket) renderers receive them
-	// via the same path as session updates.
+	// id; the agent service surfaces frames requested by a waiting session or
+	// another user-initiated flow, routed through the state manager so both local
+	// (IPC) and remote (WebSocket) renderers receive them via the same path as
+	// session updates.
 	if (sdkDownloadProgress) {
 		disposables.add(sdkDownloadProgress(p => agentService.emitDownloadProgress(
 			p.packageId,
@@ -373,6 +373,7 @@ async function main(): Promise<void> {
 			p.receivedBytes,
 			p.totalBytes,
 			p.phase === 'completed' || p.phase === 'failed',
+			p.explicitlyRequested,
 		)));
 	}
 

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -9,7 +9,7 @@ import { VSBuffer } from '../../../base/common/buffer.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { CancellationError } from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
 import { format2 } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
@@ -144,6 +144,8 @@ export interface IAgentSdkDownloadProgress {
 	readonly receivedBytes: number;
 	/** Total bytes from `Content-Length`, or `undefined` when unknown (indeterminate). */
 	readonly totalBytes: number | undefined;
+	/** Whether a user-initiated flow explicitly requested that this download be surfaced. */
+	readonly explicitlyRequested: boolean;
 	/** Short, non-localized failure reason; present only when `phase: 'failed'`. */
 	readonly error?: string;
 }
@@ -159,6 +161,13 @@ export interface IAgentSdkDownloader {
 	 * progress to clients regardless of which session triggered the fetch.
 	 */
 	readonly onDidDownloadProgress: Event<IAgentSdkDownloadProgress>;
+
+	/**
+	 * Keep download progress visible for a user-initiated flow that does not
+	 * have a session progress token, such as ChatGPT sign-in. Dispose the
+	 * returned handle when the flow finishes.
+	 */
+	acquireDownloadProgressInterest(pkg: IAgentSdkPackage): IDisposable;
 
 	/**
 	 * Returns the absolute path of the SDK root directory — the directory that
@@ -241,6 +250,8 @@ export class AgentSdkDownloader extends Disposable implements IAgentSdkDownloade
 	 * cacheDirs differ.
 	 */
 	private readonly _pendingDownloads = new Map<string, Promise<string>>();
+	/** Refcounted user-initiated progress interest, keyed by package id. */
+	private readonly _explicitProgressInterest = new Map<string, number>();
 
 	/**
 	 * Negative cache: most recent failure per package id, with an expiry.
@@ -271,6 +282,18 @@ export class AgentSdkDownloader extends Disposable implements IAgentSdkDownloade
 			return true;
 		}
 		return !!this._productService.agentSdks?.[pkg.id] && resolveSdkTarget(pkg) !== undefined;
+	}
+
+	acquireDownloadProgressInterest(pkg: IAgentSdkPackage): IDisposable {
+		this._explicitProgressInterest.set(pkg.id, (this._explicitProgressInterest.get(pkg.id) ?? 0) + 1);
+		return toDisposable(() => {
+			const count = this._explicitProgressInterest.get(pkg.id) ?? 0;
+			if (count <= 1) {
+				this._explicitProgressInterest.delete(pkg.id);
+			} else {
+				this._explicitProgressInterest.set(pkg.id, count - 1);
+			}
+		});
 	}
 
 	async isSdkResolvableWithoutDownload(pkg: IAgentSdkPackage): Promise<boolean> {
@@ -488,6 +511,7 @@ export class AgentSdkDownloader extends Disposable implements IAgentSdkDownloade
 			phase,
 			receivedBytes,
 			totalBytes,
+			explicitlyRequested: this._explicitProgressInterest.has(pkg.id),
 			...(error !== undefined ? { error } : {}),
 		});
 	}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -2001,9 +2001,10 @@ export class AgentService extends Disposable implements IAgentService {
 	 * because the download is shared across every session of that provider, we
 	 * emit a SINGLE `progress` stream keyed by that package id — not one per
 	 * session — so the client shows exactly one indicator no matter how many
-	 * sessions of the provider are awaiting it. Frames are only emitted while at
-	 * least one session has opted in (supplied a
-	 * {@link IAgentCreateSessionConfig.progressToken} on `createSession`). A
+	 * sessions of the provider are awaiting it. Frames are emitted while at least
+	 * one session has opted in (supplied a
+	 * {@link IAgentCreateSessionConfig.progressToken} on `createSession`) or a
+	 * user-initiated flow has explicitly requested progress. A
 	 * terminal frame reports `total === progress` (using `receivedBytes` when the
 	 * size was never known) so the client dismisses the indicator deterministically.
 	 *
@@ -2014,9 +2015,9 @@ export class AgentService extends Disposable implements IAgentService {
 	 * ellipsis: clients render progress as "<title>: <percent>", so an ellipsis
 	 * would read as an unusual "…:" (see #324455).
 	 */
-	emitDownloadProgress(packageId: string, displayName: string, receivedBytes: number, totalBytes: number | undefined, terminal: boolean): void {
+	emitDownloadProgress(packageId: string, displayName: string, receivedBytes: number, totalBytes: number | undefined, terminal: boolean, explicitlyRequested = false): void {
 		const sessions = this._downloadProgressInterest.get(packageId);
-		if (!sessions || sessions.size === 0) {
+		if ((!sessions || sessions.size === 0) && !explicitlyRequested) {
 			return;
 		}
 		// On a terminal frame force `progress === total` so clients treat the

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -923,7 +923,11 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	private async _signInToChatGPT(request: string): Promise<void> {
+		const progressInterest = this._agentSdkDownloader.acquireDownloadProgressInterest(CodexSdkPackage);
 		try {
+			if (!(await this._isSdkResolvableWithoutDownload())) {
+				this._publishAccountInfo({ status: 'downloading' });
+			}
 			const connection = await this._ensureConnection();
 			const account = await this._refreshAccount(connection.client);
 			if (account.status === 'signedIn' && account.authType === 'chatgpt') {
@@ -936,6 +940,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this._setOpenAIAccountState({ usageSource: 'openai', status: 'error', error: message });
+		} finally {
+			progressInterest.dispose();
 		}
 	}
 
@@ -1522,8 +1528,8 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	private async _isSdkResolvableWithoutDownload(): Promise<boolean> {
-		if (await this._agentSdkDownloader.isSdkResolvableWithoutDownload?.(CodexSdkPackage)) {
-			return true;
+		if (this._agentSdkDownloader.isAvailable(CodexSdkPackage)) {
+			return this._agentSdkDownloader.isSdkResolvableWithoutDownload(CodexSdkPackage);
 		}
 		return (await resolveCodexDevSdkRoot()) !== undefined;
 	}

--- a/src/vs/platform/agentHost/test/common/codexAccount.test.ts
+++ b/src/vs/platform/agentHost/test/common/codexAccount.test.ts
@@ -41,4 +41,13 @@ suite('Codex account metadata', () => {
 		assert.strictEqual(account.status, 'signedIn');
 		assert.strictEqual(account.rateLimit, undefined);
 	});
+
+	test('reads the downloading account state', () => {
+		const account = readCodexAccountInfo({
+			agents: [],
+			_meta: { [CODEX_ACCOUNT_META_KEY]: { status: 'downloading' } },
+		});
+
+		assert.strictEqual(account.status, 'downloading');
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -306,6 +306,18 @@ suite('AgentSdkDownloader', () => {
 		assert.strictEqual(completed.receivedBytes, tarballSize);
 	});
 
+	test('loadSdkRoot: marks progress explicitly requested by a user-initiated flow', async () => {
+		const downloader = makeDownloader();
+		const samples: IAgentSdkDownloadProgress[] = [];
+		disposables.add(downloader.onDidDownloadProgress(p => samples.push(p)));
+		disposables.add(downloader.acquireDownloadProgressInterest(ClaudeSdkPackage));
+
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+
+		assert.ok(samples.length >= 2);
+		assert.ok(samples.every(sample => sample.explicitlyRequested));
+	});
+
 	test('loadSdkRoot: cache hit returns immediately without re-downloading', async () => {
 		const downloader = makeDownloader();
 		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -31,7 +31,7 @@ import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataS
 import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agentHostGitStateService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
-import { ActionType, ActionEnvelope } from '../../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
 import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
@@ -139,6 +139,22 @@ suite('AgentService (node dispatcher)', () => {
 
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('surfaces explicitly requested SDK download progress without a session', () => {
+		const notifications: { type: string; progressToken?: string; progress?: number; total?: number; message?: string }[] = [];
+		disposables.add(service.onDidNotification(notification => notifications.push(notification)));
+
+		service.emitDownloadProgress('codex', 'Codex', 50, 100, false, true);
+
+		assert.deepStrictEqual(notifications, [{
+			type: NotificationType.Progress,
+			channel: ROOT_STATE_URI,
+			progressToken: 'codex',
+			progress: 50,
+			total: 100,
+			message: 'Downloading Codex agent',
+		}]);
+	});
 
 	// ---- Provider registration ------------------------------------------
 

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -936,6 +936,7 @@ function stubAgentSdkDownloader(): IAgentSdkDownloader {
 	return {
 		_serviceBrand: undefined,
 		onDidDownloadProgress: Event.None,
+		acquireDownloadProgressInterest: () => toDisposable(() => { }),
 		isAvailable: () => false,
 		isSdkResolvableWithoutDownload: async () => false,
 		loadSdkRoot: () => { throw new Error('test stub: downloader.loadSdkRoot should not be called'); },

--- a/src/vs/workbench/services/agentHost/browser/codexAccountService.ts
+++ b/src/vs/workbench/services/agentHost/browser/codexAccountService.ts
@@ -57,6 +57,9 @@ export function createCodexAccountMenuActions(service: ICodexAccountService, vis
 			: localize('chatGPTAccount', "ChatGPT");
 		return [new SubmenuAction('codex.chatgptAccount', accountLabel, [signOut])];
 	}
+	if (account.status === 'downloading') {
+		return [new Action('codex.downloadingAgent', localize('downloadingCodexAgent', "Downloading Codex agent…"), undefined, false)];
+	}
 	if (account.status === 'unknown' || account.status === 'signedOut' || account.status === 'error') {
 		return [new Action('codex.signInToChatGPT', localize('signInToChatGPT', "Sign in to ChatGPT"), undefined, true, () => service.signIn())];
 	}

--- a/src/vs/workbench/services/agentHost/test/browser/codexAccountService.test.ts
+++ b/src/vs/workbench/services/agentHost/test/browser/codexAccountService.test.ts
@@ -62,10 +62,20 @@ suite('CodexAccountService', () => {
 		const accountService = service('unknown');
 		const actions = createCodexAccountMenuActions(accountService);
 		assert.ok(actions[0] instanceof Action);
-		disposables.add(actions[0]);
+		disposables.add(actions[0] as Action);
 		assert.strictEqual(actions[0].label, 'Sign in to ChatGPT');
 		await actions[0].run();
 		assert.strictEqual(accountService.signInCalls, 1);
+	});
+
+	test('shows download status instead of sign-in while the Codex binary is downloading', () => {
+		const accountService = service('downloading');
+		const actions = createCodexAccountMenuActions(accountService);
+		disposables.add(actions[0] as Action);
+
+		assert.deepStrictEqual(actions.map(action => ({ label: action.label, enabled: action.enabled })), [
+			{ label: 'Downloading Codex agent…', enabled: false },
+		]);
 	});
 
 	test('hides signed-in and sign-in actions when the account surface is unavailable', () => {


### PR DESCRIPTION
When ChatGPT sign-in needs to download the Codex agent binary, surface the same determinate download notification used by session creation and replace the stale account-picker sign-in action with a disabled “Downloading Codex agent…” status.

<img width="475" height="993" alt="image" src="https://github.com/user-attachments/assets/f5ddfa82-0eda-4a07-a915-1e6c1ae60541" />


This change:
- adds ref-counted download-progress interest for user-initiated flows without a session progress token
- publishes and validates a Codex `downloading` account state
- keeps that state scoped to the sign-in attempt
- correctly checks configured product downloads before the development fallback
- adds regression coverage for downloader progress, root progress notifications, account-state parsing, and account-picker actions

## Verification

- `npm run typecheck-client`
- `npm run compile`
- `npm run hygiene`
- relevant Agent Host and Codex account test suites: 464 passing, 17 pending
- post-rebase launch of Code OSS against a throttled localhost mock download server serving a real 116 MiB Codex archive
  - verified determinate notification progress and ARIA `progressbar` semantics
  - verified the reopened account picker shows the disabled download state
  - verified completion dismisses the notification and the downloaded native Codex binary launches successfully