### PR TITLE
build: Restore native optional dependency cache checks

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine-node-modules.yml
@@ -129,6 +129,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         displayName: Mixin distro node modules
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -174,6 +174,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         displayName: Mixin distro node modules
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/copilot/setup-steps.yml
+++ b/build/azure-pipelines/copilot/setup-steps.yml
@@ -83,6 +83,10 @@ steps:
     displayName: Install vscode-capi dependencies
     condition: and(succeeded(), ne(variables.BUILD_CACHE_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+    workingDirectory: $(Build.SourcesDirectory)
+    displayName: Verify native optional dependency binaries
+
   - script: |
       set -e
       mkdir -p .build

--- a/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-node-modules.yml
@@ -102,6 +102,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -112,6 +112,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+    displayName: Verify native optional dependency binaries
+
   - script: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules

--- a/build/azure-pipelines/linux/product-build-linux-node-modules.yml
+++ b/build/azure-pipelines/linux/product-build-linux-node-modules.yml
@@ -142,6 +142,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -159,6 +159,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+    displayName: Verify native optional dependency binaries
+
   - script: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -104,6 +104,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/web/product-build-web-node-modules.yml
+++ b/build/azure-pipelines/web/product-build-web-node-modules.yml
@@ -79,6 +79,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -93,6 +93,9 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - script: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        displayName: Verify native optional dependency binaries
+
       - script: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/win32/product-build-win32-node-modules.yml
+++ b/build/azure-pipelines/win32/product-build-win32-node-modules.yml
@@ -85,6 +85,10 @@ jobs:
         displayName: Install dependencies
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+      - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+        condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+        displayName: Verify native optional dependency binaries
+
       - powershell: node build/azure-pipelines/distro/mixin-npm.ts
         condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
         displayName: Mixin distro node modules

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -100,6 +100,9 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  - powershell: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+    displayName: Verify native optional dependency binaries
+
   - powershell: node build/azure-pipelines/distro/mixin-npm.ts
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
     displayName: Mixin distro node modules


### PR DESCRIPTION
Restores the native optional dependency binary guard at every Azure Pipelines node_modules producer and consumer call site.

The guard uses the build host's platform and architecture. This is important for cross-architecture jobs: npm installs host-native transitive optional dependencies even when the VS Code artifact targets another architecture.

This follows up on the original cache-corruption report in #329346, the reverted attempt in #329442, and the related draft in #329447.

Local validation:
- [x] `npm run typecheck --prefix build`
- [x] `npm test --prefix build` (268 passing)
- [x] hygiene for all changed pipeline YAML files
- [x] YAML parsing and `git diff --check`

ADO validation:
- [x] [Fresh producer/cache-miss run 464022](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464022) — succeeded. Guards passed and caches were saved for Windows ARM64, Linux ARM64/ARMHF, Alpine x64/ARM64, macOS x64, and Web.
- [x] [Cache-hit replay 464037](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464037) — the full `node_modules` stage succeeded. Every cache restored; fresh installs, producer guards, and archive creation were skipped. The run was stopped after the relevant stage completed.
- [x] [Product consumer run 464013](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464013) — fresh installs and unconditional consumer guards passed for Windows ARM64, Linux ARM64, Alpine ARM64, macOS x64, and Web. The run was stopped after the relevant checks completed.
- [x] [Intentional failure run 464042](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464042) — a validation-only step removed `@openai/codex-linux-x64` before the Linux ARM64 guard. The guard failed with the expected poisoned-cache diagnostic and `Create node_modules archive` was skipped; remaining independent jobs were then canceled.

All cache salt and fault-injection changes live only on separate validation branches and are not part of this PR.