### PR TITLE
Fix /clear in the Agents window (#330446)

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/clearSlashCommand.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/clearSlashCommand.contribution.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { ChatSessionArchiveActionWording, ChatSessionArchiveActionWordingSettingId, getChatSessionArchiveActionWording } from '../../../../platform/chat/common/sessionArchiveActions.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
+import { IChatSlashCommandService } from '../../../../workbench/contrib/chat/common/participants/chatSlashCommands.js';
+import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
+import { SessionIsArchivedContext, SessionIsCreatedContext } from '../../../common/contextkeys.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+/**
+ * `/clear` for the Agents window.
+ *
+ * The classic workbench registers its own `/clear` in
+ * `workbench/contrib/chat/browser/chatSlashCommands.ts`, but that one archives
+ * through `IAgentSessionsService` and starts a new chat through
+ * `ACTION_ID_NEW_CHAT` — neither of which reaches the Agents window, whose
+ * sessions are owned by the sessions providers and whose new-session flow is
+ * `ISessionsService.openNewSession`. The core registration is skipped in this
+ * window so this one can take its place.
+ */
+export class ClearSlashCommandContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.clearSlashCommand';
+
+	constructor(
+		@IChatSlashCommandService slashCommandService: IChatSlashCommandService,
+		@ISessionsService sessionsService: ISessionsService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@ILogService logService: ILogService,
+		@INotificationService notificationService: INotificationService,
+	) {
+		super();
+
+		if (!environmentService.isSessionsWindow) {
+			return;
+		}
+
+		const registration = this._register(new MutableDisposable());
+		const register = () => {
+			const wording = getChatSessionArchiveActionWording(configurationService);
+			registration.clear();
+			registration.value = slashCommandService.registerSlashCommand({
+				command: 'clear',
+				detail: wording === ChatSessionArchiveActionWording.MarkAsDone
+					? localize('clear.markDone', "Start a new chat and mark the current one as done")
+					: localize('clear.archive', "Start a new chat and archive the current one"),
+				sortText: 'z2_clear',
+				executeImmediately: true,
+				// Archiving hides the session, so adding a `/clear` turn to it
+				// would only leave a stray request behind.
+				silent: true,
+				locations: [ChatAgentLocation.Chat],
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext,
+					SessionIsCreatedContext,
+					SessionIsArchivedContext.negate(),
+				),
+			}, async (_prompt, _progress, _history, _location, sessionResource) => {
+				const found = sessionsManagementService.getSessionForChatResource(sessionResource);
+				if (!found) {
+					logService.warn(`[clear] No session found for chat resource ${sessionResource.toString()}`);
+					notificationService.warn(localize('clear.sessionUnavailable', "This conversation cannot be cleared."));
+					return;
+				}
+
+				const { session } = found;
+				if (!session.isArchived.get()) {
+					await sessionsManagementService.archiveSession(session);
+				}
+				await sessionsService.openNewSession();
+			});
+		};
+		register();
+		this._register(configurationService.onDidChangeConfiguration(event => {
+			if (event.affectsConfiguration(ChatSessionArchiveActionWordingSettingId)) {
+				register();
+			}
+		}));
+	}
+}
+
+registerWorkbenchContribution2(ClearSlashCommandContribution.ID, ClearSlashCommandContribution, WorkbenchPhase.Eventually);

--- a/src/vs/sessions/contrib/chat/browser/clearSlashCommand.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/clearSlashCommand.contribution.ts
@@ -20,15 +20,8 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
 /**
- * `/clear` for the Agents window.
- *
- * The classic workbench registers its own `/clear` in
- * `workbench/contrib/chat/browser/chatSlashCommands.ts`, but that one archives
- * through `IAgentSessionsService` and starts a new chat through
- * `ACTION_ID_NEW_CHAT` — neither of which reaches the Agents window, whose
- * sessions are owned by the sessions providers and whose new-session flow is
- * `ISessionsService.openNewSession`. The core registration is skipped in this
- * window so this one can take its place.
+ * `/clear` for the Agents window. The core registration is skipped here so this
+ * one, which archives and starts a new session through the sessions services, can take its place.
  */
 export class ClearSlashCommandContribution extends Disposable implements IWorkbenchContribution {
 
@@ -60,9 +53,7 @@ export class ClearSlashCommandContribution extends Disposable implements IWorkbe
 					: localize('clear.archive', "Start a new chat and archive the current one"),
 				sortText: 'z2_clear',
 				executeImmediately: true,
-				// Archiving hides the session, so adding a `/clear` turn to it
-				// would only leave a stray request behind.
-				silent: true,
+				silent: true, // archiving hides the session, so a `/clear` turn would only be stranded in it
 				locations: [ChatAgentLocation.Chat],
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,

--- a/src/vs/sessions/contrib/chat/test/browser/clearSlashCommandContribution.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/clearSlashCommandContribution.test.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ChatSessionArchiveActionWordingSettingId } from '../../../../../platform/chat/common/sessionArchiveActions.js';
+import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService, NoOpNotification } from '../../../../../platform/notification/common/notification.js';
+import { ChatAgentLocation } from '../../../../../workbench/contrib/chat/common/constants.js';
+import { IChatSlashCallback, IChatSlashCommandService, IChatSlashData } from '../../../../../workbench/contrib/chat/common/participants/chatSlashCommands.js';
+import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { IChat, ISession } from '../../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ClearSlashCommandContribution } from '../../browser/clearSlashCommand.contribution.js';
+
+suite('ClearSlashCommandContribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	interface ISetupOptions {
+		readonly isSessionsWindow?: boolean;
+		readonly isArchived?: boolean;
+		readonly knownChatResource?: boolean;
+	}
+
+	function setup(store: DisposableStore, options: ISetupOptions = {}) {
+		const { isSessionsWindow = true, isArchived = false, knownChatResource = true } = options;
+
+		const instantiationService = store.add(new TestInstantiationService());
+		const registrations: { data: IChatSlashData; callback: IChatSlashCallback }[] = [];
+		let disposedRegistrations = 0;
+		instantiationService.stub(IChatSlashCommandService, {
+			_serviceBrand: undefined,
+			onDidChangeCommands: Event.None,
+			registerSlashCommand: (data, callback) => {
+				registrations.push({ data, callback });
+				return toDisposable(() => disposedRegistrations++);
+			},
+			executeCommand: async () => undefined,
+			getCommands: () => [],
+			hasCommand: () => false,
+		});
+		instantiationService.stub(IWorkbenchEnvironmentService, upcastPartial<IWorkbenchEnvironmentService>({ isSessionsWindow }));
+
+		const chat = upcastPartial<IChat>({ resource: URI.parse('test:///chat/main') });
+		const session = upcastPartial<ISession>({
+			sessionId: 'session',
+			resource: URI.parse('test:///session'),
+			isArchived: constObservable(isArchived),
+		});
+
+		const callOrder: string[] = [];
+		instantiationService.stub(ISessionsManagementService, upcastPartial<ISessionsManagementService>({
+			getSessionForChatResource: resource => knownChatResource && resource.toString() === chat.resource.toString()
+				? { session, chat }
+				: undefined,
+			archiveSession: async archived => {
+				callOrder.push(`archive:${archived.sessionId}`);
+			},
+		}));
+		instantiationService.stub(ISessionsService, upcastPartial<ISessionsService>({
+			openNewSession: async () => {
+				callOrder.push('openNewSession');
+				return { session: undefined, trustDeclined: false };
+			},
+		}));
+
+		const warnings: string[] = [];
+		instantiationService.stub(INotificationService, upcastPartial<INotificationService>({
+			warn: (message: string) => {
+				warnings.push(message);
+				return new NoOpNotification();
+			},
+		}));
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const configurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, configurationService);
+
+		const contribution = store.add(instantiationService.createInstance(ClearSlashCommandContribution));
+
+		return {
+			contribution,
+			chat,
+			session,
+			callOrder,
+			warnings,
+			registrations,
+			get disposedRegistrations() { return disposedRegistrations; },
+			fireConfigurationChange: (setting: string) => configurationService.onDidChangeConfigurationEmitter.fire(upcastPartial<IConfigurationChangeEvent>({
+				affectsConfiguration: (key: string) => key === setting,
+			})),
+		};
+	}
+
+	test('registers `/clear` as a silent, immediately executed chat command', () => {
+		const store = disposables.add(new DisposableStore());
+		const { registrations } = setup(store);
+
+		assert.strictEqual(registrations.length, 1);
+		const { data } = registrations[0];
+		assert.strictEqual(data.command, 'clear');
+		assert.strictEqual(data.executeImmediately, true);
+		assert.strictEqual(data.silent, true);
+		assert.deepStrictEqual(data.locations, [ChatAgentLocation.Chat]);
+	});
+
+	test('does not register outside the Agents window', () => {
+		const store = disposables.add(new DisposableStore());
+		const { registrations } = setup(store, { isSessionsWindow: false });
+
+		assert.strictEqual(registrations.length, 0);
+	});
+
+	test('archives the session, then opens a new one', async () => {
+		const store = disposables.add(new DisposableStore());
+		const { registrations, chat, session, callOrder } = setup(store);
+
+		await registrations[0].callback('', { report: () => undefined }, [], ChatAgentLocation.Chat, chat.resource, CancellationToken.None);
+
+		assert.deepStrictEqual(callOrder, [`archive:${session.sessionId}`, 'openNewSession']);
+	});
+
+	test('skips archiving a session that is already archived', async () => {
+		const store = disposables.add(new DisposableStore());
+		const { registrations, chat, callOrder } = setup(store, { isArchived: true });
+
+		await registrations[0].callback('', { report: () => undefined }, [], ChatAgentLocation.Chat, chat.resource, CancellationToken.None);
+
+		assert.deepStrictEqual(callOrder, ['openNewSession']);
+	});
+
+	test('warns and does nothing when no session owns the chat resource', async () => {
+		const store = disposables.add(new DisposableStore());
+		const { registrations, chat, callOrder, warnings } = setup(store, { knownChatResource: false });
+
+		await registrations[0].callback('', { report: () => undefined }, [], ChatAgentLocation.Chat, chat.resource, CancellationToken.None);
+
+		assert.strictEqual(warnings.length, 1);
+		assert.deepStrictEqual(callOrder, []);
+	});
+
+	test('re-registers when the archive action wording changes', () => {
+		const store = disposables.add(new DisposableStore());
+		const setupResult = setup(store);
+
+		setupResult.fireConfigurationChange(ChatSessionArchiveActionWordingSettingId);
+		assert.strictEqual(setupResult.registrations.length, 2);
+		assert.strictEqual(setupResult.disposedRegistrations, 1);
+
+		setupResult.fireConfigurationChange('chat.someOtherSetting');
+		assert.strictEqual(setupResult.registrations.length, 2);
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -466,6 +466,7 @@ import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
 import './contrib/chat/browser/btwSlashCommand.contribution.js';
+import './contrib/chat/browser/clearSlashCommand.contribution.js';
 import './contrib/chat/browser/sideChatProvider.contribution.js';
 import './contrib/providers/agentHost/browser/exportDebugLogsAction.js';
 import './contrib/providers/agentHost/browser/agentHostSessionConfigPicker.js';

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -77,29 +77,35 @@ export class ChatSlashCommandsContribution extends Disposable {
 		}, async () => {
 			chatPetService.toggle();
 		}));
-		const clearCommandRegistration = this._register(new MutableDisposable());
-		const registerClearCommand = () => {
-			const wording = getChatSessionArchiveActionWording(configurationService);
-			clearCommandRegistration.clear();
-			clearCommandRegistration.value = slashCommandService.registerSlashCommand({
-				command: 'clear',
-				detail: wording === ChatSessionArchiveActionWording.MarkAsDone
-					? nls.localize('clear.markDone', "Start a new chat and mark the current one as done")
-					: nls.localize('clear.archive', "Start a new chat and archive the current one"),
-				sortText: 'z2_clear',
-				executeImmediately: true,
-				locations: [ChatAgentLocation.Chat]
-			}, async (_prompt, _progress, _history, _location, sessionResource) => {
-				agentSessionsService.getSession(sessionResource)?.setArchived(true);
-				commandService.executeCommand(ACTION_ID_NEW_CHAT);
-			});
-		};
-		registerClearCommand();
-		this._register(configurationService.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration(ChatSessionArchiveActionWordingSettingId)) {
-				registerClearCommand();
-			}
-		}));
+		// The Agents window registers its own `/clear` (see
+		// `sessions/contrib/chat/browser/clearSlashCommand.contribution.ts`) because
+		// archiving and starting a new session there go through the sessions
+		// services, not `IAgentSessionsService` / `ACTION_ID_NEW_CHAT`.
+		if (!this.environmentService.isSessionsWindow) {
+			const clearCommandRegistration = this._register(new MutableDisposable());
+			const registerClearCommand = () => {
+				const wording = getChatSessionArchiveActionWording(configurationService);
+				clearCommandRegistration.clear();
+				clearCommandRegistration.value = slashCommandService.registerSlashCommand({
+					command: 'clear',
+					detail: wording === ChatSessionArchiveActionWording.MarkAsDone
+						? nls.localize('clear.markDone', "Start a new chat and mark the current one as done")
+						: nls.localize('clear.archive', "Start a new chat and archive the current one"),
+					sortText: 'z2_clear',
+					executeImmediately: true,
+					locations: [ChatAgentLocation.Chat]
+				}, async (_prompt, _progress, _history, _location, sessionResource) => {
+					agentSessionsService.getSession(sessionResource)?.setArchived(true);
+					commandService.executeCommand(ACTION_ID_NEW_CHAT);
+				});
+			};
+			registerClearCommand();
+			this._register(configurationService.onDidChangeConfiguration(event => {
+				if (event.affectsConfiguration(ChatSessionArchiveActionWordingSettingId)) {
+					registerClearCommand();
+				}
+			}));
+		}
 		this._store.add(slashCommandService.registerSlashCommand({
 			command: 'hooks',
 			detail: nls.localize('hooks', "Configure hooks"),

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -77,10 +77,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 		}, async () => {
 			chatPetService.toggle();
 		}));
-		// The Agents window registers its own `/clear` (see
-		// `sessions/contrib/chat/browser/clearSlashCommand.contribution.ts`) because
-		// archiving and starting a new session there go through the sessions
-		// services, not `IAgentSessionsService` / `ACTION_ID_NEW_CHAT`.
+		// The Agents window registers its own `/clear` in `sessions/contrib/chat/browser/clearSlashCommand.contribution.ts`.
 		if (!this.environmentService.isSessionsWindow) {
 			const clearCommandRegistration = this._register(new MutableDisposable());
 			const registerClearCommand = () => {


### PR DESCRIPTION
Fixes #330446

## Problem

Typing `/clear` in the Agents window chat input does nothing. The session is not marked as done and no new session is opened. The command appears in the completion list with the description "Start a new chat and mark the current one as done", but neither half happens. `/clear` continues to work correctly in the sidebar Chat view.

## Root cause

`/clear` is registered exactly once, in the shared workbench contribution `src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts`:

```ts
agentSessionsService.getSession(sessionResource)?.setArchived(true);
commandService.executeCommand(ACTION_ID_NEW_CHAT);
```

Both calls are written against the classic workbench abstractions. The Agents window is a separate workbench layer under `src/vs/sessions/` — its own window, profile and session model — so neither call reaches it.

**1. The archive half is a no-op.** The Agents window session list is driven by `ISessionsProvider` via `ISessionsManagementService.archiveSession()` (`sessions/services/sessions/browser/sessionsManagementService.ts`). For agent-host Copilot sessions — the case in the issue — the provider maintains its own session cache and dispatches `SessionIsArchivedChanged` to the backend (`sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts`). `IAgentSessionsService.getSession(...).setArchived(true)` never touches that state.

**2. The new-session half is a no-op.** `ACTION_ID_NEW_CHAT` resolves to `runNewChatAction` → `clearChatSessionPreservingType` (`chat/browser/actions/chatActions.ts`), which branches on `isIChatViewViewContext(widget.viewContext)`. The Agents window constructs its `ChatWidget` with an undefined view context (`sessions/contrib/chat/browser/chatView.ts`), so it falls through to `await widget.clear(newSessionType)` → `this.viewOptions.clear?.(...)`. Only `chatViewPane.ts`, `chatEditor.ts` and `chatQuick.ts` supply a `clear` callback; the Agents window `ChatView` does not. The call resets some input chrome and returns.

The Agents window's actual new-session entry point is `ISessionsService.openNewSession()`, which `/clear` never calls.

Slash-command routing itself is fine — `/clear` parses correctly (agent-host sessions set `supportsPromptAttachments: true`) and dispatches through `chatServiceImpl`. The handler does run; it simply has no effect.

## Change

Split `/clear` into a classic-workbench registration and a sessions-window registration, so each uses its own session APIs. A single registration cannot serve both, because `ChatSlashCommandService.registerSlashCommand` throws on an overlapping duplicate id.

- **`workbench/contrib/chat/browser/chatSlashCommands.ts`** — skip the `clear` registration (and its wording re-registration listener) when `environmentService.isSessionsWindow`. This is the same guard already used for `/debug` a few lines below.

- **`sessions/contrib/chat/browser/clearSlashCommand.contribution.ts`** (new) — an Agents-window `/clear`, modeled directly on the existing `btwSlashCommand.contribution.ts`. The handler resolves the session with `sessionsManagementService.getSessionForChatResource(...)`, archives it with `sessionsManagementService.archiveSession(session)` (the same call the Mark as Done action uses), then calls `sessionsService.openNewSession()` to show the new-session composer. It is registered as `silent: true` so archiving does not leave a stray `/clear` turn behind in the session being closed, and its `detail` follows `getChatSessionArchiveActionWording()` and re-registers on `chat.experimental.sessionArchiveActionWording` changes, matching the core command.

- **`sessions/sessions.common.main.ts`** — import the new contribution.

The Agents window's new-session composer input uses its own slash registry (`sessions/contrib/chat/browser/slashCommands.ts`) which has no `clear`. That was left alone: there is no session to clear at that point.

## Verification status

`npx tsc --noEmit -p src/tsconfig.json` passes with no errors.

**Runtime behavior has not been verified.** The checkout used here has an incomplete `node_modules` (`@eslint/compat` and `gulp-merge-json` are missing), so ESLint, the unit test runner and launching the app could not be run locally. A maintainer should confirm the following before merging:

1. Open the Agents window (`Chat: Open Agents Window`), start a Copilot agent-host session, send a message, then type `/clear`.
   - The session should move to the Done/Archived section and the new-session composer should open.
   - No stray `/clear` turn should remain in the archived session's transcript.
2. `/clear` still appears in the Agents window completion list, and its description tracks `chat.experimental.sessionArchiveActionWording` ("mark the current one as done" vs "archive the current one").
3. Regression check in the classic window: `/clear` in the sidebar Chat view and in a chat editor still archives and opens a new chat.
4. No `Already registered a command with id clear` error at startup in either window.

## Notes

- The issue estimates a July–August 2026 regression window. I was not able to pin a regression commit: the `/clear` handler body has been unchanged since before that window (only the wording changed, in 10563237268), so if this is a regression it came from the Agents window side rather than from `/clear` itself. It is also possible `/clear` never worked in the Agents window.
- The issue is already assigned to @osortega. This PR is offered as a candidate fix — happy to close it if work is already underway.
