### PR TITLE
sessions: hide secondary changes actions

### DIFF
--- a/src/vs/platform/actions/browser/buttonbar.ts
+++ b/src/vs/platform/actions/browser/buttonbar.ts
@@ -38,6 +38,7 @@ export interface IWorkbenchButtonBarOptions {
 	buttonConfigProvider?: IButtonConfigProvider;
 	small?: boolean;
 	disableWhileRunning?: boolean;
+	renderSecondaryActions?: boolean;
 }
 
 export class WorkbenchButtonBar extends ButtonBar {
@@ -90,7 +91,10 @@ export class WorkbenchButtonBar extends ButtonBar {
 		// Support instant hover between buttons
 		const hoverDelegate = this._updateStore.add(createInstantHoverDelegate());
 
-		for (let i = 0; i < actions.length; i++) {
+		const actionCount = this._options?.renderSecondaryActions === false
+			? Math.min(actions.length, 1)
+			: actions.length;
+		for (let i = 0; i < actionCount; i++) {
 
 			const secondary = i > 0;
 			const actionOrSubmenu = actions[i];
@@ -209,7 +213,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 			}));
 		}
 
-		if (secondary.length > 0) {
+		if (this._options?.renderSecondaryActions !== false && secondary.length > 0) {
 
 			const btn = this.addButton({
 				secondary: true,

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -174,6 +174,7 @@ class ChangesMenuWorkbenchButtonBarWidget extends Disposable implements IChanges
 				MenuId.AgentsChangesToolbar,
 				{
 					telemetrySource: 'changesView',
+					renderSecondaryActions: false,
 					menuOptions: sessionResource
 						? { arg: sessionResource }
 						: { shouldForwardArgs: true },
@@ -291,6 +292,7 @@ class ChangesWorkbenchButtonBarWidget extends Disposable implements IChangesButt
 			container,
 			{
 				telemetrySource: 'changesView',
+				renderSecondaryActions: false,
 				buttonConfigProvider: (action, index) => {
 					return index === 0
 						? { showIcon: false, showLabel: true, customLabel: stripIcons(action.label) }


### PR DESCRIPTION
## Summary
- add an opt-out for rendering secondary Workbench button bar actions
- configure the Changes action bar to show only its primary action
- preserve the existing secondary-action code for future use

## Validation
- validation deferred to CI as requested