### PR TITLE
fix: keep markdown preview copy button visible while scrolling code blocks

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -434,10 +434,20 @@ pre {
 }
 
 /* Code block copy button */
+
+pre:not(.hljs).has-code-block-copy-button {
+	overflow: visible;
+}
+
+pre:not(.hljs).has-code-block-copy-button > code {
+	display: block;
+	overflow: auto;
+}
+
 .code-block-copy-button {
-	position: absolute;
+	position: sticky;
 	top: 8px;
-	right: 8px;
+	margin: -8px -8px -20px auto;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -446,7 +456,7 @@ pre {
 	padding: 0;
 	border: 1px solid var(--vscode-widget-border, rgba(127, 127, 127, 0.35));
 	border-radius: 4px;
-	background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+	background-color: var(--vscode-editorWidget-background, var(--vscode-editor-background));
 	color: var(--vscode-editor-foreground);
 	cursor: pointer;
 	opacity: 0;
@@ -458,12 +468,13 @@ pre:hover > .code-block-copy-button,
 	opacity: 1;
 }
 
+/* The toolbar colors are semi transparent, so they are layered over the fill instead of replacing it */
 .code-block-copy-button:hover {
-	background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+	background-image: linear-gradient(var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31)) 0 0);
 }
 
 .code-block-copy-button:active {
-	background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+	background-image: linear-gradient(var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31)) 0 0);
 }
 
 .code-block-copy-button.copied {

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -266,7 +266,9 @@ function addCodeBlockCopyButtons() {
 					}
 				}
 			});
-			pre.appendChild(button);
+			// Must come before the code so that the sticky button starts at the top of the code block
+			pre.prepend(button);
+			pre.classList.add('has-code-block-copy-button');
 		}
 	}
 }


### PR DESCRIPTION
Before this commit, the copy button scrolled away with the top of the code block. On a block taller than the preview there was no way to copy from the middle or the end of it without scrolling back up to where the block starts.

After this commit, the button stays in view while any part of the block is on screen and leaves once the block is scrolled past. It also stays in the corner when a block is scrolled sideways, and no longer lets code show through it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix: https://github.com/microsoft/vscode/issues/330385
