### PR TITLE
Remove unused empty icon from automation cards view

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/automationsCards.css
@@ -261,13 +261,6 @@
 	flex: 1;
 }
 
-.automations-cards-empty-icon {
-	font-size: 28px;
-	color: var(--vscode-descriptionForeground);
-	margin-bottom: 4px;
-	opacity: 0.7;
-}
-
 .automations-cards-empty-title {
 	font-size: var(--vscode-agents-fontSize-heading3);
 	font-weight: var(--vscode-agents-fontWeight-semiBold);

--- a/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/automationsView.ts
@@ -22,7 +22,6 @@ import { CHAT_AUTOMATIONS_ENABLED_SETTING, ChatAutomationsEnabledContext } from 
 import { IAutomationRunner } from '../../../../../workbench/contrib/chat/common/automations/automationRunner.js';
 import { IAutomationDialogService } from '../../../../../workbench/contrib/chat/common/automations/automationDialogService.js';
 import { DAYS_OF_WEEK } from '../../../../../workbench/contrib/chat/common/automations/schedule.js';
-import { automationIcon } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { basename } from '../../../../../base/common/resources.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -276,8 +275,6 @@ class AutomationCardsSection extends Disposable {
 	private renderEmptyState(): void {
 		DOM.clearNode(this.emptyContainer);
 
-		const icon = DOM.append(this.emptyContainer, $('span.automations-cards-empty-icon'));
-		icon.classList.add(...ThemeIcon.asClassNameArray(automationIcon));
 		const title = DOM.append(this.emptyContainer, $('h3.automations-cards-empty-title'));
 		title.textContent = localize('noAutomationsYet', "No automations yet");
 		const desc = DOM.append(this.emptyContainer, $('p.automations-cards-empty-description'));


### PR DESCRIPTION
Eliminate the unused empty icon from the automation cards view to streamline the UI. The related code and styles have been removed accordingly.

