### PR TITLE
fix: guard statusbar updateStyles against pre-create config change (fixes #330262)

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -225,7 +225,14 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (this.getId() === Parts.STATUSBAR_PART && e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this._onDidChange.fire(undefined);
-				this.updateStyles();
+
+				// Only update styles once the part has been created into a
+				// container. This event can fire during early startup (e.g. when
+				// default configurations are registered) before `create` runs,
+				// at which point there is no container to style yet.
+				if (this.element) {
+					this.updateStyles();
+				}
 			}
 		}));
 	}

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -225,11 +225,6 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (this.getId() === Parts.STATUSBAR_PART && e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this._onDidChange.fire(undefined);
-
-				// Only update styles once the part has been created into a
-				// container. This event can fire during early startup (e.g. when
-				// default configurations are registered) before `create` runs,
-				// at which point there is no container to style yet.
 				if (this.element) {
 					this.updateStyles();
 				}


### PR DESCRIPTION
### Summary

The status bar throws `Assertion Failed: Argument is undefined or null.` at startup on Mac, Windows and Linux (v1.133.0-insider, 326 users). `StatusbarPart.updateStyles()` calls `assertReturnsDefined(this.getContainer())`, but the newly-added configuration-change listener invokes `updateStyles()` while default configurations are still being registered — before the part's container (`this.parent`/`this.element`) exists — so the assertion fires.

Fixes microsoft/vscode#330262
Recommended reviewer: `@hawkticehurst`

### Culprit Commit

| Field | Value |
|-------|-------|
| Commit | [`eb55ea15`](https://github.com/microsoft/vscode/commit/eb55ea151447d7607654d7046a18b37d3dca4704) |
| Author | `@hawkticehurst` |
| PR | #329701 |
| Message | Restore theme colors in Modern UI shell (#329701) |
| Why | This commit added `this.updateStyles();` inside the `onDidChangeConfiguration` listener (statusbarPart.ts:228). That listener can fire during early startup — while `registerDefaultConfigurations` runs — before `Part.create()` sets `this.parent`, so `assertReturnsDefined(this.getContainer())` in `updateStyles()` receives `undefined` and throws. |

### Code Flow

```mermaid
sequenceDiagram
    participant Reg as ConfigurationRegistry
    participant Cfg as ConfigurationService
    participant Listener as StatusbarPart config listener
    participant Update as StatusbarPart.updateStyles
    participant Assert as assertReturnsDefined

    Reg->>Cfg: registerDefaultConfigurations (startup)
    Cfg->>Listener: onDidChangeConfiguration(MODERN_UI)
    Note over Listener: Root cause:<br/>calls updateStyles() before<br/>the part container exists
    Listener->>Update: updateStyles()
    Update->>Assert: assertReturnsDefined(getContainer())
    Note over Assert: Error thrown:<br/>Argument is undefined or null
```

### Affected Files

| File | Role | Evidence |
|------|------|----------|
| `src/vs/workbench/browser/parts/statusbar/statusbarPart.ts` | crash site | L697 (from stack): `const container = assertReturnsDefined(this.getContainer());` |
| `src/vs/workbench/browser/parts/statusbar/statusbarPart.ts` | root cause | L225-L230: config listener calls `this.updateStyles()` unconditionally, before `create()` sets the container |
| `src/vs/workbench/browser/part.ts` | context | L78-L85: `create()` sets `this.parent` then calls `updateStyles()`; `getContainer()` returns `this.parent` |

### Repro Steps

The error is timing-dependent (fires only when a `MODERN_UI` default-configuration change is delivered before the status bar part is created during startup):

1. Launch VS Code (insider) so that experimental/default settings are registered during startup.
2. When `registerDefaultConfigurations` triggers an `onDidChangeConfiguration` event affecting `workbench.modernUI` before the workbench finishes creating the status bar part, `updateStyles()` runs with no container.
3. The assertion `Argument is undefined or null` is thrown from `assertReturnsDefined(this.getContainer())`.

### How the Fix Works

**Chosen approach** (`statusbarPart.ts`): guard the newly-added `updateStyles()` call in the config-change listener with `if (this.element)`, so it only runs once the part has been created into a container. This fixes the problem at its source — the producer of the premature call — rather than at the crash site. The part already models the "not yet created" state explicitly elsewhere (e.g. `addEntry` checks `if (!this.element)` at L268), so this guard is consistent with existing lifecycle handling. When the part is later created, `Part.create()` calls `updateStyles()` (part.ts:85), so no style update is lost.

**Alternatives considered:**
- Relaxing `updateStyles()` to use `this.getContainer()?...` throughout, which would weaken the invariant for the other legitimate callers that expect a container to exist and mask genuine ordering bugs.
- Wrapping the call in try/catch, which would hide the error from telemetry instead of preventing the invalid call — rejected because errors must continue to surface.

### Recommended Owner

`@hawkticehurst` — author of the culprit commit #329701 which introduced the `updateStyles()` call in the config listener, and the active owner of the Modern UI shell status bar styling work.




> Generated by [errors-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31504179817) · opus48 · 449.9 AIC · ⌖ 11.1 AIC · ⊞ 18.6K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+errors-fix%22&type=pullrequests)




### errors-fix-driver — cycle 1

**Trigger**: pr_validation_merge_conflict · **Head**: `608b3c9491313d831c06faf6a6a99a9beed9ec6d` (`608b3c9`)

| Item | Action |
|------|--------|
| Merge conflict in `statusbarPart.ts` | Resolved in `608b3c9` — `main` already landed the identical `if (this.element)` guard, so the branch now matches `main` verbatim |
| Copilot review on `statusbarPart.ts:235` (in scope) | Fixed in `608b3c9` — the flagged five-line comment was removed by taking `main`'s version (replied + resolved) |

**Push**: yes — `608b3c9` · **Copilot rerequested**: ok

**Ready gate**: CI pending on new head + Copilot re-review pending → not marking ready this cycle> Generated by [errors-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/31558166714) · opus48 · 401.2 AIC · ⌖ 11.7 AIC · ⊞ 21.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Ferrors-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: errors-fix-driver, engine: copilot, model: claude-opus-4.8, id: 31558166714, workflow_id: errors-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/31558166714 -->