### PR TITLE
byok: keep streamed token usage when a provider omits the final line break

### DIFF
--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -9,12 +9,13 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { isKimiFamily } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IDomainService } from '../../../platform/endpoint/common/domainService';
 import { IChatModelInformation } from '../../../platform/endpoint/common/endpointProvider';
-import { ChatEndpoint, normalizeKimiToolCallIds } from '../../../platform/endpoint/node/chatEndpoint';
+import { ChatEndpoint, CreateSSEProcessor, normalizeKimiToolCallIds } from '../../../platform/endpoint/node/chatEndpoint';
 import { ILogService } from '../../../platform/log/common/logService';
 import { isOpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { createCapiRequestBody, IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
 import { RawMessageConversionCallback } from '../../../platform/networking/common/openai';
 import { IChatWebSocketManager } from '../../../platform/networking/node/chatWebSocketManager';
+import { SSEProcessor } from '../../../platform/networking/node/stream';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITokenizerProvider } from '../../../platform/tokenizer/node/tokenizer';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -145,6 +146,15 @@ export class OpenAIEndpoint extends ChatEndpoint {
 	 * CAPI Copilot bearer token nor raise a missing-key error for these requests.
 	 */
 	public readonly ownsAuthorization = true;
+
+	/**
+	 * Client-side BYOK talks directly to the user's OpenAI-compatible server, which may end
+	 * the stream right after the final `include_usage` chunk without a terminating newline
+	 * or `[DONE]`. Use a processor that tolerates that so streamed usage isn't dropped. See #329436.
+	 */
+	protected override get createSSEProcessor(): CreateSSEProcessor {
+		return SSEProcessor.createWithTrailingLineFlush;
+	}
 
 	protected override getCompletionsCallback(): RawMessageConversionCallback {
 		const supportsThinking = !!this.modelMetadata.capabilities.supports.thinking;

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -10,8 +10,12 @@ import { ConfigKey, IConfigurationService } from '../../../../platform/configura
 import { IChatModelInformation, ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
 import { CustomDataPartMimeTypes } from '../../../../platform/endpoint/common/endpointTypes';
 import { ChatEndpoint } from '../../../../platform/endpoint/node/chatEndpoint';
+import { ILogService } from '../../../../platform/log/common/logService';
 import { ICreateEndpointBodyOptions, IEndpointBody, IMakeChatRequestOptions } from '../../../../platform/networking/common/networking';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
+import { TelemetryData } from '../../../../platform/telemetry/common/telemetryData';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
+import { createFakeStreamResponse } from '../../../../platform/test/node/fetcher';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
@@ -123,6 +127,40 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 				'https://api.openai.com/v1/chat/completions');
 
 			expect(endpoint.ownsAuthorization).toBe(true);
+		});
+	});
+
+	// Regression test for https://github.com/microsoft/vscode/issues/329436.
+	// Direct-to-provider BYOK streams may end right after the final `include_usage`
+	// chunk without a trailing newline or `[DONE]`. Verify the endpoint opts into
+	// flushing that final line so streamed token usage is preserved end-to-end.
+	describe('streamed usage on unterminated responses', () => {
+		async function collectUsage(response: string[]) {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{ ...modelMetadata, supported_endpoints: [ModelSupportedEndpoint.ChatCompletions] },
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const completions = await endpoint.processResponseFromChatEndpoint(
+				accessor.get(ITelemetryService),
+				accessor.get(ILogService),
+				createFakeStreamResponse(response),
+				1,
+				async () => undefined,
+				TelemetryData.createAndMarkAsIssued(),
+			);
+			const collected = [];
+			for await (const completion of completions) {
+				collected.push(completion);
+			}
+			return collected;
+		}
+
+		it('reports usage from a final chunk with no trailing newline or [DONE]', async () => {
+			const collected = await collectUsage([
+				`data: {"choices":[{"delta":{"content":"hello"},"index":0,"finish_reason":"stop"}]}\n`,
+				`data: {"choices":[],"usage":{"completion_tokens":50,"prompt_tokens":100,"total_tokens":150}}`,
+			]);
+			expect(collected[0]?.usage).toEqual({ completion_tokens: 50, prompt_tokens: 100, total_tokens: 150 });
 		});
 	});
 

--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -77,6 +77,11 @@ export function normalizeKimiToolCallIds(messages: CAPIChatMessage[], style: Kim
 }
 
 /**
+ * Creates the {@link SSEProcessor} used by {@link defaultChatResponseProcessor}.
+ */
+export type CreateSSEProcessor = typeof SSEProcessor.create;
+
+/**
  * The default processor for the stream format from CAPI
  */
 export async function defaultChatResponseProcessor(
@@ -86,9 +91,10 @@ export async function defaultChatResponseProcessor(
 	expectedNumChoices: number,
 	finishCallback: FinishedCallback,
 	telemetryData: TelemetryData,
-	cancellationToken?: CancellationToken | undefined
+	cancellationToken?: CancellationToken | undefined,
+	createSSEProcessor: CreateSSEProcessor = SSEProcessor.create
 ) {
-	const processor = await SSEProcessor.create(logService, telemetryService, expectedNumChoices, response, cancellationToken);
+	const processor = await createSSEProcessor(logService, telemetryService, expectedNumChoices, response, cancellationToken);
 	const finishedCompletions = processor.processSSE(finishCallback);
 	const chatCompletions = AsyncIterableObject.map(finishedCompletions, (solution) => {
 		const loggedReason = solution.reason ?? 'client-trimmed';
@@ -494,8 +500,17 @@ export class ChatEndpoint implements IChatEndpoint {
 		} else if (!this._supportsStreaming) {
 			return defaultNonStreamChatResponseProcessor(response, finishCallback, telemetryData);
 		} else {
-			return defaultChatResponseProcessor(telemetryService, logService, response, expectedNumChoices, finishCallback, telemetryData, cancellationToken);
+			return defaultChatResponseProcessor(telemetryService, logService, response, expectedNumChoices, finishCallback, telemetryData, cancellationToken, this.createSSEProcessor);
 		}
+	}
+
+	/**
+	 * The SSE processor factory used for the streaming Chat Completions path.
+	 * Direct-to-provider (client-side BYOK) endpoints override this to tolerate streams
+	 * that end without a terminating newline or `[DONE]`. See #329436.
+	 */
+	protected get createSSEProcessor(): CreateSSEProcessor {
+		return SSEProcessor.create;
 	}
 
 	public acquireTokenizer(): ITokenizer {

--- a/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
@@ -575,6 +575,93 @@ data: [DONE]
 		assert.strictEqual(results[0]?.usage?.total_tokens, 360);
 	});
 
+	// Regression test for https://github.com/microsoft/vscode/issues/329436.
+	// The trailing-line flush is opt-in (client-side BYOK only), so it is enabled here.
+	test('usage in a final unterminated SSE line should be reported for text completions', async function () {
+		const response = [
+			`data: {"choices":[{"text":"foo","index":0,"finish_reason":"stop"}]}\n`,
+			`data: {"choices":[],"usage":{"completion_tokens":2,"prompt_tokens":358,"total_tokens":360}}`,
+		];
+		const processor = await SSEProcessor.createWithTrailingLineFlush(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assert.deepStrictEqual(results[0]?.usage, {
+			completion_tokens: 2,
+			prompt_tokens: 358,
+			total_tokens: 360,
+		});
+	});
+
+	// Regression test for https://github.com/microsoft/vscode/issues/329436:
+	// a streamed (delta) response whose final `include_usage` chunk arrives
+	// without a trailing newline or `[DONE]`, as seen with some custom
+	// OpenAI-compatible / BYOK endpoints.
+	test('usage in a final unterminated SSE line should be reported for delta completions', async function () {
+		const response = [
+			`data: {"choices":[{"delta":{"content":"foo"},"index":0,"finish_reason":null}]}\n`,
+			`data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}\n`,
+			`data: {"choices":[],"usage":{"completion_tokens":2,"prompt_tokens":358,"total_tokens":360}}`,
+		];
+		const processor = await SSEProcessor.createWithTrailingLineFlush(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assert.deepStrictEqual(
+			{ chunks: results[0]?.solution.text, usage: results[0]?.usage },
+			{
+				chunks: ['foo'],
+				usage: { completion_tokens: 2, prompt_tokens: 358, total_tokens: 360 },
+			},
+		);
+	});
+
+	test('a malformed final unterminated SSE line does not drop the completion', async function () {
+		const response = [
+			`data: {"choices":[{"text":"foo","index":0,"finish_reason":"stop"}]}\n`,
+			`data: {"choices":[],"usage":{"completion_tokens":2,`,
+		];
+		const processor = await SSEProcessor.createWithTrailingLineFlush(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assertSimplifiedResultsEqual(results, {
+			0: {
+				finishReason: FinishedCompletionReason.Stop,
+				chunks: ['foo'],
+			},
+		});
+	});
+
+	// The trailing-line flush must stay opt-in: the default (CAPI/proxy) path is
+	// unchanged, so an unterminated final usage line is NOT flushed. See #329436.
+	test('usage in a final unterminated SSE line is not flushed by default (CAPI path)', async function () {
+		const response = [
+			`data: {"choices":[{"text":"foo","index":0,"finish_reason":"stop"}]}\n`,
+			`data: {"choices":[],"usage":{"completion_tokens":2,"prompt_tokens":358,"total_tokens":360}}`,
+		];
+		const processor = await SSEProcessor.create(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assert.deepStrictEqual(
+			{ chunks: results[0]?.solution.text, usage: results[0]?.usage },
+			{ chunks: ['foo'], usage: undefined },
+		);
+	});
+
 	test('stream containing cot_summary and cot_id', async function () {
 		const response = [
 			`data: {"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}]}\n`,

--- a/extensions/copilot/src/platform/networking/node/stream.ts
+++ b/extensions/copilot/src/platform/networking/node/stream.ts
@@ -144,6 +144,23 @@ export function splitChunk(chunk: string): [string[], string] {
 }
 
 /**
+ * Appends a single newline after the source stream ends. Direct-to-provider
+ * (client-side BYOK) servers may close immediately after their final
+ * `include_usage` SSE event without terminating the line or sending `[DONE]`.
+ * The newline lets the existing SSE parser process that buffered final event.
+ */
+function appendFinalNewline(stream: DestroyableStream<string>): DestroyableStream<string> {
+	return stream.pipeThrough(new TransformStream<string, string>({
+		transform(chunk, controller) {
+			controller.enqueue(chunk);
+		},
+		flush(controller) {
+			controller.enqueue('\n');
+		}
+	}));
+}
+
+/**
  * A single finished completion returned from the model or proxy, along with
  * some metadata.
  */
@@ -242,6 +259,30 @@ export class SSEProcessor {
 		cancellationToken?: CancellationToken
 	) {
 		const body = response.body.pipeThrough(new TextDecoderStream());
+		return new SSEProcessor(
+			logService,
+			telemetryService,
+			expectedNumChoices,
+			response,
+			body,
+			cancellationToken
+		);
+	}
+
+	/**
+	 * Creates a processor for direct-to-provider (client-side BYOK) streams that
+	 * may close after their final `include_usage` event without a terminating
+	 * newline or `[DONE]`. The regular {@link create} path is intentionally left
+	 * unchanged. See #329436.
+	 */
+	static async createWithTrailingLineFlush(
+		logService: ILogService,
+		telemetryService: ITelemetryService,
+		expectedNumChoices: number,
+		response: Response,
+		cancellationToken?: CancellationToken
+	) {
+		const body = appendFinalNewline(response.body.pipeThrough(new TextDecoderStream()));
 		return new SSEProcessor(
 			logService,
 			telemetryService,


### PR DESCRIPTION
## Summary

- Restores token usage for custom OpenAI-compatible (BYOK) models in streaming mode, so the context window indicator stays visible instead of disappearing.
- Fixes usage being logged as `undefined` when a provider ends its stream immediately after the final usage event, without a terminating line break or `[DONE]`.
- Scoped to endpoints that talk directly to a provider. Requests that go through the Copilot proxy keep their existing stream handling.

Fixes #329436

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

Client-side BYOK endpoints ask for token accounting by setting `stream_options.include_usage`, which makes the server emit a final, usage-only SSE event after the content events. The SSE reader splits incoming network chunks on newlines and holds any unterminated remainder in a buffer for the next chunk. When a provider closed the connection directly after that final event without terminating the line and without a `[DONE]` sentinel, the event stayed in that buffer. End-of-stream handling then tried to parse the buffer as bare JSON while it still carried its `data:` prefix, so parsing always failed and the usage payload was discarded.

The completion itself was unaffected, because content and `finish_reason` arrive in earlier, well-terminated events. Only the trailing usage event sat in the vulnerable position. That matches the report exactly: text streams normally, usage is `undefined`, and turning streaming off works because the non-streaming path parses one complete JSON body and never performs line framing. Because this usage value is the sole source for the BYOK context window indicator, losing it removes the indicator entirely.

### Implementation

The stream reader gains a second construction path that appends one newline after the source stream ends, letting the existing parser surface the buffered final event through its normal per-event handling. No parsing, buffering, or event-dispatch logic changed.

Endpoint wiring selects between the two construction paths through an overridable factory on the chat endpoint. The base endpoint returns the existing factory, and the direct-to-provider endpoint returns the tolerant one. The endpoint's branch that decides which processor applies still owns that decision and calls the same response processor as before, now passing the factory. Keeping the decision in one place avoids restating the API-selection conditions in the subclass, where they could drift if another API path is added later.

### Behavior and constraints

- Proxy-backed requests resolve the factory to the pre-existing behavior, so their stream handling is unchanged.
- Streams that already end with `[DONE]` finish before the appended newline is ever read, so well-formed responses of either kind behave identically.
- The appended newline is emitted only on normal stream completion, not on cancellation or abort, so cancellation semantics are preserved.
- The transform participates in the existing stream wrapper, so cancellation still propagates to the underlying network stream.
- A truncated or malformed trailing event still fails to parse and is reported through existing diagnostics; the completion is still delivered rather than dropped.
- Responses API, Anthropic Messages API, and non-streaming requests are untouched and continue through their existing processors.

### Review context

The reported symptom is reproduced by a regression test, and existing coverage confirms usage is retained for well-framed streams. The provider-side trigger is inferred rather than captured from the reporter's traffic, since the report does not include raw response bytes. The inference follows from the fact that well-framed streams already report usage correctly, so the failing stream must be framed differently; an unterminated final event is the realistic form of that difference for minimal server implementations.

One tradeoff worth confirming: the factory seam is exposed as a property returning a static function reference. Both factories are pure and ignore `this`, so this is safe today, but a future factory that relied on instance state would need binding.

</details>
