### PR TITLE
fix(launch.ps1): resolve process.argv index, WebRequest deprecation, and auth path checks

### DIFF
--- a/.agents/skills/launch/scripts/launch.ps1
+++ b/.agents/skills/launch/scripts/launch.ps1
@@ -156,18 +156,21 @@ function Copy-ProfileDirectory([string]$source, [string]$destination, [bool]$use
 	}
 }
 
-function Assert-AuthCriticalProfileFiles([string]$destination) {
+function Assert-AuthCriticalProfileFiles([string]$source, [string]$destination) {
 	$requiredPaths = @(
 		'Local State',
 		'machineid',
 		'User\globalStorage\state.vscdb',
 		'Network'
 	)
+	
+	# Only assert paths that actually existed in the source profile
 	$missingPaths = @($requiredPaths | Where-Object {
-		-not (Test-Path -LiteralPath (Join-Path $destination $_))
+		(Test-Path -LiteralPath (Join-Path $source $_)) -and (-not (Test-Path -LiteralPath (Join-Path $destination $_)))
 	})
+
 	if ($missingPaths.Count -gt 0) {
-		throw "Profile copy is missing auth-critical path(s): $($missingPaths -join ', '). Refusing to launch a profile that cannot preserve Windows authentication."
+		throw "Profile copy failed to preserve auth-critical path(s): $($missingPaths -join ', ')."
 	}
 }
 
@@ -182,7 +185,13 @@ function Test-SourceHasGitHubAuthenticationSecret([string]$node, [string]$source
 		$script = @'
 import { DatabaseSync } from 'node:sqlite';
 
-const db = new DatabaseSync(process.argv[1], { readOnly: true });
+// FIX: process.argv[2] is the first user argument passed after -e script in node
+const dbPath = process.argv[2];
+if (!dbPath) {
+	process.exit(1);
+}
+
+const db = new DatabaseSync(dbPath, { readOnly: true });
 try {
 	const row = db.prepare('SELECT 1 FROM ItemTable WHERE key LIKE ? LIMIT 1').get('secret://%github-authentication%');
 	process.stdout.write(row ? 'present' : 'absent');
@@ -190,7 +199,7 @@ try {
 	db.close();
 }
 '@
-		$result = @(& $node '--input-type=module' '-e' $script $temporaryDb 2>$null)
+		$result = @(& $node '--experimental-sqlite' '--input-type=module' '-e' $script $temporaryDb 2>$null)
 		if ($LASTEXITCODE -ne 0) {
 			return $null
 		}
@@ -467,7 +476,7 @@ try {
 		Write-LaunchError "[launch.ps1] slim copy: $sourceUserDataDir -> $destinationUdd"
 		Copy-ProfileDirectory $sourceUserDataDir $destinationUdd $true
 	}
-	Assert-AuthCriticalProfileFiles $destinationUdd
+	Assert-AuthCriticalProfileFiles $sourceUserDataDir $destinationUdd
 
 	New-Item -ItemType Directory -Force -Path $extensionsDir | Out-Null
 	if (-not $full -and $cloneExtensions) {
@@ -522,10 +531,8 @@ try {
 		}
 
 		try {
-			$request = [Net.WebRequest]::Create("http://127.0.0.1:$cdpPort/json/version")
-			$request.Timeout = 1000
-			$response = $request.GetResponse()
-			$response.Close()
+			# FIX: Using Invoke-RestMethod for clean cross-version PowerShell support without obsolete warnings
+			$null = Invoke-RestMethod -Uri "http://127.0.0.1:$cdpPort/json/version" -TimeoutSec 1 -ErrorAction Stop
 			$ready = $true
 			Write-LaunchError "[launch.ps1] CDP ready after ${second}s"
 			break


### PR DESCRIPTION

## Summary
Fixes execution errors, compatibility issues, and false-positive assertion failures in `launch.ps1` when bootstrapping isolated Code OSS instances.

## Key Changes
- **Fixed Node SQLite argument index (`Test-SourceHasGitHubAuthenticationSecret`):**
  - Updated `process.argv[1]` to `process.argv[2]` inside the inline Node module execution. Node sets `process.argv[1]` to `"[eval]"` when using `-e`, causing the database check to fail silently. Added `--experimental-sqlite` for Node v22+ compatibility.
- **Modernized CDP Port Polling:**
  - Replaced deprecated `[Net.WebRequest]::Create` with `Invoke-RestMethod` during the 90-second CDP endpoint readiness loop, ensuring compatibility across PowerShell 5.1 and PowerShell 7+.
- **Flexible Auth-Critical Path Assertion (`Assert-AuthCriticalProfileFiles`):**
  - Updated the assertion to verify only auth files that **exist in the source directory**, avoiding execution halts when running against clean or unauthenticated profile directories.

## How to Test
1. Run `./launch.ps1` against a clean source profile directory.
2. Confirm pre-flight Node script executes without `process.argv` null reference errors.
3. Verify the script waits for the CDP port and launches without PowerShell `WebRequest` deprecation warnings.