### PR TITLE
agentHost: fix stale sandbox expectation in peer chat test

### DIFF
--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3831,8 +3831,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('peer chat observes auto-approve/permissions identically to the initial chat', async () => {
+			const sandbox = { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On };
 			const options = {
-				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },
+				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: sandbox },
 				configValues: {
 					[SessionConfigKey.Mode]: 'autopilot',
 					[SessionConfigKey.AutoApprove]: 'default',
@@ -3857,11 +3858,7 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(summarize(peerMockSession), summarize(initialMockSession));
 			assert.deepStrictEqual(summarize(peerMockSession), {
 				permissionModes: ['off'],
-				sandbox: {
-					enabled: true,
-					allowBypass: true,
-					userPolicy: { filesystem: {}, network: { allowOutbound: false } },
-				},
+				sandbox: buildSandboxConfigForSdk('linux', sandbox),
 			});
 		});
 


### PR DESCRIPTION
`main` is currently red on every platform, which blocks unrelated PRs.

#330146 changed `buildSandboxConfigForSdk` so a plain enabled sandbox no longer
carries `allowBypass` / `userPolicy`, and updated its sandbox assertions to compare
against the helper rather than a hardcoded literal. One assertion in
`copilotAgentSession.test.ts` was missed and still expects the old shape:

``
+ expected - actual
   "sandbox": {
+    "allowBypass": true
     "enabled": true
+    "userPolicy": { "filesystem": {}, "network": { "allowOutbound": false } }
   }
``

The test harness pins the platform to `'linux'` for determinism, so this fails
everywhere rather than being platform-specific.

This compares against the helper, exactly as the other sandbox assertions in this
file already do.

Verified locally: `CopilotAgentSession` suite is 306 passing / 0 failing (was 1 failing).

cc @dileepyavan
