### PR TITLE
agentHost: disable Codex-owned telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
+++ b/src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts
@@ -67,23 +67,29 @@ export function buildCodexLaunchConfig(
 		`shell_environment_policy.set.${AiAgentEnvVar}="${AiAgentEnvValue}"`,
 		`features.tool_call_mcp_elicitation=false`,
 		`features.image_generation=false`,
-		...codexTelemetryOverrides(telemetry),
 	];
+	const telemetryOverrides = codexTelemetryOverrides(telemetry);
 	return {
 		env,
-		args: ['app-server', ...overrides.flatMap(value => ['-c', value]), ...extraArgs],
+		args: ['app-server', ...overrides.flatMap(value => ['-c', value]), ...extraArgs, ...telemetryOverrides.flatMap(value => ['-c', value])],
 	};
 }
 
 export function codexTelemetryOverrides(config: IAgentHostNativeOTelConfig | undefined): string[] {
-	if (!config) {
-		return [];
-	}
 	return [
-		`otel.log_user_prompt=${config.captureContent}`,
-		config.traces ? `otel.trace_exporter=${codexExporter(config.traces)}` : 'otel.trace_exporter="none"',
-		config.external ? `otel.exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'logs', config.external.protocol) })}` : 'otel.exporter="none"',
-		config.external ? `otel.metrics_exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'metrics', config.external.protocol) })}` : 'otel.metrics_exporter="none"',
+		// Codex analytics are independent from its OTel exporters and post to an
+		// OpenAI-owned endpoint. Keep them disabled even when the user configures
+		// Agent Host OTel, whose destinations are supplied explicitly below. Codex
+		// currently uses this same flag to gate its metrics exporter, so preventing
+		// product analytics also suppresses its otherwise user-directed metrics.
+		'analytics.enabled=false',
+		// Agent Host does not expose Codex's feedback flow. Disable its Sentry
+		// upload path rather than leaving an unused outbound channel available.
+		'feedback.enabled=false',
+		`otel.log_user_prompt=${config?.captureContent ?? false}`,
+		config?.traces ? `otel.trace_exporter=${codexExporter(config.traces)}` : 'otel.trace_exporter="none"',
+		config?.external ? `otel.exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'logs', config.external.protocol) })}` : 'otel.exporter="none"',
+		config?.external ? `otel.metrics_exporter=${codexExporter({ ...config.external, endpoint: resolveSignalEndpoint(config.external.endpoint, 'metrics', config.external.protocol) })}` : 'otel.metrics_exporter="none"',
 	];
 }
 

--- a/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts
@@ -10,14 +10,23 @@ import { buildCodexLaunchConfig, buildCodexResumeParams } from '../../../node/co
 suite('CodexLaunchConfig', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('adds the Copilot proxy without selecting it globally', () => {
-		const config = buildCodexLaunchConfig({ PATH: '/bin', OPENAI_API_KEY: 'personal' }, { baseUrl: 'http://127.0.0.1:1234', nonce: 'nonce' }, ['--log-level=debug']);
+	test('adds the Copilot proxy and enforces telemetry overrides after extra arguments', () => {
+		const config = buildCodexLaunchConfig({ PATH: '/bin', OPENAI_API_KEY: 'personal' }, { baseUrl: 'http://127.0.0.1:1234', nonce: 'nonce' }, ['--log-level=debug', '-c', 'analytics.enabled=true']);
 		assert.deepStrictEqual(config.env, { PATH: '/bin', OPENAI_API_KEY: 'nonce', AI_AGENT: 'github_copilot_vscode_agent' });
 		assert.ok(config.args.includes('model_providers.vscode-proxy.name="VS Code Proxy"'));
 		assert.ok(!config.args.some(argument => argument.startsWith('model_provider=')));
 		assert.ok(config.args.includes('features.image_generation=false'));
 		assert.ok(config.args.includes('shell_environment_policy.set.AI_AGENT="github_copilot_vscode_agent"'));
-		assert.strictEqual(config.args.at(-1), '--log-level=debug');
+		assert.ok(config.args.includes('--log-level=debug'));
+		assert.ok(config.args.indexOf('analytics.enabled=true') < config.args.lastIndexOf('analytics.enabled=false'));
+		assert.deepStrictEqual(config.args.slice(-12), [
+			'-c', 'analytics.enabled=false',
+			'-c', 'feedback.enabled=false',
+			'-c', 'otel.log_user_prompt=false',
+			'-c', 'otel.trace_exporter="none"',
+			'-c', 'otel.exporter="none"',
+			'-c', 'otel.metrics_exporter="none"',
+		]);
 	});
 
 	test('routes traces to loopback and logs/metrics directly to the external sink', () => {
@@ -29,6 +38,8 @@ suite('CodexLaunchConfig', () => {
 		});
 		assert.strictEqual(config.env.OTEL_SERVICE_NAME, undefined);
 		assert.strictEqual(config.env.OTEL_RESOURCE_ATTRIBUTES, 'service.namespace=vscode.agent-host,region=west%20us');
+		assert.ok(config.args.includes('analytics.enabled=false'));
+		assert.ok(config.args.includes('feedback.enabled=false'));
 		assert.ok(config.args.includes('otel.log_user_prompt=false'));
 		assert.ok(config.args.includes('otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:4567/v1/traces", protocol = "json" } }'));
 		assert.ok(config.args.includes('otel.exporter={ otlp-http = { endpoint = "http://collector:4318/v1/logs", protocol = "binary", headers = { "authorization" = "Bearer test" } } }'));


### PR DESCRIPTION
## Summary

- disable Codex product analytics and feedback uploads from the Agent Host launcher
- default prompt logging and OTel exporters to off while preserving explicitly configured Agent Host OTel destinations
- append privacy overrides after custom binary arguments so callers cannot re-enable Codex-owned telemetry
- cover the disabled defaults and override ordering in the Codex launch configuration tests

## Why

An audit of the Codex 0.146.0 source showed that product analytics are independent of OTel and post to an OpenAI-owned analytics endpoint, feedback uploads use Sentry, and metrics otherwise default to an OpenAI Statsig destination. These paths therefore need explicit launcher overrides.

Codex currently couples `analytics.enabled` to its metrics exporter. Disabling product analytics consequently suppresses metrics even when the user configured an Agent Host metrics destination; traces and logs still use the explicit Agent Host destinations.

Normal model/account API requests remain required for Codex to function, and this launcher cannot disable provider-side service logging.

## Validation

- `npm run eslint -- src/vs/platform/agentHost/node/codex/codexLaunchConfig.ts src/vs/platform/agentHost/test/node/codex/codexLaunchConfig.test.ts`
- `node_modules/.bin/tsc -p src/tsconfig.json --noEmit --pretty false`
- pre-commit hygiene hook (2 changed files)
- `git diff --check`
- behavioral assertion of generated argument ordering
- verified the bundled Codex 0.146.0 CLI accepts trailing `-c` app-server overrides

The full repository compile reaches unrelated built-in extensions but cannot finish in this restarted worktree because their per-extension dependencies are absent (`@vscode/markdown-editor`). The full Mocha unit runner is unavailable for the same incomplete dependency checkout.