### PR TITLE
nes: fix: allow configuring Xtab context lines

### DIFF
--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -887,8 +887,8 @@ export namespace ConfigKey {
 		export const InlineEditsXtabProviderModelConfigurationString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.xtabProvider.modelConfigurationString', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabProviderDefaultModelConfigurationString = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.xtabProvider.defaultModelConfigurationString', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabProviderUseVaryingLinesAbove = defineTeamInternalSetting<boolean | undefined>('chat.advanced.inlineEdits.xtabProvider.useVaryingLinesAbove', ConfigType.ExperimentBased, undefined);
-		export const InlineEditsXtabProviderNLinesAbove = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.nLinesAbove', ConfigType.ExperimentBased, undefined);
-		export const InlineEditsXtabProviderNLinesBelow = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.nLinesBelow', ConfigType.ExperimentBased, undefined);
+		export const InlineEditsXtabProviderNLinesAbove = defineSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.nLinesAbove', ConfigType.ExperimentBased, undefined);
+		export const InlineEditsXtabProviderNLinesBelow = defineSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.nLinesBelow', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsAutoExpandEditWindowLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.autoExpandEditWindowLines', ConfigType.ExperimentBased, 10);
 		export const InlineEditsXtabNRecentlyViewedDocuments = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.nRecentlyViewedDocuments', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.nDocuments);
 		export const InlineEditsXtabRecentlyViewedDocumentsMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.recentlyViewedDocuments.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.maxTokens);

--- a/extensions/copilot/src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts
+++ b/extensions/copilot/src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts
@@ -88,6 +88,8 @@ describe('ConfigurationServiceImpl - externally configurable advanced settings',
 			[ConfigKey.TeamInternal.InlineEditsExtraDebounceEndOfLine.fullyQualifiedId]: 0,
 			[ConfigKey.TeamInternal.InlineEditsDebounce.fullyQualifiedId]: 0,
 			[ConfigKey.TeamInternal.InlineEditsCacheDelay.fullyQualifiedId]: 0,
+			[ConfigKey.TeamInternal.InlineEditsXtabProviderNLinesAbove.fullyQualifiedId]: 0,
+			[ConfigKey.TeamInternal.InlineEditsXtabProviderNLinesBelow.fullyQualifiedId]: 7,
 		};
 		mockConfigStore.defaults = {};
 
@@ -105,6 +107,8 @@ describe('ConfigurationServiceImpl - externally configurable advanced settings',
 			extraDebounceEndOfLine: service.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsExtraDebounceEndOfLine, experimentationService),
 			debounce: service.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsDebounce, experimentationService),
 			cacheDelay: service.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsCacheDelay, experimentationService),
+			nLinesAbove: service.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderNLinesAbove, experimentationService),
+			nLinesBelow: service.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderNLinesBelow, experimentationService),
 		}).toEqual({
 			unification: true,
 			excludedProviders: 'completions,github.copilot',
@@ -116,6 +120,8 @@ describe('ConfigurationServiceImpl - externally configurable advanced settings',
 			extraDebounceEndOfLine: 0,
 			debounce: 0,
 			cacheDelay: 0,
+			nLinesAbove: 0,
+			nLinesBelow: 7,
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #330256.

- allow all users to configure the hidden advanced `xtabProvider.nLinesAbove` and `xtabProvider.nLinesBelow` settings
- preserve their existing keys, defaults, and experiment fallback behavior
- extend the external-user regression test with `nLinesAbove: 0` and `nLinesBelow: 7`

## Testing

- `npm run test:unit -- src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts src/extension/settingsSchema/test/common/settingsSchema.spec.ts`
- `npx eslint src/platform/configuration/common/configurationService.ts src/platform/configuration/vscode/test/configurationServiceImpl.spec.ts --max-warnings=0`