### PR TITLE
fix: populate OTel repository attributes for non-GitHub git remotes

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -162,7 +162,7 @@ Inline chat uses the same invocation shape, with `invoke_agent Inline Chat` as t
 | `github.copilot.git.repository` | When in a repo | `https://github.com/microsoft/vscode.git` |
 | `github.copilot.git.branch` | When in a repo | `main` |
 | `github.copilot.git.commit_sha` | When in a repo | `deadbeef...` |
-| `github.copilot.github.org` | GitHub remotes only | `microsoft` |
+| `github.copilot.github.org` | Recognized GitHub hosts only (github.com, `*.ghe.com`) — absent for custom-domain GitHub Enterprise Server | `microsoft` |
 | `copilot_chat.repo.remote_url` | **Legacy** — prefer `github.copilot.git.repository` | `https://github.com/...` |
 | `copilot_chat.repo.head_branch_name` | **Legacy** — prefer `github.copilot.git.branch` | `main` |
 | `copilot_chat.repo.head_commit_hash` | **Legacy** — prefer `github.copilot.git.commit_sha` | `deadbeef...` |

--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -162,7 +162,7 @@ Inline chat uses the same invocation shape, with `invoke_agent Inline Chat` as t
 | `github.copilot.git.repository` | When in a repo | `https://github.com/microsoft/vscode.git` |
 | `github.copilot.git.branch` | When in a repo | `main` |
 | `github.copilot.git.commit_sha` | When in a repo | `deadbeef...` |
-| `github.copilot.github.org` | Recognized GitHub hosts only (github.com, `*.ghe.com`) — absent for custom-domain GitHub Enterprise Server | `microsoft` |
+| `github.copilot.github.org` | Recognized GitHub hosts only — github.com, `*.ghe.com`, and ssh host aliases normalizing to either (e.g. `alias-github.com`); absent for custom-domain GitHub Enterprise Server | `microsoft` |
 | `copilot_chat.repo.remote_url` | **Legacy** — prefer `github.copilot.git.repository` | `https://github.com/...` |
 | `copilot_chat.repo.head_branch_name` | **Legacy** — prefer `github.copilot.git.branch` | `main` |
 | `copilot_chat.repo.head_commit_hash` | **Legacy** — prefer `github.copilot.git.commit_sha` | `deadbeef...` |

--- a/extensions/copilot/src/extension/conversation/vscode-node/userActions.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/userActions.ts
@@ -577,7 +577,9 @@ function reportInlineEditSurvivalEvent(res: EditSurvivalResult, sharedProps: Tel
 		...sharedProps,
 		headBranchName: res.workspace?.headBranchName,
 		headCommitHash: res.workspace?.headCommitHash,
-		remoteUrl: res.workspace?.remoteUrl,
+		// Restricted to recognized hosts: this channel is not the user's own OTel exporter,
+		// so it must keep collecting exactly the remotes it collected before.
+		remoteUrl: res.workspace?.recognizedRemoteUrl,
 		fileRelativePath: res.workspace?.fileRelativePath,
 	}, {
 		...sharedMeasures,

--- a/extensions/copilot/src/platform/git/common/gitService.ts
+++ b/extensions/copilot/src/platform/git/common/gitService.ts
@@ -129,7 +129,12 @@ export function getOrderedRemoteUrlsFromContext(repoContext: RepoContext): Itera
 
 	// Strategy 1: If there's only one remote, use that
 	if (repoContext.remoteFetchUrls?.length === 1) {
-		out.add(repoContext.remoteFetchUrls[0]!);
+		// A remote can be push-only and carry no fetch URL, so this entry may be undefined
+		// even though the declared return type is `Iterable<string>`.
+		const fetchUrl = repoContext.remoteFetchUrls[0];
+		if (fetchUrl) {
+			out.add(fetchUrl);
+		}
 		return out;
 	}
 

--- a/extensions/copilot/src/platform/git/test/node/gitService.spec.ts
+++ b/extensions/copilot/src/platform/git/test/node/gitService.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { suite, test } from 'vitest';
-import { AdoRepoId, getAdoRepoIdFromFetchUrl, getGithubRepoIdFromFetchUrl, GithubRepoId, normalizeFetchUrl, parseRemoteUrl, toGithubWebUrl } from '../../common/gitService';
+import { AdoRepoId, getAdoRepoIdFromFetchUrl, getGithubRepoIdFromFetchUrl, GithubRepoId, getOrderedRemoteUrlsFromContext, getOrderedRepoInfosFromContext, normalizeFetchUrl, parseRemoteUrl, type RepoContext, toGithubWebUrl } from '../../common/gitService';
 
 function assertGitIdEquals(a: GithubRepoId | undefined, b: { org: string; repo: string; host?: string } | undefined, message?: string) {
 	assert.strictEqual(a?.org, b?.org, message);
@@ -14,6 +14,49 @@ function assertGitIdEquals(a: GithubRepoId | undefined, b: { org: string; repo: 
 		assert.strictEqual(a?.host, b.host, message);
 	}
 }
+
+function createRepoContext(remotes: string[], remoteFetchUrls: Array<string | undefined>, upstreamRemote?: string): RepoContext {
+	return { remotes, remoteFetchUrls, upstreamRemote } as RepoContext;
+}
+
+suite('getOrderedRemoteUrlsFromContext', () => {
+	test('Should skip a lone remote that has no fetch URL', () => {
+		assert.deepStrictEqual(
+			Array.from(getOrderedRemoteUrlsFromContext(createRepoContext(['origin'], [undefined]))),
+			[]);
+	});
+
+	test('Should return a lone remote with a fetch URL', () => {
+		assert.deepStrictEqual(
+			Array.from(getOrderedRemoteUrlsFromContext(createRepoContext(['origin'], ['https://github.com/microsoft/vscode.git']))),
+			['https://github.com/microsoft/vscode.git']);
+	});
+
+	test('Should order upstream before origin', () => {
+		assert.deepStrictEqual(
+			Array.from(getOrderedRemoteUrlsFromContext(createRepoContext(
+				['origin', 'upstream'],
+				['https://github.com/fork/vscode.git', 'https://github.com/microsoft/vscode.git'],
+				'upstream'))),
+			['https://github.com/microsoft/vscode.git', 'https://github.com/fork/vscode.git']);
+	});
+});
+
+suite('getOrderedRepoInfosFromContext', () => {
+	test('Should not throw for a lone remote that has no fetch URL', () => {
+		assert.deepStrictEqual(
+			Array.from(getOrderedRepoInfosFromContext(createRepoContext(['origin'], [undefined]))),
+			[]);
+	});
+
+	test('Should skip remotes on unrecognized hosts', () => {
+		const infos = Array.from(getOrderedRepoInfosFromContext(createRepoContext(
+			['origin', 'github'],
+			['https://git.mycompany.com/owner/repo.git', 'https://github.com/microsoft/vscode.git'])));
+		assert.strictEqual(infos.length, 1);
+		assert.strictEqual(infos[0].fetchUrl, 'https://github.com/microsoft/vscode.git');
+	});
+});
 
 suite('parseRemoteUrl', () => {
 	test('Should handle basic https', () => {

--- a/extensions/copilot/src/platform/multiFileEdit/common/multiFileEditQualityTelemetry.ts
+++ b/extensions/copilot/src/platform/multiFileEdit/common/multiFileEditQualityTelemetry.ts
@@ -179,7 +179,9 @@ export class MultiFileEditInternalTelemetryService extends Disposable implements
 				messageId: edit.chatRequestId,
 				headBranchName: workspace.headBranchName,
 				headCommitHash: workspace.headCommitHash,
-				remoteUrl: workspace.remoteUrl,
+				// Restricted to recognized hosts: this channel is not the user's own OTel
+				// exporter, so it must keep collecting exactly the remotes it collected before.
+				remoteUrl: workspace.recognizedRemoteUrl,
 				fileRelativePath: workspace.fileRelativePath,
 			}).then(gitHubEnhancedTelemetryProperties => this.telemetryService.sendEnhancedGHTelemetryEvent('fastApply/editOutcome', gitHubEnhancedTelemetryProperties)).catch(() => { /* best-effort telemetry */ });
 			this.logService.debug(`Sent telemetry for ${uri.toString()} with request ID ${edit.chatRequestId}, SD request ID ${edit.speculationRequestId}, and outcome ${outcome}`);

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -211,7 +211,9 @@ export const GitHubCopilotAttr = {
 	GIT_COMMIT_SHA: 'github.copilot.git.commit_sha',
 	/**
 	 * GitHub `owner` segment derived from the remote URL. Only emitted for hosts recognized as
-	 * GitHub (github.com, `*.ghe.com`); absent for custom-domain GitHub Enterprise Server.
+	 * GitHub: github.com, `*.ghe.com`, and ssh host aliases that normalize to either (for
+	 * example `alias-github.com` or `github.com-alias`). Absent for custom-domain GitHub
+	 * Enterprise Server, which is indistinguishable from an arbitrary git host here.
 	 */
 	GITHUB_ORG: 'github.copilot.github.org',
 

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -203,13 +203,16 @@ export const GitHubCopilotAttr = {
 	/** Agent type classifier: `builtin` | `plugin` | `custom`. */
 	AGENT_TYPE: 'github.copilot.agent.type',
 
-	/** Git remote URL (normalized). Dual of `copilot_chat.repo.remote_url`. */
+	/** Git remote URL (normalized, any host). Dual of `copilot_chat.repo.remote_url`. */
 	GIT_REPOSITORY: 'github.copilot.git.repository',
 	/** Git HEAD branch. Dual of `copilot_chat.repo.head_branch_name`. */
 	GIT_BRANCH: 'github.copilot.git.branch',
 	/** Git HEAD commit. Dual of `copilot_chat.repo.head_commit_hash`. */
 	GIT_COMMIT_SHA: 'github.copilot.git.commit_sha',
-	/** GitHub `owner` segment derived from the remote URL (gated like the URL itself). */
+	/**
+	 * GitHub `owner` segment derived from the remote URL. Only emitted for hosts recognized as
+	 * GitHub (github.com, `*.ghe.com`); absent for custom-domain GitHub Enterprise Server.
+	 */
 	GITHUB_ORG: 'github.copilot.github.org',
 
 	/** Hook decision result (`block` | `approve` | `non_blocking_error` | `pass`). */

--- a/extensions/copilot/src/platform/otel/common/test/workspaceOTelMetadata.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/workspaceOTelMetadata.spec.ts
@@ -53,8 +53,108 @@ describe('resolveWorkspaceOTelMetadata', () => {
 			remotes: ['origin'],
 		});
 		const result = resolveWorkspaceOTelMetadata(gitService);
-		expect(result.remoteUrl).toBeDefined();
-		expect(result.remoteUrl).toContain('github.com');
+		expect(result.remoteUrl).toBe('https://github.com/microsoft/vscode.git');
+	});
+
+	it('resolves remote URL for self-hosted GitHub Enterprise Server on a custom domain', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['https://git.mycompany.com/owner/repo.git'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://git.mycompany.com/owner/repo.git');
+	});
+
+	it('normalizes an scp-style remote on a custom domain', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['git@git.mycompany.com:owner/repo.git'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://git.mycompany.com/owner/repo.git');
+	});
+
+	it('resolves remote URL for GitLab', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['https://gitlab.com/org/repo.git'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://gitlab.com/org/repo.git');
+	});
+
+	it('resolves remote URL for Bitbucket Server, stripping the /scm/ prefix', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['https://bitbucket.mycorp.com/scm/proj/repo.git'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://bitbucket.mycorp.com/proj/repo.git');
+	});
+
+	it('resolves remote URL for Azure DevOps', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['https://dev.azure.com/org/project/_git/repo'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://dev.azure.com/org/project/_git/repo');
+	});
+
+	it('ignores local remotes so filesystem paths never reach telemetry', () => {
+		for (const localRemote of ['file:///Users/someone/dev/repo', '/Users/someone/dev/repo', '../sibling-repo']) {
+			const gitService = createMockGitService({
+				remoteFetchUrls: [localRemote],
+				remotes: ['origin'],
+			});
+			expect(resolveWorkspaceOTelMetadata(gitService).remoteUrl).toBeUndefined();
+		}
+	});
+
+	it('handles a remote with no fetch URL', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: [undefined],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBeUndefined();
+	});
+
+	it('prefers a resolvable GitHub remote over a higher-priority unrecognized one', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'github'],
+			remoteFetchUrls: ['https://git.mycompany.com/mirror/repo.git', 'https://github.com/microsoft/vscode.git'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://github.com/microsoft/vscode.git');
+	});
+
+	it('prefers a resolvable Azure DevOps remote over a higher-priority unrecognized one', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'ado'],
+			remoteFetchUrls: ['https://git.mycompany.com/mirror/repo.git', 'https://dev.azure.com/org/project/_git/repo'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://dev.azure.com/org/project/_git/repo');
+	});
+
+	it('falls back to an unrecognized remote only when no remote resolves', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'mirror'],
+			remoteFetchUrls: ['https://git.mycompany.com/owner/repo.git', 'https://gitlab.com/org/repo.git'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://git.mycompany.com/owner/repo.git');
+	});
+
+	it('prefers the upstream remote over origin for unrecognized hosts', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'upstream'],
+			remoteFetchUrls: ['https://git.mycompany.com/fork/repo.git', 'https://git.mycompany.com/upstream/repo.git'],
+			upstreamRemote: 'upstream',
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://git.mycompany.com/upstream/repo.git');
 	});
 
 	it('computes relative file path from repo root', () => {
@@ -128,6 +228,40 @@ describe('workspaceMetadataToOTelAttributes', () => {
 			remoteUrl: 'https://gitlab.com/org/repo.git',
 		});
 		expect(attrs[GitHubCopilotAttr.GIT_REPOSITORY]).toBe('https://gitlab.com/org/repo.git');
+		expect(attrs[GitHubCopilotAttr.GITHUB_ORG]).toBeUndefined();
+	});
+
+	it('derives github.org for GitHub Enterprise Cloud remotes', () => {
+		const attrs = workspaceMetadataToOTelAttributes({
+			remoteUrl: 'https://myco.ghe.com/acme/repo.git',
+		});
+		expect(attrs[GitHubCopilotAttr.GIT_REPOSITORY]).toBe('https://myco.ghe.com/acme/repo.git');
+		expect(attrs[GitHubCopilotAttr.GITHUB_ORG]).toBe('acme');
+	});
+
+	it('derives github.org through an ssh host alias', () => {
+		const attrs = workspaceMetadataToOTelAttributes({
+			remoteUrl: 'https://alias-github.com/microsoft/vscode.git',
+		});
+		expect(attrs[GitHubCopilotAttr.GITHUB_ORG]).toBe('microsoft');
+	});
+
+	it('emits the repository URL but no github.org for custom-domain GitHub Enterprise Server', () => {
+		const attrs = workspaceMetadataToOTelAttributes({
+			remoteUrl: 'https://git.mycompany.com/owner/repo.git',
+		});
+		expect(attrs[GitHubCopilotAttr.GIT_REPOSITORY]).toBe('https://git.mycompany.com/owner/repo.git');
+		expect(attrs[CopilotChatAttr.REPO_REMOTE_URL]).toBe('https://git.mycompany.com/owner/repo.git');
+		// Distinguishing a custom GHES domain from an arbitrary git host needs the configured
+		// `github-enterprise.uri`, which this module cannot read.
+		expect(attrs[GitHubCopilotAttr.GITHUB_ORG]).toBeUndefined();
+	});
+
+	it('emits the repository URL but no github.org for Bitbucket Server', () => {
+		const attrs = workspaceMetadataToOTelAttributes({
+			remoteUrl: 'https://bitbucket.mycorp.com/proj/repo.git',
+		});
+		expect(attrs[GitHubCopilotAttr.GIT_REPOSITORY]).toBe('https://bitbucket.mycorp.com/proj/repo.git');
 		expect(attrs[GitHubCopilotAttr.GITHUB_ORG]).toBeUndefined();
 	});
 });

--- a/extensions/copilot/src/platform/otel/common/test/workspaceOTelMetadata.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/workspaceOTelMetadata.spec.ts
@@ -111,6 +111,78 @@ describe('resolveWorkspaceOTelMetadata', () => {
 		}
 	});
 
+	it('ignores loopback remotes that smuggle a filesystem path through scp syntax', () => {
+		const loopbackRemotes = [
+			'git@localhost:/Users/alice/dev/repo.git',
+			'ssh://git@localhost/Users/alice/dev/repo.git',
+			'git@127.0.0.1:/Users/alice/dev/repo.git',
+			'git@dev.localhost:/Users/alice/dev/repo.git',
+			'https://localhost:8443/Users/alice/dev/repo.git',
+			'ssh://git@[::1]/Users/alice/dev/repo.git',
+		];
+		for (const loopbackRemote of loopbackRemotes) {
+			const gitService = createMockGitService({
+				remoteFetchUrls: [loopbackRemote],
+				remotes: ['origin'],
+			});
+			expect(resolveWorkspaceOTelMetadata(gitService).remoteUrl, loopbackRemote).toBeUndefined();
+		}
+	});
+
+	it('still reports a non-loopback host that serves repositories from an absolute path', () => {
+		const gitService = createMockGitService({
+			remoteFetchUrls: ['git@git.mycompany.com:/srv/git/repo.git'],
+			remotes: ['origin'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		// An absolute path on a routable host is the server's layout, not the user's, so it is
+		// reported. The doubled slash is existing `normalizeFetchUrl` behaviour for scp-style
+		// remotes whose path is absolute.
+		expect(result.remoteUrl).toBe('https://git.mycompany.com//srv/git/repo.git');
+	});
+
+	it('skips a loopback remote but still reports a later routable one', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'mirror'],
+			remoteFetchUrls: ['git@localhost:/Users/alice/dev/repo.git', 'https://git.mycompany.com/owner/repo.git'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.remoteUrl).toBe('https://git.mycompany.com/owner/repo.git');
+	});
+
+	it('exposes recognizedRemoteUrl only for remotes that resolve to a repo id', () => {
+		const recognized = resolveWorkspaceOTelMetadata(createMockGitService({
+			remoteFetchUrls: ['https://github.com/microsoft/vscode.git'],
+			remotes: ['origin'],
+		}));
+		expect(recognized.recognizedRemoteUrl).toBe('https://github.com/microsoft/vscode.git');
+		expect(recognized.remoteUrl).toBe('https://github.com/microsoft/vscode.git');
+
+		const ado = resolveWorkspaceOTelMetadata(createMockGitService({
+			remoteFetchUrls: ['https://dev.azure.com/org/project/_git/repo'],
+			remotes: ['origin'],
+		}));
+		expect(ado.recognizedRemoteUrl).toBe('https://dev.azure.com/org/project/_git/repo');
+
+		// The whole point of the split: non-OTel telemetry channels must not widen.
+		const unrecognized = resolveWorkspaceOTelMetadata(createMockGitService({
+			remoteFetchUrls: ['https://git.mycompany.com/owner/repo.git'],
+			remotes: ['origin'],
+		}));
+		expect(unrecognized.remoteUrl).toBe('https://git.mycompany.com/owner/repo.git');
+		expect(unrecognized.recognizedRemoteUrl).toBeUndefined();
+	});
+
+	it('keeps recognizedRemoteUrl on the resolvable remote in a mixed-remote repository', () => {
+		const gitService = createMockGitService({
+			remotes: ['origin', 'github'],
+			remoteFetchUrls: ['https://git.mycompany.com/mirror/repo.git', 'https://github.com/microsoft/vscode.git'],
+		});
+		const result = resolveWorkspaceOTelMetadata(gitService);
+		expect(result.recognizedRemoteUrl).toBe('https://github.com/microsoft/vscode.git');
+		expect(result.remoteUrl).toBe('https://github.com/microsoft/vscode.git');
+	});
+
 	it('handles a remote with no fetch URL', () => {
 		const gitService = createMockGitService({
 			remoteFetchUrls: [undefined],

--- a/extensions/copilot/src/platform/otel/common/workspaceOTelMetadata.ts
+++ b/extensions/copilot/src/platform/otel/common/workspaceOTelMetadata.ts
@@ -11,7 +11,22 @@ import { CopilotChatAttr, GitHubCopilotAttr } from './genAiAttributes';
 export interface WorkspaceOTelMetadata {
 	readonly headBranchName?: string;
 	readonly headCommitHash?: string;
+	/**
+	 * Normalized remote fetch URL for OTel attributes, reported for any host so that a
+	 * repository is never silently dropped. Exported only to the user-configured OTel
+	 * pipeline.
+	 */
 	readonly remoteUrl?: string;
+	/**
+	 * Normalized remote fetch URL restricted to remotes that resolve to a repo id
+	 * (github.com, `*.ghe.com`, Azure DevOps) — the set that was reportable before
+	 * host-agnostic reporting was introduced.
+	 *
+	 * Consumers that forward the remote to a channel other than the user's own OTel
+	 * exporter (GitHub telemetry events) must use this field, so that broadening OTel
+	 * coverage does not silently widen what those channels collect.
+	 */
+	readonly recognizedRemoteUrl?: string;
 	readonly fileRelativePath?: string;
 }
 
@@ -31,7 +46,8 @@ export function resolveWorkspaceOTelMetadata(
 }
 
 function buildWorkspaceMetadata(repoContext: RepoContext, fileUri?: URI): WorkspaceOTelMetadata {
-	const remoteUrl = pickRemoteUrl(repoContext);
+	const recognizedRemoteUrl = pickRecognizedRemoteUrl(repoContext);
+	const remoteUrl = recognizedRemoteUrl ?? pickFallbackRemoteUrl(repoContext);
 
 	let fileRelativePath: string | undefined;
 	if (fileUri && isEqualOrParent(fileUri, repoContext.rootUri)) {
@@ -42,39 +58,65 @@ function buildWorkspaceMetadata(repoContext: RepoContext, fileUri?: URI): Worksp
 		headBranchName: repoContext.headBranchName,
 		headCommitHash: repoContext.headCommitHash,
 		remoteUrl,
+		recognizedRemoteUrl,
 		fileRelativePath,
 	};
 }
 
 /**
- * Picks the normalized remote fetch URL to report for a repository.
+ * Picks the normalized remote fetch URL of the highest-priority remote that resolves to a
+ * repo id (github.com, `*.ghe.com`, Azure DevOps).
  *
- * A remote that resolves to a repo id (github.com, `*.ghe.com`, Azure DevOps) always wins,
- * so repositories that already reported a URL keep reporting the same one. Only when no
- * remote resolves do we fall back to the highest-priority remote of any host: the branch
- * and commit attributes are read straight off the repo context with no host check, so the
- * repository must not be silently dropped for self-hosted GitHub Enterprise Server on a
- * custom domain, GitLab, Bitbucket Server, or a plain git server.
- *
- * Both passes walk remotes in the same priority order (a lone remote first, then the
- * upstream remote, then `origin`, then the rest). The fallback accepts only URLs that parse
- * as ssh, https, or http, which keeps local remotes (`file://`, absolute or relative paths)
- * out of telemetry rather than emitting a user's filesystem layout.
+ * This is the set of remotes that was reportable before host-agnostic reporting existed, so
+ * preferring it keeps every repository that already reported a URL reporting the same one.
  */
-function pickRemoteUrl(repoContext: RepoContext): string | undefined {
+function pickRecognizedRemoteUrl(repoContext: RepoContext): string | undefined {
 	const resolved = Array.from(getOrderedRepoInfosFromContext(repoContext))[0];
-	if (resolved?.fetchUrl) {
-		return normalizeFetchUrl(resolved.fetchUrl);
-	}
+	return resolved?.fetchUrl ? normalizeFetchUrl(resolved.fetchUrl) : undefined;
+}
+
+/**
+ * Picks the normalized remote fetch URL of the highest-priority remote on any host, used
+ * only when no remote resolves to a repo id. The branch and commit attributes are read
+ * straight off the repo context with no host check, so the repository must not be silently
+ * dropped for self-hosted GitHub Enterprise Server on a custom domain, GitLab, Bitbucket
+ * Server, or a plain git server.
+ *
+ * Remotes are walked in the same priority order as {@link pickRecognizedRemoteUrl} (a lone
+ * remote first, then the upstream remote, then `origin`, then the rest).
+ *
+ * Local remotes are excluded so a user's filesystem layout is never reported: `parseRemoteUrl`
+ * admits only ssh, https, and http, which rejects `file://` and bare paths, and loopback
+ * hosts are rejected on top of that because scp-style syntax can smuggle a local path through
+ * an accepted scheme (`git@localhost:/Users/alice/dev/repo.git`).
+ */
+function pickFallbackRemoteUrl(repoContext: RepoContext): string | undefined {
 	for (const remoteUrl of getOrderedRemoteUrlsFromContext(repoContext)) {
 		// `getOrderedRemoteUrlsFromContext` types its result as `Iterable<string>` but reads
 		// from `remoteFetchUrls: Array<string | undefined>`, so guard against empty entries.
-		if (!remoteUrl || !parseRemoteUrl(remoteUrl)) {
+		if (!remoteUrl) {
+			continue;
+		}
+		const parsed = parseRemoteUrl(remoteUrl);
+		if (!parsed || isLoopbackHost(parsed.rawHost)) {
 			continue;
 		}
 		return normalizeFetchUrl(remoteUrl);
 	}
 	return undefined;
+}
+
+/**
+ * Whether a host refers to the local machine. `parseRemoteUrl` has already lowercased the
+ * host and stripped any port.
+ */
+function isLoopbackHost(rawHost: string): boolean {
+	const host = rawHost.replace(/^\[|\]$/g, '');
+	return host === 'localhost'
+		|| host.endsWith('.localhost')
+		|| host === '::1'
+		|| host === '0.0.0.0'
+		|| /^127(?:\.\d{1,3}){3}$/.test(host);
 }
 
 /**
@@ -114,11 +156,12 @@ export function workspaceMetadataToOTelAttributes(
 /**
  * Extract the `owner` segment from a remote URL that resolves to a GitHub repository.
  *
- * Unlike the remote URL itself, this stays scoped to hosts recognized as GitHub —
- * github.com, `*.ghe.com`, and the ssh host aliases those resolve through. Returns
- * undefined for every other host, which notably includes self-hosted GitHub Enterprise
- * Server on a custom domain: telling that apart from an arbitrary git server needs the
- * configured `github-enterprise.uri`, which this module has no access to.
+ * Unlike the remote URL itself, this stays scoped to hosts recognized as GitHub: github.com,
+ * `*.ghe.com`, and ssh host aliases that normalize to either (for example `alias-github.com`
+ * or `github.com-alias`). Returns undefined for every other host, which notably includes
+ * self-hosted GitHub Enterprise Server on a custom domain: telling that apart from an
+ * arbitrary git server needs the configured `github-enterprise.uri`, which this module has
+ * no access to.
  */
 function extractGitHubOrg(remoteUrl: string): string | undefined {
 	return getGithubRepoIdFromFetchUrl(remoteUrl)?.org;

--- a/extensions/copilot/src/platform/otel/common/workspaceOTelMetadata.ts
+++ b/extensions/copilot/src/platform/otel/common/workspaceOTelMetadata.ts
@@ -5,7 +5,7 @@
 
 import { URI } from '../../../util/vs/base/common/uri';
 import { isEqualOrParent, relativePath } from '../../../util/vs/base/common/resources';
-import { getOrderedRepoInfosFromContext, type IGitService, normalizeFetchUrl, type RepoContext } from '../../git/common/gitService';
+import { getGithubRepoIdFromFetchUrl, getOrderedRemoteUrlsFromContext, getOrderedRepoInfosFromContext, type IGitService, normalizeFetchUrl, parseRemoteUrl, type RepoContext } from '../../git/common/gitService';
 import { CopilotChatAttr, GitHubCopilotAttr } from './genAiAttributes';
 
 export interface WorkspaceOTelMetadata {
@@ -31,11 +31,7 @@ export function resolveWorkspaceOTelMetadata(
 }
 
 function buildWorkspaceMetadata(repoContext: RepoContext, fileUri?: URI): WorkspaceOTelMetadata {
-	let remoteUrl: string | undefined;
-	const repoInfo = Array.from(getOrderedRepoInfosFromContext(repoContext))[0];
-	if (repoInfo?.fetchUrl) {
-		remoteUrl = normalizeFetchUrl(repoInfo.fetchUrl);
-	}
+	const remoteUrl = pickRemoteUrl(repoContext);
 
 	let fileRelativePath: string | undefined;
 	if (fileUri && isEqualOrParent(fileUri, repoContext.rootUri)) {
@@ -48,6 +44,37 @@ function buildWorkspaceMetadata(repoContext: RepoContext, fileUri?: URI): Worksp
 		remoteUrl,
 		fileRelativePath,
 	};
+}
+
+/**
+ * Picks the normalized remote fetch URL to report for a repository.
+ *
+ * A remote that resolves to a repo id (github.com, `*.ghe.com`, Azure DevOps) always wins,
+ * so repositories that already reported a URL keep reporting the same one. Only when no
+ * remote resolves do we fall back to the highest-priority remote of any host: the branch
+ * and commit attributes are read straight off the repo context with no host check, so the
+ * repository must not be silently dropped for self-hosted GitHub Enterprise Server on a
+ * custom domain, GitLab, Bitbucket Server, or a plain git server.
+ *
+ * Both passes walk remotes in the same priority order (a lone remote first, then the
+ * upstream remote, then `origin`, then the rest). The fallback accepts only URLs that parse
+ * as ssh, https, or http, which keeps local remotes (`file://`, absolute or relative paths)
+ * out of telemetry rather than emitting a user's filesystem layout.
+ */
+function pickRemoteUrl(repoContext: RepoContext): string | undefined {
+	const resolved = Array.from(getOrderedRepoInfosFromContext(repoContext))[0];
+	if (resolved?.fetchUrl) {
+		return normalizeFetchUrl(resolved.fetchUrl);
+	}
+	for (const remoteUrl of getOrderedRemoteUrlsFromContext(repoContext)) {
+		// `getOrderedRemoteUrlsFromContext` types its result as `Iterable<string>` but reads
+		// from `remoteFetchUrls: Array<string | undefined>`, so guard against empty entries.
+		if (!remoteUrl || !parseRemoteUrl(remoteUrl)) {
+			continue;
+		}
+		return normalizeFetchUrl(remoteUrl);
+	}
+	return undefined;
 }
 
 /**
@@ -85,12 +112,14 @@ export function workspaceMetadataToOTelAttributes(
 }
 
 /**
- * Extract the `owner` segment from a normalized GitHub remote URL.
- * Returns undefined for non-GitHub hosts or malformed inputs.
+ * Extract the `owner` segment from a remote URL that resolves to a GitHub repository.
+ *
+ * Unlike the remote URL itself, this stays scoped to hosts recognized as GitHub —
+ * github.com, `*.ghe.com`, and the ssh host aliases those resolve through. Returns
+ * undefined for every other host, which notably includes self-hosted GitHub Enterprise
+ * Server on a custom domain: telling that apart from an arbitrary git server needs the
+ * configured `github-enterprise.uri`, which this module has no access to.
  */
 function extractGitHubOrg(remoteUrl: string): string | undefined {
-	// Match `(https://|git@)<host>[:/]<owner>/<repo>` — normalizeFetchUrl already
-	// strips credentials and `.git` suffixes.
-	const m = remoteUrl.match(/github\.com[/:]([^/]+)\/[^/]+\/?$/i);
-	return m?.[1];
+	return getGithubRepoIdFromFetchUrl(remoteUrl)?.org;
 }


### PR DESCRIPTION
Fixes #330239

## Problem

On Copilot Chat `invoke_agent` spans, three OTel attributes were silently absent whenever the workspace's remote pointed at a self-hosted GitHub Enterprise Server instance on a custom domain (e.g. `https://git.mycompany.com/owner/repo.git`):

- `github.copilot.git.repository`
- `copilot_chat.repo.remote_url`
- `github.copilot.github.org`

Meanwhile `github.copilot.git.branch` and `github.copilot.git.commit_sha` were present and correct on the same span. No error, no log line — the attributes just never appeared, so anyone pointing an OTLP collector at their agent turns lost repository correlation entirely.

The published [monitoring docs](https://code.visualstudio.com/docs/agents/guides/monitoring-agents) state the repository attribute is emitted "when in a Git repo", so this was a documented-contract violation. GitLab, Bitbucket Server, and plain git servers were affected identically.

## Root cause

All five attributes are produced by `extensions/copilot/src/platform/otel/common/workspaceOTelMetadata.ts`.

`buildWorkspaceMetadata` read `headBranchName` and `headCommitHash` straight off `RepoContext` with no host check, but derived `remoteUrl` exclusively from:

```ts
const repoInfo = Array.from(getOrderedRepoInfosFromContext(repoContext))[0];
```

`getOrderedRepoInfosFromContext` (`platform/git/common/gitService.ts`) yields a remote only when `getGithubRepoIdFromFetchUrl(url) ?? getAdoRepoIdFromFetchUrl(url)` resolves. `getGithubRepoIdFromFetchUrl` hard-gates on `const topLevelUrls = ['github.com', 'ghe.com']`, and the Azure DevOps resolver only handles `dev.azure.com`, `ssh.dev.azure.com`, and `*.visualstudio.com`.

A custom GHES domain matches neither allowlist, so the generator yielded nothing, `remoteUrl` stayed `undefined`, and the `if (metadata.remoteUrl)` branch in `workspaceMetadataToOTelAttributes` never ran — dropping all three attributes at once. That is exactly the asymmetry described in the issue.

Secondary defect: `extractGitHubOrg` matched only `/github\.com[/:]([^/]+)\/[^/]+\/?$/i`, so it dropped the org even for `*.ghe.com` tenants and ssh host aliases (`abc-github.com`) that `getGithubRepoIdFromFetchUrl` already resolves correctly.

## Changes

### 1. Host-agnostic remote URL, without changing any existing value

Two non-exported helpers. `pickRecognizedRemoteUrl` returns the highest-priority remote that resolves to a repo id; `pickFallbackRemoteUrl` returns the highest-priority remote on any host. The resolvable one is preferred:

```ts
const recognizedRemoteUrl = pickRecognizedRemoteUrl(repoContext);
const remoteUrl = recognizedRemoteUrl ?? pickFallbackRemoteUrl(repoContext);
```

This ordering matters. A naive host-agnostic rewrite regresses mixed-remote repositories: with `origin` pointing at a GitLab mirror and a second remote at GitHub, the old code reported the GitHub URL (plus `github.org`), and a first-parseable-wins implementation would silently switch that span to the GitLab URL and drop the org. Preferring the resolvable remote makes the change **strictly additive** — no repository that already reported a URL sees a different value. Three tests lock this behaviour.

Both passes reuse `getOrderedRemoteUrlsFromContext`, so remote prioritization (a lone remote → the upstream remote → `origin` → the rest) is unchanged.

### 2. Local remotes excluded from the fallback

Removing the host gate means arbitrary remote strings become eligible, including `file:///Users/<name>/dev/repo` and relative paths, which `normalizeFetchUrl` returns verbatim from its `catch` branch. The old allowlist suppressed those incidentally.

The fallback requires `parseRemoteUrl(url)` to resolve, which admits only `ssh`, `https`, and `http`. That alone is not sufficient, because scp-style syntax can smuggle a local path through an accepted scheme — `git@localhost:/Users/alice/dev/repo.git` normalizes to `ssh://git@localhost//Users/alice/dev/repo.git` and passes the scheme check. Loopback hosts (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`, `0.0.0.0`) are therefore rejected on top of the scheme check.

Absolute paths on routable hosts are still reported: `git@git.mycompany.com:/srv/git/repo.git` is a normal self-hosted layout where the path describes the server's filesystem, not the user's.

### 3. The host-agnostic remote is scoped to OTel emission

`WorkspaceOTelMetadata` carries two remote values:

- `remoteUrl` — any host. Used for the OTel attributes; this is what fixes the issue.
- `recognizedRemoteUrl` — only remotes resolving to a repo id (github.com, `*.ghe.com`, Azure DevOps), i.e. exactly the set reportable before this PR.

Two consumers forward a remote to GitHub telemetry rather than to the user's own OTel exporter, and both now read `recognizedRemoteUrl` so their payloads are unchanged from `main`:

- `extension/conversation/vscode-node/userActions.ts` → `sendGHTelemetryEvent('inline.trackEditSurvival', ...)`
- `platform/multiFileEdit/common/multiFileEditQualityTelemetry.ts` → `sendEnhancedGHTelemetryEvent('fastApply/editOutcome', ...)`

A field split is used rather than an opt-in flag on `resolveWorkspaceOTelMetadata` because `EditSurvivalReporter` resolves a single metadata object that feeds both `emitEditSurvivalEvent` (OTel) and the GitHub event; a per-call flag would have forced the OTel path to lose the fix there too.

### 4. `extractGitHubOrg` delegates to the canonical resolver

```ts
function extractGitHubOrg(remoteUrl: string): string | undefined {
    return getGithubRepoIdFromFetchUrl(remoteUrl)?.org;
}
```

Reuses the allowlist read-only. This keeps the org attribute scoped to recognized GitHub hosts (preserving the existing `omits github.org for non-github remotes` test) while **recovering** the org for `*.ghe.com` tenants and ssh host aliases that the previous regex dropped.

### 5. Pre-existing crash, surfaced by the new tests

Adding a `remoteFetchUrls: [undefined]` case produced:

```
TypeError: Cannot read properties of undefined (reading 'trim')
    at parseRemoteUrl (gitService.ts:166)
    at getGithubRepoIdFromFetchUrl (gitService.ts:245)
    at getOrderedRepoInfosFromContext (gitService.ts:117)
```

Strategy 1 of `getOrderedRemoteUrlsFromContext` asserted `out.add(repoContext.remoteFetchUrls[0]!)`, but a push-only remote carries no fetch URL, so `undefined` escaped the declared `Iterable<string>` and threw. This predates this PR and also reaches `extension/prompt/node/repoInfoTelemetry.ts`. Fixed at source with a truthy guard; strategies 2, 3, and the trailing loop already guarded correctly.

### 6. Documentation

- `docs/monitoring/agent_monitoring.md` — the `github.copilot.github.org` row now names the full recognized set (github.com, `*.ghe.com`, and ssh host aliases normalizing to either) and notes it is absent for custom-domain GHES.
- `genAiAttributes.ts` — the `GITHUB_ORG` comment said "gated like the URL itself"; the URL is no longer gated, so it now describes the actual condition, including ssh host aliases.
- The `extractGitHubOrg` JSDoc carried the same omission and is corrected to match.

## Explicitly out of scope

**The repo id allowlist is untouched.** `getGithubRepoIdFromFetchUrl`, `getAdoRepoIdFromFetchUrl`, and `getOrderedRepoInfosFromContext` keep their exact current semantics. They feed GitHub API calls, PR creation, the coding agent, and `repoId`/`repoType` telemetry across roughly fifteen call sites; returning a `GithubRepoId` for a GitLab host would be wrong and would change outbound API behaviour. The fix is confined to the OTel metadata path.

**`github.copilot.github.org` remains absent for custom-domain GHES.** Distinguishing a self-hosted GHES domain from an arbitrary git host requires reading the `github-enterprise.uri` setting. `platform/otel/common/` currently has no dependency injection, and threading `IConfigurationService` through would mean constructor churn at call sites that do not inject it (`editSurvivalReporter`, `multiFileEditQualityTelemetry`, `userActions`) for a single telemetry string. Since `github.copilot.git.repository` is now always populated, a backend can derive the org from the URL. A test documents this limitation explicitly. Happy to follow up if maintainers would prefer the attribute plumbed through.

The following are the same class of bug in core, filed separately rather than folded in here:

- `src/vs/workbench/contrib/chat/browser/chatRepoInfo.ts` classifies `*.ghe.com` as `remoteVendor: 'other'` and omits `ssh.dev.azure.com`, disagreeing with `src/vs/platform/agentHost/node/agentHostRepoInfoTelemetry.ts`.
- `src/vs/workbench/contrib/git/common/utils.ts` `hasGitHubRemotes` uses an un-dot-anchored `endsWith('github.com')`, so `evilgithub.com` passes. The function currently has no callers.
- `src/extension/inlineChat2/node/inlineChatIntent.ts` creates an `invoke_agent Inline Chat` span that sets `AGENT_TYPE` but never spreads the workspace git attributes at all.

## Tests

20 new cases. `src/platform/otel/common/test/workspaceOTelMetadata.spec.ts`:

| Case | Asserts |
|---|---|
| GHES custom domain, https | the reported regression — URL now emitted |
| GHES custom domain, scp/ssh | `git@host:owner/repo.git` normalizes to `https://host/owner/repo.git` |
| GitLab | URL emitted |
| Bitbucket Server `/scm/` path | `/scm/` segment stripped by `normalizeFetchUrl` |
| Azure DevOps | unchanged |
| `github.com` | unchanged (tightened from a loose `toContain` to an exact match) |
| GitHub remote beats higher-priority unknown host | no regression for mixed-remote repos |
| ADO remote beats higher-priority unknown host | no regression for mixed-remote repos |
| fallback only when nothing resolves | fallback ordering |
| upstream priority preserved for unknown hosts | prioritization intact |
| `file://`, absolute path, relative path | rejected — local remotes |
| loopback: scp, `ssh://`, `127.0.0.1`, `*.localhost`, https with port, `[::1]` | rejected |
| loopback skipped, later routable remote reported | guard does not swallow the whole repo |
| absolute path on a routable host | still reported |
| `recognizedRemoteUrl` for github.com / Azure DevOps / custom GHES | set, set, `undefined` |
| `recognizedRemoteUrl` in a mixed-remote repo | pinned to the resolvable remote |
| lone remote with no fetch URL | `undefined`, no throw |
| `*.ghe.com` | `github.org` now derived (previously dropped) |
| ssh host alias | `github.org` derived |
| custom-domain GHES attributes | URL and legacy key set, `github.org` absent — documents the limitation |
| Bitbucket Server attributes | URL set, `github.org` absent |

`src/platform/git/test/node/gitService.spec.ts` adds direct coverage for `getOrderedRemoteUrlsFromContext` (lone remote with and without a fetch URL, upstream ordering) and `getOrderedRepoInfosFromContext` (no throw on a missing fetch URL, unknown hosts skipped).

## Verification

| Gate | Result |
|---|---|
| `npx vitest --run --pool=forks src/platform/otel src/platform/git src/platform/multiFileEdit src/platform/editSurvivalTracking` | PASS 333, FAIL 0 |
| `npm run typecheck` (all four tsconfig projects) | exit 0, 0 errors |
| `npx eslint` on all changed files | exit 0, 0 errors, 0 warnings |
| Full `npm run test:unit` vs. stashed baseline | 39 failed files / 425 failed tests **identical both ways**; the passing count differs only by the tests this PR adds |

The 39 pre-existing failures are environmental in this checkout — they need `dist/*.wasm` tree-sitter builds and a seeded SQLite model-metadata cache. The stashed-baseline run confirms none of them are attributable to this change.

Not performed locally: an end-to-end run against a live GHES remote with `"github.copilot.chat.otel.enabled": true` and a real Copilot session.

## Notes for reviewers

Two behavioural consequences worth a deliberate look:

- **New values, confined to the user's own exporter.** Self-hosted corporate git hostnames (`git.mycompany.com`) now appear where they previously did not, but only on spans exported to the OTLP endpoint the user configured. Following review, the two consumers that forward a remote to GitHub telemetry (`inline.trackEditSurvival` and `fastApply/editOutcome`) read `recognizedRemoteUrl` and so collect exactly what they collected on `main`.
- **Cardinality.** `github.copilot.git.repository` moves from GitHub/ADO hosts only to every host, so distinct-value cardinality on that attribute will rise. Worth a look from whoever owns OTel backend cost.

Local-path exposure is addressed by the loopback rejection described above. Credential exposure is unchanged: `normalizeFetchUrl` rebuilds from `hostname + pathname`, dropping userinfo, port, and query; the scp branch drops the user; and a `user:pass@` form does not match the scp regex, so it goes down the credential-stripping `new URL()` path.
