### PR TITLE
Remove background color from quick input titlebar

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -267,7 +267,6 @@
 	position: relative;
 	z-index: 1;
 	flex: 0 0 auto;
-	background-color: var(--vscode-panel-background);
 }
 
 .style-override.monaco-workbench .quick-input-titlebar {

--- a/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
+++ b/src/vs/workbench/contrib/styleOverrides/test/browser/styleOverrides.contribution.test.ts
@@ -415,7 +415,7 @@ suite('StyleOverridesContribution', () => {
 			globalActionsPosition: 'relative',
 			globalActionsZIndex: '1',
 			globalActionsFlexShrink: '0',
-			globalActionsBackground: 'rgb(18, 52, 86)',
+			globalActionsBackground: 'rgba(0, 0, 0, 0)',
 		});
 	});
 });


### PR DESCRIPTION
Eliminate the background color from the quick input titlebar for a cleaner appearance. This change enhances the visual integration with the overall theme.

