### PR TITLE
agentHost: configure external session discovery

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -461,6 +461,15 @@ export const AgentHostSystemProxyEnabledConfigKey = 'systemProxyEnabled';
 // sessions as adoptable agent-host sessions, and opening one adopts it in place. Experimental; off.
 export const AgentHostMigrateLegacyCopilotCliEnabledConfigKey = 'migrateLegacyCopilotCliEnabled';
 
+export const AgentHostShowExternalSessionsConfigKey = 'showExternalSessions';
+
+export const enum AgentHostExternalSessionsMode {
+	None = 'none',
+	All = 'all',
+	Last24Hours = 'last24Hours',
+	Last7Days = 'last7Days',
+}
+
 /**
  * Root config key forwarded from the renderer that gates multiple-working-directory
  * support for the Copilot provider. When `true`, the Copilot provider advertises
@@ -740,6 +749,13 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.migrateLegacyCopilotCliEnabled.title', "Migrate Legacy Copilot CLI Sessions"),
 		description: localize('agentHost.config.migrateLegacyCopilotCliEnabled.description', "Whether un-adopted extension-host Copilot CLI sessions are surfaced as adoptable agent-host sessions and migrated in place when opened."),
 		default: false,
+	}),
+	[AgentHostShowExternalSessionsConfigKey]: schemaProperty<AgentHostExternalSessionsMode>({
+		type: 'string',
+		title: localize('agentHost.config.showExternalSessions.title', "Show External Agent Sessions"),
+		description: localize('agentHost.config.showExternalSessions.description', "Controls whether sessions created outside the Agent Host are included in the session catalog."),
+		enum: [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days],
+		default: AgentHostExternalSessionsMode.Last7Days,
 	}),
 	[AgentHostCopilotMultiRootEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1649,6 +1649,23 @@ export const SESSION_META_WORKSPACELESS_KEY = 'workspaceless';
  * on resume) and never persist it themselves.
  */
 export const AH_META_WORKSPACELESS_DB_KEY = 'agentHost.workspaceless';
+const SESSION_META_EXTERNAL = 'agentHost.external';
+
+export function readSessionExternal(meta: SessionSummaryMeta | undefined): boolean {
+	return meta?.[SESSION_META_EXTERNAL] === true;
+}
+
+export function withSessionExternal(meta: SessionSummaryMeta | undefined, external: boolean): SessionSummaryMeta | undefined {
+	if (external) {
+		return { ...meta, [SESSION_META_EXTERNAL]: true };
+	}
+	if (!meta || meta[SESSION_META_EXTERNAL] === undefined) {
+		return meta;
+	}
+	const updated = { ...meta };
+	delete updated[SESSION_META_EXTERNAL];
+	return Object.keys(updated).length === 0 ? undefined : updated;
+}
 
 /**
  * Session-database metadata key recording whether a session is archived. Written by

--- a/src/vs/platform/agentHost/node/agentHostDatabase.ts
+++ b/src/vs/platform/agentHost/node/agentHostDatabase.ts
@@ -13,10 +13,11 @@ export interface IAgentHostDatabaseSession {
 	readonly session: string;
 	readonly provider: AgentProvider;
 	readonly startTime: number;
+	readonly isExternal: boolean;
 }
 
 export interface IAgentHostDatabase extends IDisposable {
-	registerSession(session: string, provider: AgentProvider, startTime: number): Promise<void>;
+	registerSession(session: string, provider: AgentProvider, startTime: number, isExternal: boolean): Promise<void>;
 	/**
 	 * Atomically registers `session` unless it is currently tombstoned (a
 	 * single statement, so a concurrent {@link markSessionTombstoned} cannot
@@ -27,6 +28,7 @@ export interface IAgentHostDatabase extends IDisposable {
 	 * explicitly create one.
 	 */
 	registerSessionIfNotTombstoned(session: string, provider: AgentProvider, startTime: number): Promise<boolean>;
+	markSessionUsedByAgentHost(session: string): Promise<void>;
 	unregisterSession(session: string): Promise<void>;
 	/** Atomically tombstones and removes a session so concurrent backfill cannot re-register it. */
 	tombstoneAndUnregisterSession(session: string): Promise<void>;
@@ -64,7 +66,8 @@ const migrations = [
 			`CREATE TABLE IF NOT EXISTS sessions (
 				session_uri TEXT PRIMARY KEY NOT NULL,
 				provider    TEXT NOT NULL,
-				start_time  INTEGER NOT NULL
+				start_time  INTEGER NOT NULL,
+				is_external INTEGER NOT NULL
 			)`,
 			`CREATE TABLE IF NOT EXISTS metadata (
 				key   TEXT PRIMARY KEY NOT NULL,
@@ -120,6 +123,10 @@ function providerBackfillKey(provider: AgentProvider): string {
 	return `sessionRegistryBackfilled:${provider}`;
 }
 
+function sessionCreatedByAgentHostKey(session: string): string {
+	return `agentHost.createdByAgentHost:${session}`;
+}
+
 /** Metadata key for a session's durable "explicitly deleted" tombstone. */
 function tombstoneKey(session: string): string {
 	return `sessionTombstone:${session}`;
@@ -140,13 +147,18 @@ export class AgentHostDatabase implements IAgentHostDatabase {
 
 	constructor(private readonly _path: string) { }
 
-	registerSession(session: string, provider: AgentProvider, startTime: number): Promise<void> {
-		return this._run(
-			`INSERT INTO sessions (session_uri, provider, start_time)
-				VALUES (?, ?, ?)
-				ON CONFLICT(session_uri) DO UPDATE SET provider = excluded.provider`,
-			[session, provider, startTime],
+	async registerSession(session: string, provider: AgentProvider, startTime: number, isExternal: boolean): Promise<void> {
+		await this._run(
+			`INSERT INTO sessions (session_uri, provider, start_time, is_external)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT(session_uri) DO UPDATE SET
+					provider = excluded.provider,
+					is_external = MIN(sessions.is_external, excluded.is_external)`,
+			[session, provider, startTime, isExternal ? 1 : 0],
 		);
+		if (!isExternal) {
+			await this._setMetadata(sessionCreatedByAgentHostKey(session), 'true');
+		}
 	}
 
 	async registerSessionIfNotTombstoned(session: string, provider: AgentProvider, startTime: number): Promise<boolean> {
@@ -157,13 +169,17 @@ export class AgentHostDatabase implements IAgentHostDatabase {
 		// inserted) and 1 when the row was inserted or updated.
 		const changes = await runReturningChanges(
 			await this._ensureDatabase(),
-			`INSERT INTO sessions (session_uri, provider, start_time)
-				SELECT ?, ?, ?
+			`INSERT INTO sessions (session_uri, provider, start_time, is_external)
+				SELECT ?, ?, ?, 1
 				WHERE NOT EXISTS (SELECT 1 FROM metadata WHERE key = ? AND value = 'true')
 				ON CONFLICT(session_uri) DO UPDATE SET provider = excluded.provider`,
 			[session, provider, startTime, tombstoneKey(session)],
 		);
 		return changes > 0;
+	}
+
+	markSessionUsedByAgentHost(session: string): Promise<void> {
+		return this._run('UPDATE sessions SET is_external = 0 WHERE session_uri = ?', [session]);
 	}
 
 	unregisterSession(session: string): Promise<void> {
@@ -194,11 +210,12 @@ export class AgentHostDatabase implements IAgentHostDatabase {
 	}
 
 	async listSessions(): Promise<readonly IAgentHostDatabaseSession[]> {
-		const rows = await all(await this._ensureDatabase(), 'SELECT session_uri, provider, start_time FROM sessions', []);
+		const rows = await all(await this._ensureDatabase(), 'SELECT session_uri, provider, start_time, is_external FROM sessions', []);
 		return rows.map(row => ({
 			session: row.session_uri as string,
 			provider: row.provider as AgentProvider,
 			startTime: row.start_time as number,
+			isExternal: row.is_external === 1,
 		}));
 	}
 
@@ -252,6 +269,13 @@ export class AgentHostDatabase implements IAgentHostDatabase {
 
 	private async _run(sql: string, parameters: readonly unknown[]): Promise<void> {
 		await run(await this._ensureDatabase(), sql, parameters);
+	}
+
+	private _setMetadata(key: string, value: string): Promise<void> {
+		return this._run(
+			'INSERT INTO metadata (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+			[key, value],
+		);
 	}
 
 	private _ensureDatabase(): Promise<Database> {

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -793,6 +793,19 @@ export class AgentHostStateManager extends Disposable {
 		});
 	}
 
+	/** Removes a session previously surfaced without materializing it. */
+	retractSurfacedSession(session: string): void {
+		if (this._sessionStates.has(session)) {
+			return;
+		}
+		this._summaryNotifier.remove(session);
+		this._onDidEmitNotification.fire({
+			type: 'root/sessionRemoved',
+			channel: ROOT_STATE_URI,
+			session,
+		});
+	}
+
 	/**
 	 * Restores a session from a previous server lifetime into the state manager
 	 * with pre-populated turns. The session is created in `ready` lifecycle

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -525,8 +525,9 @@ export class AgentService extends Disposable implements IAgentService {
 		this._register(configurationService.onDidRootConfigChange(() => {
 			const nextMode = this._getExternalSessionsMode();
 			if (nextMode !== externalSessionsMode) {
+				const previousMode = externalSessionsMode;
 				externalSessionsMode = nextMode;
-				this._queueSessionListReconciliation();
+				this._queueSessionListReconciliation(previousMode);
 			}
 		}));
 		const fileMonitorService = _fileMonitorService ?? this._register(new AgentHostFileMonitorService(this._fileService, this._logService));
@@ -871,12 +872,17 @@ export class AgentService extends Disposable implements IAgentService {
 		this._providerSubscriptions.add(provider.onDidMaterializeChat(e => this._onDidMaterializeChat(e)));
 		if (provider.onDidChangeChatList) {
 			this._providerSubscriptions.add(provider.onDidChangeChatList(() => {
-				this._onProviderChatListChanged();
 				// Re-sweep this provider on its own chat-list change even after a
 				// durable "done" marker: the first sweep may have seen nothing before
 				// the provider's store became enumerable.
-				void this._ensureProviderBackfilled(provider, true).catch(err =>
-					this._logService.warn(`[AgentService] registry backfill: retry for provider ${provider.id} after chat-list change failed`, err));
+				void this._ensureProviderBackfilled(provider, true).then(
+					() => {
+						if (!this._store.isDisposed) {
+							this._onProviderChatListChanged();
+						}
+					},
+					err => this._logService.warn(`[AgentService] registry backfill: retry for provider ${provider.id} after chat-list change failed`, err),
+				);
 			}));
 		}
 		if (provider.onMcpNotification) {
@@ -1241,7 +1247,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return false;
 		}
 	}
-	async listSessions(): Promise<IAgentSessionMetadata[]> {
+	async listSessions(mode = this._getExternalSessionsMode()): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
 		// Older hosts never registered existing on-disk sessions. Backfill the
 		// registry once before reading it so they are not lost.
@@ -1468,13 +1474,8 @@ export class AgentService extends Disposable implements IAgentService {
 			});
 		}
 		const combined = additions.length > 0 ? [...withForcedRead, ...additions.map(session => this._forceUnusedExternalSessionRead(session))] : withForcedRead;
-		const visible = combined.filter(session => this._shouldIncludeSession(session));
-		this._visibleExternalSessions.clear();
-		for (const session of visible) {
-			if (readSessionExternal(session._meta)) {
-				this._visibleExternalSessions.add(session.session.toString());
-			}
-		}
+		const visible = combined.filter(session => this._shouldIncludeSession(session, mode));
+		this._scheduleExternalSessionExpiry(visible, mode);
 
 		this._logService.trace(`[AgentService] listSessions returned ${visible.length} sessions (${additions.length} state-manager fallback)`);
 		return visible;
@@ -1500,11 +1501,11 @@ export class AgentService extends Disposable implements IAgentService {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostShowExternalSessionsConfigKey) ?? AgentHostExternalSessionsMode.Last7Days;
 	}
 
-	private _shouldIncludeSession(session: IAgentSessionMetadata): boolean {
+	private _shouldIncludeSession(session: IAgentSessionMetadata, mode = this._getExternalSessionsMode()): boolean {
 		if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._stateManager.getSessionState(session.session.toString())) {
 			return true;
 		}
-		switch (this._getExternalSessionsMode()) {
+		switch (mode) {
 			case AgentHostExternalSessionsMode.All:
 				return true;
 			case AgentHostExternalSessionsMode.Last24Hours:
@@ -1514,6 +1515,29 @@ export class AgentService extends Disposable implements IAgentService {
 			case AgentHostExternalSessionsMode.None:
 				return false;
 		}
+	}
+
+	private _scheduleExternalSessionExpiry(sessions: readonly IAgentSessionMetadata[], mode: AgentHostExternalSessionsMode): void {
+		const window = mode === AgentHostExternalSessionsMode.Last24Hours
+			? 24 * 60 * 60 * 1000
+			: mode === AgentHostExternalSessionsMode.Last7Days
+				? 7 * 24 * 60 * 60 * 1000
+				: undefined;
+		if (window === undefined) {
+			this._externalSessionExpiry.clear();
+			return;
+		}
+		let nextExpiry: number | undefined;
+		for (const session of sessions) {
+			if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._stateManager.getSessionState(session.session.toString())) {
+				continue;
+			}
+			const expiresAt = session.modifiedTime + window + 1;
+			nextExpiry = nextExpiry === undefined ? expiresAt : Math.min(nextExpiry, expiresAt);
+		}
+		this._externalSessionExpiry.value = nextExpiry === undefined
+			? undefined
+			: disposableTimeout(() => this._queueSessionListReconciliation(), Math.max(0, nextExpiry - this._now()));
 	}
 
 	/**
@@ -1540,7 +1564,8 @@ export class AgentService extends Disposable implements IAgentService {
 
 	/** Debounces provider `onDidChangeChatList` bursts into one reconciliation pass. */
 	private readonly _surfaceSessionsDebounce = this._register(new MutableDisposable());
-	private readonly _visibleExternalSessions = new Set<string>();
+	private readonly _externalSessionExpiry = this._register(new MutableDisposable());
+	private readonly _broadcastExternalSessions = new Set<string>();
 	private readonly _announcedAdoptableLegacySessions = new Set<string>();
 	private _sessionListReconciliation = Promise.resolve();
 
@@ -1551,17 +1576,24 @@ export class AgentService extends Disposable implements IAgentService {
 		}, 250);
 	}
 
-	private _queueSessionListReconciliation(): void {
+	private _queueSessionListReconciliation(previousMode?: AgentHostExternalSessionsMode): void {
 		this._sessionListReconciliation = this._sessionListReconciliation
 			.then(async () => {
-				await this._reconcileExternalSessions();
+				await this._reconcileExternalSessions(previousMode);
 				await this._surfaceAdoptableLegacySessions();
 			})
 			.catch(error => this._logService.warn('[AgentService] External session reconciliation failed', error));
 	}
 
-	private async _reconcileExternalSessions(): Promise<void> {
-		const previouslyVisible = new Set(this._visibleExternalSessions);
+	private async _reconcileExternalSessions(previousMode?: AgentHostExternalSessionsMode): Promise<void> {
+		const previouslyBroadcast = new Set(this._broadcastExternalSessions);
+		if (previouslyBroadcast.size === 0 && previousMode !== undefined) {
+			for (const session of await this.listSessions(previousMode)) {
+				if (readSessionExternal(session._meta)) {
+					previouslyBroadcast.add(session.session.toString());
+				}
+			}
+		}
 		try {
 			await this._ensureRegistryBackfilled();
 		} catch (err) {
@@ -1583,15 +1615,19 @@ export class AgentService extends Disposable implements IAgentService {
 			if (this._stateManager.getSessionState(key)) {
 				continue;
 			}
-			if (!previouslyVisible.has(key)) {
+			if (!previouslyBroadcast.has(key)) {
 				this._stateManager.announceSurfacedSession(this._surfacedSessionSummary(meta, provider));
 			}
 		}
 
-		for (const key of previouslyVisible) {
+		for (const key of previouslyBroadcast) {
 			if (!visible.has(key) && !this._stateManager.getSessionState(key)) {
 				this._stateManager.retractSurfacedSession(key);
 			}
+		}
+		this._broadcastExternalSessions.clear();
+		for (const key of visible) {
+			this._broadcastExternalSessions.add(key);
 		}
 	}
 
@@ -3691,6 +3727,10 @@ export class AgentService extends Disposable implements IAgentService {
 			if (adopted) {
 				this._sessionsUsedByAgentHost.add(sessionStr);
 				await this._sessionRegistry.markUsedByAgentHost(session);
+				const state = this._stateManager.getSessionState(sessionStr);
+				if (state && readSessionExternal(state._meta)) {
+					this._stateManager.setSessionMeta(sessionStr, withSessionExternal(state._meta, false));
+				}
 				this._reportLegacyMigration(agent.id, 'migrated', migrationStartTime, facts);
 			} else if (adoption.eligible) {
 				// Migrate setting on and a genuine legacy candidate, but not adopted
@@ -3881,6 +3921,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const providerMeta = withSessionMultiRootMetadata(meta._meta, undefined);
 		let restoredMeta = (sessionMetadata || providerMeta) ? { ...(providerMeta ?? {}), ...(sessionMetadata ?? {}) } : undefined;
 		restoredMeta = withSessionMultiRootMetadata(restoredMeta, readSessionMultiRootMetadata(sessionMetadata));
+		const registeredSession = (await this._sessionRegistry.list()).find(entry => entry.session.toString() === sessionStr);
+		restoredMeta = withSessionExternal(restoredMeta, registeredSession?.isExternal === true);
 		const summary: SessionSummary = {
 			resource: sessionStr,
 			provider: agent.id,

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -36,7 +36,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type ChatOrigin, type Customization, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, readSessionEhcliAdoptable, withSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionExternal, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionExternal, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, readSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
 import { readToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
@@ -86,7 +86,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
-import { AgentHostEditTelemetryEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
+import { AgentHostEditTelemetryEnabledConfigKey, AgentHostExternalSessionsMode, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostShowExternalSessionsConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
 import { AgentHostOctoKitService, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
 import { IAgentHostChangesetService, CHANGESET_DB_METADATA_KEYS, META_CHANGES_SUMMARY } from '../common/agentHostChangesetService.js';
 import { IAgentHostChangesetSubscriptionService } from '../common/agentHostChangesetSubscriptionService.js';
@@ -295,6 +295,7 @@ export class AgentService extends Disposable implements IAgentService {
 	 * attempt, so a later `force` while one is still queued is a no-op.
 	 */
 	private readonly _providerBackfills = new Map<AgentProvider, IProviderBackfillState>();
+	private readonly _sessionsUsedByAgentHost = new Set<string>();
 
 	/**
 	 * Backing-session URIs (as strings) whose {@link CHAT_BACKING_METADATA_KEY}
@@ -492,6 +493,7 @@ export class AgentService extends Disposable implements IAgentService {
 		providerConfigurations: readonly IAgentCustomizationSettingsRegistration[] = [],
 		private readonly _hostLaunchKind = AgentHostLaunchKind.Unknown,
 		orchestratorDatabase?: IAgentHostDatabase,
+		private readonly _now: () => number = Date.now,
 	) {
 		super();
 		this._logService.info('AgentService initialized');
@@ -519,6 +521,14 @@ export class AgentService extends Disposable implements IAgentService {
 		// via DI rather than being plumbed plain-class references.
 		const configurationService = this._register(new AgentConfigurationService(this._stateManager, this._logService, this._rootConfigResource, providerConfigurations));
 		this._configurationService = configurationService;
+		let externalSessionsMode = this._getExternalSessionsMode();
+		this._register(configurationService.onDidRootConfigChange(() => {
+			const nextMode = this._getExternalSessionsMode();
+			if (nextMode !== externalSessionsMode) {
+				externalSessionsMode = nextMode;
+				this._queueSessionListReconciliation();
+			}
+		}));
 		const fileMonitorService = _fileMonitorService ?? this._register(new AgentHostFileMonitorService(this._fileService, this._logService));
 		updateAgentHostTelemetryLevelFromConfig(this._telemetryService, this._stateManager.rootState.config?.values);
 		const services = new ServiceCollection(
@@ -1191,7 +1201,7 @@ export class AgentService extends Disposable implements IAgentService {
 			if (isSubagentSession(s.session.toString()) || await this._isChatBacking(s.session)) {
 				return undefined;
 			}
-			return { session: s.session, provider: provider.id, startTime: s.startTime };
+			return { session: s.session, provider: provider.id, startTime: s.startTime, isExternal: true };
 		}));
 		for (const { session, provider: providerId, startTime } of identities.filter((s): s is IRegisteredSession => s !== undefined)) {
 			await this._sessionRegistry.registerIfNotTombstoned(session, providerId, startTime);
@@ -1240,7 +1250,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// chat backings and subagent sessions never enter it, and a transiently
 		// missing provider snapshot no longer evicts a session.
 		const registered = await this._sessionRegistry.list();
-		const results = await Promise.all(registered.map(async ({ session, provider }): Promise<IAgentSessionMetadata | undefined> => {
+		const results = await Promise.all(registered.map(async ({ session, provider, isExternal }): Promise<IAgentSessionMetadata | undefined> => {
 			// Idle provisional sessions stay hidden until they materialize or gain
 			// turn activity (#321269). The state-manager overlay below re-surfaces
 			// them then.
@@ -1253,7 +1263,14 @@ export class AgentService extends Disposable implements IAgentService {
 				return undefined;
 			}
 			try {
-				return await this._registeredSessionMetadata(agent, session);
+				const metadata = await this._registeredSessionMetadata(agent, session);
+				if (!metadata) {
+					return undefined;
+				}
+				return this._withSessionOwnershipMetadata(
+					metadata,
+					isExternal,
+				);
 			} catch (err) {
 				this._logService.warn(`[AgentService] listSessions: failed to read metadata for ${session}`, err);
 				return undefined;
@@ -1405,6 +1422,7 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 			return s;
 		});
+		const withForcedRead = withStatus.map(session => this._forceUnusedExternalSessionRead(session));
 
 		// Overlay any session known to state but missing from the providers'
 		// `listSessions` snapshot, so renderer-side caches don't evict a
@@ -1417,7 +1435,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// Idle provisional sessions are deliberately *not* overlaid so the
 		// new-session composer's eagerly-created session doesn't leak into the
 		// list before its first message (#321269).
-		const known = new Set(withStatus.map(s => s.session.toString()));
+		const known = new Set(withForcedRead.map(s => s.session.toString()));
 		const additions: IAgentSessionMetadata[] = [];
 		for (const summary of this._stateManager.getOverlaySessionSummaries()) {
 			if (known.has(summary.resource)) {
@@ -1449,10 +1467,53 @@ export class AgentService extends Disposable implements IAgentService {
 				...(summary._meta !== undefined ? { _meta: summary._meta } : {}),
 			});
 		}
-		const combined = additions.length > 0 ? [...withStatus, ...additions] : withStatus;
+		const combined = additions.length > 0 ? [...withForcedRead, ...additions.map(session => this._forceUnusedExternalSessionRead(session))] : withForcedRead;
+		const visible = combined.filter(session => this._shouldIncludeSession(session));
+		this._visibleExternalSessions.clear();
+		for (const session of visible) {
+			if (readSessionExternal(session._meta)) {
+				this._visibleExternalSessions.add(session.session.toString());
+			}
+		}
 
-		this._logService.trace(`[AgentService] listSessions returned ${combined.length} sessions (${additions.length} state-manager fallback)`);
-		return combined;
+		this._logService.trace(`[AgentService] listSessions returned ${visible.length} sessions (${additions.length} state-manager fallback)`);
+		return visible;
+	}
+
+	private _withSessionOwnershipMetadata(session: IAgentSessionMetadata, external: boolean): IAgentSessionMetadata {
+		const { _meta: existingMeta, ...rest } = session;
+		const _meta = withSessionExternal(existingMeta, external);
+		return { ...rest, ...(_meta !== undefined ? { _meta } : {}) };
+	}
+
+	private _forceUnusedExternalSessionRead(session: IAgentSessionMetadata): IAgentSessionMetadata {
+		if (!readSessionExternal(session._meta) || this._sessionsUsedByAgentHost.has(session.session.toString())) {
+			return session;
+		}
+		return {
+			...session,
+			status: withSessionStatusFlag(session.status ?? SessionStatus.Idle, SessionStatus.IsRead, true),
+		};
+	}
+
+	private _getExternalSessionsMode(): AgentHostExternalSessionsMode {
+		return this._configurationService.getRootValue(platformRootSchema, AgentHostShowExternalSessionsConfigKey) ?? AgentHostExternalSessionsMode.Last7Days;
+	}
+
+	private _shouldIncludeSession(session: IAgentSessionMetadata): boolean {
+		if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._stateManager.getSessionState(session.session.toString())) {
+			return true;
+		}
+		switch (this._getExternalSessionsMode()) {
+			case AgentHostExternalSessionsMode.All:
+				return true;
+			case AgentHostExternalSessionsMode.Last24Hours:
+				return session.modifiedTime >= this._now() - 24 * 60 * 60 * 1000;
+			case AgentHostExternalSessionsMode.Last7Days:
+				return session.modifiedTime >= this._now() - 7 * 24 * 60 * 60 * 1000;
+			case AgentHostExternalSessionsMode.None:
+				return false;
+		}
 	}
 
 	/**
@@ -1477,30 +1538,65 @@ export class AgentService extends Disposable implements IAgentService {
 		return this._sessionRegistry.isBackfilled();
 	}
 
-	/** Debounces provider `onDidChangeChatList` bursts into one surface pass. */
+	/** Debounces provider `onDidChangeChatList` bursts into one reconciliation pass. */
 	private readonly _surfaceSessionsDebounce = this._register(new MutableDisposable());
-	/** Adoptable-legacy session keys already announced this AH lifetime, so bursts don't re-announce them. */
-	private readonly _announcedSurfacedKeys = new Set<string>();
+	private readonly _visibleExternalSessions = new Set<string>();
+	private readonly _announcedAdoptableLegacySessions = new Set<string>();
+	private _sessionListReconciliation = Promise.resolve();
 
-	/**
-	 * A provider reported its on-disk session set may have changed (e.g. a legacy
-	 * Copilot CLI session created by the extension host). Re-list and announce any
-	 * adoptable-legacy sessions not yet known to clients so they surface without a
-	 * manual reload.
-	 */
+	/** Debounces provider catalog changes before reconciling against the last catalog returned to clients. */
 	private _onProviderChatListChanged(): void {
 		this._surfaceSessionsDebounce.value = disposableTimeout(() => {
-			void this._surfaceAdoptableLegacySessions();
+			this._queueSessionListReconciliation();
 		}, 250);
 	}
 
-	private async _surfaceAdoptableLegacySessions(): Promise<void> {
+	private _queueSessionListReconciliation(): void {
+		this._sessionListReconciliation = this._sessionListReconciliation
+			.then(async () => {
+				await this._reconcileExternalSessions();
+				await this._surfaceAdoptableLegacySessions();
+			})
+			.catch(error => this._logService.warn('[AgentService] External session reconciliation failed', error));
+	}
+
+	private async _reconcileExternalSessions(): Promise<void> {
+		const previouslyVisible = new Set(this._visibleExternalSessions);
 		try {
 			await this._ensureRegistryBackfilled();
 		} catch (err) {
-			this._logService.warn('[AgentService] surfaceAdoptableLegacySessions: registry backfill failed', err);
+			this._logService.warn('[AgentService] external session reconciliation: registry backfill failed', err);
 			return;
 		}
+		const listed = await this.listSessions();
+		const visible = new Set<string>();
+		for (const meta of listed) {
+			if (!readSessionExternal(meta._meta)) {
+				continue;
+			}
+			const provider = AgentSession.provider(meta.session);
+			if (!provider) {
+				continue;
+			}
+			const key = meta.session.toString();
+			visible.add(key);
+			if (this._stateManager.getSessionState(key)) {
+				continue;
+			}
+			if (!previouslyVisible.has(key)) {
+				this._stateManager.announceSurfacedSession(this._surfacedSessionSummary(meta, provider));
+			}
+		}
+
+		for (const key of previouslyVisible) {
+			if (!visible.has(key) && !this._stateManager.getSessionState(key)) {
+				this._stateManager.retractSurfacedSession(key);
+			}
+		}
+	}
+
+	private async _surfaceAdoptableLegacySessions(): Promise<void> {
+		await this._ensureRegistryBackfilled();
 		const results = await Promise.allSettled([...this._providers.values()].map(provider => this._enumerateProviderSessions(provider)));
 		const listed: IAgentSessionMetadata[] = [];
 		for (const result of results) {
@@ -1510,49 +1606,31 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		const registered = new Set((await this._sessionRegistry.list()).map(entry => entry.session.toString()));
 		for (const meta of listed) {
-			// Only announce sessions surfaced as adoptable-legacy — never native
-			// sessions (which clients already know from their own listSessions).
-			if (!registered.has(meta.session.toString()) || !readSessionEhcliAdoptable(meta._meta)) {
+			const key = meta.session.toString();
+			if (!registered.has(key) || !readSessionEhcliAdoptable(meta._meta) || this._announcedAdoptableLegacySessions.has(key)) {
 				continue;
 			}
 			const provider = AgentSession.provider(meta.session);
-			if (!provider) {
-				continue; // defensive: malformed session URI
-			}
-			const key = meta.session.toString();
-			if (this._announcedSurfacedKeys.has(key)) {
-				continue; // already announced this lifetime
-			}
-			if (this._stateManager.getSessionState(key)) {
-				continue; // already adopted / restored
-			}
-			if (await this._sessionRegistry.isTombstoned(meta.session)) {
+			if (!provider || this._stateManager.getSessionState(key) || await this._sessionRegistry.isTombstoned(meta.session)) {
 				continue;
 			}
 			this._stateManager.announceSurfacedSession(this._surfacedSessionSummary(meta, provider));
-			this._announcedSurfacedKeys.add(key);
+			this._announcedAdoptableLegacySessions.add(key);
 		}
 	}
 
-	/** Synthesizes the minimal {@link SessionSummary} for an adoptable session surfaced by {@link listSessions}. */
+	/** Synthesizes the minimal {@link SessionSummary} for a session surfaced by {@link listSessions}. */
 	private _surfacedSessionSummary(meta: IAgentSessionMetadata, provider: string): SessionSummary {
 		return {
 			resource: meta.session.toString(),
 			provider,
 			title: meta.summary ?? '',
-			// Surfaced legacy sessions predate agent-host read ownership, which has
-			// no per-session read flag for them yet. Default them to read: the
-			// client trusts the provider's read state once it owns it, so an
-			// unflagged summary would otherwise flip every previously-seen session
-			// to unread the moment migration is turned on.
 			status: withSessionStatusFlag(meta.status ?? SessionStatus.Idle, SessionStatus.IsRead, true),
 			createdAt: new Date(meta.startTime).toISOString(),
 			modifiedAt: new Date(meta.modifiedTime).toISOString(),
 			...(meta.project ? { project: { uri: meta.project.uri.toString(), displayName: meta.project.displayName } } : {}),
 			workingDirectories: meta.workingDirectories?.map(d => d.toString()),
-			// Marks the session adoptable so clients don't passively subscribe (and
-			// thereby migrate) it before the user opens it.
-			_meta: withSessionEhcliAdoptable(meta._meta),
+			...(meta._meta !== undefined ? { _meta: meta._meta } : {}),
 		};
 	}
 
@@ -3292,6 +3370,9 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		this._stateManager.dispatchClientAction(channel, action, origin);
+		if (action.type === ActionType.ChatTurnStarted) {
+			this._markSessionUsedByAgentHost(sessionChannel);
+		}
 		if (action.type === ActionType.RootConfigChanged) {
 			this._configurationService.persistRootConfig();
 			const editTelemetryEnabled = action.config[AgentHostEditTelemetryEnabledConfigKey];
@@ -3300,6 +3381,21 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		this._sideEffects.handleAction(channel, action, clientId, clientContext);
+	}
+
+	private _markSessionUsedByAgentHost(session: string): void {
+		this._sessionsUsedByAgentHost.add(session);
+		const sessionUri = URI.parse(session);
+		const state = this._stateManager.getSessionState(session);
+		if (state && readSessionExternal(state._meta)) {
+			this._stateManager.setSessionMeta(session, withSessionExternal(state._meta, false));
+		}
+		void this._retryRegistryMutation(
+			() => this._sessionRegistry.markUsedByAgentHost(sessionUri),
+			`used marker for ${session}`,
+		).catch(error => {
+			this._logService.warn(`[AgentService] Failed to mark session as used by Agent Host: ${session}`, error);
+		});
 	}
 	private _getUnresolvedPeerChats(sessionChannel: string): readonly string[] | undefined {
 		return this._stateManager.getSessionState(sessionChannel)?.chats.filter(chat => !isDefaultChatUri(chat.resource) && !this._stateManager.getChatState(chat.resource)).map(chat => chat.resource);
@@ -3593,6 +3689,8 @@ export class AgentService extends Disposable implements IAgentService {
 		try {
 			const facts = await this._restoreSessionState(agent, session, sessionStr, adopted);
 			if (adopted) {
+				this._sessionsUsedByAgentHost.add(sessionStr);
+				await this._sessionRegistry.markUsedByAgentHost(session);
 				this._reportLegacyMigration(agent.id, 'migrated', migrationStartTime, facts);
 			} else if (adoption.eligible) {
 				// Migrate setting on and a genuine legacy candidate, but not adopted

--- a/src/vs/platform/agentHost/node/agentSessionRegistry.ts
+++ b/src/vs/platform/agentHost/node/agentSessionRegistry.ts
@@ -14,6 +14,7 @@ export interface IRegisteredSession {
 	readonly provider: AgentProvider;
 	/** Session creation time (ms since epoch) as first observed by the orchestrator. */
 	readonly startTime: number;
+	readonly isExternal: boolean;
 }
 
 /**
@@ -61,7 +62,7 @@ export class AgentSessionRegistry extends Disposable {
 	 * again rather than explicitly create one.
 	 */
 	async register(session: URI, provider: AgentProvider, startTime: number): Promise<void> {
-		await this._database.registerSession(session.toString(), provider, startTime);
+		await this._database.registerSession(session.toString(), provider, startTime, false);
 		await this._database.clearSessionTombstone(session.toString());
 	}
 
@@ -84,12 +85,17 @@ export class AgentSessionRegistry extends Disposable {
 		await this._database.tombstoneAndUnregisterSession(session.toString());
 	}
 
+	async markUsedByAgentHost(session: URI): Promise<void> {
+		await this._database.markSessionUsedByAgentHost(session.toString());
+	}
+
 	/** Every session currently recorded, in no particular order. */
 	async list(): Promise<IRegisteredSession[]> {
 		return (await this._database.listSessions()).map(entry => ({
 			session: URI.parse(entry.session),
 			provider: entry.provider,
 			startTime: entry.startTime,
+			isExternal: entry.isExternal,
 		}));
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -28,6 +28,8 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, SubagentChatSignal, resolveAgentChatContext, type IAgent, type IAgentChatAdoptionResult, type IAgentChatContext, type IAgentChatDataChange, type IAgentChatMetadata, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentDescriptor, type IAgentLegacyChat, type IAgentMaterializeChatEvent, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agent.js';
 import { IConnectionTrackerService } from '../../common/agentService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
+import { AgentHostLaunchKind } from '../../common/agentHostTelemetry.js';
+import { AgentHostExternalSessionsMode, AgentHostShowExternalSessionsConfigKey } from '../../common/agentHostSchema.js';
 import { ClaudeSessionConfigKey } from '../../common/claudeSessionConfigKeys.js';
 import { CodexSessionConfigKey } from '../../common/codexSessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
@@ -35,7 +37,7 @@ import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agent
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionState, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
+import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionExternal, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionState, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { ChatInteractivity, type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -2284,6 +2286,86 @@ suite('AgentService (node dispatcher)', () => {
 
 	suite('aggregation', () => {
 
+		class ExternalCatalogAgent extends MockAgent {
+			private readonly _onDidChangeChatList = new Emitter<void>();
+			readonly onDidChangeChatList = this._onDidChangeChatList.event;
+			readonly catalog = new Map<string, { session: URI; modifiedTime: number; status?: SessionStatus }>();
+
+			addSession(id: string, modifiedTime: number, status?: SessionStatus): URI {
+				const session = AgentSession.uri(this.id, id);
+				this.catalog.set(id, { session, modifiedTime, status });
+				(this as unknown as { _sessions: Map<string, URI> })._sessions.set(id, session);
+				return session;
+			}
+
+			removeSession(session: URI): void {
+				this.catalog.delete(AgentSession.id(session));
+				(this as unknown as { _sessions: Map<string, URI> })._sessions.delete(AgentSession.id(session));
+			}
+
+			fireChatListChanged(): void {
+				this._onDidChangeChatList.fire();
+			}
+
+			override async listLegacyChats(): Promise<IAgentChatMetadata[]> {
+				return [...this.catalog.values()].map(entry => ({
+					chat: URI.parse(buildDefaultChatUri(entry.session)),
+					startTime: entry.modifiedTime,
+					modifiedTime: entry.modifiedTime,
+					status: entry.status,
+				}));
+			}
+
+			override async getChatMetadata(chat: URI, context: URI | IAgentChatContext): Promise<IAgentChatMetadata | undefined> {
+				const session = resolveAgentChatContext(context, chat).configurationResource;
+				const entry = this.catalog.get(AgentSession.id(session));
+				return entry ? { chat, startTime: entry.modifiedTime, modifiedTime: entry.modifiedTime, status: entry.status } : undefined;
+			}
+
+			override dispose(): void {
+				this._onDidChangeChatList.dispose();
+				super.dispose();
+			}
+		}
+
+		function createExternalSessionService(now: () => number): AgentService {
+			return disposables.add(new AgentService(
+				new NullLogService(),
+				fileService,
+				createSessionDataService(),
+				{ _serviceBrand: undefined } as IProductService,
+				createNoopGitService(),
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				AgentHostLaunchKind.Unknown,
+				undefined,
+				now,
+			));
+		}
+
+		function setExternalSessionsMode(service: AgentService, mode: AgentHostExternalSessionsMode, clientSeq: number): void {
+			service.dispatchAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostShowExternalSessionsConfigKey]: mode },
+			}, 'test-client', clientSeq);
+		}
+
+		async function reconcileExternalSessions(service: AgentService): Promise<void> {
+			await (service as unknown as { _reconcileExternalSessions(): Promise<void> })._reconcileExternalSessions();
+		}
+
+		async function waitForSessionListReconciliation(service: AgentService): Promise<void> {
+			await (service as unknown as { _sessionListReconciliation: Promise<void> })._sessionListReconciliation;
+		}
+
+		function clearExternalSessionExpiry(service: AgentService): void {
+			(service as unknown as { _externalSessionExpiry: { clear(): void } })._externalSessionExpiry.clear();
+		}
+
 		test('listSessions aggregates sessions from all providers', async () => {
 			service.registerProvider(copilotAgent);
 
@@ -2291,6 +2373,154 @@ suite('AgentService (node dispatcher)', () => {
 
 			const sessions = await service.listSessions();
 			assert.strictEqual(sessions.length, 1);
+		});
+
+		test('filters external sessions in every mode with inclusive time boundaries', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			agent.addSession('recent', now);
+			agent.addSession('at-24-hours', now - day);
+			agent.addSession('older-than-24-hours', now - day - 1);
+			agent.addSession('at-7-days', now - 7 * day);
+			agent.addSession('older-than-7-days', now - 7 * day - 1);
+			svc.registerProvider(agent);
+
+			const listedByMode: Record<AgentHostExternalSessionsMode, string[]> = {
+				[AgentHostExternalSessionsMode.None]: [],
+				[AgentHostExternalSessionsMode.All]: [],
+				[AgentHostExternalSessionsMode.Last24Hours]: [],
+				[AgentHostExternalSessionsMode.Last7Days]: [],
+			};
+			let clientSeq = 1;
+			for (const mode of [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days]) {
+				setExternalSessionsMode(svc, mode, clientSeq++);
+				await waitForSessionListReconciliation(svc);
+				clearExternalSessionExpiry(svc);
+				const listed = await svc.listSessions();
+				clearExternalSessionExpiry(svc);
+				listedByMode[mode] = listed.map(session => AgentSession.id(session.session)).sort();
+			}
+
+			assert.deepStrictEqual(listedByMode, {
+				[AgentHostExternalSessionsMode.None]: [],
+				[AgentHostExternalSessionsMode.All]: ['at-24-hours', 'at-7-days', 'older-than-24-hours', 'older-than-7-days', 'recent'],
+				[AgentHostExternalSessionsMode.Last24Hours]: ['at-24-hours', 'recent'],
+				[AgentHostExternalSessionsMode.Last7Days]: ['at-24-hours', 'at-7-days', 'older-than-24-hours', 'recent'],
+			});
+		});
+
+		test('retains a restored external session when the configured mode hides external sessions', async () => {
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('restored', now);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+
+			await svc.restoreSession(session);
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None, 1);
+			await waitForSessionListReconciliation(svc);
+			const listed = await svc.listSessions();
+
+			assert.deepStrictEqual({
+				listed: listed.map(entry => entry.session.toString()),
+				externalInList: readSessionExternal(listed[0]?._meta),
+				externalInState: readSessionExternal(svc.stateManager.getSessionState(session.toString())?._meta),
+			}, {
+				listed: [session.toString()],
+				externalInList: true,
+				externalInState: true,
+			});
+		});
+
+		test('forces unused external sessions read until a message is sent through the Agent Host', async () => {
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('forced-read', now, SessionStatus.Idle);
+			svc.registerProvider(agent);
+
+			const before = (await svc.listSessions())[0];
+			(svc as unknown as { _markSessionUsedByAgentHost(session: string): void })._markSessionUsedByAgentHost(session.toString());
+			for (let attempt = 0; attempt < 20 && readSessionExternal((await svc.listSessions())[0]?._meta); attempt++) {
+				await timeout(0);
+			}
+			const after = (await svc.listSessions())[0];
+
+			assert.deepStrictEqual({
+				before: { external: readSessionExternal(before._meta), read: !!(before.status! & SessionStatus.IsRead) },
+				after: { external: readSessionExternal(after._meta), read: !!(after.status! & SessionStatus.IsRead) },
+			}, {
+				before: { external: true, read: true },
+				after: { external: false, read: false },
+			});
+		});
+
+		test('reconciles provider and configuration changes without list requests changing the broadcast baseline', async () => {
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			agent.addSession('initial', now);
+			const notifications: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionAdded) {
+					notifications.push(`add:${AgentSession.id(URI.parse(notification.summary.resource))}`);
+				} else if (notification.type === NotificationType.SessionRemoved) {
+					notifications.push(`remove:${AgentSession.id(URI.parse(notification.session))}`);
+				}
+			}));
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			await reconcileExternalSessions(svc);
+			notifications.length = 0;
+
+			agent.addSession('provider-added', now);
+			agent.fireChatListChanged();
+			assert.deepStrictEqual((await svc.listSessions()).map(entry => AgentSession.id(entry.session)).sort(), ['initial', 'provider-added']);
+			await timeout(300);
+			await waitForSessionListReconciliation(svc);
+
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None, 1);
+			await waitForSessionListReconciliation(svc);
+
+			assert.deepStrictEqual(notifications, [
+				'add:provider-added',
+				'remove:initial',
+				'remove:provider-added',
+			]);
+		});
+
+		test('reconciles when a visible external session crosses the configured time cutoff', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			let now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('expiring', now - day + 10);
+			const removed: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionRemoved) {
+					removed.push(notification.session);
+				}
+			}));
+			svc.registerProvider(agent);
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours, 1);
+			await svc.listSessions();
+			await waitForSessionListReconciliation(svc);
+			removed.length = 0;
+
+			now += 20;
+			await timeout(30);
+			await waitForSessionListReconciliation(svc);
+
+			assert.deepStrictEqual({
+				listed: (await svc.listSessions()).map(entry => entry.session.toString()),
+				removed,
+			}, {
+				listed: [],
+				removed: [session.toString()],
+			});
 		});
 
 		test('listSessions backfills the registry from provider sessions on a pre-registry host', async () => {
@@ -4507,6 +4737,19 @@ suite('AgentService (node dispatcher)', () => {
 			await localService.restoreSession(sessionResource);
 
 			assert.deepStrictEqual(localService.stateManager.getSessionState(sessionResource.toString())?._meta, { workspaceless: true });
+		});
+
+		test('restores external ownership from the session registry into live metadata', async () => {
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			const agent = disposables.add(new MockAgent('copilot'));
+			const session = await createAgentSession(agent);
+			agent.sessionMessages = [];
+			localService.registerProvider(agent);
+			await localService.listSessions();
+
+			await localService.restoreSession(session.session);
+
+			assert.strictEqual(readSessionExternal(localService.stateManager.getSessionState(session.session.toString())?._meta), true);
 		});
 
 		test('restores persisted multi-root metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -185,10 +185,10 @@ class TransientRegistryWriteDatabase implements IAgentHostDatabase {
 		this._remainingRegistryWriteFailures = count;
 	}
 
-	async registerSession(session: string, provider: string, startTime: number): Promise<void> {
+	async registerSession(session: string, provider: string, startTime: number, isExternal: boolean): Promise<void> {
 		this._beforeWrite();
 		const existing = this._sessions.get(session);
-		this._sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime });
+		this._sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime, isExternal: (existing?.isExternal ?? true) && isExternal });
 	}
 
 	async registerSessionIfNotTombstoned(session: string, provider: string, startTime: number): Promise<boolean> {
@@ -197,8 +197,15 @@ class TransientRegistryWriteDatabase implements IAgentHostDatabase {
 			return false;
 		}
 		const existing = this._sessions.get(session);
-		this._sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime });
+		this._sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime, isExternal: existing?.isExternal ?? true });
 		return true;
+	}
+
+	async markSessionUsedByAgentHost(session: string): Promise<void> {
+		const existing = this._sessions.get(session);
+		if (existing) {
+			this._sessions.set(session, { ...existing, isExternal: false });
+		}
 	}
 
 	async unregisterSession(session: string): Promise<void> {
@@ -3148,7 +3155,7 @@ suite('AgentService (node dispatcher)', () => {
 
 			const sessions = await svc.listSessions();
 			assert.strictEqual(sessions.length, 1);
-			assert.deepStrictEqual(sessions[0]._meta, { workspaceless: true });
+			assert.deepStrictEqual(sessions[0]._meta, { workspaceless: true, 'agentHost.external': true });
 		});
 
 		test('listSessions restores persisted multi-root metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/agentSessionRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSessionRegistry.test.ts
@@ -30,10 +30,10 @@ class TestAgentHostDatabase implements IAgentHostDatabase {
 		this._readFailures++;
 	}
 
-	async registerSession(session: string, provider: string, startTime: number): Promise<void> {
+	async registerSession(session: string, provider: string, startTime: number, isExternal: boolean): Promise<void> {
 		this._throwWriteFailure();
 		const existing = this.sessions.get(session);
-		this.sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime });
+		this.sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime, isExternal: (existing?.isExternal ?? true) && isExternal });
 	}
 
 	async registerSessionIfNotTombstoned(session: string, provider: string, startTime: number): Promise<boolean> {
@@ -42,8 +42,15 @@ class TestAgentHostDatabase implements IAgentHostDatabase {
 			return false;
 		}
 		const existing = this.sessions.get(session);
-		this.sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime });
+		this.sessions.set(session, { session, provider, startTime: existing?.startTime ?? startTime, isExternal: existing?.isExternal ?? true });
 		return true;
+	}
+
+	async markSessionUsedByAgentHost(session: string): Promise<void> {
+		const existing = this.sessions.get(session);
+		if (existing) {
+			this.sessions.set(session, { ...existing, isExternal: false });
+		}
 	}
 
 	async unregisterSession(session: string): Promise<void> {
@@ -170,6 +177,31 @@ suite('AgentSessionRegistry', () => {
 
 		const [entry] = await registry.list();
 		assert.strictEqual(entry.startTime, 100);
+	});
+
+	test('external classification becomes internal when the Agent Host creates or uses a session', async () => {
+		const registry = createRegistry();
+		await registry.registerIfNotTombstoned(a, 'copilot', 100);
+		await registry.registerIfNotTombstoned(b, 'claude', 200);
+		const before = (await registry.list()).map(entry => ({ session: entry.session.toString(), isExternal: entry.isExternal })).sort((x, y) => x.session.localeCompare(y.session));
+
+		await registry.register(a, 'copilot', 100);
+		await registry.markUsedByAgentHost(b);
+		const after = (await registry.list()).map(entry => ({ session: entry.session.toString(), isExternal: entry.isExternal })).sort((x, y) => x.session.localeCompare(y.session));
+
+		assert.deepStrictEqual(
+			{ before, after },
+			{
+				before: [
+					{ session: b.toString(), isExternal: true },
+					{ session: a.toString(), isExternal: true },
+				].sort((x, y) => x.session.localeCompare(y.session)),
+				after: [
+					{ session: b.toString(), isExternal: false },
+					{ session: a.toString(), isExternal: false },
+				].sort((x, y) => x.session.localeCompare(y.session)),
+			},
+		);
 	});
 
 	test('register and unregister preserve submission order', async () => {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -14,7 +14,7 @@ import '../../../../platform/agentHost/browser/agentHostEnablementService.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostAllowSignedOutWhenUsableSettingId, AgentHostSdkSandboxEnabledSettingId, AgentHostSdkSandboxWindowsEnabledSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostModelCapabilityOverridesSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostReasoningEffortOverrideSettingId, AgentHostToolSearchDeferThresholdSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostExternalSessionsMode, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostShowExternalSessionsConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
 import { AgentHostMapLegacySettingsToManagedSettingsSettingId } from '../../../../platform/agentHost/common/agentHostManagedSettings.js';
 import { DEFAULT_LOCAL_TRANSCRIPTION_MODEL } from '../../../../platform/localTranscription/common/localTranscription.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
@@ -391,6 +391,19 @@ configurationRegistry.registerConfiguration({
 				mode: 'startup'
 			},
 			agentHost: { key: AgentHostMigrateLegacyCopilotCliEnabledConfigKey },
+		},
+		[ChatConfiguration.ShowExternalAgentSessions]: {
+			type: 'string',
+			enum: [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days],
+			enumDescriptions: [
+				nls.localize('chat.agentSessions.showExternal.none', "Only shows sessions created or used by the Agent Host."),
+				nls.localize('chat.agentSessions.showExternal.all', "Shows all sessions discovered from supported external agent applications."),
+				nls.localize('chat.agentSessions.showExternal.last24Hours', "Shows external sessions updated in the last 24 hours."),
+				nls.localize('chat.agentSessions.showExternal.last7Days', "Shows external sessions updated in the last 7 days."),
+			],
+			default: AgentHostExternalSessionsMode.Last7Days,
+			markdownDescription: nls.localize('chat.agentSessions.showExternal', "Controls which external agent sessions, created outside VS Code's Agent Host, are shown."),
+			agentHost: { key: AgentHostShowExternalSessionsConfigKey },
 		},
 		[ChatConfiguration.SaveBeforeSend]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -47,6 +47,7 @@ export enum ChatConfiguration {
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',
 	AgentSessionProjectionEnabled = 'chat.agentSessionProjection.enabled',
 	MigrateLegacyCopilotCliSessions = 'chat.agentSessions.migrateLegacyCopilotCli',
+	ShowExternalAgentSessions = 'chat.agentSessions.showExternal',
 	ExtensionToolsEnabled = 'chat.extensionTools.enabled',
 	RepoInfoEnabled = 'chat.repoInfo.enabled',
 	EditRequests = 'chat.editRequests',


### PR DESCRIPTION
## Summary

- add `chat.agentSessions.showExternal` with none, all, last 24 hours, and last 7 days modes
- classify external sessions centrally in the Agent Host session registry and expose the classification through typed session metadata
- reconcile connected clients immediately while retaining live sessions, preserving legacy Copilot adoption, and forcing unused external sessions read
- keep notification baselines independent from list requests and reconcile automatically at time-window expiry
- preserve external ownership in restored live session metadata

## Validation

- `npm run compile`
- `npm run compile-client`
- targeted ESLint for all changed files
- `scripts\test.bat --run src\vs\platform\agentHost\test\node\agentSessionRegistry.test.ts --run src\vs\platform\agentHost\test\node\agentService.test.ts` (274 passing)

## Reviewer notes

The unreleased version-1 `agent-host.db` schema now includes `is_external`; existing development databases must be recreated. No migration is included by design.

Full `npm run hygiene` is blocked on Windows by an unrelated path-resolution error that resolves `remote\package.json` as `C:\C:\...`.