### PR TITLE
sessions: feat: submit feedback with Ctrl/Cmd+Enter

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -566,6 +566,10 @@ The editor feedback toolbar's visual widget is shared with workbench plan review
 through `AgentEditorCommentsOverlayWidget`. Each host keeps its own menu actions
 and state adapter, while the toolbar layout, count presentation, action rendering,
 keyboard labels, and styling have one workbench-owned implementation.
+In the Agents window, **Ctrl/Cmd+Enter** submits feedback only while editor text
+has focus and the focused editor group's active file or diff contains accepted
+feedback. Multi-diff panes may qualify through any of their resources, while the
+submission itself remains session-scoped.
 Plan review binds the plan resource to its owning session while that review is
 active. Only accepted comments created after the active review registration are
 included in plan submission, so pre-existing or already-submitted session feedback

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
@@ -4,11 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../base/common/codicons.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { GroupsOrder, IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
@@ -79,6 +83,11 @@ class SubmitFeedbackAction extends AgentFeedbackEditorAction {
 			shortTitle: localize2('agentFeedback.submitShort', 'Submit'),
 			icon: Codicon.send,
 			precondition: ChatContextKeys.enabled,
+			keybinding: {
+				weight: KeybindingWeight.SessionsContrib,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus, hasUnsubmittedAgentFeedback),
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+			},
 			menu: {
 				id: Menus.AgentFeedbackEditorContent,
 				group: 'a_submit',

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorActions.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorActions.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { decodeKeybinding } from '../../../../../base/common/keybindings.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { OS } from '../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
+import { IContext } from '../../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { hasUnsubmittedAgentFeedback, registerAgentFeedbackEditorActions, submitFeedbackActionId } from '../../browser/agentFeedbackEditorActions.js';
+
+// Fill the global registries the way the contribution does, so the assertions below
+// inspect the rule that ships rather than a copy of its when clause.
+registerAgentFeedbackEditorActions();
+
+const CTRL_CMD_ENTER = decodeKeybinding(KeyMod.CtrlCmd | KeyCode.Enter, OS)!.getHashCode();
+
+/** Minimal {@link IContext} over a plain record of context key values. */
+function context(values: Record<string, boolean>): IContext {
+	return { getValue: <T>(key: string) => values[key] as T | undefined };
+}
+
+suite('Agent Feedback - Submit Feedback keybinding', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('takes Ctrl/Cmd+Enter only in a focused editor holding submittable feedback', () => {
+		const rule = KeybindingsRegistry.getDefaultKeybindings()
+			.find(item => item.command === submitFeedbackActionId && item.keybinding?.getHashCode() === CTRL_CMD_ENTER);
+		const submittable = {
+			[ChatContextKeys.enabled.key]: true,
+			[IsSessionsWindowContext.key]: true,
+			[EditorContextKeys.editorTextFocus.key]: true,
+			[hasUnsubmittedAgentFeedback.key]: true,
+		};
+		const evaluate = (overrides: Record<string, boolean> = {}) => rule?.when?.evaluate(context({ ...submittable, ...overrides })) ?? false;
+
+		assert.deepStrictEqual({
+			bound: !!rule,
+			// A higher weight than the editor's Insert Line After, so this rule is consulted
+			// first and that command keeps the chord everywhere the when clause misses.
+			winsOverInsertLineAfter: rule?.weight1,
+			submittableFeedback: evaluate(),
+			normalWindow: evaluate({ [IsSessionsWindowContext.key]: false }),
+			unfocusedEditor: evaluate({ [EditorContextKeys.editorTextFocus.key]: false }),
+			fileWithoutFeedback: evaluate({ [hasUnsubmittedAgentFeedback.key]: false }),
+			chatDisabled: evaluate({ [ChatContextKeys.enabled.key]: false }),
+		}, {
+			bound: true,
+			winsOverInsertLineAfter: KeybindingWeight.SessionsContrib,
+			submittableFeedback: true,
+			normalWindow: false,
+			unfocusedEditor: false,
+			fileWithoutFeedback: false,
+			chatDisabled: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds **Ctrl/Cmd+Enter** to the existing per-editor **Submit Feedback** action in the Agents window.

The binding uses `SessionsContrib` priority and only applies when:

- the Agents window is active;
- editor text has focus;
- the active editor group has accepted feedback available to submit; and
- chat features are enabled through the action's existing precondition.

This lets the feedback action win over **Insert Line After** only in the applicable feedback context. Existing Ctrl/Cmd+Enter behavior remains unchanged everywhere else, including normal VS Code windows, comment/chat input widgets, the feedback textarea, and files without submittable feedback.

The binding uses the per-editor submit action so the focused file or diff still determines the feedback session. Multi-diff editors may qualify through any associated resource, while submission remains session-wide. Existing plan-review submission behavior is preserved.

## Testing

- Added a registry-level unit test for the actual registered keybinding, priority, and positive/negative contexts
- Focused Electron unit test
- `npm run typecheck-client`
- `npm run valid-layers-check`
- Targeted ESLint
- `git diff --check`
