### PR TITLE
build: validate all Authenticode signatures in sanity tests

### DIFF
--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -106,39 +106,6 @@ jobs:
             @echo off
             setlocal enabledelayedexpansion
 
-            set "NODE_VERSION=v22.22.0"
-            set "EXPECTED_HASH=5b44fd410df7b4cd0a1891a05a7b606f8fb7d8786a94997b996a372e82478d7a"
-            set "NODE_ROOT=$(Agent.TempDirectory)\nodejs"
-            set "NODE_EXE=!NODE_ROOT!\node.exe"
-
-            if not exist "!NODE_EXE!" (
-              if exist "!NODE_ROOT!" rmdir /s /q "!NODE_ROOT!"
-
-              set "NODE_ZIP=$(Agent.TempDirectory)\node.zip"
-              curl.exe -fsSL "https://nodejs.org/dist/!NODE_VERSION!/node-!NODE_VERSION!-win-arm64.zip" -o "!NODE_ZIP!"
-
-              set "ACTUAL_HASH="
-              for /f "skip=1" %%A in ('certutil -hashfile "!NODE_ZIP!" SHA256') do if not defined ACTUAL_HASH set "ACTUAL_HASH=%%A"
-              if /I not "!ACTUAL_HASH!"=="!EXPECTED_HASH!" (
-                echo Hash mismatch for node.zip
-                echo   expected: !EXPECTED_HASH!
-                echo   actual:   !ACTUAL_HASH!
-                del "!NODE_ZIP!"
-                exit /b 1
-              )
-
-              tar -xf "!NODE_ZIP!" -C "$(Agent.TempDirectory)"
-              ren "$(Agent.TempDirectory)\node-!NODE_VERSION!-win-arm64" nodejs
-              del "!NODE_ZIP!"
-            )
-
-            echo ##vso[task.prependpath]%NODE_ROOT%
-          displayName: Install Node.js (Windows ARM64)
-
-        - script: |
-            @echo off
-            setlocal enabledelayedexpansion
-
             set "PACKAGE_VERSION=10.0.26100.1"
             set "SDK_VERSION=10.0.26100.0"
             set "EXPECTED_HASH=7e37f35384a7b146730fa67dde243d46b97ce5ca73aaeb1c3141cd812b286395"
@@ -170,11 +137,10 @@ jobs:
             echo ##vso[task.prependpath]!SIGNTOOL_ROOT!
           displayName: Install SignTool (Windows ARM64)
 
-      - ${{ else }}:
-        - task: UseNode@1
-          inputs:
-            version: '22.22.0'
-          displayName: Install Node.js
+      - task: UseNode@1
+        inputs:
+          version: '22.22.0'
+        displayName: Install Node.js
 
       - task: Cache@2
         inputs:

--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -135,6 +135,41 @@ jobs:
             echo ##vso[task.prependpath]%NODE_ROOT%
           displayName: Install Node.js (Windows ARM64)
 
+        - script: |
+            @echo off
+            setlocal enabledelayedexpansion
+
+            set "PACKAGE_VERSION=10.0.26100.1"
+            set "SDK_VERSION=10.0.26100.0"
+            set "EXPECTED_HASH=7e37f35384a7b146730fa67dde243d46b97ce5ca73aaeb1c3141cd812b286395"
+            set "SDK_ROOT=$(Agent.TempDirectory)\windows-sdk-build-tools"
+            set "SIGNTOOL_ROOT=!SDK_ROOT!\bin\!SDK_VERSION!\arm64"
+            set "SIGNTOOL_EXE=!SIGNTOOL_ROOT!\signtool.exe"
+
+            if not exist "!SIGNTOOL_EXE!" (
+              if exist "!SDK_ROOT!" rmdir /s /q "!SDK_ROOT!"
+
+              set "SDK_PACKAGE=$(Agent.TempDirectory)\windows-sdk-build-tools.nupkg"
+              curl.exe -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://api.nuget.org/v3-flatcontainer/microsoft.windows.sdk.buildtools/!PACKAGE_VERSION!/microsoft.windows.sdk.buildtools.!PACKAGE_VERSION!.nupkg" -o "!SDK_PACKAGE!"
+
+              set "ACTUAL_HASH="
+              for /f "skip=1" %%A in ('certutil -hashfile "!SDK_PACKAGE!" SHA256') do if not defined ACTUAL_HASH set "ACTUAL_HASH=%%A"
+              if /I not "!ACTUAL_HASH!"=="!EXPECTED_HASH!" (
+                echo Hash mismatch for windows-sdk-build-tools.nupkg
+                echo   expected: !EXPECTED_HASH!
+                echo   actual:   !ACTUAL_HASH!
+                del "!SDK_PACKAGE!"
+                exit /b 1
+              )
+
+              mkdir "!SDK_ROOT!"
+              tar -xf "!SDK_PACKAGE!" -C "!SDK_ROOT!"
+              del "!SDK_PACKAGE!"
+            )
+
+            echo ##vso[task.prependpath]!SIGNTOOL_ROOT!
+          displayName: Install SignTool (Windows ARM64)
+
       - ${{ else }}:
         - task: UseNode@1
           inputs:

--- a/build/azure-pipelines/product-build-template.yml
+++ b/build/azure-pipelines/product-build-template.yml
@@ -373,6 +373,7 @@ stages:
                   displayName: Windows arm64
                   poolName: 1es-windows-2022-arm64
                   os: windows
+                  arch: arm64
 
             # Alpine 3.22
             - ${{ if eq(parameters.VSCODE_BUILD_ALPINE, true) }}:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -574,6 +574,7 @@ extends:
                   displayName: Windows arm64
                   poolName: 1es-windows-2022-arm64
                   os: windows
+                  arch: arm64
 
             # Alpine 3.22
             - ${{ if eq(parameters.VSCODE_BUILD_ALPINE, true) }}:
@@ -906,6 +907,7 @@ extends:
                   displayName: Windows arm64
                   poolName: 1es-windows-2022-arm64
                   os: windows
+                  arch: arm64
                   # Non-blocking: arm64 binaries are missing VersionInfo ProductName, which fails
                   # the published SanityTests run on main too.
                   continueOnError: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vscode/component-explorer": "^0.2.1-94",
         "@vscode/component-explorer-cli": "^0.2.1-95",
-        "@vscode/gulp-electron": "^1.42.0",
+        "@vscode/gulp-electron": "^1.43.0",
         "@vscode/l10n-dev": "0.0.35",
         "@vscode/telemetry-extractor": "^1.20.4",
         "@vscode/test-cli": "^0.0.6",
@@ -4335,9 +4335,9 @@
       "license": "MIT"
     },
     "node_modules/@vscode/gulp-electron": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@vscode/gulp-electron/-/gulp-electron-1.42.0.tgz",
-      "integrity": "sha512-DQLhu7p3GnGAc1tvYtArqp3duHD+b7ddpWitqYckdioFJGAszUSf7o6KZ5szo6sjFBz+E8rvpu9EMYOjdAAMzg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@vscode/gulp-electron/-/gulp-electron-1.43.0.tgz",
+      "integrity": "sha512-zGw2Vp1ARd+Cxq/M68y9MG28lwLmSMtAwe/fOqhvZaeV0lo2DvDwNu0+6xHAUAdLN3BMEEELCSfzd6NGC+Hn3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vscode/component-explorer": "^0.2.1-94",
     "@vscode/component-explorer-cli": "^0.2.1-95",
-    "@vscode/gulp-electron": "^1.42.0",
+    "@vscode/gulp-electron": "^1.43.0",
     "@vscode/l10n-dev": "0.0.35",
     "@vscode/telemetry-extractor": "^1.20.4",
     "@vscode/test-cli": "^0.0.6",

--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -89,6 +89,7 @@ export class TestContext {
 	private static readonly authenticodeInclude = /^.+\.(exe|dll|sys|cab|cat|msi|jar|ocx|ps1|psm1|psd1|ps1xml|pssc1)$/i;
 	// MXC SDK ships per-arch SPDX catalog manifests that Get-AuthenticodeSignature reports as UnknownError.
 	private static readonly authenticodeExclude = /[\\/]node_modules[\\/]@microsoft[\\/]mxc-sdk[\\/]bin[\\/][^\\/]+[\\/]_manifest[\\/][^\\/]+[\\/]manifest\.cat$/i;
+	private static readonly authenticodeTestCertificate = /Code Sign Test \(DO NOT TRUST\)/i;
 	private static readonly versionInfoInclude = /^.+\.(exe|dll|node|msi)$/i;
 	// Electron helpers (dxil/ffmpeg) and Copilot-vendored MSAL runtime DLLs ship VersionInfo that
 	// FileVersionInfo cannot resolve to a ProductName (x64: msalruntime.dll, arm64: msalruntime_arm64.dll).
@@ -504,14 +505,19 @@ export class TestContext {
 		this.log(`Validating Authenticode signature for ${filePath}`);
 		let signToolPath = this.signToolPath;
 		if (!signToolPath) {
-			const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
+			const architectures = process.arch === 'arm64' ? ['arm64', 'x64'] : ['x64'];
 			const command = `
 				$signTool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
 				if (-not $signTool) {
 					$sdkRoot = Join-Path ([Environment]::GetFolderPath('ProgramFilesX86')) 'Windows Kits\\10\\bin'
-					$signTool = Get-ChildItem (Join-Path $sdkRoot "*\\${architecture}\\signtool.exe") -ErrorAction SilentlyContinue |
-						Sort-Object FullName -Descending |
-						Select-Object -First 1 -ExpandProperty FullName
+					foreach ($architecture in @(${architectures.map(architecture => `'${architecture}'`).join(', ')})) {
+						$signTool = Get-ChildItem (Join-Path $sdkRoot "*\\$architecture\\signtool.exe") -ErrorAction SilentlyContinue |
+							Sort-Object FullName -Descending |
+							Select-Object -First 1 -ExpandProperty FullName
+						if ($signTool) {
+							break
+						}
+					}
 				}
 				if (-not $signTool) {
 					throw 'Unable to locate signtool.exe'
@@ -522,12 +528,15 @@ export class TestContext {
 			this.signToolPath = signToolPath;
 		}
 
-		const result = this.run(signToolPath, 'verify', '/pa', '/all', '/q', filePath);
+		const result = this.run(signToolPath, 'verify', '/pa', '/all', '/v', filePath);
 		if (result.error !== undefined) {
 			this.error(`Failed to validate Authenticode signatures for ${filePath}: ${result.error.message}`);
 		}
+		const details = `${result.stdout}\n${result.stderr}`.trim();
+		if (TestContext.authenticodeTestCertificate.test(details)) {
+			this.error(`Authenticode signature uses a test certificate for ${filePath}`);
+		}
 		if (result.status !== 0) {
-			const details = `${result.stdout}\n${result.stderr}`.trim();
 			this.error(`Not all Authenticode signatures are valid for ${filePath}${details ? `:\n${details}` : ''}`);
 		}
 

--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -103,6 +103,7 @@ export class TestContext {
 	private currentTestName: string | undefined;
 	private screenshotCounter = 0;
 	private wslVersion: number | undefined;
+	private signToolPath: string | undefined;
 
 	public constructor(public readonly options: Readonly<{
 		quality: 'stable' | 'insider' | 'exploration';
@@ -491,7 +492,7 @@ export class TestContext {
 	}
 
 	/**
-	 * Validates the Authenticode signature of a Windows executable.
+	 * Validates every Authenticode signature of a Windows executable.
 	 * @param filePath The path to the file to validate.
 	 */
 	public validateAuthenticodeSignature(filePath: string) {
@@ -501,7 +502,36 @@ export class TestContext {
 		}
 
 		this.log(`Validating Authenticode signature for ${filePath}`);
-		this.validateAuthenticodeSignaturesForFiles([filePath]);
+		let signToolPath = this.signToolPath;
+		if (!signToolPath) {
+			const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
+			const command = `
+				$signTool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+				if (-not $signTool) {
+					$sdkRoot = Join-Path ([Environment]::GetFolderPath('ProgramFilesX86')) 'Windows Kits\\10\\bin'
+					$signTool = Get-ChildItem (Join-Path $sdkRoot "*\\${architecture}\\signtool.exe") -ErrorAction SilentlyContinue |
+						Sort-Object FullName -Descending |
+						Select-Object -First 1 -ExpandProperty FullName
+				}
+				if (-not $signTool) {
+					throw 'Unable to locate signtool.exe'
+				}
+				$signTool
+			`;
+			signToolPath = this.runNoErrors('powershell', '-NoProfile', '-Command', command).stdout.trim();
+			this.signToolPath = signToolPath;
+		}
+
+		const result = this.run(signToolPath, 'verify', '/pa', '/all', '/q', filePath);
+		if (result.error !== undefined) {
+			this.error(`Failed to validate Authenticode signatures for ${filePath}: ${result.error.message}`);
+		}
+		if (result.status !== 0) {
+			const details = `${result.stdout}\n${result.stderr}`.trim();
+			this.error(`Not all Authenticode signatures are valid for ${filePath}${details ? `:\n${details}` : ''}`);
+		}
+
+		this.log(`All Authenticode signatures are valid for ${filePath}`);
 	}
 
 	/**
@@ -524,35 +554,6 @@ export class TestContext {
 	}
 
 	/**
-	 * Validates Authenticode signatures for the specified list of files in a single PowerShell call.
-	 */
-	private validateAuthenticodeSignaturesForFiles(files: string[]): void {
-		if (files.length === 0) {
-			return;
-		}
-
-		const fileList = files.map(file => `"${file}"`).join(',');
-		const command = `@(${fileList}) | ForEach-Object { $sig = Get-AuthenticodeSignature $_; "$($sig.Path)|$($sig.Status)" }`;
-		const result = this.runNoErrors('powershell', '-NoProfile', '-Command', command);
-
-		const invalid: string[] = [];
-		for (const line of result.stdout.trim().split('\n')) {
-			const [, filePath, status] = /^(.+)\|(\w+)$/.exec(line.trim()) ?? [];
-			if (filePath) {
-				if (status === 'Valid') {
-					this.log(`Authenticode signature is valid for ${filePath}`);
-				} else {
-					invalid.push(`${filePath}: ${status}`);
-				}
-			}
-		}
-
-		if (invalid.length > 0) {
-			this.error(`Authenticode signatures are not valid for:\n${invalid.join('\n')}`);
-		}
-	}
-
-	/**
 	 * Validates Authenticode signatures for all executable files in the specified directory.
 	 * @param dir The directory to scan for executable files.
 	 */
@@ -565,7 +566,9 @@ export class TestContext {
 		const files: string[] = [];
 		this.collectAuthenticodeFiles(dir, files);
 		this.log(`Found ${files.length} file(s) to validate Authenticode signatures`);
-		this.validateAuthenticodeSignaturesForFiles(files);
+		for (const file of files) {
+			this.validateAuthenticodeSignature(file);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- validate every embedded Authenticode signature in Windows sanity tests with `signtool verify /pa /all`
- explicitly reject the `Code Sign Test (DO NOT TRUST)` certificate independently of the build agent trust store
- allow legitimate multi-signed dependencies while failing when any signature is untrusted
- resolve and cache SignTool, with x64 fallback on Windows ARM64 agents

Fixes #330506

## Validation

- `npm --prefix .\test\sanity run compile`
- VS Code 1.132 Windows x64 archive passes Authenticode sanity validation, including legitimate multi-signed files
- VS Code 1.133 Windows x64 archive fails on the Electron DLL carrying the test signature
- ARM64 SignTool fallback resolves x64 SignTool when the native tool is unavailable
- `git diff --check`