### PR TITLE
fix: raise mocha timeout for AgentSdkDownloader tests (build fix for vscode-engineering#3401)

### DIFF
--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -179,7 +179,13 @@ suite('resolveSdkTarget', () => {
  * These run against whatever `process.platform` the test host is — the
  * pure `resolveSdkTarget` suite above covers the cross-host matrix.
  */
-suite('AgentSdkDownloader', () => {
+suite('AgentSdkDownloader', function () {
+
+	// These tests do real HTTP downloads and gzip tar extraction against a
+	// loopback server. On Windows CI that work regularly exceeds mocha's
+	// 2000ms default and produces flaky timeouts, so give the whole suite
+	// headroom (the cancel test opts into an even longer timeout locally).
+	this.timeout(20_000);
 
 	const disposables = new DisposableStore();
 	teardown(() => disposables.clear());


### PR DESCRIPTION
## Build failure

The Windows `Run unit tests (node.js)` stage failed because several node.js
unit tests in `vs/platform/agentHost/test/node/` exceeded mocha's default
2000ms timeout, e.g.:

- `AgentSdkDownloader loadSdkRoot: reports monotonic download progress ending at totalBytes`
- `AgentSdkDownloader loadSdkRoot: cache hit returns immediately without re-downloading`
- `AgentSdkDownloader loadSdkRoot: cache dir includes sdkTarget so Universal launches stay separate`
- `AgentSdkDownloader loadSdkRoot: concurrent calls in same process share one download`

Error: `Timeout of 2000ms exceeded. (vs/platform/agentHost/test/node/agentSdkDownloader.test)`

## Root cause

The `AgentSdkDownloader` integration suite exercises the real
network → cache → extract flow: each test spins up a loopback HTTP server,
downloads a gzip tarball, and extracts it to disk via `tar`. That work
routinely takes longer than mocha's 2000ms default on Windows CI (disk
I/O, AV scanning, and gzip extraction are all slower there), so the tests
flake with timeouts even though no product code changed. The suite ran on
the default timeout with no explicit headroom; only the long-running
"cancel before download completes" test opted into a longer timeout locally.

The sibling `SessionDatabase initialization retries after a transient
initialization failure` test already carries an explicit `.timeout(10_000)`
on `main`, so no change is needed there.

## How the fix works

Adds a suite-level `this.timeout(20_000)` to the `AgentSdkDownloader`
integration suite by converting the suite callback to a `function`
expression (so `this` binds to the mocha suite context). This applies to
every test in the suite while preserving the existing per-test
`this.timeout(15_000)` override on the cancellation test. The change is
test-only and does not alter any production behavior, telemetry, or error
handling.

## Validation

Static/source inspection only. The environment available to this change
cannot run the VS Code node.js unit-test suite (`scripts/test.sh`) to
completion, so the timeout increase was verified by source review: the
suite now propagates a 20s timeout to all of its tests via mocha's
suite-level `this.timeout`, matching the established pattern used by other
long-running suites in this directory (e.g.
`copilotSdkImportSession.integrationTest.ts`).

## Risk

Very low. The change only raises the allowed wall-clock time for existing
tests; it cannot mask a real product regression because these tests still
assert the same behavior and will still fail if the downloader misbehaves.
A genuinely hung download is still caught by the dedicated cancellation
test and CI's overall job timeout.

## Recommended reviewer

Recommended owner: `@Giuspepe`

Fixes microsoft/vscode-engineering#3401




> Generated by [build-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31545923230) · opus48 · 270.1 AIC · ⌖ 17.8 AIC · ⊞ 11.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-id%3A+build-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: build-fix, engine: copilot, model: claude-opus-4.8, id: 31545923230, workflow_id: build-fix, run: https://github.com/microsoft/vscode-engineering/actions/runs/31545923230 -->

<!-- gh-aw-workflow-id: build-fix -->
<!-- gh-aw-workflow-call-id: microsoft/vscode-engineering/build-fix -->