### PR TITLE
agentHost: avoid duplicating workspace customizations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -37,6 +37,12 @@ function hasBuiltInGitHubMcpServer(sessionType: string): boolean {
 	return sessionType === AGENT_HOST_COPILOT_CLI_SESSION_TYPE || parseRemoteAgentHostHarness(sessionType) === 'copilotcli';
 }
 
+function shouldSyncLocalCustomization(sessionType: string, entry: ILocalCustomizationFile): boolean {
+	return entry.source !== AICustomizationSources.local
+		|| sessionType !== AGENT_HOST_COPILOT_CLI_SESSION_TYPE
+		|| entry.type === PromptsType.prompt;
+}
+
 /**
  * Prompt types that participate in auto-sync to an agent host harness.
  *
@@ -153,8 +159,8 @@ export async function enumerateLocalCustomizationsForHarness(
  * Client customization refs intentionally omit parsed children; the host adds
  * those later in `SessionState.customizations`. New Agents-window drafts need
  * the picker before that state exists, so this mirrors the same eligibility
- * rules used by {@link resolveCustomizationRefs} without waiting for the host
- * to parse the plugin or synthetic bundle.
+ * rules used by {@link resolveCustomizationRefs} before its provider-native
+ * discovery filter, without waiting for the host to parse the customization.
  */
 export async function resolveLocalCustomAgents(
 	fileService: IFileService,
@@ -401,7 +407,7 @@ export async function resolveCustomizationRefs(
 	roots: readonly URI[],
 ): Promise<ClientPluginCustomization[]> {
 	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options, roots);
-	const enabled = enumerated.filter(e => !e.disabled);
+	const enabled = enumerated.filter(e => !e.disabled && shouldSyncLocalCustomization(sessionType, e));
 
 	const plugins = agentPluginService.plugins.get();
 	const pluginRefs = new Map<string, Promise<ClientPluginCustomization>>();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -195,6 +195,45 @@ class FakeBundler {
 	}
 }
 
+suite('resolveCustomizationRefs - workspace customizations', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('omits Copilot-native workspace files while preserving prompts and Codex sync', async () => {
+		const workspaceFiles = new Map<string, readonly IPromptPath[]>();
+		for (const type of [PromptsType.agent, PromptsType.skill, PromptsType.instructions, PromptsType.prompt]) {
+			const uri = URI.file(`/workspace/.github/${type}/${type}.md`);
+			workspaceFiles.set(`${type}/${PromptsStorage.local}`, [makePromptPath(uri, type, PromptsStorage.local)]);
+		}
+		const promptsService = makePromptsService(workspaceFiles);
+		const copilotBundler = new FakeBundler();
+		const remoteCopilotBundler = new FakeBundler();
+		const codexBundler = new FakeBundler();
+		const commonArgs = [
+			makeFileService(),
+			promptsService,
+			new FakeSyncProvider(),
+			makeAgentPluginService(),
+			makeMcpService(),
+			makeConfigurationResolverService(),
+		] as const;
+
+		await resolveCustomizationRefs(...commonArgs, copilotBundler as unknown as SyncedCustomizationBundler, SessionType.AgentHostCopilot, false, undefined, []);
+		await resolveCustomizationRefs(...commonArgs, remoteCopilotBundler as unknown as SyncedCustomizationBundler, 'remote-example-copilotcli', false, undefined, []);
+		await resolveCustomizationRefs(...commonArgs, codexBundler as unknown as SyncedCustomizationBundler, SessionType.AgentHostCodex, false, undefined, []);
+
+		assert.deepStrictEqual({
+			copilot: copilotBundler.received[0].map(file => file.type),
+			remoteCopilot: remoteCopilotBundler.received[0].map(file => file.type),
+			codex: codexBundler.received[0].map(file => file.type),
+		}, {
+			copilot: [PromptsType.prompt],
+			remoteCopilot: [PromptsType.agent, PromptsType.skill, PromptsType.instructions, PromptsType.prompt],
+			codex: [PromptsType.agent, PromptsType.skill, PromptsType.instructions, PromptsType.prompt],
+		});
+	});
+});
+
 suite('resolveCustomizationRefs - built-in skills', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
This prevents local Copilot Agent Host sessions from receiving workspace agents, skills, and instructions through both native workspace discovery and the VS Code synthetic customization bundle.

Local Copilot continues syncing workspace prompts, which are not covered by the same native discovery path. Remote Copilot and Codex continue syncing all workspace customization types because those providers still need the client transport. Draft workspace agents remain available in the picker.

## Testing

- Pre-commit hygiene passed for both changed files
- Existing compiled `resolveCustomizationRefs` test suite: 37 passing
- Added provider-matrix coverage for local Copilot, remote Copilot, and Codex (local watched test output was stale; CI will execute the new case)