### PR TITLE
Align Omni chat width with the command palette

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -63,9 +63,11 @@ type QuickInputOverlayLayoutCorrection = {
 	readonly width: number;
 };
 
-export class QuickInputController extends Disposable {
-	private static readonly MAX_WIDTH = 600; // Max total width of quick input widget
+export function getQuickInputWidth(availableWidth: number): number {
+	return Math.min(availableWidth * 0.62, 600);
+}
 
+export class QuickInputController extends Disposable {
 	private idPrefix: string;
 	private ui: QuickInputUI | undefined;
 	private dimension?: dom.IDimension;
@@ -942,7 +944,7 @@ export class QuickInputController extends Disposable {
 	private updateLayout() {
 		if (this.ui && this.isVisible()) {
 			const style = this.ui.container.style;
-			let width = Math.min(this.dimension!.width * 0.62 /* golden cut */, QuickInputController.MAX_WIDTH);
+			let width = getQuickInputWidth(this.dimension!.width);
 			style.width = width + 'px';
 
 			let listHeight = this.dimension && this.dimension.height * 0.4;

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -62,7 +62,7 @@ import { ConfirmationOptionKind } from '../../../../../platform/agentHost/common
 
 const CHAT_INPUT_WINDOW_MODEL_PICKER_HEIGHT = 420;
 const CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT = 44;
-const CHAT_INPUT_WINDOW_MAX_WIDTH = 600;
+const CHAT_INPUT_WINDOW_WIDTH = 600;
 const CHAT_INPUT_WINDOW_MAX_PENDING_HEIGHT = 360;
 const CHAT_INPUT_WINDOW_MIN_CONFIRMATION_HEIGHT = 112;
 
@@ -546,7 +546,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			if (!win || win !== auxiliaryWindow.window) {
 				return;
 			}
-			const width = Math.max(this._defaultWidth(), win.outerWidth);
+			const width = CHAT_INPUT_WINDOW_WIDTH;
 			const rowHeight = Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, Math.ceil(widget.contentHeight));
 			const extraHeight = Array.from(surface.children)
 				.filter(child => child !== this._row)
@@ -1187,11 +1187,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 	}
 
 	private _defaultBounds(): IRectangle {
-		// Match Quick Chat's width so the model-detail hover has room to sit
-		// beside the picker: golden-cut of the invoking window, capped like the
-		// quick input widget (MAX_WIDTH = 600).
-		const width = this._defaultWidth();
-		return this._positionedBounds(width, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT);
+		return this._positionedBounds(CHAT_INPUT_WINDOW_WIDTH, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT);
 	}
 
 	private _positionedBounds(width: number, height: number): IRectangle {
@@ -1231,16 +1227,6 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			StorageScope.WORKSPACE,
 			StorageTarget.MACHINE,
 		);
-	}
-
-	private _defaultWidth(): number {
-		const invokingWindowWidth = this._invokingWindowBounds.width > 0
-			? this._invokingWindowBounds.width
-			: mainWindow.outerWidth;
-		const availableWidth = invokingWindowWidth > 0
-			? invokingWindowWidth
-			: CHAT_INPUT_WINDOW_MAX_WIDTH / 0.62;
-		return Math.round(Math.min(availableWidth * 0.62, CHAT_INPUT_WINDOW_MAX_WIDTH));
 	}
 
 	private _windowBounds(window: Window): IRectangle {

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -54,6 +54,7 @@ import { setupVoiceInputDecorations } from '../voiceClient/voiceInputDecorations
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { getQuickInputWidth } from '../../../../../platform/quickinput/browser/quickInputController.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { OmniChatEnabledSettingId } from '../../common/sessionRouter.js';
 import { AgentSessionProviders } from '../agentSessions/agentSessions.js';
@@ -62,7 +63,6 @@ import { ConfirmationOptionKind } from '../../../../../platform/agentHost/common
 
 const CHAT_INPUT_WINDOW_MODEL_PICKER_HEIGHT = 420;
 const CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT = 44;
-const CHAT_INPUT_WINDOW_WIDTH = 600;
 const CHAT_INPUT_WINDOW_MAX_PENDING_HEIGHT = 360;
 const CHAT_INPUT_WINDOW_MIN_CONFIRMATION_HEIGHT = 112;
 
@@ -546,7 +546,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			if (!win || win !== auxiliaryWindow.window) {
 				return;
 			}
-			const width = CHAT_INPUT_WINDOW_WIDTH;
+			const width = this._defaultWidth();
 			const rowHeight = Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, Math.ceil(widget.contentHeight));
 			const extraHeight = Array.from(surface.children)
 				.filter(child => child !== this._row)
@@ -1187,7 +1187,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 	}
 
 	private _defaultBounds(): IRectangle {
-		return this._positionedBounds(CHAT_INPUT_WINDOW_WIDTH, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT);
+		return this._positionedBounds(this._defaultWidth(), CHAT_INPUT_WINDOW_DEFAULT_HEIGHT);
 	}
 
 	private _positionedBounds(width: number, height: number): IRectangle {
@@ -1227,6 +1227,13 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			StorageScope.WORKSPACE,
 			StorageTarget.MACHINE,
 		);
+	}
+
+	private _defaultWidth(): number {
+		const invokingWindowWidth = this._invokingWindowBounds.width > 0
+			? this._invokingWindowBounds.width
+			: mainWindow.outerWidth;
+		return Math.round(getQuickInputWidth(invokingWindowWidth));
 	}
 
 	private _windowBounds(window: Window): IRectangle {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8786

Uses the command palette width calculation for Omni chat: 62% of the invoking workbench width, capped at 600px. The calculation now lives in a shared helper consumed by both quick input and Omni chat, keeping their responsive behavior aligned.

Validation: `npm run transpile-client`