### PR TITLE
chat: fix code block spacing in tight lists

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -910,7 +910,7 @@ following list content ends up with no space above it. Add a matching top margin
 .interactive-item-container .value .rendered-markdown {
 	ul + [data-code],
 	ol + [data-code],
-	li > [data-code]:not(:first-child) {
+	li > [data-code] {
 		margin-top: 16px;
 	}
 }

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -597,30 +597,29 @@ const MULTI_TURN: IFixtureMessage[] = [
 ];
 
 // Code blocks that follow or are nested in list items should have symmetric spacing
-// above and below. Covers the two DOM shapes markdown produces: a code block that is a
-// sibling after a list, and a code block nested inside a list item (indented fence).
+// above and below. This also covers tight lists, where prose before a code block is a
+// text node and the code block is therefore still the first element child.
 const CODE_BLOCK_IN_LIST: IFixtureMessage[] = [
 	{
-		user: 'How do I set up the project?',
+		user: 'Why do the files appear while diffs fail?',
 		assistant: [
 			{
 				kind: 'markdown', text: [
-					'Follow these steps:',
+					'## Root cause',
 					'',
-					'- Clone the repository',
-					'- Install the dependencies',
+					'Git is unusable on this Mac because the Xcode license has not been accepted. Both `git --version` and `/usr/bin/git --version` currently exit with code 69 and report:',
 					'',
-					'```bash',
-					'npm install',
-					'```',
+					'> You have not agreed to the Xcode license agreements.',
 					'',
-					'- Then start the build watcher:',
+					'### Why files appear but diffs fail',
 					'',
-					'  ```bash',
-					'  npm run watch',
-					'  ```',
-					'',
-					'- Finally, launch the app',
+					'1. The session restores/caches the change-set metadata, so VS Code can display the filenames and change counts.',
+					'2. Opening a diff requires loading its original side using a `git-blob:` URI.',
+					'3. Agent Host executes roughly:',
+					'   ```bash',
+					'   git show 1e393d7b352de7927a98d0321e51ae63046c8652:<path>',
+					'   ```',
+					'4. Git refuses to run because of the Xcode license.',
 				].join('\n')
 			},
 		],


### PR DESCRIPTION
## What changed

- Apply the standard top spacing to fenced code blocks nested in list items.
- Update the existing component fixture with the ordered-list Markdown that exposed the issue.

## Why

In tight Markdown lists, prose before a fenced code block can be emitted as a text node. The code wrapper is therefore still the first *element* child, so the previous `:not(:first-child)` selector incorrectly suppressed its top margin.

## Validation

- `npm run compile`
- `npm run valid-layers-check`
- targeted ESLint and stylelint
- pre-commit hygiene
- browser computed-style probe for the tight-list DOM shape

The Component Explorer server could not be launched because its startup invokes the machine's currently broken Xcode Git installation. (Written by Copilot)