### PR TITLE
agentHost: Correlate SDK response telemetry with turns

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1355,7 +1355,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	private _turnIdForTelemetry(sdkSessionId: string | undefined): string | undefined {
-		return sdkSessionId ? this._sdkSessionsById.get(sdkSessionId)?.currentTurnId : undefined;
+		return sdkSessionId ? this._findSessionBySdkId(sdkSessionId)?.currentTurnId : undefined;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1315,7 +1315,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const additionalProperties = { initiatorClientType: this._clientTypeForTelemetry(notification.sessionId) };
 		const router = this._githubTelemetryRouter;
 		if (!router?.isTarget(notification)) {
-			this._gitHubTelemetryForwarder.forward(notification);
+			this._gitHubTelemetryForwarder.forward(notification, this._turnIdForTelemetry(notification.sessionId));
 			return;
 		}
 		if (!notification.restricted) {
@@ -1352,6 +1352,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return sdkSessionId
 			? this._findSessionBySdkId(sdkSessionId)?.currentTurnClientType ?? AgentHostClientType.Unknown
 			: AgentHostClientType.Unknown;
+	}
+
+	private _turnIdForTelemetry(sdkSessionId: string | undefined): string | undefined {
+		return sdkSessionId ? this._sdkSessionsById.get(sdkSessionId)?.currentTurnId : undefined;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -741,6 +741,7 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	get hasActiveTurn(): boolean { return this._currentTurn !== undefined; }
 	get chatUri(): URI { return this._chatChannelUri; }
+	get currentTurnId(): string | undefined { return this._currentTurn?.id; }
 	get currentTurnClientType(): AgentHostClientType { return this._currentTurn?.clientType ?? AgentHostClientType.Unknown; }
 	/**
 	 * Last model id seen on the SDK's per-LLM-call `Usage` event (or a

--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -42,6 +42,7 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selected for the response." },
 		"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type used for the response." },
 		"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Identifier for the request." },
+		"turnId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Agent Host turn identifier active when the model response was forwarded." },
 		"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub identifier for the request." },
 		"modelCallId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Identifier for the model call." },
 		"reasoningEffort": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reasoning effort used for the response." },
@@ -80,15 +81,27 @@ import { ITelemetryData, ITelemetryService } from '../../../telemetry/common/tel
 		"comment": "Reports performance and usage details for failed Copilot CLI model responses forwarded by the Copilot SDK.",
 		"${include}": [ "${CopilotSdkForwardedTelemetry}" ],
 		"type": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Type of response failure." },
+		"reason": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Sanitized model response failure message on restricted telemetry rows." },
 		"model": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Model selected for the response." },
 		"apiType": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "API type used for the response." },
 		"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Identifier for the request." },
+		"turnId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Agent Host turn identifier active when the model failure was forwarded." },
 		"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub identifier for the request." },
 		"reasoningEffort": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reasoning effort used for the response." },
+		"requestKind": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Agent Host interaction or call classification." },
 		"copilot_pid": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Process identifier for the Copilot CLI runtime." },
 		"interaction_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an interaction." },
 		"engagement_id": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Identifier that correlates events in an engagement." },
-		"transport": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Transport used for the request." }
+		"transport": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Transport used for the request." },
+		"totalTokenMax": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Effective maximum number of prompt tokens.", "isMeasurement": true },
+		"tokenCountMax": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Requested maximum number of output tokens.", "isMeasurement": true },
+		"isBYOK": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether bring-your-own-key authentication was used, encoded as 1 for true and -1 for false.", "isMeasurement": true },
+		"isAuto": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether automatic model selection was used, encoded as 1 for true and -1 for false.", "isMeasurement": true },
+		"issuedTime": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Timestamp when the failed request was issued.", "isMeasurement": true },
+		"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of images included in the failed request.", "isMeasurement": true },
+		"isVisionRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the failed request included an image, encoded as 1 for true and -1 for false.", "isMeasurement": true },
+		"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of images without a known media type in the failed request.", "isMeasurement": true },
+		"timeToComplete": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time until the request failed.", "isMeasurement": true }
 	}
 */
 
@@ -131,7 +144,7 @@ export class CopilotGitHubTelemetryForwarder {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) { }
 
-	forward(notification: GitHubTelemetryNotification): void {
+	forward(notification: GitHubTelemetryNotification, agentHostTurnId?: string): void {
 		if (notification.restricted && !this._isRestrictedTelemetryEnabled()) {
 			return;
 		}
@@ -149,6 +162,7 @@ export class CopilotGitHubTelemetryForwarder {
 			copilot_tracking_id: event.copilot_tracking_id,
 			kind: event.kind,
 			restricted: notification.restricted,
+			...(agentHostTurnId && (event.kind === 'response.success' || event.kind === 'response.error') ? { turnId: agentHostTurnId } : {}),
 		};
 
 		// VS Code's TAS assignment context, scoped to forwarded Copilot CLI

--- a/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotGitHubTelemetryForwarder.ts
@@ -162,8 +162,14 @@ export class CopilotGitHubTelemetryForwarder {
 			copilot_tracking_id: event.copilot_tracking_id,
 			kind: event.kind,
 			restricted: notification.restricted,
-			...(agentHostTurnId && (event.kind === 'response.success' || event.kind === 'response.error') ? { turnId: agentHostTurnId } : {}),
 		};
+		if (event.kind === 'response.success' || event.kind === 'response.error') {
+			if (agentHostTurnId) {
+				data.turnId = agentHostTurnId;
+			} else {
+				delete data.turnId;
+			}
+		}
 
 		// VS Code's TAS assignment context, scoped to forwarded Copilot CLI
 		// events only — deliberately not a telemetry-service-wide experiment

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -966,6 +966,48 @@ suite('CopilotAgent', () => {
 		}
 	});
 
+	test('correlates forwarded response telemetry with active SDK session turns', async () => {
+		const client = new TestCopilotClient([]);
+		const telemetryService = new class extends RecordingTelemetryService {
+			override publicLog(eventName?: string, data?: unknown): void {
+				this.events.push({ eventName: eventName ?? '', data });
+			}
+		}();
+		const agent = createTestAgent(disposables, { copilotClient: client, telemetryService }) as TestableCopilotAgent;
+		try {
+			await agent.listSessions();
+			const forward = getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry;
+			assert.ok(forward);
+
+			sdkSessionsMap(agent).set('active-session', { currentTurnId: 'turn-1' } as CopilotAgentSession);
+			sdkSessionsMap(agent).set('idle-session', { currentTurnId: undefined } as CopilotAgentSession);
+			const notification = (sessionId: string, turnId: string): GitHubTelemetryNotification => ({
+				sessionId,
+				restricted: false,
+				event: {
+					kind: 'response.success',
+					properties: { turnId },
+					metrics: {},
+				},
+			});
+
+			await forward(notification('active-session', 'runtime-active'));
+			await forward(notification('idle-session', 'runtime-idle'));
+			await forward(notification('unknown-session', 'runtime-unknown'));
+
+			assert.deepStrictEqual(telemetryService.events.map(event => ({
+				sessionId: (event.data as Record<string, unknown>).sdk_session_id,
+				turnId: (event.data as Record<string, unknown>).turnId,
+			})), [
+				{ sessionId: 'active-session', turnId: 'turn-1' },
+				{ sessionId: 'idle-session', turnId: undefined },
+				{ sessionId: 'unknown-session', turnId: undefined },
+			]);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
 	test('routes exact legacy targets exclusively and falls back to generic forwarding', async () => {
 		const client = new TestCopilotClient([]);
 		const copilotApiService = new TestCopilotApiService();

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -975,12 +975,22 @@ suite('CopilotAgent', () => {
 		}();
 		const agent = createTestAgent(disposables, { copilotClient: client, telemetryService }) as TestableCopilotAgent;
 		try {
-			await agent.listSessions();
+			await agent.listLegacyChats();
 			const forward = getCreatedClientOptions(agent).at(-1)?.onGitHubTelemetry;
 			assert.ok(forward);
 
-			sdkSessionsMap(agent).set('active-session', { currentTurnId: 'turn-1' } as CopilotAgentSession);
-			sdkSessionsMap(agent).set('idle-session', { currentTurnId: undefined } as CopilotAgentSession);
+			chatEntriesBySdkId(agent).set('active-session', {
+				chatSession: { currentTurnId: 'turn-1' } as CopilotAgentSession,
+				dispose() { },
+			});
+			chatEntriesBySdkId(agent).set('second-active-session', {
+				chatSession: { currentTurnId: 'turn-2' } as CopilotAgentSession,
+				dispose() { },
+			});
+			chatEntriesBySdkId(agent).set('idle-session', {
+				chatSession: { currentTurnId: undefined } as CopilotAgentSession,
+				dispose() { },
+			});
 			const notification = (sessionId: string, turnId: string): GitHubTelemetryNotification => ({
 				sessionId,
 				restricted: false,
@@ -992,6 +1002,8 @@ suite('CopilotAgent', () => {
 			});
 
 			await forward(notification('active-session', 'runtime-active'));
+			await forward(notification('second-active-session', 'runtime-second-active'));
+			await forward(notification('active-session', 'runtime-active-again'));
 			await forward(notification('idle-session', 'runtime-idle'));
 			await forward(notification('unknown-session', 'runtime-unknown'));
 
@@ -999,6 +1011,8 @@ suite('CopilotAgent', () => {
 				sessionId: (event.data as Record<string, unknown>).sdk_session_id,
 				turnId: (event.data as Record<string, unknown>).turnId,
 			})), [
+				{ sessionId: 'active-session', turnId: 'turn-1' },
+				{ sessionId: 'second-active-session', turnId: 'turn-2' },
 				{ sessionId: 'active-session', turnId: 'turn-1' },
 				{ sessionId: 'idle-session', turnId: undefined },
 				{ sessionId: 'unknown-session', turnId: undefined },

--- a/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
@@ -157,28 +157,28 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 	test('adds Agent Host turn correlation only to response events', () => {
 		const telemetryService = new TestTelemetryService();
 		const forwarder = new CopilotGitHubTelemetryForwarder(() => false, () => undefined, telemetryService);
-		const notification = (kind: string): GitHubTelemetryNotification => ({
+		const notification = (kind: string, properties: Record<string, string> = {}, metrics: Record<string, number> = {}): GitHubTelemetryNotification => ({
 			sessionId: 'session',
 			restricted: false,
 			event: {
 				kind,
-				properties: {},
-				metrics: {},
+				properties,
+				metrics,
 			},
 		});
 
-		forwarder.forward(notification('response.success'), 'turn-1');
-		forwarder.forward(notification('response.error'), 'turn-1');
-		forwarder.forward(notification('tool_call_executed'), 'turn-1');
-		forwarder.forward(notification('response.success'));
+		forwarder.forward(notification('response.success', { turnId: 'runtime-turn' }), 'turn-1');
+		forwarder.forward(notification('response.error', {}, { turnId: 42 }));
+		forwarder.forward(notification('tool_call_executed', { turnId: 'runtime-turn' }), 'turn-1');
+		forwarder.forward(notification('response.success', { turnId: 'runtime-turn' }));
 
 		assert.deepStrictEqual(telemetryService.events.map(event => ({
 			eventName: event.eventName,
 			turnId: event.data?.turnId,
 		})), [
 			{ eventName: 'copilotSdk/response.success', turnId: 'turn-1' },
-			{ eventName: 'copilotSdk/response.error', turnId: 'turn-1' },
-			{ eventName: 'copilotSdk/tool_call_executed', turnId: undefined },
+			{ eventName: 'copilotSdk/response.error', turnId: undefined },
+			{ eventName: 'copilotSdk/tool_call_executed', turnId: 'runtime-turn' },
 			{ eventName: 'copilotSdk/response.success', turnId: undefined },
 		]);
 	});

--- a/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
@@ -153,4 +153,33 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 			},
 		}]);
 	});
+
+	test('adds Agent Host turn correlation only to response events', () => {
+		const telemetryService = new TestTelemetryService();
+		const forwarder = new CopilotGitHubTelemetryForwarder(() => false, () => undefined, telemetryService);
+		const notification = (kind: string): GitHubTelemetryNotification => ({
+			sessionId: 'session',
+			restricted: false,
+			event: {
+				kind,
+				properties: {},
+				metrics: {},
+			},
+		});
+
+		forwarder.forward(notification('response.success'), 'turn-1');
+		forwarder.forward(notification('response.error'), 'turn-1');
+		forwarder.forward(notification('tool_call_executed'), 'turn-1');
+		forwarder.forward(notification('response.success'));
+
+		assert.deepStrictEqual(telemetryService.events.map(event => ({
+			eventName: event.eventName,
+			turnId: event.data?.turnId,
+		})), [
+			{ eventName: 'copilotSdk/response.success', turnId: 'turn-1' },
+			{ eventName: 'copilotSdk/response.error', turnId: 'turn-1' },
+			{ eventName: 'copilotSdk/tool_call_executed', turnId: undefined },
+			{ eventName: 'copilotSdk/response.success', turnId: undefined },
+		]);
+	});
 });


### PR DESCRIPTION
https://github.com/microsoft/vscode-internalbacklog/issues/8738

## Overview

### What

Correlates forwarded Copilot SDK response telemetry with the active Agent Host turn without changing event cadence:

- adds the authoritative AHP `turnId` to `copilotSdk/response.success` and `copilotSdk/response.error` while the mapped SDK session has an active turn;
- omits `turnId` when the SDK session is unknown or idle rather than emitting an empty or stale join key;
- declares the runtime's existing response-error Auto, BYOK, token-limit, image, and timing measurements;
- declares `response.error.requestKind` for companion runtime PR [github/copilot-agent-runtime#15499](https://github.com/github/copilot-agent-runtime/pull/15499).

The turn ID is resolved through the existing `SDK session id -> CopilotAgentSession` map used for forwarded-telemetry client attribution. It is added only to response events; unrelated forwarded SDK events remain unchanged.

### Why

This implements the remaining response-event correlation and failure dimensions from [microsoft/vscode#329684](https://github.com/microsoft/vscode/issues/329684). The existing `requestId` is a model/provider request identifier and does not join to Agent Host turn telemetry. Adding a separate AHP `turnId` enables exact joins to `agentHost.turnCompleted`, `agentHost.turnFailed`, and turn-scoped tool telemetry without changing `requestId` semantics.

The source and production-data audit was supplied as `telemetry-329684-audit.md` during implementation handoff. It is not added to the repository because it contains internal aggregate validation notes.

## Property-by-property parity

| Field | Source or derivation | Parity |
|---|---|---|
| `response.success.turnId` | Active `CopilotAgentSession` selected by the notification's SDK session id | ✅ Exact Agent Host turn identifier when forwarded during an active turn |
| `response.error.turnId` | Same active-session lookup | ✅ Exact Agent Host turn identifier when forwarded during an active turn |
| `response.error.requestKind` | Companion runtime mapping of structured failure source | ≈ Main-agent, subagent, and MCP-sampling classification; not every success-path interaction class applies to failures |
| `response.error.reason` | Existing sanitized restricted failure message | Declaration only; no emission change |

## Measurement-by-measurement parity

| Metric | Runtime source | Parity |
|---|---|---|
| `isAuto` | Failed model-call selection state | ✅ |
| `isBYOK` | Failed model-call provider state | ✅ |
| `totalTokenMax` / `tokenCountMax` | Effective failed-call prompt/output limits | ✅ |
| `timeToComplete` / `issuedTime` | Failed-call duration and derived issue time | ✅ |
| image measurements | Content-free failed-request fingerprint counts | ✅ |

These are declaration updates for measurements the runtime already emits; forwarding remains generic.

## Row-count and dashboard implications

- No new events or duplicate rows are introduced.
- Cadence remains one `response.*` row per runtime model-call outcome.
- `turnId` is populated only while the notification's SDK session maps to an active Agent Host turn.
- Queries should join response events to turn telemetry on `sdk_session_id + turnId` (and retain provider/session discriminators where available).
- Existing `requestId`, `gitHubRequestId`, `modelCallId`, and `interaction_id` semantics do not change.
- `requestKind` requires companion runtime PR #15499 and a subsequent CLI/SDK package adoption before it populates.

## Semantic-shift ledger

| Field | Shift | Impact |
|---|---|---|
| `requestKind` | Failure source normalizes to the success event's `conversation-*` vocabulary | Supports main/subagent failure analysis, but failure source has a smaller closed set than success interaction classes |

## Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- `.\scripts\test.bat --run src\vs\platform\agentHost\test\node\copilotGitHubTelemetryForwarder.test.ts` (5 passing)
- changed-file ESLint
- changed-file hygiene

A broad `npm run compile-client` also reached unrelated extension typechecking and failed because `extensions/markdown-language-features/markdown-editor-src` could not resolve its generated `@vscode/observables` dependency. Main-source typechecking and the focused build/test path pass.