### PR TITLE
agentHost: preserve setting source in managed bridge

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
+++ b/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
@@ -76,19 +76,19 @@ export function getGlobalConfigurationValue<T>(configurationService: IConfigurat
  * registered default and workspace/folder layers.
  */
 /** A global configuration layer that contains an explicitly configured value. */
-export type ExplicitGlobalConfigurationSource = 'policy' | 'user' | 'application';
+export type ConfigurationSource = 'policy' | 'user' | 'application';
 
 /** An explicitly configured global value and the layer that supplied it. */
-export interface IExplicitGlobalConfigurationValue<T> {
+export interface IInspectedValue<T> {
 	readonly value: T;
-	readonly source: ExplicitGlobalConfigurationSource;
+	readonly source: ConfigurationSource;
 }
 
 /** Inspects an explicitly configured global value while preserving its source layer. */
-export function inspectValue<T>(configurationService: IConfigurationService, settingId: string): IExplicitGlobalConfigurationValue<T> | undefined {
+export function inspectValue<T>(configurationService: IConfigurationService, settingId: string): IInspectedValue<T> | undefined {
 	const inspected = configurationService.inspect<T>(settingId);
 	const property = getPropertySchema(settingId);
-	const values: readonly [ExplicitGlobalConfigurationSource, T | undefined][] = [
+	const values: readonly [ConfigurationSource, T | undefined][] = [
 		['policy', inspected.policyValue],
 		['user', inspected.userValue],
 		['application', inspected.applicationValue],

--- a/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
+++ b/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
@@ -75,12 +75,27 @@ export function getGlobalConfigurationValue<T>(configurationService: IConfigurat
  * Resolves the explicitly configured global value of `settingId`, excluding the
  * registered default and workspace/folder layers.
  */
-export function getExplicitGlobalConfigurationValue<T>(configurationService: IConfigurationService, settingId: string): T | undefined {
+/** A global configuration layer that contains an explicitly configured value. */
+export type ExplicitGlobalConfigurationSource = 'policy' | 'user' | 'application';
+
+/** An explicitly configured global value and the layer that supplied it. */
+export interface IExplicitGlobalConfigurationValue<T> {
+	readonly value: T;
+	readonly source: ExplicitGlobalConfigurationSource;
+}
+
+/** Inspects an explicitly configured global value while preserving its source layer. */
+export function inspectValue<T>(configurationService: IConfigurationService, settingId: string): IExplicitGlobalConfigurationValue<T> | undefined {
 	const inspected = configurationService.inspect<T>(settingId);
 	const property = getPropertySchema(settingId);
-	for (const value of [inspected.policyValue, inspected.userValue, inspected.applicationValue]) {
+	const values: readonly [ExplicitGlobalConfigurationSource, T | undefined][] = [
+		['policy', inspected.policyValue],
+		['user', inspected.userValue],
+		['application', inspected.applicationValue],
+	];
+	for (const [source, value] of values) {
 		if (value !== undefined && matchesSchemaType(value, property?.type)) {
-			return value;
+			return { value, source };
 		}
 	}
 	return undefined;

--- a/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
+++ b/src/vs/platform/agentHost/common/agentHostConfigurationSync.ts
@@ -72,30 +72,20 @@ export function getGlobalConfigurationValue<T>(configurationService: IConfigurat
 }
 
 /**
- * Resolves the explicitly configured global value of `settingId`, excluding the
+ * Inspects the configured application-wide value of `settingId`, excluding the
  * registered default and workspace/folder layers.
  */
-/** A global configuration layer that contains an explicitly configured value. */
-export type ConfigurationSource = 'policy' | 'user' | 'application';
-
-/** An explicitly configured global value and the layer that supplied it. */
-export interface IInspectedValue<T> {
-	readonly value: T;
-	readonly source: ConfigurationSource;
-}
-
-/** Inspects an explicitly configured global value while preserving its source layer. */
-export function inspectValue<T>(configurationService: IConfigurationService, settingId: string): IInspectedValue<T> | undefined {
+export function inspectValue<T>(configurationService: IConfigurationService, settingId: string): readonly [value: T, source: 'policyValue' | 'userValue' | 'applicationValue'] | undefined {
 	const inspected = configurationService.inspect<T>(settingId);
 	const property = getPropertySchema(settingId);
-	const values: readonly [ConfigurationSource, T | undefined][] = [
-		['policy', inspected.policyValue],
-		['user', inspected.userValue],
-		['application', inspected.applicationValue],
-	];
+	const values = [
+		['policyValue', inspected.policyValue],
+		['userValue', inspected.userValue],
+		['applicationValue', inspected.applicationValue],
+	] as const;
 	for (const [source, value] of values) {
 		if (value !== undefined && matchesSchemaType(value, property?.type)) {
-			return { value, source };
+			return [value, source];
 		}
 	}
 	return undefined;

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
-import { getExplicitGlobalConfigurationValue, getGlobalConfigurationValue } from './agentHostConfigurationSync.js';
+import { getGlobalConfigurationValue, inspectValue, type IExplicitGlobalConfigurationValue } from './agentHostConfigurationSync.js';
 import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
 
 export interface IAgentHostManagedSettingsPermissions {
@@ -20,20 +20,20 @@ interface IManagedPermissionsSettingMapping {
 	contribute(configurationService: IConfigurationService): IAgentHostManagedSettingsPermissions | undefined;
 }
 
-function managedPermissionsSetting<T>(settingId: string, transform: (value: T) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
+function managedPermissionsSetting<T>(settingId: string, transform: (configuration: IExplicitGlobalConfigurationValue<T>) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
 	return {
 		settingId,
 		contribute: configurationService => {
-			const value = getExplicitGlobalConfigurationValue<T>(configurationService, settingId);
-			return value === undefined ? undefined : transform(value);
+			const configuration = inspectValue<T>(configurationService, settingId);
+			return configuration === undefined ? undefined : transform(configuration);
 		},
 	};
 }
 
 /** Compatibility mappings for legacy settings only; new controls belong directly in the SDK. */
 const managedPermissionsSettings: readonly IManagedPermissionsSettingMapping[] = [
-	managedPermissionsSetting<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, value => value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
-	managedPermissionsSetting<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, value => value === false ? { ask: ['Shell'] } : undefined),
+	managedPermissionsSetting<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, ({ value, source }) => source === 'policy' && value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
+	managedPermissionsSetting<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, ({ value }) => value === false ? { ask: ['Shell'] } : undefined),
 ];
 
 export const managedPermissionsConfigurationIds = [

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
-import { getGlobalConfigurationValue, inspectValue, type IExplicitGlobalConfigurationValue } from './agentHostConfigurationSync.js';
+import { getGlobalConfigurationValue, inspectValue, type IInspectedValue } from './agentHostConfigurationSync.js';
 import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
 
 export interface IAgentHostManagedSettingsPermissions {
@@ -20,7 +20,7 @@ interface IManagedPermissionsSettingMapping {
 	contribute(configurationService: IConfigurationService): IAgentHostManagedSettingsPermissions | undefined;
 }
 
-function managedPermissionsSetting<T>(settingId: string, transform: (configuration: IExplicitGlobalConfigurationValue<T>) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
+function managedPermissionsSetting<T>(settingId: string, transform: (configuration: IInspectedValue<T>) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
 	return {
 		settingId,
 		contribute: configurationService => {

--- a/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
+++ b/src/vs/platform/agentHost/common/agentHostManagedSettings.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
-import { getGlobalConfigurationValue, inspectValue, type IInspectedValue } from './agentHostConfigurationSync.js';
+import { getGlobalConfigurationValue, inspectValue } from './agentHostConfigurationSync.js';
 import { GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID } from './agentHostSchema.js';
 
 export interface IAgentHostManagedSettingsPermissions {
@@ -20,20 +20,20 @@ interface IManagedPermissionsSettingMapping {
 	contribute(configurationService: IConfigurationService): IAgentHostManagedSettingsPermissions | undefined;
 }
 
-function managedPermissionsSetting<T>(settingId: string, transform: (configuration: IInspectedValue<T>) => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
+function managedPermissionsSetting<T>(settingId: string, transform: (value: T, source: 'policyValue' | 'userValue' | 'applicationValue') => IAgentHostManagedSettingsPermissions | undefined): IManagedPermissionsSettingMapping {
 	return {
 		settingId,
 		contribute: configurationService => {
 			const configuration = inspectValue<T>(configurationService, settingId);
-			return configuration === undefined ? undefined : transform(configuration);
+			return configuration === undefined ? undefined : transform(...configuration);
 		},
 	};
 }
 
 /** Compatibility mappings for legacy settings only; new controls belong directly in the SDK. */
 const managedPermissionsSettings: readonly IManagedPermissionsSettingMapping[] = [
-	managedPermissionsSetting<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, ({ value, source }) => source === 'policy' && value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
-	managedPermissionsSetting<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, ({ value }) => value === false ? { ask: ['Shell'] } : undefined),
+	managedPermissionsSetting<boolean>(GLOBAL_AUTO_APPROVE_SETTING_ID, (value, source) => source === 'policyValue' && value === false ? { disableBypassPermissionsMode: 'disable' } : undefined),
+	managedPermissionsSetting<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, value => value === false ? { ask: ['Shell'] } : undefined),
 ];
 
 export const managedPermissionsConfigurationIds = [

--- a/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
@@ -110,8 +110,8 @@ suite('AgentHostConfigurationSync', () => {
 			inspectValue(malformedUserFallsBack, ALL_HOSTS_SETTING),
 			inspectValue(defaultOnly, ALL_HOSTS_SETTING),
 		], [
-			{ value: false, source: 'policy' },
-			{ value: false, source: 'application' },
+			[false, 'policyValue'],
+			[false, 'applicationValue'],
 			undefined,
 		]);
 	});

--- a/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts
@@ -8,7 +8,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { IConfigurationService, IConfigurationValue } from '../../../configuration/common/configuration.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../../registry/common/platform.js';
-import { getAgentHostConfigurationSyncEntries, getExplicitGlobalConfigurationValue, getGlobalConfigurationValue, resolveAgentHostConfigurationSyncPatch } from '../../common/agentHostConfigurationSync.js';
+import { getAgentHostConfigurationSyncEntries, getGlobalConfigurationValue, inspectValue, resolveAgentHostConfigurationSyncPatch } from '../../common/agentHostConfigurationSync.js';
 
 const ALL_HOSTS_SETTING = 'test.agentHostSync.allHosts';
 const LOCAL_ONLY_SETTING = 'test.agentHostSync.localOnly';
@@ -106,10 +106,14 @@ suite('AgentHostConfigurationSync', () => {
 		});
 
 		assert.deepStrictEqual([
-			getExplicitGlobalConfigurationValue(policyWins, ALL_HOSTS_SETTING),
-			getExplicitGlobalConfigurationValue(malformedUserFallsBack, ALL_HOSTS_SETTING),
-			getExplicitGlobalConfigurationValue(defaultOnly, ALL_HOSTS_SETTING),
-		], [false, false, undefined]);
+			inspectValue(policyWins, ALL_HOSTS_SETTING),
+			inspectValue(malformedUserFallsBack, ALL_HOSTS_SETTING),
+			inspectValue(defaultOnly, ALL_HOSTS_SETTING),
+		], [
+			{ value: false, source: 'policy' },
+			{ value: false, source: 'application' },
+			undefined,
+		]);
 	});
 
 	test('builds a patch applying transforms, including for hidden settings', () => {

--- a/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostManagedSettings.test.ts
@@ -22,7 +22,7 @@ suite('AgentHostManagedSettings', () => {
 	test('combines restrictive contributions from explicitly configured global values', () => {
 		const configurationService = createConfigurationService({
 			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, userValue: true },
-			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, applicationValue: false },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, policyValue: false },
 			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: { defaultValue: true, userValue: false },
 		});
 
@@ -40,6 +40,22 @@ suite('AgentHostManagedSettings', () => {
 		});
 
 		assert.deepStrictEqual(resolveManagedSettingsPermissions(configurationService), {});
+	});
+
+	test('does not promote user or application preferences to managed bypass restrictions', () => {
+		const userConfigurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, userValue: true },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, userValue: false },
+		});
+		const applicationConfigurationService = createConfigurationService({
+			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: { defaultValue: false, userValue: true },
+			[GLOBAL_AUTO_APPROVE_SETTING_ID]: { defaultValue: false, applicationValue: false },
+		});
+
+		assert.deepStrictEqual([
+			resolveManagedSettingsPermissions(userConfigurationService),
+			resolveManagedSettingsPermissions(applicationConfigurationService),
+		], [{}, {}]);
 	});
 
 	test('does not map legacy settings while the compatibility bridge is disabled', () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -184,6 +184,24 @@ class TerminalAutoApproveConfigurationService extends TestConfigurationService {
 	}
 }
 
+class ManagedPermissionsConfigurationService extends TestConfigurationService {
+	private globalAutoApprovePolicyValue: boolean | undefined = false;
+
+	override inspect<T>(key: string): IConfigurationValue<T> {
+		if (key === GLOBAL_AUTO_APPROVE_SETTING_ID) {
+			return {
+				...super.inspect<T>(key),
+				policyValue: this.globalAutoApprovePolicyValue as T | undefined,
+			};
+		}
+		return super.inspect<T>(key);
+	}
+
+	clearGlobalAutoApprovePolicy(): void {
+		this.globalAutoApprovePolicyValue = undefined;
+	}
+}
+
 suite('RemoteAgentHostProtocolClient', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -961,9 +979,8 @@ suite('RemoteAgentHostProtocolClient', () => {
 	});
 
 	test('forwards and clears legacy managed permissions for the local host', async () => {
-		const configurationService = new TestConfigurationService({
+		const configurationService = new ManagedPermissionsConfigurationService({
 			[AgentHostMapLegacySettingsToManagedSettingsSettingId]: true,
-			[GLOBAL_AUTO_APPROVE_SETTING_ID]: false,
 			[TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID]: false,
 		});
 		const { client, transport } = createClientForIdentity(
@@ -989,6 +1006,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		});
 
 		transport.sentMessages.length = 0;
+		configurationService.clearGlobalAutoApprovePolicy();
 		await configurationService.setUserConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID, true);
 		fireConfigurationChange(configurationService, GLOBAL_AUTO_APPROVE_SETTING_ID);
 		await configurationService.setUserConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, true);


### PR DESCRIPTION
## Summary

- preserve the source layer when inspecting legacy global settings
- only map `chat.tools.global.autoApprove: false` to the SDK bypass restriction when it comes from enterprise policy
- keep user and application preferences from becoming enterprise-strength managed restrictions

## Validation

- `npm run transpile-client`
- targeted Agent Host configuration and managed-settings tests (15 passing)
- pre-commit hygiene