### PR TITLE
Fix PWA manifest start URL for server base paths

### DIFF
--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -111,8 +111,13 @@ export async function serveFile(filePath: string, cacheControl: CacheControl, lo
 const APP_ROOT = dirname(FileAccess.asFileUri('').fsPath);
 
 const STATIC_PATH = `/static`;
+const MANIFEST_PATH = `/resources/server/manifest.json`;
 const CALLBACK_PATH = `/callback`;
 const WEB_EXTENSION_PATH = `/web-extension-resource`;
+
+interface IWebManifest {
+	start_url: string;
+}
 
 export class WebClientServer {
 
@@ -140,6 +145,9 @@ export class WebClientServer {
 	 */
 	async handle(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: URL, pathname: string): Promise<void> {
 		try {
+			if (pathname === `${STATIC_PATH}${MANIFEST_PATH}`) {
+				return this._handleManifest(req, res);
+			}
 			if (pathname.startsWith(STATIC_PATH) && pathname.charCodeAt(STATIC_PATH.length) === CharCode.Slash) {
 				return this._handleStatic(req, res, pathname.substring(STATIC_PATH.length));
 			}
@@ -163,6 +171,28 @@ export class WebClientServer {
 			return serveError(req, res, 500, 'Internal Server Error.');
 		}
 	}
+
+	private async _handleManifest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+		const filePath = join(APP_ROOT, MANIFEST_PATH);
+		let manifest: IWebManifest;
+		try {
+			manifest = JSON.parse((await promises.readFile(filePath)).toString());
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+				return serveError(req, res, 404, 'Not found');
+			}
+			throw error;
+		}
+
+		manifest.start_url = posix.join(this._getEffectiveBasePath(req), '/');
+		res.writeHead(200, {
+			'Cache-Control': 'no-store',
+			'Content-Type': 'application/json',
+			'Vary': 'X-Forwarded-Prefix'
+		});
+		return void res.end(JSON.stringify(manifest));
+	}
+
 	/**
 	 * Handle HTTP requests for /static/*
 	 * @param resourcePath The path after /static/
@@ -257,14 +287,8 @@ export class WebClientServer {
 	 * Handle HTTP requests for /
 	 */
 	private async _handleRoot(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: URL): Promise<void> {
-
-		const getFirstHeader = (headerName: string) => {
-			const val = req.headers[headerName];
-			return Array.isArray(val) ? val[0] : val;
-		};
-
 		// Prefix routes with basePath for clients
-		const basePath = getFirstHeader('x-forwarded-prefix') || this._basePath;
+		const basePath = this._getEffectiveBasePath(req);
 
 		const queryConnectionTokens = parsedUrl.searchParams.getAll(connectionTokenQueryName);
 		if (queryConnectionTokens.length === 1) {
@@ -304,12 +328,12 @@ export class WebClientServer {
 		let remoteAuthority = (
 			useTestResolver
 				? 'test+test'
-				: (getFirstHeader('x-original-host') || getFirstHeader('x-forwarded-host') || req.headers.host)
+				: (this._getFirstHeader(req, 'x-original-host') || this._getFirstHeader(req, 'x-forwarded-host') || req.headers.host)
 		);
 		if (!remoteAuthority) {
 			return serveError(req, res, 400, `Bad request.`);
 		}
-		const forwardedPort = getFirstHeader('x-forwarded-port');
+		const forwardedPort = this._getFirstHeader(req, 'x-forwarded-port');
 		if (forwardedPort) {
 			remoteAuthority = replacePort(remoteAuthority, forwardedPort);
 		}
@@ -327,7 +351,7 @@ export class WebClientServer {
 
 		if (this._logService.getLevel() === LogLevel.Trace) {
 			['x-original-host', 'x-forwarded-host', 'x-forwarded-port', 'host'].forEach(header => {
-				const value = getFirstHeader(header);
+				const value = this._getFirstHeader(req, header);
 				if (value) {
 					this._logService.trace(`[WebClientServer] ${header}: ${value}`);
 				}
@@ -466,6 +490,15 @@ export class WebClientServer {
 
 		res.writeHead(200, headers);
 		return void res.end(data);
+	}
+
+	private _getEffectiveBasePath(req: http.IncomingMessage): string {
+		return this._getFirstHeader(req, 'x-forwarded-prefix') || this._basePath;
+	}
+
+	private _getFirstHeader(req: http.IncomingMessage, headerName: string): string | undefined {
+		const value = req.headers[headerName];
+		return Array.isArray(value) ? value[0] : value;
 	}
 
 	private _getScriptCspHashes(content: string): string[] {

--- a/src/vs/server/test/node/webClientServerManifest.test.ts
+++ b/src/vs/server/test/node/webClientServerManifest.test.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type * as http from 'http';
+import { Writable } from 'stream';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { ICSSDevelopmentService } from '../../../platform/cssDev/node/cssDevService.js';
+import { TestInstantiationService } from '../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../platform/log/common/log.js';
+import product from '../../../platform/product/common/product.js';
+import { IProductService } from '../../../platform/product/common/productService.js';
+import { IRequestService } from '../../../platform/request/common/request.js';
+import { NoneServerConnectionToken } from '../../node/serverConnectionToken.js';
+import { IServerEnvironmentService } from '../../node/serverEnvironmentService.js';
+import { WebClientServer } from '../../node/webClientServer.js';
+
+interface TestResponse extends Writable {
+	readonly statusCode: number;
+	readonly responseHeaders: http.OutgoingHttpHeaders;
+	readonly body: string;
+	writeHead(statusCode: number, headers?: http.OutgoingHttpHeaders): TestResponse;
+}
+
+suite('WebClientServer manifest', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createServer(basePath: string): WebClientServer {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IServerEnvironmentService, { isBuilt: false });
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IRequestService, {});
+		instantiationService.stub(IProductService, { _serviceBrand: undefined, ...product });
+		instantiationService.stub(ICSSDevelopmentService, { isEnabled: false });
+
+		return instantiationService.createInstance(WebClientServer, new NoneServerConnectionToken(), basePath, '/oss-dev');
+	}
+
+	function createResponse(): TestResponse {
+		const chunks: Buffer[] = [];
+		const response = new Writable({
+			write(chunk, _encoding, callback) {
+				chunks.push(Buffer.from(chunk));
+				callback();
+			}
+		}) as TestResponse;
+		Object.defineProperties(response, {
+			body: { get: () => Buffer.concat(chunks).toString() },
+			responseHeaders: { value: Object.create(null) },
+			statusCode: { value: 0, writable: true }
+		});
+		response.writeHead = (statusCode, headers = Object.create(null)) => {
+			Object.assign(response, { statusCode });
+			Object.assign(response.responseHeaders, headers);
+			return response;
+		};
+		return response;
+	}
+
+	async function requestResource(server: WebClientServer, resourcePath: string, headers: http.IncomingHttpHeaders = {}, query = ''): Promise<TestResponse> {
+		const response = createResponse();
+		const pathname = `/static/${resourcePath}`;
+		const url = new URL(`http://localhost/oss-dev${pathname}${query}`);
+		await server.handle({ headers } as http.IncomingMessage, response as unknown as http.ServerResponse, url, pathname);
+		return response;
+	}
+
+	function requestManifest(server: WebClientServer, headers: http.IncomingHttpHeaders = {}, query = ''): Promise<TestResponse> {
+		return requestResource(server, 'resources/server/manifest.json', headers, query);
+	}
+
+	test('should use the configured base path in start_url', async () => {
+		const response = await requestManifest(createServer('/code'));
+
+		assert.strictEqual(JSON.parse(response.body).start_url, '/code/');
+	});
+
+	test('should preserve the root start_url by default', async () => {
+		const response = await requestManifest(createServer('/'));
+
+		assert.strictEqual(JSON.parse(response.body).start_url, '/');
+	});
+
+	test('should prefer X-Forwarded-Prefix over the configured base path', async () => {
+		const response = await requestManifest(createServer('/code'), { 'x-forwarded-prefix': '/tenant/code' });
+
+		assert.strictEqual(JSON.parse(response.body).start_url, '/tenant/code/');
+	});
+
+	test('should normalize a trailing slash and ignore the request query', async () => {
+		const configuredResponse = await requestManifest(createServer('/code/'), {}, '?v=1&tkn=synthetic');
+		const forwardedResponse = await requestManifest(createServer('/ignored'), { 'x-forwarded-prefix': '/tenant/code/' }, '?v=1');
+
+		assert.deepStrictEqual([
+			JSON.parse(configuredResponse.body).start_url,
+			JSON.parse(forwardedResponse.body).start_url
+		], ['/code/', '/tenant/code/']);
+	});
+
+	test('should not cache a manifest that depends on forwarded headers', async () => {
+		const response = await requestManifest(createServer('/code'), { 'x-forwarded-prefix': '/tenant/code' });
+
+		assert.deepStrictEqual({
+			statusCode: response.statusCode,
+			cacheControl: response.responseHeaders['Cache-Control'],
+			contentType: response.responseHeaders['Content-Type'],
+			etag: response.responseHeaders['Etag'],
+			vary: response.responseHeaders['Vary']
+		}, {
+			statusCode: 200,
+			cacheControl: 'no-store',
+			contentType: 'application/json',
+			etag: undefined,
+			vary: 'X-Forwarded-Prefix'
+		});
+	});
+
+	test('should keep serving other resources through the static handler', async () => {
+		const response = await requestResource(createServer('/code'), 'resources/server/code-192.png');
+
+		assert.deepStrictEqual({
+			statusCode: response.statusCode,
+			contentType: response.responseHeaders['Content-Type'],
+			hasEtag: typeof response.responseHeaders['Etag'] === 'string',
+			hasBody: response.body.length > 0
+		}, {
+			statusCode: 200,
+			contentType: 'image/png',
+			hasEtag: true,
+			hasBody: true
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #209601

This updates `WebClientServer` to serve the server PWA manifest with a `start_url` derived from the effective base path, including `X-Forwarded-Prefix`. The dynamic response keeps the remaining manifest fields unchanged and uses `Cache-Control: no-store` with `Vary: X-Forwarded-Prefix`.

### Testing

- `npm run test-node -- --run src/vs/server/test/node/webClientServerManifest.test.ts` (7 passing)
- Server Node.js tests under `src/vs/server/test/node` (48 passing)
- `npm run transpile-client`
- Client typecheck and targeted ESLint/formatter checks