### PR TITLE
agentHost: fix lost session customizations on materialization race

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1784,9 +1784,9 @@ export class AgentService extends Disposable implements IAgentService {
 				state.activeClients = config?.activeClient ? [config.activeClient] : [];
 			}
 		}
-		// Not via the `state` handle above: a session that materialized while the snapshot resolved has already replaced it.
+		// Discovery is asynchronous, so publish the result for clients that subscribed while it was in flight.
 		if (initialCustomizations && initialCustomizations.length > 0) {
-			this._stateManager.setSessionCustomizations(session.toString(), initialCustomizations);
+			this._stateManager.dispatchServerAction(session.toString(), { type: ActionType.SessionCustomizationsChanged, customizations: [...initialCustomizations] });
 		}
 		this._serverToolHost.advertise(session.toString());
 		// Persist resolved config values for restore. Mid-session updates are

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1742,9 +1742,6 @@ export class AgentService extends Disposable implements IAgentService {
 			state.config = sessionConfig;
 			this._stateManager.seedDefaultChatTurns(summary.resource, sourceTurns);
 			state.activeClients = config.activeClient ? [config.activeClient] : [];
-			if (initialCustomizations && initialCustomizations.length > 0) {
-				state.customizations = [...initialCustomizations];
-			}
 
 			// Refine the forked session's placeholder `Forked: …` title into one
 			// derived from the inherited chat. Forks seed pre-existing
@@ -1766,9 +1763,6 @@ export class AgentService extends Disposable implements IAgentService {
 			state.config = sessionConfig;
 			this._stateManager.seedDefaultChatTurns(summary.resource, importedTurns);
 			state.activeClients = config.activeClient ? [config.activeClient] : [];
-			if (initialCustomizations && initialCustomizations.length > 0) {
-				state.customizations = [...initialCustomizations];
-			}
 
 			// Refine the placeholder title into one generated from the imported
 			// conversation, mirroring forks. Imports seed pre-existing turns, so
@@ -1789,9 +1783,10 @@ export class AgentService extends Disposable implements IAgentService {
 				state.config = sessionConfig;
 				state.activeClients = config?.activeClient ? [config.activeClient] : [];
 			}
-			if (initialCustomizations && initialCustomizations.length > 0) {
-				state.customizations = [...initialCustomizations];
-			}
+		}
+		// Not via the `state` handle above: a session that materialized while the snapshot resolved has already replaced it.
+		if (initialCustomizations && initialCustomizations.length > 0) {
+			this._stateManager.setSessionCustomizations(session.toString(), initialCustomizations);
 		}
 		this._serverToolHost.advertise(session.toString());
 		// Persist resolved config values for restore. Mid-session updates are

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1936,7 +1936,7 @@ suite('AgentService (node dispatcher)', () => {
 			assert.deepStrictEqual(service.stateManager.getSessionState(session.toString())?.customizations, [customization]);
 		});
 
-		test('preserves initial customizations when a provisional session materializes during discovery', async () => {
+		test('publishes initial customizations to a client subscribed during discovery', async () => {
 			const customization = { type: CustomizationType.Plugin, id: customizationId('file:///plugin'), uri: 'file:///plugin', name: 'Plugin', enabled: true } as const;
 			class MaterializingCustomizationAgent extends MockAgent {
 				private readonly _onDidMaterializeChat = new Emitter<IAgentMaterializeChatEvent>();
@@ -1970,12 +1970,22 @@ suite('AgentService (node dispatcher)', () => {
 			const creation = service.createSession({ provider: agent.id });
 			const session = await agent.customizationReadStarted.p;
 			agent.materialize(session);
+			const initialSnapshot = await service.subscribe(session, 'client');
+			const initialSnapshotCustomizations = (initialSnapshot.state as SessionState).customizations;
+			const customizationChanged = Event.toPromise(Event.filter(service.onDidAction, envelope =>
+				envelope.channel === session.toString() && envelope.action.type === ActionType.SessionCustomizationsChanged));
 			agent.releaseCustomizationRead.complete();
-			await creation;
+			const [, envelope] = await Promise.all([creation, customizationChanged]);
 
-			const snapshot = await service.subscribe(session, 'client');
-
-			assert.deepStrictEqual((snapshot.state as SessionState).customizations, [customization]);
+			assert.deepStrictEqual({
+				initialSnapshotCustomizations,
+				action: envelope.action,
+				currentSnapshotCustomizations: (service.stateManager.getSnapshot(session.toString())?.state as SessionState | undefined)?.customizations,
+			}, {
+				initialSnapshotCustomizations: undefined,
+				action: { type: ActionType.SessionCustomizationsChanged, customizations: [customization] },
+				currentSnapshotCustomizations: [customization],
+			});
 		});
 
 		test('truncates working directories for a provider without multipleWorkingDirectories', async () => {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -35,7 +35,7 @@ import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agent
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
+import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionState, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { ChatInteractivity, type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -1934,6 +1934,48 @@ suite('AgentService (node dispatcher)', () => {
 			const session = await service.createSession({ provider: agent.id });
 
 			assert.deepStrictEqual(service.stateManager.getSessionState(session.toString())?.customizations, [customization]);
+		});
+
+		test('preserves initial customizations when a provisional session materializes during discovery', async () => {
+			const customization = { type: CustomizationType.Plugin, id: customizationId('file:///plugin'), uri: 'file:///plugin', name: 'Plugin', enabled: true } as const;
+			class MaterializingCustomizationAgent extends MockAgent {
+				private readonly _onDidMaterializeChat = new Emitter<IAgentMaterializeChatEvent>();
+				override readonly onDidMaterializeChat = this._onDidMaterializeChat.event;
+				readonly customizationReadStarted = new DeferredPromise<URI>();
+				readonly releaseCustomizationRead = new DeferredPromise<void>();
+				override readonly chats: IAgentChats = withChatOverrides(getChatSurface(this), base => ({
+					createChat: (chat, context, options) => createProvisionalChat(base, chat, context, options),
+				}));
+
+				override getSessionCustomizations = async (session: URI) => {
+					this.customizationReadStarted.complete(session);
+					await this.releaseCustomizationRead.p;
+					return [customization];
+				};
+
+				materialize(session: URI): void {
+					this._onDidMaterializeChat.fire({ chat: URI.parse(buildDefaultChatUri(session)), workingDirectories: undefined, project: undefined });
+				}
+
+				override dispose(): void {
+					this._onDidMaterializeChat.dispose();
+					super.dispose();
+				}
+			}
+
+			const agent = new MaterializingCustomizationAgent('codex');
+			disposables.add(toDisposable(() => agent.dispose()));
+			service.registerProvider(agent);
+
+			const creation = service.createSession({ provider: agent.id });
+			const session = await agent.customizationReadStarted.p;
+			agent.materialize(session);
+			agent.releaseCustomizationRead.complete();
+			await creation;
+
+			const snapshot = await service.subscribe(session, 'client');
+
+			assert.deepStrictEqual((snapshot.state as SessionState).customizations, [customization]);
 		});
 
 		test('truncates working directories for a provider without multipleWorkingDirectories', async () => {


### PR DESCRIPTION
## What

`AgentService.createSession` captured a provisional `SessionState` object **before** awaiting the provider's initial customization snapshot, then wrote the result onto that captured handle after the await.

Session state can be replaced while discovery is in flight (for example, by concurrent provider progress actions or session materialization). The post-await write could therefore land on an orphaned object, and the customizations would never reach the authoritative session state.

The fix dispatches `SessionCustomizationsChanged` after discovery completes. This both resolves the current session entry at dispatch time and updates clients that subscribed while discovery was still in flight.

## Why

This is the root cause of the flaky CI failure:

```
Error: Timed out waiting for parsed plugin file:///tmp/codex-customizations-plugin-XXXXXX; last state: undefined
    at waitForParsedPlugin (…/codexCustomizations.integrationTest.js:37:9)
```

Codex performs asynchronous connection, plugin, MCP, and thread startup work during new-session creation. That work widens the window in which session state can advance while `createSession` awaits customization discovery. The client-pushed plugin was written through a stale state handle and never surfaced, so the test's 60-second poll loop could not observe it.

I found this failure on at least eight job attempts across five unrelated PRs (including a UI-only PR), each passing on rerun:

- #330426, #330422 (twice), #330247, #330428, and three attempts on #329633.

The unsafe state lifetime was introduced in #328956; the lifecycle changes in #329633 appear to have widened the window and made it surface regularly.

## Reviewer notes

- The `length > 0` guard is preserved, so an empty snapshot cannot clear customizations that arrived as actions during the await.
- `state.config` and `state.activeClients` are not affected: they are written before the await, and state replacements preserve prior fields.
- Dispatching the resolved snapshot preserves authoritative state and ensures already-subscribed clients receive an action envelope.

## Validation

- Regression test `publishes initial customizations to a client subscribed during discovery` uses a deterministic two-`DeferredPromise` handshake (no sleeps). It subscribes before discovery completes, verifies the initial snapshot has no customizations, then verifies the emitted `SessionCustomizationsChanged` action and authoritative final state.
- Red before the feedback fix: `0 passing, 1 failing` (timed out waiting for the missing action envelope).
- `agentService.test.ts` + `agentSideEffects.test.ts` + `agentHostStateManager.test.ts`: 505 passing.
- `codexCustomizations.integrationTest.ts`: 3 passing.
- `npm run typecheck-client` and pre-commit hygiene clean.
