### PR TITLE
Avoid unhandled IPC cleanup rejections

### DIFF
--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -131,14 +131,15 @@ export class Client implements IChannelClient, IDisposable {
 		const disposable = toDisposable(() => result.cancel());
 		this.activeRequests.add(disposable);
 
-		result.finally(() => {
+		const cleanup = () => {
 			cancellationTokenListener.dispose();
 			this.activeRequests.delete(disposable);
 
 			if (this.activeRequests.size === 0 && this.disposeDelayer) {
 				this.disposeDelayer.trigger(() => this.disposeClient());
 			}
-		});
+		};
+		result.then(cleanup, cleanup);
 
 		return result;
 	}

--- a/src/vs/base/parts/ipc/test/node/ipc.cp.integrationTest.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.cp.integrationTest.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../common/async.js';
 import { Event } from '../../../../common/event.js';
 import { IChannel } from '../../common/ipc.js';
 import { Client } from '../../node/ipc.cp.js';
@@ -67,5 +68,10 @@ suite('IPC, Child Process', function () {
 		const answer_2 = await service.marco();
 		assert.strictEqual(answer_2, 'polo');
 		assert.strictEqual(count, 2);
+	});
+
+	test('rejected call does not cause an unhandled rejection', async () => {
+		await assert.rejects(channel.call('unknown'), /command not found: unknown/);
+		await timeout(0);
 	});
 });


### PR DESCRIPTION
This fixes the duplicate unhandled rejection created by child-process IPC request cleanup.

`Client.requestPromise` now runs cleanup through fulfillment and rejection handlers while returning the original promise unchanged, so callers still receive every IPC error. A focused integration test verifies that a handled non-cancellation rejection does not surface globally.

Fixes #330507

## Testing

- `npm run transpile-client`
- `scripts\test-integration.bat --run src\vs\base\parts\ipc\test\node\ipc.cp.integrationTest.ts`
