### PR TITLE
Report Auto in the response footer and explain its routing on hover

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -33,7 +33,6 @@ import { getAgentForIntent, Intent } from '../../common/constants';
 import { IConversationStore } from '../../conversationStore/node/conversationStore';
 import { IIntentService } from '../../intents/node/intentService';
 import { isAutoModel } from '../../../platform/endpoint/node/autoChatEndpoint';
-import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { UnknownIntent } from '../../intents/node/unknownIntent';
 import { formatAutoModeDetails, formatModelDetails } from '../../../platform/chat/common/chatModelDetails';
 import { ContributedToolName } from '../../tools/common/toolNames';
@@ -89,7 +88,6 @@ export class ChatParticipantRequestHandler {
 		@IAuthenticationService private readonly _authService: IAuthenticationService,
 		@IAuthenticationChatUpgradeService private readonly _authenticationUpgradeService: IAuthenticationChatUpgradeService,
 		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
-		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 	) {
 		this.location = this.getLocation(request);
 
@@ -262,9 +260,10 @@ export class ChatParticipantRequestHandler {
 				result = await chatResult;
 				const endpoint = await this._endpointProvider.getChatEndpoint(this.request);
 				const creditsUsed = this._chatQuotaService.getCreditsForTurn(this.turn.id);
-				const hideAutoModelName = isAutoModel(endpoint) === 1
-					&& this._experimentationService.getTreatmentVariable<boolean>('copilotchat.hideAutoModelName') === true;
-				if (hideAutoModelName) {
+				// Auto reports the user's choice ("Auto") rather than the model it
+				// picked: the resolved model and the routing rationale are surfaced in
+				// the footer's hover, via the auto-mode resolution part pushed above.
+				if (isAutoModel(endpoint) === 1) {
 					result.details = formatAutoModeDetails(creditsUsed, endpoint.multiplier);
 				} else if (this._authService.copilotToken?.isNoAuthUser) {
 					result.details = endpoint.name;

--- a/extensions/copilot/src/platform/chat/test/common/chatModelDetails.spec.ts
+++ b/extensions/copilot/src/platform/chat/test/common/chatModelDetails.spec.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { formatAutoModeDetails, formatModelDetails } from '../../common/chatModelDetails';
+
+describe('chat response footer details', () => {
+
+	it('reports the user\'s choice for Auto rather than the model it picked', () => {
+		// The resolved model and routing rationale are surfaced in the footer's
+		// hover instead, so the footer must not leak the picked model name.
+		const details = [
+			formatAutoModeDetails(0.7, undefined),
+			formatAutoModeDetails(1, undefined),
+			formatAutoModeDetails(undefined, 2),
+			formatAutoModeDetails(undefined, undefined),
+		];
+
+		expect(details).toEqual([
+			'Auto • 0.7 credits',
+			'Auto • 1 credit',
+			'Auto • 2x',
+			'Auto',
+		]);
+		expect(details.some(detail => detail.includes('GPT'))).toBe(false);
+	});
+
+	it('names the model for non-Auto picks', () => {
+		expect([
+			formatModelDetails('GPT-5.6 Luna', undefined, 0.7),
+			formatModelDetails('GPT-5.6 Luna', 2, undefined),
+		]).toEqual([
+			'GPT-5.6 Luna • 0.7 credits',
+			'GPT-5.6 Luna • 2x',
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -54,8 +54,9 @@ import { IChatAgentMetadata } from '../../common/participants/chatAgents.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatProgressResponseContent, IChatTextEditGroup } from '../../common/model/chatModel.js';
 import { chatSubcommandLeader } from '../../common/requestParser/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatErrorLevel, ChatRequestQueueKind, IChatConfirmation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatExternalEdit, IChatFollowup, IChatHookPart, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatPlanReview, IChatPlanReviewResult, IChatPullRequestContent, IChatQuestionAnswerValue, IChatQuestionAnswers, IChatQuestionCarousel, IChatService, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsageModelTotal, isChatFollowup } from '../../common/chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatErrorLevel, ChatRequestQueueKind, IChatAutoModeResolutionPart, IChatConfirmation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatExternalEdit, IChatFollowup, IChatHookPart, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatPlanReview, IChatPlanReviewResult, IChatPullRequestContent, IChatQuestionAnswerValue, IChatQuestionAnswers, IChatQuestionCarousel, IChatService, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsageModelTotal, isChatFollowup } from '../../common/chatService/chatService.js';
 import { ChatPlanReviewData } from '../../common/model/chatProgressTypes/chatPlanReviewData.js';
+import { ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { localChatSessionType, SessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
@@ -159,11 +160,11 @@ export interface IChatListItemTemplate {
 	wasResponseComplete?: boolean;
 	readonly completedResponseDisclosureDisposables: DisposableStore;
 	/**
-	 * Token-usage breakdown hover for the response footer's model/credits stat.
-	 * Template-scoped because the focusable footer container is reused across
+	 * Auto routing and token-usage hover for the response footer's model/credits
+	 * stat. Template-scoped because the focusable footer container is reused across
 	 * element renders, allowing its managed hover to be updated in place.
 	 */
-	readonly responseTokenStatsHover: MutableDisposable<IManagedHover>;
+	readonly responseFooterHover: MutableDisposable<IManagedHover>;
 
 	/** Drag handle element for reordering pending requests, if currently rendered. */
 	dragHandle?: HTMLElement;
@@ -334,6 +335,59 @@ export function getVisibleCompletedResponseItemCount(nodes: ReadonlyArray<Node>)
 }
 
 /**
+ * Managed-hover content for the response footer. The `ariaLabel` spells values
+ * out in full for screen readers, where the visible markdown may abbreviate.
+ */
+export type ResponseFooterHoverContent = { readonly markdown: MarkdownString; readonly markdownNotSupportedFallback: string; readonly ariaLabel: string };
+
+/**
+ * Joins accessible-name fragments into sentences, without doubling up the
+ * separator on fragments that already end in punctuation — screen readers
+ * otherwise announce the stray period.
+ */
+function joinAriaSentences(parts: readonly string[]): string {
+	return parts
+		.filter(part => part.length > 0)
+		.map(part => /[.!?]$/.test(part) ? part : `${part}.`)
+		.join(' ');
+}
+
+/**
+ * Auto routing explanation shown when hovering the response footer's model
+ * stat, so a turn served by Auto can explain which model it picked and how
+ * confident the router was.
+ *
+ * Returns `undefined` when the turn was not routed by Auto, in which case this
+ * section is omitted from the hover entirely. The "Learn More" link is dropped
+ * because a hover cannot reliably be moused into to follow it.
+ */
+export function formatResponseAutoModeResolution(resolution: IChatAutoModeResolutionPart | undefined): ResponseFooterHoverContent | undefined {
+	if (!resolution) {
+		return undefined;
+	}
+
+	const title = localize('chat.responseAutoMode.title', "Routed to {0}", resolution.resolvedModelName);
+	const description = ILanguageModelChatMetadata.getAutoModelDescription(undefined, { includeLearnMore: false });
+	// `fallback` means the router could not classify the turn, so there is no
+	// meaningful label or confidence to report.
+	const detail = resolution.predictedLabel === 'fallback'
+		? localize('chat.responseAutoMode.fallback', "Unable to resolve")
+		: localize('chat.responseAutoMode.detail', "{0} - Confidence {1}%",
+			resolution.predictedLabel === 'needs_reasoning'
+				? localize('chat.responseAutoMode.reasoning', "Reasoning")
+				: localize('chat.responseAutoMode.nonReasoning', "Non-reasoning"),
+			(resolution.confidence * 100).toFixed(0));
+
+	const markdown = new MarkdownString();
+	markdown.appendMarkdown(`**${escapeMarkdownSyntaxTokens(title)}**\n\n`);
+	markdown.appendMarkdown(`${description}\n\n`);
+	markdown.appendMarkdown(`${escapeMarkdownSyntaxTokens(detail)}\n\n`);
+
+	const ariaLabel = joinAriaSentences([title, description, detail]);
+	return { markdown, markdownNotSupportedFallback: ariaLabel, ariaLabel };
+}
+
+/**
  * Token consumption summary shown when hovering the response footer's model and
  * credits stat. Provider call-level reports are aggregated by model for the
  * whole turn.
@@ -342,7 +396,7 @@ export function getVisibleCompletedResponseItemCount(nodes: ReadonlyArray<Node>)
  * hover should be shown at all. The result doubles as managed-hover content and
  * carries an `ariaLabel` with exact, unabbreviated counts.
  */
-export function formatResponseTokenStats(modelTotals: readonly IChatUsageModelTotal[] | undefined): { readonly markdown: MarkdownString; readonly markdownNotSupportedFallback: string; readonly ariaLabel: string } | undefined {
+export function formatResponseTokenStats(modelTotals: readonly IChatUsageModelTotal[] | undefined): ResponseFooterHoverContent | undefined {
 	if (!modelTotals?.length) {
 		return undefined;
 	}
@@ -373,6 +427,47 @@ export function formatResponseTokenStats(modelTotals: readonly IChatUsageModelTo
 
 	const ariaLabel = ariaParts.join('. ');
 	return { markdown, markdownNotSupportedFallback: ariaLabel, ariaLabel };
+}
+
+/**
+ * Builds the response footer's hover from the Auto routing explanation and the
+ * token breakdown, either of which may be absent. Routing comes first because it
+ * explains the model name the user is pointing at; the token stats detail its cost.
+ *
+ * Returns `undefined` when neither section has anything to say, so no hover is
+ * shown at all rather than an empty one.
+ */
+export function formatResponseFooterHover(sections: readonly (ResponseFooterHoverContent | undefined)[]): ResponseFooterHoverContent | undefined {
+	const present = sections.filter((section): section is ResponseFooterHoverContent => !!section);
+	if (!present.length) {
+		return undefined;
+	}
+	if (present.length === 1) {
+		return present[0];
+	}
+
+	const markdown = new MarkdownString();
+	markdown.value = present.map(section => section.markdown.value).join('');
+	// `appendMarkdown` is bypassed above, so carry over the trust flags the
+	// sections were built with rather than silently dropping them.
+	markdown.isTrusted = present.some(section => section.markdown.isTrusted);
+	markdown.supportThemeIcons = present.some(section => section.markdown.supportThemeIcons);
+	const ariaLabel = joinAriaSentences(present.map(section => section.ariaLabel));
+	return { markdown, markdownNotSupportedFallback: ariaLabel, ariaLabel };
+}
+
+/**
+ * Finds the Auto routing result for a turn. Scans from the end so a turn that
+ * re-routed (e.g. after a retry) reports the model that actually served it.
+ */
+export function findAutoModeResolution(content: ReadonlyArray<IChatProgressResponseContent>): IChatAutoModeResolutionPart | undefined {
+	for (let index = content.length - 1; index >= 0; index--) {
+		const part = content[index];
+		if (part.kind === 'autoModeResolution') {
+			return part;
+		}
+	}
+	return undefined;
 }
 
 export function shouldCollapseCompletedResponsePart(part: IChatRendererContent): boolean {
@@ -444,10 +539,10 @@ export function reconcileChatItemHeight(
 
 /**
  * Renders the response footer: completion timestamp and the model/credits stat.
- * `tokenStatsAriaLabel` is folded into the container's accessible name so the
- * token breakdown offered on hover is also available to screen readers.
+ * `footerAriaLabel` is folded into the container's accessible name so the
+ * routing and token detail offered on hover is also available to screen readers.
  */
-export function renderChatResponseDetails(container: HTMLElement, details: string | undefined, completedAt: number | undefined, elapsedMs: number | undefined, verbose: boolean, tokenStatsAriaLabel?: string): HTMLElement | undefined {
+export function renderChatResponseDetails(container: HTMLElement, details: string | undefined, completedAt: number | undefined, elapsedMs: number | undefined, verbose: boolean, footerAriaLabel?: string): HTMLElement | undefined {
 	dom.clearNode(container);
 	container.classList.remove('chat-response-flip-active', 'chat-response-flip-down', 'chat-response-flip-reset');
 
@@ -480,7 +575,7 @@ export function renderChatResponseDetails(container: HTMLElement, details: strin
 	const accessibleElapsed = elapsed
 		? localize('chatResponseElapsed', "Elapsed time {0}", elapsed)
 		: undefined;
-	container.ariaLabel = [accessibleTiming, accessibleElapsed, details, tokenStatsAriaLabel].filter(Boolean).join(', ');
+	container.ariaLabel = [accessibleTiming, accessibleElapsed, details, footerAriaLabel].filter(Boolean).join(', ');
 	container.classList.toggle('hidden', !responseDetails);
 	container.tabIndex = responseDetails ? 0 : -1;
 	return completedAtElement;
@@ -981,7 +1076,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const requestTimestampContainer = dom.append(valueParent, $('.chat-request-timestamp-container'));
 		const elementDisposables = templateDisposables.add(new DisposableStore());
 		const completedResponseDisclosureDisposables = templateDisposables.add(new DisposableStore());
-		const responseTokenStatsHover = templateDisposables.add(new MutableDisposable<IManagedHover>());
+		const responseFooterHover = templateDisposables.add(new MutableDisposable<IManagedHover>());
 
 		const footerToolbarContainer = dom.append(rowContainer, $('.chat-footer-toolbar'));
 		if (this.rendererOptions.noFooter) {
@@ -1054,7 +1149,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}));
 		const connectionObserver = document.createElement('connection-observer') as dom.ConnectionObserverElement;
 		dom.append(container, connectionObserver);
-		const template: IChatListItemTemplate = { header, avatarContainer, requestHover, username, detail, value, requestTimestampContainer, rowContainer, elementDisposables, templateDisposables, contextKeyService, instantiationService: scopedInstantiationService, agentHover, titleToolbar, footerToolbar, footerToolbarContainer, footerDetailsContainer, disabledOverlay, checkpointToolbar, checkpointRestoreToolbar, checkpointContainer, checkpointRestoreContainer, completedResponseDisclosureDisposables, responseTokenStatsHover };
+		const template: IChatListItemTemplate = { header, avatarContainer, requestHover, username, detail, value, requestTimestampContainer, rowContainer, elementDisposables, templateDisposables, contextKeyService, instantiationService: scopedInstantiationService, agentHover, titleToolbar, footerToolbar, footerToolbarContainer, footerDetailsContainer, disabledOverlay, checkpointToolbar, checkpointRestoreToolbar, checkpointContainer, checkpointRestoreContainer, completedResponseDisclosureDisposables, responseFooterHover };
 		this.templateDataByRow.set(rowContainer, template);
 
 		templateDisposables.add(this._onDidUpdateViewModel.event(() => {
@@ -1231,13 +1326,19 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			const tokenStats = isResponseVM(element)
 				? formatResponseTokenStats(element.model.usage?.modelTotals)
 				: undefined;
+			// Turns served by Auto explain the routing decision alongside the cost, so
+			// the "Auto" the user is pointing at can say which model actually ran.
+			const autoModeResolution = isResponseVM(element)
+				? formatResponseAutoModeResolution(findAutoModeResolution(element.response.value))
+				: undefined;
+			const footerHover = formatResponseFooterHover([autoModeResolution, tokenStats]);
 			const completedAtElement = renderChatResponseDetails(
 				templateData.footerDetailsContainer,
 				details,
 				isResponseVM(element) ? element.model.completionTimestamp : undefined,
 				isResponseVM(element) ? element.model.elapsedMs : undefined,
 				isResponseVM(element) && this.configService.getValue<boolean>(ChatConfiguration.Verbose),
-				tokenStats?.ariaLabel,
+				footerHover?.ariaLabel,
 			);
 			// The container (rather than the stat span) is the hover target because it
 			// is the focusable element, which keeps the breakdown reachable by keyboard
@@ -1245,13 +1346,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			// re-render above, so an existing hover is updated in place: replacing it
 			// would re-key the hover service's target map and leave the container
 			// unregistered for `workbench.action.showHover`.
-			const tokenStatsHover = templateData.responseTokenStatsHover;
-			if (!tokenStats) {
-				tokenStatsHover.clear();
-			} else if (tokenStatsHover.value) {
-				tokenStatsHover.value.update(tokenStats);
+			const footerHoverDisposable = templateData.responseFooterHover;
+			if (!footerHover) {
+				footerHoverDisposable.clear();
+			} else if (footerHoverDisposable.value) {
+				footerHoverDisposable.value.update(footerHover);
 			} else {
-				tokenStatsHover.value = this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), templateData.footerDetailsContainer, tokenStats);
+				footerHoverDisposable.value = this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), templateData.footerDetailsContainer, footerHover);
 			}
 			if (!completedAtElement) {
 				responseTimingListeners.clear();
@@ -4295,7 +4396,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// The footer hover is template-scoped, so it outlives the element unless
 		// released here; a virtualized row would otherwise keep showing (and
 		// retaining) the previous element's token breakdown.
-		templateData.responseTokenStatsHover.clear();
+		templateData.responseFooterHover.clear();
 	}
 
 	private renderMcpServersInteractionRequired(content: IChatMcpServersStarting | IChatMcpServersStartingSerialized, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -391,15 +391,19 @@ export namespace ILanguageModelChatMetadata {
 	 *
 	 * @param discountPercent Whole-number percentage (e.g. `10` for 10%). When
 	 * omitted or not positive, the discount sentence is left out entirely.
+	 * @param options `includeLearnMore` defaults to `true`. Pass `false` for
+	 * surfaces that cannot be moused into — a transient hover, for example —
+	 * where an unreachable link is noise rather than an affordance.
 	 */
-	export function getAutoModelDescription(discountPercent?: number): string {
+	export function getAutoModelDescription(discountPercent?: number, options?: { readonly includeLearnMore?: boolean }): string {
 		const base = localize('autoModel.description', "Auto routes based on your task and real-time system health and model performance.");
-		const learnMore = localize('autoModel.learnMore', "[Learn More]({0})", autoModelSelectionDocsUrl);
-		if (typeof discountPercent === 'number' && discountPercent > 0) {
-			const discount = localize('autoModel.discount', "Models routed via auto receive a {0}% discount.", discountPercent);
-			return `${base} ${discount} ${learnMore}`;
-		}
-		return `${base} ${learnMore}`;
+		const learnMore = options?.includeLearnMore === false
+			? undefined
+			: localize('autoModel.learnMore', "[Learn More]({0})", autoModelSelectionDocsUrl);
+		const discount = typeof discountPercent === 'number' && discountPercent > 0
+			? localize('autoModel.discount', "Models routed via auto receive a {0}% discount.", discountPercent)
+			: undefined;
+		return [base, discount, learnMore].filter(Boolean).join(' ');
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -16,12 +16,12 @@ import { TestConfigurationService } from '../../../../../../platform/configurati
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
-import { buildPlanReviewProgressContent, ChatListItemRenderer, endsWithActiveSubagentContent, endsWithCompletedQuestionInteraction, formatCompletedResponseDisclosureLabel, formatResponseTokenStats, getCompletedResponseCollapseEndIndex, getFinalResponseStartIndex, getFinalResponseStartIndexAfterMovingSessionCreatedTools, getVisibleCompletedResponseItemCount, getWorkingProgressRelevantParts, IChatListItemTemplate, isFinalResponseRendered, isWaitingForMcpServers, moveSessionCreatedToolsAfterFinalResponse, reconcileChatItemHeight, renderChatRequestTimestamp, renderChatResponseDetails, shouldCollapseCompletedResponsePart, shouldCreateGroupedThinkingPart, shouldHideChatUserIdentity, shouldPinToolInvocationToThinking, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange, shouldShowFileChangesSummaryForSettings, shouldShowPillsSummaryForSettings, shouldStartNewCollapsedThinkingGroup } from '../../../browser/widget/chatListRenderer.js';
+import { buildPlanReviewProgressContent, ChatListItemRenderer, endsWithActiveSubagentContent, endsWithCompletedQuestionInteraction, findAutoModeResolution, formatCompletedResponseDisclosureLabel, formatResponseAutoModeResolution, formatResponseFooterHover, formatResponseTokenStats, getCompletedResponseCollapseEndIndex, getFinalResponseStartIndex, getFinalResponseStartIndexAfterMovingSessionCreatedTools, getVisibleCompletedResponseItemCount, getWorkingProgressRelevantParts, IChatListItemTemplate, isFinalResponseRendered, isWaitingForMcpServers, moveSessionCreatedToolsAfterFinalResponse, reconcileChatItemHeight, renderChatRequestTimestamp, renderChatResponseDetails, shouldCollapseCompletedResponsePart, shouldCreateGroupedThinkingPart, shouldHideChatUserIdentity, shouldPinToolInvocationToThinking, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange, shouldShowFileChangesSummaryForSettings, shouldShowPillsSummaryForSettings, shouldStartNewCollapsedThinkingGroup } from '../../../browser/widget/chatListRenderer.js';
 import { ChatWidget } from '../../../browser/widget/chatWidget.js';
 import { isChatTurnStatusPillsEnabled } from '../../../browser/widget/chatTurnPills.js';
 import { ChatSubagentContentPart } from '../../../browser/widget/chatContentParts/chatSubagentContentPart.js';
 import { ChatCollapsibleContentPart } from '../../../browser/widget/chatContentParts/chatCollapsibleContentPart.js';
-import { ChatRequestQueueKind, IChatMcpServersStartingSlow, IChatQuestionCarousel, IChatService, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, IChatAutoModeResolutionPart, IChatMarkdownContent, IChatMcpServersStartingSlow, IChatQuestionCarousel, IChatService, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { formatChatRequestTimestamp, formatChatResponseDetails, formatElapsedTime } from '../../../common/chatProgressFormatting.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../../common/constants.js';
 import { ChatModel } from '../../../common/model/chatModel.js';
@@ -435,6 +435,93 @@ suite('ChatListRenderer', () => {
 			], [
 				undefined,
 				undefined,
+			]);
+		});
+
+		test('explains the Auto routing decision for the footer stat hover', () => {
+			const results = ([
+				['needs_reasoning', 0.984],
+				['no_reasoning', 0.5],
+				['fallback', 0.12],
+			] as const).map(([predictedLabel, confidence]) => {
+				const resolution = formatResponseAutoModeResolution({
+					kind: 'autoModeResolution',
+					resolvedModel: 'gpt-5.6-luna',
+					resolvedModelName: 'GPT-5.6 Luna',
+					predictedLabel,
+					confidence,
+				});
+				return { predictedLabel, markdown: resolution?.markdown.value, ariaLabel: resolution?.ariaLabel };
+			});
+
+			const description = 'Auto routes based on your task and real-time system health and model performance.';
+			assert.deepStrictEqual(results, [
+				{
+					predictedLabel: 'needs_reasoning',
+					markdown: `**Routed to GPT-5.6 Luna**\n\n${description}\n\nReasoning - Confidence 98%\n\n`,
+					ariaLabel: `Routed to GPT-5.6 Luna. ${description} Reasoning - Confidence 98%.`,
+				},
+				{
+					predictedLabel: 'no_reasoning',
+					markdown: `**Routed to GPT-5.6 Luna**\n\n${description}\n\nNon-reasoning - Confidence 50%\n\n`,
+					ariaLabel: `Routed to GPT-5.6 Luna. ${description} Non-reasoning - Confidence 50%.`,
+				},
+				{
+					predictedLabel: 'fallback',
+					markdown: `**Routed to GPT-5.6 Luna**\n\n${description}\n\nUnable to resolve\n\n`,
+					ariaLabel: `Routed to GPT-5.6 Luna. ${description} Unable to resolve.`,
+				},
+			]);
+		});
+
+		test('reports no Auto routing explanation for turns Auto did not route', () => {
+			assert.strictEqual(formatResponseAutoModeResolution(undefined), undefined);
+		});
+
+		test('finds the Auto routing result that served the turn', () => {
+			const resolution = (resolvedModelName: string): IChatAutoModeResolutionPart => ({
+				kind: 'autoModeResolution',
+				resolvedModel: resolvedModelName,
+				resolvedModelName,
+				predictedLabel: 'no_reasoning',
+				confidence: 1,
+			});
+			const markdown: IChatMarkdownContent = { kind: 'markdownContent', content: new MarkdownString('hi') };
+
+			assert.deepStrictEqual([
+				findAutoModeResolution([markdown, resolution('first'), markdown, resolution('last')])?.resolvedModelName,
+				findAutoModeResolution([markdown])?.resolvedModelName,
+				findAutoModeResolution([])?.resolvedModelName,
+			], [
+				'last',
+				undefined,
+				undefined,
+			]);
+		});
+
+		test('combines the Auto routing and token sections into one footer hover', () => {
+			const routing = formatResponseAutoModeResolution({
+				kind: 'autoModeResolution',
+				resolvedModel: 'gpt-5.6-luna',
+				resolvedModelName: 'GPT-5.6 Luna',
+				predictedLabel: 'no_reasoning',
+				confidence: 0.98,
+			});
+			const tokens = formatResponseTokenStats([{ model: 'gpt-5.5', inputTokens: 40, cachedTokens: 0, outputTokens: 12 }]);
+
+			assert.deepStrictEqual([
+				formatResponseFooterHover([routing, tokens])?.markdown.value,
+				formatResponseFooterHover([undefined, tokens])?.markdown.value,
+				formatResponseFooterHover([routing, undefined])?.markdown.value,
+				formatResponseFooterHover([undefined, undefined]),
+				// Sections already ending in a period must not gain a second one.
+				formatResponseFooterHover([routing, tokens])?.ariaLabel,
+			], [
+				`${routing!.markdown.value}${tokens!.markdown.value}`,
+				tokens!.markdown.value,
+				routing!.markdown.value,
+				undefined,
+				`${routing!.ariaLabel} ${tokens!.ariaLabel}.`,
 			]);
 		});
 


### PR DESCRIPTION
A turn routed by Auto named the resolved model in its footer, so the footer contradicted the picker: the user chose `Auto`, but the turn reported `GPT-5.6 Luna`. Meanwhile the routing rationale — which model ran, and how confident the router was — already existed as an `autoModeResolution` response part, but was only reachable as a collapsible section inside the response body.

This moves the two into their proper places. The footer reports the user's choice; the hover explains what that choice did.

### Before

```
12:03 PM • GPT-5.6 Luna • 0.7 credits
```

### After

```
12:03 PM • Auto • 0.7 credits
```

...and hovering that footer shows:

> **Routed to GPT-5.6 Luna**
>
> Auto routes based on your task and real-time system health and model performance.
>
> Non-reasoning - Confidence 98%

followed by the existing token-usage breakdown.

### Notes

- The `Auto` footer label already existed, but sat behind the `copilotchat.hideAutoModelName` treatment — hiding the model name outright would have made the pick undiscoverable. The hover removes that objection, so the gate goes away.
- Driven entirely by the real router data already flowing through `IChatAutoModeResolutionPart`. No new plumbing, no synthetic values.
- Turns Auto did not route are byte-identical to before: the hover combiner short-circuits and returns the existing token-stats content unchanged.
- "Learn More" is dropped from the hover copy, since a transient hover cannot reliably be moused into to follow a link. `getAutoModelDescription` gained an optional `includeLearnMore` flag for this; both existing callers are unaffected.
- The accessible name folds in the same routing detail, so the explanation reaches screen readers too.