### PR TITLE
agentHost: restore feedback comments as one attachment

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -68,7 +68,7 @@ import type { IAgentHostRestrictedTelemetryContext } from '../agentHostRestricte
 import { buildChatErrorInfoFromCopilotSdkFields } from './copilotSdkChatError.js';
 import { getEffectiveMcpServerCustomizations, McpCustomizationController, type ISdkMcpServer } from '../shared/mcpCustomizationController.js';
 import { appendSdkToolResultContent, mapSessionEvents } from './mapSessionEvents.js';
-import { addSimpleAttachmentDisplayKindToMimeType } from './copilotAttachmentUtils.js';
+import { addAttachmentDisplayKindToMimeType, addSimpleAttachmentDisplayKindToMimeType } from './copilotAttachmentUtils.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 import { AgentHostStateManager, IAgentHostStateManager } from '../agentHostStateManager.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
@@ -2188,7 +2188,7 @@ export class CopilotAgentSession extends Disposable {
 			return {
 				type: 'blob' as const,
 				data: encodeBase64(VSBuffer.fromString(rendered)),
-				mimeType: 'text/plain',
+				mimeType: addAttachmentDisplayKindToMimeType(attachment.displayKind),
 				displayName: attachment.label,
 			};
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAttachmentUtils.ts
@@ -9,10 +9,14 @@ const attachmentDisplayKindParameter = 'x-vscode-display-kind=';
 const simpleAttachmentMimeType = 'text/x-vscode-simple-attachment';
 
 export function addSimpleAttachmentDisplayKindToMimeType(attachment: SimpleMessageAttachment): string {
-	if (attachment.displayKind === undefined) {
+	return addAttachmentDisplayKindToMimeType(attachment.displayKind);
+}
+
+export function addAttachmentDisplayKindToMimeType(displayKind: string | undefined): string {
+	if (displayKind === undefined) {
 		return 'text/plain';
 	}
-	return `${simpleAttachmentMimeType}; ${attachmentDisplayKindParameter}${encodeURIComponent(attachment.displayKind)}`;
+	return `${simpleAttachmentMimeType}; ${attachmentDisplayKindParameter}${encodeURIComponent(displayKind)}`;
 }
 
 export function readSimpleAttachmentDisplayKindFromMimeType(mimeType: string): string | undefined {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1112,9 +1112,33 @@ suite('CopilotAgentSession', () => {
 			attachments: [{
 				type: 'blob',
 				data: encodeBase64(VSBuffer.fromString(expectedText)),
-				mimeType: 'text/plain',
+				mimeType: 'text/x-vscode-simple-attachment; x-vscode-display-kind=agentFeedback',
 				displayName: '1 comment',
 			}],
+		}]);
+
+		mockSession.messages = [{
+			type: 'user.message',
+			id: 'event-1',
+			parentId: null,
+			timestamp: '2026-07-29T10:00:00.000Z',
+			data: {
+				interactionId: 'message-1',
+				content: '/act-on-feedback',
+				attachments: [{
+					type: 'blob' as const,
+					data: encodeBase64(VSBuffer.fromString(expectedText)),
+					mimeType: 'text/x-vscode-simple-attachment; x-vscode-display-kind=agentFeedback',
+					displayName: '1 comment',
+				}],
+			},
+		}];
+
+		assert.deepStrictEqual((await session.getMessages())[0].message.attachments, [{
+			type: MessageAttachmentKind.Simple,
+			label: '1 comment',
+			displayKind: AgentFeedbackAttachmentDisplayKind,
+			modelRepresentation: expectedText,
 		}]);
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -931,17 +931,14 @@ export function messageAttachmentsToVariableData(attachments: readonly MessageAt
 		return undefined;
 	}
 	const variables: IChatRequestVariableEntry[] = [];
-	// Agent feedback is sent as one annotations attachment per comment; restore
-	// them into a single aggregated agentFeedback entry so history shows one
-	// "N comments" chip rather than one chip per comment.
-	const aggregatedFeedback = aggregateAgentFeedbackAnnotationAttachments(attachments, connectionAuthority);
+	const aggregatedFeedback = aggregateAgentFeedbackAttachments(attachments, connectionAuthority);
 	if (aggregatedFeedback) {
 		variables.push(aggregatedFeedback);
 	}
 	const consumedAttachments = new Set<MessageAttachment>();
 	for (const a of attachments) {
-		if (isAgentFeedbackAnnotationsAttachment(a) || consumedAttachments.has(a)) {
-			continue; // handled by the aggregation above
+		if ((aggregatedFeedback && isAgentFeedbackMessageAttachment(a)) || consumedAttachments.has(a)) {
+			continue;
 		}
 		const element = restoreElementVariableEntry(a, a.type === MessageAttachmentKind.Simple ? a.modelRepresentation : undefined);
 		if (element) {
@@ -966,23 +963,29 @@ export function messageAttachmentsToVariableData(attachments: readonly MessageAt
 	return variables.length > 0 ? { variables } : undefined;
 }
 
-function aggregateAgentFeedbackAnnotationAttachments(attachments: readonly MessageAttachment[], connectionAuthority: string): IAgentFeedbackVariableEntry | undefined {
-	const feedbackAttachments = attachments.filter(isAgentFeedbackAnnotationsAttachment);
-	if (feedbackAttachments.length === 0) {
+function isAgentFeedbackMessageAttachment(attachment: MessageAttachment): boolean {
+	return isAgentFeedbackAnnotationsAttachment(attachment) || isAgentFeedbackAttachment(attachment);
+}
+
+function aggregateAgentFeedbackAttachments(attachments: readonly MessageAttachment[], connectionAuthority: string): IChatRequestVariableEntry | undefined {
+	const feedbackAttachments = attachments.filter(isAgentFeedbackMessageAttachment);
+	if (feedbackAttachments.length === 0 || (feedbackAttachments.length === 1 && isAgentFeedbackAttachment(feedbackAttachments[0]))) {
 		return undefined;
 	}
 	let sessionResource: string | undefined;
 	let annotationsResource: string | undefined;
-	const feedbackItems: IAgentFeedbackVariableEntry['feedbackItems'][number][] = [];
+	const feedbackItems = new Map<string, IAgentFeedbackVariableEntry['feedbackItems'][number]>();
 	for (const attachment of feedbackAttachments) {
-		annotationsResource ??= attachment.resource;
+		if (attachment.type === MessageAttachmentKind.Annotations) {
+			annotationsResource ??= attachment.resource;
+		}
 		const metadata = getAgentFeedbackAttachmentMetadata(attachment);
 		if (!metadata) {
 			continue;
 		}
 		sessionResource ??= metadata.sessionResource;
 		for (const item of metadata.feedbackItems) {
-			feedbackItems.push({
+			feedbackItems.set(item.id, {
 				id: item.id,
 				text: item.text,
 				resourceUri: toAgentHostUri(URI.parse(item.resourceUri), connectionAuthority),
@@ -991,19 +994,31 @@ function aggregateAgentFeedbackAnnotationAttachments(attachments: readonly Messa
 			});
 		}
 	}
-	if (feedbackItems.length === 0 || !sessionResource) {
-		return undefined;
+	const firstAttachment = feedbackAttachments[0];
+	if (feedbackItems.size === 0 || !sessionResource) {
+		return {
+			kind: 'generic',
+			id: generateUuid(),
+			name: firstAttachment.label,
+			value: firstAttachment.type === MessageAttachmentKind.Simple
+				? firstAttachment.modelRepresentation || firstAttachment.label
+				: firstAttachment.label,
+			_meta: firstAttachment._meta,
+		};
 	}
 	return {
 		kind: 'agentFeedback',
 		id: generateUuid(),
-		name: feedbackItems.length === 1
+		name: feedbackItems.size === 1
 			? localize('agentFeedback.one', "1 comment")
-			: localize('agentFeedback.many', "{0} comments", feedbackItems.length),
-		value: feedbackAttachments[0].label,
+			: localize('agentFeedback.many', "{0} comments", feedbackItems.size),
+		value: firstAttachment.type === MessageAttachmentKind.Simple
+			? firstAttachment.modelRepresentation || firstAttachment.label
+			: firstAttachment.label,
 		sessionResource: URI.parse(sessionResource),
 		annotationsResource: annotationsResource ? URI.parse(annotationsResource) : undefined,
-		feedbackItems,
+		feedbackItems: [...feedbackItems.values()],
+		_meta: firstAttachment._meta,
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -6076,6 +6076,53 @@ suite('AgentHostChatContribution', () => {
 			}
 		});
 
+		test('restores SDK-replayed agent feedback blobs as one request variable', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/feedback-sdk-history' });
+			const sessionUri = AgentSession.uri('copilot', 'feedback-sdk-history');
+			agentHostService.sessionStates.set(sessionUri.toString(), {
+				...createSessionState({ resource: sessionUri.toString(), provider: 'copilot', title: 'Test', status: SessionStatus.Idle, createdAt: new Date().toISOString(), modifiedAt: new Date().toISOString() }),
+				lifecycle: SessionLifecycle.Ready,
+				turns: [{
+					id: 'turn-1',
+					message: {
+						text: '/act-on-feedback',
+						origin: { kind: MessageKind.User },
+						attachments: [{
+							type: MessageAttachmentKind.Simple,
+							label: '2 comments',
+							displayKind: AgentFeedbackAttachmentDisplayKind,
+							modelRepresentation: 'Feedback comment 1',
+						}, {
+							type: MessageAttachmentKind.Simple,
+							label: '2 comments',
+							displayKind: AgentFeedbackAttachmentDisplayKind,
+							modelRepresentation: 'Feedback comment 2',
+						}],
+					},
+					responseParts: [],
+					usage: undefined,
+					state: TurnState.Complete,
+				}],
+			} as SessionState);
+
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+
+			const request = session.history[0];
+			assert.strictEqual(request.type, 'request');
+			if (request.type === 'request') {
+				assert.ok(request.variableData);
+				assert.deepStrictEqual(request.variableData.variables.map(variable => ({
+					kind: variable.kind,
+					name: variable.name,
+				})), [{
+					kind: 'generic',
+					name: '2 comments',
+				}]);
+			}
+		});
+
 		test('restores agent host completion attachments as hidden request variables', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/completion-history' });


### PR DESCRIPTION
## Summary

- preserve the agent feedback display kind when Copilot SDK attachments are replayed
- aggregate replayed feedback comments into one history attachment
- deduplicate rich feedback metadata by comment ID

## Testing

- `npm run transpile-client`
- `scripts\test.bat --run src\vs\platform\agentHost\test\node\copilotAgentSession.test.ts --run src\vs\workbench\contrib\chat\test\browser\agentSessions\agentHostChatContribution.test.ts --grep "agent feedback"` (7 passing)
- `git diff --check`

`npm run typecheck-client` and `npm run valid-layers-check` are currently blocked by the pre-existing Copilot SDK `managedSettings` typing mismatch in `copilotSessionLauncher.ts` and its tests.