### PR TITLE
sessions: protect provider telemetry identifiers

### DIFF
--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -4,10 +4,33 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isCancellationError } from '../../base/common/errors.js';
+import { StringSHA1 } from '../../base/common/hash.js';
 import { RemoteAgentHostConnectionStatus } from '../../platform/agentHost/common/remoteAgentHostService.js';
 import { isSSHHostKeyDeniedError } from '../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { PROTOCOL_VERSION } from '../../platform/agentHost/common/state/protocol/version/registry.js';
 import { ITelemetryService } from '../../platform/telemetry/common/telemetry.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_PREFIX } from './agentHostSessionsProvider.js';
+
+/** Bounded provider categories emitted by Agents window telemetry. */
+export type SessionsTelemetryProviderId = 'default-copilot' | 'local-agent-host' | 'remote-agent-host' | 'other';
+
+/** Removes connection-specific details from a sessions provider identifier. */
+export function getSessionsTelemetryProviderId(providerId: string): SessionsTelemetryProviderId {
+	if (providerId === 'default-copilot' || providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
+		return providerId;
+	}
+	if (providerId === 'remote-agent-host' || providerId.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX)) {
+		return 'remote-agent-host';
+	}
+	return 'other';
+}
+
+/** Hashes a session identifier while preserving deterministic event correlation. */
+export function hashSessionIdForTelemetry(sessionId: string): string {
+	const sha1 = new StringSHA1();
+	sha1.update(sessionId);
+	return sha1.digest();
+}
 
 // --- Titlebar button interactions ---
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ISession } from '../../../services/sessions/common/session.js';
-import { classifySessionWorkspaceTopology } from '../../../common/sessionsTelemetry.js';
+import { classifySessionWorkspaceTopology, getSessionsTelemetryProviderId, hashSessionIdForTelemetry } from '../../../common/sessionsTelemetry.js';
 
 /** Storage key for the cumulative number of times this client has been launched. */
 const APP_LAUNCH_COUNT_KEY = 'agentSessions.telemetry.summary.appLaunchCount';
@@ -257,13 +257,13 @@ export class SessionsLifecycleTracker extends Disposable {
 	 * brand-new session the user starts from the Agents window.
 	 */
 	incrementAndGetUserRequestCounters(session: ISession): IUserRequestCounters {
-		const providerId = session.providerId;
+		const providerId = getSessionsTelemetryProviderId(session.providerId);
 		const workspaceUri = session.workspace.get()?.uri.toString();
 
 		const userSessionsTotal = this._storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0) + 1;
 		this._storageService.store(TOTAL_SESSIONS_KEY, userSessionsTotal, StorageScope.APPLICATION, StorageTarget.MACHINE);
 
-		const providerCounts = this._readCounterMap(PROVIDER_SESSIONS_KEY);
+		const providerCounts = this._readProviderCounterMap();
 		const userSessionsForProvider = (providerCounts[providerId] ?? 0) + 1;
 		providerCounts[providerId] = userSessionsForProvider;
 		this._storageService.store(PROVIDER_SESSIONS_KEY, JSON.stringify(providerCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
@@ -329,14 +329,24 @@ export class SessionsLifecycleTracker extends Disposable {
 
 	private _readUserRequestCounters(providerId: string, workspaceUri: string | undefined): IUserRequestCounters {
 		const userSessionsTotal = this._storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
-		const providerCounts = this._readCounterMap(PROVIDER_SESSIONS_KEY);
-		const userSessionsForProvider = providerCounts[providerId] ?? 0;
+		const providerCounts = this._readProviderCounterMap();
+		const userSessionsForProvider = providerCounts[getSessionsTelemetryProviderId(providerId)] ?? 0;
 		let userSessionsInWorkspace = 0;
 		if (workspaceUri) {
 			const workspaceCounts = this._readCounterMap(WORKSPACE_SESSIONS_KEY);
 			userSessionsInWorkspace = workspaceCounts[workspaceUri] ?? 0;
 		}
 		return { userSessionsTotal, userSessionsInWorkspace, userSessionsForProvider };
+	}
+
+	private _readProviderCounterMap(): Record<string, number> {
+		const storedCounts = this._readCounterMap(PROVIDER_SESSIONS_KEY);
+		const providerCounts: Record<string, number> = {};
+		for (const [providerId, count] of Object.entries(storedCounts)) {
+			const telemetryProviderId = getSessionsTelemetryProviderId(providerId);
+			providerCounts[telemetryProviderId] = (providerCounts[telemetryProviderId] ?? 0) + count;
+		}
+		return providerCounts;
 	}
 
 	private _readCounterMap(key: string): Record<string, number> {
@@ -491,8 +501,8 @@ function createEntry(session: ISession, appLaunchCount: number): IStoredSessionS
 function buildSummary(sessionId: string, entry: IStoredSessionStats, reason: SessionDoneReason, appLaunchCount: number, requestCounters: IUserRequestCounters): ISessionLifecycleSummary {
 	const now = Date.now();
 	return {
-		agentSessionId: sessionId,
-		providerId: entry.providerId,
+		agentSessionId: hashSessionIdForTelemetry(sessionId),
+		providerId: getSessionsTelemetryProviderId(entry.providerId),
 		providerType: entry.providerType,
 		isolationKind: entry.isolationKind,
 		workspaceHash: entry.workspaceUriString ? hash(entry.workspaceUriString).toString(16) : '',

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
@@ -23,7 +23,7 @@ import { ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { ISendRequestOptions, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { classifySessionWorkspaceTopology } from '../../../common/sessionsTelemetry.js';
+import { classifySessionWorkspaceTopology, getSessionsTelemetryProviderId, hashSessionIdForTelemetry } from '../../../common/sessionsTelemetry.js';
 import { ISessionsPartService } from '../../../services/sessions/browser/sessionsPartService.js';
 import { ISessionLifecycleSummary, SessionDoneReason, SessionsLifecycleTracker } from './sessionsLifecycleTracker.js';
 
@@ -535,8 +535,8 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 
 	private _getSessionFields(session: ISession): SessionFields {
 		return {
-			agentSessionId: session.sessionId,
-			providerId: session.providerId,
+			agentSessionId: hashSessionIdForTelemetry(session.sessionId),
+			providerId: getSessionsTelemetryProviderId(session.providerId),
 			providerType: session.sessionType,
 			chatCount: session.chats.get().length,
 		};
@@ -871,8 +871,8 @@ type SessionRequestSentClassification = {
 	comment: 'Reports when the user sends a request from a session in the Agents window, including the user state at the time of send.';
 	isNewSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'True when the request starts a brand-new session, false when it is a new or continued chat in an existing session.' };
 	visibleSessionsCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many sessions are currently visible in the sessions grid.' };
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	chatModeKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Built-in chat mode kind (e.g., ask, agent, edit); empty when no mode is selected.' };
@@ -910,8 +910,8 @@ type SessionRequestSentClassification = {
 type SessionArchivedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user archives a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -927,8 +927,8 @@ type SessionArchivedClassification = {
 type SessionUnarchivedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user unarchives a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -944,8 +944,8 @@ type SessionUnarchivedClassification = {
 type SessionDeletedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user deletes a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -961,8 +961,8 @@ type SessionDeletedClassification = {
 type ChatDeletedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user deletes a chat from a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -978,8 +978,8 @@ type ChatDeletedClassification = {
 type ChatRenamedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user renames a chat in a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -995,8 +995,8 @@ type ChatRenamedClassification = {
 type SessionRenamedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user renames a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1012,8 +1012,8 @@ type SessionRenamedClassification = {
 type CreatePullRequestClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Create Pull Request command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1029,8 +1029,8 @@ type CreatePullRequestClassification = {
 type CreateDraftPullRequestClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Create Draft Pull Request command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1046,8 +1046,8 @@ type CreateDraftPullRequestClassification = {
 type UpdatePullRequestClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Update (Sync) Pull Request command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1063,8 +1063,8 @@ type UpdatePullRequestClassification = {
 type MergePullRequestClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Merge Pull Request command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1080,8 +1080,8 @@ type MergePullRequestClassification = {
 type CheckoutPullRequestClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Checkout Pull Request command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1097,8 +1097,8 @@ type CheckoutPullRequestClassification = {
 type InitializeRepositoryClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Initialize Repository command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1114,8 +1114,8 @@ type InitializeRepositoryClassification = {
 type CommitClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Commit command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1131,8 +1131,8 @@ type CommitClassification = {
 type CommitAndSyncClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Commit and Sync command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1148,8 +1148,8 @@ type CommitAndSyncClassification = {
 type SessionRestoredClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user restores a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1165,8 +1165,8 @@ type SessionRestoredClassification = {
 type FixCIChecksClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user runs the Fix CI Checks command for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1201,8 +1201,8 @@ type FeedbackAddedEvent = {
 type FeedbackAddedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user adds a new agent feedback comment to a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1238,8 +1238,8 @@ type FeedbackConvertedEvent = {
 type FeedbackConvertedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when an external review comment (code review or PR review) is converted into agent feedback for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1275,8 +1275,8 @@ type FeedbackReplyAddedEvent = {
 type FeedbackReplyAddedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user adds a reply to an existing agent feedback thread in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1314,8 +1314,8 @@ type FeedbackSubmittedEvent = {
 type FeedbackSubmittedClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user submits the accumulated agent feedback for a session in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1354,8 +1354,8 @@ type SessionStickinessToggledEvent = {
 type SessionStickinessToggledClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user toggles a session\'s stickiness in the sessions grid in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1388,8 +1388,8 @@ type SessionMaximizeToggledEvent = {
 type SessionMaximizeToggledClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user toggles the maximized state of a session view in the sessions grid in the Agents window.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chats currently in the session.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder).' };
@@ -1408,8 +1408,8 @@ type SessionMaximizeToggledClassification = {
 type SessionSummaryClassification = {
 	owner: 'benibenj';
 	comment: 'Single per-session summary emitted when a tracked session is finished (archived, deleted, or observed as archived/deleted in another client). Aggregates everything that happened during the session\'s lifetime.';
-	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
-	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };
 	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
 	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder), captured the first time the session was observed in this client.' };
 	workspaceHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Non-reversible hash of the workspace URI the session is tied to, used to correlate events across the same workspace without disclosing the path.' };

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
@@ -101,7 +101,7 @@ suite('SessionsLifecycleTracker', () => {
 	});
 
 	test('finalize emits summary and removes tracking entry', () => {
-		const session = createSession('s1');
+		const session = createSession('s1', { providerId: 'agenthost-example.internal:1234' });
 		tracker.recordNewChatRequestSent(session);
 		tracker.bumpCounter(session, 'feedbackAdded');
 		tracker.bumpCounter(session, 'feedbackAdded');
@@ -110,8 +110,8 @@ suite('SessionsLifecycleTracker', () => {
 		const summary = tracker.finalize(session.sessionId, 'archived', session);
 
 		assert.ok(summary);
-		assert.strictEqual(summary!.agentSessionId, 's1');
-		assert.strictEqual(summary!.providerId, 'test-provider');
+		assert.strictEqual(summary!.agentSessionId, '640d87e741e6aa4c669a82a4cd304787960513ab');
+		assert.strictEqual(summary!.providerId, 'remote-agent-host');
 		assert.strictEqual(summary!.providerType, 'test-type');
 		assert.strictEqual(summary!.doneReason, 'archived');
 		assert.strictEqual(summary!.requestsSent, 1);
@@ -414,10 +414,10 @@ suite('SessionsLifecycleTracker', () => {
 	test('incrementAndGetUserRequestCounters returns post-increment values per provider, workspace and total', () => {
 		const workspaceA = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
 		const workspaceB = createWorkspace(URI.parse('file:///ws/b'), [createFolder(URI.parse('file:///ws/b'))]);
-		const a1 = createSession('a1', { providerId: 'p1', workspace: workspaceA });
-		const a2 = createSession('a2', { providerId: 'p1', workspace: workspaceA });
-		const b = createSession('b', { providerId: 'p2', workspace: workspaceB });
-		const noWorkspace = createSession('n', { providerId: 'p1' });
+		const a1 = createSession('a1', { providerId: 'agenthost-first.example:1234', workspace: workspaceA });
+		const a2 = createSession('a2', { providerId: 'agenthost-second.example:5678', workspace: workspaceA });
+		const b = createSession('b', { providerId: 'default-copilot', workspace: workspaceB });
+		const noWorkspace = createSession('n', { providerId: 'agenthost-third.example:9012' });
 
 		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a1), { userSessionsTotal: 1, userSessionsInWorkspace: 1, userSessionsForProvider: 1 });
 		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a2), { userSessionsTotal: 2, userSessionsInWorkspace: 2, userSessionsForProvider: 2 });
@@ -425,12 +425,33 @@ suite('SessionsLifecycleTracker', () => {
 		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(noWorkspace), { userSessionsTotal: 4, userSessionsInWorkspace: 0, userSessionsForProvider: 3 });
 	});
 
+	test('provider counters migrate raw provider IDs into bounded categories', () => {
+		storage.store('agentSessions.telemetry.providerSessions', JSON.stringify({
+			'agenthost-first.example:1234': 2,
+			'agenthost-second.example:5678': 3,
+			'default-copilot': 4,
+		}), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const remoteSession = createSession('remote', { providerId: 'agenthost-third.example:9012' });
+		const copilotSession = createSession('copilot', { providerId: 'default-copilot' });
+
+		assert.deepStrictEqual([
+			tracker.incrementAndGetUserRequestCounters(remoteSession),
+			tracker.getUserRequestCounters(copilotSession),
+			JSON.parse(storage.get('agentSessions.telemetry.providerSessions', StorageScope.APPLICATION) ?? ''),
+		], [
+			{ userSessionsTotal: 1, userSessionsInWorkspace: 0, userSessionsForProvider: 6 },
+			{ userSessionsTotal: 1, userSessionsInWorkspace: 0, userSessionsForProvider: 4 },
+			{ 'remote-agent-host': 6, 'default-copilot': 4 },
+		]);
+	});
+
 	test('summary includes the request counters as observed at finalize time', () => {
 		const workspaceA = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
 		const workspaceB = createWorkspace(URI.parse('file:///ws/b'), [createFolder(URI.parse('file:///ws/b'))]);
-		const sessionToFinalize = createSession('a1', { providerId: 'p1', workspace: workspaceA });
-		const otherSameWorkspace = createSession('a2', { providerId: 'p1', workspace: workspaceA });
-		const otherDifferentEverything = createSession('b', { providerId: 'p2', workspace: workspaceB });
+		const sessionToFinalize = createSession('a1', { providerId: 'agenthost-first.example:1234', workspace: workspaceA });
+		const otherSameWorkspace = createSession('a2', { providerId: 'agenthost-second.example:5678', workspace: workspaceA });
+		const otherDifferentEverything = createSession('b', { providerId: 'default-copilot', workspace: workspaceB });
 
 		tracker.recordNewChatRequestSent(sessionToFinalize);
 		tracker.incrementAndGetUserRequestCounters(sessionToFinalize);

--- a/src/vs/sessions/test/common/sessionsTelemetry.test.ts
+++ b/src/vs/sessions/test/common/sessionsTelemetry.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
-import { classifySessionWorkspaceTopology } from '../../common/sessionsTelemetry.js';
+import { classifySessionWorkspaceTopology, getSessionsTelemetryProviderId, hashSessionIdForTelemetry } from '../../common/sessionsTelemetry.js';
 
 suite('sessionsTelemetry helpers', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -26,5 +26,33 @@ suite('sessionsTelemetry helpers', () => {
 			nonGitFolderCount: 0,
 			isMultiRoot: false,
 		});
+	});
+
+	test('provider IDs are bounded for telemetry', () => {
+		assert.deepStrictEqual([
+			getSessionsTelemetryProviderId('default-copilot'),
+			getSessionsTelemetryProviderId('local-agent-host'),
+			getSessionsTelemetryProviderId('agenthost-example.internal:1234'),
+			getSessionsTelemetryProviderId('agenthost-b3BhcXVlLXR1bm5lbC1pZA'),
+			getSessionsTelemetryProviderId('extension-provider'),
+		], [
+			'default-copilot',
+			'local-agent-host',
+			'remote-agent-host',
+			'remote-agent-host',
+			'other',
+		]);
+	});
+
+	test('session IDs are hashed for telemetry correlation', () => {
+		assert.deepStrictEqual([
+			hashSessionIdForTelemetry('agenthost-example.internal:1234:session://first'),
+			hashSessionIdForTelemetry('agenthost-example.internal:1234:session://first'),
+			hashSessionIdForTelemetry('agenthost-example.internal:1234:session://second'),
+		], [
+			'4f42482f1374bb5f11b7f1c0abbc96954bddd505',
+			'4f42482f1374bb5f11b7f1c0abbc96954bddd505',
+			'51f47747e460010ae1c437b9a269e980137d96ec',
+		]);
 	});
 });


### PR DESCRIPTION
## What

Protects Agents window telemetry from connection-specific provider details without changing event cadence:

- maps sessions providers to the bounded `default-copilot`, `local-agent-host`, `remote-agent-host`, and `other` categories before emission;
- replaces raw `agentSessionId` values with deterministic SHA-1 hashes so events for one session remain correlatable without exposing provider or resource details;
- applies the same treatment to live session action events and persisted `agents/sessionSummary` rows;
- migrates persisted per-provider request counters into the same bounded categories so `userSessionsForProvider` remains consistent with the emitted provider dimension.

`providerType` remains unchanged as the useful low-cardinality session-type dimension.

## Why

Follow-up to [microsoft/vscode-internalbacklog#8738](https://github.com/microsoft/vscode-internalbacklog/issues/8738).

Remote Agent Host provider IDs include a connection authority. Aggregated production validation over seven complete UTC days found 49 distinct dynamic provider IDs, including address-like shapes. Every observed `agentSessionId` was prefixed by its raw `providerId`, so changing only `providerId` would leave the same connection detail in the correlation field.

The shared session-field builder feeds 23 Agents action events, and lifecycle summaries build the same fields separately. This change protects both paths.

## Query impact

- `providerId` is now a bounded category. Remote hosts intentionally aggregate under `remote-agent-host`.
- `agentSessionId` remains deterministic within the new population, but its value changes from the raw ID to a hash. Queries cannot join raw historical IDs to hashed new IDs across the deployment boundary.
- `providerType` retains the existing session-type breakdown.
- Existing persisted provider counters are aggregated into their bounded categories on first read and rewritten without dynamic provider keys on the next increment.
- Event names, cadence, and row counts are unchanged.

## Validation

- `npm run transpile-client`
- `.\scripts\test.bat --run src\vs\sessions\test\common\sessionsTelemetry.test.ts --run src\vs\sessions\contrib\sessions\test\browser\sessionsLifecycleTracker.test.ts` (33 passing)
- `npm run typecheck-client`
- `npm run valid-layers-check`
- changed-file ESLint