### PR TITLE
Update Copilot SDK telemetry test expectations

### DIFF
--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -800,9 +800,9 @@ suite('CopilotAgent', () => {
 			});
 			assert.deepStrictEqual({ events: telemetryService.events, experimentProperties: telemetryService.experimentProperties }, {
 				events: [
-					{ eventName: 'copilotCli/response.success', data: expectedData('set', 'experiment:1') },
-					{ eventName: 'copilotCli/response.success', data: expectedData('wiped-sticky', 'experiment:1') },
-					{ eventName: 'copilotCli/response.success', data: expectedData('cleared') },
+					{ eventName: 'copilotSdk/response.success', data: expectedData('set', 'experiment:1') },
+					{ eventName: 'copilotSdk/response.success', data: expectedData('wiped-sticky', 'experiment:1') },
+					{ eventName: 'copilotSdk/response.success', data: expectedData('cleared') },
 				],
 				experimentProperties: {},
 			});

--- a/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitHubTelemetryForwarder.test.ts
@@ -139,7 +139,7 @@ suite('CopilotGitHubTelemetryForwarder', () => {
 		});
 
 		assert.deepStrictEqual(telemetryService.events, [{
-			eventName: 'copilotCli/response.success',
+			eventName: 'copilotSdk/response.success',
 			data: {
 				created_at: undefined,
 				model_call_id: undefined,


### PR DESCRIPTION
Updates stale Agent Host telemetry test expectations from `copilotCli/response.success` to `copilotSdk/response.success`.

Validation: 186 targeted tests passed.