### PR TITLE
Update agents window session list button styles for consistency

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -424,6 +424,9 @@ export class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListR
 	}
 
 	renderTemplate(container: HTMLElement): ITreeListTemplateData<TTemplateData> {
+		if (this.renderer.rowClassName) {
+			container.classList.add(this.renderer.rowClassName);
+		}
 		const el = append(container, $('.monaco-tl-row'));
 		const indent = append(el, $('.monaco-tl-indent'));
 		const twistie = append(el, $('.monaco-tl-twistie'));

--- a/src/vs/base/browser/ui/tree/tree.ts
+++ b/src/vs/base/browser/ui/tree/tree.ts
@@ -164,6 +164,8 @@ export interface ITreeElementRenderDetails extends IListElementRenderDetails {
 }
 
 export interface ITreeRenderer<T, TFilterData = void, TTemplateData = void> extends IListRenderer<ITreeNode<T, TFilterData>, TTemplateData> {
+	/** CSS class applied to list rows created for this renderer. */
+	readonly rowClassName?: string;
 	renderElement(element: ITreeNode<T, TFilterData>, index: number, templateData: TTemplateData, details?: ITreeElementRenderDetails): void;
 	disposeElement?(element: ITreeNode<T, TFilterData>, index: number, templateData: TTemplateData, details?: ITreeElementRenderDetails): void;
 	renderTwistie?(element: T, twistieElement: HTMLElement): boolean;

--- a/src/vs/base/test/browser/ui/tree/objectTree.test.ts
+++ b/src/vs/base/test/browser/ui/tree/objectTree.test.ts
@@ -218,6 +218,25 @@ suite('ObjectTree', function () {
 		disposeTemplate(): void { }
 	}
 
+	test('applies renderer row class names', function () {
+		const container = document.createElement('div');
+		container.style.width = '200px';
+		container.style.height = '200px';
+
+		const renderer = new class extends Renderer {
+			readonly rowClassName = 'test-tree-row';
+		};
+		const tree = new ObjectTree<number>('test', container, new Delegate(), [renderer]);
+		try {
+			tree.layout(200);
+			tree.setChildren(null, [{ element: 0 }, { element: 1 }]);
+
+			assert.strictEqual(container.querySelectorAll('.monaco-list-row.test-tree-row').length, 2);
+		} finally {
+			tree.dispose();
+		}
+	});
+
 	class IdentityProvider implements IIdentityProvider<number> {
 		getId(element: number): { toString(): string } {
 			return `${element % 100}`;

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -84,6 +84,7 @@ When grouping by workspace, the list shows only **primary** workspace sections b
 - A workspace qualifies as primary if it has recent activity (last 4 days), matches the open window's folder, or contains the most recently updated session
 - Remaining workspaces collapse behind a "+N more workspaces" toggle
 - Within each workspace or user-created group, sessions beyond 5 (configurable by the same assignment treatment) also show a "Show more" toggle and then a "Show less" toggle once expanded
+- "Show more" rows use the same horizontal inset and corner-radius tier as session rows, including the phone layout
 - The find widget bypasses all capping
 
 ### Filtering

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -21,6 +21,8 @@ When `chat.omni.enabled` is enabled, the Sessions header includes a `Codicon.arr
 | `services/sessions/browser/sessionSectionOrderService.ts` | `ISessionSectionOrderService` — manual top-level order of groups + workspace sections and workspace promotion (UI-only) |
 | `contrib/sessions/browser/views/sessionsViewActions.ts` | All registered actions (sort, group, filter, pin, archive, rename, navigate) |
 
+Renderers that need row-level styling declare `ITreeRenderer.rowClassName`; they must not traverse to tree-owned `.monaco-list-row` markup with `closest()`.
+
 ---
 
 ## Features

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -8,7 +8,7 @@
 	height: 100%;
 	min-height: 0;
 
-	.monaco-list-row:has(.session-item) {
+	.monaco-list-row.session-list-inset-row {
 		border-radius: var(--vscode-cornerRadius-medium);
 		margin: 0 10px;
 		width: calc(100% - 20px);
@@ -736,7 +736,7 @@
  * keep these rules in sync if paddings/font sizes change here.
  */
 .agent-sessions-workbench.phone-layout .sessions-list-control {
-	.monaco-list-row:has(.session-item) {
+	.monaco-list-row.session-list-inset-row {
 		/* Horizontal-only margin: virtual list rows are absolutely
 		 * positioned with JS-set `top`/`height`, so vertical margins
 		 * here would not produce reliable inter-row spacing. Any gap

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -370,6 +370,7 @@ export interface ISessionCIFixModel {
 class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, ISessionItemTemplate> {
 	static readonly TEMPLATE_ID = 'session-item';
 	readonly templateId = SessionItemRenderer.TEMPLATE_ID;
+	readonly rowClassName = 'session-list-inset-row';
 
 	private static readonly _APPROVAL_ROW_LINE_HEIGHT = 18;
 	private static readonly _APPROVAL_ROW_OVERHEAD = 14;
@@ -408,7 +409,6 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const disposables = new DisposableStore();
 		const elementDisposables = disposables.add(new DisposableStore());
 
-		container.closest('.monaco-list-row')?.classList.add('session-list-inset-row');
 		container.classList.add('session-item');
 
 		const iconContainer = DOM.append(container, $('.session-icon'));
@@ -1252,9 +1252,9 @@ class SessionGroupRenderer implements ITreeRenderer<SessionListItem, FuzzyScore,
 class SessionShowMoreRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, HTMLElement> {
 	static readonly TEMPLATE_ID = 'session-show-more';
 	readonly templateId = SessionShowMoreRenderer.TEMPLATE_ID;
+	readonly rowClassName = 'session-list-inset-row';
 
 	renderTemplate(container: HTMLElement): HTMLElement {
-		container.closest('.monaco-list-row')?.classList.add('session-list-inset-row');
 		container.classList.add('session-show-more');
 		return DOM.append(container, $('span.session-show-more-label'));
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -408,6 +408,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const disposables = new DisposableStore();
 		const elementDisposables = disposables.add(new DisposableStore());
 
+		container.closest('.monaco-list-row')?.classList.add('session-list-inset-row');
 		container.classList.add('session-item');
 
 		const iconContainer = DOM.append(container, $('.session-icon'));
@@ -1253,6 +1254,7 @@ class SessionShowMoreRenderer implements ITreeRenderer<SessionListItem, FuzzySco
 	readonly templateId = SessionShowMoreRenderer.TEMPLATE_ID;
 
 	renderTemplate(container: HTMLElement): HTMLElement {
+		container.closest('.monaco-list-row')?.classList.add('session-list-inset-row');
 		container.classList.add('session-show-more');
 		return DOM.append(container, $('span.session-show-more-label'));
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/330544

This pull request updates the styling of the "+{number} more" buttons in the agents window session list to ensure they match the width and corner rounding of chat session list items. 

### Changes Made:
- Introduced a shared inset-row marker for both session items and "show more" buttons in `sessionsList.ts`.
- Adjusted the CSS in `sessionsList.css` to ensure:
  - Both row types have the same horizontal inset/width.
  - Both have a consistent medium corner-radius.
  - Matching layout geometry for phone views.
- Updated documentation in `SESSIONS_LIST.md` to reflect these changes.

<img width="744" height="356" alt="ui-diff-20260812-164541" src="https://github.com/user-attachments/assets/468266f9-9bba-4328-9ea5-fdcdb580a478" />

### Validation:
- All relevant unit tests and checks have passed, confirming that the changes do not introduce any issues.