### PR TITLE
chat: fix empty Responses tool schemas

### DIFF
--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -44,6 +44,29 @@ const createTestOptions = (messages: Raw.ChatMessage[]): ICreateEndpointBodyOpti
 	location: undefined as any
 });
 
+const createParameterlessToolOptions = (): ICreateEndpointBodyOptions => {
+	const tools = [{
+		type: 'function' as const,
+		function: {
+			name: 'terminal_last_command',
+			description: 'Get the last command run in the active terminal.',
+			parameters: undefined,
+		}
+	}];
+	return {
+		...createTestOptions([{
+			role: Raw.ChatRole.User,
+			content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+		}]),
+		postOptions: {
+			tools
+		},
+		requestOptions: {
+			tools
+		}
+	};
+};
+
 const createMakeRequestOptions = (messages: Raw.ChatMessage[], ignoreStatefulMarker?: boolean): IMakeChatRequestOptions => ({
 	debugName: 'test',
 	messages,
@@ -127,6 +150,35 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 	});
 
 	describe('CAPI mode (useResponsesApi = false)', () => {
+		it('adds an empty object schema to a parameterless tool', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					supported_endpoints: [ModelSupportedEndpoint.ChatCompletions],
+					capabilities: {
+						...modelMetadata.capabilities,
+						supports: {
+							...modelMetadata.capabilities.supports,
+							tool_calls: true,
+						}
+					}
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(createParameterlessToolOptions());
+			endpoint.interceptBody(body);
+
+			expect(body.tools).toStrictEqual([{
+				type: 'function',
+				function: {
+					name: 'terminal_last_command',
+					description: 'Get the last command run in the active terminal.',
+					parameters: { type: 'object', properties: {} },
+				}
+			}]);
+		});
+
 		it('should set cot_id and cot_summary properties when processing thinking content', () => {
 			const endpoint = instaService.createInstance(OpenAIEndpoint,
 				{
@@ -245,6 +297,33 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 	});
 
 	describe('Responses API mode (useResponsesApi = true)', () => {
+		it('adds an empty object schema to a parameterless tool', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					capabilities: {
+						...modelMetadata.capabilities,
+						supports: {
+							...modelMetadata.capabilities.supports,
+							tool_calls: true,
+						}
+					}
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/responses');
+
+			const body = endpoint.createRequestBody(createParameterlessToolOptions());
+			endpoint.interceptBody(body);
+
+			expect(body.tools).toStrictEqual([{
+				type: 'function',
+				name: 'terminal_last_command',
+				description: 'Get the last command run in the active terminal.',
+				parameters: { type: 'object', properties: {} },
+				strict: false,
+			}]);
+		});
+
 		it('should preserve reasoning object when thinking is supported', () => {
 			const modelWithReasoningEffort = {
 				...modelMetadata,

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -96,7 +96,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 				...tool.function,
 				type: 'function',
 				strict: false,
-				parameters: (tool.function.parameters || {}) as Record<string, unknown>,
+				parameters: (tool.function.parameters || { type: 'object', properties: {} }) as Record<string, unknown>,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary

- Emits an explicit object schema for parameterless tools sent through BYOK Responses endpoints.
- Prevents strict OpenAI-compatible endpoints from rejecting requests that include tools such as `terminal_last_command`.

Fixes #330610

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

Parameterless VS Code tools reach Copilot Chat without an input schema. The language model wrapper preserves that absence as `parameters: undefined`, after which the Responses serializer previously emitted `parameters: {}`. Strict OpenAI-compatible Responses endpoints reject that shape because the parameter schema does not identify an object root.

OpenAI's official [function-calling guide](https://developers.openai.com/api/docs/guides/function-calling#function-tool-example) documents a Responses function tool's `parameters` as a JSON Schema with `type: "object"` and `properties`. A parameterless tool therefore uses the same documented shape with an empty `properties` object.

### Implementation

The Responses conversion now substitutes `{ type: "object", properties: {} }` when a function tool has no parameter schema. Supplied schemas continue to pass through unchanged.

Regression coverage exercises the same parameterless tool through both API modes. Responses now emits the flattened object-root schema, while Chat Completions retains its existing nested-tool normalization.

### Behavior and constraints

- Existing non-empty tool schemas are unchanged.
- `strict: false` remains unchanged.
- The empty object schema does not set `additionalProperties: false`, so it preserves the previous permissive argument behavior.
- The fix belongs at the Responses protocol-conversion boundary rather than on `terminal_last_command`, because any parameterless built-in or contributed tool can trigger the same rejection.

### Review context

The issue was reproduced at the final BYOK request-body boundary. The Responses variant deterministically emitted `{}`, while an otherwise equivalent Chat Completions control emitted a valid object-root schema.

</details>
