### PR TITLE
automations: show needs-input indicator when session is waiting for user input

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -473,8 +473,17 @@
 	color: var(--vscode-list-warningForeground);
 }
 
+.automations-run-card-needs-input-label {
+	font-size: 11px;
+}
+
 .automations-run-card.needs-input {
 	animation: automation-needs-input-accent-pulse 3s ease-in-out infinite;
+}
+
+.automations-run-card.needs-input.clickable:hover {
+	animation: none;
+	background-color: var(--vscode-list-hoverBackground);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -469,6 +469,30 @@
 	color: var(--vscode-progressBar-background);
 }
 
+.automations-run-card.needs-input .automations-run-card-icon {
+	color: var(--vscode-list-warningForeground);
+}
+
+.automations-run-card.needs-input {
+	animation: automation-needs-input-accent-pulse 3s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.automations-run-card.needs-input {
+		animation: none;
+		background-color: color-mix(in srgb, var(--vscode-list-warningForeground) 8%, transparent);
+	}
+}
+
+@keyframes automation-needs-input-accent-pulse {
+	0%, 100% {
+		background-color: transparent;
+	}
+	50% {
+		background-color: color-mix(in srgb, var(--vscode-list-warningForeground) 12%, transparent);
+	}
+}
+
 .automations-run-card-workspace {
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -106,9 +106,9 @@ export class AutomationsCardsWidget extends Disposable {
 						session,
 						isRead: session.isRead.read(reader),
 						supportsDelete: session.capabilities.read(reader).supportsDelete === true,
-							sessionStatus: run.status === 'running' ? session.status.read(reader) : undefined,
-						});
-					}
+						sessionStatus: run.status === 'running' ? session.status?.read(reader) : undefined,
+					});
+				}
 			}
 			this.historySection.render(allRuns, items, sessions);
 		}));
@@ -525,6 +525,8 @@ class AutomationHistorySection extends Disposable {
 			this.disposables.add(createPixelSpinner(spinnerContainer, { variant: isNeedsInput ? 'ring' : 'grid' }));
 			if (isNeedsInput) {
 				card.classList.add('needs-input');
+				const needsInputLabel = DOM.append(statusRow, $('span.automations-run-card-needs-input-label'));
+				needsInputLabel.textContent = localize('automationRunNeedsInputLabel', "Input needed");
 			}
 		} else {
 			const statusInfo = runStatusIcon(run.status);

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -34,7 +34,7 @@ import { createPixelSpinner } from '../../../../../base/browser/ui/pixelSpinner/
 import { Gesture, GestureEvent, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 
 import { AbstractCustomView } from '../../../../services/customView/browser/customView.js';
 import { ICustomViewService } from '../../../../services/customView/browser/customViewService.js';
@@ -106,8 +106,9 @@ export class AutomationsCardsWidget extends Disposable {
 						session,
 						isRead: session.isRead.read(reader),
 						supportsDelete: session.capabilities.read(reader).supportsDelete === true,
-					});
-				}
+							sessionStatus: run.status === 'running' ? session.status.read(reader) : undefined,
+						});
+					}
 			}
 			this.historySection.render(allRuns, items, sessions);
 		}));
@@ -476,7 +477,8 @@ class AutomationHistorySection extends Disposable {
 
 		const automation = automationMap.get(run.automationId);
 		const title = automation?.name ?? localize('unknownAutomation', "Unknown");
-		const statusLabel = getRunStatusLabel(run.status);
+		const isNeedsInput = run.status === 'running' && sessionState?.sessionStatus === SessionStatus.NeedsInput;
+		const statusLabel = isNeedsInput ? localize('automationRunNeedsInput', "Needs input") : getRunStatusLabel(run.status);
 		const timestamp = formatTimestamp(run.startedAt, bucketKind);
 		const ariaLabelParts = [title];
 		if (automation?.target.kind === 'workspace') {
@@ -520,7 +522,10 @@ class AutomationHistorySection extends Disposable {
 		if (run.status === 'running' || run.status === 'pending') {
 			const spinnerContainer = DOM.append(statusRow, $('span.automations-run-card-icon'));
 			spinnerContainer.setAttribute('aria-hidden', 'true');
-			this.disposables.add(createPixelSpinner(spinnerContainer, { variant: 'grid' }));
+			this.disposables.add(createPixelSpinner(spinnerContainer, { variant: isNeedsInput ? 'ring' : 'grid' }));
+			if (isNeedsInput) {
+				card.classList.add('needs-input');
+			}
 		} else {
 			const statusInfo = runStatusIcon(run.status);
 			const iconEl = DOM.append(statusRow, $('span.automations-run-card-icon.codicon'));
@@ -742,6 +747,7 @@ interface IAutomationRunSessionState {
 	readonly session: ISession;
 	readonly isRead: boolean;
 	readonly supportsDelete: boolean;
+	readonly sessionStatus: SessionStatus | undefined;
 }
 
 function isUnreadAutomationRun(run: IAutomationRun, sessionState: IAutomationRunSessionState | undefined): boolean {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -899,10 +899,24 @@ export class SessionSectionRenderer implements ITreeRenderer<SessionListItem, Fu
 	// TODO@BenV: Move automation-specific code into an AutomationSectionRenderer subclass.
 	readonly automationStatus = derived(this, reader => {
 		const runs = this.automationService.runs.read(reader);
+		const automationSessions = this.automationSessions.read(reader);
+
+		// NeedsInput takes priority: any running automation whose session is waiting for input.
+		const hasNeedsInput = runs.some(run => {
+			if (run.status !== 'running' || !run.sessionResource) {
+				return false;
+			}
+			const sessionResource = URI.parse(run.sessionResource);
+			const session = automationSessions.find(candidate => this.uriIdentityService.extUri.isEqual(candidate.resource, sessionResource));
+			return !!session && session.status.read(reader) === SessionStatus.NeedsInput;
+		});
+		if (hasNeedsInput) {
+			return SessionStatus.NeedsInput;
+		}
+
 		if (runs.some(run => run.status === 'pending' || run.status === 'running')) {
 			return SessionStatus.InProgress;
 		}
-		const automationSessions = this.automationSessions.read(reader);
 		const hasUnreadRun = runs.some(run => {
 			if ((run.status !== 'completed' && run.status !== 'failed') || !run.sessionResource) {
 				return false;
@@ -983,7 +997,10 @@ export class SessionSectionRenderer implements ITreeRenderer<SessionListItem, Fu
 			const statusIcon = template.elementDisposables.add(this.instantiationService.createInstance(SessionStatusIcon, template.statusIndicator));
 			template.elementDisposables.add(autorun(reader => {
 				const automationStatus = this.automationStatus.read(reader);
-				if (automationStatus === SessionStatus.InProgress) {
+				if (automationStatus === SessionStatus.NeedsInput) {
+					template.statusIndicator.style.display = '';
+					statusIcon.setStatus(SessionStatus.NeedsInput, true, false);
+				} else if (automationStatus === SessionStatus.InProgress) {
 					template.statusIndicator.style.display = '';
 					statusIcon.setStatus(SessionStatus.InProgress, true, false);
 				} else if (automationStatus === SessionStatus.Completed) {
@@ -1321,13 +1338,15 @@ class SessionsAccessibilityProvider {
 				return this.automationStatus
 					? derived(this, reader => {
 						switch (this.automationStatus?.read(reader)) {
-							case SessionStatus.InProgress:
-								return localize('automationsActiveAria', "{0}, run in progress", element.label);
-							case SessionStatus.Completed:
-								return localize('automationsUnreadRunAria', "{0}, unread run", element.label);
-							default:
-								return element.label;
-						}
+								case SessionStatus.NeedsInput:
+									return localize('automationsNeedsInputAria', "{0}, run needs input", element.label);
+								case SessionStatus.InProgress:
+									return localize('automationsActiveAria', "{0}, run in progress", element.label);
+								case SessionStatus.Completed:
+									return localize('automationsUnreadRunAria', "{0}, unread run", element.label);
+								default:
+									return element.label;
+							}
 					})
 					: element.label;
 			}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -906,8 +906,7 @@ export class SessionSectionRenderer implements ITreeRenderer<SessionListItem, Fu
 			if (run.status !== 'running' || !run.sessionResource) {
 				return false;
 			}
-			const sessionResource = URI.parse(run.sessionResource);
-			const session = automationSessions.find(candidate => this.uriIdentityService.extUri.isEqual(candidate.resource, sessionResource));
+			const session = automationSessions.find(candidate => this.uriIdentityService.extUri.isEqual(candidate.resource, run.sessionResource));
 			return !!session && session.status.read(reader) === SessionStatus.NeedsInput;
 		});
 		if (hasNeedsInput) {
@@ -1338,15 +1337,15 @@ class SessionsAccessibilityProvider {
 				return this.automationStatus
 					? derived(this, reader => {
 						switch (this.automationStatus?.read(reader)) {
-								case SessionStatus.NeedsInput:
-									return localize('automationsNeedsInputAria', "{0}, run needs input", element.label);
-								case SessionStatus.InProgress:
-									return localize('automationsActiveAria', "{0}, run in progress", element.label);
-								case SessionStatus.Completed:
-									return localize('automationsUnreadRunAria', "{0}, unread run", element.label);
-								default:
-									return element.label;
-							}
+							case SessionStatus.NeedsInput:
+								return localize('automationsNeedsInputAria', "{0}, run needs input", element.label);
+							case SessionStatus.InProgress:
+								return localize('automationsActiveAria', "{0}, run in progress", element.label);
+							case SessionStatus.Completed:
+								return localize('automationsUnreadRunAria', "{0}, unread run", element.label);
+							default:
+								return element.label;
+						}
 					})
 					: element.label;
 			}

--- a/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/automationsView.test.ts
@@ -27,7 +27,7 @@ import { IAutomationDialogResult, IAutomationDialogService, IShowAutomationDialo
 import { IAutomationRunDispatch, IAutomationRunner, IAutomationRunOperation } from '../../../../../workbench/contrib/chat/common/automations/automationRunner.js';
 import { AutomationMutationGuard, IAutomationRunClaim, IAutomationService, ICreateAutomationOptions, IGuardedAutomationUpdateResult, IUpdateAutomationOptions, IUpdateAutomationRunOptions } from '../../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
 import { ICustomViewService } from '../../../../services/customView/browser/customViewService.js';
@@ -245,18 +245,21 @@ class FakeSessionsManagementService extends mock<ISessionsManagementService>() i
 	sessionExists = true;
 	readonly isRead = observableValue<boolean>(this, false);
 	readonly secondIsRead = observableValue<boolean>(this, false);
+	readonly sessionStatus = observableValue<SessionStatus>(this, SessionStatus.InProgress);
 	readonly capabilities = observableValue(this, { supportsMultipleChats: false, supportsDelete: true });
 	readonly session = upcastPartial<ISession>({
 		resource: SESSION_RESOURCE,
 		sessionId: 'test/session-1',
 		isRead: this.isRead,
 		capabilities: this.capabilities,
+		status: this.sessionStatus,
 	});
 	readonly secondSession = upcastPartial<ISession>({
 		resource: SECOND_SESSION_RESOURCE,
 		sessionId: 'test/session-2',
 		isRead: this.secondIsRead,
 		capabilities: this.capabilities,
+		status: this.sessionStatus,
 	});
 	markAllReadCalls = 0;
 	markAllReadSessionCount = 0;
@@ -880,6 +883,43 @@ suite('AutomationsCardsWidget', () => {
 			buildAutomationsAccessibleContent([automation()], [run({ status: 'failed', errorMessage: 'boom' })]).includes('Daily review, Failed'),
 			true,
 		);
+	});
+
+	test('running run shows needs-input indicator when session status transitions to NeedsInput', () => {
+		const { automationService, sessionsManagementService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run({ status: 'running' })]);
+
+		const card = widget.element.querySelector<HTMLElement>('.automations-run-card');
+		assert.ok(card);
+		assert.strictEqual(card.classList.contains('needs-input'), false);
+		assert.ok(card.querySelector('.monaco-pixel-spinner'));
+		assert.strictEqual(card.querySelector('.monaco-pixel-spinner-ring'), null);
+
+		sessionsManagementService.sessionStatus.set(SessionStatus.NeedsInput, undefined);
+
+		const updatedCard = widget.element.querySelector<HTMLElement>('.automations-run-card');
+		assert.ok(updatedCard);
+		assert.strictEqual(updatedCard.classList.contains('needs-input'), true);
+		assert.ok(updatedCard.querySelector('.monaco-pixel-spinner-ring'));
+		assert.ok(updatedCard.querySelector('.automations-run-card-main')?.getAttribute('aria-label')?.includes('Needs input'));
+	});
+
+	test('needs-input indicator reverts when session status returns to InProgress', () => {
+		const { automationService, sessionsManagementService, widget } = setup();
+		automationService.setAutomations([automation()]);
+		automationService.setRuns([run({ status: 'running' })]);
+		sessionsManagementService.sessionStatus.set(SessionStatus.NeedsInput, undefined);
+
+		assert.strictEqual(widget.element.querySelector('.automations-run-card')?.classList.contains('needs-input'), true);
+
+		sessionsManagementService.sessionStatus.set(SessionStatus.InProgress, undefined);
+
+		const card = widget.element.querySelector<HTMLElement>('.automations-run-card');
+		assert.ok(card);
+		assert.strictEqual(card.classList.contains('needs-input'), false);
+		assert.ok(card.querySelector('.monaco-pixel-spinner'));
+		assert.strictEqual(card.querySelector('.monaco-pixel-spinner-ring'), null);
 	});
 });
 

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -132,6 +132,63 @@ suite('Sessions - SessionsList', () => {
 				managementCalls: [],
 			});
 		});
+
+		test('needs-input automation status takes priority over other running runs', () => {
+			const runningSession = createSession('automation-running', {
+				resource: URI.parse('test-session:/Workspace/Automation-Running'),
+			});
+			const needsInputSession = createSession('automation-needs-input', {
+				resource: URI.parse('test-session:/Workspace/Automation-Needs-Input'),
+			});
+			const runningStatus = runningSession.status as ReturnType<typeof observableValue<SessionStatus>>;
+			const needsInputStatus = needsInputSession.status as ReturnType<typeof observableValue<SessionStatus>>;
+			runningStatus.set(SessionStatus.InProgress, undefined);
+			needsInputStatus.set(SessionStatus.InProgress, undefined);
+			const runs = observableValue<readonly IAutomationRun[]>('automationRuns', []);
+			const automationService = new class extends mock<IAutomationService>() {
+				override readonly runs = runs;
+			};
+			const uriIdentityService = new class extends mock<IUriIdentityService>() {
+				override readonly extUri = new ExtUri(() => true);
+			};
+			const renderer = new SessionSectionRenderer(
+				true,
+				new class extends mock<IInstantiationService>() { },
+				new class extends mock<IContextKeyService>() { },
+				automationService,
+				constObservable([runningSession, needsInputSession]),
+				uriIdentityService,
+				new class extends mock<ICustomViewService>() { },
+			);
+			runs.set([
+				{
+					id: 'running',
+					automationId: 'automation',
+					status: 'running',
+					trigger: 'schedule',
+					sessionResource: runningSession.resource,
+					startedAt: '2026-08-10T00:00:00.000Z',
+					leaderWindowId: 1,
+				},
+				{
+					id: 'needs-input',
+					automationId: 'automation',
+					status: 'running',
+					trigger: 'schedule',
+					sessionResource: needsInputSession.resource,
+					startedAt: '2026-08-10T00:00:00.000Z',
+					leaderWindowId: 1,
+				},
+			], undefined);
+
+			assert.strictEqual(renderer.automationStatus.get(), SessionStatus.InProgress);
+
+			needsInputStatus.set(SessionStatus.NeedsInput, undefined);
+			assert.strictEqual(renderer.automationStatus.get(), SessionStatus.NeedsInput);
+
+			needsInputStatus.set(SessionStatus.InProgress, undefined);
+			assert.strictEqual(renderer.automationStatus.get(), SessionStatus.InProgress);
+		});
 	});
 
 	suite('groupByWorkspace', () => {


### PR DESCRIPTION
When a running automation's session enters NeedsInput state, the automations view now surfaces this visually:

- Automation card spinner switches from blue grid to yellow/orange ring
- Card gets a subtle accent pulse (respects prefers-reduced-motion)
- Sidebar shortcut shows the NeedsInput icon instead of generic InProgress
- Aria labels updated for screen readers

The session status observable is already reactive so no polling is needed. The view reads it for running runs only to avoid unnecessary subscriptions.

Fixes: microsoft/vscode-internalbacklog#8323

<img width="1262" height="392" alt="image" src="https://github.com/user-attachments/assets/cfa7a9a7-30e3-464d-a029-b0d27fc4b919" />
