### PR TITLE
explorer: update symbolic link decorations on visible file changes

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event } from '../../../../base/common/event.js';
+import { Event, Emitter } from '../../../../base/common/event.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IFilesConfiguration, ISortOrderConfiguration, SortOrder, LexicographicOptions } from '../common/files.js';
@@ -28,6 +28,7 @@ import { ResourceGlobMatcher } from '../../../common/resources.js';
 import { IFilesConfigurationService } from '../../../services/filesConfiguration/common/filesConfigurationService.js';
 import { IDecorationsService } from '../../../services/decorations/common/decorations.js';
 import { ExplorerDecorationsProvider } from './views/explorerDecorationsProvider.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 
 export const UNDO_REDO_SOURCE = new UndoRedoSource();
 
@@ -46,6 +47,10 @@ export class ExplorerService implements IExplorerService {
 	private onFileChangesScheduler: RunOnceScheduler;
 	private fileChangeEvents: FileChangesEvent[] = [];
 	private revealExcludeMatcher: ResourceGlobMatcher;
+
+	private readonly _onDidChangeItemDecorations = this.disposables.add(new Emitter<URI[]>());
+	readonly onDidChangeItemDecorations = this._onDidChangeItemDecorations.event;
+	private readonly symbolicLinkUris = new ResourceSet();
 
 	constructor(
 		@IFileService private fileService: IFileService,
@@ -70,33 +75,35 @@ export class ExplorerService implements IExplorerService {
 			const events = this.fileChangeEvents;
 			this.fileChangeEvents = [];
 
-			// Filter to the ones we care
-			const types = [FileChangeType.DELETED];
-			if (this.config.sortOrder === SortOrder.Modified) {
-				types.push(FileChangeType.UPDATED);
-			}
-
 			let shouldRefresh = false;
 			// For DELETED and UPDATED events go through the explorer model and check if any of the items got affected
-			this.roots.forEach(r => {
-				if (this.view && !shouldRefresh) {
-					shouldRefresh = doesFileEventAffect(r, this.view, events, types);
+			for (const r of this.roots) {
+				if (shouldRefresh) {
+					break;
 				}
-			});
+				if (this.view) {
+					shouldRefresh = await doesFileEventAffect(r, this.view, events, this.config.sortOrder, this.fileService);
+				}
+			}
 			// For ADDED events we need to go through all the events and check if the explorer is already aware of some of them
 			// Or if they affect not yet resolved parts of the explorer. If that is the case we will not refresh.
-			events.forEach(e => {
-				if (!shouldRefresh) {
-					for (const resource of e.rawAdded) {
-						const parent = this.model.findClosest(dirname(resource));
-						// Parent of the added resource is resolved and the explorer model is not aware of the added resource - we need to refresh
-						if (parent && !parent.getChild(basename(resource))) {
+			for (const e of events) {
+				if (shouldRefresh) {
+					break;
+				}
+				for (const resource of e.rawAdded) {
+					const parent = this.model.findClosest(dirname(resource));
+					if (parent) {
+						const child = parent.getChild(basename(resource));
+						// Parent of the added resource is resolved and the explorer model is not aware of the added resource,
+						// or the child is involved in a symbolic link state change (e.g., ln -sf) - we need to refresh
+						if (!child || (await hasSymbolicLinkChanged(child, this.fileService))) {
 							shouldRefresh = true;
 							break;
 						}
 					}
 				}
-			});
+			}
 
 			if (shouldRefresh) {
 				await this.refresh(false);
@@ -358,6 +365,32 @@ export class ExplorerService implements IExplorerService {
 		}
 	}
 
+	checkSymbolicLinkDecorations(items: ExplorerItem[]): void {
+		const changedDecorationUris = items
+			.filter(item => this.updateSymbolicLinkState(item))
+			.map(item => item.resource);
+
+		if (changedDecorationUris.length > 0) {
+			this._onDidChangeItemDecorations.fire(changedDecorationUris);
+		}
+	}
+
+	private updateSymbolicLinkState(item: ExplorerItem): boolean {
+		const wasSymbolicLink = this.symbolicLinkUris.has(item.resource);
+		const isSymbolicLink = item.isSymbolicLink;
+
+		if (wasSymbolicLink !== isSymbolicLink) {
+			if (isSymbolicLink) {
+				this.symbolicLinkUris.add(item.resource);
+			} else {
+				this.symbolicLinkUris.delete(item.resource);
+			}
+			return true;
+		}
+
+		return false;
+	}
+
 	// File events
 
 	private async onDidRunOperation(e: FileOperationEvent): Promise<void> {
@@ -521,14 +554,24 @@ export class ExplorerService implements IExplorerService {
 	}
 }
 
-function doesFileEventAffect(item: ExplorerItem, view: IExplorerView, events: FileChangesEvent[], types: FileChangeType[]): boolean {
+async function doesFileEventAffect(item: ExplorerItem, view: IExplorerView, events: FileChangesEvent[], sortOrder: SortOrder | undefined, fileService: IFileService): Promise<boolean> {
 	for (const [_name, child] of item.children) {
 		if (view.isItemVisible(child)) {
-			if (events.some(e => e.contains(child.resource, ...types))) {
+			if (events.some(e => e.contains(child.resource, FileChangeType.DELETED))) {
 				return true;
 			}
+
+			if (events.some(e => e.contains(child.resource, FileChangeType.UPDATED))) {
+				if (sortOrder === SortOrder.Modified) {
+					return true;
+				}
+				if (await hasSymbolicLinkChanged(child, fileService)) {
+					return true;
+				}
+			}
+
 			if (child.isDirectory && child.isDirectoryResolved) {
-				if (doesFileEventAffect(child, view, events, types)) {
+				if (await doesFileEventAffect(child, view, events, sortOrder, fileService)) {
 					return true;
 				}
 			}
@@ -536,6 +579,15 @@ function doesFileEventAffect(item: ExplorerItem, view: IExplorerView, events: Fi
 	}
 
 	return false;
+}
+
+async function hasSymbolicLinkChanged(child: ExplorerItem, fileService: IFileService): Promise<boolean> {
+	try {
+		const stat = await fileService.stat(child.resource);
+		return stat.isSymbolicLink !== child.isSymbolicLink;
+	} catch {
+		return false;
+	}
 }
 
 function getRevealExcludes(configuration: IFilesConfiguration): IExpression {

--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../base/common/uri.js';
+import { Event } from '../../../../base/common/event.js';
 import { IListService } from '../../../../platform/list/browser/listService.js';
 import { OpenEditor, ISortOrderConfiguration } from '../common/files.js';
 import { EditorResourceAccessor, SideBySideEditor, IEditorIdentifier } from '../../../common/editor.js';
@@ -23,6 +24,9 @@ export interface IExplorerService {
 	readonly _serviceBrand: undefined;
 	readonly roots: ExplorerItem[];
 	readonly sortOrderConfiguration: ISortOrderConfiguration;
+	readonly onDidChangeItemDecorations: Event<URI[]>;
+
+	checkSymbolicLinkDecorations(items: ExplorerItem[]): void;
 
 	getContext(respectMultiSelection: boolean, ignoreNestedChildren?: boolean): ExplorerItem[];
 	hasViewFocus(): boolean;

--- a/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
@@ -68,6 +68,9 @@ export class ExplorerDecorationsProvider implements IDecorationsProvider {
 		this.toDispose.add(explorerRootErrorEmitter.event((resource => {
 			this._onDidChange.fire([resource]);
 		})));
+		this.toDispose.add(explorerService.onDidChangeItemDecorations(uris => {
+			this._onDidChange.fire(uris);
+		}));
 	}
 
 	get onDidChange(): Event<URI[]> {

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -139,6 +139,8 @@ export class ExplorerDataSource implements IAsyncDataSource<ExplorerItem | Explo
 				if (element instanceof ExplorerItem && element.isRoot && !element.error && hasError && this.contextService.getWorkbenchState() !== WorkbenchState.FOLDER) {
 					explorerRootErrorEmitter.fire(element.resource);
 				}
+				// Update symbolic link decorations.
+				this.explorerService.checkSymbolicLinkDecorations(children);
 				return children;
 			}
 			, e => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Summary
This is another try to fix https://github.com/microsoft/vscode/issues/167146 by reference https://github.com/microsoft/vscode/pull/168707#issuecomment-1355295473

This fixes an issue where symbolic link decorations in the File Explorer do not update correctly when a file's symbolic link status changes on disk.

### Changes

There are two root causes, each addressed separately:

#### Problem 1: `ExplorerItem` is not refreshed when symbolic link status changes on disk.

When a file's symbolic link status changes on disk (e.g. replaced via `rm; ln`), the in-memory `ExplorerItem.isSymbolicLink` remains stale because no explorer refresh is triggered. To fix this, `onFileChangesScheduler` now compares the current disk state (`fileService.stat`) against `ExplorerItem.isSymbolicLink` for visible items during file watcher events (`UPDATED` and `ADDED`). If a discrepancy is found, it triggers an explorer refresh so that a new `ExplorerItem` is constructed with the correct state. This also handles the case where `ln -sf` is reported as an `ADDED` event by the file watcher.

#### Problem 2: Even when `ExplorerItem` is refreshed, the UI decoration cache is not invalidated.

Even after an explorer refresh constructs a new `ExplorerItem` with the correct `isSymbolicLink` value, the decoration does not update because `DecorationsService` has no way of knowing the symbolic link status has changed. To fix this, `ExplorerService.symbolicLinkUris` is introduced to remember which files are currently rendered as symbolic links. When `ExplorerItem` nodes are constructed or refreshed, `ExplorerService` compares each item's `isSymbolicLink` against this set and fires `onDidChangeItemDecorations` only when the status has actually changed (`wasSymbolicLink !== isSymbolicLink`), invalidating the decoration cache for only the affected items.

Performance: `onDidChangeItemDecorations` is fired only for the visible items whose symbolic link status has actually changed, keeping decoration re-renders to a minimum.

### Testing
Verified using the following test script (bash):

```sh
# Simple File
touch foo.txt
ln -s foo.txt bar.txt
read -p "Verify: bar.txt is a symbolic link."
rm bar.txt
touch bar.txt
read -p "Verify: bar.txt is a regular file."
rm bar.txt
ln -s foo.txt bar.txt
read -p "Verify: bar.txt is a symbolic link again."
rm bar.txt

# Symbolic link in directory
mkdir foo
ln -s foo.txt foo/bar.txt
read -p "Verify: foo/bar.txt shows symbolic link, then collapse the 'foo' directory."
rm foo/bar.txt
touch foo/bar.txt
read -p "Verify: Expand 'foo' directory, verify foo/bar.txt is a regular file, then collapse 'foo' directory."
rm foo/bar.txt
ln -s foo.txt foo/bar.txt
read -p "Verify: Expand 'foo' directory and verify foo/bar.txt is a symbolic link."
rm -r foo
rm foo.txt
```

Environment: Official Dev Container on Debian 13