### PR TITLE
agentHost: restore missing GitHub session metadata

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -261,27 +261,30 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 				if (gitState) {
 					const currentMeta = this._stateManager.getSessionState(sessionKey)?._meta;
 					const previousGitState = readSessionGitState(currentMeta);
-					if (!objectEquals(previousGitState, gitState)) {
+					const gitStateChanged = !objectEquals(previousGitState, gitState);
+					if (gitStateChanged) {
 						// Update the session's git state
 						await this._setSessionGitState(sessionKey, gitState);
+					}
 
-						// Update the session's GitHub state
-						if (gitState.githubOwner && gitState.githubRepo) {
+					if (gitState.githubOwner && gitState.githubRepo) {
+						const currentGitHubState = readSessionGitHubState(currentMeta);
+						if (currentGitHubState?.owner !== gitState.githubOwner || currentGitHubState.repo !== gitState.githubRepo) {
 							await this.setSessionGitHubState(sessionKey, {
 								owner: gitState.githubOwner,
 								repo: gitState.githubRepo
 							} satisfies ISessionGitHubState);
+						}
 
-							// The working copy switched to a different branch:
-							// look for a pull request that belongs to the new
-							// branch. The previously known pull request keeps
-							// being reported until a new one is found. Awaited
-							// so the refresh event below carries the pull
-							// request of the new branch rather than stale
-							// GitHub state.
-							if (previousGitState?.branchName !== gitState.branchName) {
-								await this._queuePullRequestLookup(sessionKey);
-							}
+						// The working copy switched to a different branch:
+						// look for a pull request that belongs to the new
+						// branch. The previously known pull request keeps
+						// being reported until a new one is found. Awaited
+						// so the refresh event below carries the pull
+						// request of the new branch rather than stale
+						// GitHub state.
+						if (gitStateChanged && previousGitState?.branchName !== gitState.branchName) {
+							await this._queuePullRequestLookup(sessionKey);
 						}
 					}
 				}

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -398,6 +398,30 @@ suite('AgentHostGitStateService', () => {
 		});
 	});
 
+	test('unchanged git state backfills missing GitHub state', async () => {
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const gitState: ISessionGitState = {
+				branchName: 'feature',
+				githubOwner: 'microsoft',
+				githubRepo: 'vscode',
+			};
+			const h = createHarness();
+			seedSession(h.stateManager, { workingDirectory: WORKING_DIRECTORY, gitState });
+			h.setGitResult(gitState);
+
+			await h.service.refreshSessionGitState(SESSION, undefined);
+
+			const persistedGitHubState = await h.db.getMetadata(META_GITHUB_STATE);
+			assert.deepStrictEqual({
+				github: readSessionGitHubState(h.stateManager.getSessionState(SESSION)?._meta),
+				persistedGitHub: persistedGitHubState ? JSON.parse(persistedGitHubState) : undefined,
+			}, {
+				github: { owner: 'microsoft', repo: 'vscode' },
+				persistedGitHub: { owner: 'microsoft', repo: 'vscode' },
+			});
+		});
+	});
+
 	test('changed git state updates the session meta and fires the run-refresh event', async () => {
 		await runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const h = createHarness();


### PR DESCRIPTION
## Summary

- reconcile GitHub repository metadata independently of Git state changes
- backfill missing GitHub metadata for restored Agent Host sessions
- add regression coverage for unchanged persisted Git state

Fixes #330316

## Testing

- `scripts\test.bat --run src\vs\platform\agentHost\test\node\agentHostGitStateService.test.ts` (42 passing)
- `npm run typecheck-client`
- `npm run valid-layers-check`