### PR TITLE
Add "New Worktree" Checkbox for Cloud Sessions

### DIFF
--- a/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
+++ b/src/vs/platform/agentHost/common/cloudSandboxAgentHost.ts
@@ -11,11 +11,25 @@
 // to reach an agent host over one transport; it does not define a new kind of agent host.
 
 import { CancellationToken } from '../../../base/common/cancellation.js';
+import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { RemoteAgentHostsEnabledSettingId } from './remoteAgentHostService.js';
 import { IReplayedTaskHistory } from './taskEventReplay.js';
 
 /** Configuration key gating the cloud-sandbox connection path. Disabled by default. */
 export const CloudSandboxEnabledSettingId = 'chat.agentHost.cloudSandbox.enabled';
+
+/**
+ * Whether cloud sandbox sessions can be created or connected to.
+ *
+ * A sandbox is reached over the remote-agent-host relay, so it needs *both* its own setting and
+ * remote agent hosts as a whole. Every entry point must agree on this, or a surface that offers the
+ * choice hands work to a path that refuses it.
+ */
+export function isCloudSandboxEnabled(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(CloudSandboxEnabledSettingId) === true
+		&& configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId) === true;
+}
 
 /** Prefix for the synthesized display address of a cloud sandbox connection. */
 export const CLOUD_SANDBOX_ADDRESS_PREFIX = 'cloudsandbox:';
@@ -56,6 +70,37 @@ export function cloudSandboxEnvironmentId(address: string): string | undefined {
  * setting keeps that from reaching everyone before the overlap is resolved.
  */
 export const CLOUD_SANDBOX_AGENT_SLUG = 'copilot-developer-cli';
+
+/**
+ * Sentinel environment id that asks Mission Control to provision a fresh sandbox VM instead of
+ * binding the new task to an existing environment. It is never a real environment: the concrete id
+ * comes back on the created session, and everything afterwards (relay connect, credential refresh)
+ * must address that one — see {@link ICloudSandboxCreatedSession.environmentId}.
+ */
+export const CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID = 'github-sandbox';
+
+/** What to provision a sandbox session for. */
+export interface ICloudSandboxCreateSessionRequest {
+	/** Repository to bind the sandbox to, as `owner/name`. Omitted for a repo-less sandbox. */
+	readonly repoNwo?: string;
+	/** Base branch the sandbox's worktree starts from. The host names the working branch. */
+	readonly baseRef?: string;
+	/**
+	 * First user turn. Mission Control persists it on the session but starts no run for an
+	 * environment-bound task, so the client still has to send it over the relay.
+	 */
+	readonly prompt: string;
+}
+
+/** A freshly provisioned sandbox task/session pair, bound to a concrete environment. */
+export interface ICloudSandboxCreatedSession {
+	/** Mission Control task id owning the session; the key its persisted AHP history is under. */
+	readonly taskId: string;
+	/** Session id, issued as `ahp-session:/<sessionId>` and listed back by the host under that id. */
+	readonly sessionId: string;
+	/** The sandbox VM Mission Control bound, never {@link CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID}. */
+	readonly environmentId: string;
+}
 
 /** A sandbox session discovered from the Copilot task list, enough to seed a session entry. */
 export interface ICloudSandboxDiscoveredSession {
@@ -217,6 +262,15 @@ export interface ICloudSandboxApiService {
 
 	/** Enumerate the caller's sandbox-backed cloud sessions, enough to seed session entries. */
 	listSessions(token: CancellationToken): Promise<ICloudSandboxDiscoveryResult>;
+
+	/**
+	 * Provision a new sandbox task and its bound session, without starting a run.
+	 *
+	 * Mission Control does not run environment-bound tasks, so this only produces the session the
+	 * client then connects to and drives — the caller still has to send {@link
+	 * ICloudSandboxCreateSessionRequest.prompt} over the relay itself.
+	 */
+	createSession(request: ICloudSandboxCreateSessionRequest, token: CancellationToken): Promise<ICloudSandboxCreatedSession>;
 
 	/**
 	 * Read a task's persisted AHP history and fold it back into session and chat state.

--- a/src/vs/sessions/contrib/chat/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/branchPicker.ts
@@ -5,14 +5,13 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { Checkbox } from '../../../../base/browser/ui/toggle/toggle.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { defaultCheckboxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import { CheckboxChip } from './checkboxChip.js';
 import './media/branchPicker.css';
 
 const FILTER_THRESHOLD = 10;
@@ -91,9 +90,7 @@ export class BranchPicker extends Disposable {
 	private _triggerElement: HTMLElement | undefined;
 	private _descriptionElement: HTMLElement | undefined;
 	private _isOpen = false;
-	private _isolationSlot: HTMLElement | undefined;
-	private _isolationRow: HTMLElement | undefined;
-	private _isolationCheckbox: Checkbox | undefined;
+	private _isolationChip: CheckboxChip | undefined;
 	private _isolationState: IBranchPickerIsolationState | undefined;
 
 	constructor(
@@ -114,68 +111,21 @@ export class BranchPicker extends Disposable {
 			return;
 		}
 
-		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot.sessions-chat-isolation-checkbox'));
-		if (isolation.slotClassName) {
-			slot.classList.add(isolation.slotClassName);
-		}
-		this._isolationSlot = slot;
-		this._renderDisposables.add(toDisposable(() => slot.remove()));
-		if (isolation.markTarget) {
-			this._renderDisposables.add(isolation.markTarget(slot));
-		}
-
-		const row = dom.append(slot, dom.$('.action-label'));
-		row.setAttribute('aria-label', isolation.ariaLabel);
-		this._isolationRow = row;
-
-		const checkbox = this._renderDisposables.add(new Checkbox(isolation.label, this._isolationState?.checked ?? false, { ...defaultCheckboxStyles, size: 14 }));
-		this._isolationCheckbox = checkbox;
-		dom.append(row, checkbox.domNode);
-		const labelSpan = dom.append(row, dom.$('span.sessions-chat-dropdown-label'));
-		labelSpan.textContent = isolation.label;
-
-		this._renderDisposables.add(checkbox.onChange(() => isolation.onToggle(checkbox.checked)));
-		this._renderDisposables.add(Gesture.addTarget(row));
-		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
-			this._renderDisposables.add(dom.addDisposableListener(row, eventType, e => {
-				if (!checkbox.enabled) {
-					return;
-				}
-				dom.EventHelper.stop(e, true);
-				checkbox.checked = !checkbox.checked;
-				isolation.onToggle(checkbox.checked);
-			}));
-		}
-
+		const chip = this._renderDisposables.add(new CheckboxChip({
+			label: isolation.label,
+			ariaLabel: isolation.ariaLabel,
+			onToggle: isolation.onToggle,
+			// Kept alongside the shared chip class so existing styling and selectors still match.
+			slotClassName: 'sessions-chat-isolation-checkbox',
+			markTarget: isolation.markTarget,
+		}));
+		this._isolationChip = chip;
+		chip.render(container);
 		this._updateIsolation();
 	}
 
 	private _updateIsolation(): void {
-		if (!this._options.isolation || !this._isolationCheckbox || !this._isolationSlot) {
-			return;
-		}
-
-		const state = this._isolationState;
-		const mode = state?.state ?? 'disabled';
-		this._isolationCheckbox.checked = state?.checked ?? false;
-		if (mode === 'enabled') {
-			this._isolationCheckbox.enable();
-		} else {
-			this._isolationCheckbox.disable();
-			// Keep focusable so keyboard users can discover the disabled reason via tooltip
-			this._isolationCheckbox.domNode.tabIndex = 0;
-		}
-		this._isolationSlot.classList.toggle('disabled', mode === 'disabled');
-		this._isolationSlot.classList.toggle('hidden', mode === 'hidden');
-
-		const reason = state?.disabledReason;
-		if (this._isolationRow) {
-			if (mode === 'disabled' && reason) {
-				this._isolationRow.title = reason;
-			} else {
-				this._isolationRow.removeAttribute('title');
-			}
-		}
+		this._isolationChip?.update(this._isolationState ?? { checked: false, state: 'disabled' });
 	}
 
 	render(container: HTMLElement): void {

--- a/src/vs/sessions/contrib/chat/browser/checkboxChip.ts
+++ b/src/vs/sessions/contrib/chat/browser/checkboxChip.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { Checkbox } from '../../../../base/browser/ui/toggle/toggle.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { defaultCheckboxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import './media/checkboxChip.css';
+
+/** Static configuration for a {@link CheckboxChip}. */
+export interface ICheckboxChipOptions {
+	readonly label: string;
+	readonly ariaLabel: string;
+	readonly onToggle: (checked: boolean) => void;
+	/** Extra class on the slot, for call-site-specific styling or test selectors. */
+	readonly slotClassName?: string;
+	readonly markTarget?: (element: HTMLElement) => IDisposable;
+}
+
+/** Per-update state for a {@link CheckboxChip}. */
+export interface ICheckboxChipState {
+	readonly checked: boolean;
+	readonly state: 'enabled' | 'disabled' | 'hidden';
+	/** Shown as a tooltip while `disabled`, explaining why the choice is unavailable. */
+	readonly disabledReason?: string;
+}
+
+/**
+ * A checkbox rendered as a chip in the new-session chip lane, matching the dropdown chips beside
+ * it. Used for the binary session choices that would be a two-item dropdown otherwise — worktree
+ * isolation, and running a cloud session in a sandbox.
+ *
+ * The whole row is clickable (not just the box) so the chip behaves like its dropdown neighbours.
+ * A disabled chip stays focusable, so keyboard users can still reach {@link
+ * ICheckboxChipState.disabledReason}.
+ */
+export class CheckboxChip extends Disposable {
+
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private _slot: HTMLElement | undefined;
+	private _row: HTMLElement | undefined;
+	private _checkbox: Checkbox | undefined;
+	private _state: ICheckboxChipState = { checked: false, state: 'disabled' };
+
+	constructor(private readonly _options: ICheckboxChipOptions) {
+		super();
+	}
+
+	/** The rendered slot, or `undefined` before the first {@link render}. */
+	get element(): HTMLElement | undefined {
+		return this._slot;
+	}
+
+	render(container: HTMLElement): HTMLElement {
+		this._renderDisposables.clear();
+
+		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot.sessions-chat-checkbox-chip'));
+		if (this._options.slotClassName) {
+			slot.classList.add(this._options.slotClassName);
+		}
+		this._slot = slot;
+		this._renderDisposables.add(toDisposable(() => {
+			slot.remove();
+			if (this._slot === slot) {
+				this._slot = undefined;
+			}
+		}));
+		if (this._options.markTarget) {
+			this._renderDisposables.add(this._options.markTarget(slot));
+		}
+
+		const row = dom.append(slot, dom.$('.action-label'));
+		row.setAttribute('aria-label', this._options.ariaLabel);
+		this._row = row;
+
+		const checkbox = this._renderDisposables.add(new Checkbox(this._options.label, this._state.checked, { ...defaultCheckboxStyles, size: 14 }));
+		this._checkbox = checkbox;
+		dom.append(row, checkbox.domNode);
+		const label = dom.append(row, dom.$('span.sessions-chat-dropdown-label'));
+		label.textContent = this._options.label;
+
+		this._renderDisposables.add(checkbox.onChange(() => this._options.onToggle(checkbox.checked)));
+		this._renderDisposables.add(Gesture.addTarget(row));
+		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
+			this._renderDisposables.add(dom.addDisposableListener(row, eventType, e => {
+				if (!checkbox.enabled) {
+					return;
+				}
+				dom.EventHelper.stop(e, true);
+				checkbox.checked = !checkbox.checked;
+				this._options.onToggle(checkbox.checked);
+			}));
+		}
+
+		this._apply();
+		return slot;
+	}
+
+	update(state: ICheckboxChipState): void {
+		this._state = state;
+		this._apply();
+	}
+
+	private _apply(): void {
+		const checkbox = this._checkbox;
+		const slot = this._slot;
+		if (!checkbox || !slot) {
+			return;
+		}
+		const { checked, state, disabledReason } = this._state;
+		checkbox.checked = checked;
+		if (state === 'enabled') {
+			checkbox.enable();
+		} else {
+			checkbox.disable();
+			// Keep focusable so keyboard users can discover the disabled reason via its tooltip.
+			checkbox.domNode.tabIndex = 0;
+		}
+		slot.classList.toggle('disabled', state === 'disabled');
+		slot.classList.toggle('hidden', state === 'hidden');
+
+		if (this._row) {
+			if (state === 'disabled' && disabledReason) {
+				this._row.title = disabledReason;
+			} else {
+				this._row.removeAttribute('title');
+			}
+		}
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/media/branchPicker.css
+++ b/src/vs/sessions/contrib/chat/browser/media/branchPicker.css
@@ -21,25 +21,3 @@
 	min-width: 0;
 	user-select: none;
 }
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .action-label {
-	cursor: pointer;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .monaco-checkbox {
-	margin-right: 6px;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox .sessions-chat-dropdown-label {
-	margin-left: 0;
-	cursor: pointer;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .action-label,
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.disabled .sessions-chat-dropdown-label {
-	cursor: default;
-}
-
-.sessions-chat-picker-slot.sessions-chat-isolation-checkbox.hidden {
-	display: none;
-}

--- a/src/vs/sessions/contrib/chat/browser/media/checkboxChip.css
+++ b/src/vs/sessions/contrib/chat/browser/media/checkboxChip.css
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip .action-label {
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip .monaco-checkbox {
+	margin-right: var(--vscode-spacing-size60);
+}
+
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip .sessions-chat-dropdown-label {
+	margin-left: 0;
+	cursor: pointer;
+}
+
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip.disabled .action-label,
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip.disabled .sessions-chat-dropdown-label {
+	cursor: default;
+}
+
+.sessions-chat-picker-slot.sessions-chat-checkbox-chip.hidden {
+	display: none;
+}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -18,15 +18,18 @@ import { SessionHasGitRepositoryContext, SessionProviderIdContext, SessionTypeCo
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { BranchPicker } from './branchPicker.js';
-import { COPILOT_PROVIDER_ID, CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
+import { COPILOT_PROVIDER_ID, CopilotChatSessionsProvider, CopilotCloudSessionType } from './copilotChatSessionsProvider.js';
 import { ModePicker, ModePickerModel } from './modePicker.js';
 import { CopilotPermissionPickerDelegate, PermissionPicker } from './permissionPicker.js';
+import { SandboxPicker } from './sandboxPicker.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { CopilotCLISessionType } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { ISessionContext } from '../../../../services/sessions/browser/sessionContext.js';
 
 const IsActiveSessionCopilotCLI = ContextKeyExpr.equals(SessionTypeContext.key, CopilotCLISessionType.id);
 const IsActiveCopilotChatSessionProvider = ContextKeyExpr.equals(SessionProviderIdContext.key, COPILOT_PROVIDER_ID);
 const IsActiveSessionCopilotChatCLI = ContextKeyExpr.and(IsActiveSessionCopilotCLI, IsActiveCopilotChatSessionProvider);
+const IsActiveSessionCopilotChatCloud = ContextKeyExpr.and(ContextKeyExpr.equals(SessionTypeContext.key, CopilotCloudSessionType.id), IsActiveCopilotChatSessionProvider);
 
 // -- Actions --
 
@@ -41,6 +44,23 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				order: 2,
 				when: ContextKeyExpr.and(IsNewChatSessionContext, IsActiveSessionCopilotChatCLI, SessionHasGitRepositoryContext),
+			}],
+		});
+	}
+	override async run(): Promise<void> { /* handled by action view item */ }
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.defaultCopilot.sandboxPicker',
+			title: localize2('sandboxPicker', "Sandbox"),
+			f1: false,
+			menu: [{
+				id: Menus.NewSessionRepositoryConfig,
+				group: 'navigation',
+				order: 3,
+				when: ContextKeyExpr.and(IsNewChatSessionContext, IsActiveSessionCopilotChatCloud, ChatContextKeys.enabled),
 			}],
 		});
 	}
@@ -141,6 +161,14 @@ class CopilotPickerActionViewItemContribution extends Disposable implements IWor
 			(_action, _options, scopedInstantiationService) => {
 				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
 				const picker = scopedInstantiationService.createInstance(BranchPicker, session);
+				return new PickerActionViewItem(picker);
+			},
+		));
+		this._register(actionViewItemService.register(
+			Menus.NewSessionRepositoryConfig, 'sessions.defaultCopilot.sandboxPicker',
+			(_action, _options, scopedInstantiationService) => {
+				const { session } = scopedInstantiationService.invokeFunction(accessor => accessor.get(ISessionContext));
+				const picker = scopedInstantiationService.createInstance(SandboxPicker, session);
 				return new PickerActionViewItem(picker);
 			},
 		));

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -654,11 +654,6 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 		return nwo && nwo.includes('/') ? nwo : undefined;
 	}
 
-	/** The base branch chosen for this session, when the user picked one. */
-	get baseRef(): string | undefined {
-		const branch = this.selectedOptions.get(BRANCH_OPTION_ID);
-		return branch?.id || undefined;
-	}
 	get chatMode(): IChatMode | undefined { return undefined; }
 	get query(): string | undefined { return this._query; }
 	get attachedContext(): IChatRequestVariableEntry[] | undefined { return this._attachedContext; }
@@ -1044,7 +1039,7 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		throw new Error('Method not implemented.');
 	}
 	setUseSandbox(useSandbox: boolean): void {
-		throw new Error('Method not implemented.');
+		// Where a committed session runs is already decided.
 	}
 	setModelId(modelId: string | undefined): void {
 		this._modelId.set(modelId, undefined);
@@ -2062,6 +2057,14 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	/**
+	 * Resolves the contribution that owns sandbox environments. A seam, because the contribution
+	 * registry is global — tests substitute a stub rather than standing one up.
+	 */
+	protected _getCloudSandboxContribution(): Pick<CloudSandboxAgentHostContribution, 'provisionSession'> {
+		return getWorkbenchContribution<CloudSandboxAgentHostContribution>(CloudSandboxAgentHostContribution.ID);
+	}
+
+	/**
 	 * Commit a cloud new-session into a GitHub-managed sandbox instead of the server-run cloud
 	 * agent: provision the sandbox, then hand the session over to the remote-agent-host provider
 	 * that owns it and send the first turn there.
@@ -2080,10 +2083,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this._onDidChangeSessions.fire({ added: [placeholder], removed: [], changed: [] });
 
 		try {
-			const contribution = getWorkbenchContribution<CloudSandboxAgentHostContribution>(CloudSandboxAgentHostContribution.ID);
-			const provisioned = await contribution.provisionSession({
+			const provisioned = await this._getCloudSandboxContribution().provisionSession({
 				repoNwo,
-				baseRef: session.baseRef,
+				// No `baseRef`: cloud sessions have no branch picker, so Mission Control picks the
+				// repository's default branch — the same branch the server-run cloud agent uses.
 				prompt: options.query,
 			}, CancellationToken.None);
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -53,6 +53,9 @@ import { CopilotCLISessionType } from '../../agentHost/browser/baseAgentHostSess
 import { createChangesets } from './copilotChatSessionsChangesets.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IAgentHostEnablementService } from '../../../../../platform/agentHost/common/agentHostEnablementService.js';
+import { isCloudSandboxEnabled } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { getWorkbenchContribution } from '../../../../../workbench/common/contributions.js';
+import { CloudSandboxAgentHostContribution } from '../../remoteAgentHost/browser/cloudSandboxAgentHostContribution.js';
 
 /** Copilot Cloud session type - cloud-hosted agent. */
 export const CopilotCloudSessionType: ISessionType = {
@@ -63,6 +66,9 @@ export const CopilotCloudSessionType: ISessionType = {
 };
 
 const STORAGE_KEY_ISOLATION_MODE = 'sessions.isolationPicker.selectedMode';
+
+/** Remembers the cloud sandbox choice across new sessions, like the isolation picker above. */
+const STORAGE_KEY_USE_SANDBOX = 'sessions.cloudSandboxPicker.useSandbox';
 
 export type IsolationMode = 'worktree' | 'workspace';
 
@@ -121,6 +127,14 @@ export interface ICopilotChatSession {
 
 	readonly isolationMode: IObservable<IsolationMode | undefined>;
 	setIsolationMode(mode: IsolationMode): void;
+
+	/**
+	 * For cloud sessions: whether the session should run in a GitHub-managed sandbox the client
+	 * drives over the Agent Host Protocol, instead of the server-run cloud agent. Always
+	 * `undefined` for session kinds that have no such choice.
+	 */
+	readonly useSandbox: IObservable<boolean | undefined>;
+	setUseSandbox(useSandbox: boolean): void;
 
 	setModelId(modelId: string | undefined): void;
 	setMode(chatMode: IChatMode | undefined): void;
@@ -235,6 +249,9 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 
 	private readonly _isolationModeObservable = observableValue<IsolationMode | undefined>(this, 'worktree');
 	readonly isolationMode: IObservable<IsolationMode | undefined> = this._isolationModeObservable;
+
+	/** A local CLI session always runs locally, so it has no cloud sandbox choice to make. */
+	readonly useSandbox: IObservable<boolean | undefined> = constObservable(undefined);
 
 	private readonly _modelIdObservable = observableValue<string | undefined>(this, undefined);
 	readonly modelId: IObservable<string | undefined> = this._modelIdObservable;
@@ -458,6 +475,10 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 		}
 	}
 
+	setUseSandbox(_useSandbox: boolean): void {
+		// A local CLI session has no cloud sandbox choice to make.
+	}
+
 	setModelId(modelId: string | undefined): void {
 		this._modelId = modelId;
 		this._modelIdObservable.set(modelId, undefined);
@@ -598,6 +619,8 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 	readonly gitHubInfo: IObservable<IGitHubInfo | undefined> = constObservable(undefined);
 	readonly branch: IObservable<string | undefined> = constObservable(undefined);
 	readonly isolationMode: IObservable<IsolationMode | undefined> = constObservable(undefined);
+	private readonly _useSandbox = observableValue<boolean | undefined>(this, false);
+	readonly useSandbox: IObservable<boolean | undefined> = this._useSandbox;
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 	readonly gitRepository?: IGitRepository | undefined;
 
@@ -621,6 +644,21 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 
 	get project(): ISessionWorkspace | undefined { return this._project; }
 	get selectedModelId(): string | undefined { return this._modelId; }
+
+	/**
+	 * The repository this session targets, as `owner/name`. Derived from the workspace root the
+	 * same way the `repositories` option is seeded in the constructor.
+	 */
+	get repoNwo(): string | undefined {
+		const nwo = this._repoUri?.path.replace(/^\//, '');
+		return nwo && nwo.includes('/') ? nwo : undefined;
+	}
+
+	/** The base branch chosen for this session, when the user picked one. */
+	get baseRef(): string | undefined {
+		const branch = this.selectedOptions.get(BRANCH_OPTION_ID);
+		return branch?.id || undefined;
+	}
 	get chatMode(): IChatMode | undefined { return undefined; }
 	get query(): string | undefined { return this._query; }
 	get attachedContext(): IChatRequestVariableEntry[] | undefined { return this._attachedContext; }
@@ -637,6 +675,7 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 		providerId: string,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 		this.sessionId = toSessionId(providerId, resource);
@@ -644,6 +683,7 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 		this.sessionType = target;
 		this.icon = CopilotCloudSessionType.icon;
 		this.createdAt = new Date();
+		this._useSandbox.set(storageService.getBoolean(STORAGE_KEY_USE_SANDBOX, StorageScope.PROFILE, false), undefined);
 
 		this._updateWhenClauseKeys();
 		this._register(this.chatSessionsService.onDidChangeOptionGroups(() => {
@@ -674,6 +714,14 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 
 	setIsolationMode(_mode: IsolationMode): void {
 		// No-op for remote sessions
+	}
+
+	setUseSandbox(useSandbox: boolean): void {
+		if (this._useSandbox.get() === useSandbox) {
+			return;
+		}
+		this._useSandbox.set(useSandbox, undefined);
+		this.storageService.store(STORAGE_KEY_USE_SANDBOX, useSandbox, StorageScope.PROFILE, StorageTarget.MACHINE);
 	}
 
 	setBranch(_branch: string | undefined): void {
@@ -884,6 +932,8 @@ class AgentSessionAdapter implements ICopilotChatSession {
 	readonly permissionLevel: IObservable<ChatPermissionLevel> = constObservable(ChatPermissionLevel.Default);
 	readonly branch: IObservable<string | undefined> = constObservable(undefined);
 	readonly isolationMode: IObservable<IsolationMode | undefined> = constObservable(undefined);
+	/** Where a committed session runs is already decided; the choice only exists before the first send. */
+	readonly useSandbox: IObservable<boolean | undefined> = constObservable(undefined);
 	readonly gitRepository?: IGitRepository | undefined;
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 
@@ -991,6 +1041,9 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		throw new Error('Method not implemented.');
 	}
 	setIsolationMode(mode: IsolationMode): void {
+		throw new Error('Method not implemented.');
+	}
+	setUseSandbox(useSandbox: boolean): void {
 		throw new Error('Method not implemented.');
 	}
 	setModelId(modelId: string | undefined): void {
@@ -2008,11 +2061,66 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		return this._toChat(session);
 	}
 
+	/**
+	 * Commit a cloud new-session into a GitHub-managed sandbox instead of the server-run cloud
+	 * agent: provision the sandbox, then hand the session over to the remote-agent-host provider
+	 * that owns it and send the first turn there.
+	 *
+	 * The committed session belongs to that other provider, which is why this fires
+	 * `onDidReplaceSession` across providers — the same swap {@link _sendFirstChat} performs, just
+	 * landing outside this provider. Mission Control starts no run for the task it creates, so the
+	 * first turn has to be dispatched here rather than being picked up server-side.
+	 */
+	private async _sendFirstChatToSandbox(session: RemoteNewSession, repoNwo: string, options: ISendRequestOptions): Promise<ISession> {
+		session.setTitle((options.title || options.query.split('\n')[0]).substring(0, 100) || localize('new session', "New Session"));
+		session.setStatus(SessionStatus.InProgress);
+		this._sessionCache.set(session.resource.toString(), session);
+		this._invalidateGroupingCaches();
+		const placeholder = this._chatToSession(session);
+		this._onDidChangeSessions.fire({ added: [placeholder], removed: [], changed: [] });
+
+		try {
+			const contribution = getWorkbenchContribution<CloudSandboxAgentHostContribution>(CloudSandboxAgentHostContribution.ID);
+			const provisioned = await contribution.provisionSession({
+				repoNwo,
+				baseRef: session.baseRef,
+				prompt: options.query,
+			}, CancellationToken.None);
+
+			// Send into the session's main chat rather than `createNewChat`, which would mint an
+			// *additional* peer chat inside a session that already has one.
+			const chat = provisioned.session.mainChat.get();
+			const committed = await provisioned.provider.sendRequest(provisioned.session.sessionId, chat.resource, options);
+
+			this._sessionCache.delete(session.resource.toString());
+			this._invalidateGroupingCaches();
+			this._sessionGroupCache.delete(session.sessionId);
+			this._clearCurrentNewSessionIfMatch(session);
+			this._onDidReplaceSession.fire({ from: placeholder, to: committed });
+			return committed;
+		} catch (error) {
+			this.logService.error(`[CopilotChatSessionsProvider] Failed to start cloud sandbox session for ${repoNwo}:`, error);
+			this._sessionCache.delete(session.resource.toString());
+			this._invalidateGroupingCaches();
+			this._sessionGroupCache.delete(session.sessionId);
+			this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
+			this._onDidChangeSessions.fire({ added: [], removed: [placeholder], changed: [] });
+			session.dispose();
+			throw error;
+		}
+	}
+
 	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
 		const newSession = this._newSessions.get(sessionId);
 		if (newSession) {
 			if (!this.uriIdentityService.extUri.isEqual(newSession.mainChat.get().resource, chatResource)) {
 				throw new Error('Chat resource does not match the main chat of the current new session');
+			}
+			// Re-check everything the sandbox path needs rather than trusting the remembered
+			// preference: the settings can be turned off, and the session may have no repository.
+			// Falling back to the server-run cloud agent is far better than refusing to send.
+			if (newSession instanceof RemoteNewSession && newSession.useSandbox.get() && newSession.repoNwo && isCloudSandboxEnabled(this.configurationService)) {
+				return this._sendFirstChatToSandbox(newSession, newSession.repoNwo, options);
 			}
 			return this._sendFirstChat(newSession, chatResource, options);
 		}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/sandboxPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/sandboxPicker.ts
@@ -14,7 +14,7 @@ import { CheckboxChip } from '../../../chat/browser/checkboxChip.js';
 import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
 import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { CopilotChatSessionsProvider, ICopilotChatSession } from './copilotChatSessionsProvider.js';
+import { CopilotChatSessionsProvider, ICopilotChatSession, RemoteNewSession } from './copilotChatSessionsProvider.js';
 
 /**
  * "Sandbox" checkbox for a new cloud session: when checked, the session runs in a GitHub-managed
@@ -53,7 +53,9 @@ export class SandboxPicker extends Disposable {
 			const session = this._session.read(reader);
 			const providerSession = session ? this._getSession(session) : undefined;
 			providerSession?.useSandbox.read(reader);
-			this._hasRepository = !!providerSession && !!session?.workspace.read(reader)?.folders.length;
+			// Exactly what the send path requires, so the chip can never promise a sandbox the
+			// send would silently decline to provision. `repoNwo` is fixed at construction.
+			this._hasRepository = providerSession instanceof RemoteNewSession && !!providerSession.repoNwo;
 			this._update();
 		}));
 	}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/sandboxPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/sandboxPicker.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { autorun, IObservable } from '../../../../../base/common/observable.js';
+import { localize } from '../../../../../nls.js';
+import { CloudSandboxEnabledSettingId, isCloudSandboxEnabled } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { CheckboxChip } from '../../../chat/browser/checkboxChip.js';
+import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
+import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { CopilotChatSessionsProvider, ICopilotChatSession } from './copilotChatSessionsProvider.js';
+
+/**
+ * "Sandbox" checkbox for a new cloud session: when checked, the session runs in a GitHub-managed
+ * sandbox this client drives over the Agent Host Protocol, instead of the server-run cloud agent.
+ *
+ * Disabled rather than hidden when the session has no repository, since a sandbox is always
+ * provisioned against one — the label is what explains the choice exists at all.
+ */
+export class SandboxPicker extends Disposable {
+
+	private readonly _chip: CheckboxChip;
+	private _hasRepository = false;
+
+	constructor(
+		private readonly _session: IObservable<IActiveSession | undefined>,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+	) {
+		super();
+
+		this._chip = this._register(new CheckboxChip({
+			label: localize('sandboxPicker.label', "Sandbox"),
+			ariaLabel: localize('sandboxPicker.checkboxAriaLabel', "Run in a GitHub-managed sandbox"),
+			onToggle: checked => this._applyToggle(checked),
+			slotClassName: 'sessions-chat-sandbox-checkbox',
+		}));
+
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(CloudSandboxEnabledSettingId) || e.affectsConfiguration(RemoteAgentHostsEnabledSettingId)) {
+				this._update();
+			}
+		}));
+
+		this._register(autorun(reader => {
+			const session = this._session.read(reader);
+			const providerSession = session ? this._getSession(session) : undefined;
+			providerSession?.useSandbox.read(reader);
+			this._hasRepository = !!providerSession && !!session?.workspace.read(reader)?.folders.length;
+			this._update();
+		}));
+	}
+
+	private _getSession(session: IActiveSession): ICopilotChatSession | undefined {
+		const provider = this._sessionsProvidersService.getProvider(session.providerId);
+		return provider instanceof CopilotChatSessionsProvider ? provider.getSession(session.sessionId) : undefined;
+	}
+
+	private _applyToggle(checked: boolean): void {
+		const session = this._session.get();
+		const providerSession = session ? this._getSession(session) : undefined;
+		if (!providerSession) {
+			return;
+		}
+		reportNewChatPickerClosed(this._telemetryService, {
+			id: 'NewChatSandboxPicker',
+			name: 'NewChatSandboxPicker',
+			optionIdBefore: String(providerSession.useSandbox.get() === true),
+			optionIdAfter: String(checked),
+			optionLabelBefore: undefined,
+			optionLabelAfter: undefined,
+			isPII: false,
+		});
+		providerSession.setUseSandbox(checked);
+	}
+
+	render(container: HTMLElement): void {
+		this._chip.render(container);
+		this._update();
+	}
+
+	private _update(): void {
+		const session = this._session.get();
+		const providerSession = session ? this._getSession(session) : undefined;
+		const enabled = isCloudSandboxEnabled(this._configurationService);
+		this._chip.update({
+			checked: enabled && providerSession?.useSandbox.get() === true,
+			state: !enabled ? 'hidden' : this._hasRepository ? 'enabled' : 'disabled',
+			disabledReason: this._hasRepository ? undefined : localize('sandboxPicker.noRepository', "A repository is required to run in a sandbox"),
+		});
+	}
+}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -10,7 +10,7 @@ import { timeout } from '../../../../../../base/common/async.js';
 import { DisposableStore, IDisposable, ImmortalReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
-import { mock } from '../../../../../../base/test/common/mock.js';
+import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { autorun, constObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService, IConfigurationValue } from '../../../../../../platform/configuration/common/configuration.js';
@@ -35,7 +35,11 @@ import { IChatResponseModel } from '../../../../../../workbench/contrib/chat/com
 import { IChatAgentData } from '../../../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { IGitService } from '../../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionChangeEvent } from '../../../../../services/sessions/common/sessionsProvider.js';
-import { GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../../services/sessions/common/session.js';
+import { GITHUB_REMOTE_FILE_SCHEME, IChat, ISession, SessionStatus } from '../../../../../services/sessions/common/session.js';
+import { CloudSandboxEnabledSettingId, type ICloudSandboxCreateSessionRequest } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { RemoteAgentHostsEnabledSettingId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { CloudSandboxAgentHostContribution, type ICloudSandboxProvisionedSession } from '../../../remoteAgentHost/browser/cloudSandboxAgentHostContribution.js';
+import { RemoteAgentHostSessionsProvider } from '../../../remoteAgentHost/browser/remoteAgentHostSessionsProvider.js';
 import { ChatConfiguration, ChatPermissionLevel } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { CopilotChatSessionsProvider, COPILOT_PROVIDER_ID, CopilotCloudSessionType, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -320,12 +324,27 @@ function createProviderWithConfig(
  * The caller can pass a custom `sendRequest` implementation to control the
  * lifecycle of the in-flight request.
  */
+/**
+ * Substitutes the sandbox contribution, which the provider otherwise resolves from the global
+ * workbench contribution registry.
+ */
+class TestSandboxCopilotProvider extends CopilotChatSessionsProvider {
+	sandboxContribution: Pick<CloudSandboxAgentHostContribution, 'provisionSession'> | undefined;
+
+	protected override _getCloudSandboxContribution(): Pick<CloudSandboxAgentHostContribution, 'provisionSession'> {
+		if (!this.sandboxContribution) {
+			throw new Error('No cloud sandbox contribution was registered');
+		}
+		return this.sandboxContribution;
+	}
+}
+
 function createProviderForSendTests(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
 	sendRequest: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>,
 	opts?: { onDidCommitSession?: Event<{ original: URI; committed: URI }>; configurationService?: TestConfigurationService; agentHostEnabled?: boolean },
-): CopilotChatSessionsProvider {
+): TestSandboxCopilotProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const configService = opts?.configurationService ?? new TestConfigurationService();
@@ -382,7 +401,7 @@ function createProviderForSendTests(
 	instantiationService.stub(IGitHubService, new TestGitHubService());
 	instantiationService.stub(IPullRequestIconCache, new TestPullRequestIconCache());
 
-	return disposables.add(instantiationService.createInstance(CopilotChatSessionsProvider));
+	return disposables.add(instantiationService.createInstance(TestSandboxCopilotProvider));
 }
 
 suite('CopilotChatSessionsProvider', () => {
@@ -1791,5 +1810,110 @@ suite('CopilotChatSessionsProvider', () => {
 			!removals.includes(untitledResource.toString()),
 			`Cloud session should not be removed after committing. Removals seen: [${removals.join(', ')}]`,
 		);
+	});
+	suite('cloud sandbox send path', () => {
+		const repoWorkspace = URI.from({ scheme: GITHUB_REMOTE_FILE_SCHEME, path: '/osortega/simple-server' });
+
+		function createSandboxProvider(opts: { enabled?: boolean; provision?: () => Promise<ICloudSandboxProvisionedSession> } = {}) {
+			const configurationService = new TestConfigurationService();
+			configurationService.setUserConfiguration(CloudSandboxEnabledSettingId, opts.enabled ?? true);
+			configurationService.setUserConfiguration(RemoteAgentHostsEnabledSettingId, true);
+
+			const cloudSends: string[] = [];
+			const provider = createProviderForSendTests(disposables, model, async (_resource, message) => {
+				cloudSends.push(message);
+				// Never settles: these tests only assert which path the send took.
+				return new Promise<ChatSendResult>(() => { });
+			}, { configurationService });
+
+			const provisionRequests: ICloudSandboxCreateSessionRequest[] = [];
+			provider.sandboxContribution = {
+				provisionSession: async request => {
+					provisionRequests.push(request);
+					if (opts.provision) {
+						return opts.provision();
+					}
+					throw new Error('provisioning failed');
+				},
+			};
+			return { provider, provisionRequests, cloudSends };
+		}
+
+		/** A provisioned session whose provider immediately commits the send. */
+		function provisionedSession(): ICloudSandboxProvisionedSession {
+			const committed = upcastPartial<ISession>({ sessionId: 'agenthost:sess-new' });
+			const sandboxSession = upcastPartial<ISession>({
+				sessionId: 'agenthost:sess-new',
+				mainChat: constObservable(upcastPartial<IChat>({ resource: URI.parse('agent-host-copilot:/sess-new') })),
+			});
+			return {
+				taskId: 'task-new',
+				sessionId: 'sess-new',
+				environmentId: 'env-new',
+				session: sandboxSession,
+				provider: upcastPartial<RemoteAgentHostSessionsProvider>({
+					sendRequest: async () => committed,
+				}) as RemoteAgentHostSessionsProvider,
+			};
+		}
+
+		test('provisions a sandbox and replaces the draft with the committed session', async () => {
+			const { provider, provisionRequests, cloudSends } = createSandboxProvider({ provision: async () => provisionedSession() });
+			const sessionInfo = provider.createNewSession(repoWorkspace, CopilotCloudSessionType.id);
+			const session = provider.getSession(sessionInfo.sessionId)!;
+			session.setUseSandbox(true);
+
+			const replacements: { from: string; to: string }[] = [];
+			disposables.add(provider.onDidReplaceSession(e => replacements.push({ from: e.from.sessionId, to: e.to.sessionId })));
+
+			const committed = await provider.sendRequest(sessionInfo.sessionId, session.mainChat.get().resource, { query: 'fix it' });
+
+			assert.deepStrictEqual({
+				committed: committed.sessionId,
+				// The repo comes from the workspace root; no baseRef, so MC picks the default branch.
+				provisionRequests,
+				// The prompt must not also go through the server-run cloud agent.
+				cloudSends,
+				replacements: replacements.map(r => ({ from: r.from === sessionInfo.sessionId, to: r.to })),
+			}, {
+				committed: 'agenthost:sess-new',
+				provisionRequests: [{ repoNwo: 'osortega/simple-server', prompt: 'fix it' }],
+				cloudSends: [],
+				replacements: [{ from: true, to: 'agenthost:sess-new' }],
+			});
+		});
+
+		test('falls back to the server-run cloud agent when the feature is disabled', async () => {
+			// A remembered preference must not strand the user with a send that always fails.
+			const { provider, provisionRequests, cloudSends } = createSandboxProvider({ enabled: false });
+			const sessionInfo = provider.createNewSession(repoWorkspace, CopilotCloudSessionType.id);
+			const session = provider.getSession(sessionInfo.sessionId)!;
+			session.setUseSandbox(true);
+
+			void provider.sendRequest(sessionInfo.sessionId, session.mainChat.get().resource, { query: 'fix it' });
+			await timeout(0);
+
+			assert.deepStrictEqual({ provisionRequests, cloudSends }, { provisionRequests: [], cloudSends: ['fix it'] });
+		});
+
+		test('a failed provision removes the placeholder instead of stranding it in the list', async () => {
+			const { provider } = createSandboxProvider();
+			const sessionInfo = provider.createNewSession(repoWorkspace, CopilotCloudSessionType.id);
+			const session = provider.getSession(sessionInfo.sessionId)!;
+			session.setUseSandbox(true);
+
+			const removed: string[] = [];
+			disposables.add(provider.onDidChangeSessions(e => removed.push(...e.removed.map(s => s.sessionId))));
+
+			await assert.rejects(() => provider.sendRequest(sessionInfo.sessionId, session.mainChat.get().resource, { query: 'fix it' }));
+
+			assert.deepStrictEqual({
+				removed,
+				stillListed: provider.getSessions().some(s => s.sessionId === sessionInfo.sessionId),
+			}, {
+				removed: [sessionInfo.sessionId],
+				stillListed: false,
+			});
+		});
 	});
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/sandboxPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/sandboxPicker.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { Event } from '../../../../../../base/common/event.js';
-import { observableValue } from '../../../../../../base/common/observable.js';
+import { constObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -13,14 +13,19 @@ import { CloudSandboxEnabledSettingId } from '../../../../../../platform/agentHo
 import { RemoteAgentHostsEnabledSettingId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AgentSessionProviders } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
+import { IChatSessionsService } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
 import { IActiveSession } from '../../../../../services/sessions/common/sessionsManagement.js';
-import { ISessionWorkspace } from '../../../../../services/sessions/common/session.js';
+import { GITHUB_REMOTE_FILE_SCHEME, ISessionFolder, ISessionWorkspace } from '../../../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
-import { CopilotChatSessionsProvider, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
+import { CopilotChatSessionsProvider, ICopilotChatSession, RemoteNewSession } from '../../browser/copilotChatSessionsProvider.js';
 import { SandboxPicker } from '../../browser/sandboxPicker.js';
 
 class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
@@ -38,41 +43,61 @@ class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
 suite('Copilot SandboxPicker', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createPicker(options: { settingEnabled?: boolean; remoteHostsEnabled?: boolean; hasRepository?: boolean; useSandbox?: boolean } = {}) {
-		const useSandbox = observableValue<boolean | undefined>('useSandbox', options.useSandbox ?? false);
-		const toggles: boolean[] = [];
-		const providerSession = upcastPartial<ICopilotChatSession>({
-			useSandbox,
-			setUseSandbox: (value: boolean) => {
-				toggles.push(value);
-				useSandbox.set(value, undefined);
-			},
-		});
-		const provider = Object.assign(Object.create(CopilotChatSessionsProvider.prototype), {
-			getSession: () => providerSession,
-		});
+	function createPicker(options: { settingEnabled?: boolean; remoteHostsEnabled?: boolean; hasRepository?: boolean; useSandbox?: boolean; committedSession?: boolean } = {}) {
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration(CloudSandboxEnabledSettingId, options.settingEnabled ?? true);
 		configurationService.setUserConfiguration(RemoteAgentHostsEnabledSettingId, options.remoteHostsEnabled ?? true);
 
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IConfigurationService, configurationService);
-		instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService(provider));
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+		instantiationService.stub(IChatSessionsService, new class extends mock<IChatSessionsService>() {
+			override readonly onDidChangeOptionGroups = Event.None;
+			override setSessionOption(): boolean { return true; }
+			override getOptionGroupsForSessionType() { return undefined; }
+		}());
 
+		// A cloud workspace is a GitHub repo URI (`github-remote-file:/owner/repo`); the
+		// repo-less case is a URI with no `owner/name` to derive.
+		const root = (options.hasRepository ?? true)
+			? URI.parse(`${GITHUB_REMOTE_FILE_SCHEME}:/osortega/simple-server`)
+			: URI.parse(`${GITHUB_REMOTE_FILE_SCHEME}:/`);
 		const workspace = upcastPartial<ISessionWorkspace>({
-			folders: (options.hasRepository ?? true) ? [upcastPartial<ISessionWorkspace['folders'][0]>({ root: URI.parse('github:/osortega/simple-server') })] : [],
+			uri: root,
+			folders: [upcastPartial<ISessionFolder>({ root, workingDirectory: root })],
 		});
+
+		const providerSession = disposables.add(instantiationService.createInstance(
+			RemoteNewSession,
+			URI.from({ scheme: AgentSessionProviders.Cloud, path: '/untitled-1' }),
+			workspace,
+			AgentSessionProviders.Cloud,
+			'default-copilot',
+		));
+		if (options.useSandbox) {
+			providerSession.setUseSandbox(true);
+		}
+		// A committed session stands in for the case where the active session is no longer the
+		// draft, whose `setUseSandbox` is a no-op rather than a throw.
+		const session: ICopilotChatSession = options.committedSession
+			? upcastPartial<ICopilotChatSession>({ useSandbox: constObservable(undefined), setUseSandbox: () => { } })
+			: providerSession;
+		const provider = Object.assign(Object.create(CopilotChatSessionsProvider.prototype), {
+			getSession: () => session,
+		});
+		instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService(provider));
+
 		const activeSession = observableValue<IActiveSession | undefined>('activeSession', upcastPartial<IActiveSession>({
 			providerId: 'default-copilot',
-			sessionId: 'session',
-			workspace: observableValue<ISessionWorkspace | undefined>('workspace', workspace),
+			sessionId: providerSession.sessionId,
 		}));
 
 		const picker = disposables.add(instantiationService.createInstance(SandboxPicker, activeSession));
 		const container = document.createElement('div');
 		picker.render(container);
-		return { container, toggles, useSandbox };
+		return { container, providerSession };
 	}
 
 	function chipState(container: HTMLElement) {
@@ -125,15 +150,25 @@ suite('Copilot SandboxPicker', () => {
 	});
 
 	test('clicking the row toggles the session preference', () => {
-		const { container, toggles } = createPicker();
+		const { container, providerSession } = createPicker();
 		const row = container.querySelector<HTMLElement>('.sessions-chat-sandbox-checkbox .action-label');
 		assert.ok(row);
 
 		row.click();
 
-		assert.deepStrictEqual({ toggles, state: chipState(container) }, {
-			toggles: [true],
+		assert.deepStrictEqual({ useSandbox: providerSession.useSandbox.get(), state: chipState(container) }, {
+			useSandbox: true,
 			state: { rendered: true, hidden: false, disabled: false, checked: 'true' },
 		});
+	});
+
+	test('toggling a committed session is a no-op rather than a throw', () => {
+		// `getSession` returns committed sessions too, and a throw out of a click handler is a
+		// far worse failure than doing nothing.
+		const { container } = createPicker({ committedSession: true });
+		const row = container.querySelector<HTMLElement>('.sessions-chat-sandbox-checkbox .action-label');
+		assert.ok(row);
+
+		assert.doesNotThrow(() => row.click());
 	});
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/sandboxPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/sandboxPicker.test.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { CloudSandboxEnabledSettingId } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { RemoteAgentHostsEnabledSettingId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
+import { IActiveSession } from '../../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionWorkspace } from '../../../../../services/sessions/common/session.js';
+import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
+import { CopilotChatSessionsProvider, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
+import { SandboxPicker } from '../../browser/sandboxPicker.js';
+
+class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
+	override readonly onDidChangeProviders = Event.None;
+
+	constructor(private readonly provider: ISessionsProvider) {
+		super();
+	}
+
+	override getProvider<T extends ISessionsProvider>(): T | undefined {
+		return this.provider as T;
+	}
+}
+
+suite('Copilot SandboxPicker', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createPicker(options: { settingEnabled?: boolean; remoteHostsEnabled?: boolean; hasRepository?: boolean; useSandbox?: boolean } = {}) {
+		const useSandbox = observableValue<boolean | undefined>('useSandbox', options.useSandbox ?? false);
+		const toggles: boolean[] = [];
+		const providerSession = upcastPartial<ICopilotChatSession>({
+			useSandbox,
+			setUseSandbox: (value: boolean) => {
+				toggles.push(value);
+				useSandbox.set(value, undefined);
+			},
+		});
+		const provider = Object.assign(Object.create(CopilotChatSessionsProvider.prototype), {
+			getSession: () => providerSession,
+		});
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration(CloudSandboxEnabledSettingId, options.settingEnabled ?? true);
+		configurationService.setUserConfiguration(RemoteAgentHostsEnabledSettingId, options.remoteHostsEnabled ?? true);
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, configurationService);
+		instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService(provider));
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+
+		const workspace = upcastPartial<ISessionWorkspace>({
+			folders: (options.hasRepository ?? true) ? [upcastPartial<ISessionWorkspace['folders'][0]>({ root: URI.parse('github:/osortega/simple-server') })] : [],
+		});
+		const activeSession = observableValue<IActiveSession | undefined>('activeSession', upcastPartial<IActiveSession>({
+			providerId: 'default-copilot',
+			sessionId: 'session',
+			workspace: observableValue<ISessionWorkspace | undefined>('workspace', workspace),
+		}));
+
+		const picker = disposables.add(instantiationService.createInstance(SandboxPicker, activeSession));
+		const container = document.createElement('div');
+		picker.render(container);
+		return { container, toggles, useSandbox };
+	}
+
+	function chipState(container: HTMLElement) {
+		const slot = container.querySelector<HTMLElement>('.sessions-chat-sandbox-checkbox');
+		const checkbox = container.querySelector<HTMLElement>('.sessions-chat-sandbox-checkbox .monaco-checkbox');
+		return {
+			rendered: !!slot,
+			hidden: slot?.classList.contains('hidden') ?? false,
+			disabled: slot?.classList.contains('disabled') ?? false,
+			checked: checkbox?.getAttribute('aria-checked') ?? undefined,
+		};
+	}
+
+	test('is enabled and unchecked by default when the setting is on and a repository is present', () => {
+		const { container } = createPicker();
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: false, disabled: false, checked: 'false' });
+	});
+
+	test('is hidden when the cloud sandbox setting is off', () => {
+		const { container } = createPicker({ settingEnabled: false });
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: true, disabled: false, checked: 'false' });
+	});
+
+	test('is hidden when remote agent hosts are off, since a sandbox is reached over that relay', () => {
+		const { container } = createPicker({ remoteHostsEnabled: false });
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: true, disabled: false, checked: 'false' });
+	});
+
+	test('shows unchecked when the feature is off despite a remembered preference', () => {
+		// The send path falls back to the server-run cloud agent in this state, so the chip must
+		// not claim the session is going to a sandbox.
+		const { container } = createPicker({ settingEnabled: false, useSandbox: true });
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: true, disabled: false, checked: 'false' });
+	});
+
+	test('is disabled without a repository, since a sandbox is always provisioned against one', () => {
+		const { container } = createPicker({ hasRepository: false });
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: false, disabled: true, checked: 'false' });
+	});
+
+	test('reflects an already-selected sandbox preference', () => {
+		const { container } = createPicker({ useSandbox: true });
+
+		assert.deepStrictEqual(chipState(container), { rendered: true, hidden: false, disabled: false, checked: 'true' });
+	});
+
+	test('clicking the row toggles the session preference', () => {
+		const { container, toggles } = createPicker();
+		const row = container.querySelector<HTMLElement>('.sessions-chat-sandbox-checkbox .action-label');
+		assert.ok(row);
+
+		row.click();
+
+		assert.deepStrictEqual({ toggles, state: chipState(container) }, {
+			toggles: [true],
+			state: { rendered: true, hidden: false, disabled: false, checked: 'true' },
+		});
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxAgentHostContribution.ts
@@ -8,7 +8,7 @@
 // CloudSandboxAgentHostService, and wires the live connection to the provider so the native session
 // machinery can enumerate and render the host's sessions.
 
-import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -22,7 +22,10 @@ import {
 	cloudSandboxAddress,
 	ICloudSandboxAgentHostService,
 	ICloudSandboxApiService,
+	isCloudSandboxEnabled,
 	type ICloudSandboxConnectOptions,
+	type ICloudSandboxCreateSessionRequest,
+	type ICloudSandboxCreatedSession,
 	type ICloudSandboxDiscoveryResult,
 } from '../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
 import { AgentSession, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agent.js';
@@ -39,6 +42,7 @@ import { IWorkbenchContribution } from '../../../../../workbench/common/contribu
 import { ChatSessionsExtensions, IAsyncChatSessionActivationRegistry, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { CloudSandboxReadOnlySessionHandler } from './cloudSandboxReadOnlySessionHandler.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISession } from '../../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionSchemeAlias, IRemoteAgentHostSessionsProviderConfig, RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 import { IRemoteAgentHostConnectionCustomizationService } from './remoteAgentHostConnectionCustomization.js';
@@ -82,6 +86,15 @@ function discoveredSessionProject(repoName: string | undefined): IAgentSessionMe
 	return { uri: URI.parse(`https://github.com/${repoName}`), displayName: repoName };
 }
 
+/**
+ * A sandbox session that has just been created, connected, and surfaced on its provider — enough
+ * for the caller to send the first turn into it.
+ */
+export interface ICloudSandboxProvisionedSession extends ICloudSandboxCreatedSession {
+	readonly provider: RemoteAgentHostSessionsProvider;
+	readonly session: ISession;
+}
+
 export class CloudSandboxAgentHostContribution extends Disposable implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.cloudSandboxAgentHost';
 
@@ -92,6 +105,12 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 	private readonly _environments = new Map<string, ICloudSandboxEnvironment>();
 	/** In-flight connects keyed by address, so concurrent opens share one attempt. */
 	private readonly _pendingConnects = new Map<string, Promise<string>>();
+	/**
+	 * Addresses being provisioned right now. A task we just created is not yet visible to a
+	 * discovery pass that started before it existed, so reconciliation would see a brand-new
+	 * environment as one that has vanished and tear it down mid-provision.
+	 */
+	private readonly _provisioning = new Set<string>();
 	/**
 	 * Read-only content providers standing in for unreachable environments, keyed by session type.
 	 * Disposed when the environment becomes reachable again.
@@ -275,7 +294,7 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 		// Only a complete scan is authoritative — a partial one is missing entries that still exist.
 		if (result.kind === 'complete') {
 			for (const address of [...this._environments.keys()]) {
-				if (present.has(address)) {
+				if (present.has(address) || this._provisioning.has(address)) {
 					continue;
 				}
 				const connected = this._remoteAgentHostService.connections.some(c => c.address === address);
@@ -299,6 +318,69 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 			await this._remoteAgentHostService.removeRemoteAgentHost(address);
 		} catch (error) {
 			this._logService.warn(`${LOG_PREFIX} Failed to disconnect ${address}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	/**
+	 * Provision a brand-new sandbox session and make it usable: create the Mission Control task,
+	 * seed it into a per-environment provider, and connect the relay.
+	 *
+	 * From the seed onward this is deliberately identical to {@link _doDiscoverAndSeed} — a created
+	 * task is just a discovered one we happen to know about first — so a later discovery pass
+	 * reconciles against it instead of duplicating it. Mission Control starts no run for an
+	 * environment-bound task, so the caller still owns sending the first turn.
+	 */
+	async provisionSession(request: ICloudSandboxCreateSessionRequest, token: CancellationToken): Promise<ICloudSandboxProvisionedSession> {
+		if (!this._isEnabled()) {
+			throw new Error('Copilot cloud sandbox connections are not enabled.');
+		}
+		const created = await this._apiService.createSession(request, token);
+		const name = request.repoNwo ?? created.taskId;
+		const address = cloudSandboxAddress(created.environmentId);
+		// The feature can be disabled while the create is in flight, and `_teardownAll` has
+		// already snapshotted the environments it knows about — so registering a provider now
+		// would leave one behind that nothing reconciles.
+		if (!this._isEnabled() || token.isCancellationRequested) {
+			throw new CancellationError();
+		}
+		this._provisioning.add(address);
+		try {
+			this._ensureProvider({ environmentId: created.environmentId, sessionId: created.sessionId, taskId: created.taskId, name });
+
+			const provider = this._providerInstances.get(address);
+			if (!provider) {
+				throw new Error(`No sessions provider was registered for sandbox environment ${created.environmentId}`);
+			}
+			const now = Date.now();
+			const project = discoveredSessionProject(request.repoNwo);
+			provider.seedSessions([{
+				// Same identity discovery seeds under: Mission Control issues the session as
+				// `ahp-session:/<id>` and the host lists that id back, so this reconciles on connect.
+				session: AgentSession.uri(CLOUD_SANDBOX_AGENT_PROVIDER, created.sessionId),
+				startTime: now,
+				modifiedTime: now,
+				summary: name,
+				...(project ? { project } : {}),
+			}]);
+
+			await this.connect({ environmentId: created.environmentId, sessionId: created.sessionId, name });
+
+			// Connecting can take minutes while the sandbox wakes, and the feature can be disabled
+			// (or the environment torn down) in the meantime — in which case `provider` is disposed
+			// and unregistered, and handing it back would send into nothing.
+			if (!this._isEnabled() || this._providerInstances.get(address) !== provider) {
+				throw new CancellationError();
+			}
+
+			// The adapter `seedSessions` created addresses the session by its raw id, which is the
+			// session id Mission Control just returned.
+			const session = provider.getSessions().find(candidate => AgentSession.id(candidate.resource) === created.sessionId);
+			if (!session) {
+				throw new Error(`Provisioned sandbox session ${created.sessionId} did not surface on its provider`);
+			}
+			return { ...created, provider, session };
+		} finally {
+			this._provisioning.delete(address);
 		}
 	}
 
@@ -563,8 +645,7 @@ export class CloudSandboxAgentHostContribution extends Disposable implements IWo
 	}
 
 	private _isEnabled(): boolean {
-		return this._configurationService.getValue<boolean>(CloudSandboxEnabledSettingId)
-			&& this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
+		return isCloudSandboxEnabled(this._configurationService);
 	}
 
 	/** Create the sessions provider for an environment if it doesn't exist yet. */

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxApiService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxApiService.ts
@@ -9,12 +9,15 @@ import { isCancellationError } from '../../../../../base/common/errors.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import {
 	CLOUD_SANDBOX_AGENT_SLUG,
+	CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID,
 	CloudSandboxAuthenticationRequiredError,
 	CloudSandboxConnectResult,
 	CloudSandboxRequestError,
 	ICloudSandboxClientToken,
 	ICloudSandboxConnectionRequest,
 	ICloudSandboxApiService,
+	ICloudSandboxCreatedSession,
+	ICloudSandboxCreateSessionRequest,
 	ICloudSandboxDiscoveredSession,
 	ICloudSandboxDiscoveryResult,
 	ICloudSandboxEnvironment,
@@ -188,6 +191,66 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 	}
 
 	/**
+	 * Provision a sandbox task bound to an on-demand environment.
+	 *
+	 * The `environment_id` sentinel is what separates this from a regular cloud task: Mission
+	 * Control provisions a VM for it and binds a session, but starts no run — so the caller owns
+	 * sending the first turn over the relay. The bound environment on the returned session is the
+	 * real VM, not the sentinel, and is the only id the relay can address.
+	 */
+	async createSession(request: ICloudSandboxCreateSessionRequest, token: CancellationToken): Promise<ICloudSandboxCreatedSession> {
+		const repository = parseNwo(request.repoNwo);
+		const context = await this._request(`${this._tasksBaseUrl()}/tasks`, 'mc.taskClient.create', 'createTask', {
+			'Accept': 'application/json',
+			'Copilot-Integration-Id': COPILOT_INTEGRATION_ID,
+		}, token, REQUEST_TIMEOUT_MS, {
+			environment_id: CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID,
+			// Persisted on the session as its first turn, so a reload that replays history from
+			// Mission Control shows the prompt even though no run was started for it.
+			prompt: request.prompt,
+			...(repository && { repositories: [repository] }),
+			...(request.baseRef && { base_ref: request.baseRef }),
+		});
+		if (!isSuccess(context)) {
+			await this._throwForStatus('task create', context);
+		}
+		const task = await this._readJson<ITaskDetail>(context);
+		const taskId = task?.id;
+		if (!taskId) {
+			throw new CloudSandboxRequestError(context.res.statusCode, 'Mission Control task create returned no task id');
+		}
+		const binding = task && getTaskEnvironmentBinding(task);
+		if (!binding) {
+			// A task with no bound session is unusable — the relay has nothing to address — but it
+			// still shows up in the user's task list, so drop it rather than leaving litter behind.
+			await this._deleteTaskBestEffort(taskId);
+			throw new CloudSandboxRequestError(context.res.statusCode, `Mission Control bound no sandbox session to task ${taskId}`);
+		}
+		this._logService.info(`${LOG_PREFIX} Provisioned sandbox task ${taskId} (session ${binding.sessionId}) on environment ${binding.environmentId}.`);
+		return { taskId, sessionId: binding.sessionId, environmentId: binding.environmentId };
+	}
+
+	/**
+	 * Delete a task we created but cannot use. Best-effort: the caller is already failing, and a
+	 * failed cleanup must not replace the error that explains why.
+	 *
+	 * Only covers tasks Mission Control actually returned to us. A create that is rejected *after*
+	 * the task record exists (HTTP 403 from the sandbox authorization check) reports no id, so
+	 * that orphan can only be cleaned up server-side.
+	 */
+	private async _deleteTaskBestEffort(taskId: string): Promise<void> {
+		try {
+			const context = await this._request(`${this._tasksBaseUrl()}/tasks/${encodeURIComponent(taskId)}`, 'mc.taskClient.delete', 'deleteTask', {
+				'Accept': 'application/json',
+				'Copilot-Integration-Id': COPILOT_INTEGRATION_ID,
+			}, CancellationToken.None, REQUEST_TIMEOUT_MS, undefined, 'DELETE');
+			this._logService.info(`${LOG_PREFIX} Cleaned up unusable sandbox task ${taskId}: HTTP ${context.res.statusCode ?? 'none'}`);
+		} catch (error) {
+			this._logService.warn(`${LOG_PREFIX} Could not clean up sandbox task ${taskId}: ${toErrorMessage(error)}`);
+		}
+	}
+
+	/**
 	 * Read a task's persisted AHP history and fold it into session/chat state.
 	 *
 	 * The only history path that survives the sandbox: `/events` is served by Mission Control's
@@ -303,7 +366,7 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 		return context;
 	}
 
-	private async _request(url: string, callSite: string, action: CloudSandboxRequestAction, headers: Record<string, string>, token: CancellationToken, timeout: number = REQUEST_TIMEOUT_MS): Promise<IRequestContext> {
+	private async _request(url: string, callSite: string, action: CloudSandboxRequestAction, headers: Record<string, string>, token: CancellationToken, timeout: number = REQUEST_TIMEOUT_MS, body?: unknown, method?: 'GET' | 'POST' | 'DELETE'): Promise<IRequestContext> {
 		const accessToken = await this._resolveGitHubToken();
 		if (!accessToken) {
 			// No request is issued, so there is no request outcome to count.
@@ -312,9 +375,10 @@ export class CloudSandboxApiService extends Disposable implements ICloudSandboxA
 		const started = Date.now();
 		try {
 			const context = await this._requestService.request({
-				type: 'GET',
+				type: method ?? (body === undefined ? 'GET' : 'POST'),
 				url,
 				headers: { ...headers, ['Authorization']: `Bearer ${accessToken}` },
+				...(body === undefined ? undefined : { data: JSON.stringify(body) }),
 				timeout,
 				callSite,
 			}, token);
@@ -434,6 +498,15 @@ function parseRetryAfter(value: string | string[] | undefined): number {
 function isCloudSandboxTask(task: ITaskSummary): boolean {
 	const isCloudCodingAgent = task.agent_collaborators?.some(c => c.slug === CLOUD_SANDBOX_AGENT_SLUG) ?? false;
 	return isCloudCodingAgent && task.compute?.provider === 'sandboxes';
+}
+
+/** Split an `owner/name` into the pair Mission Control expects, or `undefined` when unusable. */
+function parseNwo(nwo: string | undefined): { owner: string; name: string } | undefined {
+	const separator = nwo?.indexOf('/') ?? -1;
+	if (!nwo || separator <= 0 || separator === nwo.length - 1) {
+		return undefined;
+	}
+	return { owner: nwo.slice(0, separator), name: nwo.slice(separator + 1) };
 }
 
 /**

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxTelemetry.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxTelemetry.ts
@@ -10,7 +10,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 
 /** The Mission Control call being reported. A closed set, so it is safe to send verbatim. */
-export type CloudSandboxRequestAction = 'connect' | 'reconnect' | 'getEnvironment' | 'listTasks' | 'getTask' | 'getTaskEvents' | 'getRepository';
+export type CloudSandboxRequestAction = 'connect' | 'reconnect' | 'getEnvironment' | 'listTasks' | 'getTask' | 'createTask' | 'deleteTask' | 'getTaskEvents' | 'getRepository';
 
 /**
  * How a Mission Control request ended, bucketed so a count is meaningful without carrying the

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -1133,7 +1133,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		// `CLOUD_SANDBOX_AGENT_SLUG`.
 		[CloudSandboxEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot CLI cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs."),
+			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable Copilot cloud sandbox sessions over a live Agent Host Protocol relay, for slash commands and a responsive, steerable experience instead of only polling logs. Adds a Sandbox option when starting a cloud session, and connects to the sandbox when opening one."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxAgentHostContribution.test.ts
@@ -7,13 +7,19 @@ import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { mock } from '../../../../../../base/test/common/mock.js';
+import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { AgentSession } from '../../../../../../platform/agentHost/common/agent.js';
 import { IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import {
 	CloudSandboxEnabledSettingId,
+	ICloudSandboxAgentHostService,
 	ICloudSandboxApiService,
 	cloudSandboxAddress,
+	type ICloudSandboxConnectOptions,
+	type ICloudSandboxCreateSessionRequest,
+	type ICloudSandboxCreatedSession,
 	type ICloudSandboxDiscoveredSession,
 	type ICloudSandboxDiscoveryResult,
 } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
@@ -26,6 +32,7 @@ import { INotificationService } from '../../../../../../platform/notification/co
 import { IAuthenticationService } from '../../../../../../workbench/services/authentication/common/authentication.js';
 import { IChatSessionsService } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IAgentHostFilterService } from '../../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISession } from '../../../../../services/sessions/common/session.js';
 import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
 import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
 import { CloudSandboxAgentHostContribution } from '../../browser/cloudSandboxAgentHostContribution.js';
@@ -34,6 +41,7 @@ import { IRemoteAgentHostSessionsProviderConfig, RemoteAgentHostSessionsProvider
 
 class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
 	readonly seeded: IAgentSessionMetadata[] = [];
+	disposed = false;
 
 	override readonly id: string;
 
@@ -55,7 +63,20 @@ class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
 		}
 	}
 
-	override dispose(): void { /* noop */ }
+	/** Surfaces each seed under the UI resource scheme, which is what keys the raw session id. */
+	override getSessions(): ISession[] {
+		return this.seeded.map(meta => upcastPartial<ISession>({
+			resource: URI.from({ scheme: 'agent-host-copilot', path: `/${AgentSession.id(meta.session)}` }),
+		}));
+	}
+
+	override setConnectionStatus(): void { }
+
+	override setReadOnly(): void { }
+
+	override dispose(): void {
+		this.disposed = true;
+	}
 }
 
 class TestCloudSandboxContribution extends CloudSandboxAgentHostContribution {
@@ -75,17 +96,54 @@ class StubSessionsProvidersService extends Disposable {
 	getProviders(): ISessionsProvider[] { return []; }
 }
 
+interface ITestHarness {
+	readonly contribution: TestCloudSandboxContribution;
+	readonly configurationService: TestConfigurationService;
+	/** Discovery's answer, mutable so a test can change what a later pass reports. */
+	discovered: readonly ICloudSandboxDiscoveredSession[];
+	/** Runs a discovery pass and waits for it to reconcile. */
+	runDiscovery(): Promise<void>;
+	/** Runs while a `connect` is in flight, for testing what can race with it. */
+	onConnect?: () => Promise<void>;
+	readonly created: ICloudSandboxCreateSessionRequest[];
+	readonly connectedTo: string[];
+}
+
 /**
  * Creates the contribution with a discovery result, and resolves once the constructor's eager
  * `_discoverAndSeed()` pass has committed its seeds.
  */
-async function createContribution(store: Pick<DisposableStore, 'add'>, sessions: readonly ICloudSandboxDiscoveredSession[]): Promise<TestCloudSandboxContribution> {
+async function createContribution(store: Pick<DisposableStore, 'add'>, sessions: readonly ICloudSandboxDiscoveredSession[], options?: {
+	/** Task Mission Control returns from `createSession`, or a rejection. */
+	readonly createSession?: () => Promise<ICloudSandboxCreatedSession>;
+}): Promise<ITestHarness> {
 	const discoveryHandlers: (() => Promise<void>)[] = [];
 	const instantiationService = store.add(new TestInstantiationService());
+	const created: ICloudSandboxCreateSessionRequest[] = [];
+	const connectedTo: string[] = [];
+	const harness: ITestHarness = {
+		discovered: sessions,
+		created,
+		connectedTo,
+		runDiscovery: async () => { await Promise.all(discoveryHandlers.map(handler => handler())); },
+	} as ITestHarness;
 
 	instantiationService.stub(ICloudSandboxApiService, new class extends mock<ICloudSandboxApiService>() {
 		override async listSessions(_token: CancellationToken): Promise<ICloudSandboxDiscoveryResult> {
-			return { kind: 'complete', sessions };
+			return { kind: 'complete', sessions: harness.discovered };
+		}
+		override async createSession(request: ICloudSandboxCreateSessionRequest): Promise<ICloudSandboxCreatedSession> {
+			created.push(request);
+			return options?.createSession
+				? options.createSession()
+				: { taskId: 'task-new', sessionId: 'sess-new', environmentId: 'env-new' };
+		}
+	}());
+	instantiationService.stub(ICloudSandboxAgentHostService, new class extends mock<ICloudSandboxAgentHostService>() {
+		override async connect(connectOptions: ICloudSandboxConnectOptions): Promise<string> {
+			connectedTo.push(connectOptions.environmentId);
+			await harness.onConnect?.();
+			return cloudSandboxAddress(connectOptions.environmentId);
 		}
 	}());
 	instantiationService.stub(IRemoteAgentHostService, new class extends mock<IRemoteAgentHostService>() {
@@ -103,10 +161,11 @@ async function createContribution(store: Pick<DisposableStore, 'add'>, sessions:
 			return toDisposable(() => { });
 		}
 	}());
-	instantiationService.stub(IConfigurationService, new TestConfigurationService({
+	const configurationService = new TestConfigurationService({
 		[CloudSandboxEnabledSettingId]: true,
 		[RemoteAgentHostsEnabledSettingId]: true,
-	}));
+	});
+	instantiationService.stub(IConfigurationService, configurationService);
 	instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
 		override readonly onDidChangeSessions = Event.None;
 		override readonly onDidRegisterAuthenticationProvider = Event.None;
@@ -118,8 +177,8 @@ async function createContribution(store: Pick<DisposableStore, 'add'>, sessions:
 	const contribution = store.add(instantiationService.createInstance(TestCloudSandboxContribution));
 	// The constructor kicks off discovery eagerly; re-running the registered handler awaits it,
 	// because `_discoverAndSeed` serializes onto the in-flight pass.
-	await Promise.all(discoveryHandlers.map(handler => handler()));
-	return contribution;
+	await harness.runDiscovery();
+	return Object.assign(harness, { contribution, configurationService });
 }
 
 function discoveredSession(overrides?: Partial<ICloudSandboxDiscoveredSession>): ICloudSandboxDiscoveredSession {
@@ -141,7 +200,7 @@ suite('CloudSandboxAgentHostContribution', () => {
 	test('seeds the discovered repository so a never-opened session is not workspace-less', async () => {
 		// Without a project the workspace is undefined and the session groups under "Unknown".
 		// The seeded shape matches what the host reports on connect, so reconciling is a no-op.
-		const contribution = await createContribution(store, [discoveredSession()]);
+		const { contribution } = await createContribution(store, [discoveredSession()]);
 
 		const provider = contribution.stubProviders.get(cloudSandboxAddress('env-1'));
 		assert.deepStrictEqual(provider?.seeded.map(m => ({
@@ -156,7 +215,7 @@ suite('CloudSandboxAgentHostContribution', () => {
 	});
 
 	test('omits the project when discovery could not resolve a repository', async () => {
-		const contribution = await createContribution(store, [discoveredSession({ repoName: undefined })]);
+		const { contribution } = await createContribution(store, [discoveredSession({ repoName: undefined })]);
 
 		const provider = contribution.stubProviders.get(cloudSandboxAddress('env-1'));
 		assert.strictEqual(provider?.seeded[0]?.project, undefined);
@@ -165,7 +224,7 @@ suite('CloudSandboxAgentHostContribution', () => {
 	test('opts sandbox providers out of the [host] workspace-label suffix', async () => {
 		// Each sandbox is its own provider named after its task, so the suffix would put every
 		// session in a workspace group of one.
-		const contribution = await createContribution(store, [
+		const { contribution } = await createContribution(store, [
 			discoveredSession(),
 			discoveredSession({ environmentId: 'env-2', sessionId: 'sess-2', taskId: 'task-2', name: 'hi' }),
 		]);
@@ -177,5 +236,104 @@ suite('CloudSandboxAgentHostContribution', () => {
 			{ name: 'Change port to 5555', omitHostFromWorkspaceLabel: true },
 			{ name: 'hi', omitHostFromWorkspaceLabel: true },
 		]);
+	});
+});
+
+suite('CloudSandboxAgentHostContribution provisioning', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('creates the task, seeds it like a discovered one, and connects to the bound environment', async () => {
+		const harness = await createContribution(store, []);
+
+		const provisioned = await harness.contribution.provisionSession({ repoNwo: 'osortega/simple-server', prompt: 'fix it' }, CancellationToken.None);
+
+		const provider = harness.contribution.stubProviders.get(cloudSandboxAddress('env-new'));
+		assert.deepStrictEqual({
+			ids: { taskId: provisioned.taskId, sessionId: provisioned.sessionId, environmentId: provisioned.environmentId },
+			// The seed must match discovery's shape, or a later pass would duplicate the session.
+			seeded: provider?.seeded.map(m => ({ session: m.session.toString(), summary: m.summary, project: m.project?.displayName })),
+			// The relay must target the bound VM, never the `github-sandbox` sentinel.
+			connectedTo: harness.connectedTo,
+			resolvedSession: provisioned.session.resource.path,
+		}, {
+			ids: { taskId: 'task-new', sessionId: 'sess-new', environmentId: 'env-new' },
+			seeded: [{ session: 'copilot:/sess-new', summary: 'osortega/simple-server', project: 'osortega/simple-server' }],
+			connectedTo: ['env-new'],
+			resolvedSession: '/sess-new',
+		});
+	});
+
+	test('a discovery pass that cannot see the new task yet does not tear it down mid-provision', async () => {
+		// The scan was issued before the task existed, so it reports the environment as absent.
+		// Without the in-flight guard, reconciliation disposes the provider we are connecting to.
+		const harness = await createContribution(store, []);
+		harness.onConnect = () => harness.runDiscovery();
+
+		const provisioned = await harness.contribution.provisionSession({ repoNwo: 'osortega/simple-server', prompt: 'fix it' }, CancellationToken.None);
+
+		const provider = harness.contribution.stubProviders.get(cloudSandboxAddress('env-new'));
+		assert.deepStrictEqual({
+			disposed: provider?.disposed,
+			returnedLiveProvider: provisioned.provider === provider,
+		}, {
+			disposed: false,
+			returnedLiveProvider: true,
+		});
+	});
+
+	test('rejects when the feature is disabled while the sandbox is waking', async () => {
+		// Connecting waits out the VM boot, which is long enough for the setting to change.
+		// Returning a provider that teardown has already disposed would send into nothing.
+		const harness = await createContribution(store, []);
+		harness.onConnect = async () => {
+			harness.configurationService.setUserConfiguration(CloudSandboxEnabledSettingId, false);
+		};
+
+		await assert.rejects(() => harness.contribution.provisionSession({ prompt: 'fix it' }, CancellationToken.None));
+	});
+
+	test('registers nothing when the feature is disabled while the task is being created', async () => {
+		// `_teardownAll` snapshots the environments it knows about, so a provider registered after
+		// it runs is never reconciled — it would outlive the feature being turned off.
+		let disable = () => { };
+		const harness = await createContribution(store, [], {
+			createSession: async () => {
+				disable();
+				return { taskId: 'task-new', sessionId: 'sess-new', environmentId: 'env-new' };
+			},
+		});
+		disable = () => harness.configurationService.setUserConfiguration(CloudSandboxEnabledSettingId, false);
+
+		await assert.rejects(() => harness.contribution.provisionSession({ prompt: 'fix it' }, CancellationToken.None));
+
+		assert.deepStrictEqual({
+			providers: [...harness.contribution.stubProviders.keys()],
+			connectedTo: harness.connectedTo,
+		}, {
+			providers: [],
+			connectedTo: [],
+		});
+	});
+
+	test('rejects without provisioning anything when the feature is already disabled', async () => {
+		const harness = await createContribution(store, []);
+		harness.configurationService.setUserConfiguration(RemoteAgentHostsEnabledSettingId, false);
+
+		await assert.rejects(() => harness.contribution.provisionSession({ prompt: 'fix it' }, CancellationToken.None));
+
+		assert.deepStrictEqual({ created: harness.created, connectedTo: harness.connectedTo }, { created: [], connectedTo: [] });
+	});
+
+	test('a later discovery pass reconciles with the provisioned session instead of duplicating it', async () => {
+		const harness = await createContribution(store, []);
+		await harness.contribution.provisionSession({ repoNwo: 'osortega/simple-server', prompt: 'fix it' }, CancellationToken.None);
+
+		// The task is now visible to discovery, under the same session id it was created with.
+		harness.discovered = [discoveredSession({ environmentId: 'env-new', sessionId: 'sess-new', taskId: 'task-new', name: 'fix it' })];
+		await harness.runDiscovery();
+
+		const provider = harness.contribution.stubProviders.get(cloudSandboxAddress('env-new'));
+		assert.deepStrictEqual(provider?.seeded.map(m => m.session.toString()), ['copilot:/sess-new']);
 	});
 });

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxApiService.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/cloudSandboxApiService.test.ts
@@ -10,7 +10,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IRequestContext } from '../../../../../../base/parts/request/common/request.js';
-import { CLOUD_SANDBOX_AGENT_SLUG } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
+import { CLOUD_SANDBOX_AGENT_SLUG, CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID } from '../../../../../../platform/agentHost/common/cloudSandboxAgentHost.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
@@ -165,5 +165,122 @@ suite('CloudSandboxApiService repository resolution', () => {
 			// issues a second lookup for the task that shares the repository.
 			repoLookups: 2,
 		});
+	});
+});
+
+interface ICreateCall {
+	readonly url: string;
+	readonly type: string;
+	readonly body: unknown;
+}
+
+function createServiceForCreate(store: Pick<{ add<T extends { dispose(): void }>(t: T): T }, 'add'>, response: unknown, statusCode = 200, options?: { readonly failDelete?: boolean }): { service: CloudSandboxApiService; calls: ICreateCall[] } {
+	const calls: ICreateCall[] = [];
+	const instantiationService = store.add(new TestInstantiationService());
+	instantiationService.stub(IRequestService, new class extends mock<IRequestService>() {
+		override async request(opts: { url?: string; type?: string; data?: string }): Promise<IRequestContext> {
+			calls.push({ url: opts.url ?? '', type: opts.type ?? '', body: opts.data === undefined ? undefined : JSON.parse(opts.data) });
+			if (opts.type === 'DELETE' && options?.failDelete) {
+				throw new Error('delete failed');
+			}
+			return jsonResponse(response, statusCode);
+		}
+	}());
+	instantiationService.stub(IAuthenticationService, new class extends mock<IAuthenticationService>() {
+		override async getSessions() { return [{ accessToken: 'tok', id: 's', account: { id: 'a', label: 'a' }, scopes: [] }]; }
+		override readonly onDidChangeSessions = Event.None;
+	}());
+	instantiationService.stub(IProductService, { defaultChatAgent: undefined } as unknown as IProductService);
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ICloudSandboxTelemetryService, new class extends mock<ICloudSandboxTelemetryService>() {
+		override reportRequest(): void { }
+	}());
+	return { service: store.add(instantiationService.createInstance(CloudSandboxApiService)), calls };
+}
+
+suite('CloudSandboxApiService session creation', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('posts the on-demand sentinel and returns the bound environment', async () => {
+		const { service, calls } = createServiceForCreate(store, {
+			id: 'task-1',
+			sessions: [{ id: 'sess-1', environment_id: 'env-concrete' }],
+		});
+
+		const created = await service.createSession({ repoNwo: 'osortega/simple-server', baseRef: 'main', prompt: 'fix it' }, CancellationToken.None);
+
+		assert.deepStrictEqual({
+			created,
+			type: calls[0].type,
+			endsWithTasks: calls[0].url.endsWith('/agents/tasks'),
+			body: calls[0].body,
+		}, {
+			created: { taskId: 'task-1', sessionId: 'sess-1', environmentId: 'env-concrete' },
+			type: 'POST',
+			endsWithTasks: true,
+			body: {
+				environment_id: CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID,
+				prompt: 'fix it',
+				repositories: [{ owner: 'osortega', name: 'simple-server' }],
+				base_ref: 'main',
+			},
+		});
+	});
+
+	test('omits the repository and base ref when they are not supplied', async () => {
+		const { service, calls } = createServiceForCreate(store, {
+			id: 'task-2',
+			sessions: [{ id: 'sess-2', environment_id: 'env-2' }],
+		});
+
+		await service.createSession({ prompt: 'hello' }, CancellationToken.None);
+
+		assert.deepStrictEqual(calls[0].body, {
+			environment_id: CLOUD_SANDBOX_ON_DEMAND_ENVIRONMENT_ID,
+			prompt: 'hello',
+		});
+	});
+
+	test('throws when Mission Control binds no session to the created task', async () => {
+		// A task with no bound session has nothing for the relay to address, so this must not be
+		// reported as a usable sandbox.
+		const { service } = createServiceForCreate(store, { id: 'task-3', sessions: [] });
+
+		await assert.rejects(
+			() => service.createSession({ prompt: 'hello' }, CancellationToken.None),
+			/bound no sandbox session/,
+		);
+	});
+
+	test('deletes a created task that has no usable session, rather than leaving it in the task list', async () => {
+		// The task exists on the server even though it is unusable, so it would otherwise show up
+		// in the user's task list forever.
+		const { service, calls } = createServiceForCreate(store, { id: 'task-3', sessions: [] });
+
+		await assert.rejects(() => service.createSession({ prompt: 'hello' }, CancellationToken.None));
+
+		assert.deepStrictEqual(calls.map(c => `${c.type} ${c.url.replace(/^.*\/agents/, '')}`), [
+			'POST /tasks',
+			'DELETE /tasks/task-3',
+		]);
+	});
+
+	test('a failed cleanup does not replace the error explaining why creation failed', async () => {
+		const { service } = createServiceForCreate(store, { id: 'task-3', sessions: [] }, 200, { failDelete: true });
+
+		await assert.rejects(
+			() => service.createSession({ prompt: 'hello' }, CancellationToken.None),
+			/bound no sandbox session/,
+		);
+	});
+
+	test('throws on a non-success status', async () => {
+		const { service } = createServiceForCreate(store, { message: 'nope' }, 403);
+
+		await assert.rejects(
+			() => service.createSession({ prompt: 'hello' }, CancellationToken.None),
+			/HTTP 403/,
+		);
 	});
 });


### PR DESCRIPTION
This pull request introduces a "New Worktree" checkbox for cloud sessions, allowing users to choose between creating a sandbox or using a regular cloud session provider when the `chat.agentHost.cloudSandbox.enabled` setting is enabled.

### Changes Made:
- **Checkbox Implementation**: Added a checkbox in the cloud session creation process to toggle between sandbox and regular sessions.
- **Code Refactoring**: 
  - Removed the unused `baseRef` getter to streamline the session creation logic.
  - Ensured that both the picker and send paths utilize the same repository check to prevent silent failures.
- **Testing Enhancements**: 
  - Expanded the test suite from 0 to 16 tests, covering critical paths including session provisioning and sandbox interactions.
  - Verified that the race condition tests are effective and accurately catch potential issues.

### Additional Notes:
- The implementation ensures that the checkbox behaves consistently across different session types and maintains a responsive user experience.
- Further validation is needed to confirm backend behavior regarding task creation and session discovery.