### PR TITLE
Handle missing MCP manifest cache

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ConfigurationTarget } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { IFileService } from '../../files/common/files.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IUriIdentityService } from '../../uriIdentity/common/uriIdentity.js';
@@ -597,7 +597,11 @@ export class McpUserResourceManagementService extends AbstractMcpResourceManagem
 				}
 				storedMcpServerInfo.readmeUrl = readmeUrl;
 			} catch (e) {
-				this.logService.error('MCP Management Service: failed to read manifest', location.toString(), e);
+				if (toFileOperationResult(e) === FileOperationResult.FILE_NOT_FOUND) {
+					this.logService.trace('MCP Management Service: manifest not found', manifestLocation.toString());
+				} else {
+					this.logService.error('MCP Management Service: failed to read manifest', location.toString(), e);
+				}
 			}
 		}
 		return storedMcpServerInfo;

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -23,6 +23,14 @@ import { McpResourceScannerService } from '../../common/mcpResourceScannerServic
 import { UriIdentityService } from '../../../uriIdentity/common/uriIdentityService.js';
 import { IEnvironmentService } from '../../../environment/common/environment.js';
 
+class TestLogService extends NullLogService {
+	readonly errors: string[] = [];
+
+	override error(message: string | Error, ...args: unknown[]): void {
+		this.errors.push([message, ...args].join(' '));
+	}
+}
+
 class TestMcpManagementService extends AbstractCommonMcpManagementService {
 
 	override onInstallMcpServer = Event.None;
@@ -1248,6 +1256,41 @@ suite('McpResourceManagementService', () => {
 		const result = await updatePromise;
 
 		assert.strictEqual(result[0].source, gallery);
+	});
+
+	test('missing gallery metadata cache is not logged as an error', async () => {
+		const galleryResource = URI.from({ scheme: Schemas.inMemory, path: '/missing-gallery-metadata-mcp.json' });
+		await fileService.writeFile(galleryResource, VSBuffer.fromString(JSON.stringify({
+			servers: {
+				test: {
+					type: 'stdio',
+					command: 'node',
+					gallery: true,
+					version: '1.0.0'
+				}
+			}
+		}, null, '\t')));
+		const logService = new TestLogService();
+		const galleryService = disposables.add(new McpUserResourceManagementService(
+			galleryResource,
+			upcastPartial<IMcpGalleryService>({}),
+			fileService,
+			uriIdentityService,
+			logService,
+			scannerService,
+			{ _serviceBrand: undefined, onDidChangeAllowedMcpServers: Event.None, isAllowed: () => true, isServerAllowed: () => true },
+			upcastPartial<IEnvironmentService>({ userRoamingDataHome: URI.from({ scheme: Schemas.inMemory, path: '/user' }) }),
+		));
+
+		const installed = await galleryService.getInstalled();
+
+		assert.deepStrictEqual({
+			installed: installed.map(server => ({ name: server.name, version: server.version, location: server.location })),
+			errors: logService.errors,
+		}, {
+			installed: [{ name: 'test', version: '1.0.0', location: undefined }],
+			errors: [],
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #330356

Treat a missing gallery metadata manifest as an expected cache miss. The installed MCP configuration remains usable without the optional local metadata cache, so `FILE_NOT_FOUND` is now traced while malformed manifests and other read failures continue to be logged as errors.

Adds focused coverage for a gallery-backed MCP configuration whose metadata cache is absent.

## Tests

- `scripts\test.bat --run src\vs\platform\mcp\test\common\mcpManagementService.test.ts --grep "McpResourceManagementService"` (6 passing)