### PR TITLE
Stop querying prompt file providers after cancellation

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/extensionPromptFileService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/extensionPromptFileService.ts
@@ -249,6 +249,10 @@ export class ExtensionPromptFileService extends Disposable {
 		}
 
 		for (const providerEntry of providers) {
+			if (token.isCancellationRequested) {
+				break;
+			}
+
 			try {
 				const files = await providerEntry.providePromptFiles({}, token);
 				this._providerWhenClauses.set(providerEntry, files?.flatMap(file => file.when ? [file.when] : []) ?? []);
@@ -272,9 +276,10 @@ export class ExtensionPromptFileService extends Disposable {
 					} satisfies IExtensionPromptPath);
 				}
 			} catch (e) {
-				if (!isCancellationError(e)) {
-					this.logger.error(`[listFromProviders] Failed to get ${type} files from provider`, e instanceof Error ? e.message : String(e));
+				if (token.isCancellationRequested || isCancellationError(e)) {
+					break;
 				}
+				this.logger.error(`[listFromProviders] Failed to get ${type} files from provider`, e instanceof Error ? e.message : String(e));
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -2424,6 +2424,42 @@ suite('PromptsService', () => {
 			}
 		});
 
+		test('Canceled provider listing stops without logging an error', async () => {
+			const extension = {
+				identifier: { value: 'test.my-extension' },
+				enabledApiProposals: ['chatParticipantPrivate']
+			} as unknown as IExtensionDescription;
+			const cancellationTokenSource = disposables.add(new CancellationTokenSource());
+			let secondProviderCalled = false;
+			disposables.add(service.registerPromptFileProvider(extension, PromptsType.agent, {
+				providePromptFiles: async () => {
+					cancellationTokenSource.cancel();
+					throw new CancellationError();
+				}
+			}));
+			disposables.add(service.registerPromptFileProvider(extension, PromptsType.agent, {
+				providePromptFiles: async () => {
+					secondProviderCalled = true;
+					return [];
+				}
+			}));
+			const errorSpy = sinon.spy(logService, 'error');
+
+			try {
+				await service.listPromptFiles(PromptsType.agent, cancellationTokenSource.token);
+
+				assert.deepStrictEqual({
+					secondProviderCalled,
+					errorCount: errorSpy.callCount,
+				}, {
+					secondProviderCalled: false,
+					errorCount: 0,
+				});
+			} finally {
+				errorSpy.restore();
+			}
+		});
+
 		test('Contributed agent file that does not exist should not crash', async () => {
 			const nonExistentUri = URI.parse('file://extensions/my-extension/nonexistent.agent.md');
 			const existingUri = URI.parse('file://extensions/my-extension/existing.agent.md');


### PR DESCRIPTION
## Summary
Once cancellation is requested (or a provider throws a cancellation error), stop calling further prompt file providers instead of continuing to iterate through the remaining ones unnecessarily.

## Changes
- xtensionPromptFileService.ts: break out of the provider loop when the token is already cancelled before invoking a provider, or when a provider call fails with cancellation.
- Added a test asserting that once one provider is cancelled, subsequent providers are not queried and no error is logged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>