### PR TITLE
build: Bound transpile file operations

### DIFF
--- a/build/next/build-fast.ts
+++ b/build/next/build-fast.ts
@@ -9,7 +9,7 @@ import * as esbuild from 'esbuild';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getGitCommitDate } from '../lib/date.ts';
-import { applyIncrementalClientChanges } from './transpile.ts';
+import { applyIncrementalClientChanges, mapWithConcurrency, MAX_CONCURRENT_FILE_OPERATIONS } from './transpile.ts';
 
 const STATE_SCHEMA = 1;
 const BUILD_RECIPE = 1;
@@ -257,9 +257,9 @@ export async function collectSnapshot(repoRoot: string): Promise<BuildFastSnapsh
 	]);
 	const head = headOutput.toString('utf8').trim();
 	const dirtyPaths = new Set([...parseNullSeparatedPaths(trackedOutput), ...parseNullSeparatedPaths(untrackedOutput)]);
-	const dirtyEntries = await Promise.all([...dirtyPaths].sort().map(async filePath => {
+	const dirtyEntries = await mapWithConcurrency([...dirtyPaths].sort(), MAX_CONCURRENT_FILE_OPERATIONS, async filePath => {
 		return [filePath, await fingerprintFile(path.join(repoRoot, filePath))] as const;
-	}));
+	});
 	return { head, dirty: Object.fromEntries(dirtyEntries) };
 }
 

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -1054,42 +1054,51 @@ async function watch(): Promise<void> {
 
 	let pendingTsFiles: Set<string> = new Set();
 	let pendingCopyFiles: Set<string> = new Set();
+	let processingChanges = false;
 
 	const processChanges = async () => {
-		console.log('Starting transpilation...');
-		const t1 = Date.now();
-		const tsFiles = [...pendingTsFiles];
-		const filesToCopy = [...pendingCopyFiles];
-		pendingTsFiles = new Set();
-		pendingCopyFiles = new Set();
+		if (processingChanges) {
+			return;
+		}
 
+		processingChanges = true;
 		try {
-			if (tsFiles.length > 0) {
-				console.log(`[watch] Transpiling ${tsFiles.length} file(s)...`);
-				await mapWithConcurrency(tsFiles, MAX_CONCURRENT_FILE_OPERATIONS, srcPath => {
-					const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
-					const destPath = path.join(REPO_ROOT, outDir, relativePath.replace(/\.ts$/, '.js'));
-					return transpileFile(srcPath, destPath);
-				});
-			}
+			while (pendingTsFiles.size > 0 || pendingCopyFiles.size > 0) {
+				console.log('Starting transpilation...');
+				const t1 = Date.now();
+				const tsFiles = [...pendingTsFiles];
+				const filesToCopy = [...pendingCopyFiles];
+				pendingTsFiles = new Set();
+				pendingCopyFiles = new Set();
 
-			if (filesToCopy.length > 0) {
-				await mapWithConcurrency(filesToCopy, MAX_CONCURRENT_FILE_OPERATIONS, async srcPath => {
-					const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
-					const destPath = path.join(REPO_ROOT, outDir, relativePath);
-					await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-					await copyFile(srcPath, destPath);
-					console.log(`[watch] Copied ${relativePath}`);
-				});
-			}
+				try {
+					if (tsFiles.length > 0) {
+						console.log(`[watch] Transpiling ${tsFiles.length} file(s)...`);
+						await mapWithConcurrency(tsFiles, MAX_CONCURRENT_FILE_OPERATIONS, srcPath => {
+							const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
+							const destPath = path.join(REPO_ROOT, outDir, relativePath.replace(/\.ts$/, '.js'));
+							return transpileFile(srcPath, destPath);
+						});
+					}
 
-			if (tsFiles.length > 0 || filesToCopy.length > 0) {
-				console.log(`Finished transpilation with 0 errors after ${Date.now() - t1} ms`);
+					if (filesToCopy.length > 0) {
+						await mapWithConcurrency(filesToCopy, MAX_CONCURRENT_FILE_OPERATIONS, async srcPath => {
+							const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
+							const destPath = path.join(REPO_ROOT, outDir, relativePath);
+							await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+							await copyFile(srcPath, destPath);
+							console.log(`[watch] Copied ${relativePath}`);
+						});
+					}
+
+					console.log(`Finished transpilation with 0 errors after ${Date.now() - t1} ms`);
+				} catch (err) {
+					console.error('[watch] Rebuild failed:', err);
+					console.log(`Finished transpilation with 1 errors after ${Date.now() - t1} ms`);
+				}
 			}
-		} catch (err) {
-			console.error('[watch] Rebuild failed:', err);
-			console.log(`Finished transpilation with 1 errors after ${Date.now() - t1} ms`);
-			// Continue watching
+		} finally {
+			processingChanges = false;
 		}
 	};
 

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -19,7 +19,7 @@ import packageJson from '../../package.json' with { type: 'json' };
 import { useEsbuildTranspile } from '../buildConfig.ts';
 import { isWebExtension, type IScannedBuiltinExtension } from '../lib/extensions.ts';
 import { runBuildFast } from './build-fast.ts';
-import { copyFile, transpileFile } from './transpile.ts';
+import { copyFile, mapWithConcurrency, MAX_CONCURRENT_FILE_OPERATIONS, transpileFile } from './transpile.ts';
 
 const globAsync = promisify(glob);
 
@@ -545,11 +545,11 @@ async function copyAllNonTsFiles(outDir: string, excludeTests: boolean): Promise
 
 	const allFiles = [...new Set([...files, ...dtsFiles])];
 
-	await Promise.all(allFiles.map(file => {
+	await mapWithConcurrency(allFiles, MAX_CONCURRENT_FILE_OPERATIONS, file => {
 		const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
 		const destPath = path.join(REPO_ROOT, outDir, file);
 		return copyFile(srcPath, destPath);
-	}));
+	});
 
 	console.log(`[resources] Copied ${allFiles.length} files`);
 }
@@ -700,12 +700,11 @@ async function transpile(outDir: string, excludeTests: boolean): Promise<void> {
 
 	console.log(`[transpile] Found ${files.length} files`);
 
-	// Transpile all files in parallel using esbuild.transform (fastest approach)
-	await Promise.all(files.map(file => {
+	await mapWithConcurrency(files, MAX_CONCURRENT_FILE_OPERATIONS, file => {
 		const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
 		const destPath = path.join(REPO_ROOT, outDir, file.replace(/\.ts$/, '.js'));
 		return transpileFile(srcPath, destPath);
-	}));
+	});
 }
 
 // ============================================================================
@@ -1065,25 +1064,23 @@ async function watch(): Promise<void> {
 		pendingCopyFiles = new Set();
 
 		try {
-			// Transform changed TypeScript files in parallel
 			if (tsFiles.length > 0) {
 				console.log(`[watch] Transpiling ${tsFiles.length} file(s)...`);
-				await Promise.all(tsFiles.map(srcPath => {
+				await mapWithConcurrency(tsFiles, MAX_CONCURRENT_FILE_OPERATIONS, srcPath => {
 					const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
 					const destPath = path.join(REPO_ROOT, outDir, relativePath.replace(/\.ts$/, '.js'));
 					return transpileFile(srcPath, destPath);
-				}));
+				});
 			}
 
-			// Copy changed resource files in parallel
 			if (filesToCopy.length > 0) {
-				await Promise.all(filesToCopy.map(async (srcPath) => {
+				await mapWithConcurrency(filesToCopy, MAX_CONCURRENT_FILE_OPERATIONS, async srcPath => {
 					const relativePath = path.relative(path.join(REPO_ROOT, SRC_DIR), srcPath);
 					const destPath = path.join(REPO_ROOT, outDir, relativePath);
 					await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
 					await copyFile(srcPath, destPath);
 					console.log(`[watch] Copied ${relativePath}`);
-				}));
+				});
 			}
 
 			if (tsFiles.length > 0 || filesToCopy.length > 0) {

--- a/build/next/test/transpile.test.ts
+++ b/build/next/test/transpile.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import { mapWithConcurrency } from '../transpile.ts';
+
+suite('transpile', () => {
+	test('bounds concurrent work and preserves result order', async () => {
+		let active = 0;
+		let maximumActive = 0;
+
+		const results = await mapWithConcurrency([0, 1, 2, 3, 4], 2, async item => {
+			active++;
+			maximumActive = Math.max(maximumActive, active);
+			await new Promise(resolve => setImmediate(resolve));
+			active--;
+			return item * 2;
+		});
+
+		assert.deepStrictEqual({ maximumActive, results }, {
+			maximumActive: 2,
+			results: [0, 2, 4, 6, 8],
+		});
+	});
+
+	test('propagates errors and stops scheduling work', async () => {
+		const started: number[] = [];
+
+		await assert.rejects(mapWithConcurrency([0, 1, 2, 3], 2, async item => {
+			started.push(item);
+			if (item === 0) {
+				throw new Error('expected failure');
+			}
+			await new Promise(resolve => setImmediate(resolve));
+		}), /expected failure/);
+
+		assert.deepStrictEqual(started, [0, 1]);
+	});
+});

--- a/build/next/transpile.ts
+++ b/build/next/transpile.ts
@@ -9,6 +9,9 @@ import * as path from 'path';
 
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
 
+/** Keeps build I/O comfortably below the Windows CRT's 8192 file-handle limit. */
+export const MAX_CONCURRENT_FILE_OPERATIONS = 256;
+
 const transformOptions: esbuild.TransformOptions = {
 	loader: 'ts',
 	format: 'esm',
@@ -47,6 +50,36 @@ export async function copyFile(srcPath: string, destPath: string): Promise<void>
 	await fs.promises.copyFile(srcPath, destPath);
 }
 
+export async function mapWithConcurrency<T, R>(items: readonly T[], concurrency: number, task: (item: T, index: number) => Promise<R>): Promise<R[]> {
+	if (!Number.isInteger(concurrency) || concurrency < 1) {
+		throw new RangeError('Concurrency must be a positive integer.');
+	}
+
+	const results = new Array<R>(items.length);
+	let nextIndex = 0;
+	let firstError: { value: unknown } | undefined;
+
+	async function worker(): Promise<void> {
+		while (!firstError && nextIndex < items.length) {
+			const index = nextIndex++;
+			try {
+				results[index] = await task(items[index], index);
+			} catch (error) {
+				firstError ??= { value: error };
+			}
+		}
+	}
+
+	const workerCount = Math.min(concurrency, items.length);
+	await Promise.all(Array.from({ length: workerCount }, worker));
+
+	if (firstError) {
+		throw firstError.value;
+	}
+
+	return results;
+}
+
 export async function applyIncrementalClientChanges(repoRoot: string, outDir: string, changedPaths: readonly string[]): Promise<void> {
 	const destinations = new Set<string>();
 	for (const changedPath of changedPaths) {
@@ -56,7 +89,7 @@ export async function applyIncrementalClientChanges(repoRoot: string, outDir: st
 		destinations.add(getOutputRelativePath(changedPath.slice('src/'.length)));
 	}
 
-	const operations = await Promise.all([...destinations].map(async destination => {
+	const operations = await mapWithConcurrency([...destinations], MAX_CONCURRENT_FILE_OPERATIONS, async destination => {
 		const destinationPath = path.join(repoRoot, outDir, destination);
 		const resourceSource = path.join(repoRoot, 'src', destination);
 
@@ -76,7 +109,7 @@ export async function applyIncrementalClientChanges(repoRoot: string, outDir: st
 		}
 
 		return { destinationPath, kind: 'remove' as const };
-	}));
+	});
 
 	for (const operation of operations) {
 		if (operation.kind === 'remove') {
@@ -89,13 +122,13 @@ export async function applyIncrementalClientChanges(repoRoot: string, outDir: st
 		}
 	}
 
-	await Promise.all(operations.map(async operation => {
+	await mapWithConcurrency(operations, MAX_CONCURRENT_FILE_OPERATIONS, async operation => {
 		if (operation.kind === 'copy') {
 			await copyFile(operation.sourcePath, operation.destinationPath);
 		} else if (operation.kind === 'transpile') {
 			await transpileFile(operation.sourcePath, operation.destinationPath);
 		}
-	}));
+	});
 }
 
 export function getOutputRelativePath(sourceRelativePath: string): string {


### PR DESCRIPTION
## Summary

- bound transpile, resource copy, watch, and incremental file operations to 256 concurrent workers
- preserve result ordering and stop scheduling new work after the first failure
- add focused tests for concurrency limits and error propagation

## Why

The Windows build reached the CRT handle limit when the source tree grew to 8,190 TypeScript files. The full transpile used an unbounded `Promise.all`, causing `EMFILE` while opening the last files in the batch.

## Validation

- `node --test build/next/test/transpile.test.ts build/next/test/build-fast.test.ts`
- `npm --prefix build run typecheck`
- `npm run hygiene`
- `node build/next/index.ts transpile --out out-build` (8,190 TypeScript files and 1,883 resources)
- same full transpile with the process file descriptor limit reduced to 512

The repository-wide `npm run compile` currently reports an unrelated pre-existing error in `extensions/markdown-language-features/markdown-editor-src/editor.ts`: `EditorModel.setTaskCheckboxChecked` is missing.