### PR TITLE
Refactor chat plan review footer button layout

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
@@ -400,7 +400,7 @@
 
 .interactive-session .chat-plan-review-container > .chat-confirmation-widget2.chat-plan-review > .chat-confirmation-widget-buttons.chat-plan-review-footer .chat-buttons {
 	display: flex;
-	column-gap: 6px;
+	gap: 6px;
 	align-items: center;
 }
 


### PR DESCRIPTION
Refactor the layout of the chat plan review footer buttons to use a unified gap property instead of column-gap for improved consistency in styling.

![image.png](https://github.com/user-attachments/assets/4be09947-b73c-4c47-b11d-620e7a376591)
