### PR TITLE
chat: bound the wait for signed-out Agent Host models guidance

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/sessionTypeAuthRequirement.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/sessionTypeAuthRequirement.test.ts
@@ -9,7 +9,7 @@ import { GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../../../../../platform/ag
 import type { AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import type { ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { resolveAgentAuthRequirement } from '../../browser/baseAgentHostSessionsProvider.js';
-import { areLocalModelsLoaded, hasAvailableAgentHostByokModels, shouldShowSignedOutModelsNotification } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.js';
+import { areLocalModelsLoaded, getSignedOutModelsNotificationState, SignedOutModelsNotificationState } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.js';
 import { SessionTypeAuthRequirement } from '../../../../../services/sessions/common/session.js';
 
 function agent(protectedResources: ProtectedResourceMetadata[] | undefined, modelCount: number): AgentInfo {
@@ -69,26 +69,33 @@ suite('Agent Host - session type auth requirement', () => {
 	});
 
 	test('no-model notification follows sign-in and model availability', () => {
+		const ready = {
+			allowSignedOutWhenUsable: true,
+			accountResolved: true,
+			signedIn: false,
+			hasCopilotHarness: true,
+			hasModels: false,
+			localModelsLoaded: true,
+			gracePeriodElapsed: false,
+		};
 		assert.deepStrictEqual({
-			featureDisabled: shouldShowSignedOutModelsNotification(false, true, true, false, false),
-			loadingSignedOutWithoutModelsNotification: shouldShowSignedOutModelsNotification(true, false, true, false, false),
-			unresolvedAccountNotification: shouldShowSignedOutModelsNotification(true, true, false, false, false),
-			signedOutWithoutModelsNotification: shouldShowSignedOutModelsNotification(true, true, true, false, false),
-			signedOutWithModelsNotification: shouldShowSignedOutModelsNotification(true, true, true, false, true),
-			signedOutWithTargetedByokNotification: shouldShowSignedOutModelsNotification(true, true, true, false, hasAvailableAgentHostByokModels(true, true)),
-			signedOutWithSourceOnlyByokNotification: shouldShowSignedOutModelsNotification(true, true, true, false, hasAvailableAgentHostByokModels(true, false)),
-			signedOutWithClientByokDisabledNotification: shouldShowSignedOutModelsNotification(true, true, true, false, hasAvailableAgentHostByokModels(false, true)),
-			signedInWithoutModelsNotification: shouldShowSignedOutModelsNotification(true, true, true, true, false),
+			featureDisabled: getSignedOutModelsNotificationState({ ...ready, allowSignedOutWhenUsable: false }),
+			loading: getSignedOutModelsNotificationState({ ...ready, localModelsLoaded: false }),
+			loadingPastGracePeriod: getSignedOutModelsNotificationState({ ...ready, localModelsLoaded: false, gracePeriodElapsed: true }),
+			accountUnresolved: getSignedOutModelsNotificationState({ ...ready, accountResolved: false }),
+			harnessUnavailable: getSignedOutModelsNotificationState({ ...ready, hasCopilotHarness: false }),
+			visible: getSignedOutModelsNotificationState(ready),
+			modelsAvailable: getSignedOutModelsNotificationState({ ...ready, hasModels: true }),
+			signedIn: getSignedOutModelsNotificationState({ ...ready, signedIn: true }),
 		}, {
-			featureDisabled: false,
-			loadingSignedOutWithoutModelsNotification: false,
-			unresolvedAccountNotification: false,
-			signedOutWithoutModelsNotification: true,
-			signedOutWithModelsNotification: false,
-			signedOutWithTargetedByokNotification: false,
-			signedOutWithSourceOnlyByokNotification: true,
-			signedOutWithClientByokDisabledNotification: true,
-			signedInWithoutModelsNotification: false,
+			featureDisabled: SignedOutModelsNotificationState.Hidden,
+			loading: SignedOutModelsNotificationState.Waiting,
+			loadingPastGracePeriod: SignedOutModelsNotificationState.Visible,
+			accountUnresolved: SignedOutModelsNotificationState.Hidden,
+			harnessUnavailable: SignedOutModelsNotificationState.Hidden,
+			visible: SignedOutModelsNotificationState.Visible,
+			modelsAvailable: SignedOutModelsNotificationState.Hidden,
+			signedIn: SignedOutModelsNotificationState.Hidden,
 		});
 	});
 
@@ -110,4 +117,5 @@ suite('Agent Host - session type auth requirement', () => {
 			settledConfigured: true,
 		});
 	});
+
 });

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.ts
@@ -175,7 +175,15 @@ export class AgentHostSignedOutModelsNotificationContribution extends Disposable
 			this._gracePeriodElapsed = false;
 			return;
 		}
-		if (state === SignedOutModelsNotificationState.Waiting && !this._gracePeriod.value) {
+		if (state === SignedOutModelsNotificationState.Visible) {
+			// Readiness may have settled before the timer fired. Drop it so a later
+			// wait starts a full budget instead of inheriting the remainder, but keep
+			// an already elapsed flag: clearing it here would flip straight back to
+			// waiting and hide the notification that flag just made visible.
+			this._gracePeriod.clear();
+			return;
+		}
+		if (!this._gracePeriod.value) {
 			this._gracePeriod.value = disposableTimeout(() => {
 				this._gracePeriodElapsed = true;
 				this._update();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { disposableTimeout } from '../../../../../../base/common/async.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { localize } from '../../../../../../nls.js';
 import { AgentHostAllowSignedOutWhenUsableSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -24,17 +25,41 @@ const SIGNED_OUT_MODELS_NOTIFICATION_ID = 'agentHost.signedOutModels.copilot';
 const SIGN_IN_COMMAND_ID = 'workbench.action.chat.triggerSetup';
 const COPILOT_AGENT_HOST_PROVIDER_ID = 'copilotcli';
 const CLIENT_BYOK_CONTEXT_KEYS = new Set([ChatEntitlementContextKeys.clientByokEnabled.key]);
+/**
+ * Upper bound on waiting for local model readiness. Extension registration and
+ * config loading always settle, but a vendor named in the user's BYOK config may
+ * never resolve, so the wait is capped rather than open-ended.
+ */
+const NOTIFICATION_GRACE_PERIOD_MS = 5_000;
 
-export function shouldShowSignedOutModelsNotification(allowSignedOutWhenUsable: boolean, modelsLoaded: boolean, accountResolved: boolean, signedIn: boolean, hasModels: boolean): boolean {
-	return allowSignedOutWhenUsable && modelsLoaded && accountResolved && !signedIn && !hasModels;
+export const enum SignedOutModelsNotificationState {
+	Hidden,
+	Waiting,
+	Visible,
+}
+
+export function getSignedOutModelsNotificationState(options: {
+	readonly allowSignedOutWhenUsable: boolean;
+	readonly accountResolved: boolean;
+	readonly signedIn: boolean;
+	readonly hasCopilotHarness: boolean;
+	readonly hasModels: boolean;
+	readonly localModelsLoaded: boolean;
+	readonly gracePeriodElapsed: boolean;
+}): SignedOutModelsNotificationState {
+	if (!options.allowSignedOutWhenUsable || !options.accountResolved || options.signedIn || !options.hasCopilotHarness || options.hasModels) {
+		return SignedOutModelsNotificationState.Hidden;
+	}
+	// Readiness is the fast path; the grace period bounds it because a vendor named
+	// in the user's config may never resolve — no provider registers for it (an
+	// uninstalled or inactive extension), or the provider's model lookup hangs.
+	return options.localModelsLoaded || options.gracePeriodElapsed
+		? SignedOutModelsNotificationState.Visible
+		: SignedOutModelsNotificationState.Waiting;
 }
 
 export function areLocalModelsLoaded(extensionsRegistered: boolean, configurationLoaded: boolean, configuredByokVendors: readonly string[], hasResolvedVendor: (vendor: string) => boolean): boolean {
 	return extensionsRegistered && configurationLoaded && configuredByokVendors.every(hasResolvedVendor);
-}
-
-export function hasAvailableAgentHostByokModels(isClientByokEnabled: boolean, hasTargetedModels: boolean): boolean {
-	return isClientByokEnabled && hasTargetedModels;
 }
 
 /**
@@ -44,11 +69,13 @@ export class AgentHostSignedOutModelsNotificationContribution extends Disposable
 
 	static readonly ID = 'workbench.contrib.agentHostSignedOutModelsNotification';
 
-	private readonly _shown = new Set<string>();
+	private _notificationShown = false;
 	/** Startup readiness prevents transient empty catalogs from producing false notifications. */
 	private _accountResolved = false;
 	private _extensionsRegistered = false;
 	private _configurationLoaded = false;
+	private _gracePeriodElapsed = false;
+	private readonly _gracePeriod = this._register(new MutableDisposable());
 
 	constructor(
 		@IChatInputNotificationService private readonly _chatInputNotificationService: IChatInputNotificationService,
@@ -111,54 +138,66 @@ export class AgentHostSignedOutModelsNotificationContribution extends Disposable
 	}
 
 	private _update(): void {
-		// Local BYOK readiness is shared by both harnesses; Agent Host additionally waits for its bridged catalog.
+		// Local BYOK readiness is shared by both harnesses; the Agent Host's own bridged catalog is covered by the grace period.
 		const allowSignedOutWhenUsable = this._configurationService.getValue<boolean>(AgentHostAllowSignedOutWhenUsableSettingId) === true;
 		const signedIn = this._defaultAccountService.currentDefaultAccount !== null;
 		const configuredByokVendors = new Set(this._languageModelsConfigurationService.getLanguageModelsProviderGroups()
 			.map(group => group.vendor)
 			.filter(vendor => vendor !== COPILOT_VENDOR_ID));
-		const byokModelsLoaded = areLocalModelsLoaded(
+		const localModelsLoaded = areLocalModelsLoaded(
 			this._extensionsRegistered,
 			this._configurationLoaded,
 			[...configuredByokVendors],
 			vendor => this._languageModelsService.hasResolvedVendor(vendor),
 		);
 		const rootState = this._agentHostService.rootState.value;
-		const agentHostModelsLoaded = byokModelsLoaded
-			&& !!rootState
+		const hasCopilotHarness = !!rootState
 			&& !(rootState instanceof Error)
-			&& rootState.agents.some(agent => agent.provider === COPILOT_AGENT_HOST_PROVIDER_ID)
-			&& this._languageModelsService.hasResolvedVendor(SessionType.AgentHostCopilot);
-		const hasVisibleAgentHostByokModels = hasAvailableAgentHostByokModels(
-			this._chatEntitlementService.clientByokEnabled,
-			hasVisibleByokModelsTargetingSessionType(this._languageModelsService, SessionType.AgentHostCopilot),
-		);
-		this._setNotification(
-			SIGNED_OUT_MODELS_NOTIFICATION_ID,
-			shouldShowSignedOutModelsNotification(allowSignedOutWhenUsable, agentHostModelsLoaded, this._accountResolved, signedIn, hasVisibleAgentHostByokModels),
-			[SessionType.AgentHostCopilot],
-		);
+			&& rootState.agents.some(agent => agent.provider === COPILOT_AGENT_HOST_PROVIDER_ID);
+		const hasModels = this._chatEntitlementService.clientByokEnabled
+			&& hasVisibleByokModelsTargetingSessionType(this._languageModelsService, SessionType.AgentHostCopilot);
+		const state = getSignedOutModelsNotificationState({
+			allowSignedOutWhenUsable,
+			accountResolved: this._accountResolved,
+			signedIn,
+			hasCopilotHarness,
+			hasModels,
+			localModelsLoaded,
+			gracePeriodElapsed: this._gracePeriodElapsed,
+		});
+		this._updateGracePeriod(state);
+		this._setNotification(state === SignedOutModelsNotificationState.Visible);
 	}
 
-	private _setNotification(id: string, show: boolean, sessionTypes: readonly string[]): void {
-		// Reconcile by stable id so unrelated input notifications and user interaction state are preserved.
+	private _updateGracePeriod(state: SignedOutModelsNotificationState): void {
+		if (state === SignedOutModelsNotificationState.Hidden) {
+			this._gracePeriod.clear();
+			this._gracePeriodElapsed = false;
+			return;
+		}
+		if (state === SignedOutModelsNotificationState.Waiting && !this._gracePeriod.value) {
+			this._gracePeriod.value = disposableTimeout(() => {
+				this._gracePeriodElapsed = true;
+				this._update();
+			}, NOTIFICATION_GRACE_PERIOD_MS);
+		}
+	}
+
+	private _setNotification(show: boolean): void {
+		if (show === this._notificationShown) {
+			return;
+		}
+		this._notificationShown = show;
 		if (!show) {
-			if (this._shown.delete(id)) {
-				this._chatInputNotificationService.deleteNotification(id);
-			}
+			this._chatInputNotificationService.deleteNotification(SIGNED_OUT_MODELS_NOTIFICATION_ID);
 			return;
 		}
-		if (this._shown.has(id)) {
-			return;
-		}
-
-		this._shown.add(id);
-		this._chatInputNotificationService.setNotification(this._createNotification(id, sessionTypes));
+		this._chatInputNotificationService.setNotification(this._createNotification());
 	}
 
-	private _createNotification(id: string, sessionTypes: readonly string[]): IChatInputNotification {
+	private _createNotification(): IChatInputNotification {
 		return {
-			id,
+			id: SIGNED_OUT_MODELS_NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
 			message: localize('agentHost.signedOutModels.message', "Choose how you want to use Copilot."),
 			description: localize('agentHost.signedOutModels.description', "Sign in to use GitHub Copilot models, or add a model with your own API key."),
@@ -178,7 +217,7 @@ export class AgentHostSignedOutModelsNotificationContribution extends Disposable
 			],
 			dismissible: false,
 			autoDismissOnMessage: false,
-			sessionTypes,
+			sessionTypes: [SessionType.AgentHostCopilot],
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostSignedOutModelsNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostSignedOutModelsNotification.test.ts
@@ -83,10 +83,47 @@ suite('AgentHostSignedOutModelsNotification', () => {
 		fixture.clock.restore();
 	});
 
+	test('gives a later wait its own grace period instead of the remainder of an earlier one', async () => {
+		const fixture = await createFixture({ configuredVendors: ['anthropic'], resolvedVendors: [] });
+		assert.strictEqual(fixture.notifications.isShown(), false);
+
+		// Readiness settles a second in, so the notification shows without the first wait ever elapsing.
+		await fixture.clock.tickAsync(1_000);
+		fixture.resolveVendor('anthropic');
+		assert.strictEqual(fixture.notifications.isShown(), true);
+
+		// A newly configured vendor is unresolved again, so the notification waits afresh.
+		fixture.addConfiguredVendor('openai');
+		assert.strictEqual(fixture.notifications.isShown(), false);
+
+		// The first wait would have elapsed here; only the second one should govern.
+		await fixture.clock.tickAsync(GRACE_PERIOD_MS - 1_000);
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		await fixture.clock.tickAsync(1_000);
+		assert.strictEqual(fixture.notifications.isShown(), true);
+		fixture.clock.restore();
+	});
+
+	test('still waits for a vendor configured long after readiness settled', async () => {
+		const fixture = await createFixture({ configuredVendors: ['anthropic'], resolvedVendors: [] });
+
+		await fixture.clock.tickAsync(1_000);
+		fixture.resolveVendor('anthropic');
+		// Idle well past the original budget, so a leaked timer would have marked it elapsed.
+		await fixture.clock.tickAsync(GRACE_PERIOD_MS * 2);
+		assert.strictEqual(fixture.notifications.isShown(), true);
+
+		fixture.addConfiguredVendor('openai');
+
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		fixture.clock.restore();
+	});
+
 	async function createFixture(options: { configuredVendors?: string[]; resolvedVendors?: string[] } = {}) {
 		const clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
 		const notifications = new TestChatInputNotificationService();
 		const languageModels = new TestLanguageModelsService(options.resolvedVendors ?? ['anthropic']);
+		const languageModelsConfiguration = new TestLanguageModelsConfigurationService(options.configuredVendors ?? []);
 		const account = new TestDefaultAccountService();
 		const configuration = new TestConfigurationService();
 		configuration.setUserConfiguration(AgentHostAllowSignedOutWhenUsableSettingId, true);
@@ -95,11 +132,7 @@ suite('AgentHostSignedOutModelsNotification', () => {
 		instantiationService.stub(IChatInputNotificationService, notifications);
 		instantiationService.stub(IDefaultAccountService, account);
 		instantiationService.stub(ILanguageModelsService, languageModels);
-		instantiationService.stub(ILanguageModelsConfigurationService, {
-			onDidChangeLanguageModelGroups: Event.None,
-			whenReady: Promise.resolve(),
-			getLanguageModelsProviderGroups: () => (options.configuredVendors ?? []).map(vendor => ({ name: vendor, vendor } satisfies ILanguageModelsProviderGroup)),
-		});
+		instantiationService.stub(ILanguageModelsConfigurationService, languageModelsConfiguration);
 		instantiationService.stub(IAgentHostService, {
 			onAgentHostStart: Event.None,
 			rootState: new TestRootStateSubscription({ agents: [{ provider: 'copilotcli' }] } as RootState),
@@ -117,6 +150,8 @@ suite('AgentHostSignedOutModelsNotification', () => {
 			clock,
 			notifications,
 			addAgentHostByokModel: () => languageModels.addAgentHostByokModel(),
+			resolveVendor: (vendor: string) => languageModels.resolveVendor(vendor),
+			addConfiguredVendor: (vendor: string) => languageModelsConfiguration.addVendor(vendor),
 			signIn: () => account.setSignedIn(),
 		};
 	}
@@ -146,11 +181,18 @@ class TestLanguageModelsService implements Partial<ILanguageModelsService> {
 	private readonly _onDidChangeModelVisibility = new Emitter<never>();
 	readonly onDidChangeModelVisibility = this._onDidChangeModelVisibility.event as ILanguageModelsService['onDidChangeModelVisibility'];
 	private readonly _models = new Map<string, ILanguageModelChatMetadata>();
+	private readonly _resolvedVendors: Set<string>;
 
-	constructor(private readonly _resolvedVendors: readonly string[]) { }
+	constructor(resolvedVendors: readonly string[]) {
+		this._resolvedVendors = new Set(resolvedVendors);
+	}
 
 	hasResolvedVendor(vendor: string): boolean {
-		return this._resolvedVendors.includes(vendor);
+		return this._resolvedVendors.has(vendor);
+	}
+	resolveVendor(vendor: string): void {
+		this._resolvedVendors.add(vendor);
+		this._onDidChangeLanguageModels.fire(undefined as never);
 	}
 	getLanguageModelIds(): string[] {
 		return [...this._models.keys()];
@@ -165,6 +207,26 @@ class TestLanguageModelsService implements Partial<ILanguageModelsService> {
 		this._models.set('byok-source', { id: 'byok-source', isBYOK: true } as ILanguageModelChatMetadata);
 		this._models.set('byok-target', { id: 'byok-target', byokModelIdentifier: 'byok-source', targetChatSessionType: SessionType.AgentHostCopilot } as ILanguageModelChatMetadata);
 		this._onDidChangeLanguageModels.fire(undefined as never);
+	}
+}
+
+class TestLanguageModelsConfigurationService implements Partial<ILanguageModelsConfigurationService> {
+	declare readonly _serviceBrand: undefined;
+	private readonly _onDidChangeLanguageModelGroups = new Emitter<readonly ILanguageModelsProviderGroup[]>();
+	readonly onDidChangeLanguageModelGroups = this._onDidChangeLanguageModelGroups.event;
+	readonly whenReady = Promise.resolve();
+	private readonly _vendors: string[];
+
+	constructor(vendors: readonly string[]) {
+		this._vendors = [...vendors];
+	}
+
+	getLanguageModelsProviderGroups(): readonly ILanguageModelsProviderGroup[] {
+		return this._vendors.map(vendor => ({ name: vendor, vendor } satisfies ILanguageModelsProviderGroup));
+	}
+	addVendor(vendor: string): void {
+		this._vendors.push(vendor);
+		this._onDidChangeLanguageModelGroups.fire(this.getLanguageModelsProviderGroups());
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostSignedOutModelsNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostSignedOutModelsNotification.test.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { AgentHostAllowSignedOutWhenUsableSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import type { RootState } from '../../../../../../platform/agentHost/common/state/protocol/channels-root/state.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
+import { IExtensionService } from '../../../../../services/extensions/common/extensions.js';
+import { AgentHostSignedOutModelsNotificationContribution } from '../../../browser/agentSessions/agentHost/agentHostSignedOutModelsNotification.js';
+import { type IChatInputNotification, IChatInputNotificationService } from '../../../browser/widget/input/chatInputNotificationService.js';
+import { SessionType } from '../../../common/chatSessionsService.js';
+import { type ILanguageModelChatMetadata, ILanguageModelsService } from '../../../common/languageModels.js';
+import { ILanguageModelsConfigurationService, type ILanguageModelsProviderGroup } from '../../../common/languageModelsConfiguration.js';
+
+const GRACE_PERIOD_MS = 5_000;
+
+suite('AgentHostSignedOutModelsNotification', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	test('shows as soon as local model readiness settles, without waiting out the grace period', async () => {
+		const fixture = await createFixture();
+
+		assert.strictEqual(fixture.notifications.isShown(), true);
+		fixture.clock.restore();
+	});
+
+	test('waits while a configured BYOK vendor is still resolving, then shows once the grace period bounds it', async () => {
+		const fixture = await createFixture({ configuredVendors: ['anthropic'], resolvedVendors: [] });
+
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		await fixture.clock.tickAsync(GRACE_PERIOD_MS - 1);
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		await fixture.clock.tickAsync(1);
+		assert.strictEqual(fixture.notifications.isShown(), true);
+		fixture.clock.restore();
+	});
+
+	test('never shows when a model arrives while the grace period is still running', async () => {
+		const fixture = await createFixture({ configuredVendors: ['anthropic'], resolvedVendors: [] });
+
+		await fixture.clock.tickAsync(3_000);
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		fixture.addAgentHostByokModel();
+
+		await fixture.clock.tickAsync(GRACE_PERIOD_MS);
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		fixture.clock.restore();
+	});
+
+	test('hides once a model targeting the harness becomes available', async () => {
+		const fixture = await createFixture();
+		assert.strictEqual(fixture.notifications.isShown(), true);
+
+		fixture.addAgentHostByokModel();
+
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		fixture.clock.restore();
+	});
+
+	test('hides when the user signs in', async () => {
+		const fixture = await createFixture();
+		assert.strictEqual(fixture.notifications.isShown(), true);
+
+		fixture.signIn();
+
+		assert.strictEqual(fixture.notifications.isShown(), false);
+		fixture.clock.restore();
+	});
+
+	async function createFixture(options: { configuredVendors?: string[]; resolvedVendors?: string[] } = {}) {
+		const clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
+		const notifications = new TestChatInputNotificationService();
+		const languageModels = new TestLanguageModelsService(options.resolvedVendors ?? ['anthropic']);
+		const account = new TestDefaultAccountService();
+		const configuration = new TestConfigurationService();
+		configuration.setUserConfiguration(AgentHostAllowSignedOutWhenUsableSettingId, true);
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IChatInputNotificationService, notifications);
+		instantiationService.stub(IDefaultAccountService, account);
+		instantiationService.stub(ILanguageModelsService, languageModels);
+		instantiationService.stub(ILanguageModelsConfigurationService, {
+			onDidChangeLanguageModelGroups: Event.None,
+			whenReady: Promise.resolve(),
+			getLanguageModelsProviderGroups: () => (options.configuredVendors ?? []).map(vendor => ({ name: vendor, vendor } satisfies ILanguageModelsProviderGroup)),
+		});
+		instantiationService.stub(IAgentHostService, {
+			onAgentHostStart: Event.None,
+			rootState: new TestRootStateSubscription({ agents: [{ provider: 'copilotcli' }] } as RootState),
+		});
+		instantiationService.stub(IConfigurationService, configuration);
+		instantiationService.stub(IChatEntitlementService, { clientByokEnabled: true });
+		instantiationService.stub(IContextKeyService, store.add(new MockContextKeyService()));
+		instantiationService.stub(IExtensionService, { whenInstalledExtensionsRegistered: () => Promise.resolve(true) });
+
+		store.add(instantiationService.createInstance(AgentHostSignedOutModelsNotificationContribution));
+		// Let the account and extension readiness promises settle.
+		await clock.tickAsync(0);
+
+		return {
+			clock,
+			notifications,
+			addAgentHostByokModel: () => languageModels.addAgentHostByokModel(),
+			signIn: () => account.setSignedIn(),
+		};
+	}
+});
+
+class TestChatInputNotificationService implements Partial<IChatInputNotificationService> {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidChange = Event.None;
+	readonly onDidDismiss = Event.None;
+	private readonly _notifications = new Map<string, IChatInputNotification>();
+
+	setNotification(notification: IChatInputNotification): void {
+		this._notifications.set(notification.id, notification);
+	}
+	deleteNotification(id: string): void {
+		this._notifications.delete(id);
+	}
+	isShown(): boolean {
+		return this._notifications.size > 0;
+	}
+}
+
+class TestLanguageModelsService implements Partial<ILanguageModelsService> {
+	declare readonly _serviceBrand: undefined;
+	private readonly _onDidChangeLanguageModels = new Emitter<never>();
+	readonly onDidChangeLanguageModels = this._onDidChangeLanguageModels.event as ILanguageModelsService['onDidChangeLanguageModels'];
+	private readonly _onDidChangeModelVisibility = new Emitter<never>();
+	readonly onDidChangeModelVisibility = this._onDidChangeModelVisibility.event as ILanguageModelsService['onDidChangeModelVisibility'];
+	private readonly _models = new Map<string, ILanguageModelChatMetadata>();
+
+	constructor(private readonly _resolvedVendors: readonly string[]) { }
+
+	hasResolvedVendor(vendor: string): boolean {
+		return this._resolvedVendors.includes(vendor);
+	}
+	getLanguageModelIds(): string[] {
+		return [...this._models.keys()];
+	}
+	lookupLanguageModel(id: string): ILanguageModelChatMetadata | undefined {
+		return this._models.get(id);
+	}
+	isModelHidden(): boolean {
+		return false;
+	}
+	addAgentHostByokModel(): void {
+		this._models.set('byok-source', { id: 'byok-source', isBYOK: true } as ILanguageModelChatMetadata);
+		this._models.set('byok-target', { id: 'byok-target', byokModelIdentifier: 'byok-source', targetChatSessionType: SessionType.AgentHostCopilot } as ILanguageModelChatMetadata);
+		this._onDidChangeLanguageModels.fire(undefined as never);
+	}
+}
+
+class TestDefaultAccountService implements Partial<IDefaultAccountService> {
+	declare readonly _serviceBrand: undefined;
+	private readonly _onDidChangeDefaultAccount = new Emitter<never>();
+	readonly onDidChangeDefaultAccount = this._onDidChangeDefaultAccount.event as IDefaultAccountService['onDidChangeDefaultAccount'];
+	private _account: IDefaultAccountService['currentDefaultAccount'] = null;
+
+	get currentDefaultAccount() {
+		return this._account;
+	}
+	getDefaultAccount(): Promise<IDefaultAccountService['currentDefaultAccount']> {
+		return Promise.resolve(this._account);
+	}
+	setSignedIn(): void {
+		this._account = { sessionId: 'session' } as NonNullable<IDefaultAccountService['currentDefaultAccount']>;
+		this._onDidChangeDefaultAccount.fire(undefined as never);
+	}
+}
+
+class TestRootStateSubscription {
+	readonly onDidChange = Event.None;
+	readonly onDidError = Event.None;
+	readonly onWillApplyAction = Event.None;
+	readonly onDidApplyAction = Event.None;
+
+	constructor(readonly value: RootState) { }
+
+	get verifiedValue(): RootState {
+		return this.value;
+	}
+}


### PR DESCRIPTION
## Summary

- Signed-out Agent Host guidance no longer waits on the bridged model catalog to report, which could leave it hidden indefinitely.
- The notification now appears once local model readiness settles, with a five-second cap for the case where a configured vendor never resolves.
- Local readiness still gates the notification, so someone who already has a BYOK model configured does not see sign-in guidance while models load.
- The three separate predicates collapse into a single state function with explicit hidden, waiting, and visible states.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

The notification gated on two very different signals fused into one boolean. Local BYOK readiness (extension registration, configuration load, and resolution of every vendor named in the user's configuration) always settles. The second signal, `hasResolvedVendor` for the Agent Host vendor, does not: a vendor is only marked resolved after a provider returns models, and when no provider is registered the resolution path returns before recording the vendor at all. Registering a provider later does not retroactively trigger a resolution. When that signal never arrived, the guidance stayed hidden permanently even though the user had no usable models.

### Implementation

`getSignedOutModelsNotificationState` folds the inputs into hidden, waiting, or visible. The hidden conditions short-circuit first: the feature disabled, the account unresolved, the user signed in, the Copilot harness absent, or a usable model already present. Otherwise the notification becomes visible once local readiness settles or the grace period elapses, and waits until then.

The dependency on the bridged catalog is removed and replaced by the bounded wait. Local readiness is retained as the primary signal, so the timeout acts only as a ceiling rather than as the mechanism that drives correctness. The timer is a `MutableDisposable` started when the state enters waiting and cleared when it returns to hidden.

### Behavior and constraints

- Deterministic signals still drive the common path; the timer only bounds the case that can stall.
- The elapsed flag is reset together with the timer whenever the state returns to hidden, so `waiting` always implies the flag is unset and a stale timer cannot wedge the state.
- A provider that throws still marks its vendor resolved, so only a missing registration or a hanging model lookup reaches the cap.
- Notification bookkeeping is now a single boolean, and the identifier and session type are constants, since exactly one notification is reconciled.
- Shutdown tracking was removed: disposal already cancels the pending timer through the registered `MutableDisposable`.

### Review context

The grace period restarts on every transition into waiting. After startup, local readiness has already settled, so user-driven transitions such as signing out or removing the last configured model surface guidance immediately rather than after another delay. The five-second budget is the main judgement call worth a second opinion.

</details>
