### PR TITLE
chat: save dirty editors before sending messages

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -387,6 +387,11 @@ configurationRegistry.registerConfiguration({
 			},
 			agentHost: { key: AgentHostMigrateLegacyCopilotCliEnabledConfigKey },
 		},
+		[ChatConfiguration.SaveBeforeSend]: {
+			type: 'boolean',
+			description: nls.localize('chat.saveBeforeSend', "Controls whether all dirty editors except untitled editors are saved before sending a chat message."),
+			default: true,
+		},
 		'chat.implicitContext.enabled': {
 			type: 'object',
 			description: nls.localize('chat.implicitContext.enabled.1', "Enables automatically using the active editor as chat context for specified chat locations."),

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2874,9 +2874,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// Check if a custom submit handler wants to handle this submission
 		if (this.viewOptions.submitHandler) {
 			const inputValue = !query ? this.getInput() : query.query;
-			const attachedContext = this.input.getAttachedContext().asArray();
 			await saveAllBeforeChatSend(this.configurationService, this.editorService);
 			savedBeforeSend = true;
+			const attachedContext = this.input.getAttachedContext().asArray();
 			const handled = await this.viewOptions.submitHandler(inputValue, this.input.currentModeKind, attachedContext, options.isVoiceModeInput);
 			if (handled) {
 				return;
@@ -2898,6 +2898,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				this.setInput('');
 				return;
 			}
+		}
+
+		if (!savedBeforeSend) {
+			await saveAllBeforeChatSend(this.configurationService, this.editorService);
 		}
 
 		if (!options.preserveInput) {
@@ -3054,9 +3058,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 		let result: ChatSendResult;
 		try {
-			if (!savedBeforeSend) {
-				await saveAllBeforeChatSend(this.configurationService, this.editorService);
-			}
 			result = await this.chatService.sendRequest(this.viewModel.sessionResource, requestInputs.input, {
 				...selectedModelRequestOptions,
 				location: this.location,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -48,7 +48,9 @@ import product from '../../../../../platform/product/common/product.js';
 import { Progress } from '../../../../../platform/progress/common/progress.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { SaveReason } from '../../../../common/editor.js';
 import { ChatEntitlementContextKeys, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
 import { checkModeOption } from '../../common/chat.js';
 import { IChatAgentAttachmentCapabilities, IChatAgentCommand, IChatAgentData, IChatAgentService } from '../../common/participants/chatAgents.js';
@@ -157,6 +159,12 @@ export function getImmediateSilentSlashCommandPart(parsedRequest: IParsedChatReq
 
 export function shouldShowChatWelcome(itemCount: number, hasTranscriptOverlay: boolean): boolean {
 	return itemCount === 0 && !hasTranscriptOverlay;
+}
+
+export async function saveAllBeforeChatSend(configurationService: IConfigurationService, editorService: IEditorService): Promise<void> {
+	if (configurationService.getValue<boolean>(ChatConfiguration.SaveBeforeSend) !== false) {
+		await editorService.saveAll({ includeUntitled: false, reason: SaveReason.EXPLICIT });
+	}
 }
 
 /**
@@ -465,6 +473,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		private styles: IChatWidgetStyles,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IEditorService private readonly editorService: IEditorService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -2861,10 +2870,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		let savedBeforeSend = false;
 		// Check if a custom submit handler wants to handle this submission
 		if (this.viewOptions.submitHandler) {
 			const inputValue = !query ? this.getInput() : query.query;
 			const attachedContext = this.input.getAttachedContext().asArray();
+			await saveAllBeforeChatSend(this.configurationService, this.editorService);
+			savedBeforeSend = true;
 			const handled = await this.viewOptions.submitHandler(inputValue, this.input.currentModeKind, attachedContext, options.isVoiceModeInput);
 			if (handled) {
 				return;
@@ -3042,6 +3054,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 		let result: ChatSendResult;
 		try {
+			if (!savedBeforeSend) {
+				await saveAllBeforeChatSend(this.configurationService, this.editorService);
+			}
 			result = await this.chatService.sendRequest(this.viewModel.sessionResource, requestInputs.input, {
 				...selectedModelRequestOptions,
 				location: this.location,

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -41,6 +41,7 @@ export enum ChatConfiguration {
 	UtilitySmallModel = 'chat.utilitySmallModel',
 	BYOKUtilityModelDefault = 'chat.byokUtilityModelDefault',
 	RequestQueueingDefaultAction = 'chat.requestQueuing.defaultAction',
+	SaveBeforeSend = 'chat.saveBeforeSend',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
 	EditorAssociations = 'chat.editorAssociations',
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts
@@ -8,14 +8,41 @@ import { DeferredPromise } from '../../../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { OffsetRange } from '../../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
-import { acceptAndAwaitSentRequest, ChatWidget, getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight, shouldShowChatWelcome } from '../../../browser/widget/chatWidget.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { SaveReason } from '../../../../../common/editor.js';
+import { ISaveAllEditorsOptions, ISaveEditorsResult } from '../../../../../services/editor/common/editorService.js';
+import { TestEditorService } from '../../../../../test/browser/workbenchTestServices.js';
+import { acceptAndAwaitSentRequest, ChatWidget, getImmediateSilentSlashCommandPart, layoutChatWidgetForInputHeight, saveAllBeforeChatSend, shouldShowChatWelcome } from '../../../browser/widget/chatWidget.js';
 import { ChatSendResult, ChatSendResultSent, IChatSendRequestData } from '../../../common/chatService/chatService.js';
-import { ChatAgentLocation } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration } from '../../../common/constants.js';
 import { ChatRequestSlashCommandPart, ChatRequestTextPart, IParsedChatRequest } from '../../../common/requestParser/chatParserTypes.js';
 
 suite('ChatWidget', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class RecordingEditorService extends TestEditorService {
+		readonly saveAllCalls: (ISaveAllEditorsOptions | undefined)[] = [];
+
+		override async saveAll(options?: ISaveAllEditorsOptions): Promise<ISaveEditorsResult> {
+			this.saveAllCalls.push(options);
+			return { success: true, editors: [] };
+		}
+	}
+
+	test('saves non-untitled editors before sending by default', async () => {
+		const configurationService = new TestConfigurationService();
+		const editorService = store.add(new RecordingEditorService());
+
+		await saveAllBeforeChatSend(configurationService, editorService);
+		await configurationService.setUserConfiguration(ChatConfiguration.SaveBeforeSend, false);
+		await saveAllBeforeChatSend(configurationService, editorService);
+
+		assert.deepStrictEqual(editorService.saveAllCalls, [{
+			includeUntitled: false,
+			reason: SaveReason.EXPLICIT,
+		}]);
+	});
 
 	test('transcript overlays suppress the welcome state', () => {
 		assert.deepStrictEqual({


### PR DESCRIPTION
## Summary
- add a default-on `chat.saveBeforeSend` setting
- save dirty editors before regular and routed chat submissions
- exclude untitled editors from the save operation

Fixes #326041

## Validation
- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/chatWidget.test.ts`

(Written by Copilot)