### PR TITLE
agentHost: archive a session without restoring it

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionActions.ts
+++ b/src/vs/platform/agentHost/common/state/sessionActions.ts
@@ -101,36 +101,37 @@ export type NotificationType = typeof NotificationType[keyof typeof Notification
 // ---- Local aliases for short names ------------------------------------------
 // Consumers use these shorter names; they're type-only aliases.
 
-import type {
-	RootAgentsChangedAction,
-	RootActiveSessionsChangedAction,
-	ChatDeltaAction,
-	ChatReasoningAction,
-	ChatResponsePartAction,
-	ChatToolCallApprovedAction,
-	ChatToolCallCompleteAction,
-	ChatToolCallConfirmedAction,
-	ChatToolCallDeniedAction,
-	ChatToolCallDeltaAction,
-	ChatToolCallReadyAction,
-	ChatToolCallResultConfirmedAction,
-	ChatToolCallStartAction,
-	SessionTitleChangedAction,
-	ChatTurnCancelledAction,
-	ChatTurnCompleteAction,
-	ChatTurnStartedAction,
-	ChatErrorAction,
-	ChatUsageAction,
-	ChatToolCallContentChangedAction,
-	StateAction,
-	ChatPendingMessageSetAction,
-	ChatPendingMessageRemovedAction,
-	ChatQueuedMessagesReorderedAction,
-	SessionIsReadChangedAction,
-	SessionIsArchivedChangedAction,
-	SessionWorkingDirectorySetAction,
-	SessionWorkingDirectoryRemovedAction,
-	RootConfigChangedAction,
+import {
+	ActionType,
+	type RootAgentsChangedAction,
+	type RootActiveSessionsChangedAction,
+	type ChatDeltaAction,
+	type ChatReasoningAction,
+	type ChatResponsePartAction,
+	type ChatToolCallApprovedAction,
+	type ChatToolCallCompleteAction,
+	type ChatToolCallConfirmedAction,
+	type ChatToolCallDeniedAction,
+	type ChatToolCallDeltaAction,
+	type ChatToolCallReadyAction,
+	type ChatToolCallResultConfirmedAction,
+	type ChatToolCallStartAction,
+	type SessionTitleChangedAction,
+	type ChatTurnCancelledAction,
+	type ChatTurnCompleteAction,
+	type ChatTurnStartedAction,
+	type ChatErrorAction,
+	type ChatUsageAction,
+	type ChatToolCallContentChangedAction,
+	type StateAction,
+	type ChatPendingMessageSetAction,
+	type ChatPendingMessageRemovedAction,
+	type ChatQueuedMessagesReorderedAction,
+	type SessionIsReadChangedAction,
+	type SessionIsArchivedChangedAction,
+	type SessionWorkingDirectorySetAction,
+	type SessionWorkingDirectoryRemovedAction,
+	type RootConfigChangedAction,
 } from './protocol/actions.js';
 
 import type { SessionAddedParams, SessionRemovedParams, SessionSummaryChangedParams, ProgressParams, AuthRequiredParams } from './protocol/notifications.js';
@@ -212,6 +213,15 @@ export function isRootAction(action: StateAction): action is RootAction {
 
 export function isSessionAction(action: StateAction): action is SessionAction {
 	return action.type.startsWith('session/');
+}
+
+/**
+ * Whether an action sets a durable session-catalog flag: state describing the
+ * session's list entry rather than its conversation. Applying one needs no
+ * loaded session, and every root-catalog subscriber must see it.
+ */
+export function isSessionCatalogFlagAction(action: StateAction): action is IIsArchivedChangedAction | IIsReadChangedAction {
+	return action.type === ActionType.SessionIsArchivedChanged || action.type === ActionType.SessionIsReadChanged;
 }
 
 export function isChatAction(action: StateAction): action is ChatAction {

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -10,7 +10,7 @@ import { equals } from '../../../base/common/objects.js';
 import { ILogService } from '../../log/common/log.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { TelemetryLevel } from '../../telemetry/common/telemetry.js';
-import { ActionType, ActionEnvelope, ActionOrigin, INotification, IRootConfigChangedAction, SessionAction, ChatAction, RootAction, StateAction, TerminalAction, ChangesetAction, ClientChangesetAction, AnnotationsAction, ClientAnnotationsAction, isRootAction, isSessionAction, isChatAction, isChangesetAction, isAnnotationsAction, type AuthRequiredParams, type ProgressParams } from '../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, ActionOrigin, INotification, IRootConfigChangedAction, SessionAction, ChatAction, RootAction, StateAction, TerminalAction, ChangesetAction, ClientChangesetAction, AnnotationsAction, ClientAnnotationsAction, isRootAction, isSessionAction, isChatAction, isChangesetAction, isAnnotationsAction, isSessionCatalogFlagAction, type AuthRequiredParams, type ProgressParams } from '../common/state/sessionActions.js';
 import type { IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { rootReducer, sessionReducer, chatReducer, changesetReducer, annotationsReducer } from '../common/state/sessionReducers.js';
 import { createRootState, createSessionState, createChatState, createDefaultChatSummary, chatSummaryFromState, buildDefaultChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, isAhpChatChannel, isDefaultChatUri, mergeSessionWithDefaultChat, isAhpRootChannel, SessionLifecycle, withHostBuildInfo, type Changeset, type ChangesetState, type AnnotationsState, type ChatState, type ChatSummary, type Customization, type ISessionWithDefaultChat, type Message, type RootState, type SessionConfigState, type SessionMeta, type SessionState, type SessionSummary, type Turn, type URI, ROOT_STATE_URI, ChangesetStatus, IHostBuildInfo, SessionStatus } from '../common/state/sessionState.js';
@@ -1462,6 +1462,9 @@ export class AgentHostStateManager extends Disposable {
 				}
 
 				resultingState = newState;
+			} else if (isSessionCatalogFlagAction(sessionAction)) {
+				// No conversation state to reduce; the emitted envelope carries the flag.
+				this._logService.trace(`[AgentHostStateManager] Catalog flag for unloaded session: ${key}, type=${action.type}`);
 			} else if (!isAhpChatChannel(key)) {
 				this._logService.warn(`[AgentHostStateManager] Action for unknown session: ${key}, type=${action.type}`);
 			}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -29,7 +29,7 @@ import { IAgentEditAttributionService, ICancelEditAttributionFlushParams, ICommi
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import type { IAgentCustomizationSettingsRegistration } from '../common/agentCustomizationSettings.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
-import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, isSessionAction, type ChatAction, type IRootConfigChangedAction, type SessionAction, type SessionWorkingDirectoryAction, type TerminalAction, type ClientAnnotationsAction, type ClientChangesetAction } from '../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, isSessionAction, isSessionCatalogFlagAction, type ChatAction, type IRootConfigChangedAction, type SessionAction, type SessionWorkingDirectoryAction, type TerminalAction, type ClientAnnotationsAction, type ClientChangesetAction } from '../common/state/sessionActions.js';
 import { resolveSessionWorkingDirectoryAction } from '../common/state/sessionWorkingDirectories.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult, SessionConfigPropertySchema } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
@@ -3193,7 +3193,9 @@ export class AgentService extends Disposable implements IAgentService {
 		// lookup, telemetry, permissions — all keyed by session).
 		const chatChannel = isAhpChatChannel(channel) ? channel : undefined;
 		const sessionChannel = chatChannel ? parseRequiredSessionUriFromChatUri(chatChannel) : channel;
-		const requiresSessionRestore = (chatChannel !== undefined || isSessionAction(action)) && !this._stateManager.getSessionState(sessionChannel);
+		// Restoring just to set a catalog flag fails when the working directory is gone.
+		const appliesWithoutSession = chatChannel === undefined && isSessionCatalogFlagAction(action);
+		const requiresSessionRestore = (chatChannel !== undefined || isSessionAction(action)) && !appliesWithoutSession && !this._stateManager.getSessionState(sessionChannel);
 		const requiresPeerResolution = chatChannel !== undefined && !this._stateManager.getChatState(chatChannel);
 		const requiresTurnOwnerResolution = action.type === ActionType.ChatTurnStarted && (requiresSessionRestore || (this._getUnresolvedPeerChats(sessionChannel)?.length ?? 0) > 0);
 		const requiresAttachmentRewrite = this._needsAsyncRewrite(sessionChannel, action);

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -22,7 +22,7 @@ import { type IAgentService } from '../common/agentService.js';
 import { isActionEnvelopeRelevantToSubscriptionUris } from '../common/state/agentSubscription.js';
 import { ChatSourceKind } from '../common/state/protocol/channels-chat/commands.js';
 import type { CommandMap } from '../common/state/protocol/messages.js';
-import { ActionEnvelope, ActionType, INotification, isAnnotationsAction, isChangesetAction, isChatAction, isSessionAction, isTerminalAction, type ChatAction, type ClientAnnotationsAction, type ClientChangesetAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
+import { ActionEnvelope, ActionType, INotification, isAnnotationsAction, isChangesetAction, isChatAction, isSessionAction, isSessionCatalogFlagAction, isTerminalAction, type ChatAction, type ClientAnnotationsAction, type ClientChangesetAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 import { negotiateProtocolVersion } from '../common/state/protocol/version/negotiation.js';
 import { VSCODE_UPGRADE_METHOD, type UnsupportedProtocolVersionErrorDataEx } from '../common/state/protocolUpgrade.js';
@@ -1765,10 +1765,24 @@ export class ProtocolServerHandler extends Disposable {
 		if (sub?.kind === ChannelKind.State || sub?.kind === ChannelKind.ResourceWatch) {
 			return true;
 		}
+		// Catalog flags change the root list entry, so they reach every catalog
+		// subscriber — including for a session no client has loaded.
+		if (isSessionCatalogFlagAction(envelope.action) && this._isSubscribedToRoot(client)) {
+			return true;
+		}
 		if (!isAhpRootChannel(envelope.channel)) {
 			return false;
 		}
 		return isActionEnvelopeRelevantToSubscriptionUris(envelope, this._stateAndResourceWatchUris(client));
+	}
+
+	private _isSubscribedToRoot(client: IConnectedClient): boolean {
+		for (const uri of this._stateAndResourceWatchUris(client)) {
+			if (isAhpRootChannel(uri)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private *_stateAndResourceWatchUris(client: IConnectedClient): Iterable<string> {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -35,7 +35,7 @@ import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agent
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
+import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, AH_META_IS_ARCHIVED_DB_KEY, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { ChatInteractivity, type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -1324,6 +1324,34 @@ suite('AgentService (node dispatcher)', () => {
 				nextAction: { type: ActionType.SessionTitleChanged, title: 'Updated title' },
 			});
 			listener.dispose();
+		});
+
+		test('applies an archive flag to an unloaded session without restoring it', async () => {
+			const db = new TestSessionDatabase();
+			const svc = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			svc.registerProvider(agent);
+			// A session from an earlier host lifetime: known on disk but absent
+			// from state, exactly like one whose worktree has since been deleted.
+			const session = AgentSession.uri(agent.id, 'stale-session');
+			const envelopePromise = Event.toPromise(Event.filter(svc.onDidAction, envelope => envelope.origin?.clientSeq === 1));
+
+			svc.dispatchAction(session.toString(), { type: ActionType.SessionIsArchivedChanged, isArchived: true }, 'test-client', 1);
+			const envelope = await envelopePromise;
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				rejectionReason: envelope.rejectionReason,
+				action: envelope.action,
+				restored: svc.stateManager.getSessionState(session.toString()) !== undefined,
+				persisted: db.setMetadataCalls,
+			}, {
+				rejectionReason: undefined,
+				action: { type: ActionType.SessionIsArchivedChanged, isArchived: true },
+				restored: false,
+				persisted: [{ key: AH_META_IS_ARCHIVED_DB_KEY, value: 'true' }],
+			});
 		});
 
 		test('queues a working-directory mutation behind an earlier attachment rewrite from the same client', async () => {

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -473,6 +473,18 @@ suite('ProtocolServerHandler', () => {
 		assert.ok(turnStarted, 'should deliver actions after the initially missing state materializes');
 	});
 
+	test('delivers a catalog flag for an unloaded session to root-channel subscribers', () => {
+		// No client has the session loaded, so nobody is subscribed to its
+		// session channel — only the root catalog.
+		const transport = connectClient('client-1', ['ahp-root://']);
+		transport.sent.length = 0;
+
+		stateManager.dispatchClientAction(sessionUri, { type: ActionType.SessionIsArchivedChanged, isArchived: true }, { clientId: 'client-2', clientSeq: 1 });
+
+		const actions = findNotifications(transport.sent, 'action').map(message => (message.params as unknown as { action: { type: string; isArchived?: boolean } }).action);
+		assert.deepStrictEqual(actions, [{ type: ActionType.SessionIsArchivedChanged, isArchived: true }]);
+	});
+
 	test('ping responds before initialize', async () => {
 		const transport = new MockProtocolTransport();
 		disposables.add(transport);


### PR DESCRIPTION
Archiving a session in the Agents window could silently fail, and the session would reappear in the list later.

### What was happening

`session/isArchivedChanged` went through the generic session-action dispatch path, which restores an unloaded session before reducing the action. Restore fails when the session's working directory no longer exists, so the action was rejected before the host persisted `isArchived` — while the Agents window had already hidden the row optimistically. Nothing was written, so the session returned on the next list or reload.

Sessions whose worktrees have since been deleted are exactly the ones people archive most, so this hit the common case. From a debug log of one such batch, all 132 archive dispatches matched sessions whose restore failed this way.

### The change

Archive and read state describe a session's **catalog entry**, not its conversation: they carry no reducer state and are persisted from the emitted envelope. So they need no loaded session.

- `isSessionCatalogFlagAction` names that property in one place.
- `AgentService.dispatchAction` skips the restore for these actions on a session channel.
- `AgentHostStateManager` treats the unloaded case as an explicit traced branch instead of falling into the "Action for unknown session" warning.
- `ProtocolServerHandler._isRelevantToClient` routes these actions to root-channel subscribers.

Read state is included because it is the same host-owned flag, dispatched the same way and persisted by the same envelope observer — it had the identical latent failure.

### Why routing had to change too

Session-channel envelopes are delivered only to subscribers of that exact channel, and an unloaded session has none — so without this, an archive reached no other window until a full re-list. `root/sessionSummaryChanged` cannot cover it either: `SessionSummaryNotifier.flush` needs both a loaded summary and an announced baseline, neither of which exists for an unloaded session. The action itself is already a precise semantic delta that clients apply via `_handleIsArchivedChanged`, so the gap was purely routing. For loaded sessions, root subscribers now receive the action alongside the existing summary delta; both set the same observable, so it is idempotent.

### Testing

Two regression tests, each verified to fail without its corresponding fix:

- `agentService`: archiving a session absent from state is not rejected, does not restore it, and persists `isArchived`. Without the dispatch change it fails with `Session not found on backend` and nothing persisted — the exact signature from the log.
- `protocolServerHandler`: a root-only subscriber receives the archive for an unloaded session. Without the routing change it receives nothing.

511 tests pass across `agentService`, `agentSideEffects`, and `protocolServerHandler`; `typecheck-client`, `valid-layers-check`, and `hygiene` are clean.

### Not covered here

The Agents window still hides a row optimistically without reconciling a genuine rejection. This change removes the cause behind the reported failure, but that rollback gap remains and is worth a follow-up.

(Written by Copilot)
