### PR TITLE
Fix: validate native dialog responses to prevent silent auto-close

### DIFF
--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -450,11 +450,21 @@ export abstract class AbstractDialogHandler implements IDialogHandler {
 
 	protected getPromptResult<T>(prompt: IPrompt<T>, buttonIndex: number, checkboxChecked: boolean | undefined): IAsyncPromptResult<T> {
 		const promptButtons: IPromptBaseButton<T>[] = [...(prompt.buttons ?? [])];
-		if (prompt.cancelButton && typeof prompt.cancelButton !== 'string' && typeof prompt.cancelButton !== 'boolean') {
-			promptButtons.push(prompt.cancelButton);
+		const cancelButton = prompt.cancelButton && typeof prompt.cancelButton !== 'string' && typeof prompt.cancelButton !== 'boolean'
+			? prompt.cancelButton
+			: undefined;
+		if (cancelButton) {
+			promptButtons.push(cancelButton);
 		}
 
-		let result = promptButtons[buttonIndex]?.run({ checkboxChecked });
+		// `buttonIndex` should always address one of `promptButtons`, but
+		// defend against an out-of-range index resolving to no button at
+		// all: silently running no action leaves the dialog looking like
+		// it closed itself (https://github.com/microsoft/vscode/issues/329901).
+		// Fall back to the prompt's own cancel button when it has one.
+		const button = promptButtons[buttonIndex] ?? cancelButton;
+
+		let result = button?.run({ checkboxChecked });
 		if (!(result instanceof Promise)) {
 			result = Promise.resolve(result);
 		}

--- a/src/vs/platform/dialogs/electron-main/dialogMainService.ts
+++ b/src/vs/platform/dialogs/electron-main/dialogMainService.ts
@@ -13,7 +13,7 @@ import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { Promises } from '../../../base/node/pfs.js';
 import { localize } from '../../../nls.js';
 import { INativeOpenDialogOptions } from '../common/dialogs.js';
-import { massageMessageBoxOptions } from './dialogMainUtils.js';
+import { massageMessageBoxOptions, resolveMessageBoxResponse } from './dialogMainUtils.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
@@ -158,8 +158,13 @@ export class DialogMainService implements IDialogMainService {
 				result = await electron.dialog.showMessageBox(options);
 			}
 
+			const { response, wasUnexpectedResponse } = resolveMessageBoxResponse(result.response, buttonIndeces, options.cancelId);
+			if (wasUnexpectedResponse) {
+				this.logService.error(`[DialogMainService]: native message box returned out-of-range response '${result.response}' (expected 0-${buttonIndeces.length - 1}), falling back to response '${response}'. See https://github.com/microsoft/vscode/issues/329901.`);
+			}
+
 			return {
-				response: buttonIndeces[result.response],
+				response,
 				checkboxChecked: result.checkboxChecked
 			};
 		});

--- a/src/vs/platform/dialogs/electron-main/dialogMainUtils.ts
+++ b/src/vs/platform/dialogs/electron-main/dialogMainUtils.ts
@@ -110,3 +110,50 @@ export function massageMessageBoxOptions(options: MessageBoxOptions, productServ
 		buttonIndeces
 	};
 }
+
+export interface IResolvedMessageBoxResponse {
+
+	/**
+	 * The original (pre-massage) button index the response maps to.
+	 */
+	readonly response: number;
+
+	/**
+	 * `true` when `rawResponse` did not address a real button and had
+	 * to be mapped to a fallback response.
+	 */
+	readonly wasUnexpectedResponse: boolean;
+}
+
+/**
+ * Maps a native message box response back to the original button index,
+ * defending against out-of-range responses.
+ *
+ * On Windows, third-party software that inspects native file/message
+ * dialogs (for example security tooling) can send an overlapping
+ * `CDM_GETFOLDERPATH` / `TDM_CLICK_BUTTON` window message that makes
+ * Electron report a `response` outside the range of buttons that were
+ * actually shown (observed value: `420`). Indexing `buttonIndeces` with
+ * such a response silently yields `undefined`, and callers that treat the
+ * result as a button index (for example `AbstractDialogHandler#getPromptResult`)
+ * then run no button's action at all -- the dialog just closes with nothing
+ * having happened, which is the "dialog closed itself" symptom reported in
+ * https://github.com/microsoft/vscode/issues/329901. See also
+ * https://github.com/electron/electron/issues/52747.
+ *
+ * Instead of propagating an out-of-range response, fall back to the
+ * dialog's own cancel button (or, if none was designated, its last button --
+ * the same least-destructive convention `massageMessageBoxOptions` already
+ * uses as its default cancel button).
+ */
+export function resolveMessageBoxResponse(rawResponse: number, buttonIndeces: number[], cancelId: number | undefined): IResolvedMessageBoxResponse {
+	if (Number.isInteger(rawResponse) && rawResponse >= 0 && rawResponse < buttonIndeces.length) {
+		return { response: buttonIndeces[rawResponse], wasUnexpectedResponse: false };
+	}
+
+	const safeCancelId = typeof cancelId === 'number' && cancelId >= 0 && cancelId < buttonIndeces.length
+		? cancelId
+		: Math.max(0, buttonIndeces.length - 1);
+
+	return { response: buttonIndeces[safeCancelId] ?? 0, wasUnexpectedResponse: true };
+}

--- a/src/vs/platform/dialogs/test/common/dialogs.test.ts
+++ b/src/vs/platform/dialogs/test/common/dialogs.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	AbstractDialogHandler, IAsyncPromptResult, IConfirmation, IConfirmationResult,
+	IInput, IInputResult, IPrompt, IPromptButton
+} from '../../common/dialogs.js';
+
+class TestDialogHandler extends AbstractDialogHandler {
+
+	async confirm(_confirmation: IConfirmation): Promise<IConfirmationResult> {
+		throw new Error('not implemented');
+	}
+
+	async input(_input: IInput): Promise<IInputResult> {
+		throw new Error('not implemented');
+	}
+
+	async prompt<T>(_prompt: IPrompt<T>): Promise<IAsyncPromptResult<T>> {
+		throw new Error('not implemented');
+	}
+
+	async about(): Promise<void> {
+		throw new Error('not implemented');
+	}
+
+	testGetPromptResult<T>(prompt: IPrompt<T>, buttonIndex: number): IAsyncPromptResult<T> {
+		return this.getPromptResult(prompt, buttonIndex, undefined);
+	}
+}
+
+suite('AbstractDialogHandler', () => {
+
+	test('getPromptResult runs the button addressed by a valid index', async () => {
+		const handler = new TestDialogHandler();
+
+		let ranPrimary = false;
+		let ranCancel = false;
+
+		const primary: IPromptButton<void> = { label: 'Primary', run: () => { ranPrimary = true; } };
+		const prompt: IPrompt<void> = {
+			message: 'message',
+			buttons: [primary],
+			cancelButton: { run: () => { ranCancel = true; } }
+		};
+
+		await handler.testGetPromptResult(prompt, 0).result!;
+
+		strictEqual(ranPrimary, true);
+		strictEqual(ranCancel, false);
+	});
+
+	test('getPromptResult falls back to the cancel button for an out-of-range index instead of running nothing', async () => {
+		// Regression test for https://github.com/microsoft/vscode/issues/329901:
+		// an out-of-range button index (for example forwarded from a native
+		// dialog handler that received an unexpected Electron response) must
+		// not silently resolve with no button's action having run.
+		const handler = new TestDialogHandler();
+
+		let ranPrimary = false;
+		let ranCancel = false;
+
+		const primary: IPromptButton<void> = { label: 'Primary', run: () => { ranPrimary = true; } };
+		const prompt: IPrompt<void> = {
+			message: 'message',
+			buttons: [primary],
+			cancelButton: { run: () => { ranCancel = true; } }
+		};
+
+		await handler.testGetPromptResult(prompt, 420).result!;
+
+		strictEqual(ranPrimary, false);
+		strictEqual(ranCancel, true);
+	});
+
+	test('getPromptResult with an out-of-range index and no cancel button resolves without running any action', async () => {
+		// When the prompt has no dedicated cancel button there is nothing
+		// safe to fall back to; this preserves today's behavior rather than
+		// running an unrelated (and potentially destructive) button.
+		const handler = new TestDialogHandler();
+
+		let ranPrimary = false;
+		const primary: IPromptButton<void> = { label: 'Primary', run: () => { ranPrimary = true; } };
+		const prompt: IPrompt<void> = {
+			message: 'message',
+			buttons: [primary]
+		};
+
+		const result = await handler.testGetPromptResult(prompt, 420).result!;
+
+		strictEqual(ranPrimary, false);
+		strictEqual(result, undefined);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});

--- a/src/vs/platform/dialogs/test/electron-main/dialogMainUtils.test.ts
+++ b/src/vs/platform/dialogs/test/electron-main/dialogMainUtils.test.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { deepEqual } from 'assert';
+import { deepEqual, strictEqual } from 'assert';
 import { release } from 'os';
 import { isLinux, isMacintosh, isWindows } from '../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { IMassagedMessageBoxOptions, massageMessageBoxOptions } from '../../electron-main/dialogMainUtils.js';
+import { IMassagedMessageBoxOptions, massageMessageBoxOptions, resolveMessageBoxResponse } from '../../electron-main/dialogMainUtils.js';
 import product from '../../../product/common/product.js';
 import { IProductService } from '../../../product/common/productService.js';
 
@@ -166,6 +166,32 @@ suite('Dialog', () => {
 			assertOptions(fourButtonCancel_4, ['4', '3', '2', '1'], 3, 4, [3, 2, 1, 0]);
 			assertOptions(fourButtonNegativeCancel, ['4', '3', '2', '1'], 3, -1, [3, 2, 1, 0]);
 		}
+	});
+
+	test('resolveMessageBoxResponse: in-range response is mapped through buttonIndeces unchanged', () => {
+		deepEqual(resolveMessageBoxResponse(0, [2, 0, 1], 1), { response: 2, wasUnexpectedResponse: false });
+		deepEqual(resolveMessageBoxResponse(2, [2, 0, 1], 1), { response: 1, wasUnexpectedResponse: false });
+	});
+
+	test('resolveMessageBoxResponse: out-of-range response falls back to the cancel button', () => {
+		// Regression test for https://github.com/microsoft/vscode/issues/329901:
+		// Electron can report a response outside the shown button range (for
+		// example `420`) when third-party software interferes with native
+		// Windows dialogs. That must not silently resolve to `undefined`.
+		deepEqual(resolveMessageBoxResponse(420, [2, 0, 1], 1), { response: 0, wasUnexpectedResponse: true });
+		deepEqual(resolveMessageBoxResponse(-1, [2, 0, 1], 1), { response: 0, wasUnexpectedResponse: true });
+	});
+
+	test('resolveMessageBoxResponse: out-of-range response with no valid cancelId falls back to the last button', () => {
+		deepEqual(resolveMessageBoxResponse(420, [2, 0, 1], undefined), { response: 1, wasUnexpectedResponse: true });
+		deepEqual(resolveMessageBoxResponse(420, [2, 0, 1], -1 /* disabled */), { response: 1, wasUnexpectedResponse: true });
+		deepEqual(resolveMessageBoxResponse(420, [2, 0, 1], 99 /* out of range */), { response: 1, wasUnexpectedResponse: true });
+	});
+
+	test('resolveMessageBoxResponse: never throws for a single-button dialog', () => {
+		const result = resolveMessageBoxResponse(420, [0], undefined);
+		strictEqual(result.wasUnexpectedResponse, true);
+		strictEqual(result.response, 0);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
## Description

Fixes #329901 (also reported as duplicate #330592: "All dialogs closed automatically").

On Windows, third-party software that inspects native file/message dialogs (for example security tooling) can send an overlapping `CDM_GETFOLDERPATH` / `TDM_CLICK_BUTTON` window message that makes Electron report a `response` outside the range of buttons that were actually shown (observed value: `420`, see electron/electron#52747).

Traced the propagation of that bad response through this codebase:

1. `DialogMainService#showMessageBox` indexed into `buttonIndeces` with the raw Electron response. An out-of-range value silently produced `undefined` there.
2. That `undefined` crossed the IPC boundary and reached `AbstractDialogHandler#getPromptResult`, where `promptButtons[buttonIndex]?.run(...)` short-circuited on the optional chain — **no button's action ran at all**.

The dialog just closes with nothing having happened, which is indistinguishable from the dialog "closing itself" — matching the symptom reported in both issues, including the Source Control commit-confirmation flow.

## Changes

- `dialogMainUtils.ts`: adds `resolveMessageBoxResponse`, which maps an out-of-range response to the dialog's own cancel button (or its last button, the same least-destructive default `massageMessageBoxOptions` already uses) instead of leaving it `undefined`.
- `dialogMainService.ts`: uses the new helper in `showMessageBox` and logs an error when a fallback was needed, so this is diagnosable from user logs.
- `dialogs.ts` (`AbstractDialogHandler#getPromptResult`): adds an independent defensive fallback to the prompt's cancel button for an out-of-range index, since this method is shared by the native, custom, and mobile-aware dialog handlers.

## Note for reviewers

I'm aware `deepak1556`/`sbatten` already have draft PR #330128 in flight for this same issue with a broader approach (response validation + logging + fallback to custom dialogs). Opening this in case a narrower, independently-derived fix is useful in the meantime — happy to close this in favor of #330128 if/when it lands, or to adjust based on feedback.

## Testing

- Added unit tests in `dialogMainUtils.test.ts` covering in-range passthrough, out-of-range response with a valid/invalid/disabled `cancelId`, and the degenerate single-button case.
- Added `dialogs.test.ts` covering `getPromptResult`: valid index runs the right button, out-of-range index falls back to the cancel button, out-of-range index with no cancel button preserves today's no-op behavior.
- `./test/unit/electron` run for `src/vs/platform/dialogs/**`: 20/20 passing, no regressions.
- `eslint` on changed files: clean.
- `tsc --noEmit` on the full `src` tree: clean.