### PR TITLE
Style override: Update icon color for pane composite overflow in activity bar

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -185,10 +185,11 @@
  * square so it matches the other 24px composite controls. `box-sizing` keeps the
  * 16px glyph centered within the box.
  */
-.style-override .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
+.style-override.monaco-workbench .pane-composite-part > :is(.title, .header-or-footer) > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
 	box-sizing: border-box;
 	width: 24px;
 	height: 24px;
+	color: var(--vscode-icon-foreground) !important;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -318,6 +318,20 @@ suite('StyleOverridesContribution', () => {
 		});
 	});
 
+	test('pane composite overflow uses the icon foreground', () => {
+		const root = document.createElement('div');
+		root.className = 'monaco-workbench style-override modern-ui-tabs';
+		root.style.setProperty('--vscode-icon-foreground', '#123456');
+		document.body.appendChild(root);
+		store.add(toDisposable(() => root.remove()));
+
+		const overflow = createCompositeAction(root, 40, false, true);
+		overflow.actionLabel.classList.add('codicon', 'codicon-more');
+		overflow.actionLabel.style.color = 'rgba(231, 231, 231, 0.6)';
+
+		assert.strictEqual(getWindow(overflow.actionLabel).getComputedStyle(overflow.actionLabel).color, 'rgb(18, 52, 86)');
+	});
+
 	test('preserves Modern UI activity badges and horizontal pane dividers', () => {
 		const root = document.createElement('div');
 		root.className = 'monaco-workbench style-override modern-ui-tabs';


### PR DESCRIPTION
Adjust the icon color for the pane composite overflow in the activity bar to use the defined icon foreground color. Add a test to verify that the overflow icon reflects the correct color based on the foreground setting.

