### PR TITLE
sessions: Log telemetry for every agent request

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -387,7 +387,9 @@ below.
 Every `onDidSendRequest` also emits `agents/requestSent`. The event distinguishes
 the first message in a new session (`isNewSession: true`, `isNewChat: true`), the
 first message in an additional chat (`false`, `true`), and a follow-up message in
-an existing chat (`false`, `false`).
+an existing chat (`false`, `false`). The shared chat submit event carries the
+submitted attachment context so mirrored follow-up telemetry retains the same
+attachment counts and kinds as requests sent through the sessions service.
 
 When fixing transient picker state during chat loading, keep the fallback in
 `ChatView`'s reactive session-type delegate; it announces the destination as

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -384,6 +384,11 @@ the sent chat the active chat by reacting to the send events. When
 visible slot into the sent chat — see _Adding a Chat to an Existing Session_
 below.
 
+Every `onDidSendRequest` also emits `agents/requestSent`. The event distinguishes
+the first message in a new session (`isNewSession: true`, `isNewChat: true`), the
+first message in an additional chat (`false`, `true`), and a follow-up message in
+an existing chat (`false`, `false`).
+
 When fixing transient picker state during chat loading, keep the fallback in
 `ChatView`'s reactive session-type delegate; it announces the destination as
 soon as `setChat` assigns it, and the rendered target picker and chat input

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
@@ -73,15 +73,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 			// `onDidSendNewChatRequest` fires.
 			this._startWorkspaceFileCountFetch(session.workspace.get());
 		}));
-		this._register(this._sessionsManagementService.onDidSendRequest(e => {
-			if (e.isNewChat) {
-				this._logNewChatRequestSent(e);
-			} else {
-				// Follow-up request within an existing chat: count it toward
-				// `requestsSent` without incrementing `chatCount`.
-				this._lifecycleTracker.recordRequestSent(e.session);
-			}
-		}));
+		this._register(this._sessionsManagementService.onDidSendRequest(e => this._logRequestSent(e)));
 		this._register(this._sessionsManagementService.onDidArchiveSession(session => this._logSessionArchived(session)));
 		this._register(this._sessionsManagementService.onDidUnarchiveSession(session => this._logSessionUnarchived(session)));
 		this._register(this._sessionsManagementService.onDidDeleteSession(session => this._logSessionDeleted(session)));
@@ -181,16 +173,20 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 
 	// -- event handlers --------------------------------------------------------
 
-	private _logNewChatRequestSent(e: ISendRequestSentEvent): void {
-		const { session, chat, isNewSession, options } = e;
+	private _logRequestSent(e: ISendRequestSentEvent): void {
+		const { session, chat, isNewSession, isNewChat, options } = e;
 
-		const wasTracked = this._lifecycleTracker.isTracked(session.sessionId);
-		this._lifecycleTracker.recordNewChatRequestSent(session);
-		if (!wasTracked) {
-			void this._sessionsTasksService.getAllTasks(session).then(tasks => {
-				const hasWorktreeCreatedTask = tasks.some(t => t.task.runOptions?.runOn === 'worktreeCreated');
-				this._lifecycleTracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask, configuredTasksCount: tasks.length });
-			});
+		if (isNewChat) {
+			const wasTracked = this._lifecycleTracker.isTracked(session.sessionId);
+			this._lifecycleTracker.recordNewChatRequestSent(session);
+			if (!wasTracked) {
+				void this._sessionsTasksService.getAllTasks(session).then(tasks => {
+					const hasWorktreeCreatedTask = tasks.some(t => t.task.runOptions?.runOn === 'worktreeCreated');
+					this._lifecycleTracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask, configuredTasksCount: tasks.length });
+				});
+			}
+		} else {
+			this._lifecycleTracker.recordRequestSent(session);
 		}
 
 		const allSessions = this._sessionsManagementService.getSessions();
@@ -203,6 +199,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 			: this._lifecycleTracker.getUserRequestCounters(session);
 		const sync = {
 			isNewSession,
+			isNewChat,
 			visibleSessionsCount,
 			...this._getRequestFields(options),
 			...this._getSessionFields(session),
@@ -807,6 +804,7 @@ type AllSessionsFields = {
 
 type SessionRequestSentEvent = {
 	isNewSession: boolean;
+	isNewChat: boolean;
 	visibleSessionsCount: number;
 	agentSessionId: string;
 	providerId: string;
@@ -870,6 +868,7 @@ type SessionRequestSentClassification = {
 	owner: 'benibenj';
 	comment: 'Reports when the user sends a request from a session in the Agents window, including the user state at the time of send.';
 	isNewSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'True when the request starts a brand-new session, false when it is a new or continued chat in an existing session.' };
+	isNewChat: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'True when the request is the first message in a newly created chat, including the first chat in a new session; false for a follow-up message in an existing chat.' };
 	visibleSessionsCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many sessions are currently visible in the sessions grid.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'SHA-1 hash of the globally unique session identifier, used to correlate events for the same session without exposing provider or resource details.' };
 	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bounded sessions provider category: default-copilot, local-agent-host, remote-agent-host, or other.' };

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ISearchService } from '../../../../../workbench/services/search/common/search.js';
+import { IAgentFeedbackService } from '../../../agentFeedback/browser/agentFeedbackService.js';
+import { ISessionsTasksService } from '../../../chat/browser/sessionsTasksService.js';
+import { ChatInteractivity, IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISendRequestSentEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsPartService } from '../../../../services/sessions/browser/sessionsPartService.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { SessionsTelemetryContribution } from '../../browser/sessionsTelemetry.contribution.js';
+
+interface IRequestSentTelemetry {
+	readonly isNewSession: boolean;
+	readonly isNewChat: boolean;
+}
+
+class TestTelemetryService extends NullTelemetryServiceShape {
+	readonly requestSentEvents: IRequestSentTelemetry[] = [];
+
+	override publicLog2(eventName?: string, data?: object): void {
+		if (
+			eventName === 'agents/requestSent'
+			&& data
+			&& 'isNewSession' in data
+			&& typeof data.isNewSession === 'boolean'
+			&& 'isNewChat' in data
+			&& typeof data.isNewChat === 'boolean'
+		) {
+			this.requestSentEvents.push({
+				isNewSession: data.isNewSession,
+				isNewChat: data.isNewChat,
+			});
+		}
+	}
+}
+
+const chat = {
+	resource: URI.parse('test:///chat'),
+	createdAt: new Date(),
+	title: constObservable('Chat'),
+	updatedAt: constObservable(new Date()),
+	status: constObservable(SessionStatus.Completed),
+	changes: constObservable([]),
+	checkpoints: constObservable(undefined),
+	modelId: constObservable(undefined),
+	mode: constObservable(undefined),
+	isArchived: constObservable(false),
+	isRead: constObservable(true),
+	interactivity: constObservable(ChatInteractivity.Full),
+	description: constObservable(undefined),
+	lastTurnEnd: constObservable(undefined),
+} satisfies IChat;
+
+const session = {
+	sessionId: 'session',
+	providerId: 'test',
+	resource: URI.parse('test:///session'),
+	sessionType: 'test',
+	icon: Codicon.vm,
+	createdAt: new Date(),
+	workspace: constObservable(undefined),
+	title: constObservable('Session'),
+	updatedAt: constObservable(new Date()),
+	status: constObservable(SessionStatus.Completed),
+	changesets: constObservable([]),
+	changes: constObservable([]),
+	modelId: constObservable(undefined),
+	mode: constObservable(undefined),
+	loading: constObservable(false),
+	isArchived: constObservable(false),
+	isRead: constObservable(true),
+	description: constObservable(undefined),
+	lastTurnEnd: constObservable(undefined),
+	chats: constObservable([chat]),
+	mainChat: constObservable(chat),
+	capabilities: constObservable({ supportsMultipleChats: true }),
+} satisfies ISession;
+
+suite('SessionsTelemetryContribution', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('logs requestSent for new sessions, new chats, and follow-up messages', async () => {
+		const onDidSendRequest = disposables.add(new Emitter<ISendRequestSentEvent>());
+		const sessionsManagementService = new class extends mock<ISessionsManagementService>() {
+			override readonly onWillSendRequest = Event.None;
+			override readonly onDidSendRequest = onDidSendRequest.event;
+			override readonly onDidArchiveSession = Event.None;
+			override readonly onDidUnarchiveSession = Event.None;
+			override readonly onDidDeleteSession = Event.None;
+			override readonly onDidDeleteChat = Event.None;
+			override readonly onDidRenameChat = Event.None;
+			override readonly onDidRenameSession = Event.None;
+			override readonly onDidChangeSessions = Event.None;
+			override getSessions(): ISession[] { return [session]; }
+		}();
+		const sessionsService = new class extends mock<ISessionsService>() {
+			override readonly visibleSessions = constObservable([]);
+			override readonly onDidToggleSessionStickiness = Event.None;
+		}();
+		const telemetryService = new TestTelemetryService();
+		const storageService = disposables.add(new InMemoryStorageService());
+		const commandService = new class extends mock<ICommandService>() {
+			override readonly onDidExecuteCommand = Event.None;
+		}();
+		const feedbackService = new class extends mock<IAgentFeedbackService>() {
+			override readonly onDidAddFeedback = Event.None;
+			override readonly onDidConvertFeedback = Event.None;
+			override readonly onDidAddReply = Event.None;
+			override readonly onDidSubmitFeedback = Event.None;
+		}();
+		const sessionsPartService = new class extends mock<ISessionsPartService>() {
+			override readonly onDidToggleMaximizeSession = Event.None;
+		}();
+		const providersService = new class extends mock<ISessionsProvidersService>() {
+			override readonly onDidChangeProviders = Event.None;
+			override getProviders() { return []; }
+		}();
+		const tasksService = new class extends mock<ISessionsTasksService>() {
+			override readonly onDidRunTask = Event.None;
+			override async getAllTasks() { return []; }
+		}();
+
+		disposables.add(new SessionsTelemetryContribution(
+			sessionsManagementService,
+			sessionsService,
+			telemetryService,
+			new class extends mock<IUriIdentityService>() { }(),
+			storageService,
+			new class extends mock<ISearchService>() { }(),
+			new class extends mock<IConfigurationService>() { }(),
+			commandService,
+			feedbackService,
+			sessionsPartService,
+			providersService,
+			tasksService,
+		));
+
+		onDidSendRequest.fire({ session, chat, isNewSession: true, isNewChat: true, options: { query: 'new session' } });
+		onDidSendRequest.fire({ session, chat, isNewSession: false, isNewChat: true, options: { query: 'new chat' } });
+		onDidSendRequest.fire({ session, chat, isNewSession: false, isNewChat: false, options: { query: 'follow up' } });
+		await Promise.resolve();
+
+		assert.deepStrictEqual(telemetryService.requestSentEvents, [
+			{ isNewSession: true, isNewChat: true },
+			{ isNewSession: false, isNewChat: true },
+			{ isNewSession: false, isNewChat: false },
+		]);
+	});
+});

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
@@ -30,18 +30,18 @@ interface IRequestSentTelemetry {
 	readonly isNewChat: boolean;
 }
 
+function isRequestSentTelemetry(data: unknown): data is IRequestSentTelemetry {
+	return typeof data === 'object'
+		&& data !== null
+		&& typeof Reflect.get(data, 'isNewSession') === 'boolean'
+		&& typeof Reflect.get(data, 'isNewChat') === 'boolean';
+}
+
 class TestTelemetryService extends NullTelemetryServiceShape {
 	readonly requestSentEvents: IRequestSentTelemetry[] = [];
 
-	override publicLog2(eventName?: string, data?: object): void {
-		if (
-			eventName === 'agents/requestSent'
-			&& data
-			&& 'isNewSession' in data
-			&& typeof data.isNewSession === 'boolean'
-			&& 'isNewChat' in data
-			&& typeof data.isNewChat === 'boolean'
-		) {
+	override publicLog2(eventName?: string, data?: unknown): void {
+		if (eventName === 'agents/requestSent' && isRequestSentTelemetry(data)) {
 			this.requestSentEvents.push({
 				isNewSession: data.isNewSession,
 				isNewChat: data.isNewChat,

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsTelemetry.contribution.test.ts
@@ -28,13 +28,17 @@ import { SessionsTelemetryContribution } from '../../browser/sessionsTelemetry.c
 interface IRequestSentTelemetry {
 	readonly isNewSession: boolean;
 	readonly isNewChat: boolean;
+	readonly totalAttachementCount: number;
+	readonly attachmentKinds: string;
 }
 
 function isRequestSentTelemetry(data: unknown): data is IRequestSentTelemetry {
 	return typeof data === 'object'
 		&& data !== null
 		&& typeof Reflect.get(data, 'isNewSession') === 'boolean'
-		&& typeof Reflect.get(data, 'isNewChat') === 'boolean';
+		&& typeof Reflect.get(data, 'isNewChat') === 'boolean'
+		&& typeof Reflect.get(data, 'totalAttachementCount') === 'number'
+		&& typeof Reflect.get(data, 'attachmentKinds') === 'string';
 }
 
 class TestTelemetryService extends NullTelemetryServiceShape {
@@ -45,6 +49,8 @@ class TestTelemetryService extends NullTelemetryServiceShape {
 			this.requestSentEvents.push({
 				isNewSession: data.isNewSession,
 				isNewChat: data.isNewChat,
+				totalAttachementCount: data.totalAttachementCount,
+				attachmentKinds: data.attachmentKinds,
 			});
 		}
 	}
@@ -153,13 +159,22 @@ suite('SessionsTelemetryContribution', () => {
 
 		onDidSendRequest.fire({ session, chat, isNewSession: true, isNewChat: true, options: { query: 'new session' } });
 		onDidSendRequest.fire({ session, chat, isNewSession: false, isNewChat: true, options: { query: 'new chat' } });
-		onDidSendRequest.fire({ session, chat, isNewSession: false, isNewChat: false, options: { query: 'follow up' } });
+		onDidSendRequest.fire({
+			session,
+			chat,
+			isNewSession: false,
+			isNewChat: false,
+			options: {
+				query: 'follow up',
+				attachedContext: [{ kind: 'generic', id: 'context', name: 'Context', value: 'value' }],
+			},
+		});
 		await Promise.resolve();
 
 		assert.deepStrictEqual(telemetryService.requestSentEvents, [
-			{ isNewSession: true, isNewChat: true },
-			{ isNewSession: false, isNewChat: true },
-			{ isNewSession: false, isNewChat: false },
+			{ isNewSession: true, isNewChat: true, totalAttachementCount: 0, attachmentKinds: '{}' },
+			{ isNewSession: false, isNewChat: true, totalAttachementCount: 0, attachmentKinds: '{}' },
+			{ isNewSession: false, isNewChat: false, totalAttachementCount: 1, attachmentKinds: '{"generic":1}' },
 		]);
 	});
 });

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -122,7 +122,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		// UI. Sends originating from {@link sendRequest} and
 		// {@link sendNewChatRequest} are deduplicated via
 		// {@link _pendingSendChatResources}.
-		this._register(this.chatService.onDidSubmitRequest(({ chatSessionResource, message }) => {
+		this._register(this.chatService.onDidSubmitRequest(({ chatSessionResource, message, attachedContext }) => {
 			if (this._pendingSendChatResources.has(chatSessionResource.toString())) {
 				return;
 			}
@@ -133,7 +133,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 					chat: ownedChat.chat,
 					isNewSession: false,
 					isNewChat: false,
-					options: { query: message?.text ?? '' },
+					options: { query: message?.text ?? '', attachedContext },
 				});
 			}
 		}));

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -24,7 +24,8 @@ import { InMemoryStorageService, IStorageService } from '../../../../../platform
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
-import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatRequestVariableEntry } from '../../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { IChatRequestSubmittedEvent, IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.js';
 import { IChatWidgetHistoryService } from '../../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
@@ -33,7 +34,7 @@ import { SessionTypeAuthRequirement, ChatInteractivity, ChatOriginKind, IChat, I
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionModelsSnapshot, ISessionModelPickerOptions, ISessionsProvider, ISessionsProviderCreateSessionOptions, ISessionWorktreeConfiguration } from '../../common/sessionsProvider.js';
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
-import { ISessionsManagementService, ICreateNewSessionOptions, inheritableSessionTarget, WorkspaceNotTrustedError } from '../../common/sessionsManagement.js';
+import { ISessionsManagementService, ICreateNewSessionOptions, inheritableSessionTarget, ISendRequestSentEvent, WorkspaceNotTrustedError } from '../../common/sessionsManagement.js';
 import { SessionsService } from '../../browser/sessionsService.js';
 import { ISessionsPartService } from '../../browser/sessionsPartService.js';
 import { CustomViewService, ICustomViewService } from '../../../customView/browser/customViewService.js';
@@ -112,8 +113,17 @@ class TestChatWidgetService extends mock<IChatWidgetService>() {
 }
 
 class TestChatService extends mock<IChatService>() {
-	override readonly onDidSubmitRequest = Event.None;
+	private readonly _onDidSubmitRequest = new Emitter<IChatRequestSubmittedEvent>();
+	override readonly onDidSubmitRequest = this._onDidSubmitRequest.event;
 	readonly cancelledResources: URI[] = [];
+
+	submitRequest(event: IChatRequestSubmittedEvent): void {
+		this._onDidSubmitRequest.fire(event);
+	}
+
+	dispose(): void {
+		this._onDidSubmitRequest.dispose();
+	}
 
 	override async cancelCurrentRequestForSession(sessionResource: URI): Promise<void> {
 		this.cancelledResources.push(sessionResource);
@@ -200,7 +210,7 @@ function createSessionsManagementService(
 ): { service: ISessionsManagementService; view: SessionsService; chatWidgetService: TestChatWidgetService; chatService: TestChatService; contextKeyService: MockContextKeyService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const chatWidgetService = new TestChatWidgetService();
-	const chatService = new TestChatService();
+	const chatService = disposables.add(new TestChatService());
 	const providers = Array.isArray(provider) ? provider : [provider];
 	const contextKeyService = disposables.add(new MockContextKeyService());
 
@@ -956,6 +966,38 @@ suite('SessionsManagementService', () => {
 		});
 
 		completeSendRequest?.();
+	});
+
+	test('mirrored follow-up requests preserve submitted attachments', () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		const { service, chatService } = createSessionsManagementService(session, disposables);
+		const attachedContext: IChatRequestVariableEntry[] = [{ kind: 'generic', id: 'context', name: 'Context', value: 'value' }];
+		let sentEvent: ISendRequestSentEvent | undefined;
+		disposables.add(service.onDidSendRequest(event => sentEvent = event));
+
+		chatService.submitRequest({
+			chatSessionResource: chat.resource,
+			message: { text: 'follow up', parts: [] },
+			attachedContext,
+		});
+
+		assert.deepStrictEqual(sentEvent && {
+			query: sentEvent.options.query,
+			attachedContext: sentEvent.options.attachedContext,
+			isNewSession: sentEvent.isNewSession,
+			isNewChat: sentEvent.isNewChat,
+		}, {
+			query: 'follow up',
+			attachedContext,
+			isNewSession: false,
+			isNewChat: false,
+		});
 	});
 
 	test('send-follow activates only visible chat tabs', async () => {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1934,13 +1934,20 @@ export interface IChatSendRequestOptions {
 
 export type IChatModelReference = IReference<IChatModel>;
 
+/** Data from a chat request after submission begins. */
+export interface IChatRequestSubmittedEvent {
+	readonly chatSessionResource: URI;
+	readonly message?: IParsedChatRequest;
+	readonly attachedContext?: IChatRequestVariableEntry[];
+}
+
 export const IChatService = createDecorator<IChatService>('IChatService');
 
 export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionResource: URI | undefined;
 
-	readonly onDidSubmitRequest: Event<{ readonly chatSessionResource: URI; readonly message?: IParsedChatRequest }>;
+	readonly onDidSubmitRequest: Event<IChatRequestSubmittedEvent>;
 
 	readonly onDidCreateModel: Event<IChatModel>;
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -42,7 +42,7 @@ import { ChatModel, ChatRequestModel, ChatRequestRemovalReason, IChatModel, ICha
 import { ChatModelStore, IStartSessionProps } from '../model/chatModelStore.js';
 import { chatAgentLeader, ChatRequestAgentPart, ChatRequestAgentSubcommandPart, ChatRequestSlashCommandPart, ChatRequestTextPart, chatSubcommandLeader, getPromptText, IParsedChatRequest } from '../requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../requestParser/chatRequestParser.js';
-import { ChatMcpServersStarting, ChatPendingRequestChangeClassification, ChatPendingRequestChangeEvent, ChatPendingRequestChangeEventName, ChatRequestQueueKind, ChatSendResult, ChatSendResultQueued, ChatSendResultSent, ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatCompleteResponse, IChatDetail, IChatFollowup, IChatModelReference, IChatProgress, IChatQuestionAnswers, IChatSendRequestOptions, IChatSendRequestResponseState, IChatService, IChatSessionStartOptions, IChatUserActionEvent, IRemotePendingRequest, ResponseModelState } from './chatService.js';
+import { ChatMcpServersStarting, ChatPendingRequestChangeClassification, ChatPendingRequestChangeEvent, ChatPendingRequestChangeEventName, ChatRequestQueueKind, ChatSendResult, ChatSendResultQueued, ChatSendResultSent, ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatCompleteResponse, IChatDetail, IChatFollowup, IChatModelReference, IChatProgress, IChatQuestionAnswers, IChatRequestSubmittedEvent, IChatSendRequestOptions, IChatSendRequestResponseState, IChatService, IChatSessionStartOptions, IChatUserActionEvent, IRemotePendingRequest, ResponseModelState } from './chatService.js';
 import { ChatRequestTelemetry, ChatServiceTelemetry } from './chatServiceTelemetry.js';
 import { IChatSessionsService, isAgentHostTarget, isTerminalCommandPrompt, localChatSessionType } from '../chatSessionsService.js';
 import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessionStore.js';
@@ -200,7 +200,7 @@ export class ChatService extends Disposable implements IChatService {
 		return this._transferredSessionResource;
 	}
 
-	private readonly _onDidSubmitRequest = this._register(new Emitter<{ readonly chatSessionResource: URI; readonly message?: IParsedChatRequest }>());
+	private readonly _onDidSubmitRequest = this._register(new Emitter<IChatRequestSubmittedEvent>());
 	public readonly onDidSubmitRequest = this._onDidSubmitRequest.event;
 
 	public get onDidCreateModel() { return this._sessionModels.onDidCreateModel; }
@@ -1825,7 +1825,7 @@ export class ChatService extends Disposable implements IChatService {
 		if (options?.userSelectedModelId && !options.isSystemInitiated) {
 			this.languageModelsService.addToRecentlyUsedList(options.userSelectedModelId);
 		}
-		this._onDidSubmitRequest.fire({ chatSessionResource: model.sessionResource, message: parsedRequest });
+		this._onDidSubmitRequest.fire({ chatSessionResource: model.sessionResource, message: parsedRequest, attachedContext: options?.attachedContext });
 		return {
 			responseCreatedPromise: responseCreated.p,
 			responseCompletePromise: rawResponsePromise,


### PR DESCRIPTION
## Summary
- emit `agents/requestSent` for follow-up messages in existing chats
- add `isNewChat` alongside `isNewSession` to distinguish all request types
- cover new-session, new-chat, and follow-up telemetry payloads

## Testing
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `.\scripts\test.bat --run src\vs\sessions\contrib\sessions\test\browser\sessionsTelemetry.contribution.test.ts --grep "logs requestSent"`