### PR TITLE
fix: treat persistent 404 from external ingest search as empty result (fixes #330268)

### DIFF
--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
@@ -486,7 +486,16 @@ export class ExternalIngestIndex extends Disposable {
 							// On the first index or a large workspace, there might be a slight delay on the service
 							// before the index is actually ready. Workaround by retrying just once after a short delay.
 							await raceCancellationError(timeout(2000), token);
-							return await this._client.searchFilesets(filesetName, resolvedQuery, sizing.maxResultCountHint, callTracker, token);
+							try {
+								return await this._client.searchFilesets(filesetName, resolvedQuery, sizing.maxResultCountHint, callTracker, token);
+							} catch (retryErr) {
+								if (retryErr instanceof ExternalIngestRequestError && retryErr.response.status === 404) {
+									// The index is still not ready. This is an expected, benign state (not an
+									// error condition), so treat it as an empty result rather than throwing.
+									return undefined;
+								}
+								throw retryErr;
+							}
 						}
 						throw err;
 					}

--- a/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
@@ -24,7 +24,9 @@ import { GithubRequestOptions, IGithubApiFetcherService } from '../../../github/
 import { ISearchService } from '../../../search/common/searchService';
 import { createPlatformServices, TestingServiceCollection } from '../../../test/node/services';
 import { IWorkspaceService, NullWorkspaceService } from '../../../workspace/common/workspaceService';
-import { ExternalIngestClient, ExternalIngestFile, ExternalIngestFileSet, ExternalIngestUpdateIndexResult, IExternalIngestClient } from '../../node/codeSearch/externalIngestClient';
+import { FileChunkAndScore } from '../../../chunking/common/chunk';
+import { StrategySearchSizing, WorkspaceChunkQueryWithEmbeddings } from '../../common/workspaceChunkSearch';
+import { ExternalIngestClient, ExternalIngestFile, ExternalIngestFileSet, ExternalIngestRequestError, ExternalIngestUpdateIndexResult, IExternalIngestClient } from '../../node/codeSearch/externalIngestClient';
 import { ExternalIngestIndex } from '../../node/codeSearch/externalIngestIndex';
 
 const emptyProgressCb: (message: string) => void = () => { };
@@ -33,6 +35,7 @@ const testTelemetryInfo = new TelemetryCorrelationId('externalIngest.spec.ts');
 function createMockExternalIngestClient(options?: {
 	canIngestPathAndSize?: (filePath: string, size: number) => boolean;
 	canIngestDocument?: (filePath: string, data: Uint8Array) => boolean;
+	searchFilesets?: (filesetName: string, prompt: string, limit: number) => Promise<Awaited<ReturnType<IExternalIngestClient['searchFilesets']>>>;
 }): IExternalIngestClient & {
 	get ingestedFiles(): readonly ExternalIngestFile[];
 	get searchCalls(): Array<{ filesetName: string; prompt: string }>;
@@ -57,8 +60,11 @@ function createMockExternalIngestClient(options?: {
 		async deleteFileset(_filesetName: string, _callTracker: CallTracker, _token: CancellationToken): Promise<void> {
 			// no-op
 		},
-		async searchFilesets(filesetName: string, prompt: string, _limit: number, _callTracker: CallTracker, _token: CancellationToken): Promise<undefined> {
+		async searchFilesets(filesetName: string, prompt: string, limit: number, _callTracker: CallTracker, _token: CancellationToken): Promise<Awaited<ReturnType<IExternalIngestClient['searchFilesets']>>> {
 			searchCalls.push({ filesetName, prompt });
+			if (options?.searchFilesets) {
+				return options.searchFilesets(filesetName, prompt, limit);
+			}
 			return undefined;
 		},
 		canIngestPathAndSize(filePath: string, size: number): boolean {
@@ -525,6 +531,73 @@ suite('ExternalIngestIndex', () => {
 		assert.strictEqual(mockFs.countReadFileCalls(file2), 2, 'Changed file should be re-read');
 		assert.strictEqual(mockFs.countReadFileCalls(file1), 1, 'Unchanged file1 should not be re-read');
 		assert.strictEqual(mockFs.countReadFileCalls(file3), 1, 'Unchanged file3 should not be re-read');
+	});
+});
+
+suite('ExternalIngestIndex search retry on 404', () => {
+	const disposables = new DisposableStore();
+	let testingServiceCollection: TestingServiceCollection;
+
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+		testingServiceCollection = disposables.add(createPlatformServices());
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		disposables.clear();
+	});
+
+	const sizing = { maxResultCountHint: 10 } as StrategySearchSizing;
+	const query = { queryText: 'find the thing' } as WorkspaceChunkQueryWithEmbeddings;
+
+	function notReadyError(): ExternalIngestRequestError {
+		return new ExternalIngestRequestError('POST external-embeddings-code-search failed with status 404', new Response(null, { status: 404 }));
+	}
+
+	function createIndex(searchFilesets: (filesetName: string, prompt: string, limit: number) => Promise<Awaited<ReturnType<IExternalIngestClient['searchFilesets']>>>): ExternalIngestIndex {
+		const mockClient = createMockExternalIngestClient({ searchFilesets });
+		testingServiceCollection.set(IWorkspaceService, new MockWorkspaceService([URI.file('/workspace')]));
+		testingServiceCollection.set(IFileSystemService, new MockFileSystem(new ResourceMap<MockFileEntry>()));
+		testingServiceCollection.set(ISearchService, new MockFileSystem(new ResourceMap<MockFileEntry>()));
+		const accessor = disposables.add(testingServiceCollection.createTestingAccessor());
+		const instantiationService = accessor.get(IInstantiationService);
+		return disposables.add(instantiationService.createInstance(ExternalIngestIndex, mockClient, []));
+	}
+
+	async function runSearch(index: ExternalIngestIndex): Promise<readonly FileChunkAndScore[] | undefined> {
+		// Attach a no-op catch before flushing timers so a rejection during the retry
+		// backoff is never surfaced as an unhandled rejection; callers await `promise`.
+		const promise = index.search(sizing, query, testTelemetryInfo, CancellationToken.None);
+		const settled = promise.catch(() => { });
+		// Flush the 2s retry backoff timer so the retried request runs without real waiting.
+		await vi.runAllTimersAsync();
+		await settled;
+		return promise;
+	}
+
+	test('returns empty result when both search attempts fail with 404', async () => {
+		let calls = 0;
+		const index = createIndex(async () => {
+			calls++;
+			throw notReadyError();
+		});
+
+		const result = await runSearch(index);
+
+		assert.deepStrictEqual({ result, calls }, { result: [], calls: 2 });
+	});
+
+	test('rethrows when the retried search fails with a non-404 error', async () => {
+		let calls = 0;
+		const serverError = new ExternalIngestRequestError('POST external-embeddings-code-search failed with status 500', new Response(null, { status: 500 }));
+		const index = createIndex(async () => {
+			calls++;
+			throw calls === 1 ? notReadyError() : serverError;
+		});
+
+		await assert.rejects(runSearch(index), (err: unknown) => err === serverError);
+		assert.strictEqual(calls, 2, 'Search should be attempted exactly twice');
 	});
 });
 


### PR DESCRIPTION
### Summary

Workspace chunk search's external ingest index throws an unhandled `ExternalIngestRequestError: POST external-embeddings-code-search failed with status 404` when the remote embeddings index is not yet ready. The code already recognizes a 404 as the benign "index not ready yet" state and retries once after a 2s delay, but if the second attempt also returns 404 the error is re-thrown and surfaces as unhandled-error telemetry. Impact: noisy error telemetry (and a failed local-diff search leg) for a normal, transient service state during first index / large workspace.

Fixes microsoft/vscode#330268
Recommended reviewer: `@mjbvz`

### Culprit Commit

| Field | Value |
|-------|-------|
| Commit | [`5e1ee93d`](https://github.com/microsoft/vscode/commit/5e1ee93dbf7053239e451888b7a21bffd734c8d9) |
| Author | `@mjbvz` |
| PR | #4493 (copilot-chat) |
| Message | Add slight retry on first external ingest search failure |
| Why | This commit introduced the single-retry workaround at `externalIngestIndex.ts:485-489`. It classifies a 404 as the expected "index not ready" state and retries once, but the retried call's own 404 is not caught, so a persistent not-ready state re-throws instead of degrading to an empty result. |

### Code Flow

```mermaid
sequenceDiagram
    participant Search as CodeSearchChunkSearch.searchLocalDiff
    participant Index as ExternalIngestIndex.search
    participant Client as ExternalIngestClient.searchFilesets
    participant API as githubApiFetcher

    Search->>Index: search(sizing, query)
    Index->>Client: searchFilesets() [attempt 1]
    Client->>API: POST /external/embeddings/code/search
    API-->>Client: 404 (index not ready)
    Note over Index: catch 404 -> wait 2s, retry once
    Index->>Client: searchFilesets() [attempt 2]
    Client->>API: POST /external/embeddings/code/search
    API-->>Client: 404 (still not ready)
    Note over Client: 💥 throw ExternalIngestRequestError:<br/>"POST external-embeddings-code-search failed with status 404"
    Client-->>Index: rethrow (not caught on retry)
    Note over Index: reported via externalIngestIndex.search.error -> unhandled telemetry
```

### Affected Files

| File | Role | Evidence |
|------|------|----------|
| `extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts` | crash site | L173: `throw new ExternalIngestRequestError(...failed with status ${response.status})` |
| `extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts` | root cause | L485-L490: `if (err instanceof ExternalIngestRequestError && err.response.status === 404) { ... return await this._client.searchFilesets(...) }` — retry re-throws on a persistent 404 |

### Repro Steps

1. Open a large workspace (or one being indexed for the first time) with Copilot workspace chunk search / external ingest enabled.
2. Trigger a semantic workspace search (e.g. `#codebase`) while the remote embeddings index is still being built server-side.
3. The first `searchFilesets` call returns 404 (index not ready); after a 2s delay a second call also returns 404 because indexing hasn't finished.
4. The retried 404 re-throws and is recorded as an unhandled error (`externalIngestIndex.search.error`).

### How the Fix Works

**Chosen approach** — `externalIngestIndex.ts` → `ExternalIngestIndex.search()`: wrap the single retry `searchFilesets` call in its own `try/catch`. When the retried call also fails with a 404, return `undefined` — the same value the method already produces for an empty/not-ready result, which the existing `if (!searchResult || !searchResult.results) { return []; }` guard at L505 turns into an empty result. Any non-404 error on the retry is still re-thrown unchanged, so genuine failures continue to surface via `externalIngestIndex.search.error` / the telemetry pipeline. This fixes the condition at its source: the code that already knows a 404 means "index not ready" now treats a *persistent* not-ready state as the benign empty result it is, rather than an error. No `logService.error` call is removed and no genuine error is swallowed — only the already-classified benign 404 is degraded to an empty result.

**Alternatives considered**: adding a broad `try/catch` at the outer `searchLocalDiff`/`searchWorkspace` call site — rejected because it would swallow unrelated errors and sits far from where 404 is already understood as benign, hiding real failures instead of handling the specific known-benign state at its origin.

### Recommended Owner

`@mjbvz` — authored the culprit commit (`5e1ee93d`) and is the telemetry owner for `externalIngestIndex.*` events. Active in `microsoft/vscode` within the last 90 days.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31504822618) · opus48 · 415.2 AIC · ⌖ 11.3 AIC · ⊞ 18.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-id%3A+errors-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix, engine: copilot, model: claude-opus-4.8, id: 31504822618, workflow_id: errors-fix, run: https://github.com/microsoft/vscode-engineering/actions/runs/31504822618 -->

<!-- gh-aw-workflow-id: errors-fix -->
<!-- gh-aw-workflow-call-id: microsoft/vscode-engineering/errors-fix -->

---

### errors-fix-driver — cycle 1

**Trigger**: cron_review_comments · **Head**: `575e16cf48e778d13a82c3fffe17e23f7b16bf73` (`575e16c`)

| Item | Action |
|------|--------|
| Review on `externalIngestIndex.ts:495` — add persistent-404 tests (in scope) | Fixed in `575e16c` (replied + resolved) |

**Push**: yes — `575e16c` · **Copilot rerequested**: ok

**Ready gate**: ci pending after fresh push → not marking ready this cycle> [!WARNING]
> <details>
> <summary>Firewall blocked 3 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `cdn.playwright.dev`
> - `nodejs.org`
> - `releaseassets.githubusercontent.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "cdn.playwright.dev"
>     - "nodejs.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/31540411240) · opus48 · 508 AIC · ⌖ 11.9 AIC · ⊞ 21K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, model: claude-opus-4.8, id: 31540411240, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/31540411240 -->