### PR TITLE
fix: provision AgentSdkDownloader tests with a generous timeout (build fix for vscode-engineering#3401)

### DIFF
--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -209,7 +209,14 @@ suite('AgentSdkDownloader', () => {
 		hostSdkTarget = target;
 	});
 
-	setup(async () => {
+	setup(async function () {
+		// These are I/O-bound integration tests: each spins up a loopback HTTP
+		// server, downloads a gzipped tarball, and extracts it to disk. On slow
+		// Windows CI agents that legitimately exceeds the 2000ms mocha default
+		// (see microsoft/vscode-engineering#3401), so provision the whole suite
+		// with a generous timeout rather than racing the default.
+		this.timeout(15_000);
+
 		originalEnvOverride = process.env[AgentHostClaudeSdkRootEnvVar];
 		delete process.env[AgentHostClaudeSdkRootEnvVar];
 		userDataPath = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-userdata-'));

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -179,7 +179,9 @@ suite('resolveSdkTarget', () => {
  * These run against whatever `process.platform` the test host is — the
  * pure `resolveSdkTarget` suite above covers the cross-host matrix.
  */
-suite('AgentSdkDownloader', () => {
+suite('AgentSdkDownloader', function () {
+	// I/O-bound integration tests (loopback download + extract) exceed the 2000ms default on slow Windows CI (microsoft/vscode-engineering#3401).
+	this.timeout(15_000);
 
 	const disposables = new DisposableStore();
 	teardown(() => disposables.clear());
@@ -209,14 +211,7 @@ suite('AgentSdkDownloader', () => {
 		hostSdkTarget = target;
 	});
 
-	setup(async function () {
-		// These are I/O-bound integration tests: each spins up a loopback HTTP
-		// server, downloads a gzipped tarball, and extracts it to disk. On slow
-		// Windows CI agents that legitimately exceeds the 2000ms mocha default
-		// (see microsoft/vscode-engineering#3401), so provision the whole suite
-		// with a generous timeout rather than racing the default.
-		this.timeout(15_000);
-
+	setup(async () => {
 		originalEnvOverride = process.env[AgentHostClaudeSdkRootEnvVar];
 		delete process.env[AgentHostClaudeSdkRootEnvVar];
 		userDataPath = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-userdata-'));


### PR DESCRIPTION
## Build failure

The Windows `Run unit tests (node.js)` stage failed because several `vs/platform/agentHost/test/node/` unit tests exceeded the default 2000ms mocha timeout, e.g.:

- `AgentSdkDownloader loadSdkRoot: reports monotonic download progress ending at totalBytes`
- `AgentSdkDownloader loadSdkRoot: cache hit returns immediately without re-downloading`
- `AgentSdkDownloader loadSdkRoot: cache dir includes sdkTarget so Universal launches stay separate`
- `AgentSdkDownloader loadSdkRoot: concurrent calls in same process share one download`

The signature is recurring (not a one-off flake): the same `agentHost` node suite hit `Timeout of 2000ms exceeded` across multiple scheduled Windows builds with no correlated source change.

## Root cause

The `AgentSdkDownloader` suite in `src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts` contains **I/O-bound integration tests**. Each test spins up a real loopback HTTP server, downloads a gzipped tarball over the socket, and extracts it to a temp directory on disk. On slow Windows CI agents this end-to-end work legitimately exceeds mocha's 2000ms default. Only the explicit cancel test carried its own `this.timeout(15_000)`; the remaining download/extract tests raced the default. This mirrors the already-fixed `SessionDatabase` "retries after a transient initialization failure" test, which was provisioned with an explicit `.timeout(10_000)` for the same filesystem-latency reason.

## How the fix works

A suite-level `this.timeout(15_000)` is set on the `AgentSdkDownloader` suite callback (converted to a `function` so mocha's `this` context is bound). Setting the timeout on the suite callback applies it to every test runnable in the suite, so all download/extract tests are provisioned consistently instead of each needing an individual annotation. No production code changes; the tests still exercise the real network → cache → extract flow, and any genuine hang still fails (now at 15s instead of hanging the CI job). Error reporting and assertions are unchanged.

## Validation

Change is test-only and scoped to a single file. I was unable to run the node unit test suite in this environment (the checkout has no build/test toolchain provisioned and network access is restricted), so validation is by source inspection: the added timeout uses the same established mocha `this.timeout(...)` pattern already present in this suite's cancel test and in the sibling `sessionDatabase.test.ts` retry test.

## Risk

Very low. Raising a test timeout cannot mask a functional regression — a real defect still fails the assertions; only the deadline for legitimately slow I/O is relaxed. No production code, telemetry, or error handling is touched.

## Recommended reviewer

Recommended owner: `@Giuspepe`

Fixes microsoft/vscode-engineering#3401




> Generated by [build-fix](https://github.com/microsoft/vscode-engineering/actions/runs/31642289789) · opus48 · 246.2 AIC · ⌖ 10.9 AIC · ⊞ 11.1K · [◷](https://github.com/search?q=repo:microsoft%2Fvscode+%22gh-aw-workflow-id:+build-fix%22&type=pullrequests)

<!-- build-fix-driver:status:start -->
<!-- followup-cycle: 1 -->

### build-fix-driver — cycle 1

**Trigger**: shim_validation · **Head**: `5b40acfe9f8` (pushed this cycle)

| Item | Action |
|------|--------|
| Review on `agentSdkDownloader.test.ts:218` — setup-hook timeout only raised the hook deadline (in scope) | Fixed in `5b40acf`: moved `this.timeout(15_000)` onto the suite `function` callback (replied + resolved) |
| Review on `agentSdkDownloader.test.ts:217` — condense inline comment to one line (in scope) | Fixed in `5b40acf`: condensed rationale to one line (replied + resolved) |

**Push**: yes — `5b40acf` · **Copilot rerequested**: ok

**Ready gate**: CI pending + Copilot not yet re-run on new HEAD → not marking ready this cycle
<!-- build-fix-driver:status:end -->

> Generated by [build-fix-driver](https://github.com/microsoft/vscode-engineering/actions/runs/31656842040) · opus48 · 172.2 AIC · ⌖ 18.1 AIC · ⊞ 21.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+%22gh-aw-workflow-call-id%3A+microsoft%2Fvscode-engineering%2Fbuild-fix-driver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: build-fix-driver, engine: copilot, model: claude-opus-4.8, id: 31656842040, workflow_id: build-fix-driver, run: https://github.com/microsoft/vscode-engineering/actions/runs/31656842040 -->