### PR TITLE
Hide breadcrumbs in compact windows

### DIFF
--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -377,6 +377,7 @@ class AuxiliaryEditorPartImpl extends EditorPart implements IAuxiliaryEditorPart
 			if (!this.optionsDisposable.value) {
 				this.optionsDisposable.value = this.enforcePartOptions({
 					showTabs: 'none',
+					showBreadcrumbs: false,
 					closeEmptyGroups: true
 				});
 			}

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -774,23 +774,31 @@ export class BreadcrumbsControlFactory {
 		private readonly _options: IBreadcrumbsControlOptions,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IFileService fileService: IFileService
+		@IFileService fileService: IFileService,
 	) {
 		const config = this._disposables.add(BreadcrumbsConfig.IsEnabled.bindTo(configurationService));
-		this._disposables.add(config.onDidChange(() => {
-			const value = config.getValue();
-			if (!value && this._control) {
+		const isEnabled = () => config.getValue() && this._editorGroup.groupsView.partOptions.showBreadcrumbs !== false;
+		const updateControl = () => {
+			const enabled = isEnabled();
+			if (!enabled && this._control) {
 				this._controlDisposables.clear();
 				this._control = undefined;
 				this._onDidEnablementChange.fire();
-			} else if (value && !this._control) {
+			} else if (enabled && !this._control) {
 				this._control = this.createControl();
 				this._control.update();
 				this._onDidEnablementChange.fire();
 			}
+		};
+
+		this._disposables.add(config.onDidChange(updateControl));
+		this._disposables.add(this._editorGroup.groupsView.onDidChangeEditorPartOptions(e => {
+			if (e.oldPartOptions.showBreadcrumbs !== e.newPartOptions.showBreadcrumbs) {
+				updateControl();
+			}
 		}));
 
-		if (config.getValue()) {
+		if (isEnabled()) {
 			this._control = this.createControl();
 		}
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1325,6 +1325,7 @@ interface IEditorPartConfiguration {
 
 export interface IEditorPartOptions extends DeepRequiredNonNullable<IEditorPartConfiguration> {
 	hasIcons: boolean;
+	showBreadcrumbs?: boolean;
 }
 
 export interface IEditorPartOptionsChangeEvent {


### PR DESCRIPTION
## Summary

- hide editor breadcrumbs while a window uses compact title bar mode
- restore breadcrumbs when the window leaves compact mode without changing the user's breadcrumbs setting

## Testing

- `npm run eslint -- src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts`
- `npm run typecheck-client`