### PR TITLE
copilot: skip Git fallback for virtual resources

### DIFF
--- a/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
+++ b/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
@@ -210,6 +210,11 @@ export class GitServiceImpl extends Disposable implements IGitService {
 			return remotes;
 		}
 
+		if (uri.scheme !== 'file') {
+			this.logService.trace(`[GitServiceImpl][getRepositoryFetchUrls] No open repository found for non-file URI`);
+			return undefined;
+		}
+
 		try {
 			const uriStat = await vscode.workspace.fs.stat(uri);
 			if (uriStat.type !== vscode.FileType.Directory) {


### PR DESCRIPTION
## Summary

- Stops Copilot repository lookup from treating virtual resources as local filesystem paths.
- Avoids repeated `.git/config` errors for resources such as `untitled:`, `ccsettings:`, and `vscode-scm:`.
- Preserves Git API lookup for already-open repositories regardless of URI scheme.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

`getRepositoryFetchUrls` first asks the Git extension for an open repository. When none matched, it unconditionally used `workspace.fs.stat` and direct `.git/config` access. Virtual resources therefore reached a fallback that assumes a local filesystem path and generated repeated file-system-provider errors.

### Implementation

The direct `.git/config` fallback now returns early for non-`file:` URIs. The existing open-repository path remains first, so repositories already known to the Git extension continue to resolve for supported remote and virtual schemes.

### Behavior and constraints

- Local `file:` resources retain repository-root discovery and direct `.git/config` parsing.
- Non-file resources without an open Git repository are treated as having no repository remotes.
- The change does not alter repository opening, remote parsing, or Git extension state handling.

</details>