### PR TITLE
agentHost: preserve Codex session titles

### DIFF
--- a/src/vs/platform/agentHost/AGENTS.md
+++ b/src/vs/platform/agentHost/AGENTS.md
@@ -447,6 +447,7 @@ explicitly bound to the concrete chat URI AH supplies:
 - `_sessionIdByChatUri: Map<string, string>` is the exact chat-operation routing index; unbound chat URIs are rejected.
 - `_sessionIdByThreadId` continues to route app-server callbacks by thread id.
 - Initializing `chats.createChat` binds a thread to the exact host-supplied chat URI at provisioning time (including restored/forked threads); `materializeChat` re-attaches any chat's backing thread on restore.
+- A cold `getChatMetadata` read caches the backing thread's summary, timestamps, and working directories on the live runtime. Later metadata reads return those fields from memory (the app-server may be blocked on a dynamic tool call), so hydrating a runtime must never erase an already-listed session title.
 
 An additional chat is backed by a **fresh top-level thread minted eagerly** in
 `chats.createChat` (via `thread/start` or `thread/fork` at the

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -506,6 +506,13 @@ interface ICodexSession {
 	 */
 	startTime: number;
 	modifiedTime: number;
+	/**
+	 * Last summary read from the backing Codex thread. A cold metadata lookup
+	 * hydrates a live runtime, and every later lookup must preserve that title
+	 * while answering from memory; dropping it makes Agent Host replace an
+	 * existing session title with its generic "Session" fallback.
+	 */
+	summary: string | undefined;
 	/** Concrete host chat URI once bound; undefined only for direct create/fork before AH binds it. */
 	chatChannel: URI | undefined;
 	/**
@@ -2622,6 +2629,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sessionUri: parent.sessionUri,
 			startTime: parent.startTime,
 			modifiedTime: parent.modifiedTime,
+			summary: parent.summary,
 			chatChannel: parent.chatChannel,
 			workingDirectory: parent.workingDirectory,
 			workingDirectories: parent.workingDirectories,
@@ -3494,6 +3502,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sessionUri: AgentSession.uri(this.id, sessionId),
 			startTime: now,
 			modifiedTime: now,
+			summary: undefined,
 			chatChannel: target.resource,
 			workingDirectory: options?.workingDirectories?.[0],
 			workingDirectories,
@@ -3729,6 +3738,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			sessionUri: AgentSession.uri(this.id, sessionId),
 			startTime: now,
 			modifiedTime: now,
+			summary: undefined,
 			chatChannel: target?.resource,
 			workingDirectory: effectiveWorkingDirectories?.[0] ?? workingDirectory,
 			workingDirectories: effectiveWorkingDirectories,
@@ -5009,6 +5019,7 @@ export class CodexAgent extends Disposable implements IAgent {
 				chat,
 				startTime: live.startTime,
 				modifiedTime: live.modifiedTime,
+				summary: live.summary,
 				workingDirectories: live.workingDirectories ?? (live.workingDirectory ? [live.workingDirectory] : undefined),
 			};
 		}
@@ -5040,6 +5051,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			// keeps the construction time rather than falling back to 1970.
 			restored.startTime = metadata.startTime || restored.startTime;
 			restored.modifiedTime = metadata.modifiedTime || restored.modifiedTime;
+			restored.summary = metadata.summary;
 			// Require our own recorded explicit path to positively corroborate
 			// the app-server's ground-truth cwd before adopting it as managed:
 			// `read.thread.cwd` is authoritative for "what is this thread's

--- a/src/vs/platform/agentHost/test/node/codex/codexCreateChat.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexCreateChat.test.ts
@@ -1458,6 +1458,57 @@ suite('CodexAgent chat backing durability', () => {
 		}
 	});
 
+	test('a restored runtime preserves its thread summary in subsequent live metadata lookups', async () => {
+		const agent = await createAgent(disposables, { sdkResolvableWithoutDownload: true, sessionStore: createTestSessionStore() });
+		const peer = disposables.add(createTestPeer());
+		connect(agent, peer);
+
+		try {
+			const session = AgentSession.uri('codex', 'named-session');
+			const chat = URI.parse(buildDefaultChatUri(session));
+			const context = { configurationResource: session, resource: chat };
+			const providerData = JSON.stringify({ sessionId: 'named-session' });
+			const restoring = agent.getChatMetadata(chat, context, providerData);
+			const read = await readNextRequest(peer.outbound);
+			assert.strictEqual(read.method, 'thread/read');
+			peer.push({
+				id: read.id,
+				result: {
+					thread: {
+						id: 'named-thread',
+						name: 'Investigate session title loss',
+						cwd: '/repo/named',
+						createdAt: 1_700_000_000,
+						updatedAt: 1_700_000_100,
+						turns: [],
+					},
+				},
+			});
+
+			const coldMetadata = await restoring;
+			// The first lookup registers a live runtime. The second must retain
+			// the title without another app-server request: that server may be
+			// blocked waiting on the very dynamic tool call requesting metadata.
+			const liveMetadata = await agent.getChatMetadata(chat, context, providerData);
+
+			assert.deepStrictEqual({
+				coldSummary: coldMetadata?.summary,
+				liveSummary: liveMetadata?.summary,
+				liveStartTime: liveMetadata?.startTime,
+				liveModifiedTime: liveMetadata?.modifiedTime,
+				pendingAppServerBytes: peer.outbound.readableLength,
+			}, {
+				coldSummary: 'Investigate session title loss',
+				liveSummary: 'Investigate session title loss',
+				liveStartTime: 1_700_000_000_000,
+				liveModifiedTime: 1_700_000_100_000,
+				pendingAppServerBytes: 0,
+			});
+		} finally {
+			peer.dispose();
+		}
+	});
+
 	test('live peer metadata resolves the peer backing instead of the owning default chat', async () => {
 		const agent = await createAgent(disposables, { sdkResolvableWithoutDownload: true, sessionStore: createTestSessionStore() });
 		const session = AgentSession.uri('codex', 'metadata-owner');


### PR DESCRIPTION
## Summary

- preserve Codex thread summaries when a cold metadata lookup hydrates a live runtime
- return the cached summary from later in-memory metadata lookups instead of falling back to `Session`
- add a regression test for the cold-to-live metadata transition

## Root cause

`CodexAgent.getChatMetadata()` returned the thread summary during the initial cold read, but the hydrated live runtime did not retain it. A later metadata lookup took the live fast path without a summary, causing Agent Host to replace the existing title with its generic `Session` fallback.

## Verification

- `npm run compile-client`
- focused regression test (1 passing)
- full `CodexAgent chat backing durability` suite (6 passing)
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `git diff --check`
- launch-skill verification against a throwaway copy of the Insiders session registry: repeated reload/list cycles retained 492/492 named sessions with zero `Session` fallbacks