### PR TITLE
test: add UI validation evidence capture

### DIFF
--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -229,11 +229,12 @@ export class PlaywrightDriver {
 				rootSession.on('Target.detachedFromTarget', detachedListener);
 				timeout = setTimeout(() => reject(new Error(`Timed out running CDP command '${method}' on target '${targetId}'.`)), 15_000);
 			});
-			await rootSession.send('Target.sendMessageToTarget', {
+			const send = rootSession.send('Target.sendMessageToTarget', {
 				sessionId,
 				message: JSON.stringify({ id: messageId, method, params })
 			});
-			return await response;
+			const [, result] = await Promise.all([send, response]);
+			return result;
 		} finally {
 			if (listener) {
 				rootSession.off('Target.receivedMessageFromTarget', listener);

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -144,6 +144,110 @@ export class PlaywrightDriver {
 		}));
 	}
 
+	async getCDPTargets(): Promise<Protocol.Target.TargetInfo[]> {
+		const session = await this.context.newCDPSession(this.page);
+		try {
+			return (await session.send('Target.getTargets')).targetInfos;
+		} finally {
+			await session.detach();
+		}
+	}
+
+	async evaluateCDPTarget<T>(targetId: string, expression: string): Promise<T> {
+		const response = await this.sendCDPTargetCommand(targetId, 'Runtime.evaluate', {
+			expression,
+			awaitPromise: true,
+			returnByValue: true
+		}) as Protocol.Runtime.evaluateReturnValue;
+		if (response.exceptionDetails) {
+			throw new Error(response.exceptionDetails.exception?.description ?? response.exceptionDetails.text);
+		}
+		return response.result.value as T;
+	}
+
+	async evaluateCDPTargetFrame<T>(targetId: string, frameUrlPattern: string, expression: string): Promise<T> {
+		const { frameTree } = await this.sendCDPTargetCommand(targetId, 'Page.getFrameTree', {}) as Protocol.Page.getFrameTreeReturnValue;
+		const frame = findFrame(frameTree, frameUrlPattern);
+		let frameId = frame?.id;
+		if (!frameId) {
+			const { root } = await this.sendCDPTargetCommand(targetId, 'DOM.getDocument', {
+				depth: -1,
+				pierce: true
+			}) as Protocol.DOM.getDocumentReturnValue;
+			frameId = findDOMFrameId(root, frameUrlPattern);
+		}
+		if (!frameId) {
+			throw new Error(`Frame not found for URL pattern '${frameUrlPattern}'.`);
+		}
+		const { executionContextId } = await this.sendCDPTargetCommand(targetId, 'Page.createIsolatedWorld', {
+			frameId,
+			worldName: 'vscodeAutomation',
+			grantUniveralAccess: true
+		}) as Protocol.Page.createIsolatedWorldReturnValue;
+		const response = await this.sendCDPTargetCommand(targetId, 'Runtime.evaluate', {
+			expression,
+			contextId: executionContextId,
+			awaitPromise: true,
+			returnByValue: true
+		}) as Protocol.Runtime.evaluateReturnValue;
+		if (response.exceptionDetails) {
+			throw new Error(response.exceptionDetails.exception?.description ?? response.exceptionDetails.text);
+		}
+		return response.result.value as T;
+	}
+
+	private async sendCDPTargetCommand(targetId: string, method: string, params: object): Promise<unknown> {
+		const rootSession = await this.context.newCDPSession(this.page);
+		const { sessionId } = await rootSession.send('Target.attachToTarget', { targetId, flatten: false });
+		const messageId = 1;
+		let listener: ((event: { sessionId: string; message: string }) => void) | undefined;
+		let detachedListener: ((event: { sessionId: string; targetId?: string }) => void) | undefined;
+		let timeout: NodeJS.Timeout | undefined;
+		try {
+			const response = new Promise<unknown>((resolve, reject) => {
+				listener = event => {
+					if (event.sessionId !== sessionId) {
+						return;
+					}
+					const message = JSON.parse(event.message) as { id?: number; result?: unknown; error?: { message: string } };
+					if (message.id !== messageId) {
+						return;
+					}
+					if (message.error) {
+						reject(new Error(message.error.message));
+					} else {
+						resolve(message.result);
+					}
+				};
+				detachedListener = event => {
+					if (event.sessionId === sessionId) {
+						reject(new Error(`CDP target '${targetId}' detached while running '${method}'.`));
+					}
+				};
+				rootSession.on('Target.receivedMessageFromTarget', listener);
+				rootSession.on('Target.detachedFromTarget', detachedListener);
+				timeout = setTimeout(() => reject(new Error(`Timed out running CDP command '${method}' on target '${targetId}'.`)), 15_000);
+			});
+			await rootSession.send('Target.sendMessageToTarget', {
+				sessionId,
+				message: JSON.stringify({ id: messageId, method, params })
+			});
+			return await response;
+		} finally {
+			if (listener) {
+				rootSession.off('Target.receivedMessageFromTarget', listener);
+			}
+			if (detachedListener) {
+				rootSession.off('Target.detachedFromTarget', detachedListener);
+			}
+			if (timeout) {
+				clearTimeout(timeout);
+			}
+			await rootSession.send('Target.detachFromTarget', { sessionId }).catch(() => undefined);
+			await rootSession.detach();
+		}
+	}
+
 	/**
 	 * Wait for an open window/page whose URL contains the provided pattern.
 	 */
@@ -885,6 +989,40 @@ export class PlaywrightDriver {
 
 export function wait(ms: number): Promise<void> {
 	return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+function findFrame(frameTree: Protocol.Page.FrameTree, urlPattern: string): Protocol.Page.Frame | undefined {
+	if (frameTree.frame.url.includes(urlPattern)) {
+		return frameTree.frame;
+	}
+	for (const child of frameTree.childFrames ?? []) {
+		const frame = findFrame(child, urlPattern);
+		if (frame) {
+			return frame;
+		}
+	}
+	return undefined;
+}
+
+function findDOMFrameId(node: Protocol.DOM.Node, urlPattern: string): Protocol.Page.FrameId | undefined {
+	const attributes = node.attributes ?? [];
+	for (let index = 0; index < attributes.length; index += 2) {
+		if (attributes[index] === 'src' && attributes[index + 1]?.includes(urlPattern) && node.frameId) {
+			return node.frameId;
+		}
+	}
+	for (const child of [
+		...(node.children ?? []),
+		...(node.shadowRoots ?? []),
+		...(node.pseudoElements ?? []),
+		...(node.contentDocument ? [node.contentDocument] : [])
+	]) {
+		const frameId = findDOMFrameId(child, urlPattern);
+		if (frameId) {
+			return frameId;
+		}
+	}
+	return undefined;
 }
 
 export type { AxeResults };

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -198,12 +198,13 @@ export class PlaywrightDriver {
 
 	private async sendCDPTargetCommand(targetId: string, method: string, params: object): Promise<unknown> {
 		const rootSession = await this.context.newCDPSession(this.page);
-		const { sessionId } = await rootSession.send('Target.attachToTarget', { targetId, flatten: false });
+		let sessionId: string | undefined;
 		const messageId = 1;
 		let listener: ((event: { sessionId: string; message: string }) => void) | undefined;
 		let detachedListener: ((event: { sessionId: string; targetId?: string }) => void) | undefined;
 		let timeout: NodeJS.Timeout | undefined;
 		try {
+			sessionId = (await rootSession.send('Target.attachToTarget', { targetId, flatten: false })).sessionId;
 			const response = new Promise<unknown>((resolve, reject) => {
 				listener = event => {
 					if (event.sessionId !== sessionId) {
@@ -243,7 +244,9 @@ export class PlaywrightDriver {
 			if (timeout) {
 				clearTimeout(timeout);
 			}
-			await rootSession.send('Target.detachFromTarget', { sessionId }).catch(() => undefined);
+			if (sessionId) {
+				await rootSession.send('Target.detachFromTarget', { sessionId }).catch(() => undefined);
+			}
 			await rootSession.detach();
 		}
 	}

--- a/test/mcp/README.md
+++ b/test/mcp/README.md
@@ -60,6 +60,7 @@ The MCP server exposes a comprehensive set of VS Code automation tools through t
 ### Application Management
 - Start, stop, and restart VS Code instances
 - Open workspaces and folders
+- Record scenario evidence with step overlays, screenshots, video, traces, and an HTML report
 
 ### Editor Tools
 - Open, close, and navigate files
@@ -93,6 +94,19 @@ The MCP server exposes a comprehensive set of VS Code automation tools through t
 - Settings and keybindings editors
 - Notebook support
 - Chat features
+
+### Scenario evidence
+
+Start evidence capture before starting VS Code so Playwright enables video recording:
+
+1. Call `vscode_automation_evidence_start`, including any required pre-launch `userSettings`.
+2. Call `vscode_automation_evidence_step` with `started` before each action.
+3. Perform and validate the action with the relevant automation tools.
+4. Call `vscode_automation_evidence_step` with `passed`, `failed`, or `skipped`.
+5. Call `vscode_automation_evidence_finish`.
+
+Artifacts are written to `.build/vscode-playwright-mcp/evidence/<run-id>/`.
+Each evidence run uses an isolated user profile with in-memory secret storage and records every visited Playwright page as a separate video.
 
 ## Development
 

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as vscodetest from '@vscode/test-electron';
 import * as sqlite3 from '@vscode/sqlite3';
+import type { Page } from '@playwright/test';
 import { createApp, retry, parseVersion } from './utils';
 import { opts } from './options';
 
@@ -238,6 +239,9 @@ export async function getApplication({ recordVideo, workspacePath, userSettings,
 	if (opts.web && extraArgs?.length) {
 		throw new Error('Per-run extraArgs are not supported by the web automation launcher.');
 	}
+	if (extraArgs?.some(arg => arg === '--user-data-dir' || arg.startsWith('--user-data-dir='))) {
+		throw new Error('Per-run extraArgs cannot override the isolated user data directory.');
+	}
 	const testCodePath = getDevElectronPath();
 	const electronPath = testCodePath;
 	if (!fs.existsSync(electronPath || '')) {
@@ -368,7 +372,18 @@ export class ApplicationService {
 		if (!this._application) {
 			this._application = await getApplication({ recordVideo, workspacePath, userSettings, extraArgs });
 			const application = this._application;
-			application.code.driver.currentPage.on('close', () => void this._closeApplication(application).catch(error => logger.log(`Failed to close application: ${error}`)));
+			const observedPages = new Set<Page>();
+			const observePage = (page: Page) => {
+				if (observedPages.has(page)) {
+					return;
+				}
+				observedPages.add(page);
+				page.once('close', () => void this._handlePageClose(application).catch(error => logger.log(`Failed to handle page close: ${error}`)));
+			};
+			for (const page of application.code.driver.getAllWindows()) {
+				observePage(page);
+			}
+			application.code.driver.browserContext.on('page', observePage);
 			await this._runAllListeners();
 		}
 		return this._application;
@@ -382,7 +397,15 @@ export class ApplicationService {
 			return undefined;
 		}
 		try {
-			return this._application.code.driver.currentPage.isClosed() ? undefined : this._application;
+			const driver = this._application.code.driver;
+			const openWindowIndex = driver.getAllWindows().findIndex(page => !page.isClosed());
+			if (openWindowIndex < 0) {
+				return undefined;
+			}
+			if (driver.currentPage.isClosed()) {
+				driver.switchToWindow(openWindowIndex);
+			}
+			return this._application;
 		} catch {
 			return undefined;
 		}
@@ -394,6 +417,25 @@ export class ApplicationService {
 		} else if (this._closing) {
 			await this._closing;
 		}
+	}
+
+	private async _handlePageClose(application: Application): Promise<void> {
+		if (this._application !== application) {
+			return;
+		}
+		try {
+			const driver = application.code.driver;
+			const openWindowIndex = driver.getAllWindows().findIndex(page => !page.isClosed());
+			if (openWindowIndex >= 0) {
+				if (driver.currentPage.isClosed()) {
+					driver.switchToWindow(openWindowIndex);
+				}
+				return;
+			}
+		} catch {
+			// Fall through to closing the application.
+		}
+		await this._closeApplication(application);
 	}
 
 	private async _closeApplication(application: Application): Promise<void> {

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -458,7 +458,15 @@ export class ApplicationService {
 		}
 	}
 
-	async stopApplication(): Promise<void> {
+	async stopApplication(application?: Application): Promise<void> {
+		if (application) {
+			if (this._application === application) {
+				await this._closeApplication(application);
+			} else if (this._closing) {
+				await this._closing;
+			}
+			return;
+		}
 		if (this._creating) {
 			try {
 				await this._creating.promise;

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as vscodetest from '@vscode/test-electron';
+import * as sqlite3 from '@vscode/sqlite3';
 import { createApp, retry, parseVersion } from './utils';
 import { opts } from './options';
 
@@ -15,6 +16,7 @@ const rootPath = path.join(__dirname, '..', '..', '..');
 const logsRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'logs');
 const crashesRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'crashes');
 const videoRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'videos');
+const sourceVersion = (JSON.parse(fs.readFileSync(path.join(rootPath, 'package.json'), 'utf8')) as { version: string }).version;
 
 const logger = createLogger();
 
@@ -139,6 +141,10 @@ else {
 
 logger.log(`VS Code product quality: ${quality}.`);
 
+export function getProductVersion(): string {
+	return version ?? sourceVersion;
+}
+
 async function ensureStableCode(): Promise<void> {
 	let stableCodePath = opts['stable-build'];
 	if (!stableCodePath) {
@@ -226,7 +232,10 @@ async function setup(): Promise<void> {
 	logger.log('Smoketest setup done!\n');
 }
 
-export async function getApplication({ recordVideo, workspacePath }: { recordVideo?: boolean; workspacePath?: string } = {}) {
+export async function getApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, string | number | boolean | null>; extraArgs?: string[] } = {}) {
+	if (opts.web && extraArgs?.length) {
+		throw new Error('Per-run extraArgs are not supported by the web automation launcher.');
+	}
 	const testCodePath = getDevElectronPath();
 	const electronPath = testCodePath;
 	if (!fs.existsSync(electronPath || '')) {
@@ -244,6 +253,8 @@ export async function getApplication({ recordVideo, workspacePath }: { recordVid
 		codePath: opts.build,
 		// Use provided workspace path, or fall back to rootPath on CI (GitHub Actions)
 		workspacePath: workspacePath ?? (process.env.GITHUB_ACTIONS ? rootPath : undefined),
+		userDataDir: path.join(testDataPath, 'd'),
+		useInMemorySecretStorage: true,
 		logger,
 		logsPath: logsRootPath,
 		crashesPath: crashesRootPath,
@@ -254,14 +265,41 @@ export async function getApplication({ recordVideo, workspacePath }: { recordVid
 		tracing: true,
 		headless: opts.headless,
 		browser: opts.browser,
-		extraArgs: (opts.electronArgs || '').split(' ').map(arg => arg.trim()).filter(arg => !!arg),
+		extraArgs: [
+			...(opts.electronArgs || '').split(' ').map(arg => arg.trim()).filter(arg => !!arg),
+			...(extraArgs ?? [])
+		],
 		extensionDevelopmentPath: opts.extensionDevelopmentPath,
 	});
+	await preseedUserData(application.userDataPath, userSettings, !!opts.web);
 	await application.start();
-	application.code.driver.currentPage.on('close', async () => {
-		fs.rmSync(testDataPath, { recursive: true, force: true, maxRetries: 10 });
-	});
 	return application;
+}
+
+async function preseedUserData(userDataDir: string | undefined, userSettings: Record<string, string | number | boolean | null> | undefined, web: boolean): Promise<void> {
+	if (!userDataDir) {
+		throw new Error('Cannot pre-seed the MCP test profile without a user data directory.');
+	}
+
+	const userDir = path.join(userDataDir, ...(web ? ['data', 'User'] : ['User']));
+	fs.mkdirSync(userDir, { recursive: true });
+	if (userSettings) {
+		fs.writeFileSync(path.join(userDir, 'settings.json'), JSON.stringify(userSettings, undefined, 2));
+	}
+
+	const globalStorageDir = path.join(userDir, 'globalStorage');
+	fs.mkdirSync(globalStorageDir, { recursive: true });
+	const database = await new Promise<sqlite3.Database>((resolve, reject) => {
+		const instance = new sqlite3.Database(path.join(globalStorageDir, 'state.vscdb'), error => error ? reject(error) : resolve(instance));
+	});
+	try {
+		await new Promise<void>((resolve, reject) => database.exec([
+			'CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);',
+			'INSERT INTO ItemTable (key, value) VALUES (\'builtinChatExtensionEnablementMigration\', \'true\');',
+		].join(' '), error => error ? reject(error) : resolve()));
+	} finally {
+		await new Promise<void>((resolve, reject) => database.close(error => error ? reject(error) : resolve()));
+	}
 }
 
 export class ApplicationService {
@@ -284,12 +322,12 @@ export class ApplicationService {
 		return this._application;
 	}
 
-	async getOrCreateApplication({ recordVideo, workspacePath }: { recordVideo?: boolean; workspacePath?: string } = {}): Promise<Application> {
+	async getOrCreateApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, string | number | boolean | null>; extraArgs?: string[] } = {}): Promise<Application> {
 		if (this._closing) {
 			await this._closing;
 		}
 		if (!this._application) {
-			this._application = await getApplication({ recordVideo, workspacePath });
+			this._application = await getApplication({ recordVideo, workspacePath, userSettings, extraArgs });
 			this._application.code.driver.currentPage.on('close', () => {
 				this._closing = (async () => {
 					if (this._application) {
@@ -303,6 +341,15 @@ export class ApplicationService {
 			await this._runAllListeners();
 		}
 		return this._application;
+	}
+
+	async stopApplication(): Promise<void> {
+		if (this._application) {
+			await this._application.stop();
+		}
+		if (this._closing) {
+			await this._closing;
+		}
 	}
 
 	private async _runAllListeners() {

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -12,6 +12,8 @@ import * as sqlite3 from '@vscode/sqlite3';
 import { createApp, retry, parseVersion } from './utils';
 import { opts } from './options';
 
+export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+
 const rootPath = path.join(__dirname, '..', '..', '..');
 const logsRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'logs');
 const crashesRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'crashes');
@@ -232,7 +234,7 @@ async function setup(): Promise<void> {
 	logger.log('Smoketest setup done!\n');
 }
 
-export async function getApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, string | number | boolean | null>; extraArgs?: string[] } = {}) {
+export async function getApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, JSONValue>; extraArgs?: string[] } = {}) {
 	if (opts.web && extraArgs?.length) {
 		throw new Error('Per-run extraArgs are not supported by the web automation launcher.');
 	}
@@ -276,7 +278,7 @@ export async function getApplication({ recordVideo, workspacePath, userSettings,
 	return application;
 }
 
-async function preseedUserData(userDataDir: string | undefined, userSettings: Record<string, string | number | boolean | null> | undefined, web: boolean): Promise<void> {
+async function preseedUserData(userDataDir: string | undefined, userSettings: Record<string, JSONValue> | undefined, web: boolean): Promise<void> {
 	if (!userDataDir) {
 		throw new Error('Cannot pre-seed the MCP test profile without a user data directory.');
 	}
@@ -322,7 +324,7 @@ export class ApplicationService {
 		return this._application;
 	}
 
-	async getOrCreateApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, string | number | boolean | null>; extraArgs?: string[] } = {}): Promise<Application> {
+	async getOrCreateApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, JSONValue>; extraArgs?: string[] } = {}): Promise<Application> {
 		if (this._closing) {
 			await this._closing;
 		}
@@ -341,6 +343,20 @@ export class ApplicationService {
 			await this._runAllListeners();
 		}
 		return this._application;
+	}
+
+	async getApplicationIfRunning(): Promise<Application | undefined> {
+		if (this._closing) {
+			await this._closing;
+		}
+		if (!this._application) {
+			return undefined;
+		}
+		try {
+			return this._application.code.driver.currentPage.isClosed() ? undefined : this._application;
+		} catch {
+			return undefined;
+		}
 	}
 
 	async stopApplication(): Promise<void> {

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -15,6 +15,8 @@ import { opts } from './options';
 
 export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
 
+type ApplicationLaunchOptions = { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, JSONValue>; extraArgs?: string[] };
+
 const rootPath = path.join(__dirname, '..', '..', '..');
 const logsRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'logs');
 const crashesRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp', 'crashes');
@@ -331,8 +333,31 @@ async function preseedUserData(userDataDir: string | undefined, userSettings: Re
 	}
 }
 
+function launchOptionsEqual(first: ApplicationLaunchOptions, second: ApplicationLaunchOptions): boolean {
+	return !!first.recordVideo === !!second.recordVideo
+		&& first.workspacePath === second.workspacePath
+		&& jsonValueEqual(first.userSettings, second.userSettings)
+		&& jsonValueEqual(first.extraArgs, second.extraArgs);
+}
+
+function jsonValueEqual(first: JSONValue | Record<string, JSONValue> | undefined, second: JSONValue | Record<string, JSONValue> | undefined): boolean {
+	if (first === second) {
+		return true;
+	}
+	if (first === undefined || second === undefined || first === null || second === null || typeof first !== 'object' || typeof second !== 'object') {
+		return false;
+	}
+	if (Array.isArray(first) || Array.isArray(second)) {
+		return Array.isArray(first) && Array.isArray(second) && first.length === second.length && first.every((value, index) => jsonValueEqual(value, second[index]));
+	}
+	const firstKeys = Object.keys(first);
+	const secondKeys = Object.keys(second);
+	return firstKeys.length === secondKeys.length && firstKeys.every(key => Object.prototype.hasOwnProperty.call(second, key) && jsonValueEqual(first[key], second[key]));
+}
+
 export class ApplicationService {
 	private _application: Application | undefined;
+	private _creating: { options: ApplicationLaunchOptions; promise: Promise<Application> } | undefined;
 	private _closing: Promise<void> | undefined;
 	private _profileCleanup: Promise<void> | undefined;
 	private readonly _profileCleanupDelays = new Set<Promise<void>>();
@@ -362,15 +387,29 @@ export class ApplicationService {
 		await this._profileCleanup;
 	}
 
-	async getOrCreateApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, JSONValue>; extraArgs?: string[] } = {}): Promise<Application> {
-		if (this._closing) {
-			await this._closing;
+	async getOrCreateApplication(options: ApplicationLaunchOptions = {}): Promise<Application> {
+		if (this._creating) {
+			if (!launchOptionsEqual(this._creating.options, options)) {
+				throw new Error('An application launch is already in progress with different launch options.');
+			}
+			return this._creating.promise;
 		}
-		if (this._profileCleanup) {
-			await this._profileCleanup;
+		if (this._application) {
+			return this._application;
 		}
-		if (!this._application) {
-			this._application = await getApplication({ recordVideo, workspacePath, userSettings, extraArgs });
+
+		const creating = (async () => {
+			if (this._closing) {
+				await this._closing;
+			}
+			if (this._profileCleanup) {
+				await this._profileCleanup;
+			}
+			if (this._application) {
+				return this._application;
+			}
+
+			this._application = await getApplication(options);
 			const application = this._application;
 			const observedPages = new Set<Page>();
 			const observePage = (page: Page) => {
@@ -385,8 +424,16 @@ export class ApplicationService {
 			}
 			application.code.driver.browserContext.on('page', observePage);
 			await this._runAllListeners();
+			return application;
+		})();
+		this._creating = { options, promise: creating };
+		try {
+			return await creating;
+		} finally {
+			if (this._creating?.promise === creating) {
+				this._creating = undefined;
+			}
 		}
-		return this._application;
 	}
 
 	async getApplicationIfRunning(): Promise<Application | undefined> {
@@ -412,6 +459,13 @@ export class ApplicationService {
 	}
 
 	async stopApplication(): Promise<void> {
+		if (this._creating) {
+			try {
+				await this._creating.promise;
+			} catch {
+				return;
+			}
+		}
 		if (this._application) {
 			await this._closeApplication(this._application);
 		} else if (this._closing) {

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -273,9 +273,32 @@ export async function getApplication({ recordVideo, workspacePath, userSettings,
 		],
 		extensionDevelopmentPath: opts.extensionDevelopmentPath,
 	});
-	await preseedUserData(application.userDataPath, userSettings, !!opts.web);
-	await application.start();
-	return application;
+	try {
+		await preseedUserData(application.userDataPath, userSettings, !!opts.web);
+		await application.start();
+		return application;
+	} catch (error) {
+		try {
+			await application.stop();
+		} catch {
+			// Preserve the startup error.
+		}
+		await removeProfileData(application.userDataPath);
+		throw error;
+	}
+}
+
+async function removeProfileData(userDataPath: string | undefined): Promise<void> {
+	if (!userDataPath) {
+		return;
+	}
+	for (const profilePath of [userDataPath, `${userDataPath}-server`]) {
+		try {
+			await fs.promises.rm(profilePath, { recursive: true, force: true, maxRetries: 10 });
+		} catch (error) {
+			logger.log(`Failed to remove test profile '${profilePath}': ${error}`);
+		}
+	}
 }
 
 async function preseedUserData(userDataDir: string | undefined, userSettings: Record<string, JSONValue> | undefined, web: boolean): Promise<void> {
@@ -307,6 +330,8 @@ async function preseedUserData(userDataDir: string | undefined, userSettings: Re
 export class ApplicationService {
 	private _application: Application | undefined;
 	private _closing: Promise<void> | undefined;
+	private _profileCleanup: Promise<void> | undefined;
+	private readonly _profileCleanupDelays = new Set<Promise<void>>();
 	private _listeners: ((app: Application | undefined) => Promise<void> | void)[] = [];
 
 	onApplicationChange(listener: (app: Application | undefined) => Promise<void> | void): void {
@@ -324,22 +349,26 @@ export class ApplicationService {
 		return this._application;
 	}
 
+	deferProfileCleanup(until: Promise<void>): void {
+		this._profileCleanupDelays.add(until);
+		void until.finally(() => this._profileCleanupDelays.delete(until));
+	}
+
+	async waitForProfileCleanup(): Promise<void> {
+		await this._profileCleanup;
+	}
+
 	async getOrCreateApplication({ recordVideo, workspacePath, userSettings, extraArgs }: { recordVideo?: boolean; workspacePath?: string; userSettings?: Record<string, JSONValue>; extraArgs?: string[] } = {}): Promise<Application> {
 		if (this._closing) {
 			await this._closing;
 		}
+		if (this._profileCleanup) {
+			await this._profileCleanup;
+		}
 		if (!this._application) {
 			this._application = await getApplication({ recordVideo, workspacePath, userSettings, extraArgs });
-			this._application.code.driver.currentPage.on('close', () => {
-				this._closing = (async () => {
-					if (this._application) {
-						this._application.code.driver.browserContext.removeAllListeners();
-						await this._application.stop();
-						this._application = undefined;
-						await this._runAllListeners();
-					}
-				})();
-			});
+			const application = this._application;
+			application.code.driver.currentPage.on('close', () => void this._closeApplication(application).catch(error => logger.log(`Failed to close application: ${error}`)));
 			await this._runAllListeners();
 		}
 		return this._application;
@@ -361,11 +390,57 @@ export class ApplicationService {
 
 	async stopApplication(): Promise<void> {
 		if (this._application) {
-			await this._application.stop();
-		}
-		if (this._closing) {
+			await this._closeApplication(this._application);
+		} else if (this._closing) {
 			await this._closing;
 		}
+	}
+
+	private async _closeApplication(application: Application): Promise<void> {
+		if (this._application !== application) {
+			await this._closing;
+			return;
+		}
+		if (!this._closing) {
+			const closing = (async () => {
+				try {
+					application.code.driver.browserContext.removeAllListeners();
+					await application.stop();
+				} finally {
+					if (this._application === application) {
+						this._application = undefined;
+						await this._runAllListeners();
+						this._scheduleProfileCleanup(application.userDataPath);
+					}
+				}
+			})();
+			this._closing = closing;
+			try {
+				await closing;
+			} finally {
+				if (this._closing === closing) {
+					this._closing = undefined;
+				}
+			}
+		} else {
+			await this._closing;
+		}
+	}
+
+	private _scheduleProfileCleanup(userDataPath: string | undefined): void {
+		const previousCleanup = this._profileCleanup ?? Promise.resolve();
+		const cleanupDelays = [...this._profileCleanupDelays];
+		const cleanup = (async () => {
+			await previousCleanup;
+			await Promise.all(cleanupDelays);
+			await removeProfileData(userDataPath);
+		})();
+		this._profileCleanup = cleanup;
+		void cleanup.finally(() => {
+			if (this._profileCleanup === cleanup) {
+				this._profileCleanup = undefined;
+			}
+		});
 	}
 
 	private async _runAllListeners() {

--- a/test/mcp/src/automation.ts
+++ b/test/mcp/src/automation.ts
@@ -8,6 +8,7 @@ import { ApplicationService } from './application';
 import { applyAllTools } from './automationTools/index.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
+import { applyEvidenceStartTool, applyEvidenceTools, EvidenceService } from './evidence.js';
 
 export async function getServer(appService: ApplicationService): Promise<Server> {
 	const server = new McpServer({
@@ -15,6 +16,7 @@ export async function getServer(appService: ApplicationService): Promise<Server>
 		version: '1.0.0',
 		title: 'An MCP Server that can interact with a local build of VS Code. Used for verifying UI behavior.'
 	}, { capabilities: { logging: {} } });
+	const evidenceService = new EvidenceService(appService);
 
 	server.tool(
 		'vscode_automation_start',
@@ -34,6 +36,8 @@ export async function getServer(appService: ApplicationService): Promise<Server>
 			};
 		}
 	);
+	applyEvidenceStartTool(server, evidenceService);
+	applyEvidenceTools(server, evidenceService);
 
 	// Apply all VS Code automation tools using the modular structure
 	const registeredTools = applyAllTools(server, appService);

--- a/test/mcp/src/automationTools/windows.ts
+++ b/test/mcp/src/automationTools/windows.ts
@@ -100,6 +100,33 @@ export function applyWindowTools(server: McpServer, appService: ApplicationServi
 	));
 
 	tools.push(server.tool(
+		'vscode_automation_window_list_cdp_targets',
+		'List Chromium CDP targets, including out-of-process iframes',
+		async () => {
+			const app = await appService.getOrCreateApplication();
+			const targets = await app.code.driver.getCDPTargets();
+			return textResponse(`CDP targets (${targets.length}):\n${JSON.stringify(targets, null, 2)}`);
+		}
+	));
+
+	tools.push(server.tool(
+		'vscode_automation_window_cdp_target_evaluate',
+		'Evaluate JavaScript in a Chromium CDP target',
+		{
+			targetId: z.string().describe('CDP target ID'),
+			frameUrlPattern: z.string().optional().describe('Optional child frame URL substring'),
+			expression: z.string().describe('JavaScript expression to evaluate')
+		},
+		async ({ targetId, frameUrlPattern, expression }) => {
+			const app = await appService.getOrCreateApplication();
+			const result = frameUrlPattern
+				? await app.code.driver.evaluateCDPTargetFrame(targetId, frameUrlPattern, expression)
+				: await app.code.driver.evaluateCDPTarget(targetId, expression);
+			return textResponse(`Result:\n${JSON.stringify(result, null, 2)}`);
+		}
+	));
+
+	tools.push(server.tool(
 		'vscode_automation_window_click',
 		'Click on an element in the current window using a CSS selector',
 		{
@@ -216,6 +243,34 @@ export function applyWindowTools(server: McpServer, appService: ApplicationServi
 			const driver = app.code.driver;
 			await driver.pressKey(key);
 			return textResponse(`Pressed key "${key}"`);
+		}
+	));
+
+	tools.push(server.tool(
+		'vscode_automation_window_keyboard_type',
+		'Type text with Playwright keyboard events in the currently focused element',
+		{
+			text: z.string().describe('Text to type'),
+			delay: z.number().optional().describe('Delay between key presses in milliseconds')
+		},
+		async ({ text, delay }) => {
+			const app = await appService.getOrCreateApplication();
+			await app.code.driver.currentPage.keyboard.type(text, { delay });
+			return textResponse(`Typed ${text.length} character(s) with keyboard events`);
+		}
+	));
+
+	tools.push(server.tool(
+		'vscode_automation_window_press_selector',
+		'Press a key or key combination on a specific element in the current window',
+		{
+			selector: z.string().describe('CSS selector for the target element'),
+			key: z.string().describe('Key to press')
+		},
+		async ({ selector, key }) => {
+			const app = await appService.getOrCreateApplication();
+			await app.code.driver.currentPage.locator(selector).press(key);
+			return textResponse(`Pressed "${key}" on "${selector}"`);
 		}
 	));
 

--- a/test/mcp/src/evidence.ts
+++ b/test/mcp/src/evidence.ts
@@ -48,6 +48,7 @@ interface LogFileSnapshot {
 
 interface EvidenceRun {
 	id: string;
+	state: 'initializing' | 'active' | 'capturing' | 'finishing';
 	scenarioId: string;
 	title: string;
 	source?: string;
@@ -91,6 +92,9 @@ export class EvidenceService {
 		if (this.appService.application) {
 			throw new Error('Stop the existing VS Code instance before starting evidence capture so video recording can be enabled at launch.');
 		}
+		if (source && !isHttpUrl(source)) {
+			throw new Error(`Evidence source must use HTTP or HTTPS: '${source}'.`);
+		}
 
 		const startedAt = new Date().toISOString();
 		const id = `${sanitizePathSegment(scenarioId)}-${startedAt.replace(/[:.]/g, '-')}`;
@@ -104,16 +108,9 @@ export class EvidenceService {
 		let releaseProfileCleanup!: () => void;
 		const profileCleanupReady = new Promise<void>(resolve => releaseProfileCleanup = resolve);
 		this.appService.deferProfileCleanup(profileCleanupReady);
-		let app: Awaited<ReturnType<ApplicationService['getOrCreateApplication']>>;
-		try {
-			app = await this.appService.getOrCreateApplication({ recordVideo: true, workspacePath, userSettings, extraArgs });
-		} catch (error) {
-			releaseProfileCleanup();
-			await this.appService.waitForProfileCleanup();
-			throw error;
-		}
-		this.currentRun = {
+		const run: EvidenceRun = {
 			id,
+			state: 'initializing',
 			scenarioId,
 			title,
 			source,
@@ -130,12 +127,24 @@ export class EvidenceService {
 				architecture: process.arch,
 				nodeVersion: process.version,
 				vscodeVersion: getProductVersion(),
-				quality: qualityNames[app.quality] ?? String(app.quality),
+				quality: 'unknown',
 				commit: process.env.GITHUB_SHA ?? process.env.BUILD_SOURCEVERSION
 			},
 			steps: []
 		};
-		const run = this.currentRun;
+		this.currentRun = run;
+		let app: Awaited<ReturnType<ApplicationService['getOrCreateApplication']>>;
+		try {
+			app = await this.appService.getOrCreateApplication({ recordVideo: true, workspacePath, userSettings, extraArgs });
+		} catch (error) {
+			if (this.currentRun === run) {
+				this.currentRun = undefined;
+			}
+			releaseProfileCleanup();
+			await this.appService.waitForProfileCleanup();
+			throw error;
+		}
+		run.environment.quality = qualityNames[app.quality] ?? String(app.quality);
 		try {
 			run.pageListener = page => {
 				const video = page.video();
@@ -153,6 +162,7 @@ export class EvidenceService {
 			await wait(500);
 			await this.capture('00-scenario-started.png');
 			this.writeManifest();
+			run.state = 'active';
 
 			return runPath;
 		} catch (error) {
@@ -179,11 +189,9 @@ export class EvidenceService {
 
 	async step(id: string, title: string, status: StepStatus, details?: string): Promise<{ screenshot: Buffer; screenshotPath: string }> {
 		const run = this.requireRun();
-		const app = this.appService.application;
-		if (!app) {
-			throw new Error('VS Code is not running. Finish the evidence run as aborted or failed.');
+		if (run.state !== 'active') {
+			throw new Error(`Evidence run '${run.id}' is busy (${run.state}).`);
 		}
-		run.pageListener?.(app.code.driver.currentPage);
 		let step = run.steps.find(candidate => candidate.id === id);
 
 		let isNewStep = false;
@@ -210,18 +218,39 @@ export class EvidenceService {
 			throw new Error(`Step '${id}' must be started before it can be marked '${status}'.`);
 		}
 
+		run.state = 'capturing';
 		let screenshotName: string | undefined;
 		try {
-			await this.showOverlay(id, title, status);
-			await wait(status === 'started' ? 500 : 250);
-			const sequence = String(run.steps.indexOf(step) + 1).padStart(2, '0');
-			screenshotName = `${sequence}-${sanitizePathSegment(id)}-${status}.png`;
-			const screenshot = await this.capture(screenshotName);
+			let app = await this.appService.getApplicationIfRunning();
+			if (!app) {
+				throw new Error('VS Code is not running. Finish the evidence run as aborted or failed.');
+			}
+			run.pageListener?.(app.code.driver.currentPage);
+			let screenshot: Buffer | undefined;
+			for (let attempt = 0; attempt < 2; attempt++) {
+				try {
+					await this.showOverlay(id, title, status);
+					await wait(status === 'started' ? 500 : 250);
+					const sequence = String(run.steps.indexOf(step) + 1).padStart(2, '0');
+					screenshotName = `${sequence}-${sanitizePathSegment(id)}-${status}.png`;
+					screenshot = await this.capture(screenshotName);
+					break;
+				} catch (error) {
+					app = await this.appService.getApplicationIfRunning();
+					if (!app || attempt === 1) {
+						throw error;
+					}
+					run.pageListener?.(app.code.driver.currentPage);
+				}
+			}
+			if (!screenshot || !screenshotName) {
+				throw new Error(`Failed to capture evidence for step '${id}'.`);
+			}
 			step.captures.push({
 				status,
 				timestamp: new Date().toISOString(),
 				screenshot: screenshotName,
-				windowUrl: this.appService.application!.code.driver.currentPage.url(),
+				windowUrl: app.code.driver.currentPage.url(),
 				details
 			});
 			this.writeManifest();
@@ -239,11 +268,18 @@ export class EvidenceService {
 				}
 			}
 			throw error;
+		} finally {
+			if (this.currentRun === run && run.state === 'capturing') {
+				run.state = 'active';
+			}
 		}
 	}
 
 	async finish(outcome: RunOutcome, notes?: string): Promise<string> {
 		const run = this.requireRun();
+		if (run.state !== 'active') {
+			throw new Error(`Evidence run '${run.id}' is busy (${run.state}).`);
+		}
 		const activeStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'started');
 		if (activeStep && outcome !== 'aborted') {
 			throw new Error(`Step '${activeStep.id}' is still active. Complete it before finishing the run.`);
@@ -253,6 +289,7 @@ export class EvidenceService {
 			outcome = 'failed';
 			notes = [notes, `Run marked failed because step '${failedStep.id}' failed.`].filter(Boolean).join('\n');
 		}
+		run.state = 'finishing';
 
 		try {
 			let app = await this.appService.getApplicationIfRunning();
@@ -264,16 +301,22 @@ export class EvidenceService {
 				}
 			};
 			if (app) {
-				try {
-					await this.showOverlay('Result', run.title, outcome);
-					await wait(500);
-					await this.capture(`99-result-${outcome}.png`);
-				} catch (error) {
-					if (await this.appService.getApplicationIfRunning()) {
-						throw error;
+				for (let attempt = 0; attempt < 2; attempt++) {
+					try {
+						await this.showOverlay('Result', run.title, outcome);
+						await wait(500);
+						await this.capture(`99-result-${outcome}.png`);
+						break;
+					} catch (error) {
+						app = await this.appService.getApplicationIfRunning();
+						if (!app) {
+							recordApplicationClosure();
+							break;
+						}
+						if (attempt === 1) {
+							throw error;
+						}
 					}
-					app = undefined;
-					recordApplicationClosure();
 				}
 			} else {
 				recordApplicationClosure();
@@ -464,7 +507,7 @@ export function applyEvidenceStartTool(server: McpServer, evidenceService: Evide
 		{
 			scenarioId: z.string().describe('Stable scenario identifier'),
 			title: z.string().describe('Human-readable scenario title'),
-			source: z.string().url().optional().describe('Source test-plan issue URL'),
+			source: z.string().url().refine(isHttpUrl, 'Source must use HTTP or HTTPS').optional().describe('Source test-plan issue URL'),
 			scenarioPath: z.string().optional().describe('Path to the Markdown scenario definition'),
 			workspacePath: z.string().optional().describe('Workspace or folder to open'),
 			userSettings: z.record(z.string(), jsonValueSchema).optional().describe('User settings to seed before VS Code starts'),
@@ -543,4 +586,13 @@ function escapeHtml(value: string): string {
 
 function wait(milliseconds: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+function isHttpUrl(value: string): boolean {
+	try {
+		const protocol = new URL(value).protocol;
+		return protocol === 'http:' || protocol === 'https:';
+	} catch {
+		return false;
+	}
 }

--- a/test/mcp/src/evidence.ts
+++ b/test/mcp/src/evidence.ts
@@ -41,6 +41,11 @@ interface EvidenceStep {
 	captures: EvidenceCapture[];
 }
 
+interface LogFileSnapshot {
+	size: number;
+	mtimeMs: number;
+}
+
 interface EvidenceRun {
 	id: string;
 	scenarioId: string;
@@ -55,7 +60,8 @@ interface EvidenceRun {
 	runPath: string;
 	videos: Set<{ saveAs(path: string): Promise<void> }>;
 	pageListener?: (page: Page) => void;
-	logFilesBefore: Map<string, number>;
+	logFilesBefore: Map<string, LogFileSnapshot>;
+	releaseProfileCleanup: () => void;
 	artifacts: {
 		report?: string;
 		videos: string[];
@@ -91,8 +97,21 @@ export class EvidenceService {
 		const runPath = path.join(evidenceRootPath, id);
 		fs.mkdirSync(runPath, { recursive: true });
 
-		const logFilesBefore = new Map(listFiles(logsRootPath).map(file => [file, fs.statSync(file).size]));
-		const app = await this.appService.getOrCreateApplication({ recordVideo: true, workspacePath, userSettings, extraArgs });
+		const logFilesBefore = new Map<string, LogFileSnapshot>(listFiles(logsRootPath).map(file => {
+			const stat = fs.statSync(file);
+			return [file, { size: stat.size, mtimeMs: stat.mtimeMs }];
+		}));
+		let releaseProfileCleanup!: () => void;
+		const profileCleanupReady = new Promise<void>(resolve => releaseProfileCleanup = resolve);
+		this.appService.deferProfileCleanup(profileCleanupReady);
+		let app: Awaited<ReturnType<ApplicationService['getOrCreateApplication']>>;
+		try {
+			app = await this.appService.getOrCreateApplication({ recordVideo: true, workspacePath, userSettings, extraArgs });
+		} catch (error) {
+			releaseProfileCleanup();
+			await this.appService.waitForProfileCleanup();
+			throw error;
+		}
 		this.currentRun = {
 			id,
 			scenarioId,
@@ -104,6 +123,7 @@ export class EvidenceService {
 			runPath,
 			videos: new Set(),
 			logFilesBefore,
+			releaseProfileCleanup,
 			artifacts: { videos: [], logs: [] },
 			environment: {
 				platform: process.platform,
@@ -150,6 +170,8 @@ export class EvidenceService {
 				// Preserve the startup error.
 			} finally {
 				this.currentRun = undefined;
+				run.releaseProfileCleanup();
+				await this.appService.waitForProfileCleanup();
 			}
 			throw error;
 		}
@@ -164,6 +186,7 @@ export class EvidenceService {
 		run.pageListener?.(app.code.driver.currentPage);
 		let step = run.steps.find(candidate => candidate.id === id);
 
+		let isNewStep = false;
 		if (status === 'started') {
 			if (step) {
 				throw new Error(`Step '${id}' has already started.`);
@@ -174,6 +197,7 @@ export class EvidenceService {
 			}
 			step = { id, title, captures: [] };
 			run.steps.push(step);
+			isNewStep = true;
 		} else if (!step && status === 'skipped') {
 			const activeStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'started');
 			if (activeStep) {
@@ -181,25 +205,41 @@ export class EvidenceService {
 			}
 			step = { id, title, captures: [] };
 			run.steps.push(step);
+			isNewStep = true;
 		} else if (!step || step.captures.at(-1)?.status !== 'started') {
 			throw new Error(`Step '${id}' must be started before it can be marked '${status}'.`);
 		}
 
-		await this.showOverlay(id, title, status);
-		await wait(status === 'started' ? 500 : 250);
-		const sequence = String(run.steps.indexOf(step) + 1).padStart(2, '0');
-		const screenshotName = `${sequence}-${sanitizePathSegment(id)}-${status}.png`;
-		const screenshot = await this.capture(screenshotName);
-		step.captures.push({
-			status,
-			timestamp: new Date().toISOString(),
-			screenshot: screenshotName,
-			windowUrl: this.appService.application!.code.driver.currentPage.url(),
-			details
-		});
-		this.writeManifest();
+		let screenshotName: string | undefined;
+		try {
+			await this.showOverlay(id, title, status);
+			await wait(status === 'started' ? 500 : 250);
+			const sequence = String(run.steps.indexOf(step) + 1).padStart(2, '0');
+			screenshotName = `${sequence}-${sanitizePathSegment(id)}-${status}.png`;
+			const screenshot = await this.capture(screenshotName);
+			step.captures.push({
+				status,
+				timestamp: new Date().toISOString(),
+				screenshot: screenshotName,
+				windowUrl: this.appService.application!.code.driver.currentPage.url(),
+				details
+			});
+			this.writeManifest();
 
-		return { screenshot, screenshotPath: path.join(run.runPath, screenshotName) };
+			return { screenshot, screenshotPath: path.join(run.runPath, screenshotName) };
+		} catch (error) {
+			if (isNewStep && !step.captures.length) {
+				run.steps.splice(run.steps.indexOf(step), 1);
+				if (screenshotName) {
+					try {
+						fs.rmSync(path.join(run.runPath, screenshotName), { force: true });
+					} catch {
+						// Preserve the capture error.
+					}
+				}
+			}
+			throw error;
+		}
 	}
 
 	async finish(outcome: RunOutcome, notes?: string): Promise<string> {
@@ -293,6 +333,8 @@ export class EvidenceService {
 				// Preserve the primary result or finalization error.
 			}
 			this.currentRun = undefined;
+			run.releaseProfileCleanup();
+			await this.appService.waitForProfileCleanup();
 		}
 	}
 
@@ -353,16 +395,19 @@ export class EvidenceService {
 	private copyLogArtifacts(): void {
 		const run = this.requireRun();
 		for (const file of listFiles(logsRootPath)) {
-			const previousSize = run.logFilesBefore.get(file) ?? 0;
+			const previous = run.logFilesBefore.get(file);
+			const stat = fs.statSync(file);
 			const contents = fs.readFileSync(file);
-			if (contents.length <= previousSize) {
+			const wasReplacedArchive = path.extname(file).toLowerCase() === '.zip' && previous?.mtimeMs !== stat.mtimeMs;
+			const offset = wasReplacedArchive ? 0 : previous?.size ?? 0;
+			if (contents.length <= offset) {
 				continue;
 			}
 			const relativeSource = path.relative(logsRootPath, file);
 			const relativeDestination = path.join('logs', relativeSource);
 			const destination = path.join(run.runPath, relativeDestination);
 			fs.mkdirSync(path.dirname(destination), { recursive: true });
-			fs.writeFileSync(destination, contents.subarray(previousSize));
+			fs.writeFileSync(destination, contents.subarray(offset));
 			run.artifacts.logs.push(relativeDestination.replaceAll(path.sep, '/'));
 		}
 	}

--- a/test/mcp/src/evidence.ts
+++ b/test/mcp/src/evidence.ts
@@ -1,0 +1,444 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { z } from 'zod';
+import { ApplicationService, getProductVersion } from './application';
+
+const rootPath = path.join(__dirname, '..', '..', '..');
+const artifactRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp');
+const evidenceRootPath = path.join(artifactRootPath, 'evidence');
+const logsRootPath = path.join(artifactRootPath, 'logs');
+const qualityNames = ['Dev', 'Insiders', 'Stable', 'Exploration', 'OSS'];
+
+type StepStatus = 'started' | 'passed' | 'failed' | 'skipped';
+type RunOutcome = 'passed' | 'failed' | 'aborted';
+
+interface EvidenceCapture {
+	status: StepStatus;
+	timestamp: string;
+	screenshot: string;
+	windowUrl: string;
+	details?: string;
+}
+
+interface EvidenceStep {
+	id: string;
+	title: string;
+	captures: EvidenceCapture[];
+}
+
+interface EvidenceRun {
+	id: string;
+	scenarioId: string;
+	title: string;
+	source?: string;
+	scenarioPath?: string;
+	workspacePath?: string;
+	startedAt: string;
+	completedAt?: string;
+	outcome?: RunOutcome;
+	notes?: string;
+	runPath: string;
+	videos: Set<{ saveAs(path: string): Promise<void> }>;
+	pageListener?: (page: Page) => void;
+	logFilesBefore: Map<string, number>;
+	artifacts: {
+		report?: string;
+		videos: string[];
+		logs: string[];
+		finalizationError?: string;
+	};
+	environment: {
+		platform: NodeJS.Platform;
+		architecture: string;
+		nodeVersion: string;
+		vscodeVersion: string;
+		quality: string;
+		commit?: string;
+	};
+	steps: EvidenceStep[];
+}
+
+export class EvidenceService {
+	private currentRun: EvidenceRun | undefined;
+
+	constructor(private readonly appService: ApplicationService) { }
+
+	async start(scenarioId: string, title: string, source?: string, scenarioPath?: string, workspacePath?: string, userSettings?: Record<string, string | number | boolean | null>, extraArgs?: string[]): Promise<string> {
+		if (this.currentRun) {
+			throw new Error(`Evidence run '${this.currentRun.id}' is already active.`);
+		}
+		if (this.appService.application) {
+			throw new Error('Stop the existing VS Code instance before starting evidence capture so video recording can be enabled at launch.');
+		}
+
+		const startedAt = new Date().toISOString();
+		const id = `${sanitizePathSegment(scenarioId)}-${startedAt.replace(/[:.]/g, '-')}`;
+		const runPath = path.join(evidenceRootPath, id);
+		fs.mkdirSync(runPath, { recursive: true });
+
+		const logFilesBefore = new Map(listFiles(logsRootPath).map(file => [file, fs.statSync(file).size]));
+		const app = await this.appService.getOrCreateApplication({ recordVideo: true, workspacePath, userSettings, extraArgs });
+		this.currentRun = {
+			id,
+			scenarioId,
+			title,
+			source,
+			scenarioPath,
+			workspacePath,
+			startedAt,
+			runPath,
+			videos: new Set(),
+			logFilesBefore,
+			artifacts: { videos: [], logs: [] },
+			environment: {
+				platform: process.platform,
+				architecture: process.arch,
+				nodeVersion: process.version,
+				vscodeVersion: getProductVersion(),
+				quality: qualityNames[app.quality] ?? String(app.quality),
+				commit: process.env.GITHUB_SHA ?? process.env.BUILD_SOURCEVERSION
+			},
+			steps: []
+		};
+		const run = this.currentRun;
+		run.pageListener = page => {
+			const video = page.video();
+			if (video) {
+				run.videos.add(video);
+			}
+		};
+		for (const page of app.code.driver.getAllWindows()) {
+			run.pageListener(page);
+		}
+		app.code.driver.browserContext.on('page', run.pageListener);
+
+		await app.startTracing();
+		await this.showOverlay('Scenario', title, 'started');
+		await wait(500);
+		await this.capture('00-scenario-started.png');
+		this.writeManifest();
+
+		return runPath;
+	}
+
+	async step(id: string, title: string, status: StepStatus, details?: string): Promise<{ screenshot: Buffer; screenshotPath: string }> {
+		const run = this.requireRun();
+		const app = this.appService.application;
+		if (!app) {
+			throw new Error('VS Code is not running. Finish the evidence run as aborted or failed.');
+		}
+		run.pageListener?.(app.code.driver.currentPage);
+		let step = run.steps.find(candidate => candidate.id === id);
+
+		if (status === 'started') {
+			if (step) {
+				throw new Error(`Step '${id}' has already started.`);
+			}
+			const activeStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'started');
+			if (activeStep) {
+				throw new Error(`Step '${activeStep.id}' is still active. Mark it passed or failed before starting '${id}'.`);
+			}
+			step = { id, title, captures: [] };
+			run.steps.push(step);
+		} else if (!step && status === 'skipped') {
+			const activeStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'started');
+			if (activeStep) {
+				throw new Error(`Step '${activeStep.id}' is still active. Complete it before skipping '${id}'.`);
+			}
+			step = { id, title, captures: [] };
+			run.steps.push(step);
+		} else if (!step || step.captures.at(-1)?.status !== 'started') {
+			throw new Error(`Step '${id}' must be started before it can be marked '${status}'.`);
+		}
+
+		await this.showOverlay(id, title, status);
+		await wait(status === 'started' ? 500 : 250);
+		const sequence = String(run.steps.indexOf(step) + 1).padStart(2, '0');
+		const screenshotName = `${sequence}-${sanitizePathSegment(id)}-${status}.png`;
+		const screenshot = await this.capture(screenshotName);
+		step.captures.push({
+			status,
+			timestamp: new Date().toISOString(),
+			screenshot: screenshotName,
+			windowUrl: this.appService.application!.code.driver.currentPage.url(),
+			details
+		});
+		this.writeManifest();
+
+		return { screenshot, screenshotPath: path.join(run.runPath, screenshotName) };
+	}
+
+	async finish(outcome: RunOutcome, notes?: string): Promise<string> {
+		const run = this.requireRun();
+		const activeStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'started');
+		if (activeStep && outcome !== 'aborted') {
+			throw new Error(`Step '${activeStep.id}' is still active. Complete it before finishing the run.`);
+		}
+
+		try {
+			const app = this.appService.application;
+			if (app) {
+				await this.showOverlay('Result', run.title, outcome);
+				await wait(500);
+				await this.capture(`99-result-${outcome}.png`);
+			} else {
+				outcome = outcome === 'passed' ? 'failed' : outcome;
+				notes = [notes, 'VS Code closed before evidence capture was finalized.'].filter(Boolean).join('\n');
+			}
+
+			run.completedAt = new Date().toISOString();
+			run.outcome = outcome;
+			run.notes = notes;
+			this.writeManifest();
+
+			if (app) {
+				for (const page of app.code.driver.getAllWindows()) {
+					run.pageListener?.(page);
+				}
+				await app.stopTracing(undefined, true);
+				await this.appService.stopApplication();
+			}
+
+			await this.saveVideo();
+			this.copyLogArtifacts();
+			const reportPath = this.writeReport();
+			run.artifacts.report = path.relative(run.runPath, reportPath).replaceAll(path.sep, '/');
+			this.writeManifest();
+			return reportPath;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			run.completedAt ??= new Date().toISOString();
+			run.outcome = 'failed';
+			run.artifacts.finalizationError = message;
+			run.notes = [notes, `Evidence finalization failed: ${message}`].filter(Boolean).join('\n');
+			try {
+				this.writeManifest();
+			} catch {
+				// Preserve the original finalization error.
+			}
+			throw error;
+		} finally {
+			const app = this.appService.application;
+			if (app && run.pageListener) {
+				app.code.driver.browserContext.off('page', run.pageListener);
+			}
+			try {
+				await app?.stopTracing(undefined, true);
+				await this.appService.stopApplication();
+			} catch {
+				// Preserve the primary result or finalization error.
+			}
+			this.currentRun = undefined;
+		}
+	}
+
+	private requireRun(): EvidenceRun {
+		if (!this.currentRun) {
+			throw new Error('No evidence run is active. Start one with vscode_automation_evidence_start.');
+		}
+		return this.currentRun;
+	}
+
+	private async showOverlay(id: string, title: string, status: string): Promise<void> {
+		const app = this.appService.application;
+		if (!app) {
+			throw new Error('VS Code is not running.');
+		}
+		const values = JSON.stringify({ id, title, status });
+		await app.code.driver.evaluateExpression(`(() => {
+			const values = ${values};
+			let overlay = document.getElementById('vscode-ui-evidence-overlay');
+			if (!overlay) {
+				overlay = document.createElement('div');
+				overlay.id = 'vscode-ui-evidence-overlay';
+				overlay.style.cssText = 'position:fixed;top:12px;left:50%;transform:translateX(-50%);z-index:2147483647;max-width:70vw;padding:10px 16px;border-radius:6px;background:rgba(0,0,0,.88);color:#fff;font:600 14px/1.4 system-ui;box-shadow:0 4px 18px rgba(0,0,0,.35);pointer-events:none;text-align:center';
+				document.documentElement.appendChild(overlay);
+			}
+			overlay.textContent = values.id + ': ' + values.title + ' [' + values.status.toUpperCase() + ']';
+			overlay.dataset.status = values.status;
+			return overlay.textContent;
+		})()`);
+	}
+
+	private async capture(name: string): Promise<Buffer> {
+		const run = this.requireRun();
+		const app = this.appService.application;
+		if (!app) {
+			throw new Error('VS Code is not running.');
+		}
+		const screenshot = await app.code.driver.screenshotBuffer(false);
+		fs.writeFileSync(path.join(run.runPath, name), screenshot);
+		return screenshot;
+	}
+
+	private async saveVideo(): Promise<void> {
+		const run = this.requireRun();
+		if (!run.videos.size) {
+			return;
+		}
+		let index = 0;
+		for (const video of run.videos) {
+			const relativePath = `videos/recording-${++index}.webm`;
+			const destination = path.join(run.runPath, relativePath);
+			fs.mkdirSync(path.dirname(destination), { recursive: true });
+			await video.saveAs(destination);
+			run.artifacts.videos.push(relativePath);
+		}
+	}
+
+	private copyLogArtifacts(): void {
+		const run = this.requireRun();
+		for (const file of listFiles(logsRootPath)) {
+			const previousSize = run.logFilesBefore.get(file) ?? 0;
+			const contents = fs.readFileSync(file);
+			if (contents.length <= previousSize) {
+				continue;
+			}
+			const relativeSource = path.relative(logsRootPath, file);
+			const relativeDestination = path.join('logs', relativeSource);
+			const destination = path.join(run.runPath, relativeDestination);
+			fs.mkdirSync(path.dirname(destination), { recursive: true });
+			fs.writeFileSync(destination, contents.subarray(previousSize));
+			run.artifacts.logs.push(relativeDestination.replaceAll(path.sep, '/'));
+		}
+	}
+
+	private writeManifest(): void {
+		const run = this.requireRun();
+		const manifest = {
+			id: run.id,
+			scenarioId: run.scenarioId,
+			title: run.title,
+			source: run.source,
+			scenarioPath: run.scenarioPath,
+			workspacePath: run.workspacePath,
+			startedAt: run.startedAt,
+			completedAt: run.completedAt,
+			outcome: run.outcome,
+			notes: run.notes,
+			environment: run.environment,
+			artifacts: run.artifacts,
+			steps: run.steps
+		};
+		fs.writeFileSync(path.join(run.runPath, 'manifest.json'), JSON.stringify(manifest, undefined, 2));
+	}
+
+	private writeReport(): string {
+		const run = this.requireRun();
+		const rows = run.steps.map(step => {
+			const result = step.captures.at(-1);
+			const screenshots = step.captures.map(capture => `<a href="${escapeHtml(capture.screenshot)}">${escapeHtml(capture.status)}</a>`).join(', ');
+			return `<tr><td>${escapeHtml(step.id)}</td><td>${escapeHtml(step.title)}</td><td>${escapeHtml(result?.status ?? 'unknown')}</td><td>${screenshots}</td><td>${escapeHtml(result?.details ?? '')}</td></tr>`;
+		}).join('');
+		const videoElements = run.artifacts.videos.length
+			? run.artifacts.videos.map(video => `<video controls src="${escapeHtml(video)}"></video>`).join('')
+			: '<p>No video file was produced.</p>';
+		const logs = run.artifacts.logs.map(log => `<li><a href="${escapeHtml(log)}">${escapeHtml(log)}</a></li>`).join('');
+		const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>${escapeHtml(run.title)}</title>
+<style>body{font:14px system-ui;margin:32px;max-width:1200px}table{border-collapse:collapse;width:100%}th,td{border:1px solid #bbb;padding:8px;text-align:left}th{background:#eee}video{display:block;max-width:100%;margin:16px 0}.passed{color:#187b34}.failed{color:#b42318}</style></head>
+<body><h1>${escapeHtml(run.title)}</h1><p><strong>Scenario:</strong> ${escapeHtml(run.scenarioId)}<br><strong>Outcome:</strong> <span class="${escapeHtml(run.outcome ?? '')}">${escapeHtml(run.outcome ?? 'unknown')}</span><br><strong>Started:</strong> ${escapeHtml(run.startedAt)}<br><strong>Completed:</strong> ${escapeHtml(run.completedAt ?? '')}</p>
+<p><strong>Source:</strong> ${run.source ? `<a href="${escapeHtml(run.source)}">${escapeHtml(run.source)}</a>` : 'Not recorded'}<br><strong>Workspace:</strong> ${escapeHtml(run.workspacePath ?? 'Not specified')}<br><strong>Environment:</strong> ${escapeHtml(`${run.environment.platform} ${run.environment.architecture}; VS Code ${run.environment.vscodeVersion} (${run.environment.quality}); Node ${run.environment.nodeVersion}; commit ${run.environment.commit ?? 'unknown'}`)}</p>
+<p>${escapeHtml(run.notes ?? '')}</p><h2>Steps</h2><table><thead><tr><th>ID</th><th>Title</th><th>Result</th><th>Screenshots</th><th>Details</th></tr></thead><tbody>${rows}</tbody></table>
+<h2>Video</h2>${videoElements}<h2>Trace and logs</h2>${logs ? `<ul>${logs}</ul>` : '<p>No new trace or log content was produced.</p>'}</body></html>`;
+		const reportPath = path.join(run.runPath, 'report.html');
+		fs.writeFileSync(reportPath, html);
+		return reportPath;
+	}
+
+}
+
+export function applyEvidenceStartTool(server: McpServer, evidenceService: EvidenceService): RegisteredTool {
+	return server.tool(
+		'vscode_automation_evidence_start',
+		'Start VS Code with video and trace recording for a UI validation scenario',
+		{
+			scenarioId: z.string().describe('Stable scenario identifier'),
+			title: z.string().describe('Human-readable scenario title'),
+			source: z.string().url().optional().describe('Source test-plan issue URL'),
+			scenarioPath: z.string().optional().describe('Path to the Markdown scenario definition'),
+			workspacePath: z.string().optional().describe('Workspace or folder to open'),
+			userSettings: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])).optional().describe('User settings to seed before VS Code starts'),
+			extraArgs: z.array(z.string()).optional().describe('Additional VS Code command-line arguments')
+		},
+		async ({ scenarioId, title, source, scenarioPath, workspacePath, userSettings, extraArgs }) => {
+			const runPath = await evidenceService.start(scenarioId, title, source, scenarioPath, workspacePath, userSettings, extraArgs);
+			return {
+				content: [{ type: 'text' as const, text: `Evidence capture started: ${runPath}` }]
+			};
+		}
+	);
+}
+
+export function applyEvidenceTools(server: McpServer, evidenceService: EvidenceService): RegisteredTool[] {
+	return [
+		server.tool(
+			'vscode_automation_evidence_step',
+			'Mark a scenario step in the video and save a screenshot of the current VS Code window',
+			{
+				id: z.string().describe('Stable step identifier from the scenario'),
+				title: z.string().describe('Human-readable step title'),
+				status: z.enum(['started', 'passed', 'failed', 'skipped']).describe('Step lifecycle status'),
+				details: z.string().optional().describe('Validation result or failure details')
+			},
+			async ({ id, title, status, details }) => {
+				const result = await evidenceService.step(id, title, status, details);
+				return {
+					content: [
+						{ type: 'text' as const, text: `Evidence saved: ${result.screenshotPath}` },
+						{ type: 'image' as const, data: result.screenshot.toString('base64'), mimeType: 'image/png' }
+					]
+				};
+			}
+		),
+		server.tool(
+			'vscode_automation_evidence_finish',
+			'Finish a UI validation scenario, stop VS Code, and write the evidence report',
+			{
+				outcome: z.enum(['passed', 'failed', 'aborted']).describe('Overall scenario outcome'),
+				notes: z.string().optional().describe('Run summary or blocking condition')
+			},
+			async ({ outcome, notes }) => {
+				const reportPath = await evidenceService.finish(outcome, notes);
+				return {
+					content: [{ type: 'text' as const, text: `Evidence report written: ${reportPath}` }]
+				};
+			}
+		)
+	];
+}
+
+function sanitizePathSegment(value: string): string {
+	const sanitized = value.trim().replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+	return sanitized || 'unnamed';
+}
+
+function listFiles(directory: string): string[] {
+	if (!fs.existsSync(directory)) {
+		return [];
+	}
+	return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+		const entryPath = path.join(directory, entry.name);
+		return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+	});
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll('\'', '&#39;');
+}
+
+function wait(milliseconds: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/test/mcp/src/evidence.ts
+++ b/test/mcp/src/evidence.ts
@@ -8,7 +8,7 @@ import type { Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { z } from 'zod';
-import { ApplicationService, getProductVersion } from './application';
+import { ApplicationService, getProductVersion, JSONValue } from './application';
 
 const rootPath = path.join(__dirname, '..', '..', '..');
 const artifactRootPath = path.join(rootPath, '.build', 'vscode-playwright-mcp');
@@ -18,6 +18,14 @@ const qualityNames = ['Dev', 'Insiders', 'Stable', 'Exploration', 'OSS'];
 
 type StepStatus = 'started' | 'passed' | 'failed' | 'skipped';
 type RunOutcome = 'passed' | 'failed' | 'aborted';
+const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() => z.union([
+	z.string(),
+	z.number(),
+	z.boolean(),
+	z.null(),
+	z.array(jsonValueSchema),
+	z.record(z.string(), jsonValueSchema)
+]));
 
 interface EvidenceCapture {
 	status: StepStatus;
@@ -70,7 +78,7 @@ export class EvidenceService {
 
 	constructor(private readonly appService: ApplicationService) { }
 
-	async start(scenarioId: string, title: string, source?: string, scenarioPath?: string, workspacePath?: string, userSettings?: Record<string, string | number | boolean | null>, extraArgs?: string[]): Promise<string> {
+	async start(scenarioId: string, title: string, source?: string, scenarioPath?: string, workspacePath?: string, userSettings?: Record<string, JSONValue>, extraArgs?: string[]): Promise<string> {
 		if (this.currentRun) {
 			throw new Error(`Evidence run '${this.currentRun.id}' is already active.`);
 		}
@@ -108,24 +116,43 @@ export class EvidenceService {
 			steps: []
 		};
 		const run = this.currentRun;
-		run.pageListener = page => {
-			const video = page.video();
-			if (video) {
-				run.videos.add(video);
+		try {
+			run.pageListener = page => {
+				const video = page.video();
+				if (video) {
+					run.videos.add(video);
+				}
+			};
+			for (const page of app.code.driver.getAllWindows()) {
+				run.pageListener(page);
 			}
-		};
-		for (const page of app.code.driver.getAllWindows()) {
-			run.pageListener(page);
+			app.code.driver.browserContext.on('page', run.pageListener);
+
+			await app.startTracing();
+			await this.showOverlay('Scenario', title, 'started');
+			await wait(500);
+			await this.capture('00-scenario-started.png');
+			this.writeManifest();
+
+			return runPath;
+		} catch (error) {
+			try {
+				if (run.pageListener) {
+					app.code?.driver.browserContext.off('page', run.pageListener);
+				}
+			} catch {
+				// Preserve the startup error.
+			}
+			try {
+				await app.stopTracing(undefined, true);
+				await this.appService.stopApplication();
+			} catch {
+				// Preserve the startup error.
+			} finally {
+				this.currentRun = undefined;
+			}
+			throw error;
 		}
-		app.code.driver.browserContext.on('page', run.pageListener);
-
-		await app.startTracing();
-		await this.showOverlay('Scenario', title, 'started');
-		await wait(500);
-		await this.capture('00-scenario-started.png');
-		this.writeManifest();
-
-		return runPath;
 	}
 
 	async step(id: string, title: string, status: StepStatus, details?: string): Promise<{ screenshot: Buffer; screenshotPath: string }> {
@@ -181,16 +208,35 @@ export class EvidenceService {
 		if (activeStep && outcome !== 'aborted') {
 			throw new Error(`Step '${activeStep.id}' is still active. Complete it before finishing the run.`);
 		}
+		const failedStep = run.steps.find(candidate => candidate.captures.at(-1)?.status === 'failed');
+		if (failedStep && outcome === 'passed') {
+			outcome = 'failed';
+			notes = [notes, `Run marked failed because step '${failedStep.id}' failed.`].filter(Boolean).join('\n');
+		}
 
 		try {
-			const app = this.appService.application;
-			if (app) {
-				await this.showOverlay('Result', run.title, outcome);
-				await wait(500);
-				await this.capture(`99-result-${outcome}.png`);
-			} else {
+			let app = await this.appService.getApplicationIfRunning();
+			const recordApplicationClosure = () => {
 				outcome = outcome === 'passed' ? 'failed' : outcome;
-				notes = [notes, 'VS Code closed before evidence capture was finalized.'].filter(Boolean).join('\n');
+				const closureNote = 'VS Code closed before evidence capture was finalized.';
+				if (!notes?.includes(closureNote)) {
+					notes = [notes, closureNote].filter(Boolean).join('\n');
+				}
+			};
+			if (app) {
+				try {
+					await this.showOverlay('Result', run.title, outcome);
+					await wait(500);
+					await this.capture(`99-result-${outcome}.png`);
+				} catch (error) {
+					if (await this.appService.getApplicationIfRunning()) {
+						throw error;
+					}
+					app = undefined;
+					recordApplicationClosure();
+				}
+			} else {
+				recordApplicationClosure();
 			}
 
 			run.completedAt = new Date().toISOString();
@@ -199,11 +245,22 @@ export class EvidenceService {
 			this.writeManifest();
 
 			if (app) {
-				for (const page of app.code.driver.getAllWindows()) {
-					run.pageListener?.(page);
+				try {
+					for (const page of app.code.driver.getAllWindows()) {
+						run.pageListener?.(page);
+					}
+					await app.stopTracing(undefined, true);
+					await this.appService.stopApplication();
+				} catch (error) {
+					if (await this.appService.getApplicationIfRunning()) {
+						throw error;
+					}
+					app = undefined;
+					recordApplicationClosure();
+					run.outcome = outcome;
+					run.notes = notes;
+					this.writeManifest();
 				}
-				await app.stopTracing(undefined, true);
-				await this.appService.stopApplication();
 			}
 
 			await this.saveVideo();
@@ -365,7 +422,7 @@ export function applyEvidenceStartTool(server: McpServer, evidenceService: Evide
 			source: z.string().url().optional().describe('Source test-plan issue URL'),
 			scenarioPath: z.string().optional().describe('Path to the Markdown scenario definition'),
 			workspacePath: z.string().optional().describe('Workspace or folder to open'),
-			userSettings: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])).optional().describe('User settings to seed before VS Code starts'),
+			userSettings: z.record(z.string(), jsonValueSchema).optional().describe('User settings to seed before VS Code starts'),
 			extraArgs: z.array(z.string()).optional().describe('Additional VS Code command-line arguments')
 		},
 		async ({ scenarioId, title, source, scenarioPath, workspacePath, userSettings, extraArgs }) => {

--- a/test/mcp/src/evidence.ts
+++ b/test/mcp/src/evidence.ts
@@ -175,7 +175,7 @@ export class EvidenceService {
 			}
 			try {
 				await app.stopTracing(undefined, true);
-				await this.appService.stopApplication();
+				await this.appService.stopApplication(app);
 			} catch {
 				// Preserve the startup error.
 			} finally {
@@ -333,7 +333,7 @@ export class EvidenceService {
 						run.pageListener?.(page);
 					}
 					await app.stopTracing(undefined, true);
-					await this.appService.stopApplication();
+					await this.appService.stopApplication(app);
 				} catch (error) {
 					if (await this.appService.getApplicationIfRunning()) {
 						throw error;
@@ -370,8 +370,10 @@ export class EvidenceService {
 				app.code.driver.browserContext.off('page', run.pageListener);
 			}
 			try {
-				await app?.stopTracing(undefined, true);
-				await this.appService.stopApplication();
+				if (app) {
+					await app.stopTracing(undefined, true);
+					await this.appService.stopApplication(app);
+				}
 			} catch {
 				// Preserve the primary result or finalization error.
 			}


### PR DESCRIPTION
## Summary

- add evidence sessions to the VS Code automation MCP with step overlays, screenshots, videos, traces, logs, manifests, and an HTML report
- launch each run with an isolated profile and optional pre-launch settings or desktop arguments
- expose focused keyboard and CDP-target inspection tools for Integrated Browser pages and embedded custom editor surfaces
- keep evidence finalization available after application closure and handle transient-page videos and CDP target detachment

## Validation

- TypeScript compilation for `test/automation`
- TypeScript compilation for `test/mcp`
- pre-commit hygiene checks
- Browser Commenting scenario: 5/5 steps passed, with workbench and browser videos plus Playwright trace
- Agents Markdown Git markers scenario: 5/5 steps passed, including added, modified, deleted, reopen, and revert checks
- evidence bundle integrity checks for reports, manifests, screenshots, videos, traces, and logs

## Notes

The scenario definitions and generated evidence are POC artifacts and are not included in this change.

> Authored with Copilot
