### PR TITLE
agentHost: don't re-render settled tool calls on active-turn reconnect

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -4727,10 +4727,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const sessionKey = backendSession.toString();
 		const chatURI = this._getChatURI(chatSession.sessionResource);
 
-		// Extract live ChatToolInvocation objects from the initial progress
-		// array so per-tool setup adopts the same instances the chat UI holds.
-		// Settled tool calls arrive as serialized progress instead, so track
-		// their ids separately to keep per-tool setup from emitting them twice.
+		// Live invocations are adopted by per-tool setup; settled calls arrive serialized and are only tracked by id.
 		const adoptInvocations = new Map<string, ChatToolInvocation>();
 		const renderedToolCallIds = new Set<string>();
 		for (const item of initialProgress) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -172,6 +172,8 @@ type AgentHostInvocationFailedClassification = {
  * - {@link adoptInvocations} carries `ChatToolInvocation` instances that
  *   `activeTurnToProgress` already produced so per-tool setup adopts them
  *   rather than recreating UI handles.
+ * - {@link renderedToolCallIds} covers the settled tool calls the snapshot
+ *   rendered as serialized invocations, which have no live handle to adopt.
  * - {@link seedEmittedLengths} prevents the always-on graph from re-emitting
  *   markdown / reasoning prefixes already covered by the snapshot.
  * - {@link onTurnEnded} fires once when the turn reaches a terminal state.
@@ -191,6 +193,13 @@ interface IObserveTurnOptions {
 	readonly sink: (parts: IChatProgress[]) => void;
 	readonly cancellationToken: CancellationToken;
 	readonly adoptInvocations?: ReadonlyMap<string, ChatToolInvocation>;
+	/**
+	 * Tool calls the reconnect snapshot already rendered as serialized
+	 * invocations. Re-emitting one appends a duplicate row after the
+	 * snapshot's trailing markdown, which stops later markdown deltas from
+	 * merging into it and visibly splits the response mid-sentence.
+	 */
+	readonly renderedToolCallIds?: ReadonlySet<string>;
 	readonly seedEmittedLengths?: ReadonlyMap<string, number>;
 	readonly initialResponsePartCount?: number;
 	readonly onTurnEnded?: (lastTurn: Turn | undefined) => void;
@@ -3564,7 +3573,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			opts.sessionResource.authority,
 			this._otherClientToolInvocationOptions(opts.backendSession, opts.chatURI, opts.turnId),
 		);
-		if (!adopted) {
+		if (!adopted && !opts.renderedToolCallIds?.has(toolCallId)) {
 			opts.sink([invocation]);
 		}
 
@@ -3639,12 +3648,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		let invocation: ChatToolInvocation;
 		if (adopted) {
 			invocation = adopted;
-		} else if (initial.status === ToolCallStatus.Streaming) {
-			invocation = toolCallStateToStreamingInvocation(initial, subAgentInvocationId, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority);
-			opts.sink([invocation]);
 		} else {
-			invocation = toolCallStateToInvocation(initial, subAgentInvocationId, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority);
-			opts.sink([invocation]);
+			invocation = initial.status === ToolCallStatus.Streaming
+				? toolCallStateToStreamingInvocation(initial, subAgentInvocationId, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority)
+				: toolCallStateToInvocation(initial, subAgentInvocationId, opts.backendSession, this._config.connectionAuthority, opts.sessionResource.authority);
+			if (!opts.renderedToolCallIds?.has(toolCallId)) {
+				opts.sink([invocation]);
+			}
 		}
 
 		// Hook up a tool first observed after it already entered confirmation.
@@ -3909,7 +3919,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// The shared invocation is created with no `sessionResource`, so it
 		// does not `appendProgress` into a chat model. Emit it explicitly so it
 		// renders in this chat / subagent group (mirrors `_setupServerToolCall`).
-		opts.sink([invocation]);
+		if (!opts.renderedToolCallIds?.has(toolCallId)) {
+			opts.sink([invocation]);
+		}
 
 		let confirmationDispatched = false;
 
@@ -4717,10 +4729,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		// Extract live ChatToolInvocation objects from the initial progress
 		// array so per-tool setup adopts the same instances the chat UI holds.
+		// Settled tool calls arrive as serialized progress instead, so track
+		// their ids separately to keep per-tool setup from emitting them twice.
 		const adoptInvocations = new Map<string, ChatToolInvocation>();
+		const renderedToolCallIds = new Set<string>();
 		for (const item of initialProgress) {
 			if (item instanceof ChatToolInvocation) {
 				adoptInvocations.set(item.toolCallId, item);
+			} else if (item.kind === 'toolInvocationSerialized') {
+				renderedToolCallIds.add(item.toolCallId);
 			}
 		}
 
@@ -4748,6 +4765,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			sink: parts => chatSession.appendProgress(parts),
 			cancellationToken: cts.token,
 			adoptInvocations,
+			renderedToolCallIds,
 			seedEmittedLengths,
 			initialResponsePartCount,
 			onTurnEnded: () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -9468,6 +9468,60 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(lastMarkdown.content.value, ' and more');
 		}));
 
+		test('keeps a completed tool call out of streamed markdown when reconnecting mid-turn', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+
+			const sessionUri = AgentSession.uri('copilot', 'reconnect-completed-tool');
+			const sessionState = makeSessionStateWithActiveTurn(sessionUri.toString(), { streamingText: 'The real fix is' });
+			// A settled tool call ahead of the partial trailing markdown: the
+			// snapshot renders it as serialized progress, so re-emitting it
+			// would split the response mid-sentence.
+			sessionState.activeTurn!.responseParts.unshift({
+				kind: ResponsePartKind.ToolCall,
+				toolCall: {
+					status: ToolCallStatus.Completed,
+					toolCallId: 'tc-completed',
+					toolName: 'bash',
+					displayName: 'Bash',
+					invocationMessage: 'Running command',
+					pastTenseMessage: 'Ran command',
+					confirmed: ToolCallConfirmationReason.NotNeeded,
+					success: true,
+					content: [],
+				},
+			});
+			agentHostService.sessionStates.set(sessionUri.toString(), sessionState);
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/reconnect-completed-tool' });
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+
+			agentHostService.fireAction({
+				channel: sessionUri.toString(),
+				action: { type: 'chat/delta', turnId: 'turn-active', partId: 'md-active', content: ' to stop guessing.' } as ChatAction,
+				serverSeq: 1,
+				origin: undefined,
+			});
+
+			await timeout(10);
+
+			assert.deepStrictEqual((session.progressObs?.get() ?? []).map(part => {
+				switch (part.kind) {
+					case 'markdownContent':
+						return { kind: part.kind, value: part.content.value };
+					case 'toolInvocation':
+					case 'toolInvocationSerialized':
+						return { kind: part.kind, value: part.toolCallId };
+					default:
+						return { kind: part.kind, value: undefined };
+				}
+			}), [
+				{ kind: 'toolInvocationSerialized', value: 'tc-completed' },
+				{ kind: 'markdownContent', value: 'The real fix is' },
+				{ kind: 'markdownContent', value: ' to stop guessing.' },
+			]);
+		}));
+
 		test('marks session complete when turn finishes', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -9473,9 +9473,7 @@ suite('AgentHostChatContribution', () => {
 
 			const sessionUri = AgentSession.uri('copilot', 'reconnect-completed-tool');
 			const sessionState = makeSessionStateWithActiveTurn(sessionUri.toString(), { streamingText: 'The real fix is' });
-			// A settled tool call ahead of the partial trailing markdown: the
-			// snapshot renders it as serialized progress, so re-emitting it
-			// would split the response mid-sentence.
+			// A settled tool call ahead of the partial trailing markdown, which the snapshot renders as serialized progress.
 			sessionState.activeTurn!.responseParts.unshift({
 				kind: ResponsePartKind.ToolCall,
 				toolCall: {


### PR DESCRIPTION
Fixes a case where an agent response visibly split in the middle of a word, with the tail rendered outside the collapsed completed-response group.

### What happens

When the workbench reattaches to a turn that is still streaming its final prose:

1. `activeTurnToProgress` hydrates the snapshot, rendering already-settled tool calls as **serialized** progress plus the partial trailing markdown.
2. The per-part observer then emits those same tool calls **again** — `adoptInvocations` only carries live `ChatToolInvocation` handles, so a settled call has nothing to adopt.
3. Those duplicate rows land *after* the snapshot's trailing markdown, so the next `chat/delta` can no longer merge into it (`Response.updateContent` only merges with the last response part).
4. The response ends up as two markdown parts. Once complete, the disclosure collapses the first with the tool activity and leaves the second outside it.

Evidence from an Agent Host log export: the subscription snapshot ended at `…that fallback fails to`, and the very next `chat/delta` — targeting the **same** markdown part id — began `ward destroying history.` No tool activity occurred on that chat between the two fragments; the persisted SDK `assistant.message` contained the correctly joined sentence.

### The fix

Track the tool call ids the reconnect snapshot already rendered and skip re-emitting them in the three per-tool setup paths (server, other-client, client). The trailing markdown stays the last response part, so later deltas keep merging into it.

### Notes

The underlying duplication dates to `b9ef6afd4e5` (Apr 28), but it only became visible with the completed-response disclosure in `8fdf719d28a` (Jul 28). It is rare because you have to attach during the short window after tools settle but before the final prose finishes streaming.

### Validation

- New regression test in the *reconnection to active turn* suite: settled tool → partial markdown → reconnect → delta.
- Verified it **fails without the fix**, reproducing exactly the reported shape (a duplicate `toolInvocation` wedged between the two markdown fragments).
- `npm run typecheck-client` clean; full `contrib/chat` suite passes (5804 tests).

### Known adjacent gap (not addressed here)

`autoModeResolution` is emitted by the live observer but is not part of `activeTurnToProgress`, so for Auto-routed sessions it can land after the partial markdown and split it the same way. Happy to fix separately.

(Written by Copilot)
