### PR TITLE
Modern UI: Make tab hover background transparent in active editor group

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -62,6 +62,10 @@
 	row-gap: 0;
 }
 
+.modern-ui-tabs.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:not(.selected):hover {
+	background-color: transparent !important;
+}
+
 .modern-ui-tabs.monaco-workbench .part.editor .tabs-container > .tab > .tab-fill {
 	display: block;
 	position: absolute;


### PR DESCRIPTION
Enhance the visual appearance of the active editor group by making the tab hover background transparent. This change improves the user experience by providing a cleaner look when interacting with tabs.

