### PR TITLE
chat: link remote session access destinations

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
@@ -15,8 +15,11 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { localize } from '../../../../nls.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { ITunnelHostService } from '../common/tunnelHost.js';
 import { RENAME_TUNNEL_ID, SHOW_TUNNEL_HOST_OUTPUT_ID } from './tunnelHostService.js';
+
+const TUNNEL_ACCESS_DOCS_URL = 'http://aka.ms/vscode-agent-tunnel-access';
 
 export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 
@@ -29,6 +32,7 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 		action: IAction,
 		@ITunnelHostService private readonly _tunnelHostService: ITunnelHostService,
 		@IHoverService private readonly _hoverService: IHoverService,
+		@IProductService private readonly _productService: IProductService,
 	) {
 		super(undefined, action);
 
@@ -116,10 +120,13 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 				lines.push(localize('tunnelHost.hover.enabled', "Remote session access is enabled"));
 			}
 		} else {
-			lines.push(localize('tunnelHost.hover.idle', "Allow remote session access"));
+			const agentsUrl = this._productService.webUrl ? `${this._productService.webUrl.replace(/\/$/, '')}/agents` : undefined;
+			lines.push(agentsUrl
+				? localize('tunnelHost.hover.idle', "Allow connections from other machines and {0}", `[${agentsUrl.replace(/https?:\/\//, '')}](${agentsUrl})`)
+				: localize('tunnelHost.hover.idle.noWebUrl', "Allow connections from other machines"));
 		}
 
-		lines.push(`[${localize('tunnelHost.hover.showOutput', "Show Output")}](command:${SHOW_TUNNEL_HOST_OUTPUT_ID}) | [${localize('tunnelHost.hover.renameTunnel', "Rename Tunnel")}](command:${RENAME_TUNNEL_ID})`);
+		lines.push(`[${localize('tunnelHost.hover.showOutput', "Show Output")}](command:${SHOW_TUNNEL_HOST_OUTPUT_ID}) | [${localize('tunnelHost.hover.renameTunnel', "Rename Tunnel")}](command:${RENAME_TUNNEL_ID}) | [${localize('tunnelHost.hover.learnMore', "Learn More")}](${TUNNEL_ACCESS_DOCS_URL})`);
 
 		const md = new MarkdownString(lines.join('\n\n'), { isTrusted: { enabledCommands: [SHOW_TUNNEL_HOST_OUTPUT_ID, RENAME_TUNNEL_ID] } });
 		return { markdown: md, markdownNotSupportedFallback: lines[0] };
@@ -136,6 +143,6 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 			}
 			return localize('tunnelHost.hover.enabled', "Remote session access is enabled");
 		}
-		return localize('tunnelHost.hover.idle', "Allow remote session access");
+		return localize('tunnelHost.hover.idle.ariaLabel', "Allow connections from other machines and vscode.dev/agents");
 	}
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
@@ -143,6 +143,7 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 			}
 			return localize('tunnelHost.hover.enabled', "Remote session access is enabled");
 		}
-		return localize('tunnelHost.hover.idle.ariaLabel', "Allow connections from other machines and vscode.dev/agents");
+		const agentsUrl = this._productService.webUrl ? `${this._productService.webUrl.replace(/\/$/, '')}/agents` : 'vscode.dev/agents';
+		return localize('tunnelHost.hover.idle.ariaLabel', "Allow connections from other machines and {0}", agentsUrl);
 	}
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
@@ -19,7 +19,7 @@ import { IProductService } from '../../../../platform/product/common/productServ
 import { ITunnelHostService } from '../common/tunnelHost.js';
 import { RENAME_TUNNEL_ID, SHOW_TUNNEL_HOST_OUTPUT_ID } from './tunnelHostService.js';
 
-const TUNNEL_ACCESS_DOCS_URL = 'http://aka.ms/vscode-agent-tunnel-access';
+const TUNNEL_ACCESS_DOCS_URL = 'https://aka.ms/vscode-agent-tunnel-access';
 
 export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 
@@ -143,7 +143,9 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 			}
 			return localize('tunnelHost.hover.enabled', "Remote session access is enabled");
 		}
-		const agentsUrl = this._productService.webUrl ? `${this._productService.webUrl.replace(/\/$/, '')}/agents` : 'vscode.dev/agents';
-		return localize('tunnelHost.hover.idle.ariaLabel', "Allow connections from other machines and {0}", agentsUrl);
+		const agentsUrl = this._productService.webUrl ? `${this._productService.webUrl.replace(/\/$/, '')}/agents` : undefined;
+		return agentsUrl
+			? localize('tunnelHost.hover.idle.ariaLabel', "Allow connections from other machines and {0}", agentsUrl.replace(/https?:\/\//, ''))
+			: localize('tunnelHost.hover.idle.ariaLabel.noWebUrl', "Allow connections from other machines");
 	}
 }


### PR DESCRIPTION
Updates the remote session access tooltip to link to the configured agents web URL and documentation.

- Derives the agents link text and target from product.json webUrl.
- Places the documentation link with the existing tooltip actions.

(Commit message generated by Copilot)