### PR TITLE
Hide voice placeholder while typing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -44,7 +44,7 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatSessionRoutingController, IChatSessionRoutingHost } from '../sessionRouter/chatSessionRoutingController.js';
 import { combineVoiceInput } from '../voiceClient/voiceInputUtils.js';
 import { IChatInputWindowService, ChatInputWindowStorageKeys, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT, CHAT_INPUT_WINDOW_SET_VOICE_TARGET_COMMAND_ID } from '../../common/chatInputWindow.js';
-import { autorun, IReader } from '../../../../../base/common/observable.js';
+import { autorun, IReader, observableFromEvent } from '../../../../../base/common/observable.js';
 import { AgentSessionStatus } from '../agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { IVoiceSessionController } from '../voiceClient/voiceSessionController.js';
@@ -450,6 +450,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		const inputContainer = widget.input.inputContainerElement;
 		if (inputContainer) {
 			try {
+				const inputValue = observableFromEvent(this, widget.inputEditor.onDidChangeModelContent, () => widget.getInput());
 				this._windowDisposables.add(setupVoiceInputDecorations({
 					voiceSessionController: this.voiceSessionController,
 					ttsPlaybackService: this.ttsPlaybackService,
@@ -462,6 +463,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 					inputContainer,
 					glowContainer: surface,
 					isActive: this.voiceSessionController.omniInputActive,
+					inputValue,
 					isOwner: this.voiceSessionController.omniInputActive,
 				}));
 			} catch (error) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations.ts
@@ -41,6 +41,8 @@ export interface IVoiceInputDecorationsOptions {
 	readonly glowContainer?: HTMLElement;
 	/** Whether this surface is active/visible. */
 	readonly isActive: IObservable<boolean>;
+	/** Current text in the input. Voice placeholders are hidden while it is non-empty. */
+	readonly inputValue?: IObservable<string>;
 	/** Explicit ownership for surfaces such as omni that do not yet have a resource. */
 	readonly isOwner?: IObservable<boolean>;
 	/** Surface resource, compared with the voice target to avoid misrouting. */
@@ -151,6 +153,7 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		const connected = voiceSessionController.isConnected.read(reader);
 		const voiceState = voiceSessionController.voiceState.read(reader);
 		const active = isActive.read(reader);
+		const hasInput = (options.inputValue?.read(reader).length ?? 0) > 0;
 		const showTranscript = configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
 		const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 
@@ -161,6 +164,11 @@ export function setupVoiceInputDecorations(services: IVoiceInputDecorationsServi
 		}
 
 		if (visible.length === 0 || !showTranscript) {
+			if (hasInput) {
+				transcriptOverlayNode.style.display = 'none';
+				transcriptOverlayNode.classList.remove('has-transcript');
+				return;
+			}
 			const handsFree = configurationService.getValue<boolean>('agents.voice.handsFree') === true;
 			if (!showTranscript && voiceState === 'listening') {
 				// Transcript is disabled: surface a minimal "Listening..." overlay

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -512,6 +512,11 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('agents.voice.liveTranscript')),
 			() => this.configurationService.getValue<boolean>('agents.voice.liveTranscript') !== false
 		);
+		const inputValue = observableFromEvent(
+			this,
+			this._widget.inputEditor.onDidChangeModelContent,
+			() => this._widget.getInput()
+		);
 		const transcriptOverlay = $('.voice-transcript-overlay');
 		const transcriptScrollable = this._register(new DomScrollableElement(transcriptOverlay, {
 			horizontal: ScrollbarVisibility.Hidden,
@@ -667,6 +672,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const currentSession = this._currentSessionResource.read(reader);
 			const showTranscript = showTranscriptSetting.read(reader);
 			const showLiveTranscript = showLiveTranscriptSetting.read(reader);
+			const hasInput = inputValue.read(reader).length > 0;
 			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 			const showListeningPlaceholder = voiceState === 'listening' && (!showTranscript || !showLiveTranscript);
 
@@ -726,6 +732,11 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 			// Show hint when connected but no transcript yet
 			if (visible.length === 0 || !showTranscript || showListeningPlaceholder) {
+				if (hasInput) {
+					transcriptOverlayNode.style.display = 'none';
+					transcriptOverlayNode.classList.remove('has-transcript');
+					return;
+				}
 				const handsFree = this.configurationService.getValue<boolean>('agents.voice.handsFree') === true;
 				if (showListeningPlaceholder) {
 					transcriptOverlayNode.style.display = '';


### PR DESCRIPTION
## Summary

- hide listening and barge-in placeholders while the chat input contains text
- apply the behavior to both the chat view and omni-chat input
- restore the applicable voice placeholder when the input is cleared
- leave actual voice transcript rendering unchanged

Fixes #330288

## Validation

- targeted ESLint for all changed files
- TypeScript validation with `npx tsc --project src/tsconfig.json --noEmit --skipLibCheck`
- VS Code diagnostics: no errors
- `git diff --check`