### PR TITLE
Increase memory for eslint run

### DIFF
--- a/.eslint-ignore
+++ b/.eslint-ignore
@@ -24,6 +24,7 @@
 **/extensions/html-language-features/server/src/test/pathCompletionFixtures/**
 **/extensions/ipynb/notebook-out/**
 **/extensions/markdown-language-features/media/**
+**/extensions/markdown-language-features/markdown-editor-out/**
 **/extensions/markdown-language-features/notebook-out/**
 **/extensions/markdown-math/notebook-out/**
 **/extensions/mermaid-markdown-features/chat-webview-out/**

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "watch-web": "npm run gulp watch-web",
     "watch-cli": "npm run gulp watch-cli",
     "mock-policy-server": "node --experimental-strip-types scripts/mock-policy-server/server.ts",
-    "eslint": "node build/eslint.ts",
+    "eslint": "node --max-old-space-size=8192 build/eslint.ts",
     "stylelint": "node build/stylelint.ts",
     "playwright-install": "npm exec playwright install",
     "compile-build": "npm run gulp compile-build-with-mangling",


### PR DESCRIPTION
Adjust the memory allocation for the eslint process to improve performance during linting. This change increases the maximum old space size to 8192 MB.

