### PR TITLE
Fix cloud sandbox sessions grouping under "Unknown"

### DIFF
--- a/src/vs/sessions/common/agentHostSessionWorkspace.ts
+++ b/src/vs/sessions/common/agentHostSessionWorkspace.ts
@@ -33,6 +33,8 @@ export interface IAgentHostSessionWorkspaceOptions {
 	 * `baseBranchProtected` on the resulting repository.
 	 */
 	readonly branchProtectionPatterns?: readonly string[];
+	/** Overrides the inferred folder/worktree type icon. See {@link ISessionWorkspace.typeIcon}. */
+	readonly typeIcon?: ThemeIcon;
 }
 
 /**
@@ -136,6 +138,7 @@ export function buildAgentHostSessionWorkspace(project: IAgentHostSessionProject
 			}, ...additionalFolders],
 			requiresWorkspaceTrust: options.requiresWorkspaceTrust,
 			isVirtualWorkspace: false,
+			typeIcon: options.typeIcon,
 		};
 	}
 
@@ -160,5 +163,6 @@ export function buildAgentHostSessionWorkspace(project: IAgentHostSessionProject
 		}, ...additionalFolders],
 		requiresWorkspaceTrust: options.requiresWorkspaceTrust,
 		isVirtualWorkspace: false,
+		typeIcon: options.typeIcon,
 	};
 }

--- a/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
+++ b/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
@@ -106,7 +106,7 @@ export class OpenFilesViewActionViewItem extends SessionHeaderMetaActionViewItem
 			// Path and branch still describe the checkout while the worktree is pending, so withhold them.
 			const worktreePending = session?.worktreePending?.read(reader) ?? false;
 			const kind = getSessionWorkspaceKind(workspace, worktreePending);
-			const icon = kind === SessionWorkspaceKind.Virtual ? Codicon.cloudCompact : kind === SessionWorkspaceKind.Folder ? Codicon.folderCompact : Codicon.worktreeCompact;
+			const icon = workspace.typeIcon ?? (kind === SessionWorkspaceKind.Virtual ? Codicon.cloudCompact : kind === SessionWorkspaceKind.Folder ? Codicon.folderCompact : Codicon.worktreeCompact);
 			const folder = workspace.folders[0];
 			const branch = worktreePending ? undefined : folder?.gitRepository?.branchName?.trim() || undefined;
 			const workingDirectoryPath = worktreePending ? undefined : folder?.workingDirectory.fsPath;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1406,11 +1406,13 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			return false;
 		}
 		this._project = project;
-		let didChange = false;
 		transaction(tx => {
-			didChange = this._setWorkspace(this._computeWorkspace(), tx);
+			this._setWorkspace(this._computeWorkspace(), tx);
 		});
-		return didChange;
+		// Reports the metadata mutation, not whether the workspace happened to change: the caller
+		// announces this to mark the session cache dirty, and a project assigned but never
+		// persisted would be lost on reload.
+		return true;
 	}
 
 	private _setWorkspace(workspace: ISessionWorkspace | undefined, tx: ITransaction): boolean {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1388,6 +1388,31 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		return true;
 	}
 
+	/**
+	 * The session's project. Read at persist time so a value assigned after the snapshot was taken
+	 * is not lost on the next save.
+	 */
+	get project(): IAgentSessionMetadata['project'] { return this._project; }
+
+	/**
+	 * Assign a project to a session that was materialized without one, recomputing the workspace.
+	 * Refuses when the session already has a project.
+	 *
+	 * Narrower than {@link update}, which also assigns `_workingDirectories` and would clear real
+	 * working directories, revert a renamed title, and roll back the modified time.
+	 */
+	backfillProject(project: IAgentSessionMetadata['project']): boolean {
+		if (!project || this._project) {
+			return false;
+		}
+		this._project = project;
+		let didChange = false;
+		transaction(tx => {
+			didChange = this._setWorkspace(this._computeWorkspace(), tx);
+		});
+		return didChange;
+	}
+
 	private _setWorkspace(workspace: ISessionWorkspace | undefined, tx: ITransaction): boolean {
 		if (agentHostSessionWorkspaceKey(workspace) === agentHostSessionWorkspaceKey(this.workspace.get())) {
 			return false;
@@ -4669,6 +4694,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				...base,
 				summary: adapter.title.get() || base.summary,
 				modifiedTime: adapter.updatedAt.get().getTime(),
+				// A project assigned by `backfillProject` lives only on the adapter.
+				project: adapter.project ?? base.project,
 				status: withSessionStatusFlag(
 					withSessionStatusFlag(base.status ?? ProtocolSessionStatus.Idle, ProtocolSessionStatus.IsRead, adapter.isRead.get()),
 					ProtocolSessionStatus.IsArchived,

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
@@ -9,9 +9,11 @@
 // machinery can enumerate and render the host's sessions.
 
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import {
 	CLOUD_SANDBOX_AGENT_PROVIDER,
@@ -38,7 +40,7 @@ import { ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatSessi
 import { CloudSandboxReadOnlySessionHandler } from './cloudSandboxReadOnlySessionHandler.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionSchemeAlias, RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
+import { ISessionSchemeAlias, IRemoteAgentHostSessionsProviderConfig, RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 import { IRemoteAgentHostConnectionCustomizationService } from './remoteAgentHostConnectionCustomization.js';
 import { createCloudSandboxConnectionCustomization, isCloudSandboxConnectionAddress } from './cloudSandboxConnectionCustomization.js';
 import { watchForIncompatibleNotifications } from './remoteHostOptions.js';
@@ -64,6 +66,20 @@ interface ICloudSandboxEnvironment {
 	 */
 	readonly taskId?: string;
 	readonly name: string;
+}
+
+/**
+ * The repository a discovered session belongs to, matching the shape the sandbox host reports once
+ * connected so reconnecting does not visibly regroup the session.
+ *
+ * The `https` URI identifies the repository but is not backed by a file system provider, so a
+ * session discovered this way cannot browse its files until it connects.
+ */
+function discoveredSessionProject(repoName: string | undefined): IAgentSessionMetadata['project'] {
+	if (!repoName) {
+		return undefined;
+	}
+	return { uri: URI.parse(`https://github.com/${repoName}`), displayName: repoName };
 }
 
 export class CloudSandboxAgentHostContribution extends Disposable implements IWorkbenchContribution {
@@ -239,6 +255,7 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 			const provider = this._providerInstances.get(address);
 			const parsed = session.updatedAt ? Date.parse(session.updatedAt) : Number.NaN;
 			const modifiedTime = Number.isNaN(parsed) ? Date.now() : parsed;
+			const project = discoveredSessionProject(session.repoName);
 			const meta: IAgentSessionMetadata = {
 				// Seed under the agent-provider (UI) scheme, preserving the session id. Mission Control
 				// issues each session as `ahp-session:/<id>` (the id it also returns here), and the
@@ -248,6 +265,7 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 				startTime: modifiedTime,
 				modifiedTime,
 				summary: session.name,
+				...(project ? { project } : {}),
 			};
 			provider?.seedSessions([meta]);
 		}
@@ -560,12 +578,16 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 			return;
 		}
 		const store = new DisposableStore();
-		const provider = this._instantiationService.createInstance(
-			RemoteAgentHostSessionsProvider, {
+		const provider = this._instantiateProvider({
 			address,
 			name: env.name,
 			connectOnDemand: () => this.connect({ environmentId: env.environmentId, sessionId: env.sessionId, name: env.name }).then(() => { }),
 			sessionSchemeAlias: SANDBOX_SESSION_SCHEME_ALIAS,
+			// Each sandbox is its own provider named after its task, so the `[host]` suffix would
+			// put every session in a workspace group of one.
+			omitHostFromWorkspaceLabel: true,
+			// A sandbox is a disposable remote environment, not a checkout on disk.
+			workspaceTypeIcon: Codicon.package,
 		});
 		store.add(provider);
 		store.add(this._sessionsProvidersService.registerProvider(provider));
@@ -574,6 +596,13 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 		store.add(toDisposable(() => this._providerInstances.delete(address)));
 		this._providerStores.set(address, store);
 		this._logService.info(`${LOG_PREFIX} Registered sessions provider for ${address}`);
+	}
+
+	/**
+	 * Provider construction seam so tests can observe each provider's configuration.
+	 */
+	protected _instantiateProvider(config: IRemoteAgentHostSessionsProviderConfig): RemoteAgentHostSessionsProvider {
+		return this._instantiationService.createInstance(RemoteAgentHostSessionsProvider, config);
 	}
 
 	/** Wire each live connection to its provider so session enumeration runs. */

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxApiService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxApiService.ts
@@ -19,7 +19,7 @@ import {
 	ICloudSandboxDiscoveryResult,
 	ICloudSandboxEnvironment,
 } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
-import { GITHUB_DOT_COM_COPILOT_API_BASE_URI } from '../../../../../platform/agentHost/common/githubEndpoints.js';
+import { GITHUB_DOT_COM_COPILOT_API_BASE_URI, deriveGitHubEndpoints } from '../../../../../platform/agentHost/common/githubEndpoints.js';
 import { IReplayedTaskHistory, parseTaskEventsResponse, replayTaskAhpEvents, TaskEventReplayError } from '../../../../../platform/agentHost/common/taskEventReplay.js';
 import { COPILOT_INTEGRATION_ID } from '../../../../../platform/endpoint/common/licenseAgreement.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -36,11 +36,15 @@ type CloudSandboxEnvironmentAction = 'get' | 'connect' | 'reconnect';
 interface ITaskSummary {
 	readonly id: string;
 	readonly name?: string;
-	readonly html_url?: string;
 	readonly archived_at?: string | null;
 	readonly updated_at?: string;
 	readonly agent_collaborators?: readonly { readonly slug?: string }[];
 	readonly compute?: { readonly provider?: string };
+	/**
+	 * The owning repository, identified by numeric id only — the payload carries no name. See
+	 * {@link CloudSandboxApiService._resolveRepositoryName}.
+	 */
+	readonly repository?: { readonly id?: number };
 }
 
 /** A full task, which additionally carries the sessions bound to sandbox environments. */
@@ -49,6 +53,13 @@ interface ITaskDetail extends ITaskSummary {
 }
 
 const LOG_PREFIX = '[CloudSandboxApi]';
+
+/**
+ * The github.com REST API base, used for the repository-name lookup discovery needs. The CORS
+ * caveat on {@link CloudSandboxApiService._tasksBaseUrl} is specific to `api.github.com/agents/*`;
+ * the general REST API is CORS-enabled and already called from the renderer elsewhere.
+ */
+const GITHUB_DOT_COM_API_BASE_URI = deriveGitHubEndpoints(undefined).apiBaseUri;
 
 /** Per-request timeout (ms) for credential and environment calls. */
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -75,6 +86,9 @@ const FALLBACK_SCOPES = ['read:user', 'user:email', 'repo', 'workflow'];
  */
 export class CloudSandboxApiService extends Disposable implements ICloudSandboxApiService {
 	declare readonly _serviceBrand: undefined;
+
+	/** Resolved (or in-flight) repository names, keyed by numeric repository id. */
+	private readonly _repositoryNames = new Map<number, Promise<string | undefined>>();
 
 	constructor(
 		@IRequestService private readonly _requestService: IRequestService,
@@ -150,13 +164,14 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 					// No environment bound yet — a real state, not a failure to resolve.
 					return undefined;
 				}
-				const repo = parseRepoFromTaskUrl(full.html_url);
+				const repositoryId = full.repository?.id ?? task.repository?.id;
+				const repoName = repositoryId !== undefined ? await this._resolveRepositoryName(repositoryId, token) : undefined;
 				return {
 					environmentId: binding.environmentId,
 					sessionId: binding.sessionId,
 					taskId: task.id,
 					name: full.name ?? task.name ?? `Sandbox ${task.id}`,
-					repoName: repo ? `${repo.owner}/${repo.name}` : undefined,
+					repoName,
 					updatedAt: full.updated_at ?? task.updated_at,
 				};
 			} catch (error) {
@@ -167,7 +182,8 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 		}));
 
 		const sessions = discovered.filter((session): session is ICloudSandboxDiscoveredSession => session !== undefined);
-		this._logService.info(`${LOG_PREFIX} Discovery found ${sessions.length} sandbox session(s) from ${sandboxTasks.length} sandbox task(s) out of ${tasks.length} scanned${unresolved > 0 ? `; ${unresolved} unresolved` : ''}.`);
+		const unnamed = sessions.filter(session => !session.repoName).length;
+		this._logService.info(`${LOG_PREFIX} Discovery found ${sessions.length} sandbox session(s) from ${sandboxTasks.length} sandbox task(s) out of ${tasks.length} scanned${unresolved > 0 ? `; ${unresolved} unresolved` : ''}${unnamed > 0 ? `; ${unnamed} without a repository name (they group under "Unknown")` : ''}.`);
 		return { kind: unresolved > 0 ? 'partial' : 'complete', sessions };
 	}
 
@@ -192,6 +208,45 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 			throw new TaskEventReplayError('Task AHP history response was empty or not JSON.');
 		}
 		return replayTaskAhpEvents(parseTaskEventsResponse(body));
+	}
+
+	/**
+	 * Resolve a numeric repository id to its `owner/name`, memoized for the life of the service.
+	 * A task names its repository nowhere — `repository` carries an id, and the session's
+	 * `event_url` / `base_ref` are empty for tasks created through the tasks API.
+	 *
+	 * The cached promise must never reject: every task in a pass shares it, and a rejection would
+	 * count each one as unresolved (forcing the scan `partial`) and drop those sessions from the
+	 * listing entirely. A miss is evicted so the next pass retries.
+	 */
+	private _resolveRepositoryName(repositoryId: number, token: CancellationToken): Promise<string | undefined> {
+		const cached = this._repositoryNames.get(repositoryId);
+		if (cached) {
+			return cached;
+		}
+		const pending = (async () => {
+			try {
+				const url = `${GITHUB_DOT_COM_API_BASE_URI}/repositories/${repositoryId}`;
+				const context = await this._request(url, 'mc.repositoryClient.get', 'getRepository', {
+					'Accept': 'application/vnd.github.v3+json',
+				}, token, DISCOVERY_TIMEOUT_MS);
+				if (!isSuccess(context)) {
+					throw new CloudSandboxRequestError(context.res.statusCode, `HTTP ${context.res.statusCode ?? 'none'}`);
+				}
+				const body = await this._readJson<{ full_name?: string }>(context);
+				return body?.full_name;
+			} catch (error) {
+				this._logService.warn(`${LOG_PREFIX} Repository ${repositoryId} lookup failed: ${toErrorMessage(error)}`);
+				return undefined;
+			}
+		})();
+		this._repositoryNames.set(repositoryId, pending);
+		pending.then(name => {
+			if (!name && this._repositoryNames.get(repositoryId) === pending) {
+				this._repositoryNames.delete(repositoryId);
+			}
+		});
+		return pending;
 	}
 
 	/** Shared handler for the `connect`/`reconnect` endpoints (200 token or 202 waking). */
@@ -394,18 +449,3 @@ function getTaskEnvironmentBinding(task: ITaskDetail): { environmentId: string; 
 	return undefined;
 }
 
-/** The `owner/name` repository encoded in a task's `html_url`, when parseable. */
-function parseRepoFromTaskUrl(htmlUrl: string | undefined): { owner: string; name: string } | undefined {
-	if (!htmlUrl) {
-		return undefined;
-	}
-	try {
-		const match = new URL(htmlUrl).pathname.match(/^\/([^/]+)\/([^/]+)\//);
-		if (match) {
-			return { owner: match[1], name: match[2] };
-		}
-	} catch {
-		// not a parseable URL
-	}
-	return undefined;
-}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxTelemetry.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxTelemetry.ts
@@ -10,7 +10,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 
 /** The Mission Control call being reported. A closed set, so it is safe to send verbatim. */
-export type CloudSandboxRequestAction = 'connect' | 'reconnect' | 'getEnvironment' | 'listTasks' | 'getTask' | 'getTaskEvents';
+export type CloudSandboxRequestAction = 'connect' | 'reconnect' | 'getEnvironment' | 'listTasks' | 'getTask' | 'getTaskEvents' | 'getRepository';
 
 /**
  * How a Mission Control request ended, bucketed so a count is meaningful without carrying the

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -72,6 +72,14 @@ export interface IRemoteAgentHostSessionsProviderConfig {
 	 * The provider derives both directions from this pair, so they cannot drift apart.
 	 */
 	readonly sessionSchemeAlias?: ISessionSchemeAlias;
+	/**
+	 * Suppresses the `[host]` suffix that otherwise disambiguates this host's workspaces from
+	 * identically-named ones on other hosts. Set by hosts whose label names a task rather than a
+	 * location, where the suffix would put every session in a workspace group of one.
+	 */
+	readonly omitHostFromWorkspaceLabel?: boolean;
+	/** Type icon for this host's workspaces. See {@link ISessionWorkspace.typeIcon}. */
+	readonly workspaceTypeIcon?: ThemeIcon;
 }
 
 /**
@@ -150,6 +158,8 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	private readonly _connectOnDemand: (() => Promise<void>) | undefined;
 	private readonly _disconnectOnDemand: (() => Promise<void>) | undefined;
 	private readonly _sessionSchemeAlias: ISessionSchemeAlias | undefined;
+	private readonly _omitHostFromWorkspaceLabel: boolean;
+	private readonly _workspaceTypeIcon: ThemeIcon | undefined;
 	/** Storage key used for persisting {@link _sessionCache} snapshots. */
 	private readonly _storageKey: string;
 	/**
@@ -188,6 +198,8 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		this._connectOnDemand = config.connectOnDemand;
 		this._disconnectOnDemand = config.disconnectOnDemand;
 		this._sessionSchemeAlias = config.sessionSchemeAlias;
+		this._omitHostFromWorkspaceLabel = config.omitHostFromWorkspaceLabel === true;
+		this._workspaceTypeIcon = config.workspaceTypeIcon;
 		this.onDidReportConnectProgress = config.onDidReportConnectProgress;
 		this.canConnectOnDemand = !!config.connectOnDemand;
 		const displayName = config.name || config.address;
@@ -232,7 +244,8 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	}
 
 	protected _adapterOptions() {
-		const web = this.isWebPlatform;
+		const hostLabel = this._workspaceHostLabel;
+		const typeIcon = this._workspaceTypeIcon;
 		return {
 			readOnly: this._readOnly,
 			buildWorkspace: (project: IAgentSessionMetadata['project'], workingDirectories: readonly URI[] | undefined, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined) => {
@@ -240,7 +253,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 				const uriForDescription = project?.uri ?? primary;
 				const description = uriForDescription ? this._labelService.getUriLabel(dirname(uriForDescription), { relative: false }) : undefined;
 				const branchProtectionPatterns = readBranchProtectionPatterns(this._configurationService, primary ?? project?.uri);
-				return RemoteAgentHostSessionsProvider.buildWorkspace(project, workingDirectories, web ? undefined : this.label, gitHubInfo, gitState, description, branchProtectionPatterns);
+				return RemoteAgentHostSessionsProvider.buildWorkspace(project, workingDirectories, hostLabel, gitHubInfo, gitState, description, branchProtectionPatterns, typeIcon);
 			},
 		};
 	}
@@ -327,28 +340,35 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	}
 
 	/**
-	 * Seed discovered session summaries into the cache so they surface in the
-	 * sessions list **before** a connection is established (lazy discovery). Each
-	 * summary becomes a cached adapter keyed by its raw session id; entries that
-	 * already exist (e.g. from a prior live `listSessions()` or persistence) are
-	 * left untouched so the live refresh stays authoritative. Opening a seeded
-	 * session triggers `connectOnDemand` via the async activation registry, after
-	 * which `_refreshSessions` reconciles the seed with the host's real state.
+	 * Seed discovered session summaries into the cache so they surface in the sessions list
+	 * **before** a connection is established (lazy discovery).
+	 *
+	 * An entry that already exists keeps everything the host has told us, except for a missing
+	 * project: the repository name is resolved over the network and that lookup can fail, so
+	 * filling it in on a later pass is what makes retrying worth anything. Opening a seeded session
+	 * triggers `connectOnDemand`, after which `_refreshSessions` reconciles against the host.
 	 */
 	seedSessions(metas: readonly IAgentSessionMetadata[]): void {
 		const added: ISession[] = [];
+		const changed: ISession[] = [];
 		for (const rawMeta of metas) {
 			const meta = this._adoptSessionMeta(rawMeta);
 			const rawId = AgentSession.id(meta.session);
-			if (this._sessionCache.has(rawId)) {
+			const existing = this._sessionCache.get(rawId);
+			if (existing) {
+				// Announcing the change also marks the session cache dirty, so the filled-in
+				// project reaches the next persisted snapshot.
+				if (meta.project && !existing.project && existing.backfillProject(meta.project)) {
+					changed.push(existing);
+				}
 				continue;
 			}
 			const adapter = this.createAdapter(meta);
 			this._sessionCache.set(rawId, adapter);
 			added.push(adapter);
 		}
-		if (added.length > 0) {
-			this._onDidChangeSessions.fire({ added, removed: [], changed: [] });
+		if (added.length > 0 || changed.length > 0) {
+			this._onDidChangeSessions.fire({ added, removed: [], changed });
 		}
 	}
 
@@ -485,15 +505,24 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 
 	// -- Workspaces ----------------------------------------------------------
 
-	static buildWorkspace(project: IAgentSessionMetadata['project'], workingDirectories: readonly URI[] | undefined, providerLabel: string | undefined, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined, description?: string, branchProtectionPatterns?: readonly string[]): ISessionWorkspace | undefined {
-		return buildAgentHostSessionWorkspace(project, workingDirectories, { providerLabel, fallbackIcon: Codicon.remote, requiresWorkspaceTrust: true, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_REMOTE }, gitHubInfo, gitState);
+	/**
+	 * The host name appended to this host's workspace labels, or `undefined` when it would add
+	 * nothing — in web the workbench is already scoped to a single host by the host picker.
+	 */
+	private get _workspaceHostLabel(): string | undefined {
+		return this.isWebPlatform || this._omitHostFromWorkspaceLabel ? undefined : this.label;
+	}
+
+	static buildWorkspace(project: IAgentSessionMetadata['project'], workingDirectories: readonly URI[] | undefined, providerLabel: string | undefined, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined, description?: string, branchProtectionPatterns?: readonly string[], typeIcon?: ThemeIcon): ISessionWorkspace | undefined {
+		return buildAgentHostSessionWorkspace(project, workingDirectories, { providerLabel, fallbackIcon: Codicon.remote, requiresWorkspaceTrust: true, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_REMOTE, typeIcon }, gitHubInfo, gitState);
 	}
 
 	private _buildWorkspaceFromUri(uri: URI): ISessionWorkspace {
 		const folderName = basename(uri) || uri.path;
+		const hostLabel = this._workspaceHostLabel;
 		return {
 			uri,
-			label: this.isWebPlatform ? folderName : `${folderName} [${this.label}]`,
+			label: hostLabel ? `${folderName} [${hostLabel}]` : folderName,
 			description: this._labelService.getUriLabel(dirname(uri), { relative: false }),
 			group: SESSION_WORKSPACE_GROUP_REMOTE,
 			icon: Codicon.remote,

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
@@ -5,7 +5,8 @@
 
 import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { Event } from '../../../../../../base/common/event.js';import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Event } from '../../../../../../base/common/event.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
@@ -42,7 +42,11 @@ class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
 		this.id = `agenthost-${config.address}`;
 	}
 
-	/** Mirrors the real provider, which leaves already-known sessions untouched. */
+	/**
+	 * Records seeds, de-duplicating by session id. Unlike the real provider this does not model
+	 * the project backfill on an already-seeded session — that path is covered against the real
+	 * provider in `remoteAgentHostSessionsProvider.test.ts`.
+	 */
 	override seedSessions(metas: readonly IAgentSessionMetadata[]): void {
 		for (const meta of metas) {
 			if (!this.seeded.some(seen => seen.session.toString() === meta.session.toString())) {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../../base/common/event.js';import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
+import {
+	CloudSandboxEnabledSettingId,
+	ICloudSandboxApiService,
+	cloudSandboxAddress,
+	type ICloudSandboxDiscoveredSession,
+	type ICloudSandboxDiscoveryResult,
+} from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { IAuthenticationService } from '../../../../../../workbench/services/authentication/common/authentication.js';
+import { IChatSessionsService } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IAgentHostFilterService } from '../../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
+import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
+import { CloudSandboxAgentHostContribution } from '../../browser/cloudSandboxAgentHostContribution.js';
+import { IRemoteAgentHostConnectionCustomizationService } from '../../browser/remoteAgentHostConnectionCustomization.js';
+import { IRemoteAgentHostSessionsProviderConfig, RemoteAgentHostSessionsProvider } from '../../browser/remoteAgentHostSessionsProvider.js';
+
+class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
+	readonly seeded: IAgentSessionMetadata[] = [];
+
+	override readonly id: string;
+
+	constructor(readonly config: IRemoteAgentHostSessionsProviderConfig) {
+		super();
+		this.id = `agenthost-${config.address}`;
+	}
+
+	/** Mirrors the real provider, which leaves already-known sessions untouched. */
+	override seedSessions(metas: readonly IAgentSessionMetadata[]): void {
+		for (const meta of metas) {
+			if (!this.seeded.some(seen => seen.session.toString() === meta.session.toString())) {
+				this.seeded.push(meta);
+			}
+		}
+	}
+
+	override dispose(): void { /* noop */ }
+}
+
+class TestCloudSandboxContribution extends CloudSandboxAgentHostContribution {
+	readonly stubProviders = new Map<string, StubProvider>();
+
+	protected override _instantiateProvider(config: IRemoteAgentHostSessionsProviderConfig): RemoteAgentHostSessionsProvider {
+		const stub = new StubProvider(config);
+		this.stubProviders.set(config.address, stub);
+		return stub as unknown as RemoteAgentHostSessionsProvider;
+	}
+}
+
+class StubSessionsProvidersService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidChangeProviders = Event.None;
+	registerProvider(_provider: ISessionsProvider): IDisposable { return toDisposable(() => { }); }
+	getProviders(): ISessionsProvider[] { return []; }
+}
+
+/**
+ * Creates the contribution with a discovery result, and resolves once the constructor's eager
+ * `_discoverAndSeed()` pass has committed its seeds.
+ */
+async function createContribution(store: Pick<DisposableStore, 'add'>, sessions: readonly ICloudSandboxDiscoveredSession[]): Promise<TestCloudSandboxContribution> {
+	const discoveryHandlers: (() => Promise<void>)[] = [];
+	const instantiationService = store.add(new TestInstantiationService());
+
+	instantiationService.stub(ICloudSandboxApiService, new class extends mock<ICloudSandboxApiService>() {
+		override async listSessions(_token: CancellationToken): Promise<ICloudSandboxDiscoveryResult> {
+			return { kind: 'complete', sessions };
+		}
+	}());
+	instantiationService.stub(IRemoteAgentHostService, new class extends mock<IRemoteAgentHostService>() {
+		override readonly onDidChangeConnections = Event.None;
+		override readonly connections = [];
+		override async removeRemoteAgentHost(): Promise<void> { }
+	}());
+	instantiationService.stub(IRemoteAgentHostConnectionCustomizationService, new class extends mock<IRemoteAgentHostConnectionCustomizationService>() {
+		override register(): IDisposable { return toDisposable(() => { }); }
+	}());
+	instantiationService.stub(ISessionsProvidersService, store.add(new StubSessionsProvidersService()) as unknown as ISessionsProvidersService);
+	instantiationService.stub(IAgentHostFilterService, new class extends mock<IAgentHostFilterService>() {
+		override registerDiscoveryHandler(handler: () => Promise<void>): IDisposable {
+			discoveryHandlers.push(handler);
+			return toDisposable(() => { });
+		}
+	}());
+	instantiationService.stub(IConfigurationService, new TestConfigurationService({
+		[CloudSandboxEnabledSettingId]: true,
+		[RemoteAgentHostsEnabledSettingId]: true,
+	}));
+	instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+		override readonly onDidChangeSessions = Event.None;
+		override readonly onDidRegisterAuthenticationProvider = Event.None;
+	}());
+	instantiationService.stub(INotificationService, new class extends mock<INotificationService>() { }());
+	instantiationService.stub(IChatSessionsService, new class extends mock<IChatSessionsService>() { }());
+	instantiationService.stub(ILogService, new NullLogService());
+
+	const contribution = store.add(instantiationService.createInstance(TestCloudSandboxContribution));
+	// The constructor kicks off discovery eagerly; re-running the registered handler awaits it,
+	// because `_discoverAndSeed` serializes onto the in-flight pass.
+	await Promise.all(discoveryHandlers.map(handler => handler()));
+	return contribution;
+}
+
+function discoveredSession(overrides?: Partial<ICloudSandboxDiscoveredSession>): ICloudSandboxDiscoveredSession {
+	return {
+		environmentId: 'env-1',
+		sessionId: 'sess-1',
+		taskId: 'task-1',
+		name: 'Change port to 5555',
+		repoName: 'osortega/simple-server',
+		updatedAt: '2026-08-05T12:00:00Z',
+		...overrides,
+	};
+}
+
+suite('CloudSandboxAgentHostContribution', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('seeds the discovered repository so a never-opened session is not workspace-less', async () => {
+		// Without a project the workspace is undefined and the session groups under "Unknown".
+		// The seeded shape matches what the host reports on connect, so reconciling is a no-op.
+		const contribution = await createContribution(store, [discoveredSession()]);
+
+		const provider = contribution.stubProviders.get(cloudSandboxAddress('env-1'));
+		assert.deepStrictEqual(provider?.seeded.map(m => ({
+			session: m.session.toString(),
+			summary: m.summary,
+			project: m.project && { uri: m.project.uri.toString(), displayName: m.project.displayName },
+		})), [{
+			session: 'copilot:/sess-1',
+			summary: 'Change port to 5555',
+			project: { uri: 'https://github.com/osortega/simple-server', displayName: 'osortega/simple-server' },
+		}]);
+	});
+
+	test('omits the project when discovery could not resolve a repository', async () => {
+		const contribution = await createContribution(store, [discoveredSession({ repoName: undefined })]);
+
+		const provider = contribution.stubProviders.get(cloudSandboxAddress('env-1'));
+		assert.strictEqual(provider?.seeded[0]?.project, undefined);
+	});
+
+	test('opts sandbox providers out of the [host] workspace-label suffix', async () => {
+		// Each sandbox is its own provider named after its task, so the suffix would put every
+		// session in a workspace group of one.
+		const contribution = await createContribution(store, [
+			discoveredSession(),
+			discoveredSession({ environmentId: 'env-2', sessionId: 'sess-2', taskId: 'task-2', name: 'hi' }),
+		]);
+
+		assert.deepStrictEqual([...contribution.stubProviders.values()].map(p => ({
+			name: p.config.name,
+			omitHostFromWorkspaceLabel: p.config.omitHostFromWorkspaceLabel,
+		})), [
+			{ name: 'Change port to 5555', omitHostFromWorkspaceLabel: true },
+			{ name: 'hi', omitHostFromWorkspaceLabel: true },
+		]);
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxApiService.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxApiService.test.ts
@@ -1,0 +1,169 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { bufferToStream, VSBuffer } from '../../../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../../base/common/event.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IRequestContext } from '../../../../../../base/parts/request/common/request.js';
+import { CLOUD_SANDBOX_AGENT_SLUG } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../../platform/product/common/productService.js';
+import { IRequestService } from '../../../../../../platform/request/common/request.js';
+import { IAuthenticationService } from '../../../../../../workbench/services/authentication/common/authentication.js';
+import { CloudSandboxApiService } from '../../browser/cloudSandboxApiService.js';
+import { ICloudSandboxTelemetryService } from '../../browser/cloudSandboxTelemetry.js';
+
+function jsonResponse(body: unknown, statusCode = 200): IRequestContext {
+	return {
+		res: { headers: {}, statusCode },
+		stream: bufferToStream(VSBuffer.fromString(JSON.stringify(body))),
+	};
+}
+
+/** A task as Mission Control actually returns it: the repository is a bare numeric id. */
+function task(id: string, name: string, repositoryId: number | undefined, sessionId: string, environmentId: string) {
+	return {
+		id,
+		name,
+		agent_collaborators: [{ slug: CLOUD_SANDBOX_AGENT_SLUG }],
+		compute: { provider: 'sandboxes' },
+		...(repositoryId !== undefined ? { repository: { id: repositoryId } } : {}),
+		sessions: [{ id: sessionId, environment_id: environmentId }],
+	};
+}
+
+interface ITestSetup {
+	readonly service: CloudSandboxApiService;
+	readonly requestedUrls: string[];
+}
+
+function createService(store: Pick<{ add<T extends { dispose(): void }>(t: T): T }, 'add'>, options: {
+	readonly tasks: readonly unknown[];
+	/** Repository id -> response, or 'error' to fail the lookup. */
+	readonly repositories: ReadonlyMap<number, { full_name?: string } | 'error'>;
+}): ITestSetup {
+	const requestedUrls: string[] = [];
+	const instantiationService = store.add(new TestInstantiationService());
+
+	instantiationService.stub(IRequestService, new class extends mock<IRequestService>() {
+		override async request(opts: { url?: string }): Promise<IRequestContext> {
+			const url = opts.url ?? '';
+			requestedUrls.push(url);
+			const repoMatch = url.match(/\/repositories\/(\d+)$/);
+			if (repoMatch) {
+				const entry = options.repositories.get(Number(repoMatch[1]));
+				if (entry === 'error') {
+					return jsonResponse({ message: 'Not Found' }, 404);
+				}
+				return jsonResponse(entry ?? {});
+			}
+			if (/\/tasks\/[^/]+$/.test(url)) {
+				const id = url.split('/').pop()!;
+				return jsonResponse(options.tasks.find(t => (t as { id: string }).id === decodeURIComponent(id)));
+			}
+			return jsonResponse({ tasks: options.tasks });
+		}
+	}());
+	instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+		override async getSessions() { return [{ accessToken: 'tok', id: 's', account: { id: 'a', label: 'a' }, scopes: [] }]; }
+		override readonly onDidChangeSessions = Event.None;
+	}());
+	instantiationService.stub(IProductService, { defaultChatAgent: undefined } as unknown as IProductService);
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ICloudSandboxTelemetryService, new class extends mock<ICloudSandboxTelemetryService>() {
+		override reportRequest(): void { }
+	}());
+
+	return { service: store.add(instantiationService.createInstance(CloudSandboxApiService)), requestedUrls };
+}
+
+suite('CloudSandboxApiService repository resolution', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('resolves the repository name from its numeric id', async () => {
+		const { service } = createService(store, {
+			tasks: [task('task-1', 'Change port to 5555', 290012776, 'sess-1', 'env-1')],
+			repositories: new Map([[290012776, { full_name: 'osortega/simple-server' }]]),
+		});
+
+		const result = await service.listSessions(CancellationToken.None);
+
+		assert.deepStrictEqual(result, {
+			kind: 'complete',
+			sessions: [{
+				environmentId: 'env-1',
+				sessionId: 'sess-1',
+				taskId: 'task-1',
+				name: 'Change port to 5555',
+				repoName: 'osortega/simple-server',
+				updatedAt: undefined,
+			}],
+		});
+	});
+
+	test('resolves each repository once across a whole discovery pass', async () => {
+		// Tasks resolve concurrently, so the in-flight promise must be shared, not just the result.
+		const { service, requestedUrls } = createService(store, {
+			tasks: [
+				task('task-1', 'a', 290012776, 'sess-1', 'env-1'),
+				task('task-2', 'b', 290012776, 'sess-2', 'env-2'),
+				task('task-3', 'c', 999, 'sess-3', 'env-3'),
+			],
+			repositories: new Map<number, { full_name?: string }>([
+				[290012776, { full_name: 'osortega/simple-server' }],
+				[999, { full_name: 'osortega/other' }],
+			]),
+		});
+
+		const result = await service.listSessions(CancellationToken.None);
+
+		assert.deepStrictEqual({
+			names: result.kind === 'failed' ? [] : result.sessions.map(s => s.repoName),
+			repoLookups: requestedUrls.filter(u => /\/repositories\//.test(u)).length,
+		}, {
+			names: ['osortega/simple-server', 'osortega/simple-server', 'osortega/other'],
+			repoLookups: 2,
+		});
+	});
+
+	test('a failed lookup leaves every sharing session discoverable and is retried next pass', async () => {
+		// Two tasks on the same failing repository: they share one memoized promise, and if it
+		// rejects the callers that receive it drop their sessions from the listing entirely.
+		const repositories = new Map<number, { full_name?: string } | 'error'>([[290012776, 'error']]);
+		const { service, requestedUrls } = createService(store, {
+			tasks: [
+				task('task-1', 'Change port to 5555', 290012776, 'sess-1', 'env-1'),
+				task('task-2', 'hi', 290012776, 'sess-2', 'env-2'),
+			],
+			repositories,
+		});
+
+		const first = await service.listSessions(CancellationToken.None);
+		repositories.set(290012776, { full_name: 'osortega/simple-server' });
+		const second = await service.listSessions(CancellationToken.None);
+
+		assert.deepStrictEqual({
+			// `complete`, not `partial`: the sessions resolved fine, only their label did not.
+			firstKind: first.kind,
+			firstSessions: first.kind === 'failed' ? [] : first.sessions.map(s => s.sessionId),
+			firstNames: first.kind === 'failed' ? [] : first.sessions.map(s => s.repoName),
+			secondNames: second.kind === 'failed' ? [] : second.sessions.map(s => s.repoName),
+			repoLookups: requestedUrls.filter(u => /\/repositories\//.test(u)).length,
+		}, {
+			firstKind: 'complete',
+			firstSessions: ['sess-1', 'sess-2'],
+			firstNames: [undefined, undefined],
+			secondNames: ['osortega/simple-server', 'osortega/simple-server'],
+			// One per pass: the failure is evicted so the second pass retries, but neither pass
+			// issues a second lookup for the task that shares the repository.
+			repoLookups: 2,
+		});
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -5,6 +5,8 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, toDisposable, type IReference } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -191,7 +193,7 @@ function createSession(id: string, opts?: { provider?: string; summary?: string;
 	};
 }
 
-function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; preferenceKey?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean; isWebPlatform?: boolean; workspaceTrusted?: boolean }): RemoteAgentHostSessionsProvider {
+function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; preferenceKey?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean; isWebPlatform?: boolean; workspaceTrusted?: boolean; omitHostFromWorkspaceLabel?: boolean; workspaceTypeIcon?: ThemeIcon }): RemoteAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IFileDialogService, {});
@@ -239,6 +241,8 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 		address: overrides?.address ?? 'localhost:4321',
 		preferenceKey: overrides?.preferenceKey,
 		name: overrides !== undefined && Object.prototype.hasOwnProperty.call(overrides, 'connectionName') ? overrides.connectionName ?? '' : 'Test Host',
+		omitHostFromWorkspaceLabel: overrides?.omitHostFromWorkspaceLabel,
+		workspaceTypeIcon: overrides?.workspaceTypeIcon,
 	};
 
 	const providerCtor = overrides?.isWebPlatform !== undefined
@@ -1251,6 +1255,114 @@ suite('RemoteAgentHostSessionsProvider', () => {
 
 		const session = provider.getSessions().find(s => s.title.get() === 'Desc Web');
 		assert.strictEqual(session?.description.get(), undefined);
+	}));
+
+	test('a session first seen while its repository lookup failed is fixed by a later discovery pass', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		// Seeds run after the constructor has hydrated `_sessionCache`, so the cached entry is what
+		// a later pass meets. Skipping cached entries would make retrying the lookup pointless.
+		const storageService = disposables.add(new InMemoryStorageService());
+		const seed = (provider: RemoteAgentHostSessionsProvider, project?: { uri: URI; displayName: string }) => provider.seedSessions([{
+			session: AgentSession.uri('copilotcli', 'seeded-1'),
+			startTime: 0,
+			modifiedTime: 0,
+			summary: 'Seeded Session',
+			...(project ? { project } : {}),
+		}]);
+
+		// Pass 1: the lookup failed, so the session is seeded and persisted with no project.
+		const first = createProvider(disposables, new MockAgentConnection(), { storageService, noConnection: true, isWebPlatform: false, omitHostFromWorkspaceLabel: true });
+		seed(first);
+		await storageService.flush();
+		const afterFailedLookup = first.getSessions()[0].workspace.get()?.label;
+
+		// Pass 2: the cached project-less entry is hydrated first, then the lookup succeeds.
+		const second = createProvider(disposables, new MockAgentConnection(), { storageService, noConnection: true, isWebPlatform: false, omitHostFromWorkspaceLabel: true });
+		const restoredBeforeSeed = second.getSessions()[0].workspace.get()?.label;
+		seed(second, { uri: URI.parse('https://github.com/osortega/simple-server'), displayName: 'osortega/simple-server' });
+		const afterBackfill = second.getSessions()[0].workspace.get()?.label;
+
+		// The recovered project must reach the snapshot, or every reload re-strands the session.
+		await storageService.flush();
+		const third = createProvider(disposables, new MockAgentConnection(), { storageService, noConnection: true, isWebPlatform: false, omitHostFromWorkspaceLabel: true });
+
+		assert.deepStrictEqual({
+			afterFailedLookup,
+			restoredBeforeSeed,
+			afterBackfill,
+			survivesReload: third.getSessions()[0].workspace.get()?.label,
+		}, {
+			afterFailedLookup: undefined,
+			restoredBeforeSeed: undefined,
+			afterBackfill: 'osortega/simple-server',
+			survivesReload: 'osortega/simple-server',
+		});
+	}));
+
+	test('seedSessions never overwrites a project the host already reported', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('authoritative-1', {
+			summary: 'Authoritative',
+			project: { uri: URI.parse('vscode-agent-host://localhost__4321/home/user/real?_ah%3DeyJzY2hlbWUiOiJmaWxlIn0'), displayName: 'real-repo' },
+		}));
+		const provider = createProvider(disposables, connection, { isWebPlatform: false, omitHostFromWorkspaceLabel: true });
+		provider.getSessions();
+		await timeout(0);
+
+		provider.seedSessions([{
+			session: AgentSession.uri('copilotcli', 'authoritative-1'),
+			startTime: 0,
+			modifiedTime: 0,
+			summary: 'Stale Seed',
+			project: { uri: URI.parse('https://github.com/someone/stale'), displayName: 'someone/stale' },
+		}]);
+
+		assert.deepStrictEqual({
+			label: provider.getSessions()[0].workspace.get()?.label,
+			title: provider.getSessions()[0].title.get(),
+		}, {
+			label: 'real-repo',
+			title: 'Authoritative',
+		});
+	}));
+
+	test('non-web: omitHostFromWorkspaceLabel drops the [host] suffix so sessions group by repository', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const projectUri = URI.parse('vscode-agent-host://localhost__4321/home/user/vscode?_ah%3DeyJzY2hlbWUiOiJmaWxlIn0');
+		connection.addSession(createSession('sandbox-1', {
+			summary: 'Sandbox Session',
+			project: { uri: projectUri, displayName: 'osortega/simple-server' },
+		}));
+
+		const provider = createProvider(disposables, connection, { isWebPlatform: false, omitHostFromWorkspaceLabel: true });
+		provider.getSessions();
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			session: provider.getSessions()[0].workspace.get()?.label,
+			browsed: provider.resolveWorkspace(URI.parse('vscode-agent-host://localhost__4321/home/user/project'))?.label,
+		}, {
+			session: 'osortega/simple-server',
+			browsed: 'project',
+		});
+	}));
+
+	test('workspaceTypeIcon reaches the built workspace, and is absent by default', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('sandbox-icon', {
+			summary: 'Sandbox Session',
+			project: { uri: URI.parse('https://github.com/osortega/simple-server'), displayName: 'osortega/simple-server' },
+		}));
+
+		const withIcon = createProvider(disposables, connection, { isWebPlatform: false, workspaceTypeIcon: Codicon.package });
+		const withoutIcon = createProvider(disposables, new MockAgentConnection(), { isWebPlatform: false, noConnection: true });
+		withIcon.getSessions();
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			declared: withIcon.getSessions()[0].workspace.get()?.typeIcon?.id,
+			// Other hosts leave it unset so the icon stays inferred from the workspace shape.
+			browsed: withoutIcon.resolveWorkspace(URI.parse('vscode-agent-host://localhost__4321/home/user/project'))?.typeIcon,
+		}, {
+			declared: Codicon.package.id,
+			browsed: undefined,
+		});
 	}));
 
 });

--- a/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
@@ -71,7 +71,7 @@ export function buildSessionHoverContent(
 
 	if (folder && workspace) {
 		const kind = getSessionWorkspaceKind(workspace, worktreePending);
-		const folderIcon = kind === SessionWorkspaceKind.Virtual ? Codicon.cloud : kind === SessionWorkspaceKind.Folder ? Codicon.folder : Codicon.worktree;
+		const folderIcon = workspace.typeIcon ?? (kind === SessionWorkspaceKind.Virtual ? Codicon.cloud : kind === SessionWorkspaceKind.Folder ? Codicon.folder : Codicon.worktree);
 		md.appendMarkdown(`$(${folderIcon.id}) `);
 		md.appendText(worktreePending
 			? localize('agentSessions.worktreePending', "Creating worktree…")

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -109,7 +109,7 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 			const detailParts: string[] = [];
 			if (workspace?.label) {
 				const isWorkspaceFolder = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
-				const workspaceIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
+				const workspaceIcon = workspace.typeIcon ?? (workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree);
 				detailParts.push(`$(${Codicon.blank.id}) $(${workspaceIcon.id}) ${workspace.label}`);
 			} else {
 				detailParts.push(`$(${Codicon.blank.id})`);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -642,7 +642,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			// chats show their chat icon on the status icon instead (see above).
 			if (sessionStatus !== SessionStatus.InProgress) {
 				const kind = getSessionWorkspaceKind(workspace, element.worktreePending?.read(reader));
-				const icon = kind === SessionWorkspaceKind.Virtual ? Codicon.cloudCompact : kind === SessionWorkspaceKind.Folder ? Codicon.folderCompact : Codicon.worktreeCompact;
+				const icon = workspace?.typeIcon ?? (kind === SessionWorkspaceKind.Virtual ? Codicon.cloudCompact : kind === SessionWorkspaceKind.Folder ? Codicon.folderCompact : Codicon.worktreeCompact);
 				const typeIconEl = DOM.append(template.detailsRow, $('span.session-details-icon'));
 				DOM.append(typeIconEl, $(`span${ThemeIcon.asCSSSelector(icon)}`));
 				parts.push(typeIconEl);

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -911,6 +911,8 @@ export function sessionWorkspaceEqual(a: ISessionWorkspace | undefined, b: ISess
 		|| a.description !== b.description
 		|| a.group !== b.group
 		|| !ThemeIcon.isEqual(a.icon, b.icon)
+		|| a.typeIcon?.id !== b.typeIcon?.id
+		|| a.typeIcon?.color?.id !== b.typeIcon?.color?.id
 		|| a.requiresWorkspaceTrust !== b.requiresWorkspaceTrust
 		|| a.isVirtualWorkspace !== b.isVirtualWorkspace
 		|| a.folders.length !== b.folders.length) {

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -201,6 +201,12 @@ export interface ISessionWorkspace {
 	 * Whether this workspace is a virtual
 	 */
 	readonly isVirtualWorkspace: boolean;
+	/**
+	 * Overrides the type icon that would otherwise be inferred from the workspace's shape, for
+	 * providers whose workspaces are not structurally distinguishable. Unlike {@link icon}, which
+	 * identifies the workspace in pickers, this is drawn inline in dense rows.
+	 */
+	readonly typeIcon?: ThemeIcon;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -911,8 +911,8 @@ export function sessionWorkspaceEqual(a: ISessionWorkspace | undefined, b: ISess
 		|| a.description !== b.description
 		|| a.group !== b.group
 		|| !ThemeIcon.isEqual(a.icon, b.icon)
-		|| a.typeIcon?.id !== b.typeIcon?.id
-		|| a.typeIcon?.color?.id !== b.typeIcon?.color?.id
+		|| !!a.typeIcon !== !!b.typeIcon
+		|| (!!a.typeIcon && !!b.typeIcon && !ThemeIcon.isEqual(a.typeIcon, b.typeIcon))
 		|| a.requiresWorkspaceTrust !== b.requiresWorkspaceTrust
 		|| a.isVirtualWorkspace !== b.isVirtualWorkspace
 		|| a.folders.length !== b.folders.length) {

--- a/src/vs/sessions/services/sessions/test/common/session.test.ts
+++ b/src/vs/sessions/services/sessions/test/common/session.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { constObservable, IObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -160,7 +161,7 @@ suite('sessionWorkspaceEqual', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	function workspace(branchName = 'main', gitHubInfo: IObservable<IGitHubInfo | undefined> = constObservable(undefined)): ISessionWorkspace {
+	function workspace(branchName = 'main', gitHubInfo: IObservable<IGitHubInfo | undefined> = constObservable(undefined), typeIcon?: ThemeIcon): ISessionWorkspace {
 		const root = URI.file('/repo');
 		return {
 			uri: root,
@@ -182,6 +183,7 @@ suite('sessionWorkspaceEqual', () => {
 			}],
 			requiresWorkspaceTrust: true,
 			isVirtualWorkspace: false,
+			typeIcon,
 		};
 	}
 
@@ -198,6 +200,23 @@ suite('sessionWorkspaceEqual', () => {
 
 	test('returns false when folder repository metadata changes', () => {
 		assert.strictEqual(sessionWorkspaceEqual(workspace('main'), workspace('feature')), false);
+	});
+
+	test('compares typeIcon', () => {
+		const info = constObservable<IGitHubInfo | undefined>(undefined);
+		assert.deepStrictEqual({
+			added: sessionWorkspaceEqual(workspace('main', info), workspace('main', info, Codicon.package)),
+			removed: sessionWorkspaceEqual(workspace('main', info, Codicon.package), workspace('main', info)),
+			changed: sessionWorkspaceEqual(workspace('main', info, Codicon.package), workspace('main', info, Codicon.folder)),
+			same: sessionWorkspaceEqual(workspace('main', info, Codicon.package), workspace('main', info, Codicon.package)),
+			bothUnset: sessionWorkspaceEqual(workspace('main', info), workspace('main', info)),
+		}, {
+			added: false,
+			removed: false,
+			changed: false,
+			same: true,
+			bothUnset: true,
+		});
 	});
 });
 


### PR DESCRIPTION
This pull request addresses the issue of cloud sandbox sessions appearing under the "Unknown" category in the Agents window. The root cause was identified as the failure to assign a workspace to these sessions during the discovery process, despite having the necessary repository information.

### Changes made:
- Updated the `CloudSandboxApiService` to ensure the repository name is passed when seeding session metadata.
- Modified the `_doDiscoverAndSeed` method to include the `project` field in the session metadata, allowing for proper workspace assignment.
- Adjusted the `buildAgentHostSessionWorkspace` function to correctly handle the new project data.
- Removed dead code related to unused URL parsing that was previously guarding against a scenario that could never occur.
- Added tests to cover the new functionality and ensure that cloud sandbox sessions are correctly grouped under their respective repositories.

These changes will ensure that cloud sandbox sessions are displayed correctly in the Agents window, improving user experience and clarity.