### PR TITLE
Fix sign-in notification actions in the Agents window

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -57,6 +57,8 @@ export interface IDialogOptions {
 	readonly checkboxChecked?: boolean;
 	readonly type?: 'none' | 'info' | 'error' | 'question' | 'warning' | 'pending';
 	readonly extraClasses?: string[];
+	/** Classes to add to the full-window modal blocker. */
+	readonly modalBlockExtraClasses?: string[];
 	readonly inputs?: IDialogInputOptions[];
 	readonly keyEventProcessor?: (event: StandardKeyboardEvent) => void;
 	readonly renderBody?: (container: HTMLElement) => void;
@@ -128,6 +130,9 @@ export class Dialog extends Disposable {
 
 		// Modal background blocker
 		this.modalElement = this.container.appendChild($(`.monaco-dialog-modal-block.dimmed`));
+		if (options.modalBlockExtraClasses) {
+			this.modalElement.classList.add(...options.modalBlockExtraClasses);
+		}
 		this._register(addStandardDisposableListener(this.modalElement, EventType.CLICK, e => {
 			if (e.target === this.modalElement) {
 				this.element.focus(); // guide users back into the dialog if clicked elsewhere

--- a/src/vs/base/test/browser/ui/dialog/dialog.test.ts
+++ b/src/vs/base/test/browser/ui/dialog/dialog.test.ts
@@ -94,6 +94,24 @@ suite('Dialog', () => {
 		await result;
 	});
 
+	test('applies modal blocker classes', async () => {
+		const container = append(document.body, $('.test-dialog-container'));
+		disposables.add(toDisposable(() => container.remove()));
+		const dialog = disposables.add(new Dialog(container, 'Message', ['OK'], {
+			modalBlockExtraClasses: ['test-modal-block'],
+			buttonStyles: unthemedButtonStyles,
+			checkboxStyles: unthemedCheckboxStyles,
+			inputBoxStyles: unthemedInboxStyles,
+			dialogStyles: unthemedDialogStyles,
+		}));
+		const result = dialog.show();
+
+		assert.strictEqual(container.querySelector('.monaco-dialog-modal-block')?.classList.contains('test-modal-block'), true);
+
+		dialog.dispose();
+		await result;
+	});
+
 	test('prefers a pre-rendered detailElement over plain detail text and makes its links keyboard-focusable', async () => {
 		const container = append(document.body, $('.test-dialog-container'));
 		disposables.add(toDisposable(() => container.remove()));

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -44,7 +44,7 @@ Editors open as modal overlays via `ModalEditorPart`. The main editor part exist
 
 The Panel and Auxiliary Bar tab strips inherit the shared Modern UI pane-tab presentation from `workbench/contrib/styleOverrides/browser/media/tabs.css` through the workbench root's `modern-ui-tabs` class. Sessions-owned styles define only the part surface and inset; action geometry, active/hover/focus states, and badge placement remain owned by the shared pane-tab stylesheet so the Editor and Agents windows stay aligned.
 
-Standard dialogs retain their full-window modal blocker. While the Agents sign-in dialog is visible, notification toasts are raised above the blocker so authentication progress and its actions remain readable and pointer-interactive; other dialogs keep all notifications blocked.
+Standard dialogs retain their full-window modal blocker. While the Agents sign-in dialog is visible, notification toasts and Quick Input surfaces are raised above the blocker so authentication progress, its actions, and PAT input remain pointer-interactive. The sign-in dialog also allows Quick Input focus and keybindings through its focus trap; other dialogs keep these surfaces blocked.
 
 ### 2.2 Grid Tree
 

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -44,6 +44,8 @@ Editors open as modal overlays via `ModalEditorPart`. The main editor part exist
 
 The Panel and Auxiliary Bar tab strips inherit the shared Modern UI pane-tab presentation from `workbench/contrib/styleOverrides/browser/media/tabs.css` through the workbench root's `modern-ui-tabs` class. Sessions-owned styles define only the part surface and inset; action geometry, active/hover/focus states, and badge placement remain owned by the shared pane-tab stylesheet so the Editor and Agents windows stay aligned.
 
+Standard dialogs retain their full-window modal blocker. While the Agents sign-in dialog is visible, notification toasts are raised above the blocker so authentication progress and its actions remain readable and pointer-interactive; other dialogs keep all notifications blocked.
+
 ### 2.2 Grid Tree
 
 ```

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -44,7 +44,7 @@ Editors open as modal overlays via `ModalEditorPart`. The main editor part exist
 
 The Panel and Auxiliary Bar tab strips inherit the shared Modern UI pane-tab presentation from `workbench/contrib/styleOverrides/browser/media/tabs.css` through the workbench root's `modern-ui-tabs` class. Sessions-owned styles define only the part surface and inset; action geometry, active/hover/focus states, and badge placement remain owned by the shared pane-tab stylesheet so the Editor and Agents windows stay aligned.
 
-Standard dialogs retain their full-window modal blocker. While the Agents sign-in dialog is visible, notification toasts and Quick Input surfaces are raised above the blocker so authentication progress, its actions, and PAT input remain pointer-interactive. The sign-in dialog also allows Quick Input focus and keybindings through its focus trap; other dialogs keep these surfaces blocked.
+Standard dialogs retain their full-window modal blocker. The Agents sign-in blocker occupies a lower layer; while it is visible, notification toasts and Quick Input surfaces are placed between it and normal dialogs so authentication progress, its actions, and PAT input remain pointer-interactive without appearing above a later modal. The sign-in dialog also allows Quick Input focus and keybindings through its focus trap, and does not consume the Quick Input's Escape dismissal.
 
 ### 2.2 Grid Tree
 

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -90,7 +90,8 @@
 	bottom: 15px;
 }
 
-.monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible > .notifications-toasts {
+.monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible > .notifications-toasts,
+.monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible .quick-input-widget {
 	z-index: 2580; /* above the dialog modal block (2575), below workbench overlays (2600) */
 }
 

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -90,9 +90,13 @@
 	bottom: 15px;
 }
 
+.monaco-workbench.agent-sessions-workbench .monaco-dialog-modal-block.sessions-signing-in-dialog-modal-block {
+	z-index: 2570; /* below sign-in notifications and Quick Input (2571), and normal dialogs (2575) */
+}
+
 .monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible > .notifications-toasts,
 .monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible .quick-input-widget {
-	z-index: 2580; /* above the dialog modal block (2575), below workbench overlays (2600) */
+	z-index: 2571; /* above the sign-in dialog (2570), below normal dialogs (2575) */
 }
 
 .monaco-workbench.agent-sessions-workbench.nostatusbar > .notifications-center,

--- a/src/vs/sessions/browser/media/workbench.css
+++ b/src/vs/sessions/browser/media/workbench.css
@@ -90,6 +90,10 @@
 	bottom: 15px;
 }
 
+.monaco-workbench.agent-sessions-workbench.sessions-signing-in-dialog-visible > .notifications-toasts {
+	z-index: 2580; /* above the dialog modal block (2575), below workbench overlays (2600) */
+}
+
 .monaco-workbench.agent-sessions-workbench.nostatusbar > .notifications-center,
 .monaco-workbench.agent-sessions-workbench.nostatusbar > .notifications-toasts {
 	bottom: 15px;

--- a/src/vs/sessions/browser/sessionsSignInDialog.ts
+++ b/src/vs/sessions/browser/sessionsSignInDialog.ts
@@ -55,10 +55,12 @@ export class SessionsSigningInDialog extends Disposable {
 			createWorkbenchDialogOptions({
 				type: 'none',
 				extraClasses: ['chat-setup-dialog', 'sessions-welcome-dialog'],
+				modalBlockExtraClasses: ['sessions-signing-in-dialog-modal-block'],
 				detail: localize('sessions.signingIn.detail', "Please complete sign-in in the browser."),
 				icon: Codicon.agent,
 				alignment: DialogContentsAlignment.Vertical,
 				cancelId: 0,
+				disableCloseAction: true,
 				disableCloseButton: true,
 				disableDefaultAction: true,
 				isExternalFocusAllowed: target => !!target.closest('.quick-input-widget'),

--- a/src/vs/sessions/browser/sessionsSignInDialog.ts
+++ b/src/vs/sessions/browser/sessionsSignInDialog.ts
@@ -61,7 +61,8 @@ export class SessionsSigningInDialog extends Disposable {
 				cancelId: 0,
 				disableCloseButton: true,
 				disableDefaultAction: true,
-			}, keybindingService, layoutService, hostService)
+				isExternalFocusAllowed: target => !!target.closest('.quick-input-widget'),
+			}, keybindingService, layoutService, hostService, undefined, commandId => commandId.startsWith('quickInput.'))
 		));
 
 		const activeContainer = layoutService.activeContainer;

--- a/src/vs/sessions/browser/sessionsSignInDialog.ts
+++ b/src/vs/sessions/browser/sessionsSignInDialog.ts
@@ -8,7 +8,7 @@ import { Button } from '../../base/browser/ui/button/button.js';
 import { Dialog, DialogContentsAlignment } from '../../base/browser/ui/dialog/dialog.js';
 import { Codicon } from '../../base/common/codicons.js';
 import { onUnexpectedError } from '../../base/common/errors.js';
-import { Disposable, DisposableStore, IDisposable } from '../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 import { localize } from '../../nls.js';
 import { ICommandService } from '../../platform/commands/common/commands.js';
 import { IKeybindingService } from '../../platform/keybinding/common/keybinding.js';
@@ -61,17 +61,12 @@ export class SessionsSigningInDialog extends Disposable {
 				cancelId: 0,
 				disableCloseButton: true,
 				disableDefaultAction: true,
-				renderFooter: footer => {
-					const element = footer.appendChild(footer.ownerDocument.createElement('div'));
-					element.classList.add('chat-setup-dialog-footer');
-					this._register(createDialogAction(
-						element,
-						localize('sessions.cancelSignIn', "Cancel Sign-In"),
-						() => this.cancel()
-					));
-				},
 			}, keybindingService, layoutService, hostService)
 		));
+
+		const activeContainer = layoutService.activeContainer;
+		activeContainer.classList.add('sessions-signing-in-dialog-visible');
+		this._register(toDisposable(() => activeContainer.classList.remove('sessions-signing-in-dialog-visible')));
 
 		void this.show();
 	}


### PR DESCRIPTION
## Summary

- keep notification toasts interactive while the Agents sign-in dialog is visible
- raise PAT Quick Input surfaces above the sign-in dialog and allow their focus and keybindings through the dialog trap
- place authentication surfaces below later normal dialogs by giving only the Sessions sign-in blocker a lower modal tier
- remove the ineffective Cancel Sign-In footer action
- document the sign-in dialog layering and interaction contract

## Testing

- `npm run stylelint -- src/vs/sessions/browser/media/workbench.css`
- added focused unit coverage for custom modal-blocker classes
- verified the GitHub sign-in flow in an isolated Agents window: notification actions receive pointer input and the signing-in dialog has no cancel footer action
- `npm run typecheck-client` and `npm run valid-layers-check` reach the changed code and report only pre-existing errors in `assignmentService.ts` and Agent Host `managedSettings` types

## Notes

The focused unit test cannot currently execute locally because regenerating `out/` is blocked by those pre-existing client compile errors. CI will run it against a complete dependency baseline.