### PR TITLE
chore: bump gulp-electron@1.43.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vscode/component-explorer": "^0.2.1-94",
         "@vscode/component-explorer-cli": "^0.2.1-95",
-        "@vscode/gulp-electron": "^1.42.0",
+        "@vscode/gulp-electron": "^1.43.0",
         "@vscode/l10n-dev": "0.0.35",
         "@vscode/telemetry-extractor": "^1.20.4",
         "@vscode/test-cli": "^0.0.6",
@@ -4335,9 +4335,9 @@
       "license": "MIT"
     },
     "node_modules/@vscode/gulp-electron": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@vscode/gulp-electron/-/gulp-electron-1.42.0.tgz",
-      "integrity": "sha512-DQLhu7p3GnGAc1tvYtArqp3duHD+b7ddpWitqYckdioFJGAszUSf7o6KZ5szo6sjFBz+E8rvpu9EMYOjdAAMzg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@vscode/gulp-electron/-/gulp-electron-1.43.0.tgz",
+      "integrity": "sha512-zGw2Vp1ARd+Cxq/M68y9MG28lwLmSMtAwe/fOqhvZaeV0lo2DvDwNu0+6xHAUAdLN3BMEEELCSfzd6NGC+Hn3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vscode/component-explorer": "^0.2.1-94",
     "@vscode/component-explorer-cli": "^0.2.1-95",
-    "@vscode/gulp-electron": "^1.42.0",
+    "@vscode/gulp-electron": "^1.43.0",
     "@vscode/l10n-dev": "0.0.35",
     "@vscode/telemetry-extractor": "^1.20.4",
     "@vscode/test-cli": "^0.0.6",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/330506

Removes untrusted signature from the published internal builds.