### PR TITLE
Allow NOTICE fallback to complete in product builds

### DIFF
--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -1,7 +1,8 @@
 jobs:
   - job: Quality
     displayName: Quality Checks
-    timeoutInMinutes: 20
+    # Leave enough time for NOTICE retries and the fallback path to finish.
+    timeoutInMinutes: 30
     variables:
       - name: skipComponentGovernanceDetection
         value: true
@@ -154,7 +155,7 @@ jobs:
         inputs:
           outputfile: $(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt
         retryCountOnTaskFailure: 3
-        timeoutInMinutes: 10
+        timeoutInMinutes: 15
         continueOnError: true
         condition: and(succeeded(), eq(lower(variables['VSCODE_CIBUILD']), 'false'))
 


### PR DESCRIPTION
## Summary

- increase the OSPO NOTICE generation timeout from 10 to 15 minutes so its configured retries have more time to run
- increase the enclosing Quality job timeout from 20 to 30 minutes so the cached NOTICE fallback and remaining quality steps can complete
- preserve `continueOnError` behavior, allowing Publish to accept the resulting `succeededWithIssues` stage

This addresses the failure mode observed in [build 464142](https://dev.azure.com/monacotools/Monaco/Monaco%20Team/_build/results?buildId=464142), where NOTICE generation timed out, the fallback worked, but the Quality job reached its overall timeout and was reported as failed.

## Validation

- `git diff --check`
- pre-commit hygiene check
- verified the publisher accepts both `succeeded` and `succeededWithIssues` Quality stage results