### PR TITLE
chat: index only content Find can reveal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindContent.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindContent.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
-import { isMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { canceledName } from '../../../../../../base/common/errors.js';
+import { isMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { basename } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { isLocation, Location } from '../../../../../../editor/common/languages.js';
@@ -33,6 +34,21 @@ function inlineReferenceLabel(part: { inlineReference: URI | Location | IWorkspa
 }
 
 /**
+ * Whether the response renders its error message verbatim. Mirrors the renderer, which drops the
+ * error part for canceled or non-final responses, and replaces the message with fixed copy for the
+ * quota and anonymous rate-limit variants.
+ */
+function isErrorDetailsRendered(item: IChatResponseViewModel): boolean {
+	const errorDetails = item.errorDetails;
+	if (!errorDetails?.message || errorDetails.isQuotaExceeded || errorDetails.isRateLimited) {
+		return false;
+	}
+	return item.model.response === item.model.entireResponse
+		&& !item.isCanceled
+		&& errorDetails.message !== canceledName;
+}
+
+/**
  * Extracts the text a response actually *renders*, for Find to index.
  *
  * Deliberately not the accessible view's extraction: that one describes a response to a screen
@@ -47,14 +63,19 @@ function inlineReferenceLabel(part: { inlineReference: URI | Location | IWorkspa
 export function getChatFindTextParts(item: IChatResponseViewModel): IChatFindTextPart[] {
 	const parts: IChatFindTextPart[] = [];
 
-	if (item.errorDetails?.message) {
-		parts.push({ partIndex: -1, text: item.errorDetails.message });
+	if (isErrorDetailsRendered(item)) {
+		// The message is rendered as markdown, so index its plaintext form rather than the raw
+		// source; otherwise syntax characters would be counted but absent from the DOM.
+		parts.push({ partIndex: -1, text: renderAsPlaintext(new MarkdownString(item.errorDetails!.message)) });
 	}
 
 	item.response.value.forEach((part, partIndex) => {
 		switch (part.kind) {
 			case 'markdownContent': {
-				const text = renderAsPlaintext(part.content, { includeCodeBlocksFences: true, useLinkFormatter: true });
+				// No code fences or link formatting: the ``` markers are consumed by the code
+				// block, and an empty link renders as an empty anchor, so both would contribute
+				// text that is counted here but absent from the DOM.
+				const text = renderAsPlaintext(part.content);
 				if (text.trim()) {
 					parts.push({ partIndex, text });
 				}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindContent.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindContent.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
+import { isMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { basename } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { isLocation, Location } from '../../../../../../editor/common/languages.js';
+import { IWorkspaceSymbol } from '../../../../search/common/search.js';
+import { IChatResponseViewModel } from '../../../common/model/chatViewModel.js';
+
+/**
+ * A unit of searchable text from a chat response, keyed to the content part it came from.
+ * `partIndex` indexes {@link IChatResponseViewModel.response.value}; `-1` marks row-level
+ * text with no content part of its own, such as error details.
+ */
+export interface IChatFindTextPart {
+	readonly partIndex: number;
+	readonly text: string;
+}
+
+function inlineReferenceLabel(part: { inlineReference: URI | Location | IWorkspaceSymbol; name?: string }): string | undefined {
+	const ref = part.inlineReference;
+	if (URI.isUri(ref)) {
+		return part.name || basename(ref);
+	}
+	if (isLocation(ref)) {
+		return part.name || basename(ref.uri);
+	}
+	return ref.name;
+}
+
+/**
+ * Extracts the text a response actually *renders*, for Find to index.
+ *
+ * Deliberately not the accessible view's extraction: that one describes a response to a screen
+ * reader and synthesizes strings with no on-screen equivalent (result payloads, "Input:",
+ * "Errored", authentication prompts). Indexing those produces matches Find counts but can never
+ * scroll to or highlight, because the DOM has no such text.
+ *
+ * Only content whose rendering can be predicted from the model alone is indexed. Reasoning and
+ * tool invocations are excluded: where they render is decided during rendering, so indexing them
+ * makes the match count depend on how far the transcript has been drawn.
+ */
+export function getChatFindTextParts(item: IChatResponseViewModel): IChatFindTextPart[] {
+	const parts: IChatFindTextPart[] = [];
+
+	if (item.errorDetails?.message) {
+		parts.push({ partIndex: -1, text: item.errorDetails.message });
+	}
+
+	item.response.value.forEach((part, partIndex) => {
+		switch (part.kind) {
+			case 'markdownContent': {
+				const text = renderAsPlaintext(part.content, { includeCodeBlocksFences: true, useLinkFormatter: true });
+				if (text.trim()) {
+					parts.push({ partIndex, text });
+				}
+				break;
+			}
+			case 'inlineReference': {
+				// Only the label is rendered; the resolved path lives in the hover.
+				const label = inlineReferenceLabel(part);
+				if (label?.trim()) {
+					parts.push({ partIndex, text: label });
+				}
+				break;
+			}
+			case 'toolInvocation':
+			case 'toolInvocationSerialized': {
+				// Tool invocations are not indexed. Whether one renders as its own pill or inside
+				// a thinking/subagent part is decided during rendering (`isAttachedToThinking` is
+				// assigned by the renderer), so indexing them makes the match count depend on how
+				// much has rendered: a row that has not been drawn yet contributes matches that
+				// disappear once it is. Those are the "ghost" results that navigate nowhere.
+				break;
+			}
+			case 'elicitation2':
+			case 'elicitationSerialized': {
+				const title = isMarkdownString(part.title) ? renderAsPlaintext(part.title) : part.title;
+				const message = isMarkdownString(part.message) ? renderAsPlaintext(part.message) : part.message;
+				const text = [title, message].filter(value => typeof value === 'string' && value.trim()).join('\n');
+				if (text.trim()) {
+					parts.push({ partIndex, text });
+				}
+				break;
+			}
+		}
+	});
+
+	return parts;
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindModel.ts
@@ -7,7 +7,7 @@ import { createRegExp } from '../../../../../../base/common/strings.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ChatTreeItem } from '../../chat.js';
-import { getChatResponsePlaintextParts } from '../../accessibility/chatResponseAccessibleView.js';
+import { getChatFindTextParts } from './chatFindContent.js';
 import { isRequestVM, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { annotateSpecialMarkdownContentWithSource } from '../../../common/widget/annotations.js';
 import { moveResponseOutcomeToolsAfterFinalResponse } from '../chatListRenderer.js';
@@ -71,9 +71,10 @@ function buildSegments(items: readonly ChatTreeItem[]): IChatFindSegment[] {
 			// Mirrors the renderer, which puts the references slot first and code citations
 			// between the response content and the trailing parts that hold row-level text.
 			const trailingPartIndex = renderedContent.length + 1 + (item.codeCitations?.length ? 1 : 0);
-			// Reasoning is deliberately excluded: `ChatThinkingContentPart` builds its body only
-			// once expanded, so a match there could be counted but never revealed or highlighted.
-			const parts = getChatResponsePlaintextParts(item, false);
+			// Indexes only what the response renders: `getChatFindTextParts` deliberately omits
+			// reasoning and tool result payloads, whose text does not exist in the DOM until
+			// their container is expanded, so a match there could never be revealed.
+			const parts = getChatFindTextParts(item);
 			const textByRenderedPart = new Map<number, string>();
 			for (const part of parts) {
 				if (part.text.trim().length > 0) {
@@ -226,8 +227,7 @@ export class ChatFindModel extends Disposable {
 		this._matches = matches;
 
 		if (previousAnchor) {
-			const idx = matches.findIndex(m => m.itemId === previousAnchor.itemId && m.partIndex === previousAnchor.partIndex && m.occurrenceIndex === previousAnchor.occurrenceIndex);
-			this._activeIndex = idx;
+			this._activeIndex = matches.findIndex(m => m.itemId === previousAnchor.itemId && m.partIndex === previousAnchor.partIndex && m.occurrenceIndex === previousAnchor.occurrenceIndex);
 		}
 		if (this._activeIndex < 0) {
 			this._activeIndex = matches.length > 0 ? 0 : -1;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatFind/chatFindWidget.ts
@@ -206,6 +206,11 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 	private readonly _codeDecorations = new Map<CodeBlockPart, IEditorDecorationsCollection>();
 
 	private _lastFocusedElement: HTMLElement | undefined;
+	private _lastNavigationWasPrevious = false;
+	private _unlocatableSkips = 0;
+
+	/** Bounds the skip walk so a query whose matches are all unlocatable cannot spin. */
+	private static readonly MAX_UNLOCATABLE_SKIPS = 50;
 
 	constructor(
 		private readonly host: IChatFindHost,
@@ -285,6 +290,12 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 	}
 
 	find(previous: boolean): void {
+		this._lastNavigationWasPrevious = previous;
+		this._unlocatableSkips = 0;
+		this._advanceActiveMatch(previous);
+	}
+
+	private _advanceActiveMatch(previous: boolean): void {
 		if (previous) {
 			this._model.previous();
 		} else {
@@ -292,6 +303,19 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 		}
 		this._navigateToActive();
 		void this.updateResultCount();
+	}
+
+	/**
+	 * Moves past a match the DOM cannot produce, so navigation never appears to do nothing. The
+	 * index predicts where the renderer will put content, and a part nested in a lazily-built
+	 * container has no DOM node to land on; rather than stall, continue in the same direction.
+	 */
+	private _skipUnlocatableMatch(): void {
+		if (this._unlocatableSkips >= ChatFindWidget.MAX_UNLOCATABLE_SKIPS) {
+			return;
+		}
+		this._unlocatableSkips++;
+		this._advanceActiveMatch(this._lastNavigationWasPrevious);
 	}
 
 	findFirst(): void {
@@ -378,7 +402,12 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 
 	private _revealActiveMatch(match: IChatFindMatch): void {
 		const locatedMatch = this._locateMatch(match);
-		if (locatedMatch && isCodeMatch(locatedMatch)) {
+		if (!locatedMatch) {
+			this._repaintVisibleHighlights();
+			this._skipUnlocatableMatch();
+			return;
+		}
+		if (isCodeMatch(locatedMatch)) {
 			const revealCodeMatch = () => {
 				locatedMatch.codeBlock.editor.revealRangeInCenter(locatedMatch.range);
 				this._repaintVisibleHighlights();
@@ -392,7 +421,7 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 		}
 
 		const range = locatedMatch;
-		const opened = range ? this._openAncestorDisclosures(range) : false;
+		const opened = this._openAncestorDisclosures(range);
 		this._repaintVisibleHighlights();
 		if (opened) {
 			this._revealScheduler.value = dom.scheduleAtNextAnimationFrame(this._targetWindow, () => this._scrollRangeIntoView(range));
@@ -516,8 +545,20 @@ export class ChatFindWidget extends SimpleFindWidget implements IChatFindControl
 		// Counts code-block matches too: they are painted as editor decorations rather than DOM
 		// ranges, so bounding only the ranges would let an all-code result set rescan every match.
 		let locatedCount = 0;
+		// Most matches usually belong to rows the virtualized list has not rendered. Skipping them
+		// on the row lookup alone keeps a transcript-wide result set from scanning parts per repaint.
+		const renderedRows = new Map<string, boolean>();
 		for (let index = 0; index < this._model.matches.length && locatedCount < MAX_VISIBLE_HIGHLIGHTS; index++) {
-			const locatedMatch = this._locateMatch(this._model.matches[index], regex);
+			const match = this._model.matches[index];
+			let isRendered = renderedRows.get(match.itemId);
+			if (isRendered === undefined) {
+				isRendered = !!this.host.getTemplateDataForRequestId(match.itemId);
+				renderedRows.set(match.itemId, isRendered);
+			}
+			if (!isRendered) {
+				continue;
+			}
+			const locatedMatch = this._locateMatch(match, regex);
 			if (!locatedMatch) {
 				continue;
 			}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatFindModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatFindModel.test.ts
@@ -16,12 +16,16 @@ function fakeRequest(id: string, messageText: string): ChatTreeItem {
 
 /** Builds a minimal fake response item satisfying `isResponseVM` (`typeof item.setVote !== 'undefined'`). */
 function fakeResponse(id: string, value: unknown[], errorDetails?: { message: string }, codeCitations?: unknown[]): ChatTreeItem {
+	const response = { value };
 	return {
 		id,
 		setVote: () => { },
-		response: { value },
+		response,
 		errorDetails,
 		codeCitations,
+		isCanceled: false,
+		// Error details only render for a final, uncanceled response; see `isErrorDetailsRendered`.
+		model: { response, entireResponse: response },
 	} as unknown as ChatTreeItem;
 }
 
@@ -89,6 +93,22 @@ suite('ChatFindModel', () => {
 
 		assert.strictEqual(model.matches.length, before, 'count is stable across render-time flags');
 		model.dispose();
+	});
+
+	test('does not index error details the renderer replaces or omits', () => {
+		// Canceled responses drop the error part, and the quota/rate-limit variants render fixed
+		// copy instead of the message, so indexing it would count unreachable matches.
+		const canceled = fakeResponse('resp1', [], { message: 'needle failure' }) as unknown as Record<string, unknown>;
+		canceled.isCanceled = true;
+		const quota = fakeResponse('resp2', [], { message: 'needle failure' }) as unknown as Record<string, unknown>;
+		(quota.errorDetails as Record<string, unknown>).isQuotaExceeded = true;
+
+		for (const item of [canceled, quota]) {
+			const model = new ChatFindModel(() => [item as unknown as ChatTreeItem]);
+			model.setQuery('needle', { isRegex: false, matchCase: false, wholeWord: false });
+			assert.strictEqual(model.matches.length, 0);
+			model.dispose();
+		}
 	});
 
 	test('caps the total match count across segments', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatFindModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatFindModel.test.ts
@@ -56,20 +56,38 @@ suite('ChatFindModel', () => {
 		model.dispose();
 	});
 
-	test('searches tool invocation messages but not collapsed reasoning', () => {
-		// Reasoning bodies are built only on expansion, so indexing them would report matches
-		// that can never be revealed. See `buildSegments`.
+	test('does not index reasoning or tool invocations', () => {
+		// Where a tool renders is decided during rendering, and reasoning bodies are built on
+		// expansion, so indexing either makes the count depend on how far the transcript has drawn.
 		const items = [
 			fakeResponse('resp1', [
 				thinking('I should check the needle in this haystack first.'),
 				toolInvocation('Searching for needle in files', 'Searched for needle in files'),
+				markdown('A needle in the response body.'),
 			]),
 		];
 		const model = new ChatFindModel(() => items);
 		model.setQuery('needle', { isRegex: false, matchCase: false, wholeWord: false });
 
-		assert.strictEqual(model.matches.length, 1);
+		assert.strictEqual(model.matches.length, 1, 'only the rendered markdown is indexed');
 		assert.strictEqual(model.matches[0].itemId, 'resp1');
+		model.dispose();
+	});
+
+	test('match count does not change when the renderer marks a tool as grouped', () => {
+		// `isAttachedToThinking` is assigned while rendering; the index must not read it, or the
+		// count would drop as rows draw and navigation would target vanishing matches.
+		const tool = toolInvocation('Searching needle', 'Searched needle') as Record<string, unknown>;
+		const items = [fakeResponse('resp1', [tool, markdown('needle in prose')])];
+		const model = new ChatFindModel(() => items);
+
+		model.setQuery('needle', { isRegex: false, matchCase: false, wholeWord: false });
+		const before = model.matches.length;
+
+		tool.isAttachedToThinking = true;
+		model.recompute();
+
+		assert.strictEqual(model.matches.length, before, 'count is stable across render-time flags');
 		model.dispose();
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatFindWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatFindWidget.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { createRegExp } from '../../../../../../base/common/strings.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { findMatchRangesInDom, openAncestorDisclosures, rangesEqual, shouldCaptureFocusBeforeShow } from '../../../browser/widget/chatFind/chatFindWidget.js';
+import { ChatFindWidget, findMatchRangesInDom, openAncestorDisclosures, rangesEqual, shouldCaptureFocusBeforeShow } from '../../../browser/widget/chatFind/chatFindWidget.js';
 
 suite('ChatFindWidget DOM highlighting', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -135,5 +135,64 @@ suite('ChatFindWidget DOM highlighting', () => {
 	test('shouldCaptureFocusBeforeShow only captures focus when opening from hidden', () => {
 		assert.strictEqual(shouldCaptureFocusBeforeShow(false), true, 'opening from hidden captures the pre-Find focus target');
 		assert.strictEqual(shouldCaptureFocusBeforeShow(true), false, 'reopening while already visible must not overwrite it');
+	});
+});
+
+/**
+ * Exercises the walk that moves past matches the DOM cannot produce. Driving the private members
+ * directly keeps the test free of the widget's service graph while still covering the real
+ * direction, cap and termination behaviour.
+ */
+suite('ChatFindWidget unlocatable match walk', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const skipUnlocatableMatch = Reflect.get(ChatFindWidget.prototype, '_skipUnlocatableMatch') as (this: IWalkHarness) => void;
+	const maxSkips = Reflect.get(ChatFindWidget, 'MAX_UNLOCATABLE_SKIPS') as number;
+
+	interface IWalkHarness {
+		_unlocatableSkips: number;
+		_lastNavigationWasPrevious: boolean;
+		_advanceActiveMatch(previous: boolean): void;
+	}
+
+	/** Walks `locatable` from `startIndex`, skipping entries the DOM cannot produce. */
+	function runWalk(locatable: readonly boolean[], startIndex: number, previous: boolean) {
+		const directions: boolean[] = [];
+		let index = startIndex;
+		const harness: IWalkHarness = {
+			_unlocatableSkips: 0,
+			_lastNavigationWasPrevious: previous,
+			_advanceActiveMatch(wasPrevious: boolean) {
+				directions.push(wasPrevious);
+				index = (index + (wasPrevious ? -1 : 1) + locatable.length) % locatable.length;
+				if (!locatable[index]) {
+					skipUnlocatableMatch.call(harness);
+				}
+			},
+		};
+
+		harness._advanceActiveMatch(previous);
+		return { index, directions, skips: harness._unlocatableSkips };
+	}
+
+	test('advances past unlocatable matches to the next locatable one', () => {
+		// index 0 active; 1 and 2 cannot be located, 3 can.
+		const result = runWalk([true, false, false, true], 0, false);
+
+		assert.strictEqual(result.index, 3);
+		assert.strictEqual(result.skips, 2, 'skipped exactly the two unlocatable matches');
+	});
+
+	test('keeps walking backwards when navigating to the previous match', () => {
+		const result = runWalk([true, false, false, true], 3, true);
+
+		assert.strictEqual(result.index, 0);
+		assert.deepStrictEqual(result.directions, [true, true, true], 'every step kept the direction');
+	});
+
+	test('stops at the cap when nothing can be located', () => {
+		const result = runWalk(new Array(200).fill(false), 0, false);
+
+		assert.strictEqual(result.skips, maxSkips, 'gave up at the cap instead of spinning');
 	});
 });


### PR DESCRIPTION
Follow-up to #330340. Fixes Find reporting matches it cannot navigate to.

## Symptoms

Searching a common word in a long transcript showed:

- a match count that **fell as rows rendered** — one session went `9999 → 4013 → 3793`, another `5949 → 705 → 240 → 123`
- **Next moving the counter without moving the view**
- Find jumping back to the first result while navigating

## Cause

The index reused `getChatResponsePlaintextParts`, the **accessible view's** extraction. That function describes a response to a screen reader rather than mirroring what is drawn, so it:

- synthesizes text with no on-screen equivalent — `Input:`, `Files:`, `Errored`, MCP authentication prompts
- includes tool result payloads, which live in a body that only exists once expanded

Matches in that text were counted, but the painter had nothing to highlight.

The count instability had a sharper cause: **`isAttachedToThinking` is assigned by the renderer** while drawing a row. A row that had not yet rendered looked un-grouped, so its tools were indexed; once drawn, they were excluded and those matches vanished. Navigating toward one meant targeting a match that ceased to exist.

## Changes

**New `chatFindContent.ts`** — a Find-specific extraction covering markdown, inline reference labels, elicitations and error details.

Reasoning and tool invocations are deliberately **not** indexed. Where a tool renders is decided during rendering, and reasoning bodies are built on expansion; indexing either makes the count depend on how far the transcript has drawn. This is the "start small" position — broadening it needs a typed expansion API on `ChatCollapsibleContentPart`, tracked separately.

**Repaint skips unrendered rows.** One memoized row lookup before scanning parts. In a captured trace, 51,298 of 51,363 locate attempts were for rows that were not on screen.

**Navigation advances past unlocatable matches** (bounded at 50), so Next never appears to do nothing if a prediction is still wrong.

## Tradeoff

Text inside a tool pill — including a terminal command header — is no longer searchable. Those matches were real and highlighted correctly, but keeping them requires reading render-time state, which is what produced the phantom results.

## Testing

- 47 targeted tests pass, including new cases for the extraction rule and a regression test that flips `isAttachedToThinking` after indexing and asserts the count is unchanged
- `typecheck-client`, `valid-layers-check`, ESLint clean
- Verified interactively against a long agent transcript: the count now holds steady and navigation moves

Diagnosed from console traces captured behind a temporary flag; the scaffolding is removed from this branch.
