### PR TITLE
fix: enrich truncated IPC object deserialize error (fixes #330263)

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -319,7 +319,18 @@ export function deserialize(reader: IReader): any {
 
 			return result;
 		}
-		case DataType.Object: return JSON.parse(reader.read(readIntVQL(reader)).toString());
+		case DataType.Object: {
+			const length = readIntVQL(reader);
+			const buffer = reader.read(length);
+			if (buffer.byteLength < length) {
+				// The underlying message was truncated (e.g. a partial frame crossing a
+				// process boundary such as a MessagePort). Surface a diagnosable error with
+				// framing context instead of an opaque `JSON.parse` "Unexpected end of JSON
+				// input" that hides where the corruption happened.
+				throw new Error(`Truncated IPC object payload: expected ${length} bytes, received ${buffer.byteLength}`);
+			}
+			return JSON.parse(buffer.toString());
+		}
 		case DataType.Int: return readIntVQL(reader);
 	}
 }

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -323,10 +323,7 @@ export function deserialize(reader: IReader): any {
 			const length = readIntVQL(reader);
 			const buffer = reader.read(length);
 			if (buffer.byteLength < length) {
-				// The underlying message was truncated (e.g. a partial frame crossing a
-				// process boundary such as a MessagePort). Surface a diagnosable error with
-				// framing context instead of an opaque `JSON.parse` "Unexpected end of JSON
-				// input" that hides where the corruption happened.
+				// Surface a diagnosable framing error for truncated payloads instead of an opaque `JSON.parse` failure.
 				throw new Error(`Truncated IPC object payload: expected ${length} bytes, received ${buffer.byteLength}`);
 			}
 			return JSON.parse(buffer.toString());

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -384,6 +384,17 @@ suite('Base IPC', function () {
 			assert.deepStrictEqual(deserialize(new BufferReader(writer.buffer)), input);
 		});
 
+		test('deserialize reports framing context for a truncated object payload', () => {
+			const writer = new BufferWriter();
+			serialize(writer, { hello: 'world', value: 42 });
+
+			const truncated = writer.buffer.slice(0, writer.buffer.byteLength - 4);
+			assert.throws(
+				() => deserialize(new BufferReader(truncated)),
+				/Truncated IPC object payload: expected \d+ bytes, received \d+/
+			);
+		});
+
 		test('BufferWriter releases its buffers on dispose', () => {
 			const writer = new BufferWriter();
 			serialize(writer, ['a', 'b', 'c']);


### PR DESCRIPTION
### Summary

Telemetry bucket `112c22ba-c8f9-9d2c-1f93-9f46466fb2ac` reports `SyntaxError: Unexpected end of JSON input` thrown from `JSON.parse` inside `deserialize()` in `src/vs/base/parts/ipc/common/ipc.ts`, running in the agent host utility process (`agentHostMain.js`) while decoding an inbound IPC message delivered over a MessagePort. The message payload arrives truncated: the binary framing declares an object of N bytes, but fewer than N bytes are present, so `JSON.parse` on a partial/empty string fails with a context-free error that gives triage no way to see where the corruption happened. New in `1.133.0-insider` (`5a36a9c6`); not present in the `1.132.0` baseline (`df53daab`), matching the introduction of the Agent Host Protocol-over-IPC (MessagePort) plumbing.

Fixes microsoft/vscode#330263
Recommended reviewer: `@connor4312`

### Culprit Commit

Ancestry could not be git-verified in this environment (blobless checkout, credentials stripped after checkout, so `git show ` / `merge-base --is-ancestor` fail on on-demand object fetch). Within the `1.132.0` to `1.133.0-insider` regression window, the agent-host MessagePort transport that routes these IPC messages was introduced/reworked by:

- `63a042819ddd4deaffd45ac84dc176d1f00bb49a` — "agentHost: use AHP for local connections" (routes local renderer traffic through the Agent Host Protocol over MessagePort) — Connor Peet (`@connor4312`).

This is the most likely producer of the new truncated-frame path; the crash surfaces in the shared `deserialize()` utility rather than in the transport commit itself.

### Code Flow

```mermaid
flowchart TD
    A[MessagePortMain message event - native Electron layer] -->|e.data possibly truncated| B[Protocol.onMessage ipc.mp.ts:21-26 VSBuffer.wrap or alloc 0]
    B --> C[ChannelServer.onRawMessage / onBuffer ipc.ts]
    C --> D[deserialize reader ipc.ts:304]
    D -->|DataType.Object| E[readIntVQL yields length N]
    E --> F[reader.read N - BufferReader.slice returns fewer than N bytes, NO error on underflow]
    F --> G[JSON.parse of partial string ipc.ts:322]
    G -->|SyntaxError: Unexpected end of JSON input| H[telemetry bucket 112c22ba]
```

### Affected Files

- `src/vs/base/parts/ipc/common/ipc.ts` — `deserialize()` `DataType.Object` case (crash site and where the truncation first becomes observable). `BufferReader.read()` (lines 217-221) slices without erroring on underflow, so a short buffer silently yields a partial string.

### Repro Steps

Deterministic user repro is not available (the truncation originates in the native MessagePort/utility-process boundary during agent host connect/disconnect, not in reproducible TS logic). Observed across Windows/Mac/Linux, 44 users, on `1.133.0-insider`. Conceptually: deliver a MessagePort frame to the agent host whose binary object header declares more bytes than the payload actually contains (e.g. a partial/racing frame during agent host teardown) and `deserialize` will attempt `JSON.parse` on a truncated string.

### How the Fix Works

**Chosen approach** — `src/vs/base/parts/ipc/common/ipc.ts`, `deserialize()` `DataType.Object` case (the bypass site is `ipc.ts:322`, where `reader.read(N)` can return fewer than N bytes without error because `BufferReader.read` slices without bounds-checking). Before calling `JSON.parse`, read the declared length N and the actual buffer, and if the buffer is shorter than declared, throw an enriched error naming the expected vs. received byte counts. This follows the cross-process-error principle: enrich the error with diagnostic context, do not swallow it. The error is still thrown and still reaches the telemetry pipeline, but the new bucket will carry actionable framing information (`expected N, received M`) instead of an opaque `Unexpected end of JSON input`, letting the transport owner see truncation is occurring and where. This does not add a `try/catch`, does not remove any `logService.error`, and does not coerce the bad value to a benign default — the corrupt frame is still rejected loudly.

**Alternatives considered**
- Wrap `JSON.parse` in `try/catch` and return `undefined`/empty object — rejected: swallows a real cross-process corruption, hides the producer, and breaks the telemetry signal that surfaced the bug.
- Drop empty/short messages at the producer in `Protocol.onMessage` (`ipc.mp.ts`) — rejected as the primary fix: the true producer is the native MessagePort layer (not visible in TS), the exact truncation condition isn't reconstructable from source, and silently dropping frames there would mask the corruption for every channel without diagnostics. Enriching at the deserialization boundary keeps the signal while making it diagnosable for whichever transport is at fault.

### Recommended Owner

`@connor4312` — authored the 1.133 Agent Host Protocol-over-MessagePort IPC plumbing (`63a042819dd`, "agentHost: use AHP for local connections") that introduced the new transport path in which this error appears.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31504181345) · opus48 · 662.4 AIC · ⌖ 11.4 AIC · ⊞ 18.6K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+errors-fix%22&type=pullrequests)





### errors-fix-driver — cycle 1

**Trigger**: cron_review_comments · **Head**: `9222293a1bb` (`9222293`)

| Item | Action |
|------|--------|
| Review on `ipc.ts:329` (in scope) | Fixed in `9222293` (replied + resolved) |
| Review on `ipc.ts:325` (in scope, add test) | Fixed in `9222293` (replied + resolved) |
| CI | 2 checks in progress, 2 passing — no real failures |

**Push**: yes — `9222293` · **Copilot rerequested**: ok

**Ready gate**: CI pending + Copilot not yet re-run on new SHA → not marking ready this cycle> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/31540403493) · opus48 · 271.3 AIC · ⌖ 12.3 AIC · ⊞ 21K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, model: claude-opus-4.8, id: 31540403493, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/31540403493 -->