### PR TITLE
CI: make the Windows Electron download retry actually retry

### DIFF
--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -115,9 +115,12 @@ jobs:
       - name: Download Electron and Playwright
         shell: pwsh
         run: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+
           for ($i = 1; $i -le 3; $i++) {
             try {
-              npm exec -- npm-run-all2 -lp "electron ${{ env.VSCODE_ARCH }}" "playwright-install"
+              exec { npm exec -- npm-run-all2 -lp "electron ${{ env.VSCODE_ARCH }}" "playwright-install" }
               break
             }
             catch {


### PR DESCRIPTION
The Windows test workflow wraps the Electron/Playwright download in a 3-attempt retry loop, but the retry never fires.

`npm exec` is a native command, and a non-zero exit code from a native command does not raise a terminating error in PowerShell. So the `catch` block is unreachable: the first attempt falls straight through to `break`, and the step then fails on the non-zero exit code.

Seen on a PR run where a transient socket close while fetching Electron from `github.com` failed the job on its first attempt, with no retry:

```
TypeError: fetch failed
  cause: SocketError: other side closed (UND_ERR_SOCKET)
    remoteAddress: 140.82.112.3   # github.com
    bytesWritten: 243, bytesRead: 0
  at @vscode/gulp-electron/src/download.js
```

The log confirms only one attempt ran — there is a single `TypeError: fetch failed` and no `Download failed attempt 1, retrying...`.

## Fix

Wrap the call in `exec { }` from `build/azure-pipelines/win32/exec.ps1`, which checks `$lastexitcode` and throws. That is what makes `try`/`catch` work here, and it is exactly the shape the `npm ci` retry in this same file already uses — which is why that one retries correctly.

## Notes

- Linux and macOS are unaffected: their loops use `if npm exec ...; then`, which tests the exit code directly.
- This was the only PowerShell retry loop missing `exec { }`; the two `npm ci` loops (here and in `pr-node-modules.yml`) already use it.
