### PR TITLE
fix: guard against disposed InstantiationService in Settings editor search (fixes #330277)

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1588,6 +1588,13 @@ export class SettingsEditor2 extends EditorPane {
 
 		resolvedSettingsRoot.children!.push(await createTocTreeForExtensionSettings(this.extensionService, extensionSettingsGroups, filter));
 
+		// The editor may have been disposed while awaiting the async work above
+		// (e.g. extension manifest fetches). Bail out before touching services
+		// like the InstantiationService, which throws once disposed.
+		if (this._store.isDisposed) {
+			return;
+		}
+
 		resolvedSettingsRoot.children!.unshift(getCommonlyUsedData(groups));
 
 		if (toggleData && setAdditionalGroups) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1904,6 +1904,11 @@ export class SettingsEditor2 extends EditorPane {
 			await this.onConfigUpdate();
 		}
 
+		// Bail out if disposed while awaiting above; disposed services throw.
+		if (this._store.isDisposed) {
+			return;
+		}
+
 		this.settingsTargetsWidget.updateLanguageFilterIndicators(this.viewState.languageFilter);
 
 		if (query && query !== '@') {
@@ -2122,8 +2127,9 @@ export class SettingsEditor2 extends EditorPane {
 		const result = await this._searchPreferencesModel(this.defaultSettingsEditorModel, searchProvider, token);
 		stopWatch.stop();
 
-		if (token.isCancellationRequested) {
-			// Handle cancellation like this because cancellation is lost inside the search provider due to async/await
+		if (token.isCancellationRequested || this._store.isDisposed) {
+			// Handle cancellation like this because cancellation is lost inside the search provider due to async/await.
+			// Also bail out if disposed while awaiting; disposed services throw.
 			return null;
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1588,9 +1588,7 @@ export class SettingsEditor2 extends EditorPane {
 
 		resolvedSettingsRoot.children!.push(await createTocTreeForExtensionSettings(this.extensionService, extensionSettingsGroups, filter));
 
-		// The editor may have been disposed while awaiting the async work above
-		// (e.g. extension manifest fetches). Bail out before touching services
-		// like the InstantiationService, which throws once disposed.
+		// Bail out if disposed while awaiting above; disposed services throw.
 		if (this._store.isDisposed) {
 			return;
 		}


### PR DESCRIPTION
### Summary

`SettingsEditor2.onConfigUpdate` is an `async` method that awaits several long-running operations (experimental toggle data, installed-extension refresh, per-extension gallery manifest fetches, and `createTocTreeForExtensionSettings`). If the Settings editor is closed/disposed while one of those awaits is in flight, execution resumes and later calls `this.instantiationService.createInstance(SettingsTreeModel, ...)` on an already-disposed `InstantiationService`, which throws `InstantiationService has been disposed`. The throw escapes as an unhandled error (the search path `onSearchInputChanged → triggerSearch → onConfigUpdate`), producing the telemetry spike.

Fixes microsoft/vscode#330277
Recommended reviewer: `@rzhao271`

### Culprit Commit

| Field | Value |
|-------|-------|
| Commit | not identified — pre-existing |
| Author | n/a |
| PR | n/a |
| Message | n/a |
| Why | The async `onConfigUpdate` pattern with post-`await` service access is long-standing; no single commit in the regression window changed the triggering logic. The 1.132.0 spike (15.25x) most plausibly reflects increased traversal of the async extension-toggle path rather than a new defect at the crash site. Reported as pre-existing per the re-bucketing / pre-existing guidance. |

### Code Flow

```mermaid
sequenceDiagram
    participant User as User / config change
    participant Search as onSearchInputChanged / triggerSearch
    participant Cfg as onConfigUpdate (async)
    participant IS as InstantiationService
    participant Crash as createInstance

    User->>Search: change search / config
    Search->>Cfg: await onConfigUpdate()
    Note over Cfg: ⚠️ awaits gallery manifest fetches<br/>editor disposed meanwhile
    Cfg->>IS: createInstance(SettingsTreeModel, ...)
    Note over IS: store already disposed
    IS->>Crash: 💥 _throwIfDisposed()<br/>"InstantiationService has been disposed"
```

### Affected Files

| File | Role | Evidence |
|------|------|----------|
| `src/vs/platform/instantiation/common/instantiationService.ts` | crash site | L69 `_throwIfDisposed`, L119 `createInstance` (from stack) |
| `src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts` | root cause (async re-entry after dispose) | L1457-L1670: `onConfigUpdate` awaits `getExperimentalExtensionToggleData`, `refreshInstalledExtensionsList`, `getManifest`, `createTocTreeForExtensionSettings`, then `this.instantiationService.createInstance(SettingsTreeModel, ...)` at L1670 |

### Repro Steps

1. Open the Settings editor with a query that engages the extension-toggle path (extensions with recommended settings, so gallery manifest fetches are triggered).
2. Type in the search box to start `triggerSearch → onConfigUpdate`, which begins awaiting manifest fetches (subject to `EXTENSION_FETCH_TIMEOUT_MS`).
3. Immediately close the Settings editor (or switch it out) before the awaits resolve.
4. When the pending awaits resolve, `onConfigUpdate` resumes and calls `createInstance` on the now-disposed `InstantiationService`, throwing. Because timing-dependent, slow networks / many recommended-setting extensions increase the likelihood.

### How the Fix Works

**Chosen approach** (`src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts` → `onConfigUpdate`): add a disposed-guard immediately after the final `await` point (`createTocTreeForExtensionSettings`, L1589) and before any synchronous service access. If `this._store.isDisposed` is true, the method returns early, so the disposed `InstantiationService` is never touched. This is a use-after-dispose async race, and the correct place for the guard is at the async re-entry boundary in the owning object (the consumer that resumed after dispose) — not inside `InstantiationService` (fix at the re-entry site, not the shared crash site, and never by widening/silencing the base service). The existing `logService.error` telemetry pipeline is untouched, and no `try/catch` is used to swallow the error.

**Alternatives considered**: wrapping the `createInstance` call in `try/catch` — rejected because it would silence a real lifecycle bug at the crash site and hide the same use-after-dispose from every other consumer, instead of stopping the disposed object from being used.

### Recommended Owner

`@rzhao271` — settings editor area owner and recent top contributor to `settingsEditor2.ts` (write access, active within the last 90 days). Culprit author cascade did not apply (pre-existing); selected via file/area ownership.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31507563723) · opus48 · 553.1 AIC · ⌖ 11.2 AIC · ⊞ 18.6K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+errors-fix%22&type=pullrequests)




### errors-fix-driver — cycle 2

**Trigger**: cron_review_comments · **Head**: `640a7818a0f` (`640a781`)

| Item | Action |
|------|--------|
| Copilot review: incomplete guard — `triggerSearch` resumes past `onConfigUpdate` guard and reaches `createFilterModel` (L1959) / `searchWithProvider` (L2141) `createInstance` (in scope) | Fixed in `640a781` |

**Push**: yes — `640a781` · **Copilot rerequested**: ok

**Ready gate**: ci pending (VS Code PR Check + Community PR Approvals in progress) + Copilot not yet re-reviewed at new head → not marking ready this cycle> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/31540415015) · opus48 · 229.1 AIC · ⌖ 11.7 AIC · ⊞ 21K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, model: claude-opus-4.8, id: 31540415015, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/31540415015 -->