### PR TITLE
Add commands to get and set the primary side bar width (#247014)

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -1288,7 +1288,9 @@ CommandsRegistry.registerCommand({
 		return layoutService.getSize(Parts.SIDEBAR_PART).width;
 	},
 	metadata: {
-		description: 'Get the width of the primary side bar in pixels. Returns undefined when the primary side bar is hidden.'
+		description: localize2('getSideBarWidth.description', "Get the width of the primary side bar in pixels. Returns undefined when the primary side bar is hidden."),
+		args: [],
+		returns: 'The primary side bar width in pixels, or undefined when it is hidden.'
 	}
 });
 
@@ -1296,19 +1298,19 @@ CommandsRegistry.registerCommand({
 	id: 'workbench.action.setSideBarWidth',
 	handler: (accessor: ServicesAccessor, width: number): void => {
 		if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
-			throw new Error(`Invalid side bar width: ${width}`);
+			throw new Error(localize('setSideBarWidth.invalidWidth', "Invalid side bar width: {0}", width));
 		}
 
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		if (!layoutService.isVisible(Parts.SIDEBAR_PART)) {
-			throw new Error('Cannot set the width of the primary side bar while it is hidden');
+			throw new Error(localize('setSideBarWidth.sideBarHidden', "Cannot set the width of the primary side bar while it is hidden."));
 		}
 
 		const { height } = layoutService.getSize(Parts.SIDEBAR_PART);
 		layoutService.setSize(Parts.SIDEBAR_PART, { width, height });
 	},
 	metadata: {
-		description: 'Set the width of the primary side bar in pixels. The width is clamped to the layout constraints of the side bar. Fails when the primary side bar is hidden.',
+		description: localize2('setSideBarWidth.description', "Set the width of the primary side bar in pixels. The width is clamped to the layout constraints of the side bar. Fails when the primary side bar is hidden."),
 		args: [{
 			name: 'width',
 			description: 'The new width of the primary side bar in pixels',

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -22,7 +22,7 @@ import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
 import { IPaneCompositePartService } from '../../services/panecomposite/browser/panecomposite.js';
 import { ToggleAuxiliaryBarAction } from '../parts/auxiliarybar/auxiliaryBarActions.js';
 import { TogglePanelAction } from '../parts/panel/panelActions.js';
-import { ICommandService } from '../../../platform/commands/common/commands.js';
+import { CommandsRegistry, ICommandService } from '../../../platform/commands/common/commands.js';
 import { AuxiliaryBarVisibleContext, PanelAlignmentContext, PanelVisibleContext, SideBarVisibleContext, FocusedViewContext, InEditorZenModeContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, IsMainWindowFullscreenContext, PanelPositionContext, IsAuxiliaryWindowFocusedContext, IsSessionsWindowContext, TitleBarStyleContext, IsAuxiliaryWindowContext } from '../../common/contextkeys.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
@@ -1274,6 +1274,51 @@ registerAction2(IncreaseViewHeightAction);
 registerAction2(DecreaseViewSizeAction);
 registerAction2(DecreaseViewWidthAction);
 registerAction2(DecreaseViewHeightAction);
+
+// --- Get/Set Side Bar Width (for programmatic use, e.g. from extensions)
+
+CommandsRegistry.registerCommand({
+	id: 'workbench.action.getSideBarWidth',
+	handler: (accessor: ServicesAccessor): number | undefined => {
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+		if (!layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return undefined;
+		}
+
+		return layoutService.getSize(Parts.SIDEBAR_PART).width;
+	},
+	metadata: {
+		description: 'Get the width of the primary side bar in pixels. Returns undefined when the primary side bar is hidden.'
+	}
+});
+
+CommandsRegistry.registerCommand({
+	id: 'workbench.action.setSideBarWidth',
+	handler: (accessor: ServicesAccessor, width: number): void => {
+		if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
+			throw new Error(`Invalid side bar width: ${width}`);
+		}
+
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+		if (!layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			throw new Error('Cannot set the width of the primary side bar while it is hidden');
+		}
+
+		const { height } = layoutService.getSize(Parts.SIDEBAR_PART);
+		layoutService.setSize(Parts.SIDEBAR_PART, { width, height });
+	},
+	metadata: {
+		description: 'Set the width of the primary side bar in pixels. The width is clamped to the layout constraints of the side bar. Fails when the primary side bar is hidden.',
+		args: [{
+			name: 'width',
+			description: 'The new width of the primary side bar in pixels',
+			schema: {
+				'type': 'number',
+				'exclusiveMinimum': 0
+			}
+		}]
+	}
+});
 
 //#region Quick Input Alignment Actions
 

--- a/src/vs/workbench/test/browser/actions/layoutActions.test.ts
+++ b/src/vs/workbench/test/browser/actions/layoutActions.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import '../../../browser/actions/layoutActions.js';
+import { IViewSize } from '../../../../base/browser/ui/grid/grid.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { TestInstantiationService } from '../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { TestLayoutService } from '../workbenchTestServices.js';
+
+suite('Layout Actions', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestSideBarLayoutService extends TestLayoutService {
+		sideBarVisible = true;
+		sideBarSize: IViewSize = { width: 300, height: 900 };
+		override isVisible(part: Parts): boolean { return part === Parts.SIDEBAR_PART ? this.sideBarVisible : super.isVisible(part); }
+		override getSize(part: Parts): IViewSize { return this.sideBarSize; }
+		override setSize(part: Parts, size: IViewSize): void {
+			if (part === Parts.SIDEBAR_PART) {
+				this.sideBarSize = size;
+			}
+		}
+	}
+
+	function executeCommand(layoutService: IWorkbenchLayoutService, id: string, ...args: unknown[]): unknown {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IWorkbenchLayoutService, layoutService);
+
+		return instantiationService.invokeFunction(accessor => CommandsRegistry.getCommand(id)!.handler(accessor, ...args));
+	}
+
+	test('getSideBarWidth returns the width of the visible side bar', () => {
+		const layoutService = new TestSideBarLayoutService();
+
+		assert.strictEqual(executeCommand(layoutService, 'workbench.action.getSideBarWidth'), 300);
+	});
+
+	test('getSideBarWidth returns undefined when the side bar is hidden', () => {
+		const layoutService = new TestSideBarLayoutService();
+		layoutService.sideBarVisible = false;
+
+		assert.strictEqual(executeCommand(layoutService, 'workbench.action.getSideBarWidth'), undefined);
+	});
+
+	test('setSideBarWidth sets the width and preserves the height', () => {
+		const layoutService = new TestSideBarLayoutService();
+
+		executeCommand(layoutService, 'workbench.action.setSideBarWidth', 450);
+
+		assert.deepStrictEqual(layoutService.sideBarSize, { width: 450, height: 900 });
+	});
+
+	test('setSideBarWidth fails when the side bar is hidden', () => {
+		const layoutService = new TestSideBarLayoutService();
+		layoutService.sideBarVisible = false;
+
+		assert.throws(() => executeCommand(layoutService, 'workbench.action.setSideBarWidth', 450));
+		assert.deepStrictEqual(layoutService.sideBarSize, { width: 300, height: 900 });
+	});
+
+	test('setSideBarWidth fails for invalid width values', () => {
+		const layoutService = new TestSideBarLayoutService();
+
+		for (const width of [undefined, null, -1, 0, NaN, Infinity, '450', { width: 450 }]) {
+			assert.throws(() => executeCommand(layoutService, 'workbench.action.setSideBarWidth', width), `expected to throw for width: ${width}`);
+		}
+
+		assert.deepStrictEqual(layoutService.sideBarSize, { width: 300, height: 900 });
+	});
+});


### PR DESCRIPTION
Fixes #247014

This implements the backlog-approved feature request for letting extensions adjust the primary side bar width, as a pair of workbench commands — the same pattern as vscode.setEditorLayout — so no new vscode.d.ts API surface is needed:

workbench.action.getSideBarWidth → returns the primary side bar width in pixels, or undefined when it is hidden
workbench.action.setSideBarWidth (width: number) → resizes the primary side bar, preserving height; the grid clamps the value to the part's min/max layout constraints
From an extension:

Design notes, kept deliberately minimal:
- The setter validates its input (finite, positive number) since arguments arrive untyped from executeCommand, and throws rather than guessing.
- Setting the width of a hidden side bar throws instead of revealing it — visibility stays the sole job of workbench.action.toggleSidebarVisibility, so this command writes exactly one piece of state.
- Both commands register metadata with a JSON-schema args declaration, so they're self-documenting in keybindings IntelliSense.
- This intentionally does not preclude a richer layout API later (as sketched in the issue comments); it provides the capability with the smallest possible surface.

Includes unit tests (layoutActions.test.ts) covering: get while visible/hidden, set preserving height, set while hidden failing without touching state, and rejection of invalid widths. Verified with scripts/test.sh (all passing), npm run typecheck-client, and ESLint.
