### PR TITLE
agentHost: drop missing plugin cache entries

### DIFF
--- a/src/vs/platform/agentHost/node/agentPluginManager.ts
+++ b/src/vs/platform/agentHost/node/agentPluginManager.ts
@@ -6,7 +6,7 @@
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { SequencerByKey } from '../../../base/common/async.js';
 import { URI } from '../../../base/common/uri.js';
-import { IFileService } from '../../files/common/files.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentPluginManager, type ISyncedCustomization } from '../common/agentPluginManager.js';
 import { CustomizationLoadStatus, type ClientPluginCustomization, type PluginCustomization } from '../common/state/sessionState.js';
@@ -196,6 +196,9 @@ export class AgentPluginManager implements IAgentPluginManager {
 			await this._fileService.del(dir, { recursive: true });
 			return true;
 		} catch (err) {
+			if (toFileOperationResult(err) === FileOperationResult.FILE_NOT_FOUND) {
+				return true;
+			}
 			this._logService.warn(`[AgentPluginManager] Failed to remove plugin dir ${dir.toString()}`, err);
 			return false;
 		}

--- a/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
@@ -200,6 +200,23 @@ suite('AgentPluginManager', () => {
 			assert.deepStrictEqual(await readCacheNonces(), new Set(['nonce-2']));
 		});
 
+		test('drops a stale cache entry when its directory is already gone', async () => {
+			await seedPluginDir('rev', { 'index.js': 'v1' });
+			const r1 = await manager.syncCustomizations('test-client', [makeRef('rev', 'nonce-1')]);
+			const dir1 = r1[0].pluginDir!;
+			provider.lockedPaths.add(dir1.path);
+
+			await seedPluginDir('rev', { 'index.js': 'v2' });
+			await manager.syncCustomizations('test-client', [makeRef('rev', 'nonce-2')]);
+
+			provider.lockedPaths.clear();
+			await fileService.del(dir1, { recursive: true });
+			const manager2 = new AgentPluginManager(basePath, fileService, new NullLogService());
+			await manager2.syncCustomizations('test-client', [makeRef('rev', 'nonce-2')]);
+
+			assert.deepStrictEqual(await readCacheNonces(), new Set(['nonce-2']));
+		});
+
 		test('serializes concurrent syncs of the same URI', async () => {
 			await seedPluginDir('concurrent', { 'index.js': 'v1' });
 			const ref = makeRef('concurrent', 'n1');


### PR DESCRIPTION
## Summary

Treat an already-missing Agent Host plugin directory as a successful cache eviction.

This prevents a stale plugin nonce from remaining in `agentPlugins/cache.json` and being retried indefinitely, while preserving the existing retry behavior for real deletion failures such as a directory that is still locked by a running session.

## Context

I found this while scanning six recent Code - Insiders log sessions for errors and leaked-disposable warnings. The same warning appeared 105 times across those sessions:

```text
[info] [AgentPluginManager] Evicting stale nonce for plugin: vscode-synced-customization:/agent-host-copilotcli
[warning] [AgentPluginManager] Failed to remove plugin dir file:///Users/alex/Library/Application%20Support/Code%20-%20Insiders/agentPlugins/vscode-synced-customization-agent-host-copilotcli/1805361618 Unable to delete nonexistent file '/Users/alex/Library/Application Support/Code - Insiders/agentPlugins/vscode-synced-customization-agent-host-copilotcli/1805361618'
```

The warning recurred across process restarts and customization syncs, even though the directory was already absent.

## Root cause

`AgentPluginManager` persists an LRU containing the original plugin customization URI and each materialized nonce. During stale-nonce cleanup:

1. `_cleanupStaleNoncesFor` asks `_tryDeleteDir` to recursively delete the old nonce directory.
2. `IFileService.del` throws `FileOperationResult.FILE_NOT_FOUND` when that directory is already absent.
3. `_tryDeleteDir` previously treated every exception as a failed eviction and returned `false`.
4. The caller consequently kept the stale LRU entry so it could be retried later.
5. `_persistCache` wrote that stale entry back to `agentPlugins/cache.json`.
6. Every later startup or customization sync retried the same nonexistent path and emitted another warning.

The missing path is already the desired postcondition of deletion. Treating it as a failure therefore made an otherwise harmless external/cache inconsistency persistent.

## Change

`_tryDeleteDir` now treats only `FileOperationResult.FILE_NOT_FOUND` as success:

- Missing directory: eviction succeeds and the stale LRU entry is removed.
- Locked, busy, permission, or other failures: behavior is unchanged; a warning is logged and the entry remains available for a later retry.

This deliberately does not add an existence check before deletion, which would introduce a check/delete race. It keeps deletion as the authoritative operation and makes its not-found result idempotent.

## Regression test

The new test reproduces the persisted stale-entry sequence:

1. Materialize nonce 1.
2. Lock nonce 1 so syncing nonce 2 cannot evict it and therefore persists both cache entries.
3. Release the lock and delete nonce 1 independently, leaving the on-disk cache stale.
4. Construct a new `AgentPluginManager`, causing it to load and clean the persisted cache.
5. Verify that only nonce 2 remains.

The existing locked-directory tests continue to verify that genuine deletion failures are retained rather than silently dropped.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/agentPluginManager.test.ts` — 14 passing
- `npm run transpile-client`
- `git diff --check`
