### PR TITLE
markdown: refactor: delegate task checkbox toggles to setTaskCheckboxChecked

### DIFF
--- a/extensions/markdown-language-features/markdown-editor-src/editor.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/editor.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AsyncClipboardStrategy, CommentModeController, CommentsModel, EditorController, EditorModel, EditorView, GutterMarker, OffsetRange, Selection, StringEdit, StringReplacement, StringValue, VsCodeV2CommentsView, commands, findNodeOffsetById, taskCheckboxRange, vscodeHostKeyboardProfile, vscodeLocalKeyboardProfile, type CodeBlockAstNode } from '@vscode/markdown-editor';
+import { AsyncClipboardStrategy, CommentModeController, CommentsModel, EditorController, EditorModel, EditorView, GutterMarker, OffsetRange, Selection, StringEdit, StringReplacement, StringValue, VsCodeV2CommentsView, commands, findNodeOffsetById, vscodeHostKeyboardProfile, vscodeLocalKeyboardProfile, type CodeBlockAstNode } from '@vscode/markdown-editor';
 import { VirtualizedIframeEmbeddedEditorFactory, type IframeEmbeddedEditorProvider, type IframeEmbeddedEditorProviderSelector, type ResolvedIframeEmbeddedEditor } from '@vscode/markdown-editor/web-editors';
 import { Disposable, autorun, observableValue } from '@vscode/observables';
 import 'katex/dist/katex.min.css';
@@ -203,20 +203,7 @@ class Editor extends Disposable {
 				return undefined;
 			},
 			onToggleCheckbox: (item, newChecked) => {
-				if (model.readonlyMode.get()) {
-					return;
-				}
-				const doc = model.document.get();
-				const itemOffset = findNodeOffsetById(doc, item);
-				if (itemOffset === undefined) { return; }
-				const range = taskCheckboxRange(item);
-				if (!range) { return; }
-				model.applyEdit(
-					StringEdit.replace(
-						range.delta(itemOffset),
-						newChecked ? '[x]' : '[ ]'
-					)
-				);
+				model.setTaskCheckboxChecked(item, newChecked);
 			},
 			renderCustomCodeBlock: (language, content) => {
 				if (language !== 'mermaid') {

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",
-        "@vscode/markdown-editor": "^0.0.2-65",
+        "@vscode/markdown-editor": "^0.0.2-70",
         "@vscode/observables": "^0.1.1-0",
         "dompurify": "^3.4.10",
         "highlight.js": "^11.8.0",
@@ -633,9 +633,9 @@
       "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
     },
     "node_modules/@vscode/markdown-editor": {
-      "version": "0.0.2-65",
-      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-65.tgz",
-      "integrity": "sha512-2mxUbQV/8Yd0CHQh+/Cf2a6LsdPwYgne1I/w/D83NMIIFyWgXMhB9KrZOzitwsc3kTszre0rcyDs3uoCnngSiw==",
+      "version": "0.0.2-70",
+      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-70.tgz",
+      "integrity": "sha512-CGMcdCIV1ueDde/Aq8mCMghQjgYLYOgEOPsG1N/46Z+q6cweSPHt0NI7ir0984DicuAQ6I4PhGn40ogZMKqoVQ==",
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -1767,7 +1767,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "@vscode/markdown-editor": "^0.0.2-65",
+    "@vscode/markdown-editor": "^0.0.2-70",
     "@vscode/observables": "^0.1.1-0",
     "dompurify": "^3.4.10",
     "highlight.js": "^11.8.0",


### PR DESCRIPTION
cc @hediet

## What

The Markdown custom editor's webview hand-rolled the task checkbox source edit. `onToggleCheckbox` looked up the list item's offset, computed the `[ ]` range and applied the `StringEdit` itself:

```ts
onToggleCheckbox: (item, newChecked) => {
	if (model.readonlyMode.get()) {
		return;
	}
	const doc = model.document.get();
	const itemOffset = findNodeOffsetById(doc, item);
	if (itemOffset === undefined) { return; }
	const range = taskCheckboxRange(item);
	if (!range) { return; }
	model.applyEdit(
		StringEdit.replace(
			range.delta(itemOffset),
			newChecked ? '[x]' : '[ ]'
		)
	);
},
```

That logic now lives in the editor package as `EditorModel.setTaskCheckboxChecked` (microsoft/vscode-packages#253), so the webview just delegates:

```ts
onToggleCheckbox: (item, newChecked) => {
	model.setTaskCheckboxChecked(item, newChecked);
},
```

`taskCheckboxRange` is dropped from the import; `findNodeOffsetById` stays because `onEmbeddedCodeEditorEdit` still uses it.

Picking up the new API requires `@vscode/markdown-editor` ≥ `0.0.2-68`, so this also bumps the dependency to the current `next`, `0.0.2-70` (same kind of bump as #330194).

## Why this also fixes read-only mode

This is a behaviour fix, not only a cleanup. Clicking a rendered checkbox in read-only mode previously did nothing, and it was gated **twice**: the handler early-returned on `model.readonlyMode`, and `model.applyEdit` is itself read-only gated.

Read-only in this editor is a **rendering/interaction mode, not a document permission**. It hides Markdown markers and disables text editing, while selection and copy keep working — it is the "rendered document" reading mode, toggled by the lock button. Ticking a task item is part of reading a document, not authoring it, which is why the model deliberately exempts this one operation:

```ts
/** Sets a rendered task checkbox state in either editing or read-only mode. */
setTaskCheckboxChecked(item: ListItemAstNode, checked: boolean): void {
	if (item.checked === checked) { return; }
	const itemOffset = findNodeOffsetById(this.document.get(), item);
	const checkboxRange = taskCheckboxRange(item);
	if (itemOffset === undefined || checkboxRange === undefined) { return; }
	const edit = StringEdit.replace(checkboxRange.delta(itemOffset), checked ? '[x]' : '[ ]');
	this._applySourceEdit(edit, this.selection.get() ?? Selection.collapsed(0));
}
```

The exemption is scoped to exactly this method. Ordinary text edits — `applyEdit`, `applyEditForSelection`, `materializePendingParagraph` — remain gated on `readonlyMode`, and nothing about read-only semantics is broadened anywhere in this extension. The new method also preserves the current selection rather than moving the caret to the edit, so clicking a checkbox no longer disturbs the cursor, and it no-ops when the checkbox is already in the requested state.

The upstream package covers both modes with parameterized unit tests (`editorModel.test.ts`), asserting `- [ ] task` ⇄ `- [x] task` with `readonlyMode` both `false` and `true`.

## Dependency bump

`0.0.2-65` → `0.0.2-70`. The bump is required: `build/lib/extensions.ts` type-checks `markdown-editor-src/tsconfig.json`, and against `0.0.2-65` this change fails to compile with

```
markdown-editor-src/editor.ts(206,11): error TS2339: Property 'setTaskCheckboxChecked' does not exist on type 'EditorModel'.
```

`0.0.2-70` is the current `next` tag, contains the API, and is 3 commits ahead of (0 behind) the upstream merge commit `204c030`:

```console
$ npm pack @vscode/markdown-editor@0.0.2-70 && tar -xzf *.tgz
$ grep -n 'setTaskCheckboxChecked' package/dist/index.d.ts
1223:    setTaskCheckboxChecked(item: ListItemAstNode, checked: boolean): void;
```

Only the version, resolved URL and integrity hash change in `package-lock.json` — `npm install` reported `changed 1 package`. No `"$generated": true` contribution entries were touched; `npm run check-markdown-editor-package-json` still reports `unchanged` after the upgrade.

## Validation

| Check | Result |
| --- | --- |
| `tsc -p markdown-editor-src/tsconfig.json` (the tsconfig CI type-checks) | ✅ passes |
| Same typecheck against the previous `0.0.2-65` | ❌ `TS2339` — confirms the bump is required |
| `npm run build-markdown-editor` | ✅ succeeds; `markdown-editor-out/editor.js` contains the `setTaskCheckboxChecked` call |
| `npm run check-markdown-editor-package-json` | ✅ `Markdown editor manifests: unchanged` |
| `npm run test-markdown-editor-package-json` | ✅ 8/8 pass |
| Upstream `editorModel.test.ts` task checkbox tests (editing + read-only) | ✅ pass |

Not done: an interactive click-through in a source build. It needs a full `npm run compile`, and this checkout's `node_modules` is shared from a sibling worktree, which is explicitly unsupported for building. The behaviour is covered by the upstream tests above, which exercise exactly the read-only path this PR enables.

`markdown-editor-out/` is gitignored and not committed.
