### PR TITLE
agentHost: bridge legacy settings to managed permissions

### DIFF
--- a/.github/skills/policy-and-managed-settings/SKILL.md
+++ b/.github/skills/policy-and-managed-settings/SKILL.md
@@ -35,6 +35,11 @@ General rules:
 - Do not duplicate a runtime parser, matcher, or security decision in VS Code.
 - A VS Code policy is appropriate only for editor/workbench-owned behavior.
 - New Copilot enterprise controls should target the shared managed-settings/SDK model.
+- The VS Code settings-to-managed-settings bridge is a compatibility path for legacy
+  settings only. Do not add a new VS Code setting in order to bridge it; define new
+  runtime-owned controls directly in the managed-settings/SDK contract. A temporary,
+  false-by-default compatibility gate for the bridge itself is allowed; it is not a
+  runtime control and must not become a template for new mapped settings.
 - Run `npm run export-policy-data` for every VS Code or extension policy change. Never
   edit `build/lib/policies/policyData.jsonc` manually.
 

--- a/.github/skills/policy-and-managed-settings/legacy-permission-policy.md
+++ b/.github/skills/policy-and-managed-settings/legacy-permission-policy.md
@@ -5,7 +5,23 @@ before VS Code 1.133.0. The migration remains in progress.
 
 Do not use this path for new controls.
 
-## Rules
+## Compatibility paths
+
+There are two related but distinct bounded migrations:
+
+- **Legacy permission policy translation** reads only an exact enterprise `policyValue`
+  and maps the old policy to its runtime equivalent.
+- **Legacy VS Code setting translation** reads explicitly configured global values
+  (policy, user, then application) from an existing setting and contributes equivalent
+  restrictions through the declarative Agent Host bridge.
+
+Neither path is open to newly designed settings or controls. Put new runtime-owned
+controls directly in the shared managed-settings schema and SDK contract.
+The legacy-setting bridge may have a false-by-default experimental gate for staged
+adoption; that gate controls the compatibility mechanism itself and is not a mapped
+runtime control.
+
+## Legacy permission policy rules
 
 - Translate only exact enterprise `policyValue`; never user/workspace values.
 - Map only to an equivalent runtime capability.

--- a/.github/skills/policy-and-managed-settings/sdk-runtime-policy.md
+++ b/.github/skills/policy-and-managed-settings/sdk-runtime-policy.md
@@ -62,8 +62,8 @@ Bridge invariants:
 - the bridge is guarded by its own false-by-default experimental compatibility setting;
 - add mappings only for legacy settings that already exist; never create a new setting
   for this bridge;
-- mappings select one VS Code setting and use a callback typed against the SDK managed
-  permissions contract;
+- mappings select one VS Code setting and use a callback typed against the host-owned managed
+  permissions DTO;
 - mappings contribute only fields that can be flattened restrictively (`disable`, `deny`,
   and `ask`); do not flatten independent `allow` lists in VS Code;
 - only explicit global layers participate, in policy, user, then application precedence;
@@ -73,7 +73,7 @@ Bridge invariants:
 - the aggregate is supplied on SDK create and resume;
 - an empty aggregate is forwarded when settings are removed so stale restrictions clear
   across JSON/AHP serialization;
-- contributions use a typed, client-owned AHP extension request and a dedicated Agent
+- contributions use a typed, client-owned AHP extension notification and a dedicated Agent
   Host managed-settings service; do not route them through root configuration;
 - the host aggregates contributions by client and removes an owner's contribution after
   its disconnect grace expires;

--- a/.github/skills/policy-and-managed-settings/sdk-runtime-policy.md
+++ b/.github/skills/policy-and-managed-settings/sdk-runtime-policy.md
@@ -33,11 +33,9 @@ Do not add a GitHub-token/account-policy field as a substitute for managed setti
 - Permission authorization never widens sandbox access.
 - Validate rule grammar through the real SDK/runtime boundary.
 
-## Host-Injection Lifecycle (In Progress)
+## Host-Injection Lifecycle
 
-The runtime host-injection capability is still being adopted by the public SDK and VS
-Code. When an integrator uses it, host-injected managed settings are startup
-configuration:
+Host-injected managed settings are startup configuration:
 
 - supply them on local create and resume;
 - re-supply them because they are not persisted;
@@ -50,6 +48,40 @@ Policy removal must survive real JSON/AHP serialization.
 Client-injected settings are strict: malformed or unsupported rules reject create/resume.
 Server/device discovery instead uses its defined cache and fail-open/fail-closed
 degradation behavior.
+
+### VS Code legacy-setting bridge
+
+VS Code has a narrow declarative bridge for settings whose explicitly configured values
+must contribute restrictions to `managedSettings.permissions`. This is a bounded
+compatibility path for pre-existing legacy settings, not an architecture for new
+controls. New runtime-owned controls belong directly in the managed-settings schema and
+public SDK contract, without introducing or translating a VS Code setting.
+
+Bridge invariants:
+
+- the bridge is guarded by its own false-by-default experimental compatibility setting;
+- add mappings only for legacy settings that already exist; never create a new setting
+  for this bridge;
+- mappings select one VS Code setting and use a callback typed against the SDK managed
+  permissions contract;
+- mappings contribute only fields that can be flattened restrictively (`disable`, `deny`,
+  and `ask`); do not flatten independent `allow` lists in VS Code;
+- only explicit global layers participate, in policy, user, then application precedence;
+- registered defaults and workspace/folder values do not contribute;
+- contributions aggregate restrictively and are transported without parsing their rule
+  grammar in VS Code;
+- the aggregate is supplied on SDK create and resume;
+- an empty aggregate is forwarded when settings are removed so stale restrictions clear
+  across JSON/AHP serialization;
+- contributions use a typed, client-owned AHP extension request and a dedicated Agent
+  Host managed-settings service; do not route them through root configuration;
+- the host aggregates contributions by client and removes an owner's contribution after
+  its disconnect grace expires;
+- changed contributions refresh local default and peer sessions at an idle boundary
+  before the next turn.
+
+Keep additional legacy mappings in the shared bridge table and cover their scope, removal,
+create/resume, and refresh behavior in the corresponding Agent Host unit tests.
 
 The runtime composes managed sandbox floors. While sandbox configuration remains
 host-driven, verify that Agent Host applies the effective floor to session
@@ -69,3 +101,5 @@ Start with:
 - `github/copilot-agent-runtime/src/runtime/src/permissions/managed.rs`
 - `github/copilot-agent-runtime/src/runtime/src/permissions/orchestrator.rs`
 - `github/copilot-sdk/nodejs/src/types.ts`
+- `microsoft/vscode/src/vs/platform/agentHost/common/agentHostManagedSettings.ts`
+- `microsoft/vscode/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts`

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -40,6 +40,7 @@ import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETR
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import { getAgentHostConfigurationSyncEntries, resolveAgentHostConfigurationSyncPatch, resolveAgentHostConfigurationSyncValue } from '../common/agentHostConfigurationSync.js';
+import { managedPermissionsConfigurationIds, resolveManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
 import { AgentHostClientConnectionKind, toClientConnectionTelemetryMeta } from '../common/agentHostTelemetry.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
@@ -48,6 +49,7 @@ import { dirname } from '../../../base/common/resources.js';
 import { observableValue, type IObservable } from '../../../base/common/observable.js';
 import { isFileResourceRead } from '../common/resourceReadLogging.js';
 import { ResourceSet } from '../../../base/common/map.js';
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 
 const AHP_CLIENT_CONNECTION_CLOSED = -32000;
 
@@ -102,6 +104,10 @@ interface IRemoteAgentHostExtensionCommandMap {
 	'getNetworkDiagnosticsInfo': { params: undefined; result: IAgentHostNetworkDiagnosticsInfo };
 	'getManagedSettingsDiagnostics': { params: undefined; result: readonly IAgentHostManagedSettingsDiagnostics[] };
 	'diagnosticsFetch': { params: { url: string }; result: IAgentHostNetworkFetchResult };
+}
+
+interface IRemoteAgentHostExtensionNotificationMap {
+	'setClientManagedSettingsPermissions': { params: { permissions: ManagedSettingsPermissions } };
 }
 
 interface IPendingRequest {
@@ -374,6 +380,9 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			if (e.affectsConfiguration(DISABLE_REPO_INFO_TELEMETRY_SETTING_ID)) {
 				this._updateDisableRepoInfoTelemetry();
 			}
+			if (managedPermissionsConfigurationIds.some(settingId => e.affectsConfiguration(settingId))) {
+				void this._updateManagedSettingsPermissions();
+			}
 		}));
 
 		if (!isClientTransport(this._transport)) {
@@ -627,7 +636,8 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			// be a freshly restarted process that never received these values (the
 			// reconnect result itself carries none), which would otherwise leave
 			// early-read config like the migrate flag at its host-side default.
-			this._forwardClientConfig();
+			this._forwardClientConfig(false);
+			this._updateManagedSettingsPermissions(true);
 
 			// Drain the outbox BEFORE the transition so listeners reacting to
 			// {@link onDidChangeConnectionState} that synchronously dispatch see
@@ -681,7 +691,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			...this._clientConnectionTelemetryMeta(),
 			initialSubscriptions: subscriptions,
 		}, { bypassReconnectGate: true });
-		this._applyInitializeResult(initializeResult);
+		this._applyInitializeResult(initializeResult, false);
 		return {
 			result: { type: ReconnectResultType.Snapshot, snapshots: initializeResult.snapshots ?? [] },
 			freshInitialize: true,
@@ -737,14 +747,16 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return meta ? { _meta: meta } : {};
 	}
 
-	private _applyInitializeResult(result: CommandMap['initialize']['result']): void {
+	private _applyInitializeResult(result: CommandMap['initialize']['result'], forwardClientConfig = true): void {
 		this._initializeResult.set(result, undefined);
 		this._serverSeq = result.serverSeq;
 		if (result.defaultDirectory) {
 			const directory = result.defaultDirectory;
 			this._defaultDirectory = typeof directory === 'string' ? URI.parse(directory).path : URI.revive(directory).path;
 		}
-		this._forwardClientConfig();
+		if (forwardClientConfig) {
+			this._forwardClientConfig();
+		}
 	}
 
 	/**
@@ -760,13 +772,16 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * key-plus-transform can't express: values derived from several settings, and
 	 * settings contributed by an extension rather than by core.
 	 */
-	private _forwardClientConfig(): void {
+	private _forwardClientConfig(includeManagedSettings = true): void {
 		this._dispatchRootConfig(resolveAgentHostConfigurationSyncPatch(this._configurationService, this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY));
 		this._updateTelemetryLevel();
 		this._updatePreferLongContextEnabled();
 		this._updateTerminalAutoApproveEnabled();
 		this._updateTerminalAutoApproveRules();
 		this._updateDisableRepoInfoTelemetry();
+		if (includeManagedSettings) {
+			void this._updateManagedSettingsPermissions();
+		}
 	}
 
 	/**
@@ -1516,17 +1531,24 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	/** Send a typed JSON-RPC notification for a protocol-defined method. */
 	private _sendNotification<M extends keyof ClientNotificationMap>(method: M, params: ClientNotificationMap[M]['params']): void {
+		this._sendNotificationMessage(method, params);
+	}
+
+	private _sendExtensionNotification<M extends keyof IRemoteAgentHostExtensionNotificationMap>(method: M, params: IRemoteAgentHostExtensionNotificationMap[M]['params'], sendDuringReconnect = false): void {
+		this._sendNotificationMessage(method, params, sendDuringReconnect);
+	}
+
+	private _sendNotificationMessage(method: string, params: unknown, sendDuringReconnect = false): void {
 		if (this._state.kind === AgentHostClientState.Closed || this._state.kind === AgentHostClientState.Incompatible) {
 			return;
 		}
-		// Generic M can't satisfy the distributive AhpNotification union directly
 		// eslint-disable-next-line local/code-no-dangerous-type-assertions
 		const message = { jsonrpc: '2.0' as const, method, params } as ProtocolMessage;
 		if (isClientTransport(this._transport) && this._state.kind === AgentHostClientState.Connecting) {
 			this._state.outbox.push(message);
 			return;
 		}
-		if (this._state.kind === AgentHostClientState.Reconnecting) {
+		if (this._state.kind === AgentHostClientState.Reconnecting && !sendDuringReconnect) {
 			// Queue for the new transport — drained by {@link _drainAfterReconnect}
 			// once the soft-reconnect handshake completes. The outbox persists
 			// across failed attempts so a message rides through retry cycles
@@ -1581,6 +1603,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	private _updateTerminalAutoApproveRules(): void {
 		this._dispatchRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) });
+	}
+
+	private _updateManagedSettingsPermissions(sendDuringReconnect = false): void {
+		const permissions = this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY
+			? resolveManagedSettingsPermissions(this._configurationService)
+			: {};
+		this._sendExtensionNotification('setClientManagedSettingsPermissions', { permissions }, sendDuringReconnect);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -40,7 +40,7 @@ import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETR
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import { getAgentHostConfigurationSyncEntries, resolveAgentHostConfigurationSyncPatch, resolveAgentHostConfigurationSyncValue } from '../common/agentHostConfigurationSync.js';
-import { managedPermissionsConfigurationIds, resolveManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
+import { managedPermissionsConfigurationIds, resolveManagedSettingsPermissions, type IAgentHostManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
 import { AgentHostClientConnectionKind, toClientConnectionTelemetryMeta } from '../common/agentHostTelemetry.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
@@ -49,7 +49,6 @@ import { dirname } from '../../../base/common/resources.js';
 import { observableValue, type IObservable } from '../../../base/common/observable.js';
 import { isFileResourceRead } from '../common/resourceReadLogging.js';
 import { ResourceSet } from '../../../base/common/map.js';
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 
 const AHP_CLIENT_CONNECTION_CLOSED = -32000;
 
@@ -107,7 +106,7 @@ interface IRemoteAgentHostExtensionCommandMap {
 }
 
 interface IRemoteAgentHostExtensionNotificationMap {
-	'setClientManagedSettingsPermissions': { params: { permissions: ManagedSettingsPermissions } };
+	'setClientManagedSettingsPermissions': { params: { permissions: IAgentHostManagedSettingsPermissions } };
 }
 
 interface IPendingRequest {

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -624,6 +624,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			}
 
 			this._applyReconnectResult(result, freshInitialize);
+			this._updateManagedSettingsPermissions(true);
 			if (freshInitialize && result.type === ReconnectResultType.Snapshot) {
 				await this._restoreAuthenticationAfterFreshInitialize();
 				await this._restoreSubscriptionsAfterFreshInitialize(result.snapshots);
@@ -637,7 +638,6 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			// reconnect result itself carries none), which would otherwise leave
 			// early-read config like the migrate flag at its host-side default.
 			this._forwardClientConfig(false);
-			this._updateManagedSettingsPermissions(true);
 
 			// Drain the outbox BEFORE the transition so listeners reacting to
 			// {@link onDidChangeConnectionState} that synchronously dispatch see

--- a/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
+++ b/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
@@ -72,6 +72,21 @@ export function getGlobalConfigurationValue<T>(configurationService: IConfigurat
 }
 
 /**
+ * Resolves the explicitly configured global value of `settingId`, excluding the
+ * registered default and workspace/folder layers.
+ */
+export function getExplicitGlobalConfigurationValue<T>(configurationService: IConfigurationService, settingId: string): T | undefined {
+	const inspected = configurationService.inspect<T>(settingId);
+	const property = getPropertySchema(settingId);
+	for (const value of [inspected.policyValue, inspected.userValue, inspected.applicationValue]) {
+		if (value !== undefined && matchesSchemaType(value, property?.type)) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+/**
  * A setting that declares {@link IAgentHostConfigurationSync}, paired with the
  * setting id it was declared on.
  */

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -3,21 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
 import { getExplicitGlobalConfigurationValue, getGlobalConfigurationValue } from './agentHostConfigurationSync.js';
 import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
 
-type ManagedSettingsPermissionsContribution = Pick<ManagedSettingsPermissions, 'disableBypassPermissionsMode' | 'deny' | 'ask'>;
+export interface IAgentHostManagedSettingsPermissions {
+	disableBypassPermissionsMode?: 'disable';
+	deny?: string[];
+	ask?: string[];
+}
 
 export const AgentHostMapLegacySettingsToManagedSettingsSettingId = 'chat.agentHost.copilot.mapLegacySettingsToManagedSettings';
 
 interface IManagedPermissionsSettingMapping {
 	readonly settingId: string;
-	contribute(configurationService: IConfigurationService): ManagedSettingsPermissionsContribution | undefined;
+	contribute(configurationService: IConfigurationService): IAgentHostManagedSettingsPermissions | undefined;
 }
 
-function managedPermissionsSetting<T>(settingId: string, transform: (value: T) => ManagedSettingsPermissionsContribution | undefined): IManagedPermissionsSettingMapping {
+function managedPermissionsSetting<T>(settingId: string, transform: (value: T) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
 	return {
 		settingId,
 		contribute: configurationService => {
@@ -38,7 +41,7 @@ export const managedPermissionsConfigurationIds = [
 	...managedPermissionsSettings.map(mapping => mapping.settingId),
 ];
 
-export function isManagedSettingsPermissions(value: unknown): value is ManagedSettingsPermissions {
+export function isManagedSettingsPermissions(value: unknown): value is IAgentHostManagedSettingsPermissions {
 	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
 		return false;
 	}
@@ -55,12 +58,12 @@ function isStringArrayOrUndefined(value: unknown): boolean {
 	return value === undefined || (Array.isArray(value) && value.every(item => typeof item === 'string'));
 }
 
-export function resolveManagedSettingsPermissions(configurationService: IConfigurationService): ManagedSettingsPermissions {
+export function resolveManagedSettingsPermissions(configurationService: IConfigurationService): IAgentHostManagedSettingsPermissions {
 	if (getGlobalConfigurationValue<boolean>(configurationService, AgentHostMapLegacySettingsToManagedSettingsSettingId) !== true) {
 		return {};
 	}
 
-	const permissions: ManagedSettingsPermissions = {};
+	const permissions: IAgentHostManagedSettingsPermissions = {};
 	for (const mapping of managedPermissionsSettings) {
 		const contribution = mapping.contribute(configurationService);
 		if (contribution?.disableBypassPermissionsMode) {

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
+import type { IConfigurationService } from '../../configuration/common/configuration.js';
+import { getExplicitGlobalConfigurationValue, getGlobalConfigurationValue } from './agentHostConfigurationSync.js';
+import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
+
+type ManagedSettingsPermissionsContribution = Pick<ManagedSettingsPermissions, 'disableBypassPermissionsMode' | 'deny' | 'ask'>;
+
+export const AgentHostMapLegacySettingsToManagedSettingsSettingId = 'chat.agentHost.copilot.mapLegacySettingsToManagedSettings';
+
+interface IManagedPermissionsSettingMapping {
+	readonly settingId: string;
+	contribute(configurationService: IConfigurationService): ManagedSettingsPermissionsContribution | undefined;
+}
+
+function managedPermissionsSetting<T>(settingId: string, transform: (value: T) => ManagedSettingsPermissionsContribution | undefined): IManagedPermissionsSettingMapping {
+	return {
+		settingId,
+		contribute: configurationService => {
+			const value = getExplicitGlobalConfigurationValue<T>(configurationService, settingId);
+			return value === undefined ? undefined : transform(value);
+		},
+	};
+}
+
+/** Compatibility mappings for legacy settings only; new controls belong directly in the SDK. */
+const managedPermissionsSettings: readonly IManagedPermissionsSettingMapping[] = [
+	managedPermissionsSetting<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, value => value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
+	managedPermissionsSetting<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, value => value === false ? { ask: ['Shell'] } : undefined),
+];
+
+export const managedPermissionsConfigurationIds = [
+	AgentHostMapLegacySettingsToManagedSettingsSettingId,
+	...managedPermissionsSettings.map(mapping => mapping.settingId),
+];
+
+export function isManagedSettingsPermissions(value: unknown): value is ManagedSettingsPermissions {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+	const permissions = value as Record<string, unknown>;
+	if (Object.keys(permissions).some(key => key !== 'disableBypassPermissionsMode' && key !== 'deny' && key !== 'ask')) {
+		return false;
+	}
+	return (permissions.disableBypassPermissionsMode === undefined || permissions.disableBypassPermissionsMode === 'disable')
+		&& isStringArrayOrUndefined(permissions.deny)
+		&& isStringArrayOrUndefined(permissions.ask);
+}
+
+function isStringArrayOrUndefined(value: unknown): boolean {
+	return value === undefined || (Array.isArray(value) && value.every(item => typeof item === 'string'));
+}
+
+export function resolveManagedSettingsPermissions(configurationService: IConfigurationService): ManagedSettingsPermissions {
+	if (getGlobalConfigurationValue<boolean>(configurationService, AgentHostMapLegacySettingsToManagedSettingsSettingId) !== true) {
+		return {};
+	}
+
+	const permissions: ManagedSettingsPermissions = {};
+	for (const mapping of managedPermissionsSettings) {
+		const contribution = mapping.contribute(configurationService);
+		if (contribution?.disableBypassPermissionsMode) {
+			permissions.disableBypassPermissionsMode = contribution.disableBypassPermissionsMode;
+		}
+		if (contribution?.deny) {
+			permissions.deny = [...permissions.deny ?? [], ...contribution.deny];
+		}
+		if (contribution?.ask) {
+			permissions.ask = [...permissions.ask ?? [], ...contribution.ask];
+		}
+	}
+	return permissions;
+}

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -424,6 +424,9 @@ export const AgentHostTerminalAutoApproveEnabledConfigKey = 'terminalAutoApprove
  */
 export const TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID = 'chat.tools.terminal.enableAutoApprove';
 
+/** The VS Code setting ID for global auto approve enablement. */
+export const GLOBAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.global.autoApprove';
+
 /**
  * Root config key forwarded from the renderer when VS Code's
  * `chat.tools.global.autoApprove` setting changes. When `true`, the global

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -12,6 +12,7 @@ import type { IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import type { IConfigurationChangeEvent, IConfigurationService } from '../../configuration/common/configuration.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import type { IAgentServerToolHost } from './agentServerTools.js';
 import type { IActiveSubscriptionInfo, IAgentSubscription } from './state/agentSubscription.js';
 import type { IRemoteWatchHandle } from './agentHostFileSystemProvider.js';
@@ -2063,6 +2064,9 @@ export interface IAgentService {
 
 	/** Resolve managed settings through each provider's native SDK/runtime implementation. */
 	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]>;
+
+	setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void>;
+	removeClientManagedSettingsPermissions(clientId: string): void;
 
 	/**
 	 * Probe connectivity from the agent host process to a single `url`,

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -12,7 +12,6 @@ import type { IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import type { IConfigurationChangeEvent, IConfigurationService } from '../../configuration/common/configuration.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import type { IAgentServerToolHost } from './agentServerTools.js';
 import type { IActiveSubscriptionInfo, IAgentSubscription } from './state/agentSubscription.js';
 import type { IRemoteWatchHandle } from './agentHostFileSystemProvider.js';
@@ -2064,9 +2063,6 @@ export interface IAgentService {
 
 	/** Resolve managed settings through each provider's native SDK/runtime implementation. */
 	getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]>;
-
-	setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void>;
-	removeClientManagedSettingsPermissions(clientId: string): void;
 
 	/**
 	 * Probe connectivity from the agent host process to a single `url`,

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -22,6 +22,7 @@ import { AgentModelRefreshScheduler, MODEL_REFRESH_INTERVAL_MS } from './agentMo
 import { AgentService } from './agentService.js';
 import { IAgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
+import { IAgentHostManagedSettingsService } from './agentHostManagedSettingsService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -224,6 +225,7 @@ async function startAgentHost(): Promise<void> {
 
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		diServices.set(IAgentHostManagedSettingsService, agentService.managedSettingsService);
 		const editArcReporterService = disposables.add(instantiationService.createInstance(EditArcReporterService, undefined));
 		diServices.set(IEditArcReporterService, editArcReporterService);
 		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);

--- a/src/vs/platform/agentHost/node/agentHostManagedSettingsService.ts
+++ b/src/vs/platform/agentHost/node/agentHostManagedSettingsService.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import type { IAgentHostManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
 
 export const IAgentHostManagedSettingsService = createDecorator<IAgentHostManagedSettingsService>('agentHostManagedSettingsService');
 
 export interface IAgentHostManagedSettingsService {
 	readonly _serviceBrand: undefined;
 	readonly onDidChange: Event<void>;
-	readonly permissions: ManagedSettingsPermissions;
-	setClientPermissions(clientId: string, permissions: ManagedSettingsPermissions): void;
+	readonly permissions: IAgentHostManagedSettingsPermissions;
+	setClientPermissions(clientId: string, permissions: IAgentHostManagedSettingsPermissions): void;
 	removeClientPermissions(clientId: string): void;
 }
 
@@ -25,14 +25,14 @@ export class AgentHostManagedSettingsService extends Disposable implements IAgen
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
 
-	private readonly _permissionsByClient = new Map<string, ManagedSettingsPermissions>();
-	private _permissions: ManagedSettingsPermissions = {};
+	private readonly _permissionsByClient = new Map<string, IAgentHostManagedSettingsPermissions>();
+	private _permissions: IAgentHostManagedSettingsPermissions = {};
 
-	get permissions(): ManagedSettingsPermissions {
+	get permissions(): IAgentHostManagedSettingsPermissions {
 		return this._permissions;
 	}
 
-	setClientPermissions(clientId: string, permissions: ManagedSettingsPermissions): void {
+	setClientPermissions(clientId: string, permissions: IAgentHostManagedSettingsPermissions): void {
 		if (Object.keys(permissions).length === 0) {
 			this._permissionsByClient.delete(clientId);
 		} else {
@@ -48,7 +48,7 @@ export class AgentHostManagedSettingsService extends Disposable implements IAgen
 	}
 
 	private _updatePermissions(): void {
-		const permissions: ManagedSettingsPermissions = {};
+		const permissions: IAgentHostManagedSettingsPermissions = {};
 		const deny = new Set<string>();
 		const ask = new Set<string>();
 		for (const contribution of this._permissionsByClient.values()) {

--- a/src/vs/platform/agentHost/node/agentHostManagedSettingsService.ts
+++ b/src/vs/platform/agentHost/node/agentHostManagedSettingsService.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { equals } from '../../../base/common/objects.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const IAgentHostManagedSettingsService = createDecorator<IAgentHostManagedSettingsService>('agentHostManagedSettingsService');
+
+export interface IAgentHostManagedSettingsService {
+	readonly _serviceBrand: undefined;
+	readonly onDidChange: Event<void>;
+	readonly permissions: ManagedSettingsPermissions;
+	setClientPermissions(clientId: string, permissions: ManagedSettingsPermissions): void;
+	removeClientPermissions(clientId: string): void;
+}
+
+export class AgentHostManagedSettingsService extends Disposable implements IAgentHostManagedSettingsService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange = this._onDidChange.event;
+
+	private readonly _permissionsByClient = new Map<string, ManagedSettingsPermissions>();
+	private _permissions: ManagedSettingsPermissions = {};
+
+	get permissions(): ManagedSettingsPermissions {
+		return this._permissions;
+	}
+
+	setClientPermissions(clientId: string, permissions: ManagedSettingsPermissions): void {
+		if (Object.keys(permissions).length === 0) {
+			this._permissionsByClient.delete(clientId);
+		} else {
+			this._permissionsByClient.set(clientId, permissions);
+		}
+		this._updatePermissions();
+	}
+
+	removeClientPermissions(clientId: string): void {
+		if (this._permissionsByClient.delete(clientId)) {
+			this._updatePermissions();
+		}
+	}
+
+	private _updatePermissions(): void {
+		const permissions: ManagedSettingsPermissions = {};
+		const deny = new Set<string>();
+		const ask = new Set<string>();
+		for (const contribution of this._permissionsByClient.values()) {
+			if (contribution.disableBypassPermissionsMode === 'disable') {
+				permissions.disableBypassPermissionsMode = 'disable';
+			}
+			if (contribution.deny) {
+				contribution.deny.forEach(rule => deny.add(rule));
+			}
+			if (contribution.ask) {
+				contribution.ask.forEach(rule => ask.add(rule));
+			}
+		}
+		if (deny.size > 0) {
+			permissions.deny = [...deny];
+		}
+		if (ask.size > 0) {
+			permissions.ask = [...ask];
+		}
+		if (!equals(this._permissions, permissions)) {
+			this._permissions = permissions;
+			this._onDidChange.fire();
+		}
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -263,6 +263,7 @@ async function main(): Promise<void> {
 	disposables.add(agentService);
 	diServices.set(IAgentService, agentService);
 	diServices.set(IAgentHostStateManager, agentService.stateManager);
+	diServices.set(IAgentHostManagedSettingsService, agentService.managedSettingsService);
 	const networkDiagnosticsService = instantiationService.createInstance(NetworkDiagnosticsService);
 	diServices.set(INetworkDiagnosticsService, networkDiagnosticsService);
 	agentService.setNetworkDiagnosticsService(networkDiagnosticsService);
@@ -280,7 +281,6 @@ async function main(): Promise<void> {
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
-		diServices.set(IAgentHostManagedSettingsService, agentService.managedSettingsService);
 		const editArcReporterService = disposables.add(instantiationService.createInstance(EditArcReporterService, undefined));
 		diServices.set(IEditArcReporterService, editArcReporterService);
 		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -56,6 +56,7 @@ import { AgentService } from './agentService.js';
 import { IAgentHostStateManager } from './agentHostStateManager.js';
 import { AgentHostClaudeAgentEnabledEnvVar, AgentHostClaudeSdkRootEnvVar, AgentHostCodexAgentEnabledEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar, isAgentEnabled } from '../common/agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
+import { IAgentHostManagedSettingsService } from './agentHostManagedSettingsService.js';
 import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -279,6 +280,7 @@ async function main(): Promise<void> {
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		diServices.set(IAgentHostManagedSettingsService, agentService.managedSettingsService);
 		const editArcReporterService = disposables.add(instantiationService.createInstance(EditArcReporterService, undefined));
 		diServices.set(IEditArcReporterService, editArcReporterService);
 		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -22,7 +22,6 @@ import { FileChangeType, FileOperationResult, IFileChange, IFileService, toFileO
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateChatSideChatSelection, IAgentCreateChatSideChatSource, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionAdoptionResult, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, parseEditAttributionResource } from '../common/fileEditAttribution.js';
@@ -4299,14 +4298,6 @@ export class AgentService extends Disposable implements IAgentService {
 				return { provider: provider.id, error: error instanceof Error ? error.message : String(error) };
 			}
 		}));
-	}
-
-	async setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void> {
-		this._managedSettingsService.setClientPermissions(clientId, permissions);
-	}
-
-	removeClientManagedSettingsPermissions(clientId: string): void {
-		this._managedSettingsService.removeClientPermissions(clientId);
 	}
 
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -22,6 +22,7 @@ import { FileChangeType, FileOperationResult, IFileChange, IFileService, toFileO
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import { AgentProvider, AgentSession, AgentSignal, AgentHostSessionReleaseGraceMsEnvVar, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateChatSideChatSelection, IAgentCreateChatSideChatSource, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentHostManagedSettingsDiagnostics, IAgentHostNetworkDiagnosticsInfo, IAgentHostNetworkEndpoint, IAgentHostNetworkFetchResult, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionAdoptionResult, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommitEditAttributionFlushParams, IEditAttributionFlushResult, IPrepareEditAttributionFlushParams, IPreparedEditAttributionFlush, parseEditAttributionResource } from '../common/fileEditAttribution.js';
@@ -40,6 +41,7 @@ import { readToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
+import { AgentHostManagedSettingsService, type IAgentHostManagedSettingsService } from './agentHostManagedSettingsService.js';
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { ISessionDbUriFields, parseSessionDbUri } from '../common/sessionDbUri.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
@@ -268,12 +270,15 @@ export class AgentService extends Disposable implements IAgentService {
 
 	/** Authoritative state manager for the sessions process protocol. */
 	private readonly _stateManager: AgentHostStateManager;
+	private readonly _managedSettingsService = this._register(new AgentHostManagedSettingsService());
 
 	/** Exposes the state manager for co-hosting a WebSocket protocol server. */
 	get stateManager(): AgentHostStateManager { return this._stateManager; }
 
 	/** Exposes the configuration service so agent providers can share root config plumbing. */
 	get configurationService(): IAgentConfigurationService { return this._configurationService; }
+
+	get managedSettingsService(): IAgentHostManagedSettingsService { return this._managedSettingsService; }
 
 	/** Exposes the GitHub endpoint service so agent providers share GitHub (Enterprise) resource resolution. */
 	get gitHubEndpointService(): IAgentHostGitHubEndpointService { return this._gitHubEndpointService; }
@@ -4294,6 +4299,14 @@ export class AgentService extends Disposable implements IAgentService {
 				return { provider: provider.id, error: error instanceof Error ? error.message : String(error) };
 			}
 		}));
+	}
+
+	async setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void> {
+		this._managedSettingsService.setClientPermissions(clientId, permissions);
+	}
+
+	removeClientManagedSettingsPermissions(clientId: string): void {
+		this._managedSettingsService.removeClientPermissions(clientId);
 	}
 
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHubTelemetryNotification, type ManagedSettingsResolvedData, type SessionMode as CopilotSdkMode } from '@github/copilot-sdk';
+import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHubTelemetryNotification, type ManagedSettingsPermissions, type ManagedSettingsResolvedData, type SessionMode as CopilotSdkMode } from '@github/copilot-sdk';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { pathToFileURL } from 'url';
@@ -58,6 +58,7 @@ import { AgentCustomization, CustomizationLoadStatus, CustomizationType, RuleCus
 import { getByokLmAgentModelId } from '../../common/agentHostByokLm.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostManagedSettingsService } from '../agentHostManagedSettingsService.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
@@ -648,6 +649,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostManagedSettingsService private readonly _managedSettingsService: IAgentHostManagedSettingsService,
 		@IAgentHostStateManager private readonly _stateManager: AgentHostStateManager,
 		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
@@ -697,6 +699,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._register(this._configurationService.onDidRootConfigChange(() => {
 			this._restartClientIfStartupConfigChanged().catch(err =>
 				this._logService.error('[Copilot] Failed to apply root config change', err)
+			);
+		}));
+		this._register(this._managedSettingsService.onDidChange(() => {
+			this._restartClientIfStartupConfigChanged().catch(err =>
+				this._logService.error('[Copilot] Failed to apply managed settings change', err)
 			);
 		}));
 
@@ -756,6 +763,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _lastCopilotSdkLogLevelSetting: CopilotSdkLogLevelSetting = this._getCopilotSdkLogLevelSetting();
 	private _lastEnterpriseHost: string | undefined = this._getEnterpriseHost();
 	private _lastSystemProxyEnabled: boolean = this._isSystemProxyEnabled();
+	private _lastManagedSettingsPermissions: ManagedSettingsPermissions = this._managedSettingsService.permissions;
 	private _lastMigrateLegacyEnabled: boolean = this._isMigrateLegacyCopilotCliEnabled();
 
 	private _isSessionSyncEnabled(): boolean {
@@ -814,7 +822,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const copilotSdkLogLevelSetting = this._getCopilotSdkLogLevelSetting();
 		const enterpriseHost = this._getEnterpriseHost();
 		const systemProxyEnabled = this._isSystemProxyEnabled();
-		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck && this._lastCopilotSdkLogLevelSetting === copilotSdkLogLevelSetting && this._lastEnterpriseHost === enterpriseHost && this._lastSystemProxyEnabled === systemProxyEnabled) {
+		const managedSettingsPermissions = this._managedSettingsService.permissions;
+		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck && this._lastCopilotSdkLogLevelSetting === copilotSdkLogLevelSetting && this._lastEnterpriseHost === enterpriseHost && this._lastSystemProxyEnabled === systemProxyEnabled && equals(this._lastManagedSettingsPermissions, managedSettingsPermissions)) {
 			return;
 		}
 		const changed = [
@@ -823,12 +832,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._lastCopilotSdkLogLevelSetting !== copilotSdkLogLevelSetting ? `copilotSdkLogLevel=${copilotSdkLogLevelSetting}` : undefined,
 			this._lastEnterpriseHost !== enterpriseHost ? `enterpriseHost=${enterpriseHost}` : undefined,
 			this._lastSystemProxyEnabled !== systemProxyEnabled ? `systemProxy=${systemProxyEnabled}` : undefined,
+			!equals(this._lastManagedSettingsPermissions, managedSettingsPermissions) ? 'managedSettingsPermissions' : undefined,
 		].filter((v): v is string => v !== undefined).join(', ');
 		this._lastSessionSyncEnabled = sessionSync;
 		this._lastRubberDuckEnabled = rubberDuck;
 		this._lastCopilotSdkLogLevelSetting = copilotSdkLogLevelSetting;
 		this._lastEnterpriseHost = enterpriseHost;
 		this._lastSystemProxyEnabled = systemProxyEnabled;
+		this._lastManagedSettingsPermissions = managedSettingsPermissions;
 		await this._requestClientRestart(`startup config changed: ${changed}`);
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -663,6 +663,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@IAgentHostProxyResolver private readonly _proxyResolver: IAgentHostProxyResolver,
 	) {
 		super();
+		this._lastManagedSettingsPermissions = this._managedSettingsService.permissions;
 		this._plugins = this._register(this._instantiationService.createInstance(PluginController, () => this._ensureClient()));
 		this._sessionLauncher = this._instantiationService.createInstance(CopilotSessionLauncher);
 		this._configurationService.publishRootTransientValues?.({ [CopilotCliVSCodeAssignmentContextKey]: undefined });
@@ -763,7 +764,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _lastCopilotSdkLogLevelSetting: CopilotSdkLogLevelSetting = this._getCopilotSdkLogLevelSetting();
 	private _lastEnterpriseHost: string | undefined = this._getEnterpriseHost();
 	private _lastSystemProxyEnabled: boolean = this._isSystemProxyEnabled();
-	private _lastManagedSettingsPermissions: ManagedSettingsPermissions = this._managedSettingsService.permissions;
+	private _lastManagedSettingsPermissions: ManagedSettingsPermissions;
 	private _lastMigrateLegacyEnabled: boolean = this._isMigrateLegacyCopilotCliEnabled();
 
 	private _isSessionSyncEnabled(): boolean {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHubTelemetryNotification, type ManagedSettingsPermissions, type ManagedSettingsResolvedData, type SessionMode as CopilotSdkMode } from '@github/copilot-sdk';
+import { CopilotClient, RuntimeConnection, type CopilotClientOptions, type GitHubTelemetryNotification, type ManagedSettingsResolvedData, type SessionMode as CopilotSdkMode } from '@github/copilot-sdk';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { pathToFileURL } from 'url';
@@ -32,6 +32,7 @@ import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { INativeEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { workspacelessScratchDir } from '../workspacelessScratchDir.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
+import type { IAgentHostManagedSettingsPermissions } from '../../common/agentHostManagedSettings.js';
 import { IAgentHostReviewService } from '../../common/agentHostReviewService.js';
 import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
@@ -764,7 +765,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _lastCopilotSdkLogLevelSetting: CopilotSdkLogLevelSetting = this._getCopilotSdkLogLevelSetting();
 	private _lastEnterpriseHost: string | undefined = this._getEnterpriseHost();
 	private _lastSystemProxyEnabled: boolean = this._isSystemProxyEnabled();
-	private _lastManagedSettingsPermissions: ManagedSettingsPermissions;
+	private _lastManagedSettingsPermissions: IAgentHostManagedSettingsPermissions;
 	private _lastMigrateLegacyEnabled: boolean = this._isMigrateLegacyCopilotCliEnabled();
 
 	private _isSessionSyncEnabled(): boolean {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -16,6 +16,7 @@ import { AgentSession } from '../../common/agentService.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostManagedSettingsService } from '../agentHostManagedSettingsService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 import { IByokLmBridgeRegistry } from '../byokLmBridgeRegistry.js';
 import { IByokLmProxyService, type IByokLmProxyHandle } from './byokLmProxyService.js';
@@ -396,6 +397,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 
 	constructor(
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostManagedSettingsService private readonly _managedSettingsService: IAgentHostManagedSettingsService,
 		@IAgentHostTerminalManager private readonly _terminalManager: IAgentHostTerminalManager,
 		@ILogService private readonly _logService: ILogService,
 		@IFileService private readonly _fileService: IFileService,
@@ -608,6 +610,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			&& agentHostModelSupportsToolSearch(effectiveModel?.id)
 			&& clientToolNames.has(CLIENT_TOOL_SEARCH_REFERENCE_NAME);
 		const toolSearchDeferThreshold = normalizeToolSearchDeferThreshold(this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.ToolSearchDeferThreshold));
+		const managedSettingsPermissions = this._managedSettingsService.permissions;
 		const promptContext: IAgentHostPromptContext = {
 			getSetting: key => this._configurationService.getRootValue(copilotCliConfigSchema, key),
 			hasClientTool: name => clientToolNames.has(name),
@@ -653,6 +656,9 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			toolSearch: toolSearchActive ? { enabled: true, deferThreshold: toolSearchDeferThreshold } : { enabled: false },
 			largeOutput: {
 				maxSizeBytes: 8 * 1024,
+			},
+			managedSettings: {
+				permissions: managedSettingsPermissions,
 			},
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -47,6 +47,7 @@ import {
 } from '../common/state/sessionProtocol.js';
 import { isAhpResourceWatchChannel, isAhpRootChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
+import { IAgentHostManagedSettingsService } from './agentHostManagedSettingsService.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import {
 	buildOtlpLogsChannelUri,
@@ -368,6 +369,7 @@ export class ProtocolServerHandler extends Disposable {
 		private readonly _clientFileSystemProvider: AHPFileSystemProvider,
 		@ILogService private readonly _logService: ILogService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@IAgentHostManagedSettingsService private readonly _managedSettingsService: IAgentHostManagedSettingsService,
 	) {
 		super();
 		this._telemetryReporter = new AgentHostTelemetryReporter(telemetryService);
@@ -478,7 +480,7 @@ export class ProtocolServerHandler extends Disposable {
 					if (client) {
 						const permissions = ((msg as { params?: { permissions?: unknown } }).params)?.permissions;
 						if (isManagedSettingsPermissions(permissions)) {
-							void this._agentService.setClientManagedSettingsPermissions(client.clientId, permissions);
+							this._managedSettingsService.setClientPermissions(client.clientId, permissions);
 						} else {
 							this._logService.warn('[ProtocolServer] Ignoring invalid managed settings permissions contribution.');
 						}
@@ -920,7 +922,7 @@ export class ProtocolServerHandler extends Disposable {
 		if (record?.state === 'grace') {
 			record.disconnectTimeouts.set('managed-settings', disposableTimeout(() => {
 				record.disconnectTimeouts.deleteAndDispose('managed-settings');
-				this._agentService.removeClientManagedSettingsPermissions(clientId);
+				this._managedSettingsService.removeClientPermissions(clientId);
 			}, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT));
 		}
 		for (const session of this._stateManager.getSessionUris()) {

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -10,6 +10,7 @@ import { Disposable, DisposableMap, DisposableStore } from '../../../base/common
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
+import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AHPFileSystemProvider } from '../common/agentHostFileSystemProvider.js';
@@ -355,6 +356,7 @@ export class ProtocolServerHandler extends Disposable {
 	private readonly _replayBuffer: ActionEnvelope[] = [];
 	private readonly _telemetryReporter: AgentHostTelemetryReporter;
 	private readonly _connectionTelemetryTracker: AgentHostClientConnectionTelemetryTracker;
+	private readonly _managedSettingsOwnerId = generateUuid();
 
 	private readonly _onDidChangeConnectionCount = this._register(new Emitter<number>());
 
@@ -480,7 +482,7 @@ export class ProtocolServerHandler extends Disposable {
 					if (client) {
 						const permissions = ((msg as { params?: { permissions?: unknown } }).params)?.permissions;
 						if (isManagedSettingsPermissions(permissions)) {
-							this._managedSettingsService.setClientPermissions(client.clientId, permissions);
+							this._managedSettingsService.setClientPermissions(this._managedSettingsContributionId(client.clientId), permissions);
 						} else {
 							this._logService.warn('[ProtocolServer] Ignoring invalid managed settings permissions contribution.');
 						}
@@ -922,7 +924,7 @@ export class ProtocolServerHandler extends Disposable {
 		if (record?.state === 'grace') {
 			record.disconnectTimeouts.set('managed-settings', disposableTimeout(() => {
 				record.disconnectTimeouts.deleteAndDispose('managed-settings');
-				this._managedSettingsService.removeClientPermissions(clientId);
+				this._managedSettingsService.removeClientPermissions(this._managedSettingsContributionId(clientId));
 			}, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT));
 		}
 		for (const session of this._stateManager.getSessionUris()) {
@@ -1775,9 +1777,13 @@ export class ProtocolServerHandler extends Disposable {
 		}
 	}
 
+	private _managedSettingsContributionId(clientId: string): string {
+		return `${this._managedSettingsOwnerId}:${clientId}`;
+	}
+
 	override dispose(): void {
 		for (const [clientId, record] of this._clients) {
-			this._managedSettingsService.removeClientPermissions(clientId);
+			this._managedSettingsService.removeClientPermissions(this._managedSettingsContributionId(clientId));
 			if (record.state === 'active') {
 				for (const connection of [...record.connections]) {
 					const subscriptionCount = connection.subscriptions.size;

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -15,6 +15,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AHPFileSystemProvider } from '../common/agentHostFileSystemProvider.js';
 import { getAgentHostClientType } from '../common/agentHostClientInfo.js';
 import { AgentHostClientConnectionKind, AgentHostLaunchKind, AgentHostTransportKind, readClientConnectionKind, type IAgentHostClientTelemetryContext } from '../common/agentHostTelemetry.js';
+import { isManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
 import { AgentSession, type IAgentCreateChatOptions, type IAgentService, type IMcpNotification } from '../common/agentService.js';
 import { isActionEnvelopeRelevantToSubscriptionUris } from '../common/state/agentSubscription.js';
 import { ChatSourceKind } from '../common/state/protocol/channels-chat/commands.js';
@@ -473,6 +474,17 @@ export class ProtocolServerHandler extends Disposable {
 				this._handleRequest(client, msg.method, msg.params, msg.id);
 			} else if (isJsonRpcNotification(msg)) {
 				this._logService.trace(`[ProtocolServer] notification: method=${msg.method}`);
+				if ((msg as { method: string }).method === 'setClientManagedSettingsPermissions') {
+					if (client && this._config.allowExtensionMethods !== false) {
+						const permissions = ((msg as { params?: { permissions?: unknown } }).params)?.permissions;
+						if (isManagedSettingsPermissions(permissions)) {
+							void this._agentService.setClientManagedSettingsPermissions(client.clientId, permissions);
+						} else {
+							this._logService.warn('[ProtocolServer] Ignoring invalid managed settings permissions contribution.');
+						}
+					}
+					return;
+				}
 				// Notification — fire-and-forget
 				switch (msg.method) {
 					case 'unsubscribe':
@@ -904,6 +916,13 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	private _handleClientDisconnected(clientId: string): void {
+		const record = this._clients.get(clientId);
+		if (record?.state === 'grace') {
+			record.disconnectTimeouts.set('managed-settings', disposableTimeout(() => {
+				record.disconnectTimeouts.deleteAndDispose('managed-settings');
+				this._agentService.removeClientManagedSettingsPermissions(clientId);
+			}, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT));
+		}
 		for (const session of this._stateManager.getSessionUris()) {
 			const state = this._stateManager.getSessionState(session);
 			const isActive = state ? this._isActiveClient(state, clientId) : false;

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -475,7 +475,7 @@ export class ProtocolServerHandler extends Disposable {
 			} else if (isJsonRpcNotification(msg)) {
 				this._logService.trace(`[ProtocolServer] notification: method=${msg.method}`);
 				if ((msg as { method: string }).method === 'setClientManagedSettingsPermissions') {
-					if (client && this._config.allowExtensionMethods !== false) {
+					if (client) {
 						const permissions = ((msg as { params?: { permissions?: unknown } }).params)?.permissions;
 						if (isManagedSettingsPermissions(permissions)) {
 							void this._agentService.setClientManagedSettingsPermissions(client.clientId, permissions);

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -1776,7 +1776,8 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	override dispose(): void {
-		for (const record of this._clients.values()) {
+		for (const [clientId, record] of this._clients) {
+			this._managedSettingsService.removeClientPermissions(clientId);
 			if (record.state === 'active') {
 				for (const connection of [...record.connections]) {
 					const subscriptionCount = connection.subscriptions.size;

--- a/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
@@ -8,7 +8,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { IConfigurationService, IConfigurationValue } from '../../../configuration/common/configuration.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../../registry/common/platform.js';
-import { getAgentHostConfigurationSyncEntries, getGlobalConfigurationValue, resolveAgentHostConfigurationSyncPatch } from '../../common/agentHostConfigurationSync.js';
+import { getAgentHostConfigurationSyncEntries, getExplicitGlobalConfigurationValue, getGlobalConfigurationValue, resolveAgentHostConfigurationSyncPatch } from '../../common/agentHostConfigurationSync.js';
 
 const ALL_HOSTS_SETTING = 'test.agentHostSync.allHosts';
 const LOCAL_ONLY_SETTING = 'test.agentHostSync.localOnly';
@@ -92,6 +92,24 @@ suite('AgentHostConfigurationSync', () => {
 			getGlobalConfigurationValue(applicationWins, ALL_HOSTS_SETTING),
 			getGlobalConfigurationValue(defaultWins, ALL_HOSTS_SETTING),
 		], [false, false, false, true]);
+	});
+
+	test('resolves only explicit global layers when requested', () => {
+		const policyWins = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: true, userValue: true, policyValue: false, workspaceValue: true },
+		});
+		const malformedUserFallsBack = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, applicationValue: false, userValue: 'yes' as unknown as boolean },
+		});
+		const defaultOnly = createConfigurationService({
+			[ALL_HOSTS_SETTING]: { defaultValue: true, workspaceValue: false, workspaceFolderValue: false },
+		});
+
+		assert.deepStrictEqual([
+			getExplicitGlobalConfigurationValue(policyWins, ALL_HOSTS_SETTING),
+			getExplicitGlobalConfigurationValue(malformedUserFallsBack, ALL_HOSTS_SETTING),
+			getExplicitGlobalConfigurationValue(defaultOnly, ALL_HOSTS_SETTING),
+		], [false, false, undefined]);
 	});
 
 	test('builds a patch applying transforms, including for hidden settings', () => {

--- a/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import type { IConfigurationService, IConfigurationValue } from '../../../configuration/common/configuration.js';
+import { AgentHostMapLegacySettingsToManagedSettingsSettingId, resolveManagedSettingsPermissions } from '../../common/agentHostManagedSettings.js';
+import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from '../../common/agentHostSchema.js';
+
+function createConfigurationService(values: Record<string, IConfigurationValue<unknown>>): IConfigurationService {
+	return {
+		inspect: <T>(key: string) => (values[key] ?? {}) as IConfigurationValue<T>,
+	} as IConfigurationService;
+}
+
+suite('AgentHostManagedSettings', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('combines restrictive contributions from explicitly configured global values', () => {
+		const configurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, userValue: true },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, applicationValue: false },
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: { defaultValue: true, userValue: false },
+		});
+
+		assert.deepStrictEqual(resolveManagedSettingsPermissions(configurationService), {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		});
+	});
+
+	test('respects global precedence and ignores defaults and workspace values', () => {
+		const configurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, userValue: true },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, userValue: false, policyValue: true },
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: { defaultValue: false, workspaceValue: false, workspaceFolderValue: false },
+		});
+
+		assert.deepStrictEqual(resolveManagedSettingsPermissions(configurationService), {});
+	});
+
+	test('does not map legacy settings while the compatibility bridge is disabled', () => {
+		const configurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, userValue: false },
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: { defaultValue: true, userValue: false },
+		});
+
+		assert.deepStrictEqual(resolveManagedSettingsPermissions(configurationService), {});
+	});
+
+	test('returns an empty contribution after explicit restrictions are removed', () => {
+		const configurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, applicationValue: true },
+		});
+
+		assert.deepStrictEqual(resolveManagedSettingsPermissions(configurationService), {});
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1742,9 +1742,13 @@ suite('RemoteAgentHostProtocolClient', () => {
 		test('falls back to initialize with client info when the server forgot the client', async function () {
 			this.timeout(10_000);
 			const { client, transports } = createFactoryClient(createPermissionService(), agentsWindowAgentHostClientInfo);
+			let connectedRequest = Disposable.None;
 			try {
 				const connectPromise = client.connect();
 				await completeHandshake(transports[0], connectPromise);
+				connectedRequest = Event.once(Event.filter(client.onDidChangeConnectionState, state => state === AgentHostClientState.Connected))(() => {
+					void client.listSessions().catch(() => { });
+				});
 
 				transports[0].fireClose();
 				await waitForReconnecting(client);
@@ -1765,8 +1769,12 @@ suite('RemoteAgentHostProtocolClient', () => {
 					result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
 				});
 				await flushMicrotasks();
+				const managedSettingsIndex = reconnectTransport.sentMessages.findIndex(message => hasKey(message, { method: true }) && message.method === 'setClientManagedSettingsPermissions');
+				const listSessionsIndex = reconnectTransport.sentMessages.findIndex(message => hasKey(message, { method: true }) && message.method === 'listSessions');
 				assert.strictEqual(client.connectionState, AgentHostClientState.Connected);
+				assert.ok(managedSettingsIndex >= 0 && managedSettingsIndex < listSessionsIndex, 'managed settings must be sent before requests triggered by the connected transition');
 			} finally {
+				connectedRequest.dispose();
 				client.dispose();
 			}
 		});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -30,7 +30,8 @@ import { CustomizationType, MessageAttachmentKind, MessageKind, PendingMessageKi
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostDisableRepoInfoTelemetryConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
+import { AgentHostMapLegacySettingsToManagedSettingsSettingId } from '../../common/agentHostManagedSettings.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../../registry/common/platform.js';
 
@@ -104,6 +105,12 @@ function getRootConfig(notification: JsonRpcNotification): Record<string, RootCo
 
 function findLastRootConfigNotification(messages: readonly ProtocolTransportMessage[], configKey: string): JsonRpcNotification {
 	return findRootConfigNotification([...messages].reverse(), configKey);
+}
+
+function findLastManagedSettingsNotification(messages: readonly ProtocolTransportMessage[]): ProtocolTransportMessage {
+	const match = [...messages].reverse().find(message => hasKey(message, { method: true }) && message.method === 'setClientManagedSettingsPermissions');
+	assert.ok(match, 'Expected a setClientManagedSettingsPermissions notification');
+	return match;
 }
 
 /** The value forwarded for `configKey` in the first root-config notification carrying it. */
@@ -951,6 +958,47 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 		const enabled = findLastRootConfigNotification(transport.sentMessages, AgentHostDisableRepoInfoTelemetryConfigKey);
 		assert.deepStrictEqual(getRootConfig(enabled), { [AgentHostDisableRepoInfoTelemetryConfigKey]: false });
+	});
+
+	test('forwards and clears legacy managed permissions for the local host', async () => {
+		const configurationService = new TestConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: true,
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: false,
+			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: false,
+		});
+		const { client, transport } = createClientForIdentity(
+			LOCAL_AGENT_HOST_RESOURCE_IDENTITY,
+			disposables.add(new TestProtocolTransport()),
+			createPermissionService(),
+			undefined,
+			new NullLogService(),
+			configurationService,
+		);
+
+		await connectClient(client, transport);
+
+		assert.deepStrictEqual(findLastManagedSettingsNotification(transport.sentMessages), {
+			jsonrpc: '2.0',
+			method: 'setClientManagedSettingsPermissions',
+			params: {
+				permissions: {
+					disableBypassPermissionsMode: 'disable',
+					ask: ['Shell'],
+				},
+			},
+		});
+
+		transport.sentMessages.length = 0;
+		await configurationService.setUserConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID, true);
+		fireConfigurationChange(configurationService, GLOBAL_AUTO_APPROVE_SETTING_ID);
+		await configurationService.setUserConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, true);
+		fireConfigurationChange(configurationService, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID);
+
+		assert.deepStrictEqual(findLastManagedSettingsNotification(transport.sentMessages), {
+			jsonrpc: '2.0',
+			method: 'setClientManagedSettingsPermissions',
+			params: { permissions: {} },
+		});
 	});
 
 	test('forwards terminal auto-approve rules on connect', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1834,6 +1834,12 @@ suite('RemoteAgentHostProtocolClient', () => {
 			});
 
 			const restoredAuthenticate = await waitForRequestAt(reconnectTransport, 'authenticate', 0);
+			const managedSettings = reconnectTransport.sentMessages.find(message => hasKey(message, { method: true }) && message.method === 'setClientManagedSettingsPermissions');
+			assert.ok(managedSettings, 'managed settings should be restored after fresh initialization');
+			assert.ok(
+				reconnectTransport.sentMessages.indexOf(managedSettings) < reconnectTransport.sentMessages.indexOf(restoredAuthenticate),
+				'managed settings should be restored before authentication and subscriptions',
+			);
 			reconnectTransport.fireMessage({ jsonrpc: '2.0', id: restoredAuthenticate.id, result: {} });
 			const restoredSessionSubscribe = await waitForRequestAt(reconnectTransport, 'subscribe', 0);
 			assert.strictEqual((restoredSessionSubscribe.params as { channel: string }).channel, sessionUri.toString());

--- a/src/vs/platform/agentHost/test/node/agentHostManagedSettingsService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostManagedSettingsService.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { AgentHostManagedSettingsService } from '../../node/agentHostManagedSettingsService.js';
+
+suite('AgentHostManagedSettingsService', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('aggregates restrictive client contributions and removes them by owner', () => {
+		const service = store.add(new AgentHostManagedSettingsService());
+
+		service.setClientPermissions('client-1', { disableBypassPermissionsMode: 'disable' });
+		service.setClientPermissions('client-2', { ask: ['Shell'], deny: ['Write(**)'] });
+		const combined = service.permissions;
+		service.removeClientPermissions('client-1');
+		const afterFirstRemoval = service.permissions;
+		service.removeClientPermissions('client-2');
+
+		assert.deepStrictEqual({
+			combined,
+			afterFirstRemoval,
+			afterAllRemoved: service.permissions,
+		}, {
+			combined: {
+				disableBypassPermissionsMode: 'disable',
+				ask: ['Shell'],
+				deny: ['Write(**)'],
+			},
+			afterFirstRemoval: {
+				ask: ['Shell'],
+				deny: ['Write(**)'],
+			},
+			afterAllRemoved: {},
+		});
+	});
+
+	test('only fires when the effective aggregate changes', () => {
+		const service = store.add(new AgentHostManagedSettingsService());
+		let changes = 0;
+		store.add(service.onDidChange(() => changes++));
+
+		service.setClientPermissions('client-1', { ask: ['Shell'] });
+		service.setClientPermissions('client-2', { ask: ['Shell'] });
+		service.removeClientPermissions('client-1');
+		service.removeClientPermissions('client-2');
+
+		assert.strictEqual(changes, 2);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -44,6 +44,7 @@ import { CustomizationType, SessionStatus, ToolCallContributorKind, type AgentSe
 import { ActionType, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
 
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { AgentHostManagedSettingsService, IAgentHostManagedSettingsService } from '../../node/agentHostManagedSettingsService.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { IAgentHostGitService, type IBranch, type IDefaultBranch } from '../../common/agentHostGitService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
@@ -540,6 +541,7 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@ISessionDataService sessionDataService: ISessionDataService,
 		@IAgentHostGitService gitService: IAgentHostGitService,
 		@IAgentConfigurationService configurationService: IAgentConfigurationService,
+		@IAgentHostManagedSettingsService managedSettingsService: IAgentHostManagedSettingsService,
 		@IAgentHostStateManager stateManager: AgentHostStateManager,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
@@ -548,7 +550,7 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, stateManager, createTestGitHubEndpointService(), new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, managedSettingsService, stateManager, createTestGitHubEndpointService(), new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
 	}
 
 	protected override _createCopilotClient(): CopilotClient {
@@ -572,6 +574,7 @@ class TestableCopilotAgent extends CopilotAgent {
 		@ISessionDataService sessionDataService: ISessionDataService,
 		@IAgentHostGitService gitService: IAgentHostGitService,
 		@IAgentConfigurationService configurationService: IAgentConfigurationService,
+		@IAgentHostManagedSettingsService managedSettingsService: IAgentHostManagedSettingsService,
 		@IAgentHostStateManager stateManager: AgentHostStateManager,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
@@ -580,7 +583,7 @@ class TestableCopilotAgent extends CopilotAgent {
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, stateManager, createTestGitHubEndpointService(), new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, managedSettingsService, stateManager, createTestGitHubEndpointService(), new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
 	}
 
 	protected override _createCopilotClient(options: CopilotClientOptions): CopilotClient {
@@ -631,15 +634,17 @@ function getCreatedClientOptions(agent: CopilotAgent): readonly CopilotClientOpt
 	return agent.createdClientOptions;
 }
 
-function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; useRealResumePath?: boolean; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager; fileService?: FileService; copilotApiService?: ICopilotApiService; gitHubEndpointService?: IAgentHostGitHubEndpointService; telemetryService?: ITelemetryService; userHome?: URI; logService?: ILogService; proxyResolver?: IAgentHostProxyResolver; byokBridgeRegistry?: IByokLmBridgeRegistry }): { agent: CopilotAgent; instantiationService: IInstantiationService; configurationService: IAgentConfigurationService; fileService: FileService; stateManager: AgentHostStateManager } {
+function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; useRealResumePath?: boolean; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager; fileService?: FileService; copilotApiService?: ICopilotApiService; gitHubEndpointService?: IAgentHostGitHubEndpointService; telemetryService?: ITelemetryService; userHome?: URI; logService?: ILogService; proxyResolver?: IAgentHostProxyResolver; byokBridgeRegistry?: IByokLmBridgeRegistry }): { agent: CopilotAgent; instantiationService: IInstantiationService; configurationService: IAgentConfigurationService; managedSettingsService: IAgentHostManagedSettingsService; fileService: FileService; stateManager: AgentHostStateManager } {
 	const services = new ServiceCollection();
 	const logService = options?.logService ?? new NullLogService();
 	const fileService = options?.fileService ?? disposables.add(new FileService(logService));
 	const stateManager = disposables.add(new AgentHostStateManager(logService));
 	const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
+	const managedSettingsService = disposables.add(new AgentHostManagedSettingsService());
 	services.set(ILogService, logService);
 	services.set(IFileService, fileService);
 	services.set(IAgentConfigurationService, configService);
+	services.set(IAgentHostManagedSettingsService, managedSettingsService);
 	services.set(IAgentHostStateManager, stateManager);
 	services.set(IAgentHostGitHubEndpointService, options?.gitHubEndpointService ?? createTestGitHubEndpointService());
 	services.set(ISessionDataService, options?.sessionDataService ?? createNullSessionDataService());
@@ -678,7 +683,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 	const agent = options?.copilotClient
 		? instantiationService.createInstance(options.useRealResumePath ? ResumePathCopilotAgent : TestableCopilotAgent, options.copilotClient)
 		: instantiationService.createInstance(CopilotAgent);
-	return { agent, instantiationService, configurationService: configService, fileService, stateManager };
+	return { agent, instantiationService, configurationService: configService, managedSettingsService, fileService, stateManager };
 }
 
 function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; useRealResumePath?: boolean; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager; fileService?: FileService; copilotApiService?: ICopilotApiService; gitHubEndpointService?: IAgentHostGitHubEndpointService; telemetryService?: ITelemetryService; userHome?: URI; logService?: ILogService; byokBridgeRegistry?: IByokLmBridgeRegistry }): CopilotAgent {
@@ -2167,6 +2172,28 @@ suite('CopilotAgent', () => {
 					stopCount: 1,
 					logLevel: 'all',
 				});
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('restarts sessions when managed permission contributions change or are removed', async () => {
+			const client = new StopCountingClient([]);
+			const { agent, managedSettingsService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await agent.listSessions();
+
+				const restricted = { disableBypassPermissionsMode: 'disable' as const };
+				managedSettingsService.setClientPermissions('client', restricted);
+				await Promise.resolve();
+				await agent.listSessions();
+				managedSettingsService.setClientPermissions('client', restricted);
+				await Promise.resolve();
+				managedSettingsService.removeClientPermissions('client');
+				await Promise.resolve();
+
+				assert.strictEqual(client.stopCount, 2);
 			} finally {
 				await disposeAgent(agent);
 			}

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import type { CopilotClient, CopilotSession, Verbosity } from '@github/copilot-sdk';
+import type { CopilotClient, CopilotSession, ManagedSettingsPermissions, Verbosity } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -18,6 +18,7 @@ import type { IByokLmBridgeConnection, IByokLmChatRequest, IByokLmChatResult, IB
 import { CustomizationType, type ModelSelection } from '../../common/state/protocol/state.js';
 import { reasoningEffortLevels } from '../../common/reasoningEffort.js';
 import type { IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import type { IAgentHostManagedSettingsService } from '../../node/agentHostManagedSettingsService.js';
 import type { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
 import { ActiveClientToolSet } from '../../node/activeClientState.js';
 import type { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
@@ -41,12 +42,13 @@ const testRuntime: ICopilotSessionRuntime = {
 
 const testWorkingDirectory = URI.file(process.cwd());
 
-function createTestLauncher(): CopilotSessionLauncher {
+function createTestLauncher(managedSettingsPermissions?: ManagedSettingsPermissions): CopilotSessionLauncher {
 	const configurationService = {
 		getRootValue: () => undefined,
 	} as Partial<IAgentConfigurationService> as IAgentConfigurationService;
 	return new CopilotSessionLauncher(
 		configurationService,
+		{ permissions: managedSettingsPermissions ?? {} } as IAgentHostManagedSettingsService,
 		{} as IAgentHostTerminalManager,
 		new NullLogService(),
 		{} as IFileService,
@@ -322,7 +324,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('passes Agent Host defaults and exit-plan handler to create and resume', async () => {
+	test('passes Agent Host defaults, managed permissions, and exit-plan handler to create and resume', async () => {
 		const createConfigs: Parameters<CopilotClient['createSession']>[0][] = [];
 		const resumeConfigs: Parameters<CopilotClient['resumeSession']>[1][] = [];
 		const session = {
@@ -340,7 +342,11 @@ suite('CopilotSessionLauncher shared session config', () => {
 				return session;
 			},
 		};
-		const launcher = createTestLauncher();
+		const managedSettingsPermissions: ManagedSettingsPermissions = {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		};
+		const launcher = createTestLauncher(managedSettingsPermissions);
 		const pluginDir = URI.file('/tmp/synced-customizations');
 		const skillUri = URI.joinPath(pluginDir, 'skills', 'user-skill', 'SKILL.md');
 		const instructionUri = URI.joinPath(pluginDir, 'rules', 'user.instructions.md');
@@ -395,6 +401,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 				createInstructionDirectories: createConfigs[0].instructionDirectories,
 				createHasExitPlanHandler: typeof createConfigs[0].onExitPlanModeRequest === 'function',
 				createLargeOutput: createConfigs[0].largeOutput,
+				createManagedSettings: createConfigs[0].managedSettings,
 				resumeClientName: resumeConfigs[0].clientName,
 				resumeGitHubMcpToolConfig: resumeConfigs[0].githubMcpToolConfig,
 				resumePluginDirectories: resumeConfigs[0].pluginDirectories,
@@ -402,6 +409,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 				resumeInstructionDirectories: resumeConfigs[0].instructionDirectories,
 				resumeHasExitPlanHandler: typeof resumeConfigs[0].onExitPlanModeRequest === 'function',
 				resumeLargeOutput: resumeConfigs[0].largeOutput,
+				resumeManagedSettings: resumeConfigs[0].managedSettings,
 			}, {
 				createClientName: 'vscode-agent-host',
 				createGitHubMcpToolConfig: { disableFormDeferral: true },
@@ -410,6 +418,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 				createInstructionDirectories: [URI.joinPath(pluginDir, 'rules').fsPath],
 				createHasExitPlanHandler: true,
 				createLargeOutput: { maxSizeBytes: 8192 },
+				createManagedSettings: { permissions: managedSettingsPermissions },
 				resumeClientName: 'vscode-agent-host',
 				resumeGitHubMcpToolConfig: { disableFormDeferral: true },
 				resumePluginDirectories: [pluginDir.fsPath],
@@ -417,6 +426,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 				resumeInstructionDirectories: [URI.joinPath(pluginDir, 'rules').fsPath],
 				resumeHasExitPlanHandler: true,
 				resumeLargeOutput: { maxSizeBytes: 8192 },
+				resumeManagedSettings: { permissions: managedSettingsPermissions },
 			});
 		} finally {
 			sessions.dispose();

--- a/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSessionLauncher.test.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import type { CopilotClient, CopilotSession, ManagedSettingsPermissions, Verbosity } from '@github/copilot-sdk';
+import type { CopilotClient, CopilotSession, Verbosity } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { PluginFormat } from '../../../agentPlugins/common/pluginParsers.js';
+import type { IAgentHostManagedSettingsPermissions } from '../../common/agentHostManagedSettings.js';
 import type { IFileService } from '../../../files/common/files.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
@@ -42,7 +43,7 @@ const testRuntime: ICopilotSessionRuntime = {
 
 const testWorkingDirectory = URI.file(process.cwd());
 
-function createTestLauncher(managedSettingsPermissions?: ManagedSettingsPermissions): CopilotSessionLauncher {
+function createTestLauncher(managedSettingsPermissions?: IAgentHostManagedSettingsPermissions): CopilotSessionLauncher {
 	const configurationService = {
 		getRootValue: () => undefined,
 	} as Partial<IAgentConfigurationService> as IAgentConfigurationService;
@@ -342,7 +343,7 @@ suite('CopilotSessionLauncher shared session config', () => {
 				return session;
 			},
 		};
-		const managedSettingsPermissions: ManagedSettingsPermissions = {
+		const managedSettingsPermissions: IAgentHostManagedSettingsPermissions = {
 			disableBypassPermissionsMode: 'disable',
 			ask: ['Shell'],
 		};

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -526,7 +526,7 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
-	test('extension methods can be disabled', () => {
+	test('extension methods can be disabled without blocking managed settings contributions', () => {
 		const localDisposables = disposables.add(new DisposableStore());
 		const localServer = localDisposables.add(new MockProtocolServer());
 		localDisposables.add(new ProtocolServerHandler(
@@ -549,13 +549,18 @@ suite('ProtocolServerHandler', () => {
 		}));
 		transport.sent.length = 0;
 		transport.simulateMessage(request(2, 'shutdown', {}));
+		transport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { disableBypassPermissionsMode: 'disable', ask: ['Shell'] },
+		}));
 
 		assert.deepStrictEqual({
 			response: findResponse(transport.sent, 2),
 			shutdownCalls: agentService.shutdownCalls,
+			managedSettingsPermissions: agentService.managedSettingsPermissionsByClient.get('client-extension-disabled'),
 		}, {
 			response: { jsonrpc: '2.0', id: 2, error: { code: JsonRpcErrorCodes.MethodNotFound, message: 'Method not found: shutdown' } },
 			shutdownCalls: 0,
+			managedSettingsPermissions: { disableBypassPermissionsMode: 'disable', ask: ['Shell'] },
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -2483,6 +2483,45 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
+	test('scopes managed settings contributions to each protocol handler', () => {
+		const firstTransport = connectClient('shared-client-id');
+		firstTransport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { ask: ['Shell'] },
+		}));
+
+		const localDisposables = disposables.add(new DisposableStore());
+		const secondServer = localDisposables.add(new MockProtocolServer());
+		const secondHandler = localDisposables.add(new ProtocolServerHandler(
+			agentService,
+			stateManager,
+			secondServer,
+			{ defaultDirectory: URI.file('/home/testuser').toString() },
+			localDisposables.add(new AgentHostFileSystemProvider()),
+			logService,
+			NullTelemetryService,
+			managedSettingsService,
+		));
+		const secondTransport = new MockProtocolTransport();
+		secondServer.simulateConnection(secondTransport);
+		secondTransport.simulateMessage(request(1, 'initialize', {
+			protocolVersions: [PROTOCOL_VERSION],
+			clientId: 'shared-client-id',
+		}));
+		secondTransport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { disableBypassPermissionsMode: 'disable' },
+		}));
+
+		assert.deepStrictEqual(managedSettingsService.permissions, {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		});
+
+		secondTransport.simulateClose();
+		secondHandler.dispose();
+
+		assert.deepStrictEqual(managedSettingsService.permissions, { ask: ['Shell'] });
+	});
+
 	test('removes managed settings contributions for active and grace clients on dispose', () => {
 		const activeTransport = connectClient('client-managed-settings-active');
 		activeTransport.simulateMessage(notification('setClientManagedSettingsPermissions', {

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -2483,6 +2483,27 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
+	test('removes managed settings contributions for active and grace clients on dispose', () => {
+		const activeTransport = connectClient('client-managed-settings-active');
+		activeTransport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { ask: ['Shell'] },
+		}));
+		const graceTransport = connectClient('client-managed-settings-grace');
+		graceTransport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { disableBypassPermissionsMode: 'disable' },
+		}));
+		graceTransport.simulateClose();
+
+		assert.deepStrictEqual(managedSettingsService.permissions, {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		});
+
+		handler.dispose();
+
+		assert.deepStrictEqual(managedSettingsService.permissions, {});
+	});
+
 	test('removes a managed settings contribution after disconnect grace expires', () => {
 		return runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const transport = connectClient('client-managed-settings-disconnect');

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -31,6 +30,7 @@ import { AgentHostClientConnectionKind, AgentHostLaunchKind, AgentHostTransportK
 import { iterateOtlpLogRecords, OtlpLogEmitter } from '../../common/otlp/otlpLogEmitter.js';
 import { MessagePortProtocolServer } from '../../node/messagePortProtocolServer.js';
 import { AgentHostClientConnectionTelemetryTracker } from '../../node/agentHostClientConnectionTelemetry.js';
+import { AgentHostManagedSettingsService } from '../../node/agentHostManagedSettingsService.js';
 
 // ---- Mock helpers -----------------------------------------------------------
 
@@ -127,7 +127,6 @@ class MockAgentService implements IAgentService {
 	readonly listedSessions: IAgentSessionMetadata[] = [];
 	readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
 	managedSettingsDiagnostics: readonly IAgentHostManagedSettingsDiagnostics[] = [];
-	readonly managedSettingsPermissionsByClient = new Map<string, ManagedSettingsPermissions>();
 	shutdownCalls = 0;
 
 	private readonly _onDidAction = new Emitter<import('../../common/state/sessionActions.js').ActionEnvelope>();
@@ -195,12 +194,6 @@ class MockAgentService implements IAgentService {
 	async shutdown(): Promise<void> { this.shutdownCalls++; }
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> { return { version: 'test', os: 'test', arch: 'test', proxySettings: {}, proxyEnv: {}, endpoints: [] }; }
 	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> { return this.managedSettingsDiagnostics; }
-	async setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void> {
-		this.managedSettingsPermissionsByClient.set(clientId, permissions);
-	}
-	removeClientManagedSettingsPermissions(clientId: string): void {
-		this.managedSettingsPermissionsByClient.delete(clientId);
-	}
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> { return { url }; }
 	async authenticate(_params: AuthenticateParams): Promise<AuthenticateResult> { return { authenticated: true }; }
 	getAuthToken(): string | undefined { return undefined; }
@@ -287,6 +280,7 @@ suite('ProtocolServerHandler', () => {
 	let stateManager: AgentHostStateManager;
 	let server: MockProtocolServer;
 	let agentService: MockAgentService;
+	let managedSettingsService: AgentHostManagedSettingsService;
 	let handler: ProtocolServerHandler;
 	let fileSystemProvider: AgentHostFileSystemProvider;
 	let logService: CountingLogService;
@@ -326,6 +320,7 @@ suite('ProtocolServerHandler', () => {
 		server = disposables.add(new MockProtocolServer());
 		agentService = new MockAgentService();
 		agentService.setStateManager(stateManager);
+		managedSettingsService = disposables.add(new AgentHostManagedSettingsService());
 		logService = new CountingLogService();
 		telemetryService = new TestTelemetryService();
 		disposables.add(agentService);
@@ -337,6 +332,7 @@ suite('ProtocolServerHandler', () => {
 			disposables.add(fileSystemProvider = new AgentHostFileSystemProvider()),
 			logService,
 			telemetryService,
+			managedSettingsService,
 		));
 	});
 
@@ -540,6 +536,7 @@ suite('ProtocolServerHandler', () => {
 			localDisposables.add(new AgentHostFileSystemProvider()),
 			logService,
 			NullTelemetryService,
+			managedSettingsService,
 		));
 		const transport = new MockProtocolTransport();
 		localServer.simulateConnection(transport);
@@ -556,7 +553,7 @@ suite('ProtocolServerHandler', () => {
 		assert.deepStrictEqual({
 			response: findResponse(transport.sent, 2),
 			shutdownCalls: agentService.shutdownCalls,
-			managedSettingsPermissions: agentService.managedSettingsPermissionsByClient.get('client-extension-disabled'),
+			managedSettingsPermissions: managedSettingsService.permissions,
 		}, {
 			response: { jsonrpc: '2.0', id: 2, error: { code: JsonRpcErrorCodes.MethodNotFound, message: 'Method not found: shutdown' } },
 			shutdownCalls: 0,
@@ -1298,6 +1295,7 @@ suite('ProtocolServerHandler', () => {
 				localDisposables.add(new AgentHostFileSystemProvider()),
 				logService,
 				telemetryService,
+				managedSettingsService,
 			)));
 		}
 
@@ -1357,6 +1355,7 @@ suite('ProtocolServerHandler', () => {
 			localDisposables.add(new FailingAgentHostFileSystemProvider()),
 			logService,
 			localTelemetry,
+			managedSettingsService,
 		));
 		const counts: number[] = [];
 		localDisposables.add(localHandler.onDidChangeConnectionCount(count => counts.push(count)));
@@ -1393,6 +1392,7 @@ suite('ProtocolServerHandler', () => {
 			localDisposables.add(new FailingReconnectAgentHostFileSystemProvider()),
 			logService,
 			localTelemetry,
+			managedSettingsService,
 		));
 		const counts: number[] = [];
 		localDisposables.add(localHandler.onDidChangeConnectionCount(count => counts.push(count)));
@@ -2477,7 +2477,7 @@ suite('ProtocolServerHandler', () => {
 		}));
 		await Promise.resolve();
 
-		assert.deepStrictEqual(agentService.managedSettingsPermissionsByClient.get('client-managed-settings-contribution'), {
+		assert.deepStrictEqual(managedSettingsService.permissions, {
 			disableBypassPermissionsMode: 'disable',
 			ask: ['Shell'],
 		});
@@ -2493,7 +2493,7 @@ suite('ProtocolServerHandler', () => {
 
 			await new Promise(resolve => setTimeout(resolve, 30_001));
 
-			assert.strictEqual(agentService.managedSettingsPermissionsByClient.has('client-managed-settings-disconnect'), false);
+			assert.deepStrictEqual(managedSettingsService.permissions, {});
 		});
 	});
 
@@ -2543,6 +2543,7 @@ suite('ProtocolServerHandler', () => {
 			localDisposables.add(new AgentHostFileSystemProvider()),
 			logService,
 			NullTelemetryService,
+			managedSettingsService,
 		));
 		const counts: number[] = [];
 		localDisposables.add(combinedHandler.onDidChangeConnectionCount(count => counts.push(count)));
@@ -2680,6 +2681,7 @@ suite('ProtocolServerHandler', () => {
 				localDisposables.add(new AgentHostFileSystemProvider()),
 				new NullLogService(),
 				NullTelemetryService,
+				managedSettingsService,
 			));
 		});
 
@@ -2850,6 +2852,7 @@ suite('ProtocolServerHandler', () => {
 				localDisposables.add(new AgentHostFileSystemProvider()),
 				new NullLogService(),
 				NullTelemetryService,
+				managedSettingsService,
 			));
 		});
 

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type { ManagedSettingsPermissions } from '@github/copilot-sdk';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -126,6 +127,7 @@ class MockAgentService implements IAgentService {
 	readonly listedSessions: IAgentSessionMetadata[] = [];
 	readonly createSessionConfigs: (IAgentCreateSessionConfig | undefined)[] = [];
 	managedSettingsDiagnostics: readonly IAgentHostManagedSettingsDiagnostics[] = [];
+	readonly managedSettingsPermissionsByClient = new Map<string, ManagedSettingsPermissions>();
 	shutdownCalls = 0;
 
 	private readonly _onDidAction = new Emitter<import('../../common/state/sessionActions.js').ActionEnvelope>();
@@ -193,6 +195,12 @@ class MockAgentService implements IAgentService {
 	async shutdown(): Promise<void> { this.shutdownCalls++; }
 	async getNetworkDiagnosticsInfo(): Promise<IAgentHostNetworkDiagnosticsInfo> { return { version: 'test', os: 'test', arch: 'test', proxySettings: {}, proxyEnv: {}, endpoints: [] }; }
 	async getManagedSettingsDiagnostics(): Promise<readonly IAgentHostManagedSettingsDiagnostics[]> { return this.managedSettingsDiagnostics; }
+	async setClientManagedSettingsPermissions(clientId: string, permissions: ManagedSettingsPermissions): Promise<void> {
+		this.managedSettingsPermissionsByClient.set(clientId, permissions);
+	}
+	removeClientManagedSettingsPermissions(clientId: string): void {
+		this.managedSettingsPermissionsByClient.delete(clientId);
+	}
 	async diagnosticsFetch(url: string): Promise<IAgentHostNetworkFetchResult> { return { url }; }
 	async authenticate(_params: AuthenticateParams): Promise<AuthenticateResult> { return { authenticated: true }; }
 	getAuthToken(): string | undefined { return undefined; }
@@ -2450,6 +2458,38 @@ suite('ProtocolServerHandler', () => {
 
 		assert.ok(!response.error, `unexpected error: ${response.error?.message}`);
 		assert.deepStrictEqual(response.result, agentService.managedSettingsDiagnostics);
+	});
+
+	test('setClientManagedSettingsPermissions validates and attributes contributions to the connected client', async () => {
+		const transport = connectClient('client-managed-settings-contribution');
+		transport.sent.length = 0;
+
+		transport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { disableBypassPermissionsMode: 'disable', ask: ['Shell'] },
+		}));
+		transport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+			permissions: { allow: ['Shell'] },
+		}));
+		await Promise.resolve();
+
+		assert.deepStrictEqual(agentService.managedSettingsPermissionsByClient.get('client-managed-settings-contribution'), {
+			disableBypassPermissionsMode: 'disable',
+			ask: ['Shell'],
+		});
+	});
+
+	test('removes a managed settings contribution after disconnect grace expires', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const transport = connectClient('client-managed-settings-disconnect');
+			transport.simulateMessage(notification('setClientManagedSettingsPermissions', {
+				permissions: { ask: ['Shell'] },
+			}));
+			transport.simulateClose();
+
+			await new Promise(resolve => setTimeout(resolve, 30_001));
+
+			assert.strictEqual(agentService.managedSettingsPermissionsByClient.has('client-managed-settings-disconnect'), false);
+		});
 	});
 
 	test('extension request preserves ProtocolError code and data', async () => {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -15,6 +15,7 @@ import '../../../../platform/agentHost/common/agentHostStarter.config.contributi
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostAllowSignedOutWhenUsableSettingId, AgentHostSdkSandboxEnabledSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchDeferThresholdSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
 import { AgentHostAutoReplyEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
+import { AgentHostMapLegacySettingsToManagedSettingsSettingId } from '../../../../platform/agentHost/common/agentHostManagedSettings.js';
 import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../platform/localTranscription/common/localTranscription.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
@@ -1527,6 +1528,13 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.agentHost.copilotSdk.logLevel', "Controls the log level for the Copilot SDK runtime used by the local agent host. Changing this setting restarts the Copilot SDK client; active sessions are reloaded when next used."),
 			default: 'info',
 			scope: ConfigurationScope.APPLICATION,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostMapLegacySettingsToManagedSettingsSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.copilot.mapLegacySettingsToManagedSettings', "When enabled, maps supported legacy VS Code settings to equivalent Copilot SDK managed settings for local Agent Host sessions. This compatibility bridge is temporary and is not used for new settings."),
+			default: false,
+			scope: ConfigurationScope.APPLICATION_MACHINE,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOpus48PromptEnabledSettingId]: {


### PR DESCRIPTION
## Summary

Adds a gated compatibility bridge from explicitly configured legacy VS Code settings to Copilot SDK `managedSettings.permissions` for local Agent Host sessions.

The first mappings are:

| VS Code setting | Explicit global value | SDK contribution |
| --- | --- | --- |
| `chat.tools.global.autoApprove` | `false` | `disableBypassPermissionsMode: "disable"` |
| `chat.tools.terminal.enableAutoApprove` | `false` | `ask: ["Shell"]` |

The bridge is controlled by `chat.agentHost.copilot.mapLegacySettingsToManagedSettings`, which is experimental, advanced, application-machine scoped, and defaults to `false`.

## Design

- Uses a declarative, typed mapping table for existing legacy settings only.
- Reads explicit global layers in policy → user → application precedence; ignores registered defaults and workspace/folder values.
- Sends contributions through a typed VS Code AHP extension notification rather than Agent Host root configuration.
- Attributes contributions to the connected client, aggregates them restrictively, and removes them after disconnect grace.
- Sends the contribution before post-reconnect session traffic on a freshly initialized host.
- Supplies the aggregate on Copilot SDK create and resume; changes trigger the existing idle-safe session refresh lifecycle.
- Forwards an empty contribution when disabled or cleared so stale restrictions are removed.

New runtime controls should be added directly to the managed-settings/SDK contract; this bridge is intentionally limited to compatibility with existing VS Code settings.

Reference: https://github.com/github/copilot-sdk-internal/issues/209

## Validation

- `npm run typecheck-client`
- `npm run transpile-client`
- 183 focused Agent Host protocol, bridge, aggregation, launcher, and lifecycle tests
- Repository pre-commit hygiene
- `git diff --check`