### PR TITLE
Fix subagent edit placeholder merge isolation

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -9,7 +9,7 @@ import { Emitter, type Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import type { URI } from '../../../../../../base/common/uri.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
@@ -237,7 +237,6 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			// uses in the renderer (see PR #302863), and the subagent grouping matches on toolCallId.
 			const subAgentInvocationId = invocation.chatStreamToolCallId ?? invocation.callId ?? `subagent-${generateUuid()}`;
 
-			let inEdit = false;
 			const progressCallback = (parts: IChatProgress[]) => {
 				for (const part of parts) {
 					// Usage events carry the subagent's running credit total; keep the
@@ -250,24 +249,23 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					}
 					// Write certain parts immediately to the model
 					if (part.kind === 'textEdit' || part.kind === 'notebookEdit' || part.kind === 'codeblockUri') {
-						if (part.kind === 'codeblockUri' && !inEdit) {
-							inEdit = true;
-							model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('```\n') });
-						}
 						// Attach subAgentInvocationId to codeblockUri parts so they can be routed to the subagent content part
 						if (part.kind === 'codeblockUri') {
+							const editBaseUri = URI.from({ scheme: 'vscode-subagent-edit', path: `/${subAgentInvocationId}/${generateUuid()}` });
+							const openingFence = new MarkdownString('```\n');
+							openingFence.baseUri = editBaseUri;
+							const closingFence = new MarkdownString('\n```\n\n');
+							closingFence.baseUri = editBaseUri;
+
+							model.acceptResponseProgress(request, { kind: 'markdownContent', content: openingFence });
 							model.acceptResponseProgress(request, { ...part, subAgentInvocationId });
+							model.acceptResponseProgress(request, { kind: 'markdownContent', content: closingFence });
 						} else {
 							model.acceptResponseProgress(request, part);
 						}
 					} else if (part.kind === 'hook') {
 						model.acceptResponseProgress(request, { ...part, subAgentInvocationId });
 					} else if (part.kind === 'markdownContent') {
-						if (inEdit) {
-							model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('\n```\n\n') });
-							inEdit = false;
-						}
-
 						// Collect markdown content for the tool result
 						markdownParts.push(part.content.value);
 					}

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -962,12 +962,17 @@ suite('RunSubagentTool', () => {
 				},
 			};
 			const request = { id: 'request-1' };
+			let undoStopCount = 0;
 			const mockChatService: Pick<IChatService, 'getSession'> = {
 				getSession() {
 					return {
 						getRequests: () => [request],
 						acceptResponseProgress: (_request: unknown, progress: IChatProgress) => {
 							acceptedProgress.push(progress);
+							if (progress.kind === 'codeblockUri' && progress.isEdit) {
+								// ChatModel.acceptResponseProgress adds an undo stop before every edit marker.
+								response.updateContent({ kind: 'undoStop', id: `undo-${++undoStopCount}` }, true);
+							}
 							if (progress.kind === 'markdownContent' || progress.kind === 'codeblockUri') {
 								response.updateContent(progress);
 							}

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
+import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../../../platform/log/common/log.js';
@@ -21,8 +23,9 @@ import { Target } from '../../../../common/promptSyntax/promptTypes.js';
 import { MockPromptsService } from '../../promptSyntax/service/mockPromptsService.js';
 import { ExtensionIdentifier } from '../../../../../../../platform/extensions/common/extensions.js';
 import { IToolInvocation, ToolProgress } from '../../../../common/tools/languageModelToolsService.js';
-import { IChatModel, IChatRequestModeInstructions } from '../../../../common/model/chatModel.js';
+import { IChatModel, IChatRequestModeInstructions, Response } from '../../../../common/model/chatModel.js';
 import { ChatConfiguration } from '../../../../common/constants.js';
+import { annotateSpecialMarkdownContent, extractCodeblockUrisFromText } from '../../../../common/widget/annotations.js';
 
 suite('RunSubagentTool', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -912,6 +915,168 @@ suite('RunSubagentTool', () => {
 					return true;
 				}
 			);
+		});
+	});
+
+	suite('edit progress rendering', () => {
+		const countTokens = async () => 0;
+		const noProgress: ToolProgress = { report() { } };
+
+		test('isolates interleaved edits and parent markdown into separate merge domains', async () => {
+			const response = testDisposables.add(new Response([]));
+			const firstEditEmitted = new DeferredPromise<void>();
+			const secondAgentEmitted = new DeferredPromise<void>();
+			const editUris = {
+				first: URI.parse('file:///workspace/first.ts'),
+				second: URI.parse('file:///workspace/second.ts'),
+				third: URI.parse('file:///workspace/third.ts'),
+			};
+			const acceptedProgress: IChatProgress[] = [];
+			const rawEditEmissions: { subAgentInvocationId: string; parts: IChatProgress[] }[] = [];
+			const emitEdit = (subAgentInvocationId: string, progress: (parts: IChatProgress[]) => void, uri: URI) => {
+				const start = acceptedProgress.length;
+				progress([{ kind: 'codeblockUri', uri, isEdit: true }]);
+				rawEditEmissions.push({ subAgentInvocationId, parts: acceptedProgress.slice(start) });
+			};
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const mockChatAgentService: Pick<IChatAgentService, 'getDefaultAgent' | 'invokeAgent'> = {
+				getDefaultAgent() {
+					return { id: 'default-agent' } as IChatAgentService extends { getDefaultAgent(...args: infer _A): infer R } ? NonNullable<R> : never;
+				},
+				async invokeAgent(_id: string, request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void): Promise<IChatAgentResult> {
+					const subAgentInvocationId = request.subAgentInvocationId;
+					if (!subAgentInvocationId) {
+						throw new Error('Expected a subagent invocation ID');
+					}
+					if (subAgentInvocationId === 'subagent-a') {
+						emitEdit(subAgentInvocationId, progress, editUris.first);
+						firstEditEmitted.complete();
+						await secondAgentEmitted.p;
+						emitEdit(subAgentInvocationId, progress, editUris.third);
+					} else {
+						await firstEditEmitted.p;
+						emitEdit(subAgentInvocationId, progress, editUris.second);
+						secondAgentEmitted.complete();
+					}
+					return {};
+				},
+			};
+			const request = { id: 'request-1' };
+			const mockChatService: Pick<IChatService, 'getSession'> = {
+				getSession() {
+					return {
+						getRequests: () => [request],
+						acceptResponseProgress: (_request: unknown, progress: IChatProgress) => {
+							acceptedProgress.push(progress);
+							if (progress.kind === 'markdownContent' || progress.kind === 'codeblockUri') {
+								response.updateContent(progress);
+							}
+						},
+					} as unknown as IChatModel;
+				},
+			};
+			const mockInstantiationService: Pick<IInstantiationService, 'createInstance'> = {
+				createInstance(..._args: never[]): { collect: () => Promise<void> } {
+					return { collect: async () => { } };
+				},
+			};
+			const tool = testDisposables.add(new RunSubagentTool(
+				mockChatAgentService as IChatAgentService,
+				mockChatService as IChatService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				new TestConfigurationService(),
+				new MockPromptsService(),
+				mockInstantiationService as IInstantiationService,
+				{} as IProductService,
+			));
+			const sessionResource = URI.parse('test://session/edit-progress');
+			const createInvocation = (callId: string): IToolInvocation => ({
+				callId,
+				chatStreamToolCallId: callId,
+				toolId: RunSubagentTool.Id,
+				parameters: { prompt: 'edit files', description: 'test edits' },
+				context: { sessionResource },
+				userSelectedTools: { runSubagent: true },
+			} as IToolInvocation);
+
+			await Promise.all([
+				tool.invoke(createInvocation('subagent-a'), countTokens, noProgress, CancellationToken.None),
+				tool.invoke(createInvocation('subagent-b'), countTokens, noProgress, CancellationToken.None),
+			]);
+			response.updateContent({ kind: 'markdownContent', content: new MarkdownString('```text\nparent output\n```\n') });
+
+			const rendered = annotateSpecialMarkdownContent(response.value);
+			const markdownParts = rendered.filter(part => part.kind === 'markdownContent');
+			const editParts = markdownParts
+				.map(part => ({ part, extracted: extractCodeblockUrisFromText(part.content.value) }))
+				.filter((entry): entry is typeof entry & { extracted: NonNullable<typeof entry.extracted> } => !!entry.extracted)
+				.sort((a, b) => a.extracted.uri.path.localeCompare(b.extracted.uri.path));
+			const mergeKeys = editParts.map(({ part }) => part.content.baseUri?.toString());
+			const normalizedRawEmissions = rawEditEmissions.map(emission => ({
+				subAgentInvocationId: emission.subAgentInvocationId,
+				parts: emission.parts.map(part => {
+					if (part.kind === 'markdownContent') {
+						const baseUri = part.content.baseUri ? URI.from(part.content.baseUri) : undefined;
+						return {
+							kind: part.kind,
+							value: part.content.value,
+							mergeKey: baseUri ? `${baseUri.scheme}:${baseUri.path.replace(/\/[0-9a-f-]{36}$/, '/<edit-uuid>')}` : undefined,
+						};
+					}
+					return part.kind === 'codeblockUri'
+						? { kind: part.kind, uri: part.uri.toString(), subAgentInvocationId: part.subAgentInvocationId }
+						: { kind: part.kind };
+				}),
+			}));
+
+			assert.deepStrictEqual({
+				rawEditEmissions: normalizedRawEmissions,
+				edits: editParts.map(({ part, extracted }) => ({
+					uri: extracted.uri.toString(),
+					subAgentInvocationId: extracted.subAgentInvocationId,
+					textWithoutMarker: extracted.textWithoutResult,
+					mergeKeyScheme: part.content.baseUri?.scheme,
+					mergeKeyPath: part.content.baseUri ? URI.from(part.content.baseUri).path.replace(/\/[0-9a-f-]{36}$/, '/<edit-uuid>') : undefined,
+				})),
+				uniqueMergeKeys: new Set(mergeKeys).size,
+				parentMarkdown: markdownParts.find(part => !extractCodeblockUrisFromText(part.content.value))?.content.value,
+			}, {
+				rawEditEmissions: [
+					{
+						subAgentInvocationId: 'subagent-a',
+						parts: [
+							{ kind: 'markdownContent', value: '```\n', mergeKey: 'vscode-subagent-edit:/subagent-a/<edit-uuid>' },
+							{ kind: 'codeblockUri', uri: editUris.first.toString(), subAgentInvocationId: 'subagent-a' },
+							{ kind: 'markdownContent', value: '\n```\n\n', mergeKey: 'vscode-subagent-edit:/subagent-a/<edit-uuid>' },
+						],
+					},
+					{
+						subAgentInvocationId: 'subagent-b',
+						parts: [
+							{ kind: 'markdownContent', value: '```\n', mergeKey: 'vscode-subagent-edit:/subagent-b/<edit-uuid>' },
+							{ kind: 'codeblockUri', uri: editUris.second.toString(), subAgentInvocationId: 'subagent-b' },
+							{ kind: 'markdownContent', value: '\n```\n\n', mergeKey: 'vscode-subagent-edit:/subagent-b/<edit-uuid>' },
+						],
+					},
+					{
+						subAgentInvocationId: 'subagent-a',
+						parts: [
+							{ kind: 'markdownContent', value: '```\n', mergeKey: 'vscode-subagent-edit:/subagent-a/<edit-uuid>' },
+							{ kind: 'codeblockUri', uri: editUris.third.toString(), subAgentInvocationId: 'subagent-a' },
+							{ kind: 'markdownContent', value: '\n```\n\n', mergeKey: 'vscode-subagent-edit:/subagent-a/<edit-uuid>' },
+						],
+					},
+				],
+				edits: [
+					{ uri: editUris.first.toString(), subAgentInvocationId: 'subagent-a', textWithoutMarker: '```\n\n```\n\n', mergeKeyScheme: 'vscode-subagent-edit', mergeKeyPath: '/subagent-a/<edit-uuid>' },
+					{ uri: editUris.second.toString(), subAgentInvocationId: 'subagent-b', textWithoutMarker: '```\n\n```\n\n', mergeKeyScheme: 'vscode-subagent-edit', mergeKeyPath: '/subagent-b/<edit-uuid>' },
+					{ uri: editUris.third.toString(), subAgentInvocationId: 'subagent-a', textWithoutMarker: '```\n\n```\n\n', mergeKeyScheme: 'vscode-subagent-edit', mergeKeyPath: '/subagent-a/<edit-uuid>' },
+				],
+				uniqueMergeKeys: 3,
+				parentMarkdown: '```text\nparent output\n```\n',
+			});
 		});
 	});
 


### PR DESCRIPTION
Fixes #303648

A subagent edit is rendered as an empty fenced Markdown block plus a `codeblockUri` marker. This change gives every such edit its own Markdown merge domain, so a subagent edit placeholder can no longer absorb the parent agent's later output.

## Root cause

`RunSubagentTool.progressCallback` kept an `inEdit` flag across progress callbacks. It emitted an unkeyed opening fence when the marker arrived, then waited for a later subagent `markdownContent` event to emit the closing fence.

The parent and all subagents write into one response, and an edit `codeblockUri` inserts an `undoStop` before the scoped URI. That leaves two ways for unrelated output to join the unkeyed placeholder:

- if the subagent already emitted the unkeyed closing fence, later parent Markdown merges with it in `Response.updateContent`, because both carry the default merge key;
- otherwise `annotateSpecialMarkdownContent` ignores the `undoStop` when locating the preceding renderable item, appends the URI marker to the unkeyed opening fence, moves that Markdown after the stop, and merges compatible later Markdown into the same block.

The renderer then routes the merged block by the first `subAgentInvocationId` it finds and extracts the first URI marker for code-block rendering, so the parent's code block is replaced by edit UI, or a later marker leaks as literal markup.

The file edit itself still succeeds, because `textEdit` and `notebookEdit` are forwarded independently of this Markdown path. That also explains the workaround reported on the issue: a later main-agent edit emits its own marker sequence, which flushes the pending placeholder before the code block renders.

Parent Markdown never passes through `RunSubagentTool.progressCallback`. It meets the placeholder only later, through the shared response and the annotation and rendering pipeline.

### Minimal trigger

Parallel subagents are not required. The bug reproduces when:

1. `runSubagent` invokes a subagent;
2. an edit tool emits `codeblockUri(uri, true)`;
3. the parent later emits merge-compatible Markdown, such as a fenced code block.

Parallel subagents and multiple edits only increase the number of markers that can collide.

```text
Before

A: open -> URI(A) ........ close
B:        open -> URI(B) ........ close
parent:                         fenced Markdown

shared merge domain -> markers and parent code can collapse into one block
```

## The fix

Every `codeblockUri` event now emits one synchronous, per-edit sequence:

```text
After

K = vscode-subagent-edit:/<subAgentInvocationId>/<fresh-uuid>

open(K) -> URI(subagent) -> close(K)

the next edit uses K2; parent Markdown has no edit key
K != K2 != parent merge domain
```

The three `acceptResponseProgress` calls run without an `await`, so another callback cannot interleave inside them. The opening and closing fences share one synthetic `baseUri`, and every edit gets a fresh UUID: a subagent-only key would still merge consecutive edits from the same subagent into one block. `textEdit`, `notebookEdit`, hook, usage and tool-result behavior are unchanged.

## Why this is a narrow path

This is not a general Markdown rendering failure. It requires the `runSubagent` edit-placeholder adapter and an edit `codeblockUri`. Direct main-agent edits, read-only subagents, and progress that never emits an edit URI marker do not take this path. The reported routing into the subagent container uses the collapsed-tools UI path (`chat.agent.thinking.collapsedTools`, default `always`); that routing was introduced in #290171.

## Testing

The regression test drives two concurrent subagent invocations in `A1 -> B1 -> A2` order, then appends a parent fenced code block. It asserts both layers of the contract: that raw progress is exactly `opening fence -> scoped codeblockUri -> closing fence` for every edit, and that the real response-merge and annotation pipeline yields three distinct edit blocks with the parent code block preserved unchanged.

- `npm run compile-client` — 0 errors
- `./scripts/test.sh --run vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.js` — 34 passing (33 `RunSubagentTool` tests plus the runner clean-state test)

Both were run on this branch after rebasing onto current `main`.
