### PR TITLE
Fix Extension Host restart when adding first root folder

### DIFF
--- a/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
@@ -176,9 +176,14 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 	}
 
 	async enterWorkspace(workspaceUri: URI): Promise<void> {
-		const stopped = await this.extensionService.stopExtensionHosts(localize('restartExtensionHost.reason', "Opening a multi-root workspace"));
-		if (!stopped) {
-			return;
+		const isFromEmptyWorkspace = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
+
+		let stopped = true;
+		if (!isFromEmptyWorkspace) {
+			stopped = await this.extensionService.stopExtensionHosts(localize('restartExtensionHost.reason', "Opening a multi-root workspace"));
+			if (!stopped) {
+				return;
+			}
 		}
 
 		const oldWorkspace = toWorkspaceIdentifier(this.contextService.getWorkspace());
@@ -195,6 +200,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 			}
 
 			// Fire event to allow participants to join
+			// and possibly migrate data into this workspace
 			await this.fireDidEnterWorkspace(oldWorkspace, result.workspace);
 		}
 
@@ -205,7 +211,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 
 		// Restart the extension host: entering a workspace means a new location for
 		// storage and potentially a change in the workspace.rootPath property.
-		else {
+		else if (!isFromEmptyWorkspace) {
 			this.extensionService.startExtensionHosts();
 		}
 	}

--- a/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
@@ -177,9 +177,10 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 
 	async enterWorkspace(workspaceUri: URI): Promise<void> {
 		const isFromEmptyWorkspace = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
+		const shouldPreserveExtensionHost = isFromEmptyWorkspace && !this.environmentService.remoteAuthority;
 
 		let stopped = true;
-		if (!isFromEmptyWorkspace) {
+		if (!shouldPreserveExtensionHost) {
 			stopped = await this.extensionService.stopExtensionHosts(localize('restartExtensionHost.reason', "Opening a multi-root workspace"));
 			if (!stopped) {
 				return;
@@ -199,8 +200,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 				this.workingCopyBackupService.reinitialize(newBackupWorkspaceHome);
 			}
 
-			// Fire event to allow participants to join
-			// and possibly migrate data into this workspace
+			// Fire event to allow participants to join and migrate workspace data
 			await this.fireDidEnterWorkspace(oldWorkspace, result.workspace);
 		}
 
@@ -211,7 +211,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 
 		// Restart the extension host: entering a workspace means a new location for
 		// storage and potentially a change in the workspace.rootPath property.
-		else if (!isFromEmptyWorkspace) {
+		else if (!shouldPreserveExtensionHost) {
 			this.extensionService.startExtensionHosts();
 		}
 	}


### PR DESCRIPTION
### Problem
When a user launches VS Code with no folder open (`WorkbenchState.EMPTY`) and starts an in-progress session (such as a GitHub Copilot Chat session), adding a folder to the workspace via `workbench.action.addRootFolder` causes VS Code to restart the Extension Host process. This triggers a *"Please confirm restart of extensions — A session is in progress"* dialog and destroys active in-memory session states.

### Root cause
In `NativeWorkspaceEditingService.enterWorkspace()`, entering a workspace from an empty window previously executed `extensionService.stopExtensionHosts()` and `extensionService.startExtensionHosts()` unconditionally. Teardown of the Extension Host process destroys active extension states (like active Copilot Chat sessions) in memory.

### Fix
- Updated `NativeWorkspaceEditingService.enterWorkspace()` to inspect whether the transition originates from an empty workspace (`isFromEmptyWorkspace = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY`).
- When `isFromEmptyWorkspace` is true, the Extension Host is kept running without process teardown or restart prompts.
- Workspace storage is updated in-place, and `fireDidEnterWorkspace` continues to fire normally to allow participants (such as `chatSessionStore.ts`) to migrate disk storage roots while keeping active extension sessions alive.

### Tests
- Manually verified that adding a folder to an empty workspace in desktop VS Code no longer prompts for extension host restart or kills running chat sessions.
- Verified that `onDidEnterWorkspace` fires correctly to handle session migration on disk.
