### PR TITLE
sessions: offer sign-in from GitHub workspace picker

### DIFF
--- a/src/vs/sessions/browser/sessionsAuthGate.ts
+++ b/src/vs/sessions/browser/sessionsAuthGate.ts
@@ -52,6 +52,11 @@ export function shouldForceGitHubSignIn(allowSignedOutWhenUsable: boolean): bool
 	return !allowSignedOutWhenUsable;
 }
 
+/** Whether the GitHub workspace group should offer sign-in. */
+export function shouldShowGitHubWorkspaceGroupSignIn(signedIn: boolean, allowSignedOutWhenUsable: boolean): boolean {
+	return !signedIn && allowSignedOutWhenUsable;
+}
+
 /**
  * How the conditional-auth UI should treat the current default-account snapshot.
  * The crucial distinction is {@link Unresolved}: on startup

--- a/src/vs/sessions/common/sessionCommands.ts
+++ b/src/vs/sessions/common/sessionCommands.ts
@@ -27,3 +27,6 @@ export const RETURN_TO_VSCODE_EDITOR_COMMAND_ID = 'agents.returnToVSCodeEditor';
 
 /** Checks whether the Agents window is the only open main window. Registered in `vscodeActions.ts`. */
 export const SHOULD_SHOW_RETURN_TO_VSCODE_EDITOR_COMMAND_ID = 'agents.shouldShowReturnToVSCodeEditor';
+
+/** Starts GitHub Copilot sign-in. Registered in `account.contribution.ts`. */
+export const AGENTIC_SIGN_IN_COMMAND_ID = 'workbench.action.agenticSignIn';

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -54,6 +54,7 @@ import { language } from '../../../../base/common/platform.js';
 import { AgentHostCodexAgentEnabledSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { ChatAIDisabledSettingId } from '../../../../platform/chat/common/chatSettings.js';
 import { CHAT_SETUP_ACTION_ID } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
+import { AGENTIC_SIGN_IN_COMMAND_ID } from '../../../common/sessionCommands.js';
 
 // --- Account Menu Items --- //
 const AccountMenu = Menus.AccountMenu;
@@ -64,7 +65,6 @@ const PERSONALIZE_ACTION_IDS: readonly string[] = [
 	'workbench.action.openSettings',
 ];
 const SIGN_OUT_ACTION_ID = 'workbench.action.agenticSignOut';
-const SIGN_IN_ACTION_ID = 'workbench.action.agenticSignIn';
 const accountDateFormatter = safeIntl.DateTimeFormat(language, { month: 'short', day: 'numeric' });
 const accountTimeFormatter = safeIntl.DateTimeFormat(language, { hour: 'numeric', minute: 'numeric' });
 
@@ -81,7 +81,7 @@ registerUpdateTitleBarMenuPlacement(Menus.TitleBarUpdate, {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.agenticSignIn',
+			id: AGENTIC_SIGN_IN_COMMAND_ID,
 			title: localize2('signIn', "Sign in to use GitHub Copilot"),
 			icon: Codicon.signIn,
 			menu: {
@@ -768,7 +768,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				signOut = action;
 				continue;
 			}
-			if (action.id === SIGN_IN_ACTION_ID) {
+			if (action.id === AGENTIC_SIGN_IN_COMMAND_ID) {
 				if (!this.isAccountLoading) {
 					signIn = action;
 				}

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -22,9 +22,10 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { localize } from '../../../../nls.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISession, SessionTypeAuthRequirement } from '../../../services/sessions/common/session.js';
+import { ISession, SESSION_WORKSPACE_GROUP_GITHUB, SessionTypeAuthRequirement } from '../../../services/sessions/common/session.js';
 import { IOpenNewSessionResult, ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { isAllowSignedOutWhenUsableEnabled } from '../../../browser/sessionsAuthGate.js';
+import { isAllowSignedOutWhenUsableEnabled, shouldShowGitHubWorkspaceGroupSignIn } from '../../../browser/sessionsAuthGate.js';
+import { AGENTIC_SIGN_IN_COMMAND_ID } from '../../../common/sessionCommands.js';
 import { IAquariumService, IMountedToggleHandle } from '../../aquarium/browser/aquariumOverlay.js';
 import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
@@ -160,6 +161,20 @@ export class NewChatWidget extends Disposable {
 		const PickerCtor = isWeb ? WebWorkspacePicker : WorkspacePicker;
 		this._workspacePicker = this._register(this.instantiationService.createInstance(PickerCtor, {
 			canRestoreWorkspace: () => !this._isQuickChatComposer.get(),
+			getWorkspaceGroupAction: group => {
+				if (group === SESSION_WORKSPACE_GROUP_GITHUB && shouldShowGitHubWorkspaceGroupSignIn(
+					this.defaultAccountService.currentDefaultAccount !== null,
+					isAllowSignedOutWhenUsableEnabled(this.configurationService),
+				)) {
+					return {
+						label: localize('workspacePicker.signInGitHub', "Sign in to GitHub"),
+						icon: Codicon.signIn,
+						commandId: AGENTIC_SIGN_IN_COMMAND_ID,
+						hideBrowseActions: true,
+					};
+				}
+				return undefined;
+			},
 		}));
 
 		const feedbackChanged = observableSignalFromEvent(this, this.agentFeedbackService.onDidChangeFeedback);

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -170,7 +170,7 @@ export class NewChatWidget extends Disposable {
 						label: localize('workspacePicker.signInGitHub', "Sign in to GitHub"),
 						icon: Codicon.signIn,
 						commandId: AGENTIC_SIGN_IN_COMMAND_ID,
-						hideBrowseActions: true,
+						hideWorkspaceItems: true,
 					};
 				}
 				return undefined;

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -91,7 +91,7 @@ export interface IWorkspacePickerGroupAction {
 	readonly description?: string;
 	readonly icon: ThemeIcon;
 	readonly commandId: string;
-	readonly hideBrowseActions?: boolean;
+	readonly hideWorkspaceItems?: boolean;
 }
 
 interface IBrowsedWorkspaceSelection {
@@ -821,13 +821,18 @@ export class WorkspacePicker extends Disposable {
 		// Collect recent workspaces from picker storage across all providers
 		const allProviders = this.sessionsProvidersService.getProviders();
 		const providerIds = new Set(allProviders.map(p => p.id));
+		const availableTabs = this._getAvailableTabs();
+		const activeGroup = this._activeTab ?? (availableTabs.length === 1 ? availableTabs[0].id : undefined);
+		const workspaceGroupAction = this.options.getWorkspaceGroupAction?.(activeGroup);
 		const tabFilter = this._isTabFiltered()
 			? (w: IResolvedFolderWorkspace) => w.workspace.group === this._activeTab
 			: undefined;
 		// Own recents first, then VS Code recents (merged and deduplicated by the service)
-		const recentWorkspaces = this._getRecentWorkspaces()
-			.filter(w => providerIds.has(w.providerId))
-			.filter(w => !tabFilter || tabFilter(w));
+		const recentWorkspaces = workspaceGroupAction?.hideWorkspaceItems
+			? []
+			: this._getRecentWorkspaces()
+				.filter(w => providerIds.has(w.providerId))
+				.filter(w => !tabFilter || tabFilter(w));
 
 		// Build flat list in recency order (no source grouping)
 		for (const { workspace, providerId } of recentWorkspaces) {
@@ -847,11 +852,8 @@ export class WorkspacePicker extends Disposable {
 			});
 		}
 
-		const availableTabs = this._getAvailableTabs();
-		const activeGroup = this._activeTab ?? (availableTabs.length === 1 ? availableTabs[0].id : undefined);
-		const workspaceGroupAction = this.options.getWorkspaceGroupAction?.(activeGroup);
 		// Browse actions from all providers (filtered to the active tab)
-		const allBrowseActions = workspaceGroupAction?.hideBrowseActions ? [] : this._getAllBrowseActions();
+		const allBrowseActions = workspaceGroupAction?.hideWorkspaceItems ? [] : this._getAllBrowseActions();
 		// Remote providers with connection status — shown as dynamic rows
 		// in the Manage submenu on the Remote tab.
 		const remoteProviders = allProviders.filter(isAgentHostProvider).filter(p => p.connectionStatus !== undefined);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -83,6 +83,15 @@ export interface IWorkspacePickerOptions {
 	readonly canRestoreWorkspace?: () => boolean;
 	readonly restoreFromSessions?: boolean;
 	readonly sessionWorkspaceProviderFilter?: (providerId: string) => boolean;
+	readonly getWorkspaceGroupAction?: (group: string | undefined) => IWorkspacePickerGroupAction | undefined;
+}
+
+export interface IWorkspacePickerGroupAction {
+	readonly label: string;
+	readonly description?: string;
+	readonly icon: ThemeIcon;
+	readonly commandId: string;
+	readonly hideBrowseActions?: boolean;
 }
 
 interface IBrowsedWorkspaceSelection {
@@ -204,11 +213,7 @@ export class WorkspacePicker extends Disposable {
 
 		this._tabbedWidget = this._register(this.instantiationService.createInstance(TabbedActionListWidget));
 		this._pickerGroupContext = SessionWorkspacePickerGroupContext.bindTo(this.contextKeyService);
-		this._register(this._tabbedWidget.onDidChangeTab(tab => {
-			this._activeTab = tab;
-			this._userPickedTab = true;
-			this._pickerGroupContext.set(tab);
-		}));
+		this._register(this._tabbedWidget.onDidChangeTab(tab => this._selectWorkspaceGroup(tab)));
 		this._register(this._tabbedWidget.onDidHide(() => {
 			this._pickerGroupContext.reset();
 		}));
@@ -272,6 +277,12 @@ export class WorkspacePicker extends Disposable {
 				this._userPickedTab = false;
 			}
 		}));
+	}
+
+	protected _selectWorkspaceGroup(group: string): void {
+		this._activeTab = group;
+		this._userPickedTab = true;
+		this._pickerGroupContext.set(group);
 	}
 
 	/**
@@ -836,15 +847,28 @@ export class WorkspacePicker extends Disposable {
 			});
 		}
 
+		const availableTabs = this._getAvailableTabs();
+		const activeGroup = this._activeTab ?? (availableTabs.length === 1 ? availableTabs[0].id : undefined);
+		const workspaceGroupAction = this.options.getWorkspaceGroupAction?.(activeGroup);
 		// Browse actions from all providers (filtered to the active tab)
-		const allBrowseActions = this._getAllBrowseActions();
+		const allBrowseActions = workspaceGroupAction?.hideBrowseActions ? [] : this._getAllBrowseActions();
 		// Remote providers with connection status — shown as dynamic rows
 		// in the Manage submenu on the Remote tab.
 		const remoteProviders = allProviders.filter(isAgentHostProvider).filter(p => p.connectionStatus !== undefined);
 		const includeRemoteProviders = this._activeTab === SESSION_WORKSPACE_GROUP_REMOTE;
 
-		if (items.length > 0 && (allBrowseActions.length > 0)) {
+		if (items.length > 0 && (workspaceGroupAction || allBrowseActions.length > 0)) {
 			items.push({ kind: ActionListItemKind.Separator, label: '' });
+		}
+
+		if (workspaceGroupAction) {
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: workspaceGroupAction.label,
+				description: workspaceGroupAction.description,
+				group: { title: '', icon: workspaceGroupAction.icon },
+				item: { commandId: workspaceGroupAction.commandId },
+			});
 		}
 
 		// Render each browse action individually. Within a tab, actions are

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -1634,11 +1634,12 @@ function createTestablePicker(
 	remoteAgentHostsEnabled = true,
 	options: IWorkspacePickerOptions = {},
 	commandService: Partial<ICommandService> = { executeCommand: async () => { } },
+	storageService: IStorageService = disposables.add(new TestStorageService()),
 ): TestablePicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.stub(IActionWidgetService, { isVisible: false, hide: () => { }, show: () => { } });
 	instantiationService.stub(IContextViewService, { showContextView: () => ({ close: () => { } }), hideContextView: () => { }, layout: () => { } });
-	instantiationService.stub(IStorageService, disposables.add(new TestStorageService()));
+	instantiationService.stub(IStorageService, storageService);
 	instantiationService.stub(IUriIdentityService, { extUri });
 	instantiationService.stub(ISessionsProvidersService, providersService);
 	instantiationService.stub(IRemoteAgentHostService, {});
@@ -1737,8 +1738,17 @@ suite('WorkspacePicker - Tab discovery', () => {
 
 	test('shows a sign-in action in the GitHub group', async () => {
 		const executedCommands: string[] = [];
+		const storage = disposables.add(new TestStorageService());
+		seedStorage(storage, [{ uri: URI.file('/recent-repository'), providerId: 'p1', checked: true }]);
+		const baseProvider = createMockProvider('p1', { browseActions: [makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_GITHUB)] });
 		providersService.setProviders([
-			createMockProvider('p1', { browseActions: [makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_GITHUB)] }),
+			{
+				...baseProvider,
+				resolveWorkspace: uri => {
+					const workspace = baseProvider.resolveWorkspace(uri);
+					return workspace ? { ...workspace, group: SESSION_WORKSPACE_GROUP_GITHUB } : undefined;
+				},
+			},
 		]);
 		const picker = createTestablePicker(disposables, providersService, false, {
 			restoreFromSessions: false,
@@ -1746,13 +1756,13 @@ suite('WorkspacePicker - Tab discovery', () => {
 				label: 'Sign in to GitHub',
 				icon: Codicon.signIn,
 				commandId: AGENTIC_SIGN_IN_COMMAND_ID,
-				hideBrowseActions: true,
+				hideWorkspaceItems: true,
 			} : undefined,
 		}, {
 			executeCommand: async commandId => {
 				executedCommands.push(commandId);
 			},
-		});
+		}, storage);
 		picker.selectWorkspaceGroup(SESSION_WORKSPACE_GROUP_GITHUB);
 		await picker.select('Sign in to GitHub');
 		assert.deepStrictEqual({

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -30,7 +30,7 @@ import { extUri } from '../../../../../base/common/resources.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
-import { ISession, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
+import { ISession, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_GITHUB, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { IWorkspacePickerItem, IWorkspacePickerOptions, WorkspacePicker } from '../../browser/sessionWorkspacePicker.js';
 import { NewSessionWorkspacePreselectionSource } from '../../browser/newSessionComposerService.js';
 import { ISessionsRecentWorkspacesService, SessionsRecentWorkspacesService } from '../../../../services/sessions/browser/sessionsRecentWorkspacesService.js';
@@ -50,6 +50,7 @@ import { MockContextKeyService } from '../../../../../platform/keybinding/test/c
 import { IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { INotification, INotificationHandle, INotificationService, NoOpNotification, NotificationMessage } from '../../../../../platform/notification/common/notification.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
+import { AGENTIC_SIGN_IN_COMMAND_ID } from '../../../../common/sessionCommands.js';
 
 // ---- Storage key (must match the one in sessionWorkspacePicker.ts) ----------
 const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
@@ -1597,6 +1598,24 @@ class TestablePicker extends WorkspacePicker {
 	getAvailableTabs(): string[] {
 		return this._getAvailableTabs().map(t => t.id);
 	}
+
+	selectWorkspaceGroup(group: string): void {
+		this._selectWorkspaceGroup(group);
+	}
+
+	getItems() {
+		return this._buildItems();
+	}
+
+	getItemLabels(): string[] {
+		return this.getItems().flatMap(entry => entry.label ? [entry.label] : []);
+	}
+
+	async select(label: string): Promise<void> {
+		const entry = this.getItems().find(candidate => candidate.label === label);
+		assert.ok(entry?.item, `Expected picker item '${label}'`);
+		await this._dispatchPickerItem(entry.item);
+	}
 }
 
 function makeBrowseAction(providerId: string, group: string | undefined, label = 'browse'): ISessionWorkspaceBrowseAction {
@@ -1609,7 +1628,13 @@ function makeBrowseAction(providerId: string, group: string | undefined, label =
 	};
 }
 
-function createTestablePicker(disposables: DisposableStore, providersService: MockSessionsProvidersService, remoteAgentHostsEnabled = true): TestablePicker {
+function createTestablePicker(
+	disposables: DisposableStore,
+	providersService: MockSessionsProvidersService,
+	remoteAgentHostsEnabled = true,
+	options: IWorkspacePickerOptions = {},
+	commandService: Partial<ICommandService> = { executeCommand: async () => { } },
+): TestablePicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.stub(IActionWidgetService, { isVisible: false, hide: () => { }, show: () => { } });
 	instantiationService.stub(IContextViewService, { showContextView: () => ({ close: () => { } }), hideContextView: () => { }, layout: () => { } });
@@ -1622,7 +1647,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 	instantiationService.stub(IPreferencesService, {});
 	instantiationService.stub(IOutputService, {});
 	instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: remoteAgentHostsEnabled }));
-	instantiationService.stub(ICommandService, { executeCommand: async () => { } });
+	instantiationService.stub(ICommandService, commandService);
 	instantiationService.stub(IFileDialogService, {});
 	instantiationService.stub(IFileService, upcastPartial<IFileService>({
 		onDidChangeFileSystemProviderRegistrations: Event.None,
@@ -1630,7 +1655,10 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 		exists: async () => true,
 	}));
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
-	instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
+	instantiationService.stub(IMenuService, {
+		createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }),
+		getMenuActions: () => [],
+	});
 	instantiationService.stub(INotificationService, new TestNotificationService());
 	instantiationService.stub(IWorkspacesService, {
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
@@ -1638,7 +1666,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 	});
 	instantiationService.stub(ISessionsRecentWorkspacesService, disposables.add(instantiationService.createInstance(SessionsRecentWorkspacesService)));
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
-	return disposables.add(instantiationService.createInstance(TestablePicker, {}));
+	return disposables.add(instantiationService.createInstance(TestablePicker, options));
 }
 
 suite('WorkspacePicker - Tab discovery', () => {
@@ -1705,6 +1733,37 @@ suite('WorkspacePicker - Tab discovery', () => {
 		]);
 		const picker = createTestablePicker(disposables, providersService);
 		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE]);
+	});
+
+	test('shows a sign-in action in the GitHub group', async () => {
+		const executedCommands: string[] = [];
+		providersService.setProviders([
+			createMockProvider('p1', { browseActions: [makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_GITHUB)] }),
+		]);
+		const picker = createTestablePicker(disposables, providersService, false, {
+			restoreFromSessions: false,
+			getWorkspaceGroupAction: group => group === SESSION_WORKSPACE_GROUP_GITHUB ? {
+				label: 'Sign in to GitHub',
+				icon: Codicon.signIn,
+				commandId: AGENTIC_SIGN_IN_COMMAND_ID,
+				hideBrowseActions: true,
+			} : undefined,
+		}, {
+			executeCommand: async commandId => {
+				executedCommands.push(commandId);
+			},
+		});
+		picker.selectWorkspaceGroup(SESSION_WORKSPACE_GROUP_GITHUB);
+		await picker.select('Sign in to GitHub');
+		assert.deepStrictEqual({
+			tabs: picker.getAvailableTabs(),
+			itemLabels: picker.getItemLabels(),
+			executedCommands,
+		}, {
+			tabs: [SESSION_WORKSPACE_GROUP_GITHUB],
+			itemLabels: ['Sign in to GitHub'],
+			executedCommands: [AGENTIC_SIGN_IN_COMMAND_ID],
+		});
 	});
 
 	test('discovers groups from recent workspaces does not add extra tabs', () => {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -23,7 +23,7 @@ import { AgentSessionProviders, AgentSessionTarget } from '../../../../../workbe
 import { IChatService, IChatSendRequestOptions } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatResponseModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, gitHubInfoEqual, sessionWorkspaceEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset, IChatCheckpoints, ChatInteractivity, SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
+import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, ISideChatSelection, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, gitHubInfoEqual, sessionWorkspaceEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_GITHUB, ISessionChangeset, IChatCheckpoints, ChatInteractivity, SessionTypeAuthRequirement } from '../../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
 import { IDeleteChatOptions, ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions, ISessionModelsSnapshot, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
@@ -62,7 +62,6 @@ export const CopilotCloudSessionType: ISessionType = {
 	authRequirement: SessionTypeAuthRequirement.GitHub,
 };
 
-const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");
 const STORAGE_KEY_ISOLATION_MODE = 'sessions.isolationPicker.selectedMode';
 
 export type IsolationMode = 'worktree' | 'workspace';

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -755,6 +755,7 @@ export interface ISessionCapabilities {
  * of contributed values.
  */
 export const SESSION_WORKSPACE_GROUP_LOCAL = localize('sessionWorkspaceGroup.local', "Local");
+export const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");
 export const SESSION_WORKSPACE_GROUP_REMOTE = localize('sessionWorkspaceGroup.remote', "Remote");
 
 /**

--- a/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
+++ b/src/vs/sessions/test/browser/sessionsAuthGate.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
-import { ConditionalAuthState, conditionalAuthState, shouldForceGitHubSignIn, shouldShowDiscoveredConfigNudge } from '../../browser/sessionsAuthGate.js';
+import { ConditionalAuthState, conditionalAuthState, shouldForceGitHubSignIn, shouldShowDiscoveredConfigNudge, shouldShowGitHubWorkspaceGroupSignIn } from '../../browser/sessionsAuthGate.js';
 
 suite('Sessions - Auth Gate', () => {
 
@@ -19,6 +19,15 @@ suite('Sessions - Auth Gate', () => {
 			featureDisabled: true,
 			featureEnabled: false,
 		});
+	});
+
+	test('GitHub workspace group offers sign-in only for signed-out opted-in users', () => {
+		assert.deepStrictEqual([
+			shouldShowGitHubWorkspaceGroupSignIn(false, false),
+			shouldShowGitHubWorkspaceGroupSignIn(false, true),
+			shouldShowGitHubWorkspaceGroupSignIn(true, false),
+			shouldShowGitHubWorkspaceGroupSignIn(true, true),
+		], [false, true, false, false]);
 	});
 
 	test('conditionalAuthState treats an unresolved account as unknown, never signed out', () => {


### PR DESCRIPTION
## Summary

- Keeps the GitHub workspace tab available when the Agents window allows signed-out use.
- Replaces the unusable repository picker with a **Sign in to GitHub** action while signed out.
- Restores normal repository selection after the user signs in.

<img width="880" height="297" alt="image" src="https://github.com/user-attachments/assets/78a0e0f4-a075-4c36-b68a-01ce21d111e9" />


<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

With `chat.agentHost.allowSignedOutWhenUsable` enabled, users can enter the Agents window without a GitHub account. The workspace picker still exposed the GitHub tab and its repository **Select...** action, even though repository discovery requires GitHub authentication.

### Implementation

The generic workspace picker accepts an optional group-specific action. The new-session surface provides a localized GitHub sign-in action only when the user is signed out under the signed-out opt-in. That action invokes the existing Agents sign-in command rather than adding another authentication path.

A group action can suppress the group's provider browse actions. The signed-out GitHub action uses this capability so the tab contains only the actionable sign-in row; signed-in users continue to receive the provider's repository browse action.

The GitHub workspace group and sign-in command identifiers are shared constants so the provider, picker policy, and account contribution use the same identities.

### Behavior and constraints

- Local and Remote workspace tabs are unchanged.
- The GitHub tab remains visible rather than disappearing based on authentication state.
- Selecting the tab does not start authentication automatically; users explicitly activate the sign-in row.
- The sign-in row uses the existing action-list keyboard and accessibility behavior.
- Existing checked and recent workspace restoration behavior is unchanged.

</details>
