### PR TITLE
agentHost: bound telemetry hang activity and endpoint categories

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -12,6 +12,7 @@ import type { SessionMode } from '../common/agentHostSchema.js';
 import { getTelemetryChatSessionId } from '../common/agentTelemetryCorrelation.js';
 import { readAgentErrorTelemetryMeta } from '../common/meta/agentErrorMeta.js';
 import type { ErrorInfo, MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
+import { ActionType } from '../common/state/sessionActions.js';
 import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry, type IAgentHostRestrictedTelemetryContext } from './agentHostRestrictedTelemetry.js';
@@ -252,27 +253,48 @@ export interface IAgentHostTurnCompletedReport {
  */
 export type AgentHostTurnHangReason = 'noProgress' | 'stalledAfterProgress' | 'waitingOnUser' | 'runningTool';
 
-type AgentHostTurnActivityNamespace = 'annotations' | 'auth' | 'changeset' | 'chat' | 'resourceWatch' | 'root' | 'session' | 'terminal';
-export type AgentHostTurnActivityTelemetryKind = 'none' | 'other' | `${AgentHostTurnActivityNamespace}.${string}`;
+const turnActivityKindsByActionType = {
+	[ActionType.ChatTurnStarted]: 'chat.turnStarted',
+	[ActionType.ChatDelta]: 'chat.delta',
+	[ActionType.ChatResponsePart]: 'chat.responsePart',
+	[ActionType.ChatToolCallStart]: 'chat.toolCallStart',
+	[ActionType.ChatToolCallDelta]: 'chat.toolCallDelta',
+	[ActionType.ChatToolCallReady]: 'chat.toolCallReady',
+	[ActionType.ChatToolCallConfirmed]: 'chat.toolCallConfirmed',
+	[ActionType.ChatToolCallComplete]: 'chat.toolCallComplete',
+	[ActionType.ChatToolCallResultConfirmed]: 'chat.toolCallResultConfirmed',
+	[ActionType.ChatToolCallContentChanged]: 'chat.toolCallContentChanged',
+	[ActionType.ChatToolCallAuthRequired]: 'chat.toolCallAuthRequired',
+	[ActionType.ChatToolCallAuthResolved]: 'chat.toolCallAuthResolved',
+	[ActionType.ChatTurnComplete]: 'chat.turnComplete',
+	[ActionType.ChatTurnCancelled]: 'chat.turnCancelled',
+	[ActionType.ChatError]: 'chat.error',
+	[ActionType.ChatActivityChanged]: 'chat.activityChanged',
+	[ActionType.ChatWorkingDirectorySet]: 'chat.workingDirectorySet',
+	[ActionType.ChatWorkingDirectoryRemoved]: 'chat.workingDirectoryRemoved',
+	[ActionType.ChatUsage]: 'chat.usage',
+	[ActionType.ChatReasoning]: 'chat.reasoning',
+	[ActionType.ChatPendingMessageSet]: 'chat.pendingMessageSet',
+	[ActionType.ChatPendingMessageRemoved]: 'chat.pendingMessageRemoved',
+	[ActionType.ChatQueuedMessagesReordered]: 'chat.queuedMessagesReordered',
+	[ActionType.ChatDraftChanged]: 'chat.draftChanged',
+	[ActionType.ChatInputRequested]: 'chat.inputRequested',
+	[ActionType.ChatInputAnswerChanged]: 'chat.inputAnswerChanged',
+	[ActionType.ChatInputCompleted]: 'chat.inputCompleted',
+	[ActionType.ChatTruncated]: 'chat.truncated',
+	[ActionType.ChatTurnsLoaded]: 'chat.turnsLoaded',
+	[ActionType.SessionInputNeededSet]: 'session.inputNeededSet',
+	[ActionType.SessionInputNeededRemoved]: 'session.inputNeededRemoved',
+} as const;
 
-const agentHostTurnActivityNamespaces: readonly AgentHostTurnActivityNamespace[] = ['annotations', 'auth', 'changeset', 'chat', 'resourceWatch', 'root', 'session', 'terminal'];
-const safeAgentHostTurnActivityActionPattern = /^[A-Za-z][A-Za-z0-9]*$/;
-
-function isAgentHostTurnActivityNamespace(value: string): value is AgentHostTurnActivityNamespace {
-	return agentHostTurnActivityNamespaces.includes(value as AgentHostTurnActivityNamespace);
-}
+export type AgentHostTurnActivityTelemetryKind = 'none' | 'other' | typeof turnActivityKindsByActionType[keyof typeof turnActivityKindsByActionType];
 
 function normalizeTurnActivityKind(activityKind: string): AgentHostTurnActivityTelemetryKind {
 	if (activityKind === 'none') {
 		return 'none';
 	}
 
-	const [namespace, action, ...rest] = activityKind.split('/');
-	if (rest.length > 0 || !namespace || !action || !isAgentHostTurnActivityNamespace(namespace) || !safeAgentHostTurnActivityActionPattern.test(action)) {
-		return 'other';
-	}
-
-	return `${namespace}.${action}`;
+	return turnActivityKindsByActionType[activityKind as keyof typeof turnActivityKindsByActionType] ?? 'other';
 }
 
 export interface IAgentHostTurnHungEvent {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -252,6 +252,29 @@ export interface IAgentHostTurnCompletedReport {
  */
 export type AgentHostTurnHangReason = 'noProgress' | 'stalledAfterProgress' | 'waitingOnUser' | 'runningTool';
 
+type AgentHostTurnActivityNamespace = 'annotations' | 'auth' | 'changeset' | 'chat' | 'resourceWatch' | 'root' | 'session' | 'terminal';
+export type AgentHostTurnActivityTelemetryKind = 'none' | 'other' | `${AgentHostTurnActivityNamespace}.${string}`;
+
+const agentHostTurnActivityNamespaces: readonly AgentHostTurnActivityNamespace[] = ['annotations', 'auth', 'changeset', 'chat', 'resourceWatch', 'root', 'session', 'terminal'];
+const safeAgentHostTurnActivityActionPattern = /^[A-Za-z][A-Za-z0-9]*$/;
+
+function isAgentHostTurnActivityNamespace(value: string): value is AgentHostTurnActivityNamespace {
+	return agentHostTurnActivityNamespaces.includes(value as AgentHostTurnActivityNamespace);
+}
+
+function normalizeTurnActivityKind(activityKind: string): AgentHostTurnActivityTelemetryKind {
+	if (activityKind === 'none') {
+		return 'none';
+	}
+
+	const [namespace, action, ...rest] = activityKind.split('/');
+	if (rest.length > 0 || !namespace || !action || !isAgentHostTurnActivityNamespace(namespace) || !safeAgentHostTurnActivityActionPattern.test(action)) {
+		return 'other';
+	}
+
+	return `${namespace}.${action}`;
+}
+
 export interface IAgentHostTurnHungEvent {
 	provider: string;
 	agentSessionId: string;
@@ -261,7 +284,7 @@ export interface IAgentHostTurnHungEvent {
 	hangReason: AgentHostTurnHangReason;
 	isExpected: boolean;
 	hadAnyProgress: boolean;
-	lastActivityKind: string;
+	lastActivityKind: AgentHostTurnActivityTelemetryKind;
 	blockedOn: SessionInputRequestKind | undefined;
 	toolId: string | undefined;
 	toolSourceKind: string | undefined;
@@ -282,7 +305,7 @@ export type IAgentHostTurnHungClassification = {
 	hangReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded state the turn was quiet in: noProgress, stalledAfterProgress, waitingOnUser, or runningTool.' };
 	isExpected: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the quiet period is explained by a legitimate wait (blocked on the user or running a tool) rather than an unexplained hang.' };
 	hadAnyProgress: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether any turn activity at all was observed before the watchdog fired.' };
-	lastActivityKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The protocol action type of the last observed turn activity, or none when the turn never produced any.' };
+	lastActivityKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'A bounded category for the last observed turn activity, preserving the AHP action namespace and action name without slash-like syntax. Values are none, other, or categories such as chat.delta and chat.toolCallReady.' };
 	blockedOn: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The kind of outstanding user-blocking session input request, when there is one. Client tool execution is not counted, since it is delegated work rather than a prompt.' };
 	toolId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the tool the turn appears to be stuck on. When hangReason is waitingOnUser this is the tool gated by the blocking request, which is exact; when it is runningTool this is the longest-running in-flight tool call, which is a best guess when several are running. Undefined when no tool explains the hang.' };
 	toolSourceKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the stuck tool is provided by the agent host, an MCP server, or a client.' };
@@ -1062,7 +1085,7 @@ export class AgentHostTelemetryReporter {
 			hangReason: report.hangReason,
 			isExpected: report.hangReason === 'waitingOnUser' || report.hangReason === 'runningTool',
 			hadAnyProgress: report.hadAnyProgress,
-			lastActivityKind: report.lastActivityKind,
+			lastActivityKind: normalizeTurnActivityKind(report.lastActivityKind),
 			blockedOn: report.blockedOn,
 			toolId: report.toolId,
 			toolSourceKind: report.toolSourceKind,

--- a/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts
@@ -8,7 +8,6 @@ import { getErrorCode } from '../../../../base/common/errors.js';
 import type { URI } from '../../../../base/common/uri.js';
 import { packErrorForTelemetry } from '../../../telemetry/common/errorTelemetry.js';
 import type { ITelemetryService } from '../../../telemetry/common/telemetry.js';
-import { TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession } from '../../common/agentService.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 
@@ -30,6 +29,38 @@ type CopilotSessionFailureCorrelation = {
 	readonly turnId: string | undefined;
 	readonly sdkSessionId: string;
 };
+
+export type CopilotModelCallEndpointTelemetryKind = 'anthropicMessages' | 'chatCompletions' | 'other' | 'responses' | 'responsesWebSocket';
+
+const normalizedCopilotApiEndpointKinds = new Map<string, CopilotModelCallEndpointTelemetryKind>([
+	['/chat/completions', 'chatCompletions'],
+	['/responses', 'responses'],
+	['/v1/messages', 'anthropicMessages'],
+	['ws:/responses', 'responsesWebSocket'],
+]);
+
+export function normalizeCopilotApiEndpoint(endpoint: string | undefined): CopilotModelCallEndpointTelemetryKind | undefined {
+	if (!endpoint) {
+		return undefined;
+	}
+
+	const trimmedEndpoint = endpoint.trim();
+	const directMatch = normalizedCopilotApiEndpointKinds.get(trimmedEndpoint.toLowerCase());
+	if (directMatch) {
+		return directMatch;
+	}
+
+	if (URL.canParse(trimmedEndpoint)) {
+		const parsed = new URL(trimmedEndpoint);
+		const normalizedPath = parsed.pathname.replace(/\/+$/, '') || '/';
+		if ((parsed.protocol === 'ws:' || parsed.protocol === 'wss:') && normalizedPath === '/responses') {
+			return 'responsesWebSocket';
+		}
+		return normalizedCopilotApiEndpointKinds.get(normalizedPath.toLowerCase()) ?? 'other';
+	}
+
+	return 'other';
+}
 
 export function createCopilotFailureCorrelation(sessionUri: URI, chatUri: URI, turnId: string | undefined, sdkSessionId: string): CopilotSessionFailureCorrelation {
 	return {
@@ -286,7 +317,7 @@ type CopilotModelCallFailureEvent = CopilotSessionFailureCorrelation & {
 	failureKind: string | undefined;
 	source: string;
 	transport: string | undefined;
-	apiEndpoint: TelemetryTrustedValue<string> | undefined;
+	apiEndpoint: CopilotModelCallEndpointTelemetryKind | undefined;
 	statusCode: number | undefined;
 	durationMs: number | undefined;
 	model: string | undefined;
@@ -317,7 +348,7 @@ type CopilotModelCallFailureClassification = {
 	failureKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the SDK model call failed at the API or transport boundary.' };
 	source: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the model call came from the top-level agent, a subagent, or MCP sampling.' };
 	transport: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The HTTP or WebSocket transport used by the failed model call.' };
-	apiEndpoint: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded API endpoint used by the failed model call.' };
+	apiEndpoint: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The bounded API endpoint category used by the failed model call. Values are chatCompletions, responses, responsesWebSocket, anthropicMessages, or other.' };
 	statusCode: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The HTTP status code, when available.' };
 	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration of the failed model call in milliseconds.' };
 	model: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider model identifier used by the failed call.' };
@@ -349,7 +380,7 @@ export function reportCopilotModelCallFailure(telemetryService: ITelemetryServic
 		failureKind: event.data.failureKind,
 		source: event.data.source,
 		transport: event.data.transport,
-		apiEndpoint: event.data.apiEndpoint ? new TelemetryTrustedValue(event.data.apiEndpoint) : undefined,
+		apiEndpoint: normalizeCopilotApiEndpoint(event.data.apiEndpoint),
 		statusCode: event.data.statusCode,
 		durationMs: event.data.durationMs,
 		model: event.data.isByok ? 'byokModel' : event.data.model,

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -9,10 +9,12 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { hash } from '../../../../base/common/hash.js';
 import { ITelemetryData, ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentSession } from '../../common/agentService.js';
+import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import type { ToolDefinition } from '../../common/state/protocol/state.js';
 import { IAgentHostInternalTelemetryContext, IAgentHostRestrictedTelemetry, IAgentHostRestrictedTelemetryContext, TelemetryMeasurements, TelemetryProps } from '../../node/agentHostRestrictedTelemetry.js';
 import { AgentHostTelemetryReporter } from '../../node/agentHostTelemetryReporter.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
+import { ActionType } from '../../common/state/sessionActions.js';
 
 interface IRestrictedCall {
 	eventName: string;
@@ -313,6 +315,94 @@ suite('AgentHostTelemetryReporter', () => {
 				confirmationNotNeededReason: undefined,
 				sandboxWrapped: undefined,
 				requestUnsandboxedExecution: undefined,
+			},
+		}]);
+	});
+
+	test('turnHung emits bounded last activity categories', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.turnHung({
+			provider: 'copilot',
+			session,
+			turnId: 'turn-1',
+			hangReason: 'stalledAfterProgress',
+			hadAnyProgress: true,
+			lastActivityKind: ActionType.ChatToolCallDelta,
+			blockedOn: undefined,
+			toolId: undefined,
+			toolSourceKind: undefined,
+			inFlightToolCallCount: 0,
+			quietTimeMs: 1000,
+			turnElapsedMs: 2000,
+			model: undefined,
+			modelTelemetryKind: undefined,
+			modelSelectionKind: 'default',
+			permissionLevel: undefined,
+		});
+		reporter.turnHung({
+			provider: 'copilot',
+			session,
+			turnId: 'turn-2',
+			hangReason: 'stalledAfterProgress',
+			hadAnyProgress: true,
+			lastActivityKind: 'custom/path/value',
+			blockedOn: undefined,
+			toolId: undefined,
+			toolSourceKind: undefined,
+			inFlightToolCallCount: 0,
+			quietTimeMs: 1000,
+			turnElapsedMs: 2000,
+			model: undefined,
+			modelTelemetryKind: undefined,
+			modelSelectionKind: 'default',
+			permissionLevel: undefined,
+		});
+
+		assert.deepStrictEqual(service.standardEvents, [{
+			eventName: 'agentHost.turnHung',
+			data: {
+				provider: 'copilot',
+				agentSessionId: AgentSession.id(session),
+				chatSessionId: getTelemetryChatSessionId(session),
+				isSubagentSession: false,
+				turnId: 'turn-1',
+				hangReason: 'stalledAfterProgress',
+				isExpected: false,
+				hadAnyProgress: true,
+				lastActivityKind: 'chat.toolCallDelta',
+				blockedOn: undefined,
+				toolId: undefined,
+				toolSourceKind: undefined,
+				inFlightToolCallCount: 0,
+				quietTimeMs: 1000,
+				turnElapsedMs: 2000,
+				model: undefined,
+				modelSelectionKind: 'default',
+				permissionLevel: undefined,
+			},
+		}, {
+			eventName: 'agentHost.turnHung',
+			data: {
+				provider: 'copilot',
+				agentSessionId: AgentSession.id(session),
+				chatSessionId: getTelemetryChatSessionId(session),
+				isSubagentSession: false,
+				turnId: 'turn-2',
+				hangReason: 'stalledAfterProgress',
+				isExpected: false,
+				hadAnyProgress: true,
+				lastActivityKind: 'other',
+				blockedOn: undefined,
+				toolId: undefined,
+				toolSourceKind: undefined,
+				inFlightToolCallCount: 0,
+				quietTimeMs: 1000,
+				turnElapsedMs: 2000,
+				model: undefined,
+				modelSelectionKind: 'default',
+				permissionLevel: undefined,
 			},
 		}]);
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts
@@ -250,7 +250,7 @@ suite('AgentSideEffects — turn hang telemetry', () => {
 			hangReason: 'stalledAfterProgress',
 			isExpected: false,
 			hadAnyProgress: true,
-			lastActivityKind: ActionType.ChatDelta,
+			lastActivityKind: 'chat.delta',
 		}]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -21,7 +21,7 @@ import { ServiceCollection } from '../../../instantiation/common/serviceCollecti
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from '../../../telemetry/common/gdprTypings.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { NullTelemetryServiceShape, TelemetryTrustedValue } from '../../../telemetry/common/telemetryUtils.js';
+import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
@@ -5839,7 +5839,7 @@ suite('CopilotAgentSession', () => {
 					failureKind: 'transport',
 					source: 'subagent',
 					transport: 'websocket',
-					apiEndpoint: new TelemetryTrustedValue('/chat/completions'),
+					apiEndpoint: 'chatCompletions',
 					statusCode: 502,
 					durationMs: 42,
 					model: 'byokModel',

--- a/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
@@ -6,11 +6,33 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession } from '../../common/agentService.js';
 import { readAgentErrorTelemetryMeta } from '../../common/meta/agentErrorMeta.js';
 import { buildChatUri, buildSubagentSessionUri } from '../../common/state/sessionState.js';
-import { classifyCopilotClientFailure, createCopilotFailureCorrelation } from '../../node/copilot/copilotFailureTelemetry.js';
+import { classifyCopilotClientFailure, createCopilotFailureCorrelation, normalizeCopilotApiEndpoint, reportCopilotModelCallFailure } from '../../node/copilot/copilotFailureTelemetry.js';
+
+class CapturingTelemetryService implements ITelemetryService {
+	declare readonly _serviceBrand: undefined;
+	readonly telemetryLevel = TelemetryLevel.USAGE;
+	readonly sessionId = 'test-session';
+	readonly machineId = 'test-machine';
+	readonly sqmId = 'test-sqm';
+	readonly devDeviceId = 'test-dev-device';
+	readonly firstSessionDate = 'test-first-session-date';
+	readonly sendErrorTelemetry = true;
+	readonly events: { eventName: string; data: Record<string, unknown> | undefined }[] = [];
+
+	publicLog(): void { }
+	publicLog2(): void { }
+	publicLogError(): void { }
+	publicLogError2(eventName: string, data?: Record<string, unknown>): void {
+		this.events.push({ eventName, data });
+	}
+	setExperimentProperty(): void { }
+	setCommonProperty(): void { }
+}
 
 suite('CopilotFailureTelemetry', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -58,6 +80,91 @@ suite('CopilotFailureTelemetry', () => {
 
 		assert.strictEqual(value, String(Number(value)));
 		assert.strictEqual(value.includes('/'), false);
+	});
+
+	test('normalizes only allowlisted Copilot API endpoints', () => {
+		assert.deepStrictEqual([
+			normalizeCopilotApiEndpoint('/chat/completions'),
+			normalizeCopilotApiEndpoint('/responses'),
+			normalizeCopilotApiEndpoint('/v1/messages'),
+			normalizeCopilotApiEndpoint('ws:/responses'),
+			normalizeCopilotApiEndpoint('https://api.githubcopilot.com/responses'),
+			normalizeCopilotApiEndpoint('https://contoso.example/private/deployment'),
+			normalizeCopilotApiEndpoint(undefined),
+		], [
+			'chatCompletions',
+			'responses',
+			'anthropicMessages',
+			'responsesWebSocket',
+			'responses',
+			'other',
+			undefined,
+		]);
+	});
+
+	test('reports bounded model call endpoint categories instead of raw endpoints', () => {
+		const telemetryService = new CapturingTelemetryService();
+		const session = AgentSession.uri('copilotcli', 'agent-session-id');
+		const chat = URI.parse(buildChatUri(session, 'peer-chat-id'));
+		const correlation = createCopilotFailureCorrelation(session, chat, 'turn-id', 'sdk-session-id');
+
+		reportCopilotModelCallFailure(telemetryService, {
+			id: 'event-1',
+			parentId: 'parent-1',
+			agentId: 'agent-1',
+			data: {
+				source: 'top-level',
+				failureKind: 'api',
+				transport: 'http',
+				apiEndpoint: 'https://contoso.example/private/deployment',
+				statusCode: 500,
+				durationMs: 42,
+				model: 'gpt-5.6-sol',
+				reasoningEffort: 'high',
+				isAuto: false,
+				isByok: false,
+				rte: true,
+				badRequestKind: undefined,
+				apiCallId: 'api-call-id',
+				providerCallId: 'provider-call-id',
+				serviceRequestId: 'service-request-id',
+				requestFingerprint: undefined,
+			},
+		} as Parameters<typeof reportCopilotModelCallFailure>[1], correlation);
+
+		assert.deepStrictEqual(telemetryService.events, [{
+			eventName: 'agentHost.copilotModelCallFailure',
+			data: {
+				agentSessionId: 'agent-session-id',
+				chatSessionId: getTelemetryChatSessionId(chat),
+				turnId: 'turn-id',
+				sdkSessionId: 'sdk-session-id',
+				sdkEventId: 'event-1',
+				sdkParentEventId: 'parent-1',
+				sdkAgentId: 'agent-1',
+				failureKind: 'api',
+				source: 'top-level',
+				transport: 'http',
+				apiEndpoint: 'other',
+				statusCode: 500,
+				durationMs: 42,
+				model: 'gpt-5.6-sol',
+				reasoningEffort: 'high',
+				isAuto: false,
+				isByok: false,
+				rte: true,
+				badRequestKind: undefined,
+				apiCallId: 'api-call-id',
+				providerCallId: 'provider-call-id',
+				serviceRequestId: 'service-request-id',
+				messageCount: undefined,
+				toolCallCount: undefined,
+				toolResultMessageCount: undefined,
+				namelessToolCallCount: undefined,
+				imagePartCount: undefined,
+				imagePartsMissingMediaType: undefined,
+			},
+		}]);
 	});
 
 	test('drops empty provider request identifiers', () => {

--- a/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { SessionEventPayload } from '@github/copilot-sdk';
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -107,16 +108,18 @@ suite('CopilotFailureTelemetry', () => {
 		const session = AgentSession.uri('copilotcli', 'agent-session-id');
 		const chat = URI.parse(buildChatUri(session, 'peer-chat-id'));
 		const correlation = createCopilotFailureCorrelation(session, chat, 'turn-id', 'sdk-session-id');
-
-		reportCopilotModelCallFailure(telemetryService, {
+		const event: SessionEventPayload<'model.call_failure'> = {
+			type: 'model.call_failure',
 			id: 'event-1',
 			parentId: 'parent-1',
 			agentId: 'agent-1',
+			timestamp: '2026-01-01T00:00:00.000Z',
+			ephemeral: true,
 			data: {
-				source: 'top-level',
+				source: 'top_level',
 				failureKind: 'api',
 				transport: 'http',
-				apiEndpoint: 'https://contoso.example/private/deployment',
+				apiEndpoint: '/responses',
 				statusCode: 500,
 				durationMs: 42,
 				model: 'gpt-5.6-sol',
@@ -130,7 +133,9 @@ suite('CopilotFailureTelemetry', () => {
 				serviceRequestId: 'service-request-id',
 				requestFingerprint: undefined,
 			},
-		} as Parameters<typeof reportCopilotModelCallFailure>[1], correlation);
+		};
+
+		reportCopilotModelCallFailure(telemetryService, event, correlation);
 
 		assert.deepStrictEqual(telemetryService.events, [{
 			eventName: 'agentHost.copilotModelCallFailure',
@@ -143,9 +148,9 @@ suite('CopilotFailureTelemetry', () => {
 				sdkParentEventId: 'parent-1',
 				sdkAgentId: 'agent-1',
 				failureKind: 'api',
-				source: 'top-level',
+				source: 'top_level',
 				transport: 'http',
-				apiEndpoint: 'other',
+				apiEndpoint: 'responses',
 				statusCode: 500,
 				durationMs: 42,
 				model: 'gpt-5.6-sol',


### PR DESCRIPTION
## Summary
- normalize hung-turn `lastActivityKind` into bounded telemetry categories so slash-shaped AHP action names stop getting scrubbed as file paths
- normalize Copilot model-call `apiEndpoint` into an allowlisted privacy-safe category set instead of emitting raw relative, websocket, or custom URLs
- add focused tests covering slash-containing activity names and standard/custom endpoint inputs

## Why
Production telemetry showed two quality issues:
1. `agentHost.turnHung` rows with slash-shaped action names were being scrubbed to `<REDACTED: user-file-path>`
2. `agentHost.copilotModelCallFailure` rows were still getting `apiEndpoint` scrubbed even when wrapped in `TelemetryTrustedValue`

## Testing
- `npm run transpile-client`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts src/vs/platform/agentHost/node/copilot/copilotFailureTelemetry.ts src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts --run src/vs/platform/agentHost/test/node/agentHostTurnHangTelemetry.test.ts --run src/vs/platform/agentHost/test/node/copilotFailureTelemetry.test.ts --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`

(Written by Copilot)
