### PR TITLE
Update font weights for composite bar and tabs

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -380,7 +380,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	min-width: 0;
-	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
 .chat-composite-bar-tab-lock,

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -65,13 +65,9 @@
 	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
-/*
- * Auxiliary bar single-composite header label (e.g. "Chat") — render it Strong
- * like the part title-labels so it matches the primary side bar section header
- * instead of looking like a lighter composite tab.
- */
+/* Auxiliary bar composite header labels use the same regular body role as other tabs. */
 .style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
-	font-weight: var(--vscode-fontWeight-semiBold);
+	font-weight: var(--vscode-fontWeight-regular);
 }
 
 .style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label.codicon {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -81,11 +81,6 @@
 	z-index: 1;
 }
 
-.modern-ui-tabs .part.editor .tabs-container > .tab > .tab-label > .monaco-icon-label-container {
-	font-weight: var(--vscode-fontWeight-semiBold);
-}
-
-
 .modern-ui-tabs .part.editor .tabs-container > .tab.sticky-compact {
 	justify-content: center;
 	padding: 0 !important;
@@ -518,7 +513,7 @@
 
 .modern-ui-tabs .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
 	font-size: var(--vscode-fontSize-body1);
-	font-weight: var(--vscode-fontWeight-semiBold);
+	font-weight: var(--vscode-fontWeight-regular);
 	line-height: 22px; /* keep consistent with other 22px title/control heights */
 }
 
@@ -698,7 +693,6 @@
 
 .modern-ui-tabs .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
 	font-size: var(--vscode-fontSize-body1);
-	font-weight: var(--vscode-fontWeight-semiBold);
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -64,6 +64,8 @@ function createCompositeAction(root: HTMLElement, titleHeight: number, checked: 
 	root.style.setProperty('--vscode-spacing-size40', '4px');
 	root.style.setProperty('--vscode-spacing-size240', '24px');
 	root.style.setProperty('--vscode-spacing-size320', '32px');
+	root.style.setProperty('--vscode-fontWeight-regular', '400');
+	root.style.setProperty('--vscode-fontWeight-semiBold', '600');
 	const part = appendElement(root, 'part pane-composite-part');
 	const title = appendElement(part, 'title');
 	title.style.height = `${titleHeight}px`;
@@ -286,6 +288,33 @@ suite('StyleOverridesContribution', () => {
 			agentsIconIndicatorBottomInset: 5.5,
 			agentsIconBadgeTop: '13px',
 			agentsIconBadgeRight: '2px',
+		});
+	});
+
+	test('pane composite actions use regular label weight', () => {
+		const regularRoot = document.createElement('div');
+		regularRoot.className = 'monaco-workbench style-override modern-ui-tabs';
+		document.body.appendChild(regularRoot);
+		store.add(toDisposable(() => regularRoot.remove()));
+		const regular = createCompositeAction(regularRoot, 40, true);
+		const auxiliary = createCompositeAction(regularRoot, 40, true);
+		auxiliary.actionItem.closest('.part')?.classList.add('auxiliarybar');
+
+		const agentsRoot = document.createElement('div');
+		agentsRoot.className = 'monaco-workbench modern-ui-tabs';
+		document.body.appendChild(agentsRoot);
+		store.add(toDisposable(() => agentsRoot.remove()));
+		const agents = createCompositeAction(agentsRoot, 35, true);
+
+		const targetWindow = getWindow(regular.actionLabel);
+		assert.deepStrictEqual({
+			regularLabelWeight: targetWindow.getComputedStyle(regular.actionLabel).fontWeight,
+			auxiliaryLabelWeight: targetWindow.getComputedStyle(auxiliary.actionLabel).fontWeight,
+			agentsLabelWeight: targetWindow.getComputedStyle(agents.actionLabel).fontWeight,
+		}, {
+			regularLabelWeight: '400',
+			auxiliaryLabelWeight: '400',
+			agentsLabelWeight: '400',
 		});
 	});
 


### PR DESCRIPTION
Change font weights for composite bar and tabs to regular for consistency across the UI. This update enhances the visual uniformity of the interface.

Resolves https://github.com/microsoft/vscode/issues/325064