### PR TITLE
chat: refresh agent host models on sign out

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -15,7 +15,7 @@ import { IAgentHostEnablementService } from '../../../../../../platform/agentHos
 import { LOCAL_AGENT_HOST_AUTHORITY } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { NotificationType } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
-import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { type AgentInfo, type RootState, type SessionModelInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CHATGPT_SUBSCRIPTION_MODEL_SOURCE_ID } from '../../../../../../platform/agentHost/common/agentModelSource.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
@@ -25,6 +25,7 @@ import { Registry } from '../../../../../../platform/registry/common/platform.js
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IAgentHostFileSystemService } from '../../../../../services/agentHost/common/agentHostFileSystemService.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
+import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatSessionsService, isLocalAgentHostTarget } from '../../../common/chatSessionsService.js';
 import { ICustomizationHarnessService } from '../../../common/customizationHarnessService.js';
@@ -34,7 +35,7 @@ import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { AgentCustomizationItemProvider } from './agentCustomizationItemProvider.js';
 import { AgentHostDownloadProgress } from './agentHostDownloadProgress.js';
 import { authenticateProtectedResources, AgentHostAuthTokenCache, resolveAuthenticationInteractively } from './agentHostAuth.js';
-import { AgentHostLanguageModelProvider, agentHostProviderSupportsAutoModel } from './agentHostLanguageModelProvider.js';
+import { AgentHostLanguageModelProvider, agentHostProviderSupportsAutoModel, filterAgentHostModelsAvailableWithoutCopilotAccount } from './agentHostLanguageModelProvider.js';
 import { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 import { AgentHostPromptCacheNotification } from './agentHostPromptCacheNotification.js';
 import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
@@ -121,12 +122,15 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	private _initialized = false;
 	private _didStartInitialAuthentication = false;
 	private _promptCacheNotification: AgentHostPromptCacheNotification | undefined;
+	private _defaultAccountResolved = false;
+	private _hasDefaultAccount = false;
 
 	constructor(
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
 		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 		@ILogService private readonly _logService: ILogService,
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -170,6 +174,25 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			this._authTokenCache.clear(notification.resource);
 			this._authenticateWithServer(this._getRootAgents())
 				.catch(() => { /* best-effort */ });
+		}));
+
+		this._register(this._defaultAccountService.onDidChangeDefaultAccount(account => {
+			this._updateDefaultAccount(account !== null);
+		}));
+		this._defaultAccountService.getDefaultAccount().then(account => {
+			if (!this._store.isDisposed) {
+				this._updateDefaultAccount(account !== null);
+			}
+		});
+		this._register(this._chatEntitlementService.onDidChangeAnonymous(() => {
+			if (this._defaultAccountResolved) {
+				this._refreshModelProviders();
+			}
+		}));
+		this._register(this._languageModelsService.onDidChangeLanguageModels(vendor => {
+			if (this._defaultAccountResolved && !this._hasDefaultAccount && !this._chatEntitlementService.anonymous && !vendor.startsWith(LOCAL_AGENT_HOST_SESSION_TYPE_PREFIX)) {
+				this._refreshModelProviders();
+			}
 		}));
 
 		// Surface the agent host's lazy, first-use SDK download as a progress
@@ -234,7 +257,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			} else {
 				// Push updated models to existing model provider
 				const modelProvider = this._modelProviders.get(agent.provider);
-				modelProvider?.updateModels(agent.models);
+				modelProvider?.updateModels(this._getModelsAvailableForAccount(agent));
 			}
 		}
 	}
@@ -330,17 +353,42 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		this._modelProviders.set(agent.provider, modelProvider);
 		store.add(toDisposable(() => this._modelProviders.delete(agent.provider)));
 		store.add(this._languageModelsService.registerLanguageModelProvider(vendor, modelProvider));
-		modelProvider.updateModels(agent.models);
+		modelProvider.updateModels(this._getModelsAvailableForAccount(agent));
 
-		// Re-authenticate when credentials change
-		store.add(this._defaultAccountService.onDidChangeDefaultAccount(() => {
-			const agents = this._getRootAgents();
-			this._authenticateWithServer(agents).catch(() => { /* best-effort */ });
-		}));
 		store.add(this._authenticationService.onDidChangeSessions(() => {
 			const agents = this._getRootAgents();
 			this._authenticateWithServer(agents).catch(() => { /* best-effort */ });
 		}));
+	}
+
+	private _updateDefaultAccount(hasDefaultAccount: boolean): void {
+		const signedOut = this._defaultAccountResolved && this._hasDefaultAccount && !hasDefaultAccount && !this._chatEntitlementService.anonymous;
+		this._defaultAccountResolved = true;
+		this._hasDefaultAccount = hasDefaultAccount;
+		this._authTokenCache.clear();
+		this._refreshModelProviders();
+		if (signedOut) {
+			void this._agentHostService.restartAgentHost().catch(error => this._logService.error('[AgentHost] Failed to restart after sign-out', error));
+		} else {
+			this._authenticateWithServer(this._getRootAgents()).catch(() => { /* best-effort */ });
+		}
+	}
+
+	private _refreshModelProviders(): void {
+		for (const agent of this._getRootAgents()) {
+			this._modelProviders.get(agent.provider)?.updateModels(this._getModelsAvailableForAccount(agent));
+		}
+	}
+
+	private _getModelsAvailableForAccount(agent: AgentInfo): readonly SessionModelInfo[] {
+		if (!this._defaultAccountResolved || this._hasDefaultAccount || this._chatEntitlementService.anonymous) {
+			return agent.models;
+		}
+		return filterAgentHostModelsAvailableWithoutCopilotAccount(
+			agent.models,
+			protectedResourcesRequireGitHubCopilotSignIn(agent.protectedResources ?? []),
+			identifier => this._languageModelsService.lookupLanguageModel(identifier)?.isBYOK === true,
+		);
 	}
 
 	private _getRootAgents(): readonly AgentInfo[] {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -34,6 +34,21 @@ export function agentHostProviderSupportsAutoModel(provider: string): boolean {
 	return provider === 'copilotcli';
 }
 
+/** Filters a harness catalog after sign-out, retaining only copies of validated BYOK models. */
+export function filterAgentHostModelsAvailableWithoutCopilotAccount(
+	models: readonly SessionModelInfo[],
+	requiresCopilotSignIn: boolean,
+	isByokModel: (identifier: string) => boolean,
+): readonly SessionModelInfo[] {
+	if (!requiresCopilotSignIn) {
+		return models;
+	}
+	return models.filter(model => {
+		const identifier = readAgentModelByokIdentifier(model);
+		return identifier !== undefined && isByokModel(identifier);
+	});
+}
+
 /**
  * Exposes models available from the agent host process as selectable
  * language models in the chat model picker. Models are provided from

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -64,6 +64,7 @@ import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../../../plat
 import { MenuId, MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { registerAndCreateHistoryNavigationContext } from '../../../../../../platform/history/browser/contextScopedHistoryWidget.js';
@@ -589,6 +590,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _modelSelectionController: ChatInputModelSelectionController;
 	private readonly _currentLanguageModel: IObservable<ILanguageModelChatMetadataAndIdentifier | undefined>;
 	private readonly _modelSelectionRuntime: IChatInputModelSelectionRuntime;
+	private defaultAccountResolved = false;
 
 	/**
 	 * Per-editor store of each model's configuration (e.g. context size, thinking
@@ -769,6 +771,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		@IVoiceModeOnboardingService private readonly voiceModeOnboardingService: IVoiceModeOnboardingService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 		this._modelSelectionDiagnostics = new ChatModelSelectionDiagnostics(this.logService, this.storageService, () => ({
@@ -1014,8 +1017,28 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			// lost, its models).
 			this._updateInputContentContextKeys();
 		};
-		this._register(this.languageModelsService.onDidChangeLanguageModels(() => updateAfterModelListChange(false)));
+		this._register(this.languageModelsService.onDidChangeLanguageModels(() => {
+			if (this.defaultAccountResolved && this.defaultAccountService.currentDefaultAccount === null && !this.entitlementService.anonymous) {
+				this._modelSelectionController.revalidateForSessionType(() => { });
+			}
+			updateAfterModelListChange(false);
+		}));
 		this._register(this.languageModelsService.onDidChangeModelVisibility(() => updateAfterModelListChange(true)));
+		const updateAfterCopilotAccountStateChange = (hasDefaultAccount: boolean) => {
+			this.defaultAccountResolved = true;
+			if (!hasDefaultAccount && !this.entitlementService.anonymous) {
+				this._modelSelectionController.revalidateForSessionType(() => { });
+				updateAfterModelListChange(false);
+			} else {
+				updateAfterModelListChange(true);
+			}
+		};
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(account => updateAfterCopilotAccountStateChange(account !== null)));
+		this.defaultAccountService.getDefaultAccount().then(account => {
+			if (!this._store.isDisposed) {
+				updateAfterCopilotAccountStateChange(account !== null);
+			}
+		});
 
 		this._register(this.onDidChangeCurrentChatMode(() => {
 			this.accessibilityService.alert(this._currentModeObservable.get().label.get());

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { IDefaultAccount } from '../../../../../../base/common/defaultAccount.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, IDisposable, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -53,7 +54,7 @@ import { IChatEditingService } from '../../../common/editing/chatEditingService.
 import { IChatResponseFileChangesService } from '../../../browser/chatResponseFileChangesService.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IChatSessionsService, type IChatSession, type IChatSessionItemController, type IChatSessionRequestHistoryItem, type IChatSessionServerRequest, type IChatSessionsExtensionPoint } from '../../../common/chatSessionsService.js';
-import { ILanguageModelsService, type ILanguageModelChatMetadata } from '../../../common/languageModels.js';
+import { ILanguageModelsService, type ILanguageModelChatMetadata, type ILanguageModelChatProvider } from '../../../common/languageModels.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IPathService } from '../../../../../services/path/common/pathService.js';
@@ -259,7 +260,8 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 
 	override async disposeSession(session: URI): Promise<void> { this.disposedSessions.push(session); }
 	async shutdown(): Promise<void> { }
-	override async restartAgentHost(): Promise<void> { }
+	public restartAgentHostCalls = 0;
+	override async restartAgentHost(): Promise<void> { this.restartAgentHostCalls++; }
 
 	// Protocol methods
 	public override readonly clientId = 'test-window-1';
@@ -654,7 +656,7 @@ class MockWorkingCopyService extends mock<IWorkingCopyService>() {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false, languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>, configOverrides?: Record<string, unknown>, chatSessionsServiceOverride?: Partial<IChatSessionsService>, chatDebugServiceOverride?: Partial<IChatDebugService>, remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>, customizationServiceOverride?: IAgentHostCustomizationService, agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService>, languageModelsServiceOverride?: Partial<ILanguageModelsService>, workspaceFolders: readonly URI[] = []) {
+function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false, languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>, configOverrides?: Record<string, unknown>, chatSessionsServiceOverride?: Partial<IChatSessionsService>, chatDebugServiceOverride?: Partial<IChatDebugService>, remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>, customizationServiceOverride?: IAgentHostCustomizationService, agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService>, languageModelsServiceOverride?: Partial<ILanguageModelsService>, workspaceFolders: readonly URI[] = [], defaultAccountServiceOverride?: Partial<IDefaultAccountService>) {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const agentHostService = new MockAgentHostService();
@@ -681,7 +683,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(ILogService, new NullLogService());
 	instantiationService.stub(IProductService, { quality: 'insider' });
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
-	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {} } as Partial<IChatEntitlementService> as IChatEntitlementService);
+	instantiationService.stub(IChatEntitlementService, { entitlement: ChatEntitlement.Free, quotas: {}, anonymous: false, onDidChangeAnonymous: Event.None } as Partial<IChatEntitlementService> as IChatEntitlementService);
 	instantiationService.stub(IChatAgentService, chatAgentService);
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
 	instantiationService.stub(IFileService, TestFileService);
@@ -729,11 +731,12 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		resolveEvent: async () => undefined,
 		...chatDebugServiceOverride,
 	});
-	instantiationService.stub(IDefaultAccountService, { onDidChangeDefaultAccount: Event.None, getDefaultAccount: async () => null });
+	instantiationService.stub(IDefaultAccountService, { onDidChangeDefaultAccount: Event.None, getDefaultAccount: async () => null, ...defaultAccountServiceOverride });
 	const commandService = new MockCommandService();
 	instantiationService.stub(ICommandService, commandService);
 	instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None, ...authServiceOverride });
 	instantiationService.stub(ILanguageModelsService, {
+		onDidChangeLanguageModels: Event.None,
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
 		lookupLanguageModel: (modelId: string) => languageModels?.get(modelId),
@@ -947,8 +950,8 @@ function createSessionListController(disposables: DisposableStore, instantiation
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListController, sessionType, provider, sessionListStore, description, 'local'));
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>; customizationServiceOverride?: IAgentHostCustomizationService; agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService>; languageModelsServiceOverride?: Partial<ILanguageModelsService>; workspaceFolders?: readonly URI[] }) {
-	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController, modelService, workingCopyService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, false, opts?.languageModelToolsServiceOverride, opts?.configOverrides, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride, opts?.remoteAgentHostServiceOverride, opts?.customizationServiceOverride, opts?.agentHostTerminalServiceOverride, opts?.languageModelsServiceOverride, opts?.workspaceFolders);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; languageModelToolsServiceOverride?: Partial<ILanguageModelToolsService>; configOverrides?: Record<string, unknown>; provider?: string; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService>; remoteAgentHostServiceOverride?: Partial<IRemoteAgentHostService>; customizationServiceOverride?: IAgentHostCustomizationService; agentHostTerminalServiceOverride?: Partial<IAgentHostTerminalService>; languageModelsServiceOverride?: Partial<ILanguageModelsService>; workspaceFolders?: readonly URI[]; defaultAccountServiceOverride?: Partial<IDefaultAccountService> }) {
+	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController, modelService, workingCopyService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, false, opts?.languageModelToolsServiceOverride, opts?.configOverrides, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride, opts?.remoteAgentHostServiceOverride, opts?.customizationServiceOverride, opts?.agentHostTerminalServiceOverride, opts?.languageModelsServiceOverride, opts?.workspaceFolders, opts?.defaultAccountServiceOverride);
 
 	const listController = createSessionListController(disposables, instantiationService, agentHostService);
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -10913,6 +10916,64 @@ suite('AgentHostChatContribution', () => {
 			await timeout(0);
 
 			assert.deepStrictEqual(agentHostService.authenticateCalls, []);
+		});
+
+		test('withdraws Copilot models and restarts the agent host on live sign-out', async () => {
+			const account = upcastPartial<IDefaultAccount>({
+				authenticationProvider: { id: 'github', name: 'GitHub', enterprise: false },
+				accountName: 'test',
+				sessionId: 'session',
+				enterprise: false,
+			});
+			const accountChanged = disposables.add(new Emitter<IDefaultAccount | null>());
+			let registeredProvider: ILanguageModelChatProvider | undefined;
+			const byokIdentifier = 'azure/Azure/gpt-5';
+			const { agentHostService } = createContribution(disposables, {
+				defaultAccountServiceOverride: {
+					onDidChangeDefaultAccount: accountChanged.event,
+					getDefaultAccount: async () => account,
+				},
+				languageModelsServiceOverride: {
+					registerLanguageModelProvider: (_vendor, provider) => {
+						registeredProvider = provider;
+						return toDisposable(() => { });
+					},
+					lookupLanguageModel: identifier => identifier === byokIdentifier
+						? upcastPartial<ILanguageModelChatMetadata>({ id: 'gpt-5', name: 'GPT-5', vendor: 'azure', isBYOK: true })
+						: undefined,
+				},
+			});
+			await timeout(0);
+			agentHostService.setRootState({
+				agents: [{
+					...protectedAgents()[0],
+					models: [
+						{ provider: 'copilot', id: 'claude-opus-5', name: 'Claude Opus 5' },
+						{ provider: 'copilot', id: 'azure/gpt-5', name: 'Azure GPT-5', _meta: { byokModelIdentifier: byokIdentifier } },
+					],
+				}],
+				activeSessions: 0,
+			});
+			await timeout(0);
+			const signedInModels = await registeredProvider!.provideLanguageModelChatInfo({ silent: true }, CancellationToken.None);
+			let providerChanges = 0;
+			disposables.add(registeredProvider!.onDidChange(() => providerChanges++));
+
+			accountChanged.fire(null);
+			await timeout(0);
+			const signedOutModels = await registeredProvider!.provideLanguageModelChatInfo({ silent: true }, CancellationToken.None);
+
+			assert.deepStrictEqual({
+				signedInModels: signedInModels.map(model => model.metadata.name),
+				signedOutModels: signedOutModels.map(model => model.metadata.name),
+				providerChanges,
+				restartAgentHostCalls: agentHostService.restartAgentHostCalls,
+			}, {
+				signedInModels: ['Claude Opus 5', 'Azure GPT-5'],
+				signedOutModels: ['Azure GPT-5'],
+				providerChanges: 1,
+				restartAgentHostCalls: 1,
+			});
 		});
 
 		test('propagates interactive authentication errors for eager-created sessions', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
@@ -8,7 +8,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { SessionModelInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ILanguageModelChatMetadata } from '../../../common/languageModels.js';
-import { AgentHostLanguageModelProvider } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
+import { AgentHostLanguageModelProvider, filterAgentHostModelsAvailableWithoutCopilotAccount } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 
 suite('AgentHostLanguageModelProvider', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -217,6 +217,20 @@ suite('AgentHostLanguageModelProvider', () => {
 			grouped: { byokModelIdentifier: 'openrouter/OpenRouter 2/aion-labs/aion-3.0', manageModelsId: 'openrouter/OpenRouter 2/aion-labs/aion-3.0' },
 			groupless: { byokModelIdentifier: 'anthropic/claude-sonnet-4', manageModelsId: 'anthropic/claude-sonnet-4' },
 			native: { byokModelIdentifier: undefined, manageModelsId: undefined },
+		});
+	});
+
+	test('keeps only valid BYOK models for a signed-out Copilot-authenticated harness', () => {
+		const native = makeModel('claude-opus-5');
+		const byok = makeModel('azure/gpt-5', { byokModelIdentifier: 'azure/Azure/gpt-5' });
+		const invalidByok = makeModel('openai/gpt-5', { byokModelIdentifier: 'openai/OpenAI/gpt-5' });
+
+		assert.deepStrictEqual({
+			signedIn: filterAgentHostModelsAvailableWithoutCopilotAccount([native, byok, invalidByok], false, () => false).map(model => model.id),
+			signedOut: filterAgentHostModelsAvailableWithoutCopilotAccount([native, byok, invalidByok], true, identifier => identifier === 'azure/Azure/gpt-5').map(model => model.id),
+		}, {
+			signedIn: ['claude-opus-5', 'azure/gpt-5', 'openai/gpt-5'],
+			signedOut: ['azure/gpt-5'],
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Removes Copilot-backed Agent Host models from model pickers immediately after GitHub sign-out.
- Preserves validated BYOK models that remain usable without a Copilot account.
- Restarts the local Agent Host to discard stale credentials and replaces an invalid active model selection.

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

GitHub sign-out changed the default account, but the Agent Host bridge continued publishing the catalog from its last root state. The host process also retained the previously forwarded credential because the authentication flow had no live revocation path. Language model consumers therefore received no provider change to invalidate the stale Copilot models, and an already-selected model could remain active.

### Implementation

The local Agent Host contribution now owns the account transition globally rather than registering one listener per discovered agent. It tracks initial account resolution, clears its forwarded-token cache on changes, and republishes each harness catalog according to the current account state.

For a signed-out harness whose protected resources require GitHub Copilot, catalog publication keeps only models carrying a BYOK identifier that resolves to registered BYOK metadata. Updating the bridged provider emits its normal change event, which drives the existing language-model store refresh instead of adding picker-specific cache invalidation.

A live signed-out transition also restarts the local Agent Host so the previous process cannot retain the old credential. The model catalog is withdrawn before the restart completes. Chat input model selection strictly revalidates on authoritative account and catalog changes so an unavailable selection is cleared or replaced from the refreshed pool.

### Behavior and constraints

- Anonymous access keeps the full catalog.
- Harnesses that do not require Copilot sign-in remain unchanged.
- Unvalidated or missing BYOK source metadata fails closed and does not remain selectable.
- Sign-in continues through the existing authentication flow.
- Restart failures are logged; the already-filtered provider catalog remains in effect.

### Review context

The main tradeoff is restarting the local Agent Host on live sign-out. This is intentional because filtering the workbench catalog alone would leave the previous bearer token resident in the running host process.

</details>