### PR TITLE
sessions: preserve single pane dismissal state

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -545,6 +545,9 @@ export abstract class BaseLayoutController extends Disposable {
 		return false;
 	}
 
+	/** Hook invoked before a session working set is queued for application. */
+	protected _onWillApplyWorkingSet(_workingSet: IEditorWorkingSet | 'empty'): void { }
+
 	// --- Editor part reveal ---
 
 	/**
@@ -682,6 +685,7 @@ export abstract class BaseLayoutController extends Disposable {
 		const workingSet: IEditorWorkingSet | 'empty' = sessionResource
 			? (this._workingSets.get(sessionResource) ?? 'empty')
 			: 'empty';
+		this._onWillApplyWorkingSet(workingSet);
 
 		return this._workingSetSequencer.queue(async () => {
 			// When multiple sessions are visible, applying a working set must never

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDockedTabsCoordinator.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDockedTabsCoordinator.ts
@@ -61,8 +61,6 @@ export interface IManagedTabsTarget {
 export interface IReconcileTrigger {
 	/** Open the default docked tabs *if the group is empty* — a session switch, a side-pane reveal, or a settled layout restore. */
 	readonly openDefaultsIfEmpty?: boolean;
-	/** The active session resource changed, so session defaults may be restored without affecting same-session dismissals. */
-	readonly sessionSwitch?: boolean;
 	/** Ensure the Changes tab, inactive, when a new-session view becomes eligible or finishes restoring. */
 	readonly ensureChanges?: boolean;
 	/** Ensure the Changes tab, opened **active**, even in a non-empty group — new-session submit (so the detail panel maps to Changes rather than the still-present Files placeholder). */
@@ -73,7 +71,6 @@ export interface IReconcileTrigger {
 function mergeTriggers(a: IReconcileTrigger, b: IReconcileTrigger): IReconcileTrigger {
 	return {
 		openDefaultsIfEmpty: a.openDefaultsIfEmpty || b.openDefaultsIfEmpty,
-		sessionSwitch: a.sessionSwitch || b.sessionSwitch,
 		ensureChanges: a.ensureChanges || b.ensureChanges,
 		ensureChangesActive: a.ensureChangesActive || b.ensureChangesActive,
 	};
@@ -146,13 +143,9 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 		// Existing, and Quick Chat alike — a quick chat's target wants neither tab, so this
 		// reconciles any stray managed tabs away). The New/Existing-specific "ensure the
 		// Changes tab" nuances are supplied by those strategies via `queueReconcile`.
-		let previousSessionKey: string | undefined;
 		this._register(autorun(reader => {
 			const target = this._readTarget(reader);
-			const sessionKey = this._sessionsService.activeSession.read(reader)?.resource.toString();
-			const sessionSwitch = previousSessionKey !== undefined && previousSessionKey !== sessionKey;
-			previousSessionKey = sessionKey;
-			this.queueReconcile(target, { openDefaultsIfEmpty: true, sessionSwitch });
+			this.queueReconcile(target, { openDefaultsIfEmpty: true });
 		}));
 
 		// [Ambient trigger] The user opened the side pane.
@@ -334,14 +327,13 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 			const openIntoEmpty = !!trigger.openDefaultsIfEmpty && group.editors.length === 0;
 			const changesPresent = !!changesResource && !!this._findChangesEditor(group, changesResource);
 			const filesPresent = group.editors.some(editor => editor instanceof EmptyFileEditorInput);
-			const onlyManagedEditors = group.editors.every(editor => editor instanceof DockedEditorInput);
 			const activeChangesResource = this._editorService.activeEditor && this.getChangesEditorResource(this._editorService.activeEditor);
 			const activateChanges = !!trigger.ensureChangesActive && !!changesResource && (!activeChangesResource || !isEqual(activeChangesResource, changesResource));
 			const ensureAllInputs = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)
 				&& !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
 
 			const openChanges = target.wantsChangesTab && !!changesResource && (activateChanges || (!changesPresent && (openIntoEmpty || ensureAllInputs || trigger.ensureChanges)));
-			const openFiles = target.wantsFilesTab && !filesPresent && (openIntoEmpty || ensureAllInputs || (trigger.sessionSwitch && onlyManagedEditors));
+			const openFiles = target.wantsFilesTab && !filesPresent && (openIntoEmpty || ensureAllInputs);
 			const isCreated = this._sessionsService.activeSession.get()?.isCreated.get() ?? false;
 			const openFilesFirst = openChanges && openFiles && !isCreated && group.editors.length === 0;
 

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDockedTabsCoordinator.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneDockedTabsCoordinator.ts
@@ -65,6 +65,8 @@ export interface IReconcileTrigger {
 	readonly ensureChanges?: boolean;
 	/** Ensure the Changes tab, opened **active**, even in a non-empty group — new-session submit (so the detail panel maps to Changes rather than the still-present Files placeholder). */
 	readonly ensureChangesActive?: boolean;
+	/** A saved working set finished restoring for the active session. */
+	readonly workingSetRestored?: boolean;
 }
 
 /** OR-combines two triggers so accumulated intents are never dropped when reconciles are coalesced. */
@@ -73,6 +75,7 @@ function mergeTriggers(a: IReconcileTrigger, b: IReconcileTrigger): IReconcileTr
 		openDefaultsIfEmpty: a.openDefaultsIfEmpty || b.openDefaultsIfEmpty,
 		ensureChanges: a.ensureChanges || b.ensureChanges,
 		ensureChangesActive: a.ensureChangesActive || b.ensureChangesActive,
+		workingSetRestored: a.workingSetRestored || b.workingSetRestored,
 	};
 }
 
@@ -103,6 +106,9 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 
 	private _generation = 0;
 	private _lastSyncedSessionKey: string | undefined;
+	private _preserveMissingFilesForSessionKey: string | undefined;
+	private _filesTabDismissed = false;
+	private _changingFilesInternally = false;
 
 	// The pending reconcile intents, **scoped to the session they were queued for**. Multiple
 	// triggers can fire for one logical event on the same session (e.g. submit fires the
@@ -145,6 +151,9 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 		// Changes tab" nuances are supplied by those strategies via `queueReconcile`.
 		this._register(autorun(reader => {
 			const target = this._readTarget(reader);
+			if (!target.wantsChangesTab) {
+				this._filesTabDismissed = false;
+			}
 			this.queueReconcile(target, { openDefaultsIfEmpty: true });
 		}));
 
@@ -173,7 +182,7 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 			const session = this._sessionsService.activeSession.get();
 			const target = this._readTarget(undefined);
 			const ensureChanges = target.wantsChangesTab && session?.isCreated.get() === false;
-			this.queueReconcile(target, { openDefaultsIfEmpty: true, ensureChanges });
+			this.queueReconcile(target, { openDefaultsIfEmpty: true, ensureChanges, workingSetRestored: true });
 		}));
 
 		// [Tidy strip] Opening a real workspace file makes the empty Files placeholder
@@ -185,6 +194,9 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 		// `onWillOpenEditor` while the editor is already in the group), when it targets a
 		// non-main-part group, or during a restore-driven open.
 		this._register(this._editorService.onWillOpenEditor(e => {
+			if (e.editor instanceof EmptyFileEditorInput && !this._changingFilesInternally && !this._ctx.isRestoringSessionLayout) {
+				this._filesTabDismissed = false;
+			}
 			if (this._ctx.isRestoringSessionLayout || !this._isWorkspaceFileEditor(e.editor)) {
 				return;
 			}
@@ -193,6 +205,15 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 				return;
 			}
 			void this._sequencer.queue(() => this._removeFilesTab(this._editorGroupsService.mainPart.activeGroup)).catch(onUnexpectedError);
+		}));
+		this._register(this._editorService.onDidCloseEditor(e => {
+			if (e.editor instanceof EmptyFileEditorInput
+				&& !this._changingFilesInternally
+				&& !this._ctx.isRestoringSessionLayout
+				&& !this._layoutService.isEditorPartAutoVisibilitySuppressed()
+				&& this._readTarget(undefined).wantsChangesTab) {
+				this._filesTabDismissed = true;
+			}
 		}));
 
 		// [Editor-area collapse] When the editor area is hidden **while the detail panel (aux
@@ -246,6 +267,11 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 	getChangesEditorResource(editor: EditorInput): URI | undefined {
 		const resource = editor.resource;
 		return resource && this._sessionChangesService.getSessionResource(resource) ? resource : undefined;
+	}
+
+	prepareWorkingSetRestore(hasSavedWorkingSet: boolean): void {
+		const sessionKey = this._sessionsService.activeSession.get()?.resource.toString();
+		this._preserveMissingFilesForSessionKey = hasSavedWorkingSet && this._filesTabDismissed ? sessionKey : undefined;
 	}
 
 	// --- Trigger plumbing (called by the New/Existing lifecycle strategies) -----------------
@@ -322,6 +348,14 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 				return;
 			}
 			this._updateFilesEditors(group, target.workspace);
+			const sessionKey = this._sessionsService.activeSession.get()?.resource.toString();
+			const preserveMissingFiles = !!trigger.workingSetRestored && this._preserveMissingFilesForSessionKey === sessionKey;
+			if (preserveMissingFiles) {
+				await this._removeFilesTab(group);
+				if (generation !== this._generation) {
+					return;
+				}
+			}
 
 			// [2] Decide which docked inputs to open, from the trigger + group state.
 			const openIntoEmpty = !!trigger.openDefaultsIfEmpty && group.editors.length === 0;
@@ -333,7 +367,7 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 				&& !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
 
 			const openChanges = target.wantsChangesTab && !!changesResource && (activateChanges || (!changesPresent && (openIntoEmpty || ensureAllInputs || trigger.ensureChanges)));
-			const openFiles = target.wantsFilesTab && !filesPresent && (openIntoEmpty || ensureAllInputs);
+			const openFiles = target.wantsFilesTab && !filesPresent && !preserveMissingFiles && (openIntoEmpty || ensureAllInputs);
 			const isCreated = this._sessionsService.activeSession.get()?.isCreated.get() ?? false;
 			const openFilesFirst = openChanges && openFiles && !isCreated && group.editors.length === 0;
 
@@ -362,6 +396,9 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 		} finally {
 			suppression.dispose();
 			if (generation === this._generation) {
+				if (trigger.workingSetRestored) {
+					this._preserveMissingFilesForSessionKey = undefined;
+				}
 				this._updateAddTabContexts(target);
 			}
 		}
@@ -394,9 +431,12 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 
 	private async _openFilesTab(group: IEditorGroup, workspace: ISessionWorkspace | undefined): Promise<void> {
 		const suppression = this._layoutService.suppressEditorPartAutoVisibility();
+		this._changingFilesInternally = true;
 		try {
 			await this._editorService.openEditor(this._instantiationService.createInstance(EmptyFileEditorInput, workspace), FILES_TAB_OPTIONS, group);
+			this._filesTabDismissed = false;
 		} finally {
+			this._changingFilesInternally = false;
 			suppression.dispose();
 		}
 	}
@@ -404,7 +444,12 @@ export class SinglePaneDockedTabsCoordinator extends Disposable {
 	private async _removeFilesTab(group: IEditorGroup): Promise<void> {
 		const placeholder = group.editors.find((editor): editor is EmptyFileEditorInput => editor instanceof EmptyFileEditorInput);
 		if (placeholder) {
-			await this._closeManagedEditors(group, [placeholder]);
+			this._changingFilesInternally = true;
+			try {
+				await this._closeManagedEditors(group, [placeholder]);
+			} finally {
+				this._changingFilesInternally = false;
+			}
 		}
 	}
 

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneExistingSessionStrategy.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneExistingSessionStrategy.ts
@@ -85,6 +85,7 @@ export class SinglePaneExistingSessionStrategy extends SinglePaneLayoutStrategy 
 		this._register(this._editorService.onDidCloseEditor(() => {
 			const session = this._sessionsService.activeSession.get();
 			if (this._ctx.isRestoringSessionLayout
+				|| this._ctx.multipleSessionsVisibleObs.get()
 				|| this._layoutService.isEditorPartAutoVisibilitySuppressed()
 				|| !session
 				|| session.isQuickChat?.get()

--- a/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneVisibilityProfileStore.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePane/singlePaneVisibilityProfileStore.ts
@@ -20,16 +20,6 @@ export const enum SessionVisibilityProfile {
 	Existing,
 }
 
-/**
- * Tracks a pending auxiliary-bar reveal while it is waiting for the managed docked tabs to
- * populate the (initially empty) editor group with content, so the detail panel is never
- * revealed empty.
- */
-export const enum PendingAuxiliaryBarRestore {
-	WaitingForEmptyGroup,
-	WaitingForContent,
-}
-
 const SINGLE_PANE_VISIBILITY_STATE_KEY = 'sessions.singlePane.sidePaneVisibility';
 const DEFAULT_NEW_SESSION_VISIBILITY_STATE: ISidePaneVisibilityState = {
 	editorVisible: false,

--- a/src/vs/sessions/contrib/layout/browser/singlePaneLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/singlePaneLayoutController.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IEditorWorkingSet } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { LifecyclePhase } from '../../../../workbench/services/lifecycle/common/lifecycle.js';
 import { BaseLayoutController } from './baseSessionLayoutController.js';
 import { ISinglePaneLayoutContext } from './singlePane/singlePaneLayoutStrategy.js';
@@ -45,6 +46,7 @@ export class SinglePaneLayoutController extends BaseLayoutController {
 
 	private _context: ISinglePaneLayoutContext | undefined;
 	private _existingSession: SinglePaneExistingSessionStrategy | undefined;
+	private _managedTabs: SinglePaneDockedTabsCoordinator | undefined;
 
 	protected override get _layoutStateStorageKey(): string {
 		return SINGLE_PANE_LAYOUT_STATE_KEY;
@@ -87,8 +89,8 @@ export class SinglePaneLayoutController extends BaseLayoutController {
 			if (this._store.isDisposed) {
 				return;
 			}
-			const managedTabs = this._register(this._instantiationService.createInstance(SinglePaneDockedTabsCoordinator, this._ctx));
-			this._existingSession?.registerManagedTabs(managedTabs);
+			this._managedTabs = this._register(this._instantiationService.createInstance(SinglePaneDockedTabsCoordinator, this._ctx));
+			this._existingSession?.registerManagedTabs(this._managedTabs);
 		});
 	}
 
@@ -123,5 +125,9 @@ export class SinglePaneLayoutController extends BaseLayoutController {
 
 	protected override _shouldHideEditorPartOnApply(_editorPartHidden: boolean): boolean {
 		return false;
+	}
+
+	protected override _onWillApplyWorkingSet(workingSet: IEditorWorkingSet | 'empty'): void {
+		this._managedTabs?.prepareWorkingSetRestore(workingSet !== 'empty');
 	}
 }

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -3374,6 +3374,69 @@ suite('LayoutController (desktop)', () => {
 		});
 	});
 
+	test('[managed tabs / session switch] removes a dismissed Files tab restored by a previously visited session', async () => {
+		createSinglePaneController({ activateAux: true });
+		await settle();
+
+		const sessionA = makeSession(URI.parse('session:a'));
+		harness.activeSessionObs.set(sessionA, undefined);
+		await settle();
+
+		const sessionB = makeSession(URI.parse('session:b'));
+		harness.activeSessionObs.set(sessionB, undefined);
+		await settle();
+		const filesTab = harness.activeGroupEditors.find(editor => editor instanceof EmptyFileEditorInput)!;
+		harness.activeGroupEditors.splice(harness.activeGroupEditors.indexOf(filesTab), 1);
+		harness.onDidCloseEditor.fire({ editor: filesTab });
+		harness.onDidEditorsChange.fire();
+		await settle();
+
+		harness.onApplyWorkingSet = workingSet => {
+			if (workingSet === 'empty' || workingSet.name !== `session-working-set:${sessionA.resource.toString()}`) {
+				return;
+			}
+			harness.activeGroupEditors.push(store.add(harness.instaService.createInstance(EmptyFileEditorInput, sessionA.workspace.get())));
+			harness.onDidEditorsChange.fire();
+		};
+		harness.activeSessionObs.set(sessionA, undefined);
+		await settle();
+
+		const incomingChangesResource = harness.sessionChangesService.getChangesEditorResource(sessionA.resource);
+		assert.deepStrictEqual({
+			hasIncomingChangesTab: harness.activeGroupEditors.some(editor => editor.resource && isEqual(editor.resource, incomingChangesResource)),
+			hasFilesTab: hasFilesTab(),
+		}, {
+			hasIncomingChangesTab: true,
+			hasFilesTab: false,
+		});
+	});
+
+	test('[managed tabs / session switch] keeps restored Files after a transiently empty group', async () => {
+		createSinglePaneController({ activateAux: true });
+		await settle();
+
+		const sessionA = makeSession(URI.parse('session:a'));
+		harness.activeSessionObs.set(sessionA, undefined);
+		await settle();
+		harness.activeSessionObs.set(makeSession(URI.parse('session:b')), undefined);
+		await settle();
+
+		harness.activeGroupEditors.length = 0;
+		harness.activeEditorInput = undefined;
+		harness.onDidEditorsChange.fire();
+		harness.onApplyWorkingSet = workingSet => {
+			if (workingSet === 'empty' || workingSet.name !== `session-working-set:${sessionA.resource.toString()}`) {
+				return;
+			}
+			harness.activeGroupEditors.push(store.add(harness.instaService.createInstance(EmptyFileEditorInput, sessionA.workspace.get())));
+			harness.onDidEditorsChange.fire();
+		};
+		harness.activeSessionObs.set(sessionA, undefined);
+		await settle();
+
+		assert.strictEqual(hasFilesTab(), true);
+	});
+
 	test('[managed tabs / add-tab] a missing Changes tab flips SinglePaneChangesTabMissingContext', async () => {
 		createSinglePaneController({ activateAux: true });
 		await settle();

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -3318,7 +3318,7 @@ suite('LayoutController (desktop)', () => {
 	});
 
 	test('[managed tabs / close] re-opens the default tabs for the new session after switching (empty group)', async () => {
-		createSinglePaneController({ activateAux: true });
+		const controller = createSinglePaneController({ activateAux: true });
 		await settle();
 
 		harness.activeSessionObs.set(makeSession(URI.parse('session:1')), undefined);
@@ -3331,12 +3331,47 @@ suite('LayoutController (desktop)', () => {
 		await settle();
 		assert.strictEqual(hasFilesTab(), false);
 
-		// Switching sessions closes the previous session's tabs (stale) leaving an
-		// empty group, so the new session's defaults are opened.
+		// The switched-to session's working set closes the previous session's tabs,
+		// leaving an empty group when the restore settles.
 		harness.activeSessionObs.set(makeSession(URI.parse('session:2')), undefined);
+		controller.runWithRestore(() => {
+			harness.activeGroupEditors.length = 0;
+			harness.activeEditorInput = undefined;
+			harness.onDidEditorsChange.fire();
+		});
 		await settle();
 
 		assert.strictEqual(hasFilesTab(), true, 'the default tabs are opened for the new session');
+	});
+
+	test('[managed tabs / session switch] preserves a dismissed Files tab while replacing Changes in place', async () => {
+		createSinglePaneController({ activateAux: true });
+		await settle();
+
+		const session1 = makeSession(URI.parse('session:1'));
+		harness.activeSessionObs.set(session1, undefined);
+		await settle();
+		const filesTab = harness.activeGroupEditors.find(editor => editor instanceof EmptyFileEditorInput)!;
+		harness.activeGroupEditors.splice(harness.activeGroupEditors.indexOf(filesTab), 1);
+		harness.onDidCloseEditor.fire({ editor: filesTab });
+		harness.onDidEditorsChange.fire();
+		await settle();
+		assert.deepStrictEqual({ hasChangesTab: hasChangesTab(), hasFilesTab: hasFilesTab() }, { hasChangesTab: true, hasFilesTab: false });
+
+		const session2 = makeSession(URI.parse('session:2'));
+		harness.activeSessionObs.set(session2, undefined);
+		await settle();
+
+		const incomingChangesResource = harness.sessionChangesService.getChangesEditorResource(session2.resource);
+		assert.deepStrictEqual({
+			hasIncomingChangesTab: harness.activeGroupEditors.some(editor => editor.resource && isEqual(editor.resource, incomingChangesResource)),
+			hasFilesTab: hasFilesTab(),
+			editorCount: harness.activeGroupEditors.length,
+		}, {
+			hasIncomingChangesTab: true,
+			hasFilesTab: false,
+			editorCount: 1,
+		});
 	});
 
 	test('[managed tabs / add-tab] a missing Changes tab flips SinglePaneChangesTabMissingContext', async () => {

--- a/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
@@ -226,7 +226,7 @@ export interface ITestLayoutHarness {
 	 * tests to simulate external visibility changes (e.g. the single-pane detail
 	 * panel) while `_isRestoringSessionLayout` is true.
 	 */
-	onApplyWorkingSet?: () => void;
+	onApplyWorkingSet?: (workingSet: IEditorWorkingSet | 'empty') => void;
 	/**
 	 * Optional async hook awaited at the start of `openChangesEditor`, letting a
 	 * test pause a managed-tab reconcile mid-open (e.g. to switch sessions and
@@ -675,7 +675,7 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 		override saveWorkingSet(name: string): IEditorWorkingSet { harness.saveWorkingSetCalls.push(name); return { id: name, name }; }
 		override async applyWorkingSet(workingSet: IEditorWorkingSet | 'empty') {
 			harness.applyWorkingSetCalls.push(workingSet);
-			harness.onApplyWorkingSet?.();
+			harness.onApplyWorkingSet?.(workingSet);
 			return true;
 		}
 		override deleteWorkingSet() { }

--- a/src/vs/sessions/contrib/layout/test/browser/singlePaneStrategies.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/singlePaneStrategies.test.ts
@@ -233,6 +233,41 @@ suite('SinglePane layout strategies', () => {
 		});
 	});
 
+	test('Existing Session keeps the side pane open when multiple sessions are visible', async () => {
+		const ctx = setup();
+		const session = makeSession(URI.parse('session:/existing'));
+		const otherSession = makeSession(URI.parse('session:/other'));
+		const editor = store.add(new TestStubEditorInput(URI.file('/repo/file.ts')));
+		harness.activeGroupEditors.push(editor);
+		store.add(harness.instaService.createInstance(
+			SinglePaneExistingSessionStrategy,
+			ctx,
+			harness.instaService.createInstance(SinglePaneVisibilityProfileStore),
+			createDetailPanel()
+		));
+		harness.activeSessionObs.set(session, undefined);
+		harness.visibleSessionsObs.set([session, otherSession], undefined);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.setPartHiddenCalls.length = 0;
+
+		harness.activeGroupEditors.length = 0;
+		harness.editorGroupsHaveContent = false;
+		harness.onDidCloseEditor.fire({ editor, groupId: 1 });
+		harness.onDidEditorsChange.fire();
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			editorVisible: harness.partVisibility.get(Parts.EDITOR_PART),
+			auxiliaryBarVisible: harness.partVisibility.get(Parts.AUXILIARYBAR_PART),
+			visibilityChanges: harness.setPartHiddenCalls,
+		}, {
+			editorVisible: true,
+			auxiliaryBarVisible: true,
+			visibilityChanges: [],
+		});
+	});
+
 	test('Quick Chat hides the side pane once on entry', async () => {
 		const ctx = setup();
 		const editor = store.add(new TestStubEditorInput(URI.parse('search-editor://outgoing')));


### PR DESCRIPTION
Follow-up to #330573.

## What changed
- avoid globally hiding the side pane when an editor closes while multiple Existing sessions are visible
- preserve a user-dismissed Files tab across Existing-to-Existing navigation while continuing to replace Changes in place
- keep empty-group default restoration and superseded-reconcile generation safety
- remove the unused `PendingAuxiliaryBarRestore` enum
- add focused multi-session close and session-switch dismissal coverage

## Validation
- affected layout suites: 144 passing
- `npm run compile`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run hygiene`
- `git diff --check`