### PR TITLE
agentHost: restore legacy subagent names after restart

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -319,6 +319,7 @@ export async function mapSessionEvents(
 	const toolInfoByCallId = new Map<string, IToolStartInfo>();
 	const editToolCallIds: string[] = [];
 	const completionsByCallId = new Map<string, ToolExecutionCompleteData>();
+	const subagentInfoByToolCallId = new Map<string, ISubagentInfo>();
 
 	// The SDK tags events that originate from a sub-agent with an
 	// envelope-level `agentId` (the deprecated `data.parentToolCallId` is no
@@ -333,6 +334,11 @@ export async function mapSessionEvents(
 
 	for (const e of events) {
 		if (e.type === 'subagent.started') {
+			subagentInfoByToolCallId.set(e.data.toolCallId, {
+				agentName: e.data.agentName,
+				agentDisplayName: e.data.agentDisplayName,
+				agentDescription: e.data.agentDescription,
+			});
 			if (e.agentId) {
 				parentToolCallIdByAgentId.set(e.agentId, e.data.toolCallId);
 			}
@@ -388,8 +394,6 @@ export async function mapSessionEvents(
 	const subagentTurnStates = new Map<string, TurnState>();
 	const terminatedSubagentTurns = new Set<string>();
 	const subagentTurns = new Map<string, Turn[]>();
-	const subagentInfoByToolCallId = new Map<string, ISubagentInfo>();
-
 	let parentBuilder: ITurnBuilder | undefined;
 	let parentTurnState = TurnState.Cancelled;
 	let parentTurnTerminated = false;
@@ -614,12 +618,6 @@ export async function mapSessionEvents(
 				break;
 			}
 			case 'subagent.started': {
-				const d = e.data;
-				subagentInfoByToolCallId.set(d.toolCallId, {
-					agentName: d.agentName,
-					agentDisplayName: d.agentDisplayName,
-					agentDescription: d.agentDescription,
-				});
 				break;
 			}
 			case 'tool.execution_start': {

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -879,6 +879,42 @@ suite('mapSessionEvents — subagent routing', () => {
 		]);
 	});
 
+	test('reconstructs subagent content when legacy completion precedes subagent start', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'summarize the service' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-task', name: 'task' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-task', toolName: 'task', arguments: { description: 'Summarize agent service', agent_type: 'explore' } } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-task', success: true, result: { content: 'Agent started in background.' } } },
+			{ type: 'subagent.started', agentId: 'agent-1', data: { toolCallId: 'tc-task', agentName: 'explore', agentDisplayName: 'Explore Agent', agentDescription: 'Explores' } },
+			{ type: 'user.message', agentId: 'agent-1', data: { interactionId: 'subagent-prompt', content: 'Inspect agentService.ts.' } },
+			{ type: 'assistant.message', agentId: 'agent-1', data: { messageId: 'm3', content: 'Summary complete.' } },
+		];
+
+		const { turns, subagentTurnsByToolCallId } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const toolCall = turns[0].responseParts.find((part): part is ToolCallResponsePart => part.kind === ResponsePartKind.ToolCall)?.toolCall;
+		const subagentContent = toolCall?.status === ToolCallStatus.Completed
+			? toolCall.content?.find(content => content.type === ToolResultContentType.Subagent)
+			: undefined;
+
+		assert.deepStrictEqual({
+			description: toolCall ? readToolCallMeta(toolCall).subagentDescription : undefined,
+			subagentContent,
+			childMarkdown: subagentTurnsByToolCallId.get('tc-task')?.flatMap(turn => turn.responseParts)
+				.filter(part => part.kind === ResponsePartKind.Markdown)
+				.map(part => part.content),
+		}, {
+			description: 'Summarize agent service',
+			subagentContent: {
+				type: ToolResultContentType.Subagent,
+				resource: 'copilot:/test-session/subagent/tc-task',
+				title: 'Explore Agent',
+				agentName: 'explore',
+				description: 'Explores',
+			},
+			childMarkdown: ['Summary complete.'],
+		});
+	});
+
 	test('drops subagent user messages whose agentId cannot be mapped', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', id: 'root-message', data: { interactionId: 'm1', content: 'Continue the task' } },


### PR DESCRIPTION
## What changed

- pre-collect `subagent.started` metadata while replaying Copilot session events
- reconstruct subagent result metadata independent of whether start arrives before or after task completion
- add a regression for legacy completion-before-start event ordering

## Why

Legacy extension-host Copilot CLI sessions can persist a background task completion before the matching `subagent.started` event. The parent tool retains its task description and child transcript, but without the subagent result metadata the Agent Host chat catalog restores the child with a generic **Subagent** label. Current sessions usually use the opposite order and are unaffected.

## Validation

- `npm run compile`
- `npm run valid-layers-check`
- `npm run define-class-fields-check`
- full `mapSessionEvents.test.ts` suite (36 passing)
- full Agent Host unit suite (4,067 passing)
- pre-commit hygiene
- focused code review