### PR TITLE
agentHost: stabilize command auto-approver initialization

### DIFF
--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -177,6 +177,48 @@ const neverMatchRegex = /(?!.*)/;
 const transientEnvVarRegex = /^[A-Z_][A-Z0-9_]*=/i;
 const sedFileWriteParser = new SedFileWriteParser();
 
+interface ITreeSitterResources {
+	readonly parserClass: typeof Parser;
+	readonly queryClass: typeof Query;
+	readonly bashLanguage: PromiseSettledResult<Language>;
+	readonly powershellLanguage: PromiseSettledResult<Language>;
+}
+
+let treeSitterResourcesPromise: Promise<ITreeSitterResources> | undefined;
+
+function getTreeSitterResources(): Promise<ITreeSitterResources> {
+	// Parser.init and Language.load mutate process-global WASM state, so load them once.
+	return treeSitterResourcesPromise ??= loadTreeSitterResources();
+}
+
+async function loadTreeSitterResources(): Promise<ITreeSitterResources> {
+	const { default: TreeSitter } = await import('@vscode/tree-sitter-wasm');
+	const moduleRoot = URI.joinPath(FileAccess.asFileUri(getAppNodeModulesPath()), '@vscode', 'tree-sitter-wasm', 'wasm');
+	const wasmPath = URI.joinPath(moduleRoot, 'tree-sitter.wasm').fsPath;
+
+	await TreeSitter.Parser.init({
+		locateFile() {
+			return wasmPath;
+		}
+	});
+
+	const loadGrammar = async (fileName: string) => {
+		const grammarWasm = await fs.promises.readFile(URI.joinPath(moduleRoot, fileName).fsPath);
+		return TreeSitter.Language.load(new Uint8Array(grammarWasm.buffer, grammarWasm.byteOffset, grammarWasm.byteLength));
+	};
+	const [bashLanguage, powershellLanguage] = await Promise.allSettled([
+		loadGrammar('tree-sitter-bash.wasm'),
+		loadGrammar('tree-sitter-powershell.wasm'),
+	]);
+
+	return {
+		parserClass: TreeSitter.Parser,
+		queryClass: TreeSitter.Query,
+		bashLanguage,
+		powershellLanguage,
+	};
+}
+
 /**
  * Auto-approves or denies shell commands based on terminal auto-approve rules.
  *
@@ -391,30 +433,13 @@ export class CommandAutoApprover extends Disposable {
 
 	private async _initTreeSitter(): Promise<void> {
 		try {
-			const { default: TreeSitter } = (await import('@vscode/tree-sitter-wasm'));
+			const resources = await getTreeSitterResources();
 
 			if (this._store.isDisposed) {
 				return;
 			}
 
-			// Resolve WASM files from node_modules. In the desktop app the `.wasm`
-			// files are unpacked next to the ASAR archive (`node_modules.asar.unpacked`),
-			// while in dev and on the server (which has no ASAR) they live in a plain
-			// `node_modules`.
-			const moduleRoot = URI.joinPath(FileAccess.asFileUri(getAppNodeModulesPath()), '@vscode', 'tree-sitter-wasm', 'wasm');
-			const wasmPath = URI.joinPath(moduleRoot, 'tree-sitter.wasm').fsPath;
-
-			await TreeSitter.Parser.init({
-				locateFile() {
-					return wasmPath;
-				}
-			});
-
-			if (this._store.isDisposed) {
-				return;
-			}
-
-			const parser = new TreeSitter.Parser();
+			const parser = new resources.parserClass();
 			this._register(toDisposable(() => {
 				try {
 					parser.delete();
@@ -423,36 +448,20 @@ export class CommandAutoApprover extends Disposable {
 				}
 			}));
 
-			// Load the bash and PowerShell grammars. A failure to load one must
-			// not disable auto-approval for the other, so each is settled
-			// independently and assigned only if it resolved.
-			const loadGrammar = async (fileName: string) => {
-				const grammarWasm = await fs.promises.readFile(URI.joinPath(moduleRoot, fileName).fsPath);
-				return TreeSitter.Language.load(new Uint8Array(grammarWasm.buffer, grammarWasm.byteOffset, grammarWasm.byteLength));
-			};
-			const [bashLanguage, powershellLanguage] = await Promise.allSettled([
-				loadGrammar('tree-sitter-bash.wasm'),
-				loadGrammar('tree-sitter-powershell.wasm'),
-			]);
-
-			if (this._store.isDisposed) {
-				return;
-			}
-
 			this._parser = parser;
-			this._queryClass = TreeSitter.Query;
+			this._queryClass = resources.queryClass;
 			// A grammar that fails to load leaves its language undefined, so
 			// commands for that shell fall back to `noMatch` and require
 			// confirmation rather than auto-approving.
-			if (bashLanguage.status === 'fulfilled') {
-				this._bashLanguage = bashLanguage.value;
+			if (resources.bashLanguage.status === 'fulfilled') {
+				this._bashLanguage = resources.bashLanguage.value;
 			} else {
-				this._logService.warn('[CommandAutoApprover] Failed to load the bash grammar; bash commands will require confirmation', bashLanguage.reason);
+				this._logService.warn('[CommandAutoApprover] Failed to load the bash grammar; bash commands will require confirmation', resources.bashLanguage.reason);
 			}
-			if (powershellLanguage.status === 'fulfilled') {
-				this._powershellLanguage = powershellLanguage.value;
+			if (resources.powershellLanguage.status === 'fulfilled') {
+				this._powershellLanguage = resources.powershellLanguage.value;
 			} else {
-				this._logService.warn('[CommandAutoApprover] Failed to load the PowerShell grammar; PowerShell commands will require confirmation', powershellLanguage.reason);
+				this._logService.warn('[CommandAutoApprover] Failed to load the PowerShell grammar; PowerShell commands will require confirmation', resources.powershellLanguage.reason);
 			}
 			this._logService.info(`[CommandAutoApprover] Tree-sitter initialized (bash=${this._bashLanguage ? 'available' : 'unavailable'}, powershell=${this._powershellLanguage ? 'available' : 'unavailable'})`);
 		} catch (err) {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2241,6 +2241,10 @@ suite('AgentService (node dispatcher)', () => {
 				prepareSessionDeletion: async () => undefined,
 				removeSessionWorktree: async () => { removeWorktreeCalls++; },
 			} as unknown as WorktreeIsolation);
+			// Flush the provider backfill before injecting failures: its
+			// registry write is fire-and-forget and would otherwise consume
+			// part of the failure budget intended for the unregistration.
+			await svc.listSessions();
 			db.failRegistryWrites(2);
 
 			await assert.rejects(svc.disposeSession(session), /transient registry write failure/);

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -8,6 +8,25 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { CommandAutoApprover, type ICommandApprovalEvaluation } from '../../node/commandAutoApprover.js';
 
+suite('CommandAutoApprover initialization', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('initializes concurrent approvers', async () => {
+		const approvers = Array.from({ length: 20 }, () => disposables.add(new CommandAutoApprover(new NullLogService())));
+
+		await Promise.all(approvers.map(approver => approver.initialize()));
+
+		assert.deepStrictEqual(
+			approvers.map(approver => [
+				approver.shouldAutoApprove('ls'),
+				approver.shouldAutoApprove('Get-ChildItem', { language: 'powershell' }),
+			]),
+			Array.from({ length: approvers.length }, () => ['approved', 'approved']),
+		);
+	});
+});
+
 suite('CommandAutoApprover', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
Fixes the flaky Windows `node.js` unit-test failures reported for `main` ([build 464074](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464074), [build 464010](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464010)), where 41 tests across `agentSideEffects.test.js`, `commandAutoApprover.test.js` and `sessionPermissions.test.js` fail together — every assertion returning `'noMatch'`/`undefined` where `'approved'` or `'denied'` was expected.

### Root cause

`@vscode/tree-sitter-wasm`'s `initializeBinding` has no single-flight guard — it `await`s *before* assigning the cached module:

```js
var Module3 = null;
async function initializeBinding(moduleOptions) {
  if (!Module3) {
    Module3 = await tree_sitter_default(moduleOptions);  // await precedes assignment
  }
  return Module3;
}
```

Any caller arriving before the first one resolves also passes the `!Module3` check and instantiates a **competing WASM module**. This reproduces against the library alone, with no VS Code code involved — two overlapping `Parser.init()` calls fail outright:

```
TypeError: _ts_init is not a function
    at Parser.init (tree-sitter.js:3871:25)
```

The loser of the race observes a half-constructed module whose `wasmExports` are not yet bound.

Neither degenerate case fails, which is what makes this intermittent rather than deterministic:

| Pattern | Result |
|---|---|
| 50 *simultaneous* inits | passes — all await before touching the module handle |
| Sequential re-init | passes — `Module3` is already cached |
| Genuinely *overlapping* inits | **fails** — competing modules, half-initialized loser |

`CommandAutoApprover` fires `_initTreeSitter()` un-awaited from its constructor, and one approver is constructed per `AgentSideEffects` → `SessionPermissionManager`. In `agentSideEffects.test.ts` that is one per test via `setup()` (164 tests), plus ~30 more inside individual tests, plus the `commandAutoApprover` and `sessionPermissions` suites — hundreds of overlapping initializations in a single Node process.

When an approver loses the race, the `catch` in `_initTreeSitter` swallows the error and leaves `_parser` / `_bashLanguage` / `_powershellLanguage` undefined. `_extractSubCommands` then returns `undefined` and `evaluate` **fails closed to `noMatch`**. Because the degradation is per-approver and permanent, every test using that approver fails — hence the all-or-nothing block of 41 failures.

### Why it surfaced now

There is no single regression commit. The race has been latent since fbabc5c (tree-sitter adoption, Mar 31). Two gradual pressures pushed it past the threshold:

- cb0cb56 (Jul 29) added the PowerShell grammar, doubling per-approver WASM work from one `Language.load()` to two.
- `agentSideEffects.test.ts` grew from 148 to 164 tests since late July, each adding another overlapping initialization.

On contended Windows CI agents this widened the overlap window enough to lose the race in roughly 30% of runs (6 of 20 iterations in build 464074).

> [!NOTE]
> The automated investigation for build 464010 attributed this to c4d713e (#330424) and filed microsoft/vscode-engineering#3584 against that author. **That attribution is incorrect** — build 463994, at the earlier commit b741771, already showed the identical 41 failures, and later builds containing c4d713e passed. #3584 should be retargeted or closed against this PR.
>
> Credit to @benibenj, whose independent investigation earlier the same day reached the same conclusion and the same fix shape.

### Change

- Hoist tree-sitter module init and grammar loading into a single process-wide promise, so `Parser.init()` and each `Language.load()` happen exactly once and every approver observes a fully initialized parser.
- Keep the `Parser` instance per `CommandAutoApprover` so it remains individually disposable; the shared `Language`/`Query` objects are not deleted by instances.
- Fail-closed behavior is unchanged: a grammar that fails to load leaves its language undefined, so those commands still require confirmation rather than being auto-approved.

### Second fix: a racy sibling test exposed by the timing change

CI surfaced a second, independent failure on the Electron jobs (macOS and Linux):

```
1) AgentService (node dispatcher) disposeSession
     reports failed unregistration and allows deletion to retry durably:
   AssertionError [ERR_ASSERTION]: Missing expected rejection.
```

That test budgets exactly two registry write failures via `db.failRegistryWrites(2)` and relies on both being consumed by the unregistration, because `_retryRegistryMutation` makes exactly two attempts before giving up. The provider backfill's `markProviderBackfilled` write is fire-and-forget, so when it lands after the injection it steals part of that budget — the retry then succeeds and `disposeSession` resolves instead of rejecting.

Instrumenting the fake database shows the intended ordering, with the backfill settling *before* the injection:

```
write#1 by registerSessionIfNotTombstoned
write#2 by markProviderBackfilled      <- fire-and-forget; must land before the injection
write#3 by registerSession
write#4 by clearSessionTombstone
--- failRegistryWrites(2) ---
write#1..#3 by tombstoneAndUnregisterSession
```

This is latent rather than newly introduced, but it is coupled to this PR: removing the per-approver WASM work also removes roughly two file reads and two WASM compiles from every `AgentService` construction, which is enough to reorder when that fire-and-forget write lands on slower CI agents.

The fix mirrors the pattern already used by the sibling test `retries a transient registry registration failure before reporting creation success`, which awaits `listSessions()` before injecting failures. `listSessions()` → `_ensureRegistryBackfilled()` awaits the in-flight provider backfill, so after it no background registry write can be pending and the budget is deterministically consumed by `disposeSession` alone.

### Testing

- Added a regression test that initializes 20 approvers concurrently and asserts both the bash and PowerShell grammars resolve for every one of them.
- `agentSideEffects.test.ts` + `commandAutoApprover.test.ts`: 207 passing.
- Stress-ran both suites for 20 fresh-process iterations (4,140 tests) with no failures.
- Full unit suite locally: 30553 passing, 0 failing.
- Flaky pipeline validation (definition 700, Windows, 20 iterations): [build 464161](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464161).

