### PR TITLE
sessions: fix model picker desyncing from the session

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -358,14 +358,9 @@ Every `ISession` wrapper must delegate optional provider-owned observables such 
    → Management fires onWillSendRequest(session); the view follows the send to
      keep the newest chat active in the visible slot
   → ChatView clears the embedded ChatWidget before loading a different chat,
-    while its session-target picker keeps the destination chat's exact type
-    (including extension-host Copilot CLI); before any chat is assigned it
-    defaults to Agent Host Copilot. Chat input context keys also derive model
-    targeting from that delegated type while the model resource is absent, so
-    the model picker remains mounted during loading. Before clearing the old
-    model, the view locks to the destination contributed chat session type (for
-    example agent-host-codex), keeping the Agent Host mode and permission
-    pickers mounted too; follow-up turns therefore route to the owning provider
+    then locks it to the contributed chat session type (for example
+    agent-host-codex) before setting the model, so follow-up turns keep routing
+    to the provider that owns the session; local chat sessions unlock
    → Delegates to provider.sendRequest(sessionId, chatResource, options)
    → Provider sends request, returns committed session
    → Management fires onDidStartSession(committedSession) + onDidSendRequest(...)
@@ -386,17 +381,17 @@ the sent chat the active chat by reacting to the send events. When
 visible slot into the sent chat — see _Adding a Chat to an Existing Session_
 below.
 
-When fixing transient picker state during chat loading, keep the fallback in
-`ChatView`'s reactive session-type delegate; it announces the destination as
-soon as `setChat` assigns it, and the rendered target picker and chat input
-context keys react before the model loads. Changing the shared picker's defaults
-or visibility would alter intentional behavior outside that transition.
-All chat-input context derived from the session type must use the same effective
-type (the scoped delegate when provided, otherwise the model resource), or
-individual picker slots can disappear during the handoff.
-Likewise, update the widget's coding-agent lock from the destination type before
-clearing the old model; waiting for the new model to load transiently hides
-Agent Host-only mode and permission actions.
+`ChatView` must **not** pass a `sessionTypePickerDelegate` to its `ChatWidget`.
+That option means "the user picks the session type here" (the welcome view and
+the automations dialog, which have no chat model of their own). `ChatInputPart`
+listens to `onDidChangeActiveSessionProvider` and reconciles the model and mode
+for the newly picked type, so a delegate that merely announces the displayed
+chat makes every navigation re-apply the remembered per-session-type model —
+while the input is still bound to the outgoing chat, which persists the wrong
+model into that chat's input state. A previous attempt to reduce picker flicker
+during loading did exactly this and desynchronized the model picker from the
+session; see the revert of #329889. Fix transient picker state during loading
+some other way.
 
 For agent-host sessions, the floating turn-status pills above the chat input read
 the viewed chat's `lastTurnChanges` while the turn streams. They remain visible

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -7,8 +7,7 @@ import './media/chatView.css';
 import './media/voiceChatView.css';
 import { renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { Emitter } from '../../../../base/common/event.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableFromEvent, observableValue } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -26,14 +25,13 @@ import { IVoiceSessionController } from '../../../../workbench/contrib/chat/brow
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from '../../../../workbench/common/theme.js';
 import { ChatWidget } from '../../../../workbench/contrib/chat/browser/widget/chatWidget.js';
-import { ISessionTypePickerDelegate, setModelPreservingInputTypedWhileLoading } from '../../../../workbench/contrib/chat/browser/chat.js';
-import { AgentSessionTarget } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
+import { setModelPreservingInputTypedWhileLoading } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatModelReference, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { isChatTranscriptContextVariableEntry, IChatRequestTranscriptContextVariableEntry, IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { IChatModel } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
-import { SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChatSessionsService, localChatSessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { AbstractChatView, ChatViewKind, IChatViewOptions } from '../../../browser/parts/chatView.js';
 import { ChatInteractivity, getSessionStatusMessage, IChat, ISession } from '../../../services/sessions/common/session.js';
 import { IChatViewFactory } from '../../../services/chatView/browser/chatViewFactory.js';
@@ -48,27 +46,6 @@ import { activeSessionViewBackground, activeSessionViewForeground, agentsPanelBa
 import { setupVoiceInputDecorations } from './voiceInputDecorations.js';
 import { INewChatVoiceTargetService } from './newChatVoice.js';
 import { ISessionsChatViewStateService } from './chatViewStateService.js';
-
-export function getChatViewSessionType(chatResource: URI | undefined): AgentSessionTarget {
-	return chatResource ? getChatSessionType(chatResource) : SessionType.AgentHostCopilot;
-}
-
-export class ChatViewSessionTypeDelegate extends Disposable implements ISessionTypePickerDelegate {
-
-	private readonly _onDidChangeActiveSessionProvider = this._register(new Emitter<AgentSessionTarget>());
-	readonly onDidChangeActiveSessionProvider = this._onDidChangeActiveSessionProvider.event;
-
-	private _chatResource: URI | undefined;
-
-	getActiveSessionProvider(): AgentSessionTarget {
-		return getChatViewSessionType(this._chatResource);
-	}
-
-	setChatResource(resource: URI): void {
-		this._chatResource = resource;
-		this._onDidChangeActiveSessionProvider.fire(this.getActiveSessionProvider());
-	}
-}
 
 /**
  * A session view that hosts a {@link NewChatWidget} — the "new session" UI
@@ -176,7 +153,6 @@ export class ChatView extends AbstractChatView {
 	/** Tracks the currently loaded chat resource to avoid redundant reloads. */
 	private _currentChatResource: URI | undefined;
 	private readonly _currentChatResourceObs = observableValue<URI | undefined>(this, undefined);
-	private readonly _sessionTypeDelegate = this._register(new ChatViewSessionTypeDelegate());
 	private readonly _currentSessionObs = observableValue<ISession | undefined>(this, undefined);
 	private _historyKey: string | undefined;
 
@@ -198,6 +174,7 @@ export class ChatView extends AbstractChatView {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IChatService private readonly chatService: IChatService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
@@ -239,7 +216,6 @@ export class ChatView extends AbstractChatView {
 				supportsChangingModes: true,
 				inputEditorMinLines: 2,
 				isSessionsWindow: true,
-				sessionTypePickerDelegate: this._sessionTypeDelegate,
 				enableFind: true
 			},
 			this._buildStyles(this._isActive)
@@ -378,7 +354,6 @@ export class ChatView extends AbstractChatView {
 		}
 
 		this._currentChatResource = resource;
-		this._sessionTypeDelegate.setChatResource(resource);
 		this._currentChatResourceObs.set(resource, undefined);
 
 		// Cancel any in-flight load for the previous chat and start a fresh one.
@@ -400,6 +375,7 @@ export class ChatView extends AbstractChatView {
 				return;
 			}
 			this._modelRef.value = ref;
+			this._updateWidgetLockState(getChatSessionType(ref.object.sessionResource));
 			setModelPreservingInputTypedWhileLoading(this._widget, inputBeforeLoad, () => this._widget.setModel(ref.object));
 			const widgetViewState = this.viewStateService.get(resource);
 			if (widgetViewState) {
@@ -446,6 +422,20 @@ export class ChatView extends AbstractChatView {
 	private _applyHistoryKey(): void {
 		const scopedHistory = this.configurationService.getValue<boolean>(AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING) !== false;
 		this._widget.inputPart.setHistoryKey(scopedHistory ? this._historyKey : undefined);
+	}
+
+	private _updateWidgetLockState(sessionType: string): void {
+		if (sessionType === localChatSessionType) {
+			this._widget.unlockFromCodingAgent();
+			return;
+		}
+
+		const contribution = this.chatSessionsService.getChatSessionContribution(sessionType);
+		if (contribution) {
+			this._widget.lockToCodingAgent(contribution.name, contribution.displayName, sessionType, contribution.agentHostProviderId);
+		} else {
+			this._widget.unlockFromCodingAgent();
+		}
 	}
 
 	override toJSON(): object {

--- a/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/chatView.test.ts
@@ -10,8 +10,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CHAT_WIDGET_VIEW_STATE_CACHE_LIMIT } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { ChatInputNoticeHost, ChatInputNoticeLane } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputNoticeHost.js';
-import { SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ChatViewSessionTypeDelegate, findTranscriptContextEntry, getChatViewSessionType, getGettingReadyMessage, NewChatView, shouldShowGettingReady } from '../../browser/chatView.js';
+import { findTranscriptContextEntry, getGettingReadyMessage, NewChatView, shouldShowGettingReady } from '../../browser/chatView.js';
 import { SessionsChatViewStateService } from '../../browser/chatViewStateService.js';
 import { NewChatInSessionWidget } from '../../browser/newChatInSessionWidget.js';
 import { NewChatWidget } from '../../browser/newChatWidget.js';
@@ -45,35 +44,6 @@ suite('Sessions - Chat View', () => {
 		});
 
 		assert.doesNotThrow(() => view.setVisible(false));
-	});
-
-	test('defaults the session target to Agent Host and preserves the loaded session type', () => {
-		assert.deepStrictEqual({
-			beforeChatAssigned: getChatViewSessionType(undefined),
-			agentHost: getChatViewSessionType(URI.parse(`${SessionType.AgentHostClaude}:///chat`)),
-			extensionHost: getChatViewSessionType(URI.parse(`${SessionType.CopilotCLI}:///chat`)),
-		}, {
-			beforeChatAssigned: SessionType.AgentHostCopilot,
-			agentHost: SessionType.AgentHostClaude,
-			extensionHost: SessionType.CopilotCLI,
-		});
-	});
-
-	test('announces the destination session type before its chat model loads', () => {
-		const delegate = disposables.add(new ChatViewSessionTypeDelegate());
-		const changes: string[] = [];
-		disposables.add(delegate.onDidChangeActiveSessionProvider(type => changes.push(type)));
-
-		delegate.setChatResource(URI.parse(`${SessionType.AgentHostClaude}:///chat`));
-		delegate.setChatResource(URI.parse(`${SessionType.CopilotCLI}:///chat`));
-
-		assert.deepStrictEqual({
-			initial: getChatViewSessionType(undefined),
-			changes,
-		}, {
-			initial: SessionType.AgentHostCopilot,
-			changes: [SessionType.AgentHostClaude, SessionType.CopilotCLI],
-		});
 	});
 
 	test('stores view state independently by chat resource', () => {


### PR DESCRIPTION
Reverts the `ChatView` session-type delegate wiring from #329889, which desynchronized the model picker from the viewed session. Resuming an Opus 5 session would show — and then persist — `gpt-5.6-sol`.

## Root cause

`sessionTypePickerDelegate` means *"the user picks the session type here"*. It exists for the welcome view and the automations dialog, which have no chat model of their own. `ChatInputPart` listens to that delegate's `onDidChangeActiveSessionProvider` and reconciles the model and mode for the newly picked type:

```ts
this.checkModeInSessionPool(newSessionType);
this.revalidateModelForSessionType();   // "Reconcile the current model after an explicit session-type pick"
```

`ChatView`'s delegate instead fired on **every chat navigation**, from `_loadChat` and *before* the widget rebinds:

```ts
this._currentChatResource = resource;
this._sessionTypeDelegate.setChatResource(resource);  // fires synchronously
...
if (previousChatResource) { this._clearCurrentChat(); }   // widget.setModel(undefined) — AFTER
```

So each navigation re-applied the remembered per-session-type model while the input was still bound to the **outgoing** chat. `_applyModel` → `runtime.applyModel` → `_syncInputStateToModel()` therefore wrote that model into the outgoing chat's persisted input state.

The corruption was silent while the remembered model happened to match, and became visible the moment an explicit pick made them differ.

## Evidence

From an Agents window log bundle, `[ChatModelSelection]` diagnostics show the exact sequence. Note every affected switch was between chats of the **same** type (`agent-host-copilotcli` → `agent-host-copilotcli`), where a session-type announcement is meaningless:

```
12:04:56.978  explicit-selection      conv=d43abfdb  model=gpt-5.6-sol      ← user picks
12:04:59.432  conversation-restore    conv=767d6151  desired=claude-opus-5  action=apply   ✅
12:05:02.325  initialize              conv=767d6151  result=gpt-5.6-sol  reason=remembered ❌ clobber
12:05:10.288  conversation-restore    conv=42ca61ac  desired=claude-opus-5  action=apply   ✅
12:05:12.784  initialize              conv=42ca61ac  result=gpt-5.6-sol  reason=remembered ❌ clobber
12:05:18+     initialize ... (no conversation-restore at all — state is now persisted wrong)
```

Confirmed by replaying the production call sequence against the real `ChatInputModelSelectionController`: restoring a conversation to Opus 5, then `revalidateForSessionType(() => initialize('gpt-5.6-sol'))` while bound to the outgoing conversation flips both the picker **and** the outgoing conversation's stored model to `gpt-5.6-sol`.

## What changed

- Removed `ChatViewSessionTypeDelegate` / `getChatViewSessionType` and stopped passing `sessionTypePickerDelegate` to the Agents-window `ChatWidget`.
- Restored `_updateWidgetLockState` (and the `IChatSessionsService` injection it needs) so the widget still locks to the contributed chat session type when the model loads.
- Removed the two tests covering the deleted delegate.
- `SESSIONS.md` records **why** the delegate must not be reintroduced here.

The two incidental hunks from #329889 are left in place: `getVisibleOptionGroupsModeAndUpdateContextKeys` using `getEffectiveSessionType` (now falls back to the session resource for the Agents window, i.e. the pre-#329889 behavior) and the target picker's label re-render on delegate change (inert without a `ChatView` delegate, still correct for the welcome view and automations dialog).

## Reviewer notes

- ⚠️ **This brings back the picker blink on session switch** that #329889 was fixing. That needs a solution which does not route through the explicit-pick pathway — e.g. a display-only notification that updates context keys / lock state / picker rendering without touching model reconciliation.
- ⚠️ **Already-corrupted sessions stay corrupted.** Sessions whose input state was rewritten keep the wrong model persisted; this stops new damage but does not repair existing state.
- `git diff 0b8b8c6f3f5^ -- chatView.ts` filtered for delegate/lock-state/session-type shows zero differences, so the file's behavior matches the pre-regression version exactly.

## Validation

- `npm run typecheck-client` — clean
- `npm run hygiene` — clean
- `eslint` on changed files — clean
- 56 tests passing: `Sessions - Chat View`, `ChatInputModelSelectionController`, `SessionTypePickerActionItem`

(Written by Copilot)
