### PR TITLE
agentHost: discover Codex workspace custom agents

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -4442,6 +4442,11 @@ export class CodexAgent extends Disposable implements IAgent {
 				this._fire(sessionUri, { type: ActionType.ChatTurnComplete, turnId: effectiveTurnId, duration });
 				return;
 			}
+		} else if (session.firstTurnSent && !session.needsResume && customizationsChanged) {
+			// Workspace agents have no client-push event to reconcile them. A
+			// send-time signature change must resume the existing thread so Codex
+			// reloads its roles and developer instructions without losing history.
+			session.needsResume = true;
 		}
 		if (session.needsResume) {
 			try {

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -635,6 +635,12 @@ interface ICodexSession {
 	readonly codexTurnIdByHostTurnId: Map<string, string>;
 	/** Set when this session was restored (Phase 3) and needs `thread/resume` before the first `turn/start`. */
 	needsResume: boolean;
+	/**
+	 * Set when launch-only settings changed on a subscribed live thread. Codex
+	 * ignores `thread/resume` overrides for such a thread, so release the live
+	 * subscription before resuming its persisted history with the new settings.
+	 */
+	unsubscribeBeforeResume: boolean;
 	/** In-flight resume shared by history loading and the first send. */
 	resumePromise: Promise<void> | undefined;
 	/** Most recent user prompt sent on this session — used as fallback userMessage text in `turn/started`. */
@@ -1272,7 +1278,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			} else {
 				// A thread with history is resumed (with the current config) on
 				// its next turn rather than restarted, so nothing is lost.
-				session.needsResume = true;
+				this._markSessionForReload(session);
 			}
 		}
 	}
@@ -2653,6 +2659,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			hostTurnIdByAppTurnId: new Map<string, string>(),
 			codexTurnIdByHostTurnId: new Map<string, string>(),
 			needsResume: false,
+			unsubscribeBeforeResume: false,
 			resumePromise: undefined,
 			lastPromptText: '',
 			disposed: false,
@@ -3269,7 +3276,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			await this._restartThreadWithCurrentTools(session);
 			this._persistMaterializedSession(session);
 		} else {
-			session.needsResume = true;
+			this._markSessionForReload(session);
 		}
 	}
 
@@ -3525,6 +3532,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			hostTurnIdByAppTurnId: new Map<string, string>(),
 			codexTurnIdByHostTurnId: new Map<string, string>(),
 			needsResume: false,
+			unsubscribeBeforeResume: false,
 			resumePromise: undefined,
 			lastPromptText: '',
 			disposed: false,
@@ -3760,6 +3768,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			hostTurnIdByAppTurnId: new Map<string, string>(),
 			codexTurnIdByHostTurnId: new Map<string, string>(),
 			needsResume: true,
+			unsubscribeBeforeResume: false,
 			resumePromise: undefined,
 			lastPromptText: '',
 			disposed: false,
@@ -4446,7 +4455,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			// Workspace agents have no client-push event to reconcile them. A
 			// send-time signature change must resume the existing thread so Codex
 			// reloads its roles and developer instructions without losing history.
-			session.needsResume = true;
+			this._markSessionForReload(session);
 		}
 		if (session.needsResume) {
 			try {
@@ -4958,6 +4967,12 @@ export class CodexAgent extends Disposable implements IAgent {
 					throw new Error(`Cannot resume Codex session ${session.sessionId}: no backing thread`);
 				}
 				const conn = connection ?? await this._ensureConnection();
+				if (session.unsubscribeBeforeResume) {
+					// `thread/resume` deliberately rejoins a loaded subscribed thread and
+					// ignores conflicting overrides. Unsubscribe first so app-server
+					// reloads the persisted history with the current launch-only config.
+					await conn.client.request<'thread/unsubscribe'>('thread/unsubscribe', { threadId });
+				}
 				const mcpServers = this._buildSessionMcpServers(session);
 				const customizationLaunch = await this._buildCustomizationLaunch(session);
 				const multiRootActive = this._isMultiRootActive(session);
@@ -4983,11 +4998,17 @@ export class CodexAgent extends Disposable implements IAgent {
 				session.materializedMcpSig = mcpServersSignature(mcpServers);
 				session.materializedCustomizationsSig = customizationLaunch.signature;
 				session.needsResume = false;
+				session.unsubscribeBeforeResume = false;
 			})().finally(() => {
 				session.resumePromise = undefined;
 			});
 		}
 		await session.resumePromise;
+	}
+
+	private _markSessionForReload(session: ICodexSession): void {
+		session.unsubscribeBeforeResume = true;
+		session.needsResume = true;
 	}
 
 	/**
@@ -5398,7 +5419,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			await this._restartThreadWithCurrentTools(session);
 			this._persistMaterializedSession(session);
 		} else {
-			session.needsResume = true;
+			this._markSessionForReload(session);
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -40,8 +40,8 @@ import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
 import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpServersFromConfig, codexMcpToolsChanged, codexStartupErrorNeedsAuth, injectCodexMcpAuthTokens, inventoryToSdkServers, normalizeCodexMcpResourceUrl, translateCodexMcpStartupState, type ICodexMcpServerConfigJson, type ICodexMcpServerEntry } from './codexMcpServers.js';
-import { codexHooksToContainers, codexSelectedCapabilityRootCandidates, codexSkillsToContainers } from './codexCustomizations.js';
-import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfigFromPlugins, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
+import { codexHooksToContainers, codexSelectedCapabilityRootCandidates, codexSkillsToContainers, discoverCodexWorkspaceAgents } from './codexCustomizations.js';
+import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfig, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from './codexClientCustomizations.js';
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import { McpAuthRequiredReason, McpServerStatus, type AhpMcpUiHostCapabilities, type Customization, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -1474,10 +1474,12 @@ export class CodexAgent extends Disposable implements IAgent {
 		};
 	}
 
+	private _workingDirectories(session: ICodexSession): readonly URI[] {
+		return session.workingDirectories ?? (session.workingDirectory ? [session.workingDirectory] : []);
+	}
+
 	private _runtimeWorkspaceRoots(session: ICodexSession): string[] {
-		const workingDirectories = session.workingDirectories
-			?? (session.workingDirectory ? [session.workingDirectory] : []);
-		return distinctAbsolutePaths(workingDirectories.map(directory => directory.fsPath));
+		return distinctAbsolutePaths(this._workingDirectories(session).map(directory => directory.fsPath));
 	}
 
 	private _isMultiRootActive(session: ICodexSession): boolean {
@@ -1508,7 +1510,8 @@ export class CodexAgent extends Disposable implements IAgent {
 		readonly signature: string;
 	}> {
 		const plugins = session.clientCustomizations.enabledPlugins();
-		const customization = await codexCustomizationConfigFromPlugins(plugins, session.agent, this._fileService);
+		const workspaceAgents = await discoverCodexWorkspaceAgents(this._workingDirectories(session), this._fileService);
+		const customization = await codexCustomizationConfig(workspaceAgents.agents, plugins, session.agent, this._fileService);
 		const config: Record<string, JsonValue> = {};
 		if (customization.agentRoles.length > 0) {
 			const root = session.customizationDirectory?.fsPath
@@ -4134,9 +4137,9 @@ export class CodexAgent extends Disposable implements IAgent {
 			session.serverToolsAdvertised = true;
 			this._serverToolHost.advertise(configResource.toString());
 		}
-		// Surface the skills/hooks codex loaded for this working directory (from
-		// `.agents`/`.codex`) in the Customizations view now that the connection
-		// is ready and the cwd is known. Best-effort and fire-and-forget.
+		// Surface workspace agents and the skills/hooks codex loaded for this
+		// working directory in the Customizations view now that the connection is
+		// ready and the cwd is known. Best-effort and fire-and-forget.
 		void this._refreshSkillHookCustomizations(session);
 		// Re-apply the client-plugin skill roots against the now-ready
 		// connection (they may have been synced before it came up).
@@ -5466,14 +5469,15 @@ export class CodexAgent extends Disposable implements IAgent {
 		const controller = this._getOrCreateMcpController(session);
 		controller.applyAll(inventoryToSdkServers(this._mcpInventory));
 		this._refreshMcpCustomizationIds(session, controller);
-		// Append the skills/hooks codex loaded for this session's working
-		// directory (best-effort; empty until the app-server connection is
-		// ready, after which `_refreshSkillHookCustomizations` pushes updates).
-		const skillHookContainers = await this._fetchSkillHookContainers(session);
-		// Client-pushed ("Open Plugin") customizations first (they carry the
-		// user's enablement overlay), then codex's discovered MCP servers and
-		// the `.agents`/`.codex` skills/hooks.
+		const [workspaceAgents, skillHookContainers] = await Promise.all([
+			discoverCodexWorkspaceAgents(this._workingDirectories(session), this._fileService),
+			this._fetchSkillHookContainers(session),
+		]);
+		// Workspace custom agents come from the Agent Host's session-scoped
+		// scan. Client-pushed customizations remain for plugins/extensions, then
+		// codex's own MCP, skill, and hook catalogs complete the surface.
 		return [
+			...workspaceAgents.containers,
 			...session.clientCustomizations.toCustomizations(),
 			...controller.topLevelCustomizations(),
 			...skillHookContainers,
@@ -5503,22 +5507,26 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Re-fetches this session's skill/hook customizations and upserts each
+	 * Re-fetches this session's workspace agent, skill, and hook customizations and upserts each
 	 * container into session state via {@link ActionType.SessionCustomizationUpdated}.
 	 * Called after materialization (when the connection is ready and the cwd is
-	 * known) so the workbench Customizations surface reflects what codex loaded
-	 * from the working directory's `.agents`/`.codex` folders. Upserts (keyed by
-	 * customization id) leave the MCP customizations untouched.
+	 * known) so the workbench Customizations surface reflects workspace agents
+	 * and what codex loaded from the working directory's `.agents`/`.codex`
+	 * folders. Upserts (keyed by customization id) leave MCP customizations
+	 * untouched.
 	 */
 	private async _refreshSkillHookCustomizations(session: ICodexSession): Promise<void> {
 		if (session.disposed) {
 			return;
 		}
-		const containers = await this._fetchSkillHookContainers(session);
+		const [workspaceAgents, skillHookContainers] = await Promise.all([
+			discoverCodexWorkspaceAgents(this._workingDirectories(session), this._fileService),
+			this._fetchSkillHookContainers(session),
+		]);
 		if (session.disposed) {
 			return;
 		}
-		for (const container of containers) {
+		for (const container of [...workspaceAgents.containers, ...skillHookContainers]) {
 			this._fire(session.sessionUri, { type: ActionType.SessionCustomizationUpdated, customization: container });
 		}
 	}

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { parseFrontMatter } from '../../../../base/common/yaml.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
 import { IFileService } from '../../../files/common/files.js';
-import { parseRuleFile, type IMcpServerDefinition, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
+import { parseRuleFile, type IMcpServerDefinition, type IParsedAgent, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import type { AgentSelection } from '../../common/state/protocol/state.js';
 import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
@@ -196,7 +196,13 @@ export function codexSkillRootsFromPlugins(plugins: readonly ICodexClientPlugin[
 	return [...roots].sort();
 }
 
-export async function codexCustomizationConfigFromPlugins(
+/**
+ * Builds Codex's launch-time roles and developer instructions. Workspace
+ * agents are processed first so the session's own repository wins a role-name
+ * collision with a global client plugin.
+ */
+export async function codexCustomizationConfig(
+	workspaceAgents: readonly IParsedAgent[],
 	plugins: readonly ICodexClientPlugin[],
 	selectedAgent: AgentSelection | undefined,
 	fileService: IFileService,
@@ -207,24 +213,42 @@ export async function codexCustomizationConfigFromPlugins(
 	let selectedAgentMatch = SelectedAgentMatch.None;
 	const selectedAgentUri = selectedAgent?.uri;
 
+	const addAgent = async (agent: IParsedAgent, match: SelectedAgentMatch): Promise<void> => {
+		try {
+			const content = (await fileService.readFile(agent.uri)).value.toString();
+			const frontmatter = parseFrontMatter(content);
+			const name = frontmatter?.getStringValue('name')?.trim() || agent.name;
+			const description = frontmatter?.getStringValue('description')?.trim() || agent.description || name;
+			const instructions = frontmatter?.body ?? content;
+			const model = frontmatter?.getStringArrayValue('model')?.map(value => value.trim()).find(Boolean) || agent.model;
+			const infer = frontmatter?.getBooleanValue('infer');
+			const disableModelInvocation = frontmatter?.getBooleanValue('disable-model-invocation') ?? (infer === false ? true : agent.disableModelInvocation);
+			if (!disableModelInvocation && !agentRoles.has(name)) {
+				agentRoles.set(name, {
+					name,
+					description,
+					instructions,
+					...(model ? { model } : {}),
+				});
+			}
+			if (match > selectedAgentMatch) {
+				selectedAgentInstructions = instructions;
+				selectedAgentMatch = match;
+			}
+		} catch { }
+	};
+
+	for (const agent of workspaceAgents) {
+		const match = selectedAgentUri && extUri.isEqual(agent.uri, URI.parse(selectedAgentUri))
+			? SelectedAgentMatch.Exact
+			: SelectedAgentMatch.None;
+		await addAgent(agent, match);
+	}
+
 	for (const plugin of plugins) {
 		for (const agent of plugin.parsed?.agents ?? []) {
-			try {
-				const content = (await fileService.readFile(agent.uri)).value.toString();
-				const frontmatter = parseFrontMatter(content);
-				const name = frontmatter?.getStringValue('name')?.trim() || agent.name;
-				const description = frontmatter?.getStringValue('description')?.trim() || agent.description || name;
-				const instructions = frontmatter?.body ?? content;
-				const model = frontmatter?.getStringValue('model')?.trim() || undefined;
-				if (!agentRoles.has(name)) {
-					agentRoles.set(name, { name, description, instructions, ...(model ? { model } : {}) });
-				}
-				const match = selectedAgentUri ? matchSelectedAgent(plugin, agent.uri, selectedAgentUri) : SelectedAgentMatch.None;
-				if (match > selectedAgentMatch) {
-					selectedAgentInstructions = instructions;
-					selectedAgentMatch = match;
-				}
-			} catch { }
+			const match = selectedAgentUri ? matchSelectedAgent(plugin, agent.uri, selectedAgentUri) : SelectedAgentMatch.None;
+			await addAgent(agent, match);
 		}
 
 		for (const instruction of plugin.parsed?.instructions ?? []) {

--- a/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexClientCustomizations.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { parseFrontMatter } from '../../../../base/common/yaml.js';
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../common/agentHostFileSystemService.js';
 import { IFileService } from '../../../files/common/files.js';
-import { parseRuleFile, type IMcpServerDefinition, type IParsedAgent, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
+import { parseRuleFile, resolveAgentDisableModelInvocation, type IMcpServerDefinition, type IParsedAgent, type IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import type { AgentSelection } from '../../common/state/protocol/state.js';
 import { type ChildCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
@@ -222,7 +222,7 @@ export async function codexCustomizationConfig(
 			const instructions = frontmatter?.body ?? content;
 			const model = frontmatter?.getStringArrayValue('model')?.map(value => value.trim()).find(Boolean) || agent.model;
 			const infer = frontmatter?.getBooleanValue('infer');
-			const disableModelInvocation = frontmatter?.getBooleanValue('disable-model-invocation') ?? (infer === false ? true : agent.disableModelInvocation);
+			const disableModelInvocation = resolveAgentDisableModelInvocation(infer, frontmatter?.getBooleanValue('disable-model-invocation'), agent.disableModelInvocation);
 			if (!disableModelInvocation && !agentRoles.has(name)) {
 				agentRoles.set(name, {
 					name,

--- a/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
@@ -63,12 +63,24 @@ export async function discoverCodexWorkspaceAgents(
 		}
 		seenDirectories.add(directoryKey);
 
+		let candidateFiles: readonly URI[];
+		try {
+			const stat = await fileService.resolve(directory);
+			candidateFiles = stat.children
+				?.filter(child => {
+					const filename = basename(child.resource);
+					return child.isFile && filename.endsWith('.md') && filename !== 'README.md';
+				})
+				.map(child => child.resource) ?? [];
+		} catch {
+			continue;
+		}
+
 		const children: IParsedAgent[] = [];
-		for (const resource of await readAgentComponents([directory], fileService)) {
-			const filename = basename(resource.uri);
-			// Match the VS Code/Copilot workspace convention: flat, exact-case
-			// markdown files, with README.md reserved for documentation.
-			if (!filename.endsWith('.md') || filename === 'README.md' || seenNames.has(resource.name)) {
+		// Candidate filtering happens before frontmatter parsing and name
+		// de-duplication so README metadata cannot suppress a real agent.
+		for (const resource of await readAgentComponents(candidateFiles, fileService)) {
+			if (seenNames.has(resource.name)) {
 				continue;
 			}
 			seenNames.add(resource.name);

--- a/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
+++ b/src/vs/platform/agentHost/node/codex/codexCustomizations.ts
@@ -6,9 +6,11 @@
 import { createHash } from 'crypto';
 import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, normalize } from '../../../../base/common/path.js';
-import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
+import { basename, extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CustomizationLoadStatus, CustomizationType, customizationId, type DirectoryCustomization, type HookCustomization, type SkillCustomization } from '../../common/state/sessionState.js';
+import { readAgentComponents, toParsedAgent, type IParsedAgent } from '../../../agentPlugins/common/pluginParsers.js';
+import type { IFileService } from '../../../files/common/files.js';
 import type { HookMetadata } from './protocol/generated/v2/HookMetadata.js';
 import type { HooksListResponse } from './protocol/generated/v2/HooksListResponse.js';
 import type { SelectedCapabilityRoot } from './protocol/generated/v2/SelectedCapabilityRoot.js';
@@ -35,6 +37,65 @@ import type { SkillsListResponse } from './protocol/generated/v2/SkillsListRespo
 const CODEX_SKILLS_SCHEME = 'codex-skills';
 /** Synthetic URI scheme for the codex hooks container. */
 const CODEX_HOOKS_SCHEME = 'codex-hooks';
+
+export interface ICodexWorkspaceAgentDiscovery {
+	readonly agents: readonly IParsedAgent[];
+	readonly containers: readonly DirectoryCustomization[];
+}
+
+/**
+ * Discovers custom agents owned by the session's workspace roots.
+ */
+export async function discoverCodexWorkspaceAgents(
+	workingDirectories: readonly URI[],
+	fileService: IFileService,
+): Promise<ICodexWorkspaceAgentDiscovery> {
+	const agents: IParsedAgent[] = [];
+	const containers: DirectoryCustomization[] = [];
+	const seenDirectories = new Set<string>();
+	const seenNames = new Set<string>();
+
+	for (const workingDirectory of workingDirectories) {
+		const directory = URI.joinPath(workingDirectory, '.github', 'agents');
+		const directoryKey = extUriBiasedIgnorePathCase.getComparisonKey(directory);
+		if (seenDirectories.has(directoryKey)) {
+			continue;
+		}
+		seenDirectories.add(directoryKey);
+
+		const children: IParsedAgent[] = [];
+		for (const resource of await readAgentComponents([directory], fileService)) {
+			const filename = basename(resource.uri);
+			// Match the VS Code/Copilot workspace convention: flat, exact-case
+			// markdown files, with README.md reserved for documentation.
+			if (!filename.endsWith('.md') || filename === 'README.md' || seenNames.has(resource.name)) {
+				continue;
+			}
+			seenNames.add(resource.name);
+			const agent = toParsedAgent(resource);
+			agents.push(agent);
+			children.push(agent);
+		}
+
+		if (children.length === 0) {
+			continue;
+		}
+		const uri = directory.toString();
+		containers.push({
+			type: CustomizationType.Directory,
+			id: customizationId(uri),
+			uri,
+			name: '.github',
+			enabled: true,
+			contents: CustomizationType.Agent,
+			writable: true,
+			load: { kind: CustomizationLoadStatus.Loaded },
+			children: children.map(agent => agent.customization),
+		});
+	}
+
+	return { agents, containers };
+}
 
 function localFileComparisonKey(resource: URI): { readonly key: string; readonly resource: URI } | undefined {
 	if (resource.scheme !== Schemas.file || !resource.path.startsWith('/') || !isAbsolute(resource.fsPath)) {

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -17,7 +17,7 @@ import { McpServerType, type IMcpServerConfiguration } from '../../../../mcp/com
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../common/agentHostFileSystemService.js';
 import type { ISyncedCustomization } from '../../../common/agentPluginManager.js';
 import { CustomizationType, McpServerStatus, type PluginCustomization } from '../../../common/state/protocol/channels-session/state.js';
-import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfigFromPlugins, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
+import { CodexClientCustomizationStore, codexAgentRoleToml, codexCustomizationConfig, codexMcpServersFromPlugins, codexSkillCapabilityRoots, codexSkillRootsFromPlugins, type ICodexClientPlugin } from '../../../node/codex/codexClientCustomizations.js';
 
 suite('codexClientCustomizations', () => {
 	const disposables = new DisposableStore();
@@ -139,7 +139,7 @@ suite('codexClientCustomizations', () => {
 			instructions: [instructionDef(instructionUri, 'repo')],
 		}))];
 
-		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: agentUri.toString() }, fileService);
+		const config = await codexCustomizationConfig([], plugins, { uri: agentUri.toString() }, fileService);
 
 		assert.deepStrictEqual(config, {
 			agentRoles: [{
@@ -159,6 +159,36 @@ suite('codexClientCustomizations', () => {
 		].join('\n'));
 	});
 
+	test('converts a selected workspace agent without a client plugin', async () => {
+		const agentUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.github/agents/reviewer.agent.md' });
+		await fileService.writeFile(agentUri, VSBuffer.fromString([
+			'---',
+			'name: Workspace Reviewer',
+			'description: Reviews workspace changes',
+			'model: [gpt-first, gpt-second]',
+			'tools: [read_file, search]',
+			'---',
+			'Review the workspace change.',
+		].join('\n')));
+
+		const config = await codexCustomizationConfig(
+			[agentDef(agentUri, 'reviewer')],
+			[],
+			{ uri: agentUri.toString() },
+			fileService,
+		);
+
+		assert.deepStrictEqual(config, {
+			agentRoles: [{
+				name: 'Workspace Reviewer',
+				description: 'Reviews workspace changes',
+				instructions: 'Review the workspace change.',
+				model: 'gpt-first',
+			}],
+			developerInstructions: 'Review the workspace change.',
+		});
+	});
+
 	test('does not promote path-scoped plugin instructions to thread-global instructions', async () => {
 		const globalInstructionUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/rules/global.instructions.md' });
 		const scopedInstructionUri = URI.from({ scheme: Schemas.inMemory, path: '/plugin/rules/typescript.instructions.md' });
@@ -171,7 +201,7 @@ suite('codexClientCustomizations', () => {
 			],
 		}))];
 
-		const config = await codexCustomizationConfigFromPlugins(plugins, undefined, fileService);
+		const config = await codexCustomizationConfig([], plugins, undefined, fileService);
 
 		assert.strictEqual(config.developerInstructions, 'Apply globally.');
 	});
@@ -197,7 +227,7 @@ suite('codexClientCustomizations', () => {
 			parsed: parsed({ agents: [agentDef(syncedAgentUri, 'reviewer')] }),
 		}];
 
-		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: sourceAgentUri.toString() }, fileService);
+		const config = await codexCustomizationConfig([], plugins, { uri: sourceAgentUri.toString() }, fileService);
 
 		assert.strictEqual(config.developerInstructions, 'Apply synced reviewer instructions.');
 	});
@@ -222,7 +252,7 @@ suite('codexClientCustomizations', () => {
 			parsed: parsed({ agents: [agentDef(syncedAgentUri, 'reviewer')] }),
 		}];
 
-		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: sourceAgentUri.toString() }, fileService);
+		const config = await codexCustomizationConfig([], plugins, { uri: sourceAgentUri.toString() }, fileService);
 
 		assert.strictEqual(config.developerInstructions, 'Apply loose reviewer instructions.');
 	});
@@ -253,7 +283,7 @@ suite('codexClientCustomizations', () => {
 			},
 		];
 
-		const config = await codexCustomizationConfigFromPlugins(plugins, { uri: selectedAgentUri.toString() }, fileService);
+		const config = await codexCustomizationConfig([], plugins, { uri: selectedAgentUri.toString() }, fileService);
 
 		assert.strictEqual(config.developerInstructions, 'Apply exact reviewer instructions.');
 	});

--- a/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexClientCustomizations.test.ts
@@ -167,6 +167,8 @@ suite('codexClientCustomizations', () => {
 			'description: Reviews workspace changes',
 			'model: [gpt-first, gpt-second]',
 			'tools: [read_file, search]',
+			'infer: true',
+			'disable-model-invocation: true',
 			'---',
 			'Review the workspace change.',
 		].join('\n')));

--- a/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
@@ -4,19 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { sep } from '../../../../../base/common/path.js';
 import { isLinux } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../log/common/log.js';
 import { CustomizationType } from '../../../common/state/protocol/channels-session/state.js';
-import { codexHooksToContainers, codexSelectedCapabilityRootCandidates, codexSkillsToContainers } from '../../../node/codex/codexCustomizations.js';
+import { codexHooksToContainers, codexSelectedCapabilityRootCandidates, codexSkillsToContainers, discoverCodexWorkspaceAgents } from '../../../node/codex/codexCustomizations.js';
 import type { HookMetadata } from '../../../node/codex/protocol/generated/v2/HookMetadata.js';
 import type { SkillMetadata } from '../../../node/codex/protocol/generated/v2/SkillMetadata.js';
 import type { SkillScope } from '../../../node/codex/protocol/generated/v2/SkillScope.js';
 import type { SkillsListResponse } from '../../../node/codex/protocol/generated/v2/SkillsListResponse.js';
 
 suite('codexCustomizations', () => {
+
+	const disposables = new DisposableStore();
+	teardown(() => disposables.clear());
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -28,6 +36,79 @@ suite('codexCustomizations', () => {
 
 	const hook = (key: string, eventName: HookMetadata['eventName'], sourcePath: string, displayOrder = 0, enabled = true): HookMetadata =>
 		({ key, eventName, handlerType: 'command', matcher: null, command: 'echo hi', timeoutSec: 5n, statusMessage: null, additionalContextLimit: null, sourcePath, source: 'project', pluginId: null, displayOrder: BigInt(displayOrder), enabled, isManaged: false, currentHash: 'h', trustStatus: 'trusted' });
+
+	test('discovers workspace agents without client-pushed local customizations', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		const workspace = URI.from({ scheme: Schemas.inMemory, path: '/workspace' });
+		const agentsDirectory = URI.joinPath(workspace, '.github', 'agents');
+		const agent = URI.joinPath(agentsDirectory, 'reviewer.agent.md');
+		await fileService.createFolder(agentsDirectory);
+		await Promise.all([
+			fileService.writeFile(agent, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews carefully\nmodel: [gpt-first, gpt-second]\ntools: [read_file, search]\n---\nReview every change.')),
+			fileService.writeFile(URI.joinPath(agentsDirectory, 'README.md'), VSBuffer.fromString('Documentation only.')),
+		]);
+
+		const discovered = await discoverCodexWorkspaceAgents([workspace], fileService);
+
+		assert.deepStrictEqual({
+			agents: discovered.agents.map(item => ({ name: item.name, uri: item.uri.toString() })),
+			containers: discovered.containers.map(container => ({
+				uri: container.uri,
+				contents: container.contents,
+				writable: container.writable,
+				children: container.children?.map(child => ({ name: child.name, uri: child.uri, model: child.type === CustomizationType.Agent ? child.model : undefined, tools: child.type === CustomizationType.Agent ? child.tools : undefined })),
+			})),
+		}, {
+			agents: [{ name: 'Reviewer', uri: agent.toString() }],
+			containers: [{
+				uri: agentsDirectory.toString(),
+				contents: CustomizationType.Agent,
+				writable: true,
+				children: [{ name: 'Reviewer', uri: agent.toString(), model: 'gpt-first', tools: ['read_file', 'search'] }],
+			}],
+		});
+	});
+
+	test('discovers every workspace root with primary-root name precedence', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		const primaryWorkspace = URI.from({ scheme: Schemas.inMemory, path: '/primary' });
+		const secondaryWorkspace = URI.from({ scheme: Schemas.inMemory, path: '/secondary' });
+		const primaryDirectory = URI.joinPath(primaryWorkspace, '.github', 'agents');
+		const secondaryDirectory = URI.joinPath(secondaryWorkspace, '.github', 'agents');
+		const primaryAgent = URI.joinPath(primaryDirectory, 'reviewer.agent.md');
+		const secondaryAgent = URI.joinPath(secondaryDirectory, 'reviewer.agent.md');
+		const secondaryOnlyAgent = URI.joinPath(secondaryDirectory, 'secondary.agent.md');
+		await Promise.all([
+			fileService.createFolder(primaryDirectory),
+			fileService.createFolder(secondaryDirectory),
+		]);
+		await Promise.all([
+			fileService.writeFile(primaryAgent, VSBuffer.fromString('---\nname: Shared Reviewer\n---\nUse the primary workspace instructions.')),
+			fileService.writeFile(secondaryAgent, VSBuffer.fromString('---\nname: Shared Reviewer\n---\nDo not use the duplicate.')),
+			fileService.writeFile(secondaryOnlyAgent, VSBuffer.fromString('---\nname: Secondary Agent\n---\nUse the secondary workspace instructions.')),
+		]);
+
+		const discovered = await discoverCodexWorkspaceAgents([primaryWorkspace, secondaryWorkspace, primaryWorkspace], fileService);
+
+		assert.deepStrictEqual({
+			agents: discovered.agents.map(agent => ({ name: agent.name, uri: agent.uri.toString() })),
+			containers: discovered.containers.map(container => ({
+				uri: container.uri,
+				children: container.children?.map(child => ({ name: child.name, uri: child.uri })),
+			})),
+		}, {
+			agents: [
+				{ name: 'Shared Reviewer', uri: primaryAgent.toString() },
+				{ name: 'Secondary Agent', uri: secondaryOnlyAgent.toString() },
+			],
+			containers: [
+				{ uri: primaryDirectory.toString(), children: [{ name: 'Shared Reviewer', uri: primaryAgent.toString() }] },
+				{ uri: secondaryDirectory.toString(), children: [{ name: 'Secondary Agent', uri: secondaryOnlyAgent.toString() }] },
+			],
+		});
+	});
 
 	test('groups skills by scope into read-only containers, sorted by name', () => {
 		const containers = codexSkillsToContainers(skillsResponse({

--- a/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexCustomizations.test.ts
@@ -45,14 +45,14 @@ suite('codexCustomizations', () => {
 		const agent = URI.joinPath(agentsDirectory, 'reviewer.agent.md');
 		await fileService.createFolder(agentsDirectory);
 		await Promise.all([
-			fileService.writeFile(agent, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews carefully\nmodel: [gpt-first, gpt-second]\ntools: [read_file, search]\n---\nReview every change.')),
-			fileService.writeFile(URI.joinPath(agentsDirectory, 'README.md'), VSBuffer.fromString('Documentation only.')),
+			fileService.writeFile(agent, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews carefully\nmodel: [gpt-first, gpt-second]\ntools: [read_file, search]\ninfer: true\ndisable-model-invocation: true\n---\nReview every change.')),
+			fileService.writeFile(URI.joinPath(agentsDirectory, 'README.md'), VSBuffer.fromString('---\nname: Reviewer\n---\nDocumentation only.')),
 		]);
 
 		const discovered = await discoverCodexWorkspaceAgents([workspace], fileService);
 
 		assert.deepStrictEqual({
-			agents: discovered.agents.map(item => ({ name: item.name, uri: item.uri.toString() })),
+			agents: discovered.agents.map(item => ({ name: item.name, uri: item.uri.toString(), agentInvocable: item.disableModelInvocation !== true })),
 			containers: discovered.containers.map(container => ({
 				uri: container.uri,
 				contents: container.contents,
@@ -60,7 +60,7 @@ suite('codexCustomizations', () => {
 				children: container.children?.map(child => ({ name: child.name, uri: child.uri, model: child.type === CustomizationType.Agent ? child.model : undefined, tools: child.type === CustomizationType.Agent ? child.tools : undefined })),
 			})),
 		}, {
-			agents: [{ name: 'Reviewer', uri: agent.toString() }],
+			agents: [{ name: 'Reviewer', uri: agent.toString(), agentInvocable: true }],
 			containers: [{
 				uri: agentsDirectory.toString(),
 				contents: CustomizationType.Agent,

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -879,6 +879,64 @@ suite('CodexAgent prewarm eviction', () => {
 		peer.exit();
 	});
 
+	test('resumes an established thread when the selected workspace agent changes', async () => {
+		const agent = await createAgent(disposables);
+		agent['_schedulePrewarm'] = () => { };
+		agent['_refreshSkillHookCustomizations'] = async () => { };
+		agent['_refreshSkillExtraRoots'] = async () => { };
+		const peer = disposables.add(createTestPeer());
+		agent['_connection'] = {
+			kind: 'ready',
+			client: new CodexAppServerClient(peer.transport),
+			usageSource: 'github',
+			child: { kill: () => true },
+		} as never;
+
+		const repo = URI.file('/repo-workspace-agent-edit');
+		const agentUri = URI.joinPath(repo, '.github', 'agents', 'reviewer.agent.md');
+		await agent['_fileService'].writeFile(agentUri, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews changes\n---\nUse the original instructions.'));
+		const { session } = await createSession(agent, {
+			workingDirectories: [repo],
+			model: { id: COPILOT_TEST_MODEL },
+			agent: { uri: agentUri.toString() },
+		});
+		const chat = URI.parse(buildDefaultChatUri(session));
+
+		const firstSend = agent.chats.sendMessage(chat, 'first', [repo], undefined, 'turn-1');
+		const start = await readNextRequest(peer.outbound);
+		peer.push({ id: start.id, result: { thread: { id: 'thread-workspace-agent' } } });
+		const firstTurn = await readNextRequest(peer.outbound);
+		peer.push({ id: firstTurn.id, result: {} });
+		await firstSend;
+
+		await agent['_fileService'].writeFile(agentUri, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews changes\n---\nUse the updated instructions.'));
+		const secondSend = agent.chats.sendMessage(chat, 'second', [repo], undefined, 'turn-2');
+		const resume = await readNextRequest(peer.outbound);
+		const resumedAgents = resume.params.config?.['agents'] as Record<string, { description: string; config_file: string }>;
+		const resumedRoleFile = await fs.promises.readFile(resumedAgents.Reviewer.config_file, 'utf8');
+		peer.push({ id: resume.id, result: { thread: { id: 'thread-workspace-agent', cwd: repo.fsPath }, cwd: repo.fsPath } });
+		const secondTurn = await readNextRequest(peer.outbound);
+		peer.push({ id: secondTurn.id, result: {} });
+		await secondSend;
+
+		assert.deepStrictEqual({
+			start: { method: start.method, developerInstructions: start.params.developerInstructions },
+			firstTurn: { method: firstTurn.method, developerInstructions: firstTurn.params.collaborationMode?.settings.developer_instructions },
+			resume: { method: resume.method, developerInstructions: resume.params.developerInstructions },
+			secondTurn: { method: secondTurn.method, developerInstructions: secondTurn.params.collaborationMode?.settings.developer_instructions },
+			resumedRoleFile,
+			needsResume: agent['_sessions'].get(AgentSession.id(session))?.needsResume,
+		}, {
+			start: { method: 'thread/start', developerInstructions: 'Use the original instructions.' },
+			firstTurn: { method: 'turn/start', developerInstructions: 'Use the original instructions.' },
+			resume: { method: 'thread/resume', developerInstructions: 'Use the updated instructions.' },
+			secondTurn: { method: 'turn/start', developerInstructions: 'Use the updated instructions.' },
+			resumedRoleFile: 'name = "Reviewer"\ndescription = "Reviews changes"\ndeveloper_instructions = "Use the updated instructions."\n',
+			needsResume: false,
+		});
+		peer.exit();
+	});
+
 	test('fresh multi-root start selects only existing secondary skill directories', async () => {
 		const agent = await createAgent(disposables, { multiRootEnabled: true });
 		const peer = disposables.add(createTestPeer());

--- a/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPrewarmEviction.test.ts
@@ -911,6 +911,8 @@ suite('CodexAgent prewarm eviction', () => {
 
 		await agent['_fileService'].writeFile(agentUri, VSBuffer.fromString('---\nname: Reviewer\ndescription: Reviews changes\n---\nUse the updated instructions.'));
 		const secondSend = agent.chats.sendMessage(chat, 'second', [repo], undefined, 'turn-2');
+		const unsubscribe = await readNextRequest(peer.outbound);
+		peer.push({ id: unsubscribe.id, result: {} });
 		const resume = await readNextRequest(peer.outbound);
 		const resumedAgents = resume.params.config?.['agents'] as Record<string, { description: string; config_file: string }>;
 		const resumedRoleFile = await fs.promises.readFile(resumedAgents.Reviewer.config_file, 'utf8');
@@ -922,6 +924,7 @@ suite('CodexAgent prewarm eviction', () => {
 		assert.deepStrictEqual({
 			start: { method: start.method, developerInstructions: start.params.developerInstructions },
 			firstTurn: { method: firstTurn.method, developerInstructions: firstTurn.params.collaborationMode?.settings.developer_instructions },
+			unsubscribe: { method: unsubscribe.method, threadId: unsubscribe.params.threadId },
 			resume: { method: resume.method, developerInstructions: resume.params.developerInstructions },
 			secondTurn: { method: secondTurn.method, developerInstructions: secondTurn.params.collaborationMode?.settings.developer_instructions },
 			resumedRoleFile,
@@ -929,6 +932,7 @@ suite('CodexAgent prewarm eviction', () => {
 		}, {
 			start: { method: 'thread/start', developerInstructions: 'Use the original instructions.' },
 			firstTurn: { method: 'turn/start', developerInstructions: 'Use the original instructions.' },
+			unsubscribe: { method: 'thread/unsubscribe', threadId: 'thread-workspace-agent' },
 			resume: { method: 'thread/resume', developerInstructions: 'Use the updated instructions.' },
 			secondTurn: { method: 'turn/start', developerInstructions: 'Use the updated instructions.' },
 			resumedRoleFile: 'name = "Reviewer"\ndescription = "Reviews changes"\ndeveloper_instructions = "Use the updated instructions."\n',

--- a/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/codexCustomizations.integrationTest.ts
@@ -18,11 +18,12 @@ import { ActionType } from '../../../common/state/sessionActions.js';
 import { AgentHostCodexEnabledConfigKey } from '../../../common/agentHostSchema.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
 import { type SubscribeResult } from '../../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
+import { buildDefaultChatUri, customizationId, CustomizationType, MessageKind, ROOT_STATE_URI, type ClientPluginCustomization, type DirectoryCustomization, type McpServerCustomization, type PluginCustomization, type URI as ProtocolURI } from '../../../common/state/sessionState.js';
 import { fetchSessionWithChat, getActionEnvelope, isActionNotification, type IServerHandle, startRealServer, stopServer, TestProtocolClient } from '../serverIntegrationTestHelpers.js';
 import { CODEX_SDK_ROOT } from '../e2e/providers/codexTestConfiguration.js';
 
 const AGENT_MARKER = 'CODEX_CUSTOM_AGENT_INSTRUCTION_MARKER';
+const WORKSPACE_AGENT_MARKER = 'CODEX_WORKSPACE_AGENT_INSTRUCTION_MARKER';
 const RULE_MARKER = 'CODEX_PLUGIN_RULE_MARKER';
 const SKILL_MARKER = 'CODEX_PLUGIN_SKILL_DESCRIPTION_MARKER';
 const MCP_MARKER = 'CODEX_PLUGIN_MCP_TOOL_MARKER';
@@ -58,6 +59,23 @@ async function waitForParsedPlugin(client: TestProtocolClient, sessionUri: strin
 		await new Promise<void>(resolve => setTimeout(resolve, 100));
 	}
 	throw new Error(`Timed out waiting for parsed plugin ${pluginUri}; last state: ${JSON.stringify(lastPlugin)}`);
+}
+
+async function waitForWorkspaceAgent(client: TestProtocolClient, sessionUri: string, agentUri: string): Promise<DirectoryCustomization> {
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		const session = await fetchSessionWithChat(client, sessionUri);
+		const directory = session.customizations?.find((customization): customization is DirectoryCustomization =>
+			customization.type === CustomizationType.Directory
+			&& customization.contents === CustomizationType.Agent
+			&& customization.children?.some(child => child.type === CustomizationType.Agent && child.uri === agentUri) === true
+		);
+		if (directory) {
+			return directory;
+		}
+		await new Promise<void>(resolve => setTimeout(resolve, 100));
+	}
+	throw new Error(`Timed out waiting for workspace agent ${agentUri}`);
 }
 
 suite('Agent Host Provider Integration — Codex Customizations', function () {
@@ -251,6 +269,74 @@ suite('Agent Host Provider Integration — Codex Customizations', function () {
 		assert.ok(developerText.includes(RULE_MARKER), 'plugin instructions must reach the Codex developer message');
 		assert.ok(requestText.includes(SKILL_MARKER), 'plugin skills must be advertised in the Codex model request');
 		assert.ok(requestText.includes(MCP_MARKER), 'plugin MCP tools must be advertised in the Codex model request');
+	});
+
+	test('workspace agent is exposed and selected without client customization sync', async function () {
+		this.timeout(180_000);
+
+		const workspaceDir = await mkdtemp(join(tmpdir(), 'codex-workspace-agent-'));
+		tempDirs.push(workspaceDir);
+		const agentsDir = join(workspaceDir, '.github', 'agents');
+		const agentFile = join(agentsDir, 'workspace-reviewer.agent.md');
+		const agentUri = URI.file(agentFile).toString();
+		await mkdir(agentsDir, { recursive: true });
+		await writeFile(agentFile, [
+			'---',
+			'name: Workspace Reviewer',
+			'description: Reviews this workspace.',
+			'---',
+			`Always follow ${WORKSPACE_AGENT_MARKER}.`,
+		].join('\n'));
+
+		const clientId = 'codex-workspace-agent-client';
+		await client.call('initialize', { channel: ROOT_STATE_URI, protocolVersions: [PROTOCOL_VERSION], clientId }, 30_000);
+		await client.call('authenticate', { channel: ROOT_STATE_URI, resource: 'https://api.github.com', token: 'not-a-real-token' }, 30_000);
+		const sessionUri = URI.from({ scheme: 'codex', path: `/${generateUuid()}` }).toString();
+		await client.call('createSession', {
+			channel: sessionUri,
+			provider: 'codex',
+			workingDirectories: [URI.file(workspaceDir).toString()],
+			config: { isolation: 'folder' },
+			activeClient: { clientId, tools: [], customizations: [] },
+		}, 30_000);
+		createdSessions.push(sessionUri);
+		await client.call<SubscribeResult>('subscribe', { channel: sessionUri });
+		await client.call<SubscribeResult>('subscribe', { channel: buildDefaultChatUri(sessionUri) });
+		client.clearReceived();
+
+		const directory = await waitForWorkspaceAgent(client, sessionUri, agentUri);
+		assert.deepStrictEqual(directory.children?.map(child => ({ type: child.type, name: child.name, uri: child.uri })), [{
+			type: CustomizationType.Agent,
+			name: 'Workspace Reviewer',
+			uri: agentUri,
+		}]);
+
+		const turnId = 'turn-codex-workspace-agent';
+		client.dispatch({
+			channel: buildDefaultChatUri(sessionUri),
+			clientSeq: 1,
+			action: {
+				type: ActionType.ChatTurnStarted,
+				turnId,
+				startedAt: '2026-08-13T00:00:00.000Z',
+				message: {
+					text: 'Reply with exactly CODEX_WORKSPACE_AGENT_OK.',
+					origin: { kind: MessageKind.User },
+					agent: { uri: agentUri },
+				},
+			},
+		});
+		await client.waitForNotification(notification =>
+			isActionNotification(notification, 'chat/turnComplete')
+			&& getActionEnvelope(notification).channel === buildDefaultChatUri(sessionUri)
+			&& (getActionEnvelope(notification).action as { turnId?: string }).turnId === turnId,
+			120_000,
+		);
+
+		const requests = (server.mockLlm?.getRequests?.() ?? []) as readonly ICapturedRequest[];
+		const responsesRequest = [...requests].reverse().find(request => request.path.includes('/responses'));
+		assert.ok(responsesRequest, `expected a Codex /responses request; got paths: ${requests.map(request => request.path).join(', ')}`);
+		assert.ok(developerInputText(responsesRequest.body).includes(WORKSPACE_AGENT_MARKER), 'selected workspace-agent instructions must reach the Codex developer message');
 	});
 
 	test('standalone host registers Codex after runtime enablement', async function () {

--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -98,8 +98,16 @@ export interface INamedPluginResource {
 	readonly description?: string;
 }
 
+/** A parsed agent resource with the frontmatter metadata shared by providers. */
+export interface IAgentPluginResource extends INamedPluginResource {
+	readonly model?: string;
+	readonly tools?: readonly string[];
+	readonly disableModelInvocation?: boolean;
+	readonly disableUserInvocation?: boolean;
+}
+
 /** A parsed agent paired with its protocol-level child customization. */
-export interface IParsedAgent extends INamedPluginResource {
+export interface IParsedAgent extends IAgentPluginResource {
 	readonly customization: AgentCustomization;
 }
 
@@ -299,7 +307,7 @@ function buildChildId(uri: URI, disambiguator?: string): string {
 	return `${base.replace(/#/g, '%23')}#${disambiguator}`;
 }
 
-function makeAgentCustomization(resource: INamedPluginResource): AgentCustomization {
+function makeAgentCustomization(resource: IAgentPluginResource): AgentCustomization {
 	const uri = resource.uri.toString();
 	return {
 		type: CustomizationType.Agent,
@@ -307,6 +315,10 @@ function makeAgentCustomization(resource: INamedPluginResource): AgentCustomizat
 		uri,
 		name: resource.name,
 		...(resource.description ? { description: resource.description } : {}),
+		...(resource.model ? { model: resource.model } : {}),
+		...(resource.tools?.length ? { tools: [...resource.tools] } : {}),
+		...(resource.disableModelInvocation ? { disableModelInvocation: true } : {}),
+		...(resource.disableUserInvocation ? { disableUserInvocation: true } : {}),
 	};
 }
 
@@ -1100,26 +1112,30 @@ export async function readAgentComponents(
 	dirs: readonly URI[],
 	fileService: IFileService,
 	options?: { readonly containmentRoot?: URI },
-): Promise<readonly INamedPluginResource[]> {
+): Promise<readonly IAgentPluginResource[]> {
 	const files = await readMarkdownComponents(dirs, fileService, options);
 	if (files.length === 0) {
 		return files;
 	}
 	const enriched = await Promise.all(files.map(async file => {
 		try {
-			const { name, description } = await parseAgentFile(file.uri, fileService);
+			const parsed = await parseAgentFile(file.uri, fileService);
 			return {
 				uri: file.uri,
-				name: name || file.name,
-				...(description ? { description } : {}),
-			} satisfies INamedPluginResource;
+				name: parsed.name || file.name,
+				...(parsed.description ? { description: parsed.description } : {}),
+				...(parsed.model ? { model: parsed.model } : {}),
+				...(parsed.tools?.length ? { tools: parsed.tools } : {}),
+				...(parsed.disableModelInvocation ? { disableModelInvocation: true } : {}),
+				...(parsed.userInvocable === false ? { disableUserInvocation: true } : {}),
+			} satisfies IAgentPluginResource;
 		} catch {
 			return file;
 		}
 	}));
 	// De-dupe again in case frontmatter `name` collides; first-seen wins.
 	const seen = new Set<string>();
-	const result: INamedPluginResource[] = [];
+	const result: IAgentPluginResource[] = [];
 	for (const item of enriched) {
 		if (seen.has(item.name)) {
 			continue;
@@ -1131,7 +1147,7 @@ export async function readAgentComponents(
 	return result;
 }
 
-export async function parseAgentFile(uri: URI, fileService: IFileService): Promise<{ name: string; description?: string; userInvocable?: boolean }> {
+export async function parseAgentFile(uri: URI, fileService: IFileService): Promise<{ name: string; description?: string; userInvocable?: boolean; model?: string; tools?: readonly string[]; disableModelInvocation?: boolean }> {
 	// Use regex to strip the trailing `.agent.md` or .md before parsing, so we can fall back to a cleaner name if frontmatter is missing or broken.
 	const nameFromFile = basename(uri).replace(/(\.agent)?\.md$/i, '');
 	try {
@@ -1140,7 +1156,11 @@ export async function parseAgentFile(uri: URI, fileService: IFileService): Promi
 		const name = frontmatter?.getStringValue('name')?.trim() || nameFromFile;
 		const description = frontmatter?.getStringValue('description')?.trim();
 		const userInvocable = frontmatter?.getBooleanValue('user-invocable');
-		return { name, description, userInvocable };
+		const model = frontmatter?.getStringArrayValue('model')?.map(value => value.trim()).find(Boolean);
+		const tools = frontmatter?.getStringArrayValue('tools')?.map(value => value.trim()).filter(Boolean);
+		const infer = frontmatter?.getBooleanValue('infer');
+		const disableModelInvocation = frontmatter?.getBooleanValue('disable-model-invocation') ?? (infer === false ? true : undefined);
+		return { name, description, userInvocable, model, tools, disableModelInvocation };
 	} catch {
 		return { name: nameFromFile };
 	}
@@ -1339,8 +1359,8 @@ export async function parsePlugin(
 	};
 }
 
-/** Pairs an agent {@link INamedPluginResource} with its protocol-level {@link AgentCustomization}. */
-export function toParsedAgent(resource: INamedPluginResource): IParsedAgent {
+/** Pairs an agent {@link IAgentPluginResource} with its protocol-level {@link AgentCustomization}. */
+export function toParsedAgent(resource: IAgentPluginResource): IParsedAgent {
 	return { ...resource, customization: makeAgentCustomization(resource) };
 }
 

--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -1159,11 +1159,16 @@ export async function parseAgentFile(uri: URI, fileService: IFileService): Promi
 		const model = frontmatter?.getStringArrayValue('model')?.map(value => value.trim()).find(Boolean);
 		const tools = frontmatter?.getStringArrayValue('tools')?.map(value => value.trim()).filter(Boolean);
 		const infer = frontmatter?.getBooleanValue('infer');
-		const disableModelInvocation = frontmatter?.getBooleanValue('disable-model-invocation') ?? (infer === false ? true : undefined);
+		const disableModelInvocation = resolveAgentDisableModelInvocation(infer, frontmatter?.getBooleanValue('disable-model-invocation'));
 		return { name, description, userInvocable, model, tools, disableModelInvocation };
 	} catch {
 		return { name: nameFromFile };
 	}
+}
+
+/** Resolves the deprecated `infer` field before its modern replacement, matching workspace-agent parsing. */
+export function resolveAgentDisableModelInvocation(infer: boolean | undefined, disableModelInvocation: boolean | undefined, fallback?: boolean): boolean | undefined {
+	return infer !== undefined ? !infer : (disableModelInvocation ?? fallback);
 }
 
 export async function parseSkillFile(uri: URI, fileService: IFileService): Promise<{ name: string; description?: string; userInvokable?: boolean }> {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
@@ -210,9 +210,8 @@ class AgentCustomizationScope extends Disposable {
 						this._sessionType,
 						shouldSyncWorkspaceDotMcp(this._sessionType, this._roots, this._configurationService.getValue(AgentHostCopilotMultiRootEnabledSettingId) === true),
 						this._options,
-						this._roots,
 					),
-					resolveLocalCustomAgents(this._fileService, this._promptsService, this._syncProvider, this._agentPluginService, this._sessionType, this._options, this._roots),
+					resolveLocalCustomAgents(this._fileService, this._promptsService, this._syncProvider, this._agentPluginService, this._sessionType, this._options),
 				]);
 				if (seq !== this._updateSeq) {
 					return;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -104,23 +104,16 @@ export async function enumerateLocalCustomizationsForHarness(
 	sessionType: string,
 	token: CancellationToken,
 	options: ILocalCustomizationSyncOptions | undefined,
-	roots: readonly URI[],
 ): Promise<readonly ILocalCustomizationFile[]> {
 	const result: ILocalCustomizationFile[] = [];
 	const seenUris = new ResourceSet();
 	const storageSources = options?.includeUserStorage
 		? [PromptsStorage.user, ...SYNCABLE_STORAGE_SOURCES]
 		: SYNCABLE_STORAGE_SOURCES;
-	const rootsToResolve = roots.length > 0 ? roots : [undefined];
 	for (const type of SYNCABLE_PROMPT_TYPES) {
 		const userDisabled = promptsService.getDisabledPromptFiles(type);
 		const lists = await Promise.all(
-			storageSources.map(async storage => {
-				const filesByRoot = storage === PromptsStorage.local
-					? await Promise.all(rootsToResolve.map(root => promptsService.listPromptFilesForStorage(type, storage, token, root)))
-					: [await promptsService.listPromptFilesForStorage(type, storage, token)];
-				return filesByRoot.flat();
-			}),
+			storageSources.map(storage => promptsService.listPromptFilesForStorage(type, storage, token)),
 		);
 		for (let i = 0; i < lists.length; i++) {
 			const source = storageSources[i];
@@ -162,13 +155,12 @@ export async function resolveLocalCustomAgents(
 	agentPluginService: IAgentPluginService,
 	sessionType: string,
 	options: ILocalCustomizationSyncOptions | undefined,
-	roots: readonly URI[],
 ): Promise<readonly AgentCustomization[]> {
 	const plugins = agentPluginService.plugins.get();
 	const result: AgentCustomization[] = [];
 	const parser = new PromptFileParser();
 	const pending: Promise<void>[] = [];
-	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options, roots);
+	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options);
 
 	for (const agent of enumerated) {
 		if (agent.type !== PromptsType.agent || agent.disabled) {
@@ -397,9 +389,8 @@ export async function resolveCustomizationRefs(
 	sessionType: string,
 	includeWorkspaceDotMcp: boolean,
 	options: ILocalCustomizationSyncOptions | undefined,
-	roots: readonly URI[],
 ): Promise<ClientPluginCustomization[]> {
-	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options, roots);
+	const enumerated = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, sessionType, CancellationToken.None, options);
 	const enabled = enumerated.filter(e => !e.disabled);
 
 	const plugins = agentPluginService.plugins.get();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/enumerateLocalCustomizationsForHarness.test.ts
@@ -52,7 +52,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [makePromptPath(builtin, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage)]],
 		]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
 
 		assert.deepStrictEqual(result, [{
 			uri: builtin,
@@ -64,15 +64,17 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		}]);
 	});
 
-	test('combines extension and built-in storage entries', async () => {
+	test('combines extension and built-in storage entries without workspace-local files', async () => {
 		const extensionAgent = URI.file('/extension/agents/foo.agent.md');
 		const builtinSkill = URI.file('/builtin/merge/SKILL.md');
+		const workspaceAgent = URI.file('/workspace/.github/agents/local.agent.md');
 		const promptsService = makePromptsService(new Map([
 			[`${PromptsType.agent}/${PromptsStorage.extension}`, [makePromptPath(extensionAgent, PromptsType.agent, PromptsStorage.extension)]],
+			[`${PromptsType.agent}/${PromptsStorage.local}`, [makePromptPath(workspaceAgent, PromptsType.agent, PromptsStorage.local)]],
 			[`${PromptsType.skill}/${BUILTIN_STORAGE}`, [makePromptPath(builtinSkill, PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage)]],
 		]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
 
 		assert.deepStrictEqual(result.map((e: { uri: URI; type: PromptsType; source: unknown; disabled: boolean }) => ({ uri: e.uri.toString(), type: e.type, source: e.source, disabled: e.disabled })), [
 			{ uri: extensionAgent.toString(), type: PromptsType.agent, source: AICustomizationSources.extension, disabled: false },
@@ -87,7 +89,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		]));
 		const syncProvider = new FakeSyncProvider(new Set([builtin.toString()]));
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, syncProvider, SessionType.CopilotCLI, CancellationToken.None, undefined);
 
 		assert.strictEqual(result.length, 1);
 		assert.strictEqual(result[0].disabled, true);
@@ -105,8 +107,8 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			[`${PromptsType.prompt}/${PromptsStorage.user}`, [makePromptPath(userPrompt, PromptsType.prompt, PromptsStorage.user)]],
 		]));
 
-		const localResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
-		const remoteResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, { includeUserStorage: true }, []);
+		const localResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
+		const remoteResult = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, { includeUserStorage: true });
 
 		assert.deepStrictEqual({
 			local: localResult,
@@ -138,7 +140,6 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			SessionType.CopilotCLI,
 			CancellationToken.None,
 			{ includeUserStorage: true },
-			[]
 		);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
@@ -163,7 +164,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			new Map([[PromptsType.skill, new ResourceSet([disabledSkill])]]),
 		);
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
 			{ uri: disabledSkill.toString(), disabled: true },
@@ -188,7 +189,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 			new Map([[PromptsType.agent, new ResourceSet([hiddenAgent])]]),
 		);
 
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
 
 		assert.deepStrictEqual(result.map(item => ({ uri: item.uri.toString(), disabled: item.disabled })), [
 			{ uri: hiddenAgent.toString(), disabled: false },
@@ -201,7 +202,7 @@ suite('enumerateLocalCustomizationsForHarness', () => {
 		// throwing). Model that here to confirm enumeration is a no-op outside
 		// Sessions.
 		const promptsService = makePromptsService(new Map());
-		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined, []);
+		const result = await enumerateLocalCustomizationsForHarness(promptsService, new FakeSyncProvider(), SessionType.CopilotCLI, CancellationToken.None, undefined);
 		assert.deepStrictEqual(result, []);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -217,7 +217,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -250,7 +249,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(bundler.received[0].map(f => f.uri.toString()), [enabled.toString()]);
@@ -284,7 +282,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(bundler.received[0].map(f => f.uri.toString()), [enabled.toString()]);
@@ -310,7 +307,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -347,7 +343,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		await resolveCustomizationRefs(
 			makeFileService(),
@@ -360,7 +355,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			{ includeUserStorage: true },
-			[]
 		);
 
 		assert.deepStrictEqual({
@@ -390,7 +384,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -413,7 +406,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -435,7 +427,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(refs.map(ref => ({ uri: ref.uri, name: ref.name })), [
@@ -456,7 +447,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -477,7 +467,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -495,7 +484,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		assert.deepStrictEqual(refs, []);
 	});
@@ -517,7 +505,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		assert.deepStrictEqual(refs.map(r => r.uri), [pluginUri.toString()]);
 	});
@@ -537,7 +524,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 		assert.deepStrictEqual(refs, []);
 		// Use CancellationToken so the import isn't dead in the bundle.
@@ -561,7 +547,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -597,7 +582,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			'agent-host-copilotcli',
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, [[
@@ -620,7 +604,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			'remote-test-copilotcli',
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, []);
@@ -640,7 +623,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			'agent-host-claude',
 			false,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(bundler.receivedMcp, [[
@@ -665,7 +647,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		// No loose files and no non-plugin MCP servers: bundler is never called.
@@ -690,7 +671,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -713,7 +693,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -736,7 +715,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -759,7 +737,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			true,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -786,7 +763,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			true,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -809,7 +785,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -837,7 +812,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -860,7 +834,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -890,7 +863,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 0);
@@ -913,7 +885,6 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			SessionType.CopilotCLI,
 			false,
 			undefined,
-			[]
 		);
 
 		assert.strictEqual(bundler.received.length, 1);
@@ -950,7 +921,6 @@ suite('resolveLocalCustomAgents', () => {
 			makeAgentPluginService([plugin]),
 			SessionType.CopilotCLI,
 			undefined,
-			[]
 		);
 
 		assert.deepStrictEqual(agents, [{


### PR DESCRIPTION
## Summary

- stop the client from bundling workspace-local chat customizations into the plugin sent to Agent Host
- discover `.github/agents/*.md` inside the Codex Agent Host for each session workspace root
- preserve multi-root precedence, surface discovered agents in Customizations, and apply the selected agent's instructions
- honor VS Code's `infer` precedence and filter reserved documentation before agent-name de-duplication
- resume established Codex threads when workspace agent roles or selected instructions change
- carry supported agent frontmatter into Codex roles and cover discovery, selection, reconciliation, and integration behavior with tests

This makes the harness authoritative for workspace discovery, preventing duplicate Agent Picker entries while retaining Codex workspace custom-agent support.

Fixes #330591

## Validation

- `npm run compile`
- `npm run compile-client` after review fixes
- `npm run hygiene`
- focused unit suites: 119 passing initially; 107 passing after review fixes
- Codex customization integration tests: 4 passing
- targeted real Codex app-server regression
- Launch skill manual verification: workspace agent appeared exactly once and was selectable
- `git diff --check`

## Reviewer notes

Codex currently cannot enforce VS Code tool allowlists, so parsed tool metadata is surfaced but not applied to the role. Model lists use the first model, and path-scoped instructions have no Codex equivalent. The separate MCP "Built-in" labeling follow-up is intentionally not included.