### PR TITLE
agentHost: rename Copilot SDK telemetry prefix

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -7,7 +7,7 @@ import type { GitHubTelemetryNotification } from '@github/copilot-sdk';
 import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/telemetry.js';
 
 /* __GDPR__FRAGMENT__
-	"CopilotCliForwardedTelemetry": {
+	"CopilotSdkForwardedTelemetry": {
 		"created_at": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Timestamp when the SDK created the event." },
 		"model_call_id": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "SDK identifier for the model call." },
 		"exp_assignment_context": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Experiment assignment context from the Copilot CLI runtime." },
@@ -34,10 +34,10 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 */
 
 /* __GDPR__
-	"copilotCli/response.success": {
+	"copilotSdk/response.success": {
 		"owner": "amunger",
 		"comment": "Reports performance and usage details for successful Copilot CLI model responses forwarded by the Copilot SDK.",
-		"${include}": [ "${CopilotCliForwardedTelemetry}" ],
+		"${include}": [ "${CopilotSdkForwardedTelemetry}" ],
 		"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reason the response completed." },
 		"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selected for the response." },
 		"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type used for the response." },
@@ -75,10 +75,10 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 */
 
 /* __GDPR__
-	"copilotCli/response.error": {
+	"copilotSdk/response.error": {
 		"owner": "amunger",
 		"comment": "Reports performance and usage details for failed Copilot CLI model responses forwarded by the Copilot SDK.",
-		"${include}": [ "${CopilotCliForwardedTelemetry}" ],
+		"${include}": [ "${CopilotSdkForwardedTelemetry}" ],
 		"type": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Type of response failure." },
 		"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selected for the response." },
 		"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type used for the response." },
@@ -93,10 +93,10 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 */
 
 /* __GDPR__
-	"copilotCli/task_complete_todo_state": {
+	"copilotSdk/task_complete_todo_state": {
 		"owner": "amunger",
 		"comment": "Reports the aggregate state of the Copilot CLI todo list when task completion is recorded. Contains only todo-status counts and derived boolean indicators; it does not contain todo text or other user content.",
-		"${include}": [ "${CopilotCliForwardedTelemetry}" ],
+		"${include}": [ "${CopilotSdkForwardedTelemetry}" ],
 		"copilot_pid": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Process identifier for the Copilot CLI runtime." },
 		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
 		"engagement_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an engagement." },
@@ -158,6 +158,6 @@ export class CopilotGitHubTelemetryForwarder {
 			}
 		}
 
-		this._telemetryService.publicLog(`copilotCli/${event.kind}`, data);
+		this._telemetryService.publicLog(`copilotSdk/${event.kind}`, data);
 	}
 }

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -819,7 +819,7 @@ suite('CopilotAgent', () => {
 				enhanced: telemetryService.enhancedEvents,
 				internal: telemetryService.internalEvents,
 			}, {
-				generic: ['copilotCli/unknown_restricted', 'copilotCli/tool_call_executed'],
+				generic: ['copilotSdk/unknown_restricted', 'copilotSdk/tool_call_executed'],
 				enhanced: ['engine.messages.length'],
 				internal: ['engine.messages.length'],
 			});

--- a/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
@@ -67,7 +67,7 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 		});
 
 		assert.deepStrictEqual(telemetryService.events, [{
-			eventName: 'copilotCli/tool_call_executed',
+			eventName: 'copilotSdk/tool_call_executed',
 			data: {
 				cli_version: '1.0.69',
 				os_platform: 'win32',
@@ -109,7 +109,7 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 		forwarder.forward(notification);
 
 		assert.deepStrictEqual(telemetryService.events, [{
-			eventName: 'copilotCli/restricted_event',
+			eventName: 'copilotSdk/restricted_event',
 			data: {
 				created_at: undefined,
 				model_call_id: undefined,


### PR DESCRIPTION
## Summary
- rename the Copilot SDK telemetry forwarder event prefix from `copilotCli/` to `copilotSdk/`
- update matching GDPR classifications and unit-test expectations

## Validation
- `npm run compile`
- `npm run eslint -- src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts`
- `scripts/test.bat --run src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts` (132 passing)