### PR TITLE
Seed Quick Open (Ctrl+P) filter value from editor selection

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -58,6 +58,8 @@ import { ASK_QUICK_QUESTION_ACTION_ID } from '../../chat/browser/actions/chatQui
 import { IChatWidgetService, IQuickChatService } from '../../chat/browser/chat.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ICustomEditorLabelService } from '../../../services/editor/common/customEditorLabelService.js';
+import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
+import { getSelectionSearchString } from '../../../../editor/contrib/find/browser/findController.js';
 
 export interface IAnythingQuickPickItem extends IPickerQuickAccessItem, IQuickPickItemWithResource {
 	readonly editor?: EditorInput | IResourceEditorInput;
@@ -112,9 +114,15 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private readonly pickState: IAnythingPickState;
 
-	get defaultFilterValue(): DefaultQuickAccessFilterValue | undefined {
+	get defaultFilterValue(): DefaultQuickAccessFilterValue | string | undefined {
 		if (this.configuration.preserveInput) {
 			return DefaultQuickAccessFilterValue.LAST;
+		}
+
+		// Prefer the current editor selection as default filter, same as workspace symbol search (Ctrl+T)
+		const editor = this.codeEditorService.getFocusedCodeEditor();
+		if (editor) {
+			return getSelectionSearchString(editor) ?? undefined;
 		}
 
 		return undefined;
@@ -143,7 +151,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		@IQuickChatService private readonly quickChatService: IQuickChatService,
 		@ILogService private readonly logService: ILogService,
 		@ICustomEditorLabelService private readonly customEditorLabelService: ICustomEditorLabelService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
 	) {
 		super(AnythingQuickAccessProvider.PREFIX, {
 			canAcceptInBackground: true,

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -119,10 +119,10 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			return DefaultQuickAccessFilterValue.LAST;
 		}
 
-		// Prefer the current editor selection as default filter, same as workspace symbol search (Ctrl+T)
+		// Prefer the current editor selection as default filter, but only an explicit selection (unlike Ctrl+T, an idle cursor's word would fire on nearly every invocation)
 		const editor = this.codeEditorService.getFocusedCodeEditor();
 		if (editor) {
-			return getSelectionSearchString(editor) ?? undefined;
+			return getSelectionSearchString(editor, 'single', true) ?? undefined;
 		}
 
 		return undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When text is selected in the editor and you press Ctrl+P, Quick Open now pre-fills
the filter with that selection.

This is the same existing behavior of Find in Files (Ctrl+Shift+F) and Go to Symbol (Ctrl+T).

It only seeds from an explicit, non-empty selection. Intentionally it does not honor `editor.find.seedSearchStringFromSelection`, since that setting's default  would introduce word-at-cursor seeding here.

<img width="780" height="550" alt="selection" src="https://github.com/user-attachments/assets/9c5ca8de-47dc-4ae2-8f12-f320df5588c5" />

