### PR TITLE
agentHost: scope client customizations to session working directories

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { disposableTimeout, raceCancellationError } from '../../../../../base/common/async.js';
+import { disposableTimeout, raceCancellation, raceCancellationError } from '../../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { arrayEquals, structuralEquals } from '../../../../../base/common/equals.js';
@@ -25,7 +25,7 @@ import { KNOWN_MODE_VALUES, SessionConfigKey } from '../../../../../platform/age
 import { migrateLegacyAutopilotConfig } from '../../../../../platform/agentHost/common/agentHostSchema.js';
 import type { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ResolveSessionConfigResult, type SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { AgentCustomization, ChangesSummary, ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, type ClientPluginCustomization, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionActiveClient, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { AgentCustomization, ChangesSummary, ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, type ClientPluginCustomization, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isChatAction, isSessionAction, NotificationType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AgentCapabilities, AgentInfo, buildChatUri, buildDefaultChatUri, getSessionRelatedPullRequestUrls, isDefaultChatUri, isSessionStatusArchived, isSessionStatusRead, parseChatUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionMeta, SessionSourceControlOutcome, StateComponents, withSessionMultiRootMetadata, withSessionStatusFlag, withSessionWorkspaceless, type ChatSummary, type ISessionGitState, type ISessionMultiRootMetadata } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -35,7 +35,7 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { AgentHostDownloadProgress } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostDownloadProgress.js';
-import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
+import { areCustomizationScopeRootsEqual, IAgentCustomizationScope, IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { ChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
 import { IChatSendRequestOptions, IChatService, type IChatModelReference } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
@@ -64,6 +64,13 @@ const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototy
 // new drafts, so they stay visible (disabled) while a draft re-resolves rather
 // than blanking then reappearing.
 const SEEDED_CONFIG_SCHEMA_KEYS = [SessionConfigKey.Isolation, SessionConfigKey.Branch] as const;
+
+/** Cancels its token when replaced or disposed by a mutable disposable. */
+class ActiveClientSyncCancellationTokenSource extends CancellationTokenSource {
+	override dispose(): void {
+		super.dispose(true);
+	}
+}
 
 /**
  * {@link SessionConfigKey.Isolation} value that runs a session in its own git worktree.
@@ -654,6 +661,8 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	// list refresh). See `_applySessionMetaFromState` / `setMeta`.
 	private _project: IAgentSessionMetadata['project'];
 	private _workingDirectories: readonly URI[] | undefined;
+	/** Working-directory set used to resolve session customizations. */
+	get workingDirectories(): readonly URI[] { return this._workingDirectories ?? []; }
 	// The directory that the current `mode` custom-agent URI is rooted at. Used to
 	// compute the agent's repo-relative path so the selection can be rebased onto
 	// its worktree twin when the session relocates into an isolated worktree (see
@@ -1515,8 +1524,7 @@ interface INewSessionConstructionContext {
 	 * takes over ownership of the same `sessionId` key.
 	 */
 	readonly onSessionState?: (sessionId: string, state: SessionState | undefined) => void;
-	/** Initial active-client snapshot for the eager `createSession`. Drift is reconciled by the handler before the first message. */
-	readonly activeClient?: SessionActiveClient;
+	readonly activeClientScope?: IAgentCustomizationScope;
 }
 
 /**
@@ -1579,6 +1587,10 @@ class NewSession extends Disposable {
 		}));
 	}
 
+	getClientCustomAgents(): readonly AgentCustomization[] {
+		return this._activeClientScope?.customAgents.get() ?? [];
+	}
+
 	/**
 	 * Latest resolved config. Replaces what used to live in `_newSessionConfigs`.
 	 * `undefined` indicates the most recent {@link resolveConfig} failed and no
@@ -1621,7 +1633,7 @@ class NewSession extends Disposable {
 	private readonly _stateListener = this._register(new MutableDisposable());
 	private readonly _onSessionState: ((sessionId: string, state: SessionState | undefined) => void) | undefined;
 
-	private readonly _initialActiveClient: SessionActiveClient | undefined;
+	private readonly _activeClientScope: IAgentCustomizationScope | undefined;
 	private readonly _initialMetadata: Record<string, unknown> | undefined;
 
 	private readonly _logService: ILogService;
@@ -1645,7 +1657,10 @@ class NewSession extends Disposable {
 		this._providerId = ctx.providerId;
 		this._logService = ctx.logService;
 		this._onSessionState = ctx.onSessionState;
-		this._initialActiveClient = ctx.activeClient;
+		this._activeClientScope = ctx.activeClientScope;
+		if (this._activeClientScope) {
+			this._register(this._activeClientScope);
+		}
 		this._initialMetadata = ctx.initialMetadata;
 
 		const resource = URI.from({ scheme: ctx.resourceScheme, path: `/${generateUuid()}` });
@@ -1946,6 +1961,11 @@ class NewSession extends Disposable {
 
 		void (async () => {
 			try {
+				await this._activeClientScope?.whenResolved();
+				if (this._backendUri?.toString() !== backendUri.toString()) {
+					return;
+				}
+				const activeClient = this._activeClientScope?.activeClient(connection.clientId).get();
 				await connection.createSession({
 					provider: this.agentProvider,
 					session: backendUri,
@@ -1959,7 +1979,7 @@ class NewSession extends Disposable {
 					// `progress` frame so `_handleProgress` can correlate it.
 					progressToken: generateUuid(),
 					...(this._selectedAgent ? { agent: { uri: this._selectedAgent.uri } } : {}),
-					...(this._initialActiveClient ? { activeClient: this._initialActiveClient } : {}),
+					...(activeClient ? { activeClient } : {}),
 				});
 			} catch (err) {
 				this._logService.warn(`[${this._providerId}] Eager createSession failed for ${backendUri.toString()}: ${err}`);
@@ -2306,6 +2326,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	/** True while a {@link _refreshSessions} call is awaiting `listSessions()`. */
 	private _sessionRefreshInFlight = false;
 
+	private readonly _activeSessionScope = this._register(new MutableDisposable<IAgentCustomizationScope>());
+	private readonly _activeClientSyncCancellation = this._register(new MutableDisposable<ActiveClientSyncCancellationTokenSource>());
+	private _activeSessionScopeSessionType: string | undefined;
+	private _activeSessionScopeRoots: readonly URI[] | undefined;
+
 	constructor(
 		@IChatSessionsService protected readonly _chatSessionsService: IChatSessionsService,
 		@IChatService protected readonly _chatService: IChatService,
@@ -2582,8 +2607,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	private _syncActiveClient(): void {
+		const cancellation = new ActiveClientSyncCancellationTokenSource();
+		this._activeClientSyncCancellation.value = cancellation;
 		const activeSession = this._sessionsService.activeSession.get();
 		if (!activeSession || activeSession.providerId !== this.id) {
+			this._clearActiveSessionScope();
 			return;
 		}
 
@@ -2591,13 +2619,47 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const cached = rawId ? this._sessionCache.get(rawId) : undefined;
 		const connection = this.connection;
 		if (!rawId || !cached || !connection) {
+			this._clearActiveSessionScope();
 			return;
 		}
 
-		const activeClient = this._activeClientService.getActiveClient(
-			this.resourceSchemeForProvider(cached.agentProvider),
-			connection.clientId,
-		);
+		const sessionType = this.resourceSchemeForProvider(cached.agentProvider);
+		let scope = this._activeSessionScope.value;
+		if (!scope || this._activeSessionScopeSessionType !== sessionType || !areCustomizationScopeRootsEqual(this._activeSessionScopeRoots, cached.workingDirectories)) {
+			scope = this._activeClientService.acquireScope(sessionType, cached.workingDirectories);
+			this._activeSessionScope.value = scope;
+			this._activeSessionScopeSessionType = scope ? sessionType : undefined;
+			this._activeSessionScopeRoots = scope ? [...cached.workingDirectories] : undefined;
+		}
+		if (!scope) {
+			return;
+		}
+
+		void this._dispatchActiveClientWhenResolved(cancellation.token, activeSession.sessionId, rawId, cached, connection, scope);
+	}
+
+	private async _dispatchActiveClientWhenResolved(
+		token: CancellationToken,
+		activeSessionId: string,
+		rawId: string,
+		cached: AgentHostSessionAdapter,
+		connection: IAgentConnection,
+		scope: IAgentCustomizationScope,
+	): Promise<void> {
+		await raceCancellation(scope.whenResolved(), token);
+		const activeSession = this._sessionsService.activeSession.get();
+		if (
+			token.isCancellationRequested ||
+			scope !== this._activeSessionScope.value ||
+			this.connection !== connection ||
+			this._sessionCache.get(rawId) !== cached ||
+			activeSession?.providerId !== this.id ||
+			activeSession.sessionId !== activeSessionId
+		) {
+			return;
+		}
+
+		const activeClient = scope.activeClient(connection.clientId).get();
 		const existing = this._lastSessionStates.get(cached.sessionId)?.activeClients.find(client => client.clientId === activeClient.clientId);
 		if (equals(existing, activeClient)) {
 			return;
@@ -2607,6 +2669,13 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			type: ActionType.SessionActiveClientSet,
 			activeClient,
 		});
+	}
+
+	private _clearActiveSessionScope(): void {
+		this._activeClientSyncCancellation.clear();
+		this._activeSessionScope.clear();
+		this._activeSessionScopeSessionType = undefined;
+		this._activeSessionScopeRoots = undefined;
 	}
 
 	getSessions(): ISession[] {
@@ -2727,38 +2796,43 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// composer re-seeds a fresh draft).
 		const connection = this.connection;
 		const resourceScheme = this.resourceSchemeForProvider(sessionType.id);
-		const newSession = this._instantiationService.createInstance(NewSession, {
-			workspace,
-			quickChat,
-			sessionType,
-			providerId: this.id,
-			icon: sessionType.icon,
-			resourceScheme,
-			backendSessionScheme: this._backendSessionScheme(sessionType.id),
-			authenticationPending: this.authenticationPending,
-			logService: this._logService,
-			initialConfigValues: this._initialNewSessionConfig(workspace),
-			initialConfigSchema: this._seededConfigSchema(),
-			initialMetadata,
-			instantiationService: this._instantiationService,
-			onSessionState: (id, state) => state === undefined
-				? this._handleNewSessionStateGone(id)
-				: this._handleNewSessionStateUpdate(id, state),
-			activeClient: connection
-				? this._activeClientService.getActiveClient(resourceScheme, connection.clientId)
-				: undefined,
-		}, {
-			icon: this.iconForAgentProvider(sessionType.id) ?? this.icon,
-			loading: this.authenticationPending,
-			mapDiffUri: this._diffUriMapper(),
-			gitHubService: this._gitHubService,
-			instantiationService: this._instantiationService,
-			getConnection: () => this.connection,
-			agentCapabilities: this._agentCapabilities,
-			...this._adapterOptions(),
-		} satisfies IAgentHostAdapterOptions);
+		const activeClientScope = this._activeClientService.acquireScope(resourceScheme, workspace?.folders.map(folder => folder.root) ?? []);
+		let newSession: NewSession;
+		try {
+			newSession = this._instantiationService.createInstance(NewSession, {
+				workspace,
+				quickChat,
+				sessionType,
+				providerId: this.id,
+				icon: sessionType.icon,
+				resourceScheme,
+				backendSessionScheme: this._backendSessionScheme(sessionType.id),
+				authenticationPending: this.authenticationPending,
+				logService: this._logService,
+				initialConfigValues: this._initialNewSessionConfig(workspace),
+				initialConfigSchema: this._seededConfigSchema(),
+				initialMetadata,
+				instantiationService: this._instantiationService,
+				onSessionState: (id, state) => state === undefined
+					? this._handleNewSessionStateGone(id)
+					: this._handleNewSessionStateUpdate(id, state),
+				activeClientScope,
+			}, {
+				icon: this.iconForAgentProvider(sessionType.id) ?? this.icon,
+				loading: this.authenticationPending,
+				mapDiffUri: this._diffUriMapper(),
+				gitHubService: this._gitHubService,
+				instantiationService: this._instantiationService,
+				getConnection: () => this.connection,
+				agentCapabilities: this._agentCapabilities,
+				...this._adapterOptions(),
+			} satisfies IAgentHostAdapterOptions);
+		} catch (err) {
+			activeClientScope?.dispose();
+			throw err;
+		}
 		this._newSessions.set(newSession.sessionId, newSession);
-		newSession.observeClientCustomAgents(this._activeClientService.getCustomAgents(resourceScheme), () => {
+		newSession.observeClientCustomAgents(activeClientScope?.customAgents ?? constObservable([]), () => {
 			this._onDidChangeCustomAgents.fire();
 			this._onDidChangeCustomizations.fire();
 		});
@@ -3477,7 +3551,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!newSession) {
 			return stateAgents;
 		}
-		const clientAgents = this._activeClientService.getCustomAgents(newSession.session.resource.scheme).get();
+		const clientAgents = newSession.getClientCustomAgents();
 		if (clientAgents.length === 0) {
 			return stateAgents;
 		}
@@ -4985,6 +5059,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			this._onDidChangeSessions.fire({ added: [], removed: [cached], changed: [] });
 			cached.dispose();
 		}
+		this._syncActiveClient();
 	}
 
 	private _removeCachedSession(rawId: string, expected?: AgentHostSessionAdapter): AgentHostSessionAdapter | undefined {

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -39,7 +39,7 @@ import { ISessionChangeEvent } from '../../../../../services/sessions/common/ses
 import { ChatInteractivity, ChatOriginKind, getChatCapabilities, ISession, SessionStatus } from '../../../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../../services/sessions/browser/sessionsService.js';
-import { IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
+import { IAgentCustomizationScope, IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { LocalAgentHostSessionsProvider } from '../../browser/localAgentHostSessionsProvider.js';
 import { AgentHostSessionAdapter } from '../../browser/baseAgentHostSessionsProvider.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
@@ -414,7 +414,7 @@ function createSchemaDefaultConfigurationService(): TestConfigurationService {
 
 function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = [
 	{ type: 'agent-host-copilotcli', name: 'copilot', displayName: 'Copilot', description: 'test', icon: undefined },
-], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; hiddenLanguageModelIds?: ReadonlySet<string>; languageModelVisibilityChanges?: Event<void>; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; activeClientAgents?: IObservable<readonly AgentCustomization[]>; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService }): LocalAgentHostSessionsProvider {
+], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; acquireOrLoadSession?: (resource: URI) => Promise<IChatModelReference | undefined>; languageModelIds?: string[]; lookupLanguageModel?: (modelId: string) => ILanguageModelChatMetadata | undefined; hiddenLanguageModelIds?: ReadonlySet<string>; languageModelVisibilityChanges?: Event<void>; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; visibleSessions?: IObservable<readonly (IActiveSession | undefined)[]>; activeClient?: Omit<SessionActiveClient, 'clientId'>; activeClientAgents?: IObservable<readonly AgentCustomization[]>; activeClientScope?: (sessionType: string, roots: readonly URI[]) => IAgentCustomizationScope | undefined; storageService?: IStorageService; isSessionsWindow?: boolean; confirmDelete?: boolean; workspaceTrusted?: boolean; gitHubService?: IGitHubService }): LocalAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -464,8 +464,15 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 		override readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> = visibleSessionsObs;
 	}());
 	instantiationService.stub(IAgentHostActiveClientService, new class extends mock<IAgentHostActiveClientService>() {
-		override getActiveClient = (_sessionType: string, clientId: string) => ({ clientId, ...(options?.activeClient ?? { tools: [], customizations: [] }) });
-		override getCustomAgents = (_sessionType: string) => options?.activeClientAgents ?? constObservable([]);
+		override acquireScope = (sessionType: string, roots: readonly URI[]) => options?.activeClientScope?.(sessionType, roots) ?? ({
+			customizations: constObservable(options?.activeClient?.customizations ?? []),
+			customAgents: options?.activeClientAgents ?? constObservable([]),
+			tools: constObservable(options?.activeClient?.tools ?? []),
+			isResolved: constObservable(true),
+			whenResolved: () => Promise.resolve(),
+			activeClient: (clientId: string) => constObservable({ clientId, ...(options?.activeClient ?? { tools: [], customizations: [] }) }),
+			dispose: () => { },
+		});
 	}());
 
 	return disposables.add(instantiationService.createInstance(LocalAgentHostSessionsProvider));
@@ -3241,7 +3248,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		});
 	});
 
-	test('joins the active client with customizations when opening an existing session', () => {
+	test('joins the active client with customizations when opening an existing session', async () => {
 		const activeSession = observableValue<IActiveSession | undefined>('activeSession', undefined);
 		const activeClient = {
 			tools: [],
@@ -3253,14 +3260,18 @@ suite('LocalAgentHostSessionsProvider', () => {
 				enabled: true,
 			}],
 		} satisfies Omit<SessionActiveClient, 'clientId'>;
+		agentHost.addSession(createSession('active-client'));
 		const provider = createProvider(disposables, agentHost, undefined, { activeSession, activeClient });
+		provider.getSessions();
+		await timeout(0);
+		agentHost.dispatchedActions.length = 0;
 		const resource = URI.from({ scheme: 'agent-host-copilotcli', path: '/active-client' });
 		activeSession.set({
 			providerId: provider.id,
 			sessionId: `${provider.id}:${resource.toString()}`,
 			resource,
 		} as IActiveSession, undefined);
-		fireSessionAdded(agentHost, 'active-client');
+		await timeout(0);
 
 		assert.deepStrictEqual(agentHost.dispatchedActions.filter(dispatch => dispatch.action.type === ActionType.SessionActiveClientSet), [{
 			channel: AgentSession.uri('copilotcli', 'active-client').toString(),
@@ -3271,6 +3282,86 @@ suite('LocalAgentHostSessionsProvider', () => {
 			clientId: 'test-local-client',
 			clientSeq: 0,
 		}]);
+	});
+
+	test('does not publish empty customizations while resolving an unobserved active session scope', async () => {
+		const activeSession = observableValue<IActiveSession | undefined>('activeSession', undefined);
+		const resolution = new DeferredPromise<void>();
+		let scopeRequests = 0;
+		let activeClientReads = 0;
+		const activeClient = {
+			tools: [],
+			customizations: [{
+				type: CustomizationType.Plugin,
+				id: 'file:///customizations/resolved',
+				uri: 'file:///customizations/resolved',
+				name: 'Resolved Customization',
+				enabled: true,
+			}],
+		} satisfies Omit<SessionActiveClient, 'clientId'>;
+		const scope: IAgentCustomizationScope = {
+			customizations: constObservable(activeClient.customizations),
+			customAgents: constObservable([]),
+			tools: constObservable(activeClient.tools),
+			isResolved: constObservable(true),
+			whenResolved: () => resolution.p,
+			activeClient: clientId => {
+				activeClientReads++;
+				return constObservable({ clientId, ...activeClient });
+			},
+			dispose: () => { },
+		};
+		agentHost.addSession(createSession('delayed-active-client', {
+			workingDirectory: URI.file('/home/user/delayed-active-client'),
+		}));
+		const provider = createProvider(disposables, agentHost, undefined, {
+			activeSession,
+			activeClientScope: () => {
+				scopeRequests++;
+				return scope;
+			},
+		});
+		provider.getSessions();
+		await timeout(0);
+		agentHost.dispatchedActions.length = 0;
+		const resource = URI.from({ scheme: 'agent-host-copilotcli', path: '/delayed-active-client' });
+		activeSession.set({
+			providerId: provider.id,
+			sessionId: `${provider.id}:${resource.toString()}`,
+			resource,
+		} as IActiveSession, undefined);
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			scopeRequests,
+			activeClientReads,
+			actions: agentHost.dispatchedActions.filter(dispatch => dispatch.action.type === ActionType.SessionActiveClientSet),
+		}, {
+			scopeRequests: 1,
+			activeClientReads: 0,
+			actions: [],
+		});
+
+		resolution.complete();
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			scopeRequests,
+			activeClientReads,
+			actions: agentHost.dispatchedActions.filter(dispatch => dispatch.action.type === ActionType.SessionActiveClientSet),
+		}, {
+			scopeRequests: 1,
+			activeClientReads: 1,
+			actions: [{
+				channel: AgentSession.uri('copilotcli', 'delayed-active-client').toString(),
+				action: {
+					type: ActionType.SessionActiveClientSet,
+					activeClient: { clientId: 'test-local-client', ...activeClient },
+				},
+				clientId: 'test-local-client',
+				clientSeq: 0,
+			}],
+		});
 	});
 
 	test('createNewSession eagerly creates the backend session with the client-allocated URI', async () => {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -974,6 +974,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		const agentRegistration = agentStore.add(this._activeClientService.registerForAgent(sessionType, { includeUserStorage: true }));
 		const syncProvider = agentRegistration.syncProvider;
+		// The management UI remains ambient while individual sessions use their working-directory scopes.
+		const ambientScope = agentStore.add(agentRegistration.acquireScope([]));
 
 		const itemProvider = agentStore.add(this._instantiationService.createInstance(AgentCustomizationItemProvider,
 			sanitized,
@@ -989,8 +991,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 					run: () => pluginController.removeConfiguredPlugin(customization),
 				}];
 			},
-			syncedUri => agentRegistration.bundler.getOrigin(syncedUri)
+			syncedUri => agentRegistration.getOrigin(syncedUri)
 		));
+		itemProvider.setDraftCustomAgents(ambientScope.customAgents);
+		itemProvider.setDraftCustomizations(ambientScope.customizations);
 
 		const harnessDescriptor = createRemoteAgentHarnessDescriptor(sessionType, displayName, pluginController, itemProvider, syncProvider);
 		agentStore.add(this._customizationHarnessService.registerExternalHarness(harnessDescriptor));

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -231,8 +231,15 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 		override readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> = constObservable<readonly (IActiveSession | undefined)[]>([]);
 	}());
 	instantiationService.stub(IAgentHostActiveClientService, new class extends mock<IAgentHostActiveClientService>() {
-		override getActiveClient = (_sessionType: string, clientId: string) => ({ clientId, tools: [], customizations: [] });
-		override getCustomAgents = () => constObservable([]);
+		override acquireScope = (_sessionType: string, _roots: readonly URI[]) => ({
+			customizations: constObservable([]),
+			customAgents: constObservable([]),
+			tools: constObservable([]),
+			isResolved: constObservable(true),
+			whenResolved: () => Promise.resolve(),
+			activeClient: (clientId: string) => constObservable({ clientId, tools: [], customizations: [] }),
+			dispose: () => { },
+		});
 	}());
 
 	const config: IRemoteAgentHostSessionsProviderConfig = {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
@@ -3,20 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { Delayer } from '../../../../../../base/common/async.js';
+import { DeferredPromise, Delayer } from '../../../../../../base/common/async.js';
 import { onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
+import { hash } from '../../../../../../base/common/hash.js';
+import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { equals } from '../../../../../../base/common/objects.js';
-import { autorun, derived, IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
-import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
-import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { autorun, derived, IObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { AgentHostCopilotMultiRootEnabledSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
 import type { AgentCustomization, SessionActiveClient, ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import type { ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
 import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
@@ -27,21 +31,34 @@ import { AgentCustomizationSyncProvider } from './agentCustomizationSyncProvider
 import { type ILocalCustomizationSyncOptions, resolveCustomizationRefs, resolveLocalCustomAgents, shouldSyncWorkspaceDotMcp } from './agentHostLocalCustomizations.js';
 import { toolDataToDefinition } from './agentHostToolUtils.js';
 import { IAgentHostToolSetEnablementService, isToolEnabledInSet } from './agentHostToolSetEnablementService.js';
-import { SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { type ISyncedCustomizationOrigin, SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
 
 export const IAgentHostActiveClientService = createDecorator<IAgentHostActiveClientService>('agentHostActiveClientService');
 
-/**
- * The exposed `syncProvider` is the same instance the service uses to resolve
- * customizations; the contribution wires it into its harness so opt-out toggles
- * propagate. The `bundler` is exposed so the contribution can recover the
- * original provenance of files flattened into the synthetic synced bundle (via
- * {@link SyncedCustomizationBundler.getOrigin}).
- */
+/** Identity a published customization set is resolved against. Refcounted; disposed by each holder. */
+export interface IAgentCustomizationScope extends IDisposable {
+	readonly customizations: IObservable<readonly ClientPluginCustomization[]>;
+	readonly customAgents: IObservable<readonly AgentCustomization[]>;
+	/** Tools available to this scope's active client. */
+	readonly tools: IObservable<readonly ToolDefinition[]>;
+	/** Composed active-client view for this scope. */
+	activeClient(clientId: string): IObservable<SessionActiveClient>;
+	/**
+	 * `false` until the initial customization resolution completes. Publishing an
+	 * unresolved scope would transiently wipe the host's customization state.
+	 */
+	readonly isResolved: IObservable<boolean>;
+	/** Resolves once the scope's initial customization resolution has completed. */
+	whenResolved(): Promise<void>;
+}
+
+/** Registration-level customization state for an agent harness. */
 export interface IAgentRegistration extends IDisposable {
 	readonly syncProvider: ICustomizationSyncProvider;
-	readonly bundler: SyncedCustomizationBundler;
+	/** Acquires (or shares) the scope for `roots`. Refcounted: torn down when the last holder disposes. */
+	acquireScope(roots: readonly URI[]): IAgentCustomizationScope;
+	/** Recovers provenance for a synced URI produced by any scope of this agent. */
+	getOrigin(syncedUri: URI): ISyncedCustomizationOrigin | undefined;
 }
 
 export type IAgentRegistrationOptions = ILocalCustomizationSyncOptions;
@@ -49,124 +66,191 @@ export type IAgentRegistrationOptions = ILocalCustomizationSyncOptions;
 export interface IAgentHostActiveClientService {
 	readonly _serviceBrand: undefined;
 
-	/**
-	 * Constructs the per-sessionType {@link AgentCustomizationSyncProvider}
-	 * and {@link SyncedCustomizationBundler}, builds the `customizations`
-	 * observable from them, wires it to {@link IPromptsService} change events,
-	 * and resolves the initial value. Disposing the returned handle tears all
-	 * of that down. The created `syncProvider` is exposed on the returned
-	 * object so the contribution can pass the same instance to its
-	 * customization harness.
-	 */
+	/** Registers an agent harness and its registration-level customization sync provider. */
 	registerForAgent(sessionType: string, options?: IAgentRegistrationOptions): IAgentRegistration;
 
-	/** Returns a {@link SessionActiveClient} for `sessionType` using the caller-supplied `clientId`. Customizations are empty when `sessionType` has not been registered. */
-	getActiveClient(sessionType: string, clientId: string): SessionActiveClient;
-
-	getCustomizations(sessionType: string): IObservable<readonly ClientPluginCustomization[]>;
-
-	/** Selectable local agents available before the host has parsed the customization refs. */
-	getCustomAgents(sessionType: string): IObservable<readonly AgentCustomization[]>;
-
-	/**
-	 * Returns the tools this client advertises to the agent host for `sessionType`.
-	 *
-	 * Chat Customizations are the source of truth: a tool is advertised only when it is an enabled
-	 * member of a tool set surfaced in the Agents window Tools section (`deprecated !== true`).
-	 * Editor-only tool sets are not created in the Agents window. Enablement is tri-state per
-	 * {@link IAgentHostToolSetEnablementService}.
-	 */
-	getClientTools(sessionType: string): IObservable<readonly ToolDefinition[]>;
+	/** Acquires a customization scope for a registered agent. Returns `undefined` when `sessionType` has no registration. */
+	acquireScope(sessionType: string, roots: readonly URI[]): IAgentCustomizationScope | undefined;
 }
 
-export class AgentHostActiveClientService extends Disposable implements IAgentHostActiveClientService {
-	declare readonly _serviceBrand: undefined;
+class AgentRegistration extends Disposable implements IAgentRegistration {
 
-	private readonly _customizationsByType: ISettableObservable<ReadonlyMap<string, IObservable<readonly ClientPluginCustomization[]>>>;
-	private readonly _customAgentsByType: ISettableObservable<ReadonlyMap<string, IObservable<readonly AgentCustomization[]>>>;
+	readonly syncProvider: ICustomizationSyncProvider;
 
-	private readonly _allToolsObs: IObservable<readonly IToolData[]>;
-	private readonly _allToolSetsObs: IObservable<Iterable<IToolSet>>;
-
-	/** Cached per-`sessionType` advertised-tools observable, so callers (e.g. autoruns) reuse one stable derived. */
-	private readonly _clientToolsByType = new Map<string, IObservable<readonly ToolDefinition[]>>();
+	private readonly _scopes = new Map<string, AgentCustomizationScope>();
+	private _isDisposed = false;
 
 	constructor(
-		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
+		private readonly _sessionType: string,
+		private readonly _options: IAgentRegistrationOptions | undefined,
+		private readonly _instantiationService: IInstantiationService,
+		storageService: IStorageService,
+		private readonly _getClientTools: (sessionType: string) => IObservable<readonly ToolDefinition[]>,
+		private readonly _onDispose: () => void,
+	) {
+		super();
+		this.syncProvider = this._register(new AgentCustomizationSyncProvider(_sessionType, storageService));
+	}
+
+	acquireScope(roots: readonly URI[]): IAgentCustomizationScope {
+		const normalizedRoots = normalizeRoots(roots);
+		const scopeKey = getScopeKey(normalizedRoots);
+		let scope = this._scopes.get(scopeKey);
+		if (!scope) {
+			// Referenced by the teardown callback below, which only runs once the
+			// scope has been constructed.
+			const createdScope: AgentCustomizationScope = this._instantiationService.createInstance(
+				AgentCustomizationScope,
+				this._sessionType,
+				normalizedRoots,
+				this.syncProvider,
+				this._options,
+				this._getClientTools,
+				() => this._removeScope(scopeKey, createdScope),
+			);
+			scope = createdScope;
+			this._scopes.set(scopeKey, scope);
+		}
+		return scope.acquire();
+	}
+
+	getOrigin(syncedUri: URI): ISyncedCustomizationOrigin | undefined {
+		for (const scope of this._scopes.values()) {
+			const origin = scope.getOrigin(syncedUri);
+			if (origin) {
+				return origin;
+			}
+		}
+		return undefined;
+	}
+
+	override dispose(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		const scopes = [...this._scopes.values()];
+		this._scopes.clear();
+		for (const scope of scopes) {
+			scope.dispose();
+		}
+		super.dispose();
+		this._onDispose();
+	}
+
+	private _removeScope(scopeKey: string, scope: AgentCustomizationScope): void {
+		if (this._scopes.get(scopeKey) === scope) {
+			this._scopes.delete(scopeKey);
+		}
+	}
+}
+
+/** Owns the customization bundle and resolution lifecycle for one working-directory scope. */
+class AgentCustomizationScope extends Disposable {
+
+	private readonly _bundler: SyncedCustomizationBundler;
+	private readonly _updateDelayer: Delayer<void>;
+	private readonly _customizations = observableValue<readonly ClientPluginCustomization[]>('agentCustomizations', []);
+	private readonly _customAgents = observableValue<readonly AgentCustomization[]>('agentCustomAgents', []);
+	private readonly _isResolved = observableValue('agentCustomizationsResolved', false);
+	private readonly _initialResolution = new DeferredPromise<void>();
+	private readonly _activeClients = new Map<string, IObservable<SessionActiveClient>>();
+	private _refCount = 0;
+	private _updateSeq = 0;
+	private _isDisposed = false;
+
+	get customizations(): IObservable<readonly ClientPluginCustomization[]> {
+		return this._customizations;
+	}
+
+	get customAgents(): IObservable<readonly AgentCustomization[]> {
+		return this._customAgents;
+	}
+
+	get tools(): IObservable<readonly ToolDefinition[]> {
+		return this._getClientTools(this._sessionType);
+	}
+
+	get isResolved(): IObservable<boolean> {
+		return this._isResolved;
+	}
+
+	constructor(
+		private readonly _sessionType: string,
+		private readonly _roots: readonly URI[],
+		private readonly _syncProvider: ICustomizationSyncProvider,
+		private readonly _options: IAgentRegistrationOptions | undefined,
+		private readonly _getClientTools: (sessionType: string) => IObservable<readonly ToolDefinition[]>,
+		private readonly _onDispose: () => void,
+		@IFileService private readonly _fileService: IFileService,
 		@IPromptsService private readonly _promptsService: IPromptsService,
 		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
-		@IStorageService private readonly _storageService: IStorageService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IFileService private readonly _fileService: IFileService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IMcpService private readonly _mcpService: IMcpService,
 		@IConfigurationResolverService private readonly _configurationResolverService: IConfigurationResolverService,
-		@IAgentHostToolSetEnablementService private readonly _toolSetEnablementService: IAgentHostToolSetEnablementService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
-		this._customizationsByType = observableValue('agentHostCustomizationsByType', new Map());
-		this._customAgentsByType = observableValue('agentHostCustomAgentsByType', new Map());
+		this._bundler = this._register(instantiationService.createInstance(SyncedCustomizationBundler, createScopeAuthority(_sessionType, _roots)));
+		this._updateDelayer = this._register(new Delayer<void>(CUSTOMIZATION_UPDATE_DEBOUNCE_DELAY));
 
-		// Pass `undefined` for the model: agent-host sessions use server-side model selection.
-		this._allToolsObs = this._toolsService.observeTools(undefined);
-		this._allToolSetsObs = this._toolsService.toolSets;
-	}
-
-	registerForAgent(sessionType: string, options?: IAgentRegistrationOptions): IAgentRegistration {
-		const store = new DisposableStore();
-		const syncProvider = store.add(new AgentCustomizationSyncProvider(sessionType, this._storageService));
-		const bundler = store.add(this._instantiationService.createInstance(SyncedCustomizationBundler, sessionType));
-		const customizations = observableValue<readonly ClientPluginCustomization[]>('agentCustomizations', []);
-		const customAgents = observableValue<readonly AgentCustomization[]>('agentCustomAgents', []);
-		// Gate for seeding folder-root `.mcp.json` servers from every workspace
-		// folder (not just the session's primary). Evaluated fresh on each sync
-		// so folder/setting changes are reflected. See `shouldSyncWorkspaceDotMcp`.
-		const shouldIncludeWorkspaceDotMcp = () => shouldSyncWorkspaceDotMcp(
-			sessionType,
-			this._workspaceContextService.getWorkspace().folders.length,
-			this._configurationService.getValue(AgentHostCopilotMultiRootEnabledSettingId) === true,
-		);
-		let updateSeq = 0;
 		const updateCustomizations = async () => {
-			const seq = ++updateSeq;
+			const seq = ++this._updateSeq;
+			let completedInitialResolution = false;
 			try {
 				const [refs, agents] = await Promise.all([
-					resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, this._mcpService, this._configurationResolverService, bundler, sessionType, shouldIncludeWorkspaceDotMcp(), options),
-					resolveLocalCustomAgents(this._fileService, this._promptsService, syncProvider, this._agentPluginService, sessionType, options),
+					resolveCustomizationRefs(
+						this._fileService,
+						this._promptsService,
+						this._syncProvider,
+						this._agentPluginService,
+						this._mcpService,
+						this._configurationResolverService,
+						this._bundler,
+						this._sessionType,
+						shouldSyncWorkspaceDotMcp(this._sessionType, this._roots, this._configurationService.getValue(AgentHostCopilotMultiRootEnabledSettingId) === true),
+						this._options,
+						this._roots,
+					),
+					resolveLocalCustomAgents(this._fileService, this._promptsService, this._syncProvider, this._agentPluginService, this._sessionType, this._options, this._roots),
 				]);
-				if (seq !== updateSeq) {
+				if (seq !== this._updateSeq) {
 					return;
 				}
-				if (!equals(customizations.get(), refs)) {
-					customizations.set(refs, undefined);
-				}
-				if (!equals(customAgents.get(), agents)) {
-					customAgents.set(agents, undefined);
-				}
+				transaction(tx => {
+					if (!equals(this._customizations.get(), refs)) {
+						this._customizations.set(refs, tx);
+					}
+					if (!equals(this._customAgents.get(), agents)) {
+						this._customAgents.set(agents, tx);
+					}
+					this._isResolved.set(true, tx);
+				});
+				completedInitialResolution = true;
 			} catch (err) {
 				onUnexpectedError(err);
+				if (seq === this._updateSeq) {
+					transaction(tx => this._isResolved.set(true, tx));
+					completedInitialResolution = true;
+				}
+			} finally {
+				if (completedInitialResolution && !this._initialResolution.isSettled) {
+					this._initialResolution.complete();
+				}
 			}
 		};
-		// Many of the events below can fire in quick succession (e.g. during
-		// initialization or when a config change touches several providers at
-		// once), so debounce the re-resolution into a single update.
-		const updateDelayer = store.add(new Delayer<void>(CUSTOMIZATION_UPDATE_DEBOUNCE_DELAY));
 		const scheduleUpdate = () => {
-			updateDelayer.trigger(() => updateCustomizations()).catch(() => { /* delayer disposed */ });
+			this._updateDelayer.trigger(() => updateCustomizations()).catch(() => { /* delayer disposed */ });
 		};
-		store.add(syncProvider.onDidChange(() => scheduleUpdate()));
-		store.add(Event.any(
+
+		this._register(this._syncProvider.onDidChange(() => scheduleUpdate()));
+		this._register(Event.any(
 			this._promptsService.onDidChangeCustomAgents,
 			this._promptsService.onDidChangeSlashCommands,
 			this._promptsService.onDidChangeSkills,
 			this._promptsService.onDidChangeInstructions,
 		)(() => scheduleUpdate()));
-		// Plugin discovery completes asynchronously and may happen after the
-		// agent registration's initial customization resolution. Observe the
-		// plugin inventory and its mutable contributions so newly discovered,
-		// enabled, or updated plugins are published without restarting.
-		store.add(autorun(reader => {
+		this._register(autorun(reader => {
 			for (const plugin of this._agentPluginService.plugins.read(reader)) {
 				plugin.enablement.read(reader);
 				plugin.hooks.read(reader);
@@ -178,90 +262,131 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 			}
 			scheduleUpdate();
 		}));
-		// Re-resolve when MCP servers configured in VS Code change (added,
-		// removed, enabled/disabled, or reconfigured) so they stay in sync.
-		store.add(autorun(reader => {
+		this._register(autorun(reader => {
 			for (const server of this._mcpService.servers.read(reader)) {
 				server.enablement.read(reader);
 				server.readDefinitions().read(reader);
 			}
 			scheduleUpdate();
 		}));
-		// Re-resolve when the multi-root gate inputs change so folder-root
-		// `.mcp.json` seeding stays correct without waiting for another trigger:
-		// workspace-folder add/remove (folder count / new folder's servers) and
-		// the multi-root setting toggle.
-		store.add(this._workspaceContextService.onDidChangeWorkspaceFolders(() => scheduleUpdate()));
-		store.add(this._configurationService.onDidChangeConfiguration(e => {
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AgentHostCopilotMultiRootEnabledSettingId)) {
 				scheduleUpdate();
 			}
 		}));
-		store.add(this._setCustomizations(sessionType, customizations));
-		store.add(this._setCustomAgents(sessionType, customAgents));
+	}
+
+	acquire(): IAgentCustomizationScope {
+		this._refCount++;
+		let released = false;
 		return {
-			syncProvider,
-			bundler,
-			dispose: () => store.dispose(),
+			customizations: this.customizations,
+			customAgents: this.customAgents,
+			tools: this.tools,
+			isResolved: this.isResolved,
+			whenResolved: () => this._initialResolution.p,
+			activeClient: clientId => this.activeClient(clientId),
+			dispose: () => {
+				if (!released) {
+					released = true;
+					this._release();
+				}
+			},
 		};
 	}
 
-	private _setCustomAgents(sessionType: string, customAgents: IObservable<readonly AgentCustomization[]>): IDisposable {
-		const next = new Map(this._customAgentsByType.get());
-		next.set(sessionType, customAgents);
-		this._customAgentsByType.set(next, undefined);
-		return toDisposable(() => {
-			const current = this._customAgentsByType.get();
-			if (current.get(sessionType) !== customAgents) {
-				return;
-			}
-			const removed = new Map(current);
-			removed.delete(sessionType);
-			this._customAgentsByType.set(removed, undefined);
-		});
+	getOrigin(syncedUri: URI): ISyncedCustomizationOrigin | undefined {
+		return this._bundler.getOrigin(syncedUri);
 	}
 
-	private _setCustomizations(sessionType: string, customizations: IObservable<readonly ClientPluginCustomization[]>): IDisposable {
-		const next = new Map(this._customizationsByType.get());
-		next.set(sessionType, customizations);
-		this._customizationsByType.set(next, undefined);
-		return toDisposable(() => {
-			const current = this._customizationsByType.get();
-			if (current.get(sessionType) !== customizations) {
-				return;
-			}
-			const removed = new Map(current);
-			removed.delete(sessionType);
-			this._customizationsByType.set(removed, undefined);
-		});
+	activeClient(clientId: string): IObservable<SessionActiveClient> {
+		let activeClient = this._activeClients.get(clientId);
+		if (!activeClient) {
+			activeClient = derived(reader => {
+				// Keep changes to the complete scope picture in the composed view's
+				// dependency set so consumers can coalesce a customization burst.
+				this._customAgents.read(reader);
+				return {
+					clientId,
+					tools: [...this.tools.read(reader)],
+					customizations: [...this._customizations.read(reader)],
+				};
+			});
+			this._activeClients.set(clientId, activeClient);
+		}
+		return activeClient;
 	}
 
-	getActiveClient(sessionType: string, clientId: string): SessionActiveClient {
-		return {
-			clientId,
-			tools: [...this.getClientTools(sessionType).get()],
-			customizations: [...(this._customizationsByType.get().get(sessionType)?.get() ?? [])],
-		};
+	override dispose(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		this._updateSeq++;
+		if (!this._initialResolution.isSettled) {
+			this._initialResolution.complete();
+		}
+		super.dispose();
+		this._onDispose();
 	}
 
-	getCustomizations(sessionType: string): IObservable<readonly ClientPluginCustomization[]> {
-		return derived(reader => this._customizationsByType.read(reader).get(sessionType)?.read(reader) ?? EMPTY_CUSTOMIZATIONS);
+	private _release(): void {
+		if (--this._refCount === 0) {
+			this.dispose();
+		}
+	}
+}
+
+export class AgentHostActiveClientService extends Disposable implements IAgentHostActiveClientService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _allToolsObs: IObservable<readonly IToolData[]>;
+	private readonly _allToolSetsObs: IObservable<Iterable<IToolSet>>;
+	private readonly _clientToolsByType = new Map<string, IObservable<readonly ToolDefinition[]>>();
+	private readonly _registrationsByType = new Map<string, AgentRegistration>();
+	private _isDisposed = false;
+
+	constructor(
+		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IAgentHostToolSetEnablementService private readonly _toolSetEnablementService: IAgentHostToolSetEnablementService,
+	) {
+		super();
+		this._allToolsObs = this._toolsService.observeTools(undefined);
+		this._allToolSetsObs = this._toolsService.toolSets;
 	}
 
-	getCustomAgents(sessionType: string): IObservable<readonly AgentCustomization[]> {
-		return derived(reader => this._customAgentsByType.read(reader).get(sessionType)?.read(reader) ?? EMPTY_CUSTOM_AGENTS);
+	registerForAgent(sessionType: string, options?: IAgentRegistrationOptions): IAgentRegistration {
+		// Referenced by the teardown callback below, which only runs once the
+		// registration has been constructed.
+		const registration: AgentRegistration = new AgentRegistration(
+			sessionType,
+			options,
+			this._instantiationService,
+			this._storageService,
+			type => this._getClientTools(type),
+			() => {
+				if (this._registrationsByType.get(sessionType) === registration) {
+					this._registrationsByType.delete(sessionType);
+				}
+			},
+		);
+		this._registrationsByType.set(sessionType, registration);
+		return registration;
 	}
 
-	getClientTools(sessionType: string): IObservable<readonly ToolDefinition[]> {
+	acquireScope(sessionType: string, roots: readonly URI[]): IAgentCustomizationScope | undefined {
+		return this._registrationsByType.get(sessionType)?.acquireScope(roots);
+	}
+
+	private _getClientTools(sessionType: string): IObservable<readonly ToolDefinition[]> {
 		let obs = this._clientToolsByType.get(sessionType);
 		if (!obs) {
 			obs = derived(reader => {
 				const tools = this._allToolsObs.read(reader);
 				const toolSets = this._allToolSetsObs.read(reader);
 				const enablement = this._toolSetEnablementService.observe(sessionType).read(reader);
-
-				// Collect the ids of tools that are enabled members of at least one tool set surfaced in
-				// the Agents window Tools section (non-deprecated).
 				const enabledToolIds = new Set<string>();
 				for (const ts of toolSets) {
 					if (ts.deprecated) {
@@ -279,10 +404,50 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 		}
 		return obs;
 	}
+
+	override dispose(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		const registrations = [...this._registrationsByType.values()];
+		this._registrationsByType.clear();
+		for (const registration of registrations) {
+			registration.dispose();
+		}
+		super.dispose();
+	}
 }
 
-const EMPTY_CUSTOMIZATIONS: readonly ClientPluginCustomization[] = Object.freeze([]);
-const EMPTY_CUSTOM_AGENTS: readonly AgentCustomization[] = Object.freeze([]);
+function normalizeRoots(roots: readonly URI[]): readonly URI[] {
+	const rootsByUri = new ResourceMap<URI>(root => extUriBiasedIgnorePathCase.getComparisonKey(root));
+	for (const root of roots) {
+		rootsByUri.set(root, root);
+	}
+	// Ordinal (not locale) ordering: this order feeds `getScopeKey`, whose hash
+	// becomes an on-disk plugin cache directory name on the agent host side.
+	return [...rootsByUri.values()].sort((a, b) => {
+		const left = extUriBiasedIgnorePathCase.getComparisonKey(a);
+		const right = extUriBiasedIgnorePathCase.getComparisonKey(b);
+		return left < right ? -1 : left > right ? 1 : 0;
+	});
+}
+
+/** Returns whether two working-directory sets describe the same customization scope. */
+export function areCustomizationScopeRootsEqual(first: readonly URI[] | undefined, second: readonly URI[]): boolean {
+	const toComparisonKey = (root: URI) => extUriBiasedIgnorePathCase.getComparisonKey(root);
+	const firstRoots = new ResourceSet(first ?? [], toComparisonKey);
+	const secondRoots = new ResourceSet(second, toComparisonKey);
+	return firstRoots.size === secondRoots.size && [...firstRoots].every(root => secondRoots.has(root));
+}
+
+function getScopeKey(roots: readonly URI[]): string {
+	return roots.map(root => extUriBiasedIgnorePathCase.getComparisonKey(root)).join('\n');
+}
+
+function createScopeAuthority(sessionType: string, roots: readonly URI[]): string {
+	return `${sessionType}-${hash(getScopeKey(roots))}`;
+}
 
 /** Debounce window (ms) used to coalesce bursts of customization change events into a single re-resolution. */
 const CUSTOMIZATION_UPDATE_DEBOUNCE_DELAY = 50;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -285,11 +285,13 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 		const agentRegistration = store.add(this._activeClientService.registerForAgent(sessionType));
 		const syncProvider = agentRegistration.syncProvider;
+		// The management UI remains ambient while individual sessions use their working-directory scopes.
+		const ambientScope = store.add(agentRegistration.acquireScope([]));
 
 		const itemProvider = store.add(this._instantiationService.createInstance(AgentCustomizationItemProvider, 'local', undefined,
-			syncedUri => agentRegistration.bundler.getOrigin(syncedUri)));
-		itemProvider.setDraftCustomAgents(this._activeClientService.getCustomAgents(sessionType));
-		itemProvider.setDraftCustomizations(this._activeClientService.getCustomizations(sessionType));
+			syncedUri => agentRegistration.getOrigin(syncedUri)));
+		itemProvider.setDraftCustomAgents(ambientScope.customAgents);
+		itemProvider.setDraftCustomizations(ambientScope.customizations);
 		// `[Agent Host]` suffix disambiguates from the extension-host Copilot CLI harness, which uses the same displayName.
 		store.add(this._customizationHarnessService.registerExternalHarness({
 			id: sessionType,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -5,6 +5,7 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Iterable } from '../../../../../../base/common/iterator.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 import { basename, isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { parseRemoteAgentHostHarness } from '../../../../../../platform/agentHost/common/agentHostSessionType.js';
@@ -103,22 +104,31 @@ export async function enumerateLocalCustomizationsForHarness(
 	syncProvider: ICustomizationSyncProvider,
 	sessionType: string,
 	token: CancellationToken,
-	options?: ILocalCustomizationSyncOptions,
+	options: ILocalCustomizationSyncOptions | undefined,
+	roots: readonly URI[],
 ): Promise<readonly ILocalCustomizationFile[]> {
 	const result: ILocalCustomizationFile[] = [];
+	const seenUris = new ResourceSet();
 	const storageSources = options?.includeUserStorage
 		? [PromptsStorage.user, ...SYNCABLE_STORAGE_SOURCES]
 		: SYNCABLE_STORAGE_SOURCES;
+	const rootsToResolve = roots.length > 0 ? roots : [undefined];
 	for (const type of SYNCABLE_PROMPT_TYPES) {
 		const userDisabled = promptsService.getDisabledPromptFiles(type);
 		const lists = await Promise.all(
-			storageSources.map(storage => promptsService.listPromptFilesForStorage(type, storage, token)),
+			storageSources.map(async storage => {
+				const filesByRoot = storage === PromptsStorage.local
+					? await Promise.all(rootsToResolve.map(root => promptsService.listPromptFilesForStorage(type, storage, token, root)))
+					: [await promptsService.listPromptFilesForStorage(type, storage, token)];
+				return filesByRoot.flat();
+			}),
 		);
 		for (let i = 0; i < lists.length; i++) {
 			const source = storageSources[i];
 			const honourUserDisabled = isUserToggleableCustomization(type, source);
 			for (const file of lists[i]) {
-				if (matchesSessionType(file.sessionTypes, sessionType)) {
+				if (matchesSessionType(file.sessionTypes, sessionType) && !seenUris.has(file.uri)) {
+					seenUris.add(file.uri);
 					result.push({
 						uri: file.uri,
 						type,
@@ -152,13 +162,14 @@ export async function resolveLocalCustomAgents(
 	syncProvider: ICustomizationSyncProvider,
 	agentPluginService: IAgentPluginService,
 	sessionType: string,
-	options?: ILocalCustomizationSyncOptions,
+	options: ILocalCustomizationSyncOptions | undefined,
+	roots: readonly URI[],
 ): Promise<readonly AgentCustomization[]> {
 	const plugins = agentPluginService.plugins.get();
 	const result: AgentCustomization[] = [];
 	const parser = new PromptFileParser();
 	const pending: Promise<void>[] = [];
-	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options);
+	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options, roots);
 
 	for (const agent of enumerated) {
 		if (agent.type !== PromptsType.agent || agent.disabled) {
@@ -283,15 +294,12 @@ async function resolveConfigurationForSync(
  * be seeded into a session's synced customizations, rather than only the
  * primary (working-directory) folder's — which the SDK already auto-discovers.
  *
- * True only for the local Copilot Agent Host harness, in a multi-root workspace,
- * with the multi-root setting enabled. Kept as a pure function so the gate can
- * be unit-tested independently of {@link AgentHostActiveClientService}'s wiring
- * (a regression here would otherwise leave the feature tests — which call the
- * collector with the flag hardcoded — green).
+ * True only for the local Copilot Agent Host harness with multiple working
+ * directories and the multi-root setting enabled.
  */
-export function shouldSyncWorkspaceDotMcp(sessionType: string, workspaceFolderCount: number, multiRootSettingEnabled: boolean): boolean {
+export function shouldSyncWorkspaceDotMcp(sessionType: string, roots: readonly URI[], multiRootSettingEnabled: boolean): boolean {
 	return sessionType === AGENT_HOST_COPILOT_CLI_SESSION_TYPE
-		&& workspaceFolderCount > 1
+		&& roots.length > 1
 		&& multiRootSettingEnabled;
 }
 
@@ -388,10 +396,11 @@ export async function resolveCustomizationRefs(
 	configurationResolverService: IConfigurationResolverService,
 	bundler: SyncedCustomizationBundler,
 	sessionType: string,
-	includeWorkspaceDotMcp: boolean = false,
-	options?: ILocalCustomizationSyncOptions,
+	includeWorkspaceDotMcp: boolean,
+	options: ILocalCustomizationSyncOptions | undefined,
+	roots: readonly URI[],
 ): Promise<ClientPluginCustomization[]> {
-	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options);
+	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options, roots);
 	const enabled = enumerated.filter(e => !e.disabled);
 
 	const plugins = agentPluginService.plugins.get();
@@ -409,14 +418,17 @@ export async function resolveCustomizationRefs(
 					// ignored, sync will probably fail later though...
 				}
 
-				return {
+				const ref: ClientPluginCustomization = {
 					type: CustomizationType.Plugin,
 					id: customizationId(key),
 					uri: key as ProtocolURI,
 					name: plugin.label,
-					nonce: nonce?.toString(16),
 					enabled: true,
 				};
+				if (nonce !== undefined) {
+					ref.nonce = nonce.toString(16);
+				}
+				return ref;
 			})();
 			pluginRefs.set(key, promise);
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -14,7 +14,7 @@ import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IRef
 import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { equals } from '../../../../../../base/common/objects.js';
-import { autorun, autorunPerKeyedItem, constObservable, derived, derivedOpts, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
+import { autorun, autorunPerKeyedItem, constObservable, derived, derivedOpts, IObservable, ISettableObservable, observableValue, transaction, waitForState } from '../../../../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, isEqual } from '../../../../../../base/common/resources.js';
 import { StopWatch } from '../../../../../../base/common/stopwatch.js';
 import { Mutable } from '../../../../../../base/common/types.js';
@@ -44,7 +44,7 @@ import { CompletionItemKind as AhpCompletionItemKind, ContentEncoding, type Comp
 import { ConfirmationOptionKind, CustomizationType, JsonPrimitive, McpServerAuthRequiredState, McpServerStatus, SessionInputRequestKind, TerminalClaimKind, ToolCallContributorKind, ToolResultContentType, type ConfirmationOption, type ProtectedResourceMetadata, type SessionActiveClient, type SessionInputRequest, type SessionToolClientExecutionRequest } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, ChatTurnStartedAction, isChatAction, type ClientChatAction, type ClientSessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { buildSubagentChatUri, ChatOriginKind, getInlineToolInput, getToolSubagentContent, isChatReadOnly, isMessageHiddenFromTranscript, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionStatus, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, parseChatUri, mergeSessionWithDefaultChat, readUsageInfoMeta, withMessageHiddenFromTranscript, type ChatState, type ISessionWithDefaultChat, type ClientPluginCustomization, type ICompletedToolCall, type InputRequestResponsePart, type MarkdownResponsePart, type Message, type MessageAttachment, type MessageAnnotationsAttachment, type MessageChatAttachment, type MessageResourceAttachment, type MessageEmbeddedResourceAttachment, type ModelSelection, type PendingMessage, type ReasoningResponsePart, type RootState, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest, type SessionState, type StringOrMarkdown, type ToolCallResponsePart, type ToolCallState, type ToolInput, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentChatUri, ChatOriginKind, getInlineToolInput, getToolSubagentContent, isChatReadOnly, isMessageHiddenFromTranscript, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, SessionStatus, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, parseChatUri, mergeSessionWithDefaultChat, readUsageInfoMeta, withMessageHiddenFromTranscript, type ChatState, type ISessionWithDefaultChat, type ICompletedToolCall, type InputRequestResponsePart, type MarkdownResponsePart, type Message, type MessageAttachment, type MessageAnnotationsAttachment, type MessageChatAttachment, type MessageResourceAttachment, type MessageEmbeddedResourceAttachment, type ModelSelection, type PendingMessage, type ReasoningResponsePart, type RootState, type ChatInputAnswer, type ChatInputQuestion, type ChatInputRequest, type SessionState, type StringOrMarkdown, type ToolCallResponsePart, type ToolCallState, type ToolInput, type Turn } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -90,7 +90,7 @@ import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgent
 import { ILanguageModelToolsService, IToolResult, stringifyPromptTsxPart, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { IChatWidgetService } from '../../chat.js';
 import { getAgentSessionProviderIcon } from '../agentSessions.js';
-import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
+import { IAgentCustomizationScope, IAgentHostActiveClientService } from './agentHostActiveClientService.js';
 import { IAgentHostCustomizationService } from './agentHostCustomizationService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostSessionWorkingDirectorySynchronizer } from './agentHostSessionWorkingDirectorySynchronizer.js';
@@ -766,9 +766,119 @@ function offsetToPosition(text: string, offset: number): IPosition {
 	}
 	return { lineNumber, column };
 }
+
+class ActiveClientEntry extends Disposable {
+
+	private readonly _activeClient: IObservable<SessionActiveClient>;
+	private readonly _state = observableValue(this, true);
+	private readonly _cancellation = new CancellationTokenSource();
+	private readonly _reconcileSignal = observableValue(this, 0);
+	private readonly _stateSubscription = this._register(new MutableDisposable<IDisposable>());
+	private readonly _publishDelayer: Delayer<void>;
+	private _backendSession: URI | undefined;
+	private _claimRequested = false;
+	private _lastPublished: SessionActiveClient | undefined;
+
+	constructor(
+		private readonly _scope: IAgentCustomizationScope,
+		clientId: string,
+		debounceDelay: number,
+		private readonly _getSessionState: (backendSession: URI) => SessionState | undefined,
+		private readonly _dispatch: (backendSession: URI, action: ClientSessionAction) => void,
+	) {
+		super();
+		this._activeClient = _scope.activeClient(clientId);
+		this._publishDelayer = this._register(new Delayer<void>(debounceDelay));
+		this._register(_scope);
+		this._register(toDisposable(() => this._cancellation.dispose(true)));
+		this._register(autorun(reader => {
+			if (!this._scope.isResolved.read(reader)) {
+				return;
+			}
+			this._activeClient.read(reader);
+			this._reconcileSignal.read(reader);
+			this._requestReconciliation();
+		}));
+	}
+
+	/** Snapshot of the composed active-client view. */
+	getActiveClient(): SessionActiveClient {
+		return this._activeClient.get();
+	}
+
+	/** Resolves once no active-client publish is pending. */
+	async whenSettled(): Promise<void> {
+		await waitForState(this._state, state => !state, undefined, this._cancellation.token);
+	}
+
+	/** Binds the backend session and requests this client join it. */
+	claim(backendSession: URI): void {
+		this._backendSession = backendSession;
+		this._claimRequested = true;
+		this._requestReconciliation();
+	}
+
+	/** Binds the backend session and reconciles without claiming it. */
+	attach(backendSession: URI, sessionSubscription: IAgentSubscription<SessionState> | undefined): void {
+		this._backendSession = backendSession;
+		this._stateSubscription.value = sessionSubscription?.onDidChange(() => {
+			this._reconcileSignal.set(this._reconcileSignal.get() + 1, undefined);
+		});
+		this._requestReconciliation();
+	}
+
+	private _requestReconciliation(): void {
+		if (this._cancellation.token.isCancellationRequested) {
+			return;
+		}
+		if (!this._scope.isResolved.get()) {
+			this._state.set(true, undefined);
+			return;
+		}
+		if (!this._backendSession) {
+			this._state.set(false, undefined);
+			return;
+		}
+		this._state.set(true, undefined);
+		this._publishDelayer.trigger(async () => {
+			try {
+				if (this._cancellation.token.isCancellationRequested) {
+					return;
+				}
+				const backendSession = this._backendSession;
+				if (!backendSession || !this._scope.isResolved.get()) {
+					return;
+				}
+				const activeClient = this._activeClient.get();
+				const existing = this._getSessionState(backendSession)?.activeClients.find(client => client.clientId === activeClient.clientId);
+				if (!existing && !this._claimRequested) {
+					return;
+				}
+				if (equals(existing, activeClient)) {
+					this._lastPublished = undefined;
+					return;
+				}
+				if (equals(this._lastPublished, activeClient)) {
+					return;
+				}
+				this._dispatch(backendSession, {
+					type: ActionType.SessionActiveClientSet,
+					activeClient,
+				});
+				this._lastPublished = activeClient;
+			} finally {
+				if (this._scope.isResolved.get()) {
+					this._state.set(false, undefined);
+				}
+			}
+		}).catch(() => { /* delayer disposed */ });
+	}
+}
+
 export class AgentHostSessionHandler extends Disposable implements IChatSessionContentProvider {
 
 	private static readonly DRAFT_SYNC_DEBOUNCE_MS = 500;
+	private static readonly ACTIVE_CLIENT_RECONCILIATION_DEBOUNCE_MS = 5;
 
 	private readonly _activeSessions = new ResourceMap<AgentHostChatSession>();
 	private readonly _chatURIsBySessionResource = new ResourceMap<string>();
@@ -799,8 +909,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * already be cleared by then.
 	 */
 	private readonly _inputNeededWatcherBackends = new ResourceMap<URI>();
-	/** One-shot per-session subscription reconciling client data after session state hydration. */
-	private readonly _activeClientRefreshSubscriptions = this._register(new DisposableResourceMap());
+	/** One reconciliation owner per active session. */
+	private readonly _activeClientEntries = new ResourceMap<ActiveClientEntry>();
 	/** Historical turns with file edits, pending hydration into the editing session. */
 	private readonly _pendingHistoryTurns = new ResourceMap<readonly Turn[]>();
 	/**
@@ -929,20 +1039,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// again.
 		this._register(this._customizationService.onDidChangeCustomizations(() => this._reconcileSurfacedMcpAuthServers()));
 
-		this._register(autorun(reader => {
-			const defs = this._activeClientService.getClientTools(this._config.sessionType).read(reader);
-			const clientId = this._config.connection.clientId;
-			for (const [sessionResource] of this._activeSessions) {
-				const backendSession = this._resolveSessionUri(sessionResource);
-				const state = this._getSessionState(backendSession.toString());
-				const existing = state?.activeClients.find(c => c.clientId === clientId);
-				if (existing) {
-					this._dispatchAction(backendSession, {
-						type: ActionType.SessionActiveClientSet,
-						activeClient: { ...existing, tools: [...defs] },
-					});
-				}
+		this._register(toDisposable(() => {
+			for (const entry of this._activeClientEntries.values()) {
+				entry.dispose();
 			}
+			this._activeClientEntries.clear();
 		}));
 
 		// When the user clicks "Continue in Background" on an AHP terminal
@@ -988,21 +1089,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				sessionResource => this._resolveSessionUri(sessionResource),
 			)),
 		));
-
-		// Push customization changes to sessions where this client is already active without reclaiming.
-		const customizationsObs = this._activeClientService.getCustomizations(config.sessionType);
-		this._register(autorun(reader => {
-			const refs = customizationsObs.read(reader);
-			const clientId = this._config.connection.clientId;
-			for (const [sessionResource] of this._activeSessions) {
-				const backendSession = this._resolveSessionUri(sessionResource);
-				const state = this._getSessionState(backendSession.toString());
-				const existing = state?.activeClients.find(c => c.clientId === clientId);
-				if (existing && !equals(existing.customizations ?? [], refs)) {
-					this._dispatchActiveClient(backendSession, [...refs]);
-				}
-			}
-		}));
 
 		this._registerAgent();
 	}
@@ -1158,6 +1244,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// session closing while we await our subscriptions does not tear down
 		// the shared session subscription (which would strand us forever).
 		const hydrationKey = resolvedSession.toString();
+		this._ensureActiveClientEntry(sessionResource);
 		this._hydratingChatSessions.set(hydrationKey, (this._hydratingChatSessions.get(hydrationKey) ?? 0) + 1);
 		try {
 			if (!isNewSession) {
@@ -1302,71 +1389,76 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._hydratingChatSessions.delete(hydrationKey);
 			}
 		}
-		const session = this._instantiationService.createInstance(
-			AgentHostChatSession,
-			sessionResource,
-			history,
-			sessionTitle,
-			sessionSubscription,
-			chatSubscription,
-			this._config.promptCacheNotification,
-			(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
-				if (!this._getSessionState(resolvedSession.toString())) {
-					throw new Error('Cannot fork session before the initial request');
-				}
+		let session: AgentHostChatSession;
+		try {
+			session = this._instantiationService.createInstance(
+				AgentHostChatSession,
+				sessionResource,
+				history,
+				sessionTitle,
+				sessionSubscription,
+				chatSubscription,
+				this._config.promptCacheNotification,
+				(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
+					if (!this._getSessionState(resolvedSession.toString())) {
+						throw new Error('Cannot fork session before the initial request');
+					}
 
-				return this._forkSession(sessionResource, resolvedSession, request, token);
-			},
-			(title: string, _token: CancellationToken) => {
-				this._config.connection.dispatch(resolvedSession.toString(), {
-					type: ActionType.SessionTitleChanged,
-					title,
-				});
-				return Promise.resolve();
-			},
-			draftInputState,
-			initialProgress,
-			historySubagentObservations,
-			() => {
-				this._activeSessions.delete(sessionResource);
-				this._activeClientRefreshSubscriptions.deleteAndDispose(sessionResource);
-				this._pendingMessageSubscriptions.deleteAndDispose(sessionResource);
-				this._draftSyncSubscriptions.deleteAndDispose(sessionResource);
-				this._serverTurnWatchers.deleteAndDispose(sessionResource);
-				this._mcpAuthWatchers.deleteAndDispose(sessionResource);
-				this._releaseSessionInputNeeded(sessionResource);
-				this._pendingHistoryTurns.delete(sessionResource);
-				this._surfacedMcpAuthServers.delete(sessionResource);
-				const chatURI = this._chatURIsBySessionResource.get(sessionResource);
-				this._chatURIsBySessionResource.delete(sessionResource);
-				if (chatURI) {
-					this._releaseChatSessionSubscriptions(resolvedSession.toString(), chatURI);
-				}
-			},
-			() => {
-				const sessionKey = resolvedSession.toString();
-				const chatURI = this._chatURIsBySessionResource.get(sessionResource);
-				if (!chatURI) {
+					return this._forkSession(sessionResource, resolvedSession, request, token);
+				},
+				(title: string, _token: CancellationToken) => {
+					this._config.connection.dispatch(resolvedSession.toString(), {
+						type: ActionType.SessionTitleChanged,
+						title,
+					});
+					return Promise.resolve();
+				},
+				draftInputState,
+				initialProgress,
+				historySubagentObservations,
+				() => {
+					this._activeSessions.delete(sessionResource);
+					this._disposeActiveClientEntry(sessionResource);
+					this._pendingMessageSubscriptions.deleteAndDispose(sessionResource);
+					this._draftSyncSubscriptions.deleteAndDispose(sessionResource);
+					this._serverTurnWatchers.deleteAndDispose(sessionResource);
+					this._mcpAuthWatchers.deleteAndDispose(sessionResource);
+					this._releaseSessionInputNeeded(sessionResource);
+					this._pendingHistoryTurns.delete(sessionResource);
+					this._surfacedMcpAuthServers.delete(sessionResource);
+					const chatURI = this._chatURIsBySessionResource.get(sessionResource);
+					this._chatURIsBySessionResource.delete(sessionResource);
+					if (chatURI) {
+						this._releaseChatSessionSubscriptions(resolvedSession.toString(), chatURI);
+					}
+				},
+				() => {
+					const sessionKey = resolvedSession.toString();
+					const chatURI = this._chatURIsBySessionResource.get(sessionResource);
+					if (!chatURI) {
+						return true;
+					}
+					const turnId = this._getSessionState(sessionKey, chatURI)?.activeTurn?.id;
+					if (!turnId) {
+						// No active turn (likely a race with completion). Noop-success.
+						return true;
+					}
+					this._logService.info(`[AgentHost] Cancellation requested for ${sessionKey}, dispatching turnCancelled`);
+					this._config.connection.dispatch(chatURI, {
+						type: ActionType.ChatTurnCancelled,
+						turnId,
+						duration: this._turnDuration(chatURI, turnId),
+					});
 					return true;
-				}
-				const turnId = this._getSessionState(sessionKey, chatURI)?.activeTurn?.id;
-				if (!turnId) {
-					// No active turn (likely a race with completion). Noop-success.
-					return true;
-				}
-				this._logService.info(`[AgentHost] Cancellation requested for ${sessionKey}, dispatching turnCancelled`);
-				this._config.connection.dispatch(chatURI, {
-					type: ActionType.ChatTurnCancelled,
-					turnId,
-					duration: this._turnDuration(chatURI, turnId),
-				});
-				return true;
-			},
-		);
-		this._activeSessions.set(sessionResource, session);
-		if (sessionSubscription) {
-			this._ensureActiveClientRefreshSubscription(sessionResource, resolvedSession, sessionSubscription);
+				},
+			);
+		} catch (err) {
+			historySubagentObservations.dispose();
+			this._disposeActiveClientEntry(sessionResource);
+			throw err;
 		}
+		this._activeSessions.set(sessionResource, session);
+		this._configureActiveClientReconciliation(sessionResource, resolvedSession, sessionSubscription);
 
 		if (!isNewSession) {
 			// Only wire up pending-message/draft sync once the chat URI has been
@@ -1879,59 +1971,64 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return chatURI;
 	}
 
-	private _getCurrentActiveClient(): SessionActiveClient {
-		return this._activeClientService.getActiveClient(this._config.sessionType, this._config.connection.clientId);
-	}
-
-	private _ensureActiveClient(backendSession: URI): void {
-		const state = this._getSessionState(backendSession.toString());
-		const activeClient = this._getCurrentActiveClient();
-		const existing = state?.activeClients.find(c => c.clientId === activeClient.clientId);
-		if (equals(existing, activeClient)) {
-			return;
+	private _getCurrentActiveClient(sessionResource: URI): SessionActiveClient {
+		const entry = this._activeClientEntries.get(sessionResource);
+		if (entry) {
+			return entry.getActiveClient();
 		}
-		this._dispatchAction(backendSession, {
-			type: ActionType.SessionActiveClientSet,
-			activeClient,
-		});
-	}
 
-	/** Refreshes this client's data once it appears in hydrated state without claiming another client's session. */
-	private _ensureActiveClientRefreshSubscription(sessionResource: URI, backendSession: URI, sessionSubscription: IAgentSubscription<SessionState>): void {
-		if (this._activeClientRefreshSubscriptions.has(sessionResource)) {
-			return;
-		}
-		const refresh = () => {
-			const state = this._getSessionState(backendSession.toString());
-			const activeClient = this._getCurrentActiveClient();
-			const existing = state?.activeClients.find(c => c.clientId === activeClient.clientId);
-			if (!existing) {
-				return;
-			}
-
-			this._activeClientRefreshSubscriptions.deleteAndDispose(sessionResource);
-			if (!equals(existing, activeClient)) {
-				this._dispatchAction(backendSession, {
-					type: ActionType.SessionActiveClientSet,
-					activeClient,
-				});
-			}
+		return {
+			clientId: this._config.connection.clientId,
+			tools: [],
+			customizations: [],
 		};
-		this._activeClientRefreshSubscriptions.set(sessionResource, sessionSubscription.onDidChange(refresh));
-		refresh();
 	}
 
-	/**
-	 * Dispatches `session/activeClientSet` to add this connection as an
-	 * active client for this session and publish the current customizations
-	 * and client-provided tools. This client never removes itself.
-	 */
-	private _dispatchActiveClient(backendSession: URI, customizations: ClientPluginCustomization[]): void {
-		const current = this._getCurrentActiveClient();
-		this._dispatchAction(backendSession, {
-			type: ActionType.SessionActiveClientSet,
-			activeClient: { ...current, customizations },
-		});
+	private _ensureActiveClient(sessionResource: URI, backendSession: URI): ActiveClientEntry | undefined {
+		const entry = this._ensureActiveClientEntry(sessionResource);
+		if (!entry) {
+			return undefined;
+		}
+		entry.claim(backendSession);
+		return entry;
+	}
+
+	private _ensureActiveClientEntry(sessionResource: URI): ActiveClientEntry | undefined {
+		const existing = this._activeClientEntries.get(sessionResource);
+		if (existing) {
+			return existing;
+		}
+
+		const scope = this._activeClientService.acquireScope(this._config.sessionType, this._resolveCustomizationScopeRoots(sessionResource));
+		if (!scope) {
+			return undefined;
+		}
+
+		const entry = new ActiveClientEntry(
+			scope,
+			this._config.connection.clientId,
+			AgentHostSessionHandler.ACTIVE_CLIENT_RECONCILIATION_DEBOUNCE_MS,
+			backendSession => this._getSessionState(backendSession.toString()),
+			(backendSession, action) => this._dispatchAction(backendSession, action),
+		);
+		this._activeClientEntries.set(sessionResource, entry);
+		return entry;
+	}
+
+	private _configureActiveClientReconciliation(sessionResource: URI, backendSession: URI, sessionSubscription: IAgentSubscription<SessionState> | undefined): void {
+		const entry = this._ensureActiveClientEntry(sessionResource);
+		if (!entry) {
+			return;
+		}
+		entry.attach(backendSession, sessionSubscription);
+	}
+
+	private _disposeActiveClientEntry(sessionResource: URI): void {
+		const entry = this._activeClientEntries.get(sessionResource);
+		if (entry) {
+			this._activeClientEntries.delete(sessionResource);
+			entry.dispose();
+		}
 	}
 
 	// ---- Server-initiated turn detection ------------------------------------
@@ -2621,7 +2718,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// turn goes out. We only do this on turn start (not on session open)
 		// so that opening a session doesn't eagerly register this client while
 		// another client is in the middle of a turn.
-		this._ensureActiveClient(session);
+		this._ensureActiveClient(request.sessionResource, session);
 
 		// Model and agent selection now travel on the turn message itself rather
 		// than via the removed `session/modelChanged` / `session/agentChanged`
@@ -4819,7 +4916,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		onFailureStage?.('authentication');
 		const protectedResources = await this._ensureRequiredAuthentication(model);
 
-		const activeClient = this._getCurrentActiveClient();
+		const activeClientEntry = this._ensureActiveClientEntry(sessionResource);
+		if (activeClientEntry) {
+			await activeClientEntry.whenSettled();
+		}
+		const activeClient = this._getCurrentActiveClient(sessionResource);
 
 		// Opt in to bring-up progress (chiefly the lazy first-use SDK download)
 		// so the editor window surfaces the same download notification the
@@ -4879,7 +4980,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// Subscribe to the new session's state
 		onFailureStage?.('subscribeSession');
 		const newSub = this._ensureSessionSubscription(session.toString());
-		this._ensureActiveClientRefreshSubscription(sessionResource, session, newSub);
+		this._configureActiveClientReconciliation(sessionResource, session, newSub);
 		if (!this._getSessionState(session.toString())) {
 			// Wait for the subscription to hydrate. `_whenSubscriptionHydrated`
 			// settles on snapshot, error, or cancellation and attaches its
@@ -5270,15 +5371,25 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	private _resolveRequestedWorkingDirectory(sessionResource: URI): URI | undefined {
 		return this._config.resolveWorkingDirectory?.(sessionResource)
-			?? this._newSessionFolderService.getFolder(sessionResource)
-			?? this._workingDirectoryResolver.resolve(sessionResource)
-			?? this._newSessionFolderService.getDefaultFolder()
+			?? this._newSessionFolderService?.getFolder(sessionResource)
+			?? this._workingDirectoryResolver?.resolve(sessionResource)
+			?? this._newSessionFolderService?.getDefaultFolder()
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 
+	/** `undefined` is preserved for createSession to let the host choose its working directories. */
 	private _resolveRequestedWorkingDirectories(sessionResource: URI): readonly URI[] | undefined {
 		const primary = this._resolveRequestedWorkingDirectory(sessionResource);
 		return computeWorkingDirectories(primary, this._workspaceContextService.getWorkspace().folders.map(folder => folder.uri), this._getRootState(), this._config.provider);
+	}
+
+	/**
+	 * Scope roots always describe a concrete customization lookup. This differs
+	 * from `_resolveRequestedWorkingDirectories`: its `undefined` is protocol
+	 * meaningful and lets the host choose working directories for createSession.
+	 */
+	private _resolveCustomizationScopeRoots(sessionResource: URI): readonly URI[] {
+		return this._resolveRequestedWorkingDirectories(sessionResource) ?? [];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostToolUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostToolUtils.ts
@@ -10,12 +10,13 @@ import type { IToolData } from '../../../common/tools/languageModelToolsService.
  * Converts an internal {@link IToolData} to a protocol {@link ToolDefinition}.
  */
 export function toolDataToDefinition(tool: IToolData): ToolDefinition {
-	return {
+	const definition: ToolDefinition = {
 		name: tool.toolReferenceName ?? tool.id,
 		title: tool.displayName,
 		description: tool.modelDescription,
-		inputSchema: tool.inputSchema?.type === 'object'
-			? tool.inputSchema as ToolDefinition['inputSchema']
-			: undefined,
 	};
+	if (tool.inputSchema?.type === 'object') {
+		definition.inputSchema = tool.inputSchema as ToolDefinition['inputSchema'];
+	}
+	return definition;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -50,7 +50,7 @@
 
 import { SequencerByKey } from '../../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { equals } from '../../../../../../base/common/objects.js';
 import { autorun } from '../../../../../../base/common/observable.js';
@@ -74,7 +74,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { ChatConfiguration, getChatPermissionLevelFromDefaultConfiguration, type IChatDefaultConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IAgentHostNewSessionFolderService, computeDesiredWorkingDirectories, computeWorkingDirectories, hasImmutablePrimaryWorkingDirectory, supportsMultipleWorkingDirectories } from './agentHostNewSessionFolderService.js';
-import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
+import { areCustomizationScopeRootsEqual, IAgentCustomizationScope, IAgentHostActiveClientService } from './agentHostActiveClientService.js';
 import { type IAgentHostImportConversation, IAgentHostImportConversationStore } from './agentHostImportConversationStore.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
@@ -196,9 +196,30 @@ interface IProvisionalGeneration {
 
 type ProvisionalOperationResult = URI | void;
 
+class ActiveClientBinding extends Disposable {
+	constructor(
+		readonly roots: readonly URI[],
+		readonly scope: IAgentCustomizationScope | undefined,
+		clientId: string,
+		publish: () => void,
+	) {
+		super();
+		if (scope) {
+			this._register(scope);
+			this._register(autorun(reader => {
+				if (!scope.isResolved.read(reader)) {
+					return;
+				}
+				scope.activeClient(clientId).read(reader);
+				publish();
+			}));
+		}
+	}
+}
+
 interface IEntry {
 	readonly provider: string;
-	readonly activeClientSync: DisposableStore;
+	readonly activeClientBinding: MutableDisposable<ActiveClientBinding>;
 	generation: IProvisionalGeneration | undefined;
 	/**
 	 * Workbench-owned snapshot of session-config values for this provisional.
@@ -304,6 +325,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				if (!entry.usesWorkspaceRootSet && (this._computeWorkingDirectories(entry.workingDirectory, entry.provider)?.length ?? 0) > 1) {
 					entry.usesWorkspaceRootSet = true;
 				}
+				this._updateActiveClientScope(entry);
 				if (entry.usesWorkspaceRootSet && !this._generationMatchingDesiredState(entry)) {
 					void this._queue(sessionResource, () => this._reconcileGeneration(sessionResource, entry));
 				}
@@ -335,6 +357,16 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			current,
 			this._workspaceContextService.getWorkspace().folders.map(folder => folder.uri),
 		);
+	}
+
+	private _updateActiveClientScope(entry: IEntry): void {
+		const roots = this._computeEntryWorkingDirectories(entry) ?? [];
+		if (entry.activeClientBinding.value && areCustomizationScopeRootsEqual(entry.activeClientBinding.value.roots, roots)) {
+			return;
+		}
+
+		const scope = this._activeClientService.acquireScope(`agent-host-${entry.provider}`, roots);
+		entry.activeClientBinding.value = new ActiveClientBinding(roots, scope, this._agentHostService.clientId, () => this._publishActiveClient(entry));
 	}
 
 	getInitialSessionMetadata(): Record<string, unknown> | undefined {
@@ -417,7 +449,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 	private _createEntry(provider: string, config: Record<string, unknown>, configVersion: number, workingDirectory: URI | undefined, resolvedConfig?: ResolveSessionConfigResult): IEntry {
 		const entry: IEntry = {
 			provider,
-			activeClientSync: new DisposableStore(),
+			activeClientBinding: new MutableDisposable(),
 			generation: undefined,
 			config,
 			configVersion,
@@ -426,10 +458,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			resolvedConfig,
 			disposed: false,
 		};
-		entry.activeClientSync.add(autorun(reader => {
-			this._activeClientService.getCustomizations(`agent-host-${provider}`).read(reader);
-			this._publishActiveClient(entry);
-		}));
+		this._updateActiveClientScope(entry);
 		return entry;
 	}
 
@@ -437,9 +466,17 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		if (entry.disposed || !entry.generation) {
 			return;
 		}
+		const scope = entry.activeClientBinding.value?.scope;
+		if (!scope?.isResolved.get()) {
+			return;
+		}
+		const activeClient = scope.activeClient(this._agentHostService.clientId).get();
+		if (!activeClient) {
+			return;
+		}
 		this._agentHostService.dispatch(entry.generation.backendSession.toString(), {
 			type: ActionType.SessionActiveClientSet,
-			activeClient: this._activeClientService.getActiveClient(`agent-host-${entry.provider}`, this._agentHostService.clientId),
+			activeClient,
 		});
 	}
 
@@ -661,12 +698,13 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				// Publish the real mapping before retiring the untitled entry so consumers never observe a partial swap.
 				const newEntry = this._createEntry(provider, config, configVersion, targetWorkingDirectory, oldEntry.resolvedConfig);
 				newEntry.usesWorkspaceRootSet = oldEntry.usesWorkspaceRootSet;
+				this._updateActiveClientScope(newEntry);
 				newEntry.generation = { backendSession: created, workingDirectory: targetWorkingDirectory, workingDirectories: targetWorkingDirectories };
 				this._entries.set(newSessionResource, newEntry);
 				this._publishActiveClient(newEntry);
 				this._entries.delete(oldSessionResource);
 				oldEntry.disposed = true;
-				oldEntry.activeClientSync.dispose();
+				oldEntry.activeClientBinding.dispose();
 				this._resolvedConfigs.delete(oldSessionResource);
 				this._resolvedConfigRequestSeq.delete(oldSessionResource);
 				this._rebound.add(oldSessionResource);
@@ -704,6 +742,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		}
 		entry.workingDirectory = newWorkingDirectory;
 		entry.usesWorkspaceRootSet = (this._computeWorkingDirectories(newWorkingDirectory, entry.provider)?.length ?? 0) > 1;
+		this._updateActiveClientScope(entry);
 		entry.configVersion++;
 		entry.resolvedConfig = undefined;
 		const work = this._queue(sessionResource, async () => {
@@ -745,7 +784,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 			return Promise.resolve();
 		}
 		entry.disposed = true;
-		entry.activeClientSync.dispose();
+		entry.activeClientBinding.dispose();
 		this._entries.delete(sessionResource);
 		this._onDidChange.fire(sessionResource);
 		return this._queue(sessionResource, async () => {
@@ -761,7 +800,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		// awaiting in `dispose()` to keep workbench teardown synchronous.
 		for (const [, entry] of this._entries) {
 			entry.disposed = true;
-			entry.activeClientSync.dispose();
+			entry.activeClientBinding.dispose();
 			if (entry.generation) {
 				this._agentHostService.disposeSession(entry.generation.backendSession).catch(() => { /* swallow on shutdown */ });
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/syncedCustomizationBundler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/syncedCustomizationBundler.ts
@@ -5,6 +5,7 @@
 
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
 import { basename, dirname } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { hash } from '../../../../../../base/common/hash.js';
@@ -96,7 +97,8 @@ interface IBundleResult {
  * backed by an in-memory filesystem.
  *
  * Each bundler instance is namespaced by its authority string so that
- * multiple agents can coexist under the same scheme without conflicts.
+ * multiple agent workspace scopes can coexist under the same scheme without
+ * conflicts.
  * The plugin is mounted at `vscode-synced-customization:///{authority}/`
  * and structured as:
  *
@@ -118,7 +120,7 @@ export class SyncedCustomizationBundler extends Disposable {
 	private _lastNonce: string | undefined;
 	private _lastRef: IBundleResult | undefined;
 	/** Maps a synced (destination) URI string back to its original source location. Rebuilt on every {@link bundle}. */
-	private _originByDest = new Map<string, ISyncedCustomizationOrigin>();
+	private _originByDest = new ResourceMap<ISyncedCustomizationOrigin>();
 
 	constructor(
 		authority: string,
@@ -160,7 +162,7 @@ export class SyncedCustomizationBundler extends Disposable {
 		// bundle (a frequent case when a change event fires but content is
 		// identical).
 		const entries: { destUri: URI; content: VSBuffer; hashPart: string }[] = [];
-		const originByDest = new Map<string, ISyncedCustomizationOrigin>();
+		const originByDest = new ResourceMap<ISyncedCustomizationOrigin>();
 		await Promise.all(syncable.map(async file => {
 			const dir = pluginDirForType(file.type)!;
 			const fileName = basename(file.uri);
@@ -184,7 +186,7 @@ export class SyncedCustomizationBundler extends Disposable {
 			// provenance (extension/plugin/built-in) can be recovered later.
 			// Only files that carry a source have recoverable provenance.
 			if (file.source !== undefined) {
-				originByDest.set(destUri.toString(), {
+				originByDest.set(destUri, {
 					uri: file.uri,
 					source: file.source,
 					extensionId: file.extensionId,
@@ -281,6 +283,6 @@ export class SyncedCustomizationBundler extends Disposable {
 	 * for URIs that are not part of the most recent bundle.
 	 */
 	getOrigin(syncedUri: URI): ISyncedCustomizationOrigin | undefined {
-		return this._originByDest.get(syncedUri.toString());
+		return this._originByDest.get(syncedUri);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -629,9 +629,9 @@ export interface IPromptsService extends IDisposable {
 	listPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]>;
 
 	/**
-	 * List all available prompt files.
+	 * Lists all available prompt files from a storage location. For local storage, root scopes relative locations; it is ignored for other storages, and without it the current workspace folders are used.
 	 */
-	listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly IPromptPath[]>;
+	listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken, root?: URI): Promise<readonly IPromptPath[]>;
 
 	/**
 	 * Get a list of prompt source folders based on the provided prompt type.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -399,14 +399,14 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 
-	public async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly IPromptPath[]> {
+	public async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken, root?: URI): Promise<readonly IPromptPath[]> {
 		let promptPaths: readonly IPromptPath[];
 		switch (storage) {
 			case PromptsStorage.extension:
 				promptPaths = await this.getExtensionPromptFiles(type, token);
 				break;
 			case PromptsStorage.local:
-				promptPaths = this.areStandalonePromptFilesBlocked(type) ? [] : await this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath)));
+				promptPaths = this.areStandalonePromptFilesBlocked(type) ? [] : await this.fileLocator.listFiles(type, PromptsStorage.local, token, root).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath)));
 				break;
 			case PromptsStorage.user:
 				promptPaths = this.areStandalonePromptFilesBlocked(type) ? [] : await this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath)));

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -103,8 +103,10 @@ export class PromptFilesLocator {
 		return getPromptFileDefaultLocations(type);
 	}
 
-	public async getWorkspaceFolderRoots(includeParents: boolean, logger?: Logger): Promise<URI[]> {
-		const workspaceFolders = this.getWorkspaceFolders();
+	public async getWorkspaceFolderRoots(includeParents: boolean, logger?: Logger, root?: URI): Promise<URI[]> {
+		const workspaceFolders = root
+			? root.scheme === AGENT_HOST_SCHEME ? [] : [{ uri: root }]
+			: this.getWorkspaceFolders();
 		if (includeParents) {
 			const roots = new ResourceSet();
 			const userHome = await this.pathService.userHome();
@@ -169,13 +171,14 @@ export class PromptFilesLocator {
 	 *
 	 * @returns List of prompt files found in the workspace.
 	 */
-	public async listFiles(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly URI[]> {
+	public async listFiles(type: PromptsType, storage: PromptsStorage, token: CancellationToken, root?: URI): Promise<readonly URI[]> {
 		if (storage !== PromptsStorage.user && storage !== PromptsStorage.local) {
 			throw new Error(`Unsupported prompt file storage: ${storage}`);
 		}
 
 		const configuredLocations = this.getPromptSourceFolders(type);
-		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations.filter(loc => loc.storage === storage));
+		const localRoot = storage === PromptsStorage.local ? root : undefined;
+		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations.filter(loc => loc.storage === storage), undefined, localRoot);
 
 		if (storage === PromptsStorage.user && (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt)) {
 			absoluteLocations.push(this.userDataFolder);
@@ -185,7 +188,7 @@ export class PromptFilesLocator {
 
 		for (const { searchRoot, filePattern } of absoluteLocations) {
 			const files = (filePattern === undefined)
-				? await this.resolveFilesAtLocation(searchRoot, type, token) // if the location does not contain a glob pattern, resolve the location directly
+				? await this.resolveFilesAtLocation(searchRoot, type, token, 0, localRoot) // if the location does not contain a glob pattern, resolve the location directly
 				: await this.searchFilesInLocation(searchRoot, filePattern, token);
 			for (const file of files) {
 				if (getPromptFileType(file) === type) {
@@ -539,12 +542,12 @@ export class PromptFilesLocator {
 	 * If userHome is provided, paths starting with `~` will be expanded. Otherwise these paths are ignored.
 	 * Preserves the type and location properties from the source folder definitions.
 	 */
-	private async toAbsoluteLocations(type: PromptsType, configuredLocations: readonly IPromptSourceFolder[], defaultLocations?: readonly IPromptSourceFolder[]): Promise<IResolvedPromptSourceFolder[]> {
+	private async toAbsoluteLocations(type: PromptsType, configuredLocations: readonly IPromptSourceFolder[], defaultLocations?: readonly IPromptSourceFolder[], root?: URI): Promise<IResolvedPromptSourceFolder[]> {
 		const result: IResolvedPromptSourceFolder[] = [];
 		const seen = new ResourceSet();
 
 		const userHome = await this.pathService.userHome();
-		const rootFolders = await this.getWorkspaceFolderRoots(this.configService.getValue(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS) === true);
+		const rootFolders = await this.getWorkspaceFolderRoots(this.configService.getValue(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS) === true, undefined, root);
 
 		// Create a set of default paths for quick lookup
 		const defaultPaths = new Set(defaultLocations?.map(loc => loc.path));
@@ -623,7 +626,7 @@ export class PromptFilesLocator {
 	 * the location is not a workspace folder root and does not contain wildcards, to support subdirectories while avoiding
 	 * accidentally broad traversal.
 	 */
-	private async resolveFilesAtLocation(location: URI, type: PromptsType, token: CancellationToken, depth: number = 0): Promise<URI[]> {
+	private async resolveFilesAtLocation(location: URI, type: PromptsType, token: CancellationToken, depth: number = 0, root?: URI): Promise<URI[]> {
 		if (type === PromptsType.skill) {
 			return this.findAgentSkillsInFolder(location, token);
 		}
@@ -631,7 +634,7 @@ export class PromptFilesLocator {
 		// - the location is not a workspace folder root (to avoid full workspace traversal)
 		// - the path does not contain wildcards (already filtered upstream, but guard here too)
 		// - the recursion depth hasn't exceeded the limit
-		const isWorkspaceRoot = depth === 0 && this.getWorkspaceFolders().some(f => isEqual(f.uri, location));
+		const isWorkspaceRoot = depth === 0 && (root ? isEqual(root, location) : this.getWorkspaceFolders().some(f => isEqual(f.uri, location)));
 		const recursive = type === PromptsType.instructions
 			&& !isWorkspaceRoot
 			&& !hasGlobPattern(location.path)
@@ -650,7 +653,7 @@ export class PromptFilesLocator {
 						result.push(child.resource);
 					} else if (recursive && child.isDirectory) {
 						// Recursively search subdirectories for instructions
-						const subFiles = await this.resolveFilesAtLocation(child.resource, type, token, depth + 1);
+						const subFiles = await this.resolveFilesAtLocation(child.resource, type, token, depth + 1, root);
 						result.push(...subFiles);
 					}
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -31,7 +31,7 @@ import { BrowserViewAttachmentDisplayKind, BrowserViewAttachmentMetadataKey } fr
 import { AgentSystemNotificationKind, AgentSystemNotificationSeverity, toAgentSystemNotificationMeta } from '../../../../../../platform/agentHost/common/meta/agentSystemNotificationMeta.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction as AgentHostChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { ProtocolError, type IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { ChatInteractivity, ConfirmationOptionKind, CustomizationType, McpAuthRequiredReason, McpServerStatus, type ClientPluginCustomization, type ProtectedResourceMetadata, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ChatInteractivity, ConfirmationOptionKind, CustomizationType, McpAuthRequiredReason, McpServerStatus, type AgentCustomization, type ClientPluginCustomization, type ProtectedResourceMetadata, type SessionActiveClient, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ChatOriginKind, SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallRiskAssessmentKind, ToolCallRiskAssessmentStatus, createSessionState, createChatState, createDefaultChatSummary, buildChatUri, buildDefaultChatUri, parseDefaultChatUri, isAhpChatChannel, createActiveTurn, isAhpRootChannel, PolicyState, ResponsePartKind, ROOT_STATE_URI, StateComponents, buildSubagentChatUri, ToolResultContentType, MessageAttachmentKind, MessageKind, PendingMessageKind, withSessionMultiRootMetadata, type SessionState, type SessionSummary, type ChatState, type ISessionWithDefaultChat, RootState, type ToolCallState, type AgentInfo, type MessageAttachment, type MessageChatAttachment } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionsParams, type CompletionsResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { sessionReducer, chatReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
@@ -95,7 +95,6 @@ import { CHAT_SETUP_ACTION_ID } from '../../../browser/actions/chatActions.js';
 import { type ContextKeyValue } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IAgentHostProtectedResourcesService } from '../../../browser/agentSessions/agentHost/agentHostProtectedResourcesService.js';
-import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
 import { ILanguageModelToolsService, ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
@@ -892,14 +891,44 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	} as Partial<IAgentHostImportConversationStore> as IAgentHostImportConversationStore);
 	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService(chatService as Partial<IChatService> as IChatService, instantiationService.get(IWorkspaceContextService)));
 	instantiationService.stub(IAgentHostNewSessionFolderService, newSessionFolderService);
-	const customizationsByType = new Map<string, IObservable<readonly ClientPluginCustomization[]>>();
-	const seedActiveClient = (sessionType: string, entry: { customizations: IObservable<readonly ClientPluginCustomization[]> }): IDisposable => {
-		customizationsByType.set(sessionType, entry.customizations);
+	const customizationsByScope = new Map<string, { readonly customizations: IObservable<readonly ClientPluginCustomization[]>; readonly customAgents: IObservable<readonly AgentCustomization[]>; readonly tools: IObservable<readonly ToolDefinition[]>; readonly isResolved: IObservable<boolean>; readonly whenResolved: Promise<void> }>();
+	const scopeKey = (sessionType: string, roots: readonly URI[]) => `${sessionType}\n${roots.map(root => root.toString()).sort().join('\n')}`;
+	const seedActiveClient = (sessionType: string, entry: { customizations: IObservable<readonly ClientPluginCustomization[]>; customAgents?: IObservable<readonly AgentCustomization[]>; tools?: IObservable<readonly ToolDefinition[]>; isResolved?: IObservable<boolean>; whenResolved?: Promise<void> }, roots: readonly URI[] = []): IDisposable => {
+		const key = scopeKey(sessionType, roots);
+		const scopeEntry = {
+			customizations: entry.customizations,
+			customAgents: entry.customAgents ?? constObservable<readonly AgentCustomization[]>([]),
+			tools: entry.tools ?? constObservable<readonly ToolDefinition[]>([]),
+			isResolved: entry.isResolved ?? constObservable(true),
+			whenResolved: entry.whenResolved ?? Promise.resolve(),
+		};
+		customizationsByScope.set(key, scopeEntry);
 		return toDisposable(() => {
-			if (customizationsByType.get(sessionType) === entry.customizations) {
-				customizationsByType.delete(sessionType);
+			if (customizationsByScope.get(key) === scopeEntry) {
+				customizationsByScope.delete(key);
 			}
 		});
+	};
+	const acquireScope = (sessionType: string, roots: readonly URI[]) => {
+		const entry = customizationsByScope.get(scopeKey(sessionType, roots)) ?? {
+			customizations: constObservable<readonly ClientPluginCustomization[]>([]),
+			customAgents: constObservable<readonly AgentCustomization[]>([]),
+			tools: constObservable<readonly ToolDefinition[]>([]),
+			isResolved: constObservable(true),
+			whenResolved: Promise.resolve(),
+		};
+		return {
+			customizations: entry.customizations,
+			customAgents: entry.customAgents,
+			tools: entry.tools,
+			isResolved: entry.isResolved,
+			whenResolved: () => entry.whenResolved,
+			activeClient: (clientId: string) => derived(reader => {
+				entry.customAgents.read(reader);
+				return { clientId, tools: [...entry.tools.read(reader)], customizations: [...entry.customizations.read(reader)] };
+			}),
+			dispose: () => { },
+		};
 	};
 	const activeClientService: IAgentHostActiveClientService = {
 		_serviceBrand: undefined,
@@ -916,20 +945,12 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 					isDisabled: () => false,
 					setDisabled: () => { },
 				},
-				bundler: new class extends mock<SyncedCustomizationBundler>() {
-					override getOrigin() { return undefined; }
-				},
+				acquireScope: roots => acquireScope(sessionType, roots),
+				getOrigin: () => undefined,
 				dispose: () => inner.dispose(),
 			};
 		},
-		getActiveClient: (sessionType: string, clientId: string) => ({
-			clientId,
-			tools: [],
-			customizations: [...(customizationsByType.get(sessionType)?.get() ?? [])],
-		}),
-		getCustomizations: (sessionType: string) => derived(reader => customizationsByType.get(sessionType)?.read(reader) ?? []),
-		getCustomAgents: () => constObservable([]),
-		getClientTools: () => constObservable<readonly ToolDefinition[]>([]),
+		acquireScope,
 	};
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);
 	instantiationService.stub(IAgentHostProtectedResourcesService, { onDidChange: Event.None, getProtectedResources: () => undefined });
@@ -10281,6 +10302,51 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(createCall!.activeClient!.customizations?.[0].uri, 'file:///plugin-a');
 		});
 
+		test('waits for initial scope resolution before creating a session', async () => {
+			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<ClientPluginCustomization[]>('customizations', []);
+			const isResolved = observableValue('initialScopeResolved', false);
+			const initialResolution = new DeferredPromise<void>();
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations, isResolved, whenResolved: initialResolution.p }));
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/new-initial-scope' });
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+			const turnPromise = registered.impl.invoke(makeRequest({ sessionResource }), () => { }, [], CancellationToken.None);
+			await timeout(10);
+			assert.strictEqual(agentHostService.createSessionCalls.length, 0);
+
+			customizations.set([
+				{ type: CustomizationType.Plugin, id: 'file:///initial-plugin', uri: 'file:///initial-plugin', name: 'Initial Plugin', enabled: true },
+			], undefined);
+			isResolved.set(true, undefined);
+			initialResolution.complete();
+			await timeout(10);
+
+			const turnAction = agentHostService.turnActions[0];
+			assert.ok(turnAction);
+			const action = turnAction.action as ITurnStartedAction;
+			agentHostService.fireAction({ channel: turnAction.channel.toString(), action: turnAction.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: turnAction.clientSeq } });
+			agentHostService.fireAction({ channel: turnAction.channel.toString(), action: { type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session: turnAction.channel.toString(), turnId: action.turnId } as ChatAction, serverSeq: 2, origin: undefined });
+			await turnPromise;
+
+			assert.deepStrictEqual(
+				agentHostService.createSessionCalls.map(call => call.activeClient?.customizations?.map(customization => customization.uri)),
+				[['file:///initial-plugin']],
+			);
+		});
+
 		test('re-dispatches activeClientSet when customizations observable changes', async () => {
 			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables);
 
@@ -10308,6 +10374,7 @@ suite('AgentHostChatContribution', () => {
 			customizations.set([
 				{ type: CustomizationType.Plugin, id: 'file:///plugin-b', uri: 'file:///plugin-b', name: 'Plugin B', enabled: true },
 			], undefined);
+			await timeout(10);
 
 			const activeClientAction = agentHostService.dispatchedActions.find(
 				d => d.action.type === 'session/activeClientSet'
@@ -10316,6 +10383,204 @@ suite('AgentHostChatContribution', () => {
 			const ac = activeClientAction!.action as { activeClient: { customizations?: ClientPluginCustomization[] } };
 			assert.strictEqual(ac.activeClient.customizations?.length, 1);
 			assert.strictEqual(ac.activeClient.customizations?.[0].uri, 'file:///plugin-b');
+		});
+
+		test('reasserts a claimed active client after session state loses it', async () => {
+			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<readonly ClientPluginCustomization[]>('driftCustomizations', [
+				{ type: CustomizationType.Plugin, id: 'file:///drift-plugin', uri: 'file:///drift-plugin', name: 'Drift Plugin', enabled: true },
+			]);
+			const tools = observableValue<readonly ToolDefinition[]>('driftTools', [{ name: 'drift_tool' }]);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations, tools }));
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
+			customizations.set([
+				{ type: CustomizationType.Plugin, id: 'file:///drift-plugin-updated', uri: 'file:///drift-plugin-updated', name: 'Updated Drift Plugin', enabled: true },
+			], undefined);
+			await timeout(10);
+			const initial = agentHostService.dispatchedActions.find(action => action.action.type === ActionType.SessionActiveClientSet)!;
+			assert.ok(initial);
+			agentHostService.fireAction({
+				channel: initial.channel.toString(),
+				action: initial.action,
+				serverSeq: 2,
+				origin: { clientId: agentHostService.clientId, clientSeq: initial.clientSeq },
+			});
+			await timeout(10);
+			agentHostService.dispatchedActions.length = 0;
+
+			agentHostService.fireAction({
+				channel: initial.channel.toString(),
+				action: { type: ActionType.SessionActiveClientRemoved, clientId: agentHostService.clientId },
+				serverSeq: 3,
+				origin: undefined,
+			});
+			await timeout(10);
+
+			assert.deepStrictEqual(
+				agentHostService.dispatchedActions
+					.filter(action => action.action.type === ActionType.SessionActiveClientSet)
+					.map(action => (action.action as { activeClient: SessionActiveClient }).activeClient),
+				[{
+					clientId: agentHostService.clientId,
+					tools: [{ name: 'drift_tool' }],
+					customizations: [{ type: CustomizationType.Plugin, id: 'file:///drift-plugin-updated', uri: 'file:///drift-plugin-updated', name: 'Updated Drift Plugin', enabled: true }],
+				}],
+			);
+			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
+			await turnPromise;
+		});
+
+		test('does not republish an unacknowledged active-client payload on repeated state changes', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<readonly ClientPluginCustomization[]>('nonConvergingCustomizations', []);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations }));
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
+			customizations.set([
+				{ type: CustomizationType.Plugin, id: 'file:///non-converging-plugin', uri: 'file:///non-converging-plugin', name: 'Non-converging Plugin', enabled: true },
+			], undefined);
+			await timeout(10);
+			const published = agentHostService.dispatchedActions.find(action => action.action.type === ActionType.SessionActiveClientSet)!;
+			assert.ok(published);
+			agentHostService.dispatchedActions.length = 0;
+			const activeClient = (published.action as { activeClient: SessionActiveClient }).activeClient;
+			const nonConvergingActiveClient: SessionActiveClient = {
+				...activeClient,
+				customizations: (activeClient.customizations ?? []).map(customization => ({ ...customization, nonce: undefined })),
+			};
+
+			for (let serverSeq = 2; serverSeq < 5; serverSeq++) {
+				agentHostService.fireAction({
+					channel: published.channel.toString(),
+					action: { type: ActionType.SessionActiveClientSet, activeClient: nonConvergingActiveClient },
+					serverSeq,
+					origin: undefined,
+				});
+				await timeout(10);
+			}
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions.filter(action => action.action.type === ActionType.SessionActiveClientSet), []);
+			fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session, turnId } as ChatAction);
+			await turnPromise;
+		}));
+
+		test('coalesces customization, custom-agent, and tool changes into one active-client dispatch', async () => {
+			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<readonly ClientPluginCustomization[]>('burstCustomizations', []);
+			const customAgents = observableValue<readonly AgentCustomization[]>('burstCustomAgents', []);
+			const tools = observableValue<readonly ToolDefinition[]>('burstTools', []);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations, customAgents, tools }));
+			const sessionResource = AgentSession.uri('copilot', 'coalesced-active-client');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClients: [{ clientId: agentHostService.clientId, tools: [], customizations: [] }],
+			});
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+			await timeout(10);
+			agentHostService.dispatchedActions.length = 0;
+
+			customizations.set([{ type: CustomizationType.Plugin, id: 'file:///burst-plugin', uri: 'file:///burst-plugin', name: 'Burst Plugin', enabled: true }], undefined);
+			customAgents.set([{ type: CustomizationType.Agent, id: 'burst-agent', uri: 'file:///burst-agent.agent.md', name: 'Burst Agent' }], undefined);
+			tools.set([{ name: 'burst_tool' }], undefined);
+			await timeout(10);
+
+			assert.deepStrictEqual(
+				agentHostService.dispatchedActions
+					.filter(action => action.action.type === ActionType.SessionActiveClientSet)
+					.map(action => (action.action as { activeClient: SessionActiveClient }).activeClient),
+				[{
+					clientId: agentHostService.clientId,
+					tools: [{ name: 'burst_tool' }],
+					customizations: [{ type: CustomizationType.Plugin, id: 'file:///burst-plugin', uri: 'file:///burst-plugin', name: 'Burst Plugin', enabled: true }],
+				}],
+			);
+		});
+
+		test('dispatches customization changes only to the session with the matching working-directory scope', async () => {
+			const rootA = URI.file('c:\\scope-a');
+			const rootB = URI.file('c:\\scope-b');
+			const { instantiationService, agentHostService, chatAgentService, seedActiveClient } = createTestServices(disposables, {
+				resolve: sessionResource => sessionResource.path === '/scope-a' ? rootA : rootB,
+			});
+			const customizationsA = observableValue<ClientPluginCustomization[]>('customizationsA', []);
+			const customizationsB = observableValue<ClientPluginCustomization[]>('customizationsB', []);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations: customizationsA }, [rootA]));
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations: customizationsB }, [rootB]));
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const first = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/scope-a' }),
+			});
+			first.fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session: first.session, turnId: first.turnId } as ChatAction);
+			await first.turnPromise;
+			const second = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/scope-b' }),
+			});
+			second.fire({ type: 'chat/turnComplete', endedAt: '2025-01-01T00:00:00.000Z', session: second.session, turnId: second.turnId } as ChatAction);
+			await second.turnPromise;
+
+			agentHostService.dispatchedActions.length = 0;
+			customizationsA.set([
+				{ type: CustomizationType.Plugin, id: 'file:///scope-a-plugin', uri: 'file:///scope-a-plugin', name: 'Scope A Plugin', enabled: true },
+			], undefined);
+			await timeout(10);
+
+			assert.deepStrictEqual(
+				agentHostService.dispatchedActions
+					.filter(action => action.action.type === ActionType.SessionActiveClientSet)
+					.map(action => ({
+						channel: action.channel.toString(),
+						customizations: (action.action as { activeClient: { customizations: readonly ClientPluginCustomization[] } }).activeClient.customizations.map(customization => customization.uri),
+					})),
+				[{ channel: AgentSession.uri('copilot', 'scope-a').toString(), customizations: ['file:///scope-a-plugin'] }],
+			);
 		});
 
 		test('does not dispatch activeClientSet when an existing session is restored and this client is already active', async () => {
@@ -10355,6 +10620,60 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(
 				agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientSet').length,
 				0,
+			);
+		});
+
+		test('publishes only resolved customizations when restoring a session', async () => {
+			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
+			const sessionResource = AgentSession.uri('copilot', 'resolved-customizations');
+			const customization: ClientPluginCustomization = { type: CustomizationType.Plugin, id: 'file:///resolved-plugin', uri: 'file:///resolved-plugin', name: 'Resolved Plugin', enabled: true };
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClients: [{
+					clientId: agentHostService.clientId,
+					tools: [],
+					customizations: [],
+				}],
+			});
+			const customizations = observableValue<readonly ClientPluginCustomization[]>('resolvedCustomizations', []);
+			const isResolved = observableValue('resolvedCustomizationsReady', false);
+			const resolution = new DeferredPromise<void>();
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations, isResolved, whenResolved: resolution.p }));
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+			await timeout(10);
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions.filter(action => action.action.type === ActionType.SessionActiveClientSet), []);
+
+			customizations.set([customization], undefined);
+			isResolved.set(true, undefined);
+			resolution.complete();
+			await timeout(10);
+
+			assert.deepStrictEqual(
+				agentHostService.dispatchedActions
+					.filter(action => action.action.type === ActionType.SessionActiveClientSet)
+					.map(action => (action.action as { activeClient: { customizations: readonly ClientPluginCustomization[] } }).activeClient.customizations),
+				[[customization]],
 			);
 		});
 
@@ -10410,6 +10729,41 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(activeClientActions[0].channel, sessionResource.toString());
 		});
 
+		test('does not claim another client session while reconciling scope changes', async () => {
+			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
+			const customizations = observableValue<readonly ClientPluginCustomization[]>('otherClientCustomizations', []);
+			disposables.add(seedActiveClient('agent-host-copilot', { customizations }));
+			const sessionResource = AgentSession.uri('copilot', 'other-client-session');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClients: [{ clientId: 'other-client', tools: [], customizations: [] }],
+			});
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+			customizations.set([{ type: CustomizationType.Plugin, id: 'file:///other-client-plugin', uri: 'file:///other-client-plugin', name: 'Other Client Plugin', enabled: true }], undefined);
+			await timeout(10);
+
+			assert.deepStrictEqual(agentHostService.dispatchedActions.filter(action => action.action.type === ActionType.SessionActiveClientSet), []);
+		});
+
 		test('refreshes stale customizations on open when the current client is already active', async () => {
 			const { instantiationService, agentHostService, seedActiveClient } = createTestServices(disposables);
 			const customizations = observableValue<ClientPluginCustomization[]>('customizations', [
@@ -10449,6 +10803,7 @@ suite('AgentHostChatContribution', () => {
 			// a session where only another client is active.
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
 			disposables.add(toDisposable(() => chatSession.dispose()));
+			await timeout(10);
 
 			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientSet');
 			assert.strictEqual(activeClientActions.length, 1);
@@ -10523,6 +10878,8 @@ suite('AgentHostChatContribution', () => {
 				serverSeq: 2,
 				origin: undefined,
 			});
+
+			await timeout(10);
 
 			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === ActionType.SessionActiveClientSet);
 			assert.strictEqual(activeClientActions.length, 1);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -11,6 +11,7 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { constObservable, observableValue, autorun } from '../../../../../../base/common/observable.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
@@ -36,6 +37,7 @@ import { PieceCtorKind, PromptNodeType } from '../../../common/tools/promptTsxTy
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { IConfigurationResolverService } from '../../../../../services/configurationResolver/common/configurationResolver.js';
 import { AgentHostSessionHandler, toolDataToDefinition, toolResultToProtocol, UNOBSERVED_CLIENT_TOOL_GRACE_MS } from '../../../browser/agentSessions/agentHost/agentHostSessionHandler.js';
 import { AgentHostActiveClientService, IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
@@ -62,7 +64,9 @@ import { IOutputService } from '../../../../../services/output/common/output.js'
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
-import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
+import { IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
+import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 
 // =============================================================================
 // Unit tests for toolDataToDefinition and toolResultToProtocol
@@ -74,6 +78,86 @@ suite('AgentHostClientTools', () => {
 
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shares a customization scope for equivalent root sets', async () => {
+		const resolvedRoots: URI[] = [];
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, TestFileService);
+		instantiationService.stub(IAgentHostFileSystemService, {
+			ensureSyncedCustomizationProvider: () => { },
+		});
+		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+		instantiationService.stub(IConfigurationService, {
+			getValue: () => false,
+			onDidChangeConfiguration: Event.None,
+		} as Partial<IConfigurationService> as IConfigurationService);
+		instantiationService.stub(IConfigurationResolverService, {} as Partial<IConfigurationResolverService>);
+		instantiationService.stub(IPromptsService, new class extends mock<IPromptsService>() {
+			override readonly onDidChangeCustomAgents = Event.None;
+			override readonly onDidChangeSlashCommands = Event.None;
+			override readonly onDidChangeSkills = Event.None;
+			override readonly onDidChangeInstructions = Event.None;
+			override getDisabledPromptFiles() { return new ResourceSet(); }
+			override async listPromptFilesForStorage(_type: PromptsType, storage: PromptsStorage, _token: CancellationToken, root?: URI) {
+				if (storage === PromptsStorage.local && root) {
+					resolvedRoots.push(root);
+				}
+				return [];
+			}
+		}());
+		instantiationService.stub(IAgentPluginService, {
+			plugins: observableValue('plugins', []),
+		});
+		instantiationService.stub(IMcpService, {
+			servers: observableValue('mcpServers', []),
+		});
+		instantiationService.stub(ILanguageModelToolsService, {
+			observeTools: () => constObservable([]),
+			toolSets: constObservable([]),
+		} as Partial<ILanguageModelToolsService> as ILanguageModelToolsService);
+		instantiationService.stub(IAgentHostToolSetEnablementService, {
+			observe: () => constObservable<IToolEnablementState>({ toolSets: new Map(), tools: new Map() }),
+			getState: () => ({ toolSets: new Map(), tools: new Map() }),
+			setToolSetEnabled: () => { },
+			setToolEnabled: () => { },
+		});
+
+		const service = disposables.add(instantiationService.createInstance(AgentHostActiveClientService));
+		const registration = disposables.add(service.registerForAgent('agent-host-claude'));
+		const rootA = URI.file('/Workspace-A');
+		const rootB = URI.file('/Workspace-B');
+		const unregisteredScope = service.acquireScope('unregistered-agent', []);
+		const unresolvedScope = registration.acquireScope([URI.file('/unresolved-workspace')]);
+		const unresolved = unresolvedScope.whenResolved();
+		unresolvedScope.dispose();
+		assert.strictEqual(await unresolved, undefined);
+		const first = registration.acquireScope([rootB, rootA, rootA]);
+		const second = registration.acquireScope([rootA, rootB]);
+		await first.whenResolved();
+
+		const sharedScopeState = {
+			customizations: first.customizations === second.customizations,
+			customAgents: first.customAgents === second.customAgents,
+			resolvedRoots,
+		};
+		first.dispose();
+		second.dispose();
+		registration.dispose();
+
+		assert.deepStrictEqual({
+			unregisteredScope,
+			sharedScopeState,
+			scopeAfterRegistrationDisposal: service.acquireScope('agent-host-claude', []),
+		}, {
+			unregisteredScope: undefined,
+			sharedScopeState: {
+				customizations: true,
+				customAgents: true,
+				resolvedRoots: [rootA, rootB, rootA, rootB, rootA, rootB, rootA, rootB, rootA, rootB, rootA, rootB, rootA, rootB, rootA, rootB],
+			},
+			scopeAfterRegistrationDisposal: undefined,
+		});
+	});
 
 	// ── toolDataToDefinition ─────────────────────────────────────────────
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { observableValue } from '../../../../../../base/common/observable.js';
+import { constObservable, derived, observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -213,8 +213,15 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		insta.stub(IAgentHostImportConversationStore, importStore);
 		customizations = observableValue<readonly ClientPluginCustomization[]>('customizations', []);
 		insta.stub(IAgentHostActiveClientService, {
-			getCustomizations: () => customizations,
-			getActiveClient: (_sessionType: string, clientId: string) => ({ clientId, tools: [], customizations: [...customizations.get()] }),
+			acquireScope: (_sessionType: string, _roots: readonly URI[]) => ({
+				customizations,
+				customAgents: constObservable([]),
+				tools: constObservable([]),
+				isResolved: constObservable(true),
+				whenResolved: () => Promise.resolve(),
+				activeClient: clientId => derived(reader => ({ clientId, tools: [], customizations: [...customizations.read(reader)] })),
+				dispose: () => { },
+			}),
 		} as Partial<IAgentHostActiveClientService> as IAgentHostActiveClientService);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
@@ -52,7 +52,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [makePromptPath(builtin, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage)]],
 		]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 
 		assert.deepStrictEqual(result, [{
 			uri: builtin,
@@ -74,13 +74,104 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [makePromptPath(builtinSkill, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage)]],
 		]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 
 		assert.deepStrictEqual(result.map((e: { uri: URI; type: PromptsType; source: unknown; disabled: boolean }) => ({ uri: e.uri.toString(), type: e.type, source: e.source, disabled: e.disabled })), [
 			{ uri: workspaceAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.local, disabled: false },
 			{ uri: extensionAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.extension, disabled: false },
 			{ uri: builtinSkill.toString(), type: PromptsType.skill, source: AICustomizationSources.builtin, disabled: false },
 		]);
+	});
+
+	test('resolves only local storage against the supplied workspace root', async () => {
+		const root = URI.file('/workspace');
+		const roots: (URI | undefined)[] = [];
+		const promptsService = {
+			async listPromptFilesForStorage(_type: PromptsType, _storage: PromptsStorage, _token: CancellationToken, scopeRoot?: URI): Promise<readonly IPromptPath[]> {
+				roots.push(scopeRoot);
+				return [];
+			},
+			getDisabledPromptFiles(): ResourceSet {
+				return new ResourceSet();
+			},
+		} as unknown as IPromptsService;
+
+		await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, [root]);
+
+		assert.deepStrictEqual(roots, Array.from({ length: 4 }, () => [root, undefined, undefined, undefined]).flat());
+	});
+
+	test('unions customizations from every root without duplicates', async () => {
+		const rootA = URI.file('/workspace-a');
+		const rootB = URI.file('/workspace-b');
+		const shared = URI.file('/shared/.github/agents/shared.agent.md');
+		const calls = new Map<PromptsStorage, number>();
+		const promptsService = {
+			async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, _token: CancellationToken, root?: URI): Promise<readonly IPromptPath[]> {
+				calls.set(storage, (calls.get(storage) ?? 0) + 1);
+				if (type !== PromptsType.agent || storage !== PromptsStorage.local) {
+					return [];
+				}
+				if (root?.toString() === rootA.toString()) {
+					return [
+						makePromptPath(URI.joinPath(rootA, '.github', 'agents', 'first.agent.md'), type, storage),
+						makePromptPath(shared, type, storage),
+					];
+				}
+				if (root?.toString() === rootB.toString()) {
+					return [
+						makePromptPath(URI.joinPath(rootB, '.github', 'agents', 'second.agent.md'), type, storage),
+						makePromptPath(shared, type, storage),
+					];
+				}
+				return [];
+			},
+			getDisabledPromptFiles(): ResourceSet {
+				return new ResourceSet();
+			},
+		} as unknown as IPromptsService;
+
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, [rootA, rootB]);
+
+		assert.deepStrictEqual({
+			uris: result.map(item => item.uri.toString()),
+			calls: [...calls.entries()],
+		}, {
+			uris: [
+				URI.joinPath(rootA, '.github', 'agents', 'first.agent.md').toString(),
+				shared.toString(),
+				URI.joinPath(rootB, '.github', 'agents', 'second.agent.md').toString(),
+			],
+			calls: [
+				[PromptsStorage.local, 8],
+				[PromptsStorage.plugin, 4],
+				[PromptsStorage.extension, 4],
+				[PromptsStorage.builtIn, 4],
+			],
+		});
+	});
+
+	test('uses ambient prompt discovery for an empty root set', async () => {
+		const ambient = URI.file('/ambient/.github/agents/ambient.agent.md');
+		const roots: (URI | undefined)[] = [];
+		const promptsService = {
+			async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, _token: CancellationToken, root?: URI): Promise<readonly IPromptPath[]> {
+				roots.push(root);
+				return type === PromptsType.agent && storage === PromptsStorage.local && root === undefined
+					? [makePromptPath(ambient, type, storage)]
+					: [];
+			},
+			getDisabledPromptFiles(): ResourceSet {
+				return new ResourceSet();
+			},
+		} as unknown as IPromptsService;
+
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+
+		assert.deepStrictEqual({ result: result.map(item => item.uri.toString()), roots }, {
+			result: [ambient.toString()],
+			roots: Array<URI | undefined>(16).fill(undefined),
+		});
 	});
 
 	test('marks built-in skills disabled when the sync provider says so', async () => {
@@ -90,7 +181,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		]));
 		const syncProvider = new FakeSyncProvider(new Set([builtin.toString()]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 
 		assert.strictEqual(result.length, 1);
 		assert.strictEqual(result[0].disabled, true);
@@ -108,8 +199,8 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			[`${PromptsType.prompt}/${PromptsStorage.user}`, [makePromptPath(userPrompt, PromptsType.prompt, PromptsStorage.user)]],
 		]));
 
-		const localResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
-		const remoteResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, { includeUserStorage: true });
+		const localResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const remoteResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, { includeUserStorage: true }, []);
 
 		assert.deepStrictEqual({
 			local: localResult,
@@ -141,6 +232,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			SessionType.CopilotCLI,
 			CancellationToken.None,
 			{ includeUserStorage: true },
+			[]
 		);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
@@ -165,7 +257,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			new Map([[PromptsType.skill, new ResourceSet([disabledSkill])]]),
 		);
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
 			{ uri: disabledSkill.toString(), disabled: true },
@@ -190,7 +282,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			new Map([[PromptsType.agent, new ResourceSet([hiddenAgent])]]),
 		);
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
 			{ uri: hiddenAgent.toString(), disabled: false },
@@ -203,7 +295,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		// throwing). Model that here to confirm enumeration is a no-op outside
 		// Sessions.
 		const promptsService = makePromptsService(new Map());
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
 		assert.deepStrictEqual(result, []);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -215,6 +215,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -245,6 +248,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(bundler.received[0].map(f => f.uri.toString()), [enabled.toString()]);
@@ -276,6 +282,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(bundler.received[0].map(f => f.uri.toString()), [enabled.toString()]);
@@ -299,6 +308,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -333,6 +345,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			localBundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		await resolveCustomizationRefs(
 			makeFileService(),
@@ -345,6 +360,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			{ includeUserStorage: true },
+			[]
 		);
 
 		assert.deepStrictEqual({
@@ -372,6 +388,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -392,6 +411,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -411,6 +433,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(refs.map(ref => ({ uri: ref.uri, name: ref.name })), [
@@ -429,6 +454,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -447,6 +475,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -462,6 +493,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -481,6 +515,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		assert.deepStrictEqual(refs.map(r => r.uri), [pluginUri.toString()]);
 	});
@@ -498,6 +535,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 		assert.deepStrictEqual(refs, []);
 		// Use CancellationToken so the import isn't dead in the bundle.
@@ -519,6 +559,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -552,6 +595,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			'agent-host-copilotcli',
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, [[
@@ -572,6 +618,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			'remote-test-copilotcli',
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, []);
@@ -589,6 +638,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			'agent-host-claude',
+			false,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, [[
@@ -611,6 +663,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		// No loose files and no non-plugin MCP servers: bundler is never called.
@@ -633,6 +688,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -653,6 +711,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -673,6 +734,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -694,6 +758,8 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 			true,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -719,6 +785,8 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 			true,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -739,6 +807,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -764,6 +835,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -784,6 +858,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService({ '${workspaceFolder}': '/ws' }),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -811,6 +888,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			throwingResolver,
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -831,6 +911,9 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makeConfigurationResolverService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
+			false,
+			undefined,
+			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -866,6 +949,8 @@ suite('resolveLocalCustomAgents', () => {
 			new FakeSyncProvider(),
 			makeAgentPluginService([plugin]),
 			SessionType.CopilotCLI,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(agents, [{
@@ -895,6 +980,8 @@ suite('resolveLocalCustomAgents', () => {
 			new FakeSyncProvider(),
 			makeAgentPluginService(),
 			SessionType.CopilotCLI,
+			undefined,
+			[]
 		);
 
 		assert.deepStrictEqual(agents, [{
@@ -917,31 +1004,30 @@ suite('shouldSyncWorkspaceDotMcp - multi-root gate', () => {
 	// the feature tests green) fails here.
 	const LOCAL_COPILOT = 'agent-host-copilotcli';
 
-	test('true only for local Copilot + multi-root workspace + setting enabled', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, 2, true), true);
+	test('true only for local Copilot + multiple roots + setting enabled', () => {
+		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, [URI.file('/workspace-a'), URI.file('/workspace-b')], true), true);
 	});
 
 	test('false when the multi-root setting is disabled', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, 2, false), false);
+		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, [URI.file('/workspace-a'), URI.file('/workspace-b')], false), false);
 	});
 
-	test('false for a single-folder workspace', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, 1, true), false);
-	});
-
-	test('false for an empty workspace', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, 0, true), false);
+	test('false for a single root or workspace-less scope', () => {
+		assert.deepStrictEqual([
+			shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, [URI.file('/workspace')], true),
+			shouldSyncWorkspaceDotMcp(LOCAL_COPILOT, [], true),
+		], [false, false]);
 	});
 
 	test('false for a non-Copilot harness (e.g. Claude)', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp('agent-host-claude', 2, true), false);
+		assert.strictEqual(shouldSyncWorkspaceDotMcp('agent-host-claude', [URI.file('/workspace-a'), URI.file('/workspace-b')], true), false);
 	});
 
 	test('false for the Copilot CLI (extension host) harness', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp('copilotcli', 2, true), false);
+		assert.strictEqual(shouldSyncWorkspaceDotMcp('copilotcli', [URI.file('/workspace-a'), URI.file('/workspace-b')], true), false);
 	});
 
 	test('false for a remote Copilot Agent Host session', () => {
-		assert.strictEqual(shouldSyncWorkspaceDotMcp('remote-myauthority-copilotcli', 2, true), false);
+		assert.strictEqual(shouldSyncWorkspaceDotMcp('remote-myauthority-copilotcli', [URI.file('/workspace-a'), URI.file('/workspace-b')], true), false);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
@@ -37,7 +37,7 @@ export class MockPromptsService implements IPromptsService {
 	getSyntaxParserFor(_model: any): any { throw new Error('Not implemented'); }
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	listPromptFiles(_type: any): Promise<readonly any[]> { throw new Error('Not implemented'); }
-	listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly IPromptPath[]> { throw new Error('Not implemented'); }
+	listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken, root?: URI): Promise<readonly IPromptPath[]> { throw new Error('Not implemented'); }
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	getSourceFolders(_type: any): Promise<readonly any[]> { throw new Error('Not implemented'); }
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -220,6 +220,27 @@ suite('PromptsService', () => {
 		instaService.stub(IPromptsService, service);
 	});
 
+	test('lists local prompt files relative to an explicit root and its parent repository', async () => {
+		const parentRoot = URI.file('/parent-repo');
+		const explicitRoot = URI.joinPath(parentRoot, 'packages/explicit-root');
+		const siblingRoot = URI.file('/sibling-root');
+		workspaceContextService.setWorkspace(testWorkspace(explicitRoot, siblingRoot));
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, true);
+		await mockFiles(fileService, [
+			{ path: '/parent-repo/.git/HEAD', contents: ['ref: refs/heads/main'] },
+			{ path: '/parent-repo/.github/prompts/parent.prompt.md', contents: ['parent'] },
+			{ path: '/parent-repo/packages/explicit-root/.github/prompts/explicit.prompt.md', contents: ['explicit'] },
+			{ path: '/sibling-root/.github/prompts/sibling.prompt.md', contents: ['sibling'] },
+		]);
+
+		const files = await service.listPromptFilesForStorage(PromptsType.prompt, PromptsStorage.local, CancellationToken.None, explicitRoot);
+
+		assert.deepStrictEqual(files.map(file => file.uri.path), [
+			'/parent-repo/packages/explicit-root/.github/prompts/explicit.prompt.md',
+			'/parent-repo/.github/prompts/parent.prompt.md',
+		]);
+	});
+
 	suite('IAgentSource.isEquals', () => {
 		test('returns true for equivalent local sources', () => {
 			const left: IAgentSource = { storage: PromptsStorage.local };


### PR DESCRIPTION
The synthetic `vscode-synced-customization` plugin was keyed only by session type, so one bundle identity was shared by every session of a provider and resolved against whatever workspace folder happened to be ambient. In the Agents window the ambient folder is swapped on every active-session change, so switching sessions re-resolved and re-published customizations to **every** live session, and one repository's instructions, prompts, skills and workspace MCP servers leaked into sessions running in another. The agent host then re-materialized and re-bound plugins each time, and the nonce cache never hit because ping-ponging between two repos evicted each bundle in turn.

## What changed

**Customizations are keyed by the session's working-directory set.** `IAgentHostActiveClientService` hands out refcounted `IAgentCustomizationScope`s, shared between sessions with identical roots, each owning its own bundler with an authority derived from the normalized root set. `IWorkspaceContextService` is gone from the service. `IPromptsService.listPromptFilesForStorage` takes an optional explicit root; omitted, it behaves exactly as before.

**Publishing is consolidated.** Four separate `activeClientSet` dispatch sites in the session handler became one debounced per-session reconciler, held in a self-contained `ActiveClientEntry`. The claim/no-claim distinction is now explicit: the client publishes only where it is already an active client, or where it explicitly claimed the session at open.

**Publishing is gated on resolution.** A freshly acquired scope reports an empty customization set until it resolves; publishing that would transiently wipe the host's state, so nothing publishes from an unresolved scope, and session creation waits for the pending publish to settle.

## Verification

Validated against Agent Host log captures of the same flow (message a session, switch to a session in another repo, switch back):

| | before | after scoping | after consolidation |
|---|---|---|---|
| client→server dispatches | 16 | 5 | **4** |
| empty-customization publishes | 7 | 0 | **0** |
| consecutive duplicate dispatches | — | 3 | **0** |

Each repository resolves to its own authority and nonce, byte-stable across app restarts, with no re-materialization on return and no cross-repo content in either session.

A later capture caught a dispatch loop (344 identical actions in 8s) when a plugin was disabled, the UI switched, and the plugin re-enabled: an identical payload is now never re-sent, so a payload the server does not acknowledge costs one dispatch rather than spinning.

## Notes

- Tools remain workspace-independent today but now live on the scope, delegating to a shared per-`sessionType` derived so identical computations are not duplicated per scope.
- The AI Customization management UI deliberately keeps ambient (window-scoped) behaviour via an empty root set; only sessions are folder-scoped.
- The bundle URI shape changes, so sessions running against the old identity re-materialize once on first launch after this lands.
