### PR TITLE
Show failing CI sessions in Omni Chat

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -346,6 +346,20 @@ Use the narrowest mechanism that represents the change:
 Do not add an event that mirrors an observable value. Do not use storage keys or
 provider internals as a side channel between components.
 
+### Omni CI attention boundary
+
+The floating Omni Chat input owns the presentation contract for external
+attention items. `IChatInputWindowService` defines and owns the narrow
+`IChatInputWindowCIFailureProvider` registration API in `vs/workbench`; it must
+not depend on Sessions models or import from `vs/sessions`.
+
+The Sessions-layer `OmniCIFailureContribution` owns the registration lifetime.
+It adapts `BlockedSessions` into UI-neutral failure data and delegates actions
+to the singleton `BlockedSessionsCIFixModel`. The title-bar blocked-sessions
+dropdown uses that same singleton so optimistic hiding and duplicate-submission
+guards apply globally across both surfaces. Disposing the contribution removes
+the provider registration and all Sessions-owned observations.
+
 ## Agents Window telemetry
 
 On the first Agents-window handoff, `SelectAgentsFolderContribution` immediately

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsCIFixModel.ts
@@ -7,6 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { derived, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ISession } from '../../../services/sessions/common/session.js';
@@ -15,6 +16,13 @@ import { IGitHubService } from '../../github/browser/githubService.js';
 import { GitHubPullRequestCIModel } from '../../github/browser/models/githubPullRequestCIModel.js';
 import { GitHubCheckStatus } from '../../github/common/types.js';
 import { ISessionCIFixModel, ISessionCIFixState } from './views/sessionsList.js';
+
+export interface IBlockedSessionsCIFixModel extends ISessionCIFixModel {
+	readonly _serviceBrand: undefined;
+	readonly hiddenSessions: IObservable<ReadonlySet<string>>;
+}
+
+export const IBlockedSessionsCIFixModel = createDecorator<IBlockedSessionsCIFixModel>('blockedSessionsCIFixModel');
 
 /**
  * Backs the per-session "Fix CI" row shown in the blocked-sessions dropdown for
@@ -28,7 +36,9 @@ import { ISessionCIFixModel, ISessionCIFixState } from './views/sessionsList.js'
  * by the time the submit resolves the session is in progress and so is no longer
  * blocked, keeping it out of the list without a flicker.
  */
-export class BlockedSessionsCIFixModel extends Disposable implements ISessionCIFixModel {
+export class BlockedSessionsCIFixModel extends Disposable implements IBlockedSessionsCIFixModel {
+
+	declare readonly _serviceBrand: undefined;
 
 	/** Cached CI-state observables, keyed by session, to keep references stable and GC-friendly. */
 	private readonly _states = new WeakMap<ISession, IObservable<ISessionCIFixState | undefined>>();

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
@@ -13,7 +13,7 @@ import { AgentSessionApprovalKind, AgentSessionApprovalModel, agentSessionApprov
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../blockedSessions/browser/blockedSessions.js';
-import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
+import { BlockedSessionsCIFixModel, IBlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 import { getFirstApprovalAcrossChats, IApprovedSession } from './views/sessionsList.js';
 
 /**
@@ -57,10 +57,10 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 	}
 
 	/** Drives the per-session "Fix CI" row; shared with the dropdown list. */
-	private readonly _ciFixModel: BlockedSessionsCIFixModel;
+	private readonly _ciFixModel: IBlockedSessionsCIFixModel;
 
 	/** The CI-fix model, shared with the dropdown list so the fix action and the hide-while-fixing agree. */
-	get ciFixModel(): BlockedSessionsCIFixModel {
+	get ciFixModel(): IBlockedSessionsCIFixModel {
 		return this._ciFixModel;
 	}
 
@@ -106,15 +106,16 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IProductService productService: IProductService,
+		@IBlockedSessionsCIFixModel sharedCIFixModel: IBlockedSessionsCIFixModel,
 	) {
 		super();
 
-		// The model owns the approval model, blocked-sessions model and CI-fix model;
-		// the optional parameters are test seams so fixtures/tests can supply preset
-		// instances (only register — and thus dispose — the ones we created ourselves).
+		// The model owns the approval and blocked-session models it creates. The CI-fix
+		// model is a shared service so every surface uses one in-flight submission guard.
+		// Optional parameters remain test seams for fixtures to supply preset instances.
 		this._approvalModel = approvalModel ?? this._register(instantiationService.createInstance(AgentSessionApprovalModel));
 		this._blockedSessionsModel = blockedSessions ?? this._register(instantiationService.createInstance(BlockedSessions));
-		this._ciFixModel = ciFixModel ?? this._register(instantiationService.createInstance(BlockedSessionsCIFixModel));
+		this._ciFixModel = ciFixModel ?? sharedCIFixModel;
 
 		// The blocked-sessions feature is only enabled outside of stable builds.
 		const enabled = productService.quality !== 'stable';

--- a/src/vs/sessions/contrib/sessions/browser/omniCIFailureContribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/omniCIFailureContribution.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { equals } from '../../../../base/common/arrays.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derivedOpts, IObservable } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IChatInputWindowCIFailure, IChatInputWindowCIFailureProvider, IChatInputWindowService } from '../../../../workbench/contrib/chat/common/chatInputWindow.js';
+import { BlockedSessionReason, BlockedSessions } from '../../blockedSessions/browser/blockedSessions.js';
+import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
+
+export class OmniCIFailureProvider extends Disposable implements IChatInputWindowCIFailureProvider {
+
+	readonly failures: IObservable<readonly IChatInputWindowCIFailure[]>;
+
+	constructor(
+		private readonly _blockedSessions: BlockedSessions,
+		private readonly _ciFixModel: BlockedSessionsCIFixModel,
+		enabled: boolean,
+	) {
+		super();
+
+		this.failures = derivedOpts({
+			owner: this,
+			equalsFn: (a, b) => equals(a, b, (x, y) =>
+				x.sessionResource.toString() === y.sessionResource.toString()
+				&& x.occurrenceId === y.occurrenceId
+				&& x.label === y.label
+				&& x.failed === y.failed
+				&& x.pending === y.pending
+				&& x.updatedAt === y.updatedAt),
+		}, reader => {
+			if (!enabled) {
+				return [];
+			}
+
+			const hiddenSessions = this._ciFixModel.hiddenSessions.read(reader);
+			const failures: IChatInputWindowCIFailure[] = [];
+			for (const blocked of this._blockedSessions.blockedSessionsWithReasons.read(reader)) {
+				if (blocked.reason !== BlockedSessionReason.FailingCI || hiddenSessions.has(blocked.session.sessionId)) {
+					continue;
+				}
+				const state = this._ciFixModel.getCIFix(blocked.session).read(reader);
+				if (!state) {
+					continue;
+				}
+				failures.push({
+					sessionResource: blocked.session.resource,
+					occurrenceId: blocked.occurrenceId,
+					label: blocked.session.title.read(reader),
+					failed: state.failed,
+					pending: state.pending,
+					updatedAt: blocked.session.updatedAt.read(reader).getTime(),
+				});
+			}
+			return failures;
+		});
+	}
+
+	fixCI(sessionResource: URI): void {
+		const blocked = this._blockedSessions.blockedSessionsWithReasons.get().find(candidate =>
+			candidate.reason === BlockedSessionReason.FailingCI
+			&& candidate.session.resource.toString() === sessionResource.toString());
+		if (blocked) {
+			this._ciFixModel.fixCI(blocked.session);
+		}
+	}
+}
+
+export class OmniCIFailureContribution extends Disposable {
+
+	static readonly ID = 'sessions.contrib.omniCIFailure';
+
+	constructor(
+		@IChatInputWindowService chatInputWindowService: IChatInputWindowService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IProductService productService: IProductService,
+	) {
+		super();
+
+		const blockedSessions = this._register(instantiationService.createInstance(BlockedSessions));
+		const ciFixModel = this._register(instantiationService.createInstance(BlockedSessionsCIFixModel));
+		const provider = this._register(new OmniCIFailureProvider(blockedSessions, ciFixModel, productService.quality !== 'stable'));
+		this._register(chatInputWindowService.registerCIFailureProvider(provider));
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/omniCIFailureContribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/omniCIFailureContribution.ts
@@ -11,7 +11,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IChatInputWindowCIFailure, IChatInputWindowCIFailureProvider, IChatInputWindowService } from '../../../../workbench/contrib/chat/common/chatInputWindow.js';
 import { BlockedSessionReason, BlockedSessions } from '../../blockedSessions/browser/blockedSessions.js';
-import { BlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
+import { IBlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 
 export class OmniCIFailureProvider extends Disposable implements IChatInputWindowCIFailureProvider {
 
@@ -19,7 +19,7 @@ export class OmniCIFailureProvider extends Disposable implements IChatInputWindo
 
 	constructor(
 		private readonly _blockedSessions: BlockedSessions,
-		private readonly _ciFixModel: BlockedSessionsCIFixModel,
+		private readonly _ciFixModel: IBlockedSessionsCIFixModel,
 		enabled: boolean,
 	) {
 		super();
@@ -79,11 +79,11 @@ export class OmniCIFailureContribution extends Disposable {
 		@IChatInputWindowService chatInputWindowService: IChatInputWindowService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IProductService productService: IProductService,
+		@IBlockedSessionsCIFixModel ciFixModel: IBlockedSessionsCIFixModel,
 	) {
 		super();
 
 		const blockedSessions = this._register(instantiationService.createInstance(BlockedSessions));
-		const ciFixModel = this._register(instantiationService.createInstance(BlockedSessionsCIFixModel));
 		const provider = this._register(new OmniCIFailureProvider(blockedSessions, ciFixModel, productService.quality !== 'stable'));
 		this._register(chatInputWindowService.registerCIFailureProvider(provider));
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IViewDescriptor, IViewsRegistry, Extensions as ViewContainerExtensions, WindowEnablement, ViewContainer, IViewContainersRegistry, ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -27,10 +28,13 @@ import { CHAT_INPUT_WINDOW_TOGGLE_COMMAND_ID } from '../../../../workbench/contr
 import { OmniChatEnabledSettingId } from '../../../../workbench/contrib/chat/common/sessionRouter.js';
 import { Menus } from '../../../browser/menus.js';
 import { OmniCIFailureContribution } from './omniCIFailureContribution.js';
+import { BlockedSessionsCIFixModel, IBlockedSessionsCIFixModel } from './blockedSessionsCIFixModel.js';
 
 const agentSessionsViewIcon = registerIcon('chat-sessions-icon', Codicon.commentDiscussionSparkle, localize('agentSessionsViewIcon', 'Icon for Agent Sessions View'));
 const AGENT_SESSIONS_VIEW_TITLE = localize2('agentSessions.view.label', "Sessions");
 const SessionsContainerId = 'agentic.workbench.view.sessionsContainer';
+
+registerSingleton(IBlockedSessionsCIFixModel, BlockedSessionsCIFixModel, InstantiationType.Delayed);
 
 const agentSessionsViewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: SessionsContainerId,

--- a/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessions.contribution.ts
@@ -26,6 +26,7 @@ import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actio
 import { CHAT_INPUT_WINDOW_TOGGLE_COMMAND_ID } from '../../../../workbench/contrib/chat/common/chatInputWindow.js';
 import { OmniChatEnabledSettingId } from '../../../../workbench/contrib/chat/common/sessionRouter.js';
 import { Menus } from '../../../browser/menus.js';
+import { OmniCIFailureContribution } from './omniCIFailureContribution.js';
 
 const agentSessionsViewIcon = registerIcon('chat-sessions-icon', Codicon.commentDiscussionSparkle, localize('agentSessionsViewIcon', 'Icon for Agent Sessions View'));
 const AGENT_SESSIONS_VIEW_TITLE = localize2('agentSessions.view.label', "Sessions");
@@ -90,6 +91,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 });
 
 registerWorkbenchContribution2(SessionsTitleBarContribution.ID, SessionsTitleBarContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(OmniCIFailureContribution.ID, OmniCIFailureContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(NewSessionActionViewItemContribution.ID, NewSessionActionViewItemContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(SessionConversationsActionViewItemContribution.ID, SessionConversationsActionViewItemContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(SessionsMouseNavigationContribution.ID, SessionsMouseNavigationContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/sessions/contrib/sessions/test/browser/blockedSessionsIndicatorModel.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/blockedSessionsIndicatorModel.test.ts
@@ -42,6 +42,7 @@ suite('BlockedSessionsIndicatorModel', () => {
 			sessionsService as unknown as ISessionsService,
 			instantiationService,
 			productService,
+			ciFixModel as unknown as BlockedSessionsCIFixModel,
 		));
 		// Keep the derived live so it recomputes on visibility/dismissal changes.
 		store.add(autorun(reader => { model.blockedSessions.read(reader); }));

--- a/src/vs/sessions/contrib/sessions/test/browser/omniCIFailureContribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/omniCIFailureContribution.test.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ISession } from '../../../../services/sessions/common/session.js';
 import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../../blockedSessions/browser/blockedSessions.js';
-import { BlockedSessionsCIFixModel } from '../../browser/blockedSessionsCIFixModel.js';
+import { IBlockedSessionsCIFixModel } from '../../browser/blockedSessionsCIFixModel.js';
 import { OmniCIFailureProvider } from '../../browser/omniCIFailureContribution.js';
 import { ISessionCIFixState } from '../../browser/views/sessionsList.js';
 
@@ -26,7 +26,7 @@ suite('OmniCIFailureProvider', () => {
 		const ciFixModel = new TestCIFixModel();
 		const provider = store.add(new OmniCIFailureProvider(
 			blockedSessions as unknown as BlockedSessions,
-			ciFixModel as unknown as BlockedSessionsCIFixModel,
+			ciFixModel as unknown as IBlockedSessionsCIFixModel,
 			enabled,
 		));
 		return { provider, blockedSessions, ciFixModel };

--- a/src/vs/sessions/contrib/sessions/test/browser/omniCIFailureContribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/omniCIFailureContribution.test.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ISession } from '../../../../services/sessions/common/session.js';
+import { BlockedSessionReason, BlockedSessions, IBlockedSession } from '../../../blockedSessions/browser/blockedSessions.js';
+import { BlockedSessionsCIFixModel } from '../../browser/blockedSessionsCIFixModel.js';
+import { OmniCIFailureProvider } from '../../browser/omniCIFailureContribution.js';
+import { ISessionCIFixState } from '../../browser/views/sessionsList.js';
+
+suite('OmniCIFailureProvider', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createProvider(enabled = true): {
+		provider: OmniCIFailureProvider;
+		blockedSessions: TestBlockedSessions;
+		ciFixModel: TestCIFixModel;
+	} {
+		const blockedSessions = new TestBlockedSessions();
+		const ciFixModel = new TestCIFixModel();
+		const provider = store.add(new OmniCIFailureProvider(
+			blockedSessions as unknown as BlockedSessions,
+			ciFixModel as unknown as BlockedSessionsCIFixModel,
+			enabled,
+		));
+		return { provider, blockedSessions, ciFixModel };
+	}
+
+	function snapshot(provider: OmniCIFailureProvider) {
+		return provider.failures.get().map(failure => ({
+			resource: failure.sessionResource.toString(),
+			occurrenceId: failure.occurrenceId,
+			label: failure.label,
+			failed: failure.failed,
+			pending: failure.pending,
+			updatedAt: failure.updatedAt,
+		}));
+	}
+
+	test('publishes only actionable failing CI sessions', () => {
+		const { provider, blockedSessions, ciFixModel } = createProvider();
+		const failing = new TestSession('failing', 'Failing CI', 2000);
+		const needsInput = new TestSession('input', 'Needs Input', 3000);
+		const alreadyFixed = new TestSession('fixed', 'Already Fixed', 1000);
+		blockedSessions.setBlocked([
+			blocked(needsInput, BlockedSessionReason.NeedsInput, 'needsInput'),
+			blocked(failing, BlockedSessionReason.FailingCI, 'failingCI:sha1'),
+			blocked(alreadyFixed, BlockedSessionReason.FailingCI, 'failingCI:sha2'),
+		]);
+		ciFixModel.setState(failing, { failed: 2, pending: 1 });
+		ciFixModel.setState(alreadyFixed, undefined);
+
+		assert.deepStrictEqual(snapshot(provider), [{
+			resource: 'test-session:/failing',
+			occurrenceId: 'failingCI:sha1',
+			label: 'Failing CI',
+			failed: 2,
+			pending: 1,
+			updatedAt: 2000,
+		}]);
+	});
+
+	test('updates counts and hides fixes in flight', () => {
+		const { provider, blockedSessions, ciFixModel } = createProvider();
+		const session = new TestSession('session', 'Session', 1000);
+		blockedSessions.setBlocked([blocked(session, BlockedSessionReason.FailingCI, 'failingCI:sha1')]);
+		ciFixModel.setState(session, { failed: 1, pending: 2 });
+		assert.deepStrictEqual(snapshot(provider).map(({ failed, pending }) => ({ failed, pending })), [{ failed: 1, pending: 2 }]);
+
+		ciFixModel.setState(session, { failed: 3, pending: 0 });
+		assert.deepStrictEqual(snapshot(provider).map(({ failed, pending }) => ({ failed, pending })), [{ failed: 3, pending: 0 }]);
+
+		ciFixModel.setHidden(['session']);
+		assert.deepStrictEqual(snapshot(provider), []);
+	});
+
+	test('dispatches a fix once to the current failing session and respects gating', () => {
+		const { provider, blockedSessions, ciFixModel } = createProvider();
+		const session = new TestSession('session', 'Session', 1000);
+		blockedSessions.setBlocked([blocked(session, BlockedSessionReason.FailingCI, 'failingCI:sha1')]);
+		ciFixModel.setState(session, { failed: 1, pending: 0 });
+
+		provider.fixCI(session.resource);
+		provider.fixCI(URI.parse('test-session:/missing'));
+
+		const disabled = createProvider(false);
+		disabled.blockedSessions.setBlocked([blocked(session, BlockedSessionReason.FailingCI, 'failingCI:sha1')]);
+		disabled.ciFixModel.setState(session, { failed: 1, pending: 0 });
+		assert.deepStrictEqual({
+			fixed: ciFixModel.fixedSessionIds,
+			disabledFailures: snapshot(disabled.provider),
+		}, {
+			fixed: ['session'],
+			disabledFailures: [],
+		});
+	});
+});
+
+function blocked(session: TestSession, reason: BlockedSessionReason, occurrenceId: string): IBlockedSession {
+	return { session: session as unknown as ISession, reason, occurrenceId };
+}
+
+class TestSession {
+	readonly resource: URI;
+	readonly title: IObservable<string>;
+	readonly updatedAt: IObservable<Date>;
+
+	constructor(
+		readonly sessionId: string,
+		title: string,
+		updatedAt: number,
+	) {
+		this.resource = URI.parse(`test-session:/${sessionId}`);
+		this.title = observableValue(`test.title.${sessionId}`, title);
+		this.updatedAt = observableValue(`test.updatedAt.${sessionId}`, new Date(updatedAt));
+	}
+}
+
+class TestBlockedSessions {
+	private readonly _blocked = observableValue<readonly IBlockedSession[]>('test.blocked', []);
+	readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]> = this._blocked;
+
+	setBlocked(blocked: readonly IBlockedSession[]): void {
+		this._blocked.set(blocked, undefined);
+	}
+}
+
+class TestCIFixModel {
+	private readonly _hidden = observableValue<ReadonlySet<string>>('test.hidden', new Set());
+	readonly hiddenSessions: IObservable<ReadonlySet<string>> = this._hidden;
+	private readonly _states = new Map<ISession, ISettableObservable<ISessionCIFixState | undefined>>();
+	readonly fixedSessionIds: string[] = [];
+
+	getCIFix(session: ISession): IObservable<ISessionCIFixState | undefined> {
+		return this._stateFor(session);
+	}
+
+	private _stateFor(session: ISession): ISettableObservable<ISessionCIFixState | undefined> {
+		let state = this._states.get(session);
+		if (!state) {
+			state = observableValue(`test.ci.${session.sessionId}`, undefined);
+			this._states.set(session, state);
+		}
+		return state;
+	}
+
+	setState(session: TestSession, state: ISessionCIFixState | undefined): void {
+		this._stateFor(session as unknown as ISession).set(state, undefined);
+	}
+
+	setHidden(sessionIds: readonly string[]): void {
+		this._hidden.set(new Set(sessionIds), undefined);
+	}
+
+	fixCI(session: ISession): void {
+		this.fixedSessionIds.push(session.sessionId);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -11,7 +11,7 @@ import { IAnchor } from '../../../../../base/browser/ui/contextview/contextview.
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
-import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { AnchorPosition } from '../../../../../base/common/layout.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
@@ -30,6 +30,8 @@ import { IAuxiliaryWindowService, IAuxiliaryWindow } from '../../../../services/
 import { IRectangle } from '../../../../../platform/window/common/window.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
+import { chartsOrange } from '../../../../../platform/theme/common/colors/chartsColors.js';
 import { editorBackground } from '../../../../../platform/theme/common/colorRegistry.js';
 import { inputBackground, inputBorder } from '../../../../../platform/theme/common/colors/inputColors.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
@@ -44,7 +46,7 @@ import { ChatWidget } from '../widget/chatWidget.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatSessionRoutingController, IChatSessionRoutingHost } from '../sessionRouter/chatSessionRoutingController.js';
 import { combineVoiceInput } from '../voiceClient/voiceInputUtils.js';
-import { IChatInputWindowService, ChatInputWindowStorageKeys, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT, CHAT_INPUT_WINDOW_SET_VOICE_TARGET_COMMAND_ID } from '../../common/chatInputWindow.js';
+import { IChatInputWindowCIFailure, IChatInputWindowCIFailureProvider, IChatInputWindowService, ChatInputWindowStorageKeys, CHAT_INPUT_WINDOW_DEFAULT_HEIGHT, CHAT_INPUT_WINDOW_SET_VOICE_TARGET_COMMAND_ID } from '../../common/chatInputWindow.js';
 import { autorun, IReader, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { AgentSessionStatus } from '../agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
@@ -70,6 +72,21 @@ const CHAT_INPUT_WINDOW_MAX_PENDING_HEIGHT = 360;
 const CHAT_INPUT_WINDOW_MIN_CONFIRMATION_HEIGHT = 112;
 
 type ChatInputActionWidgetPlacement = 'above' | 'right';
+
+interface IChatInputWindowPendingChat {
+	readonly kind: 'chat';
+	readonly id: string;
+	readonly model: IChatModel;
+}
+
+interface IChatInputWindowPendingCIFailure {
+	readonly kind: 'ciFailure';
+	readonly id: string;
+	readonly failure: IChatInputWindowCIFailure;
+	readonly provider: IChatInputWindowCIFailureProvider;
+}
+
+type ChatInputWindowPendingItem = IChatInputWindowPendingChat | IChatInputWindowPendingCIFailure;
 
 function getDescendantElements(parent: HTMLElement, className?: string): HTMLElement[] {
 	const result: HTMLElement[] = [];
@@ -110,6 +127,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 	private _pendingPromptIndex = 0;
 	private _activePendingSessionResource: URI | undefined;
 	private readonly _dismissedPendingRequests = observableValue<ReadonlySet<string>>(this, new Set());
+	private readonly _ciFailureProviders = observableValue<readonly IChatInputWindowCIFailureProvider[]>(this, []);
 	private _fitWindowToContent: () => void = () => { };
 	/** The single input row; routing results are inserted immediately after it. */
 	private _row: HTMLElement | undefined;
@@ -140,6 +158,17 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 
 	get hasFocus(): boolean {
 		return this._window?.window.document.hasFocus() ?? false;
+	}
+
+	registerCIFailureProvider(provider: IChatInputWindowCIFailureProvider): IDisposable {
+		this._ciFailureProviders.set([...this._ciFailureProviders.get(), provider], undefined);
+		return toDisposable(() => {
+			const providers = this._ciFailureProviders.get();
+			const index = providers.indexOf(provider);
+			if (index >= 0) {
+				this._ciFailureProviders.set(providers.filter(candidate => candidate !== provider), undefined);
+			}
+		});
 	}
 
 	constructor(
@@ -675,9 +704,46 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		const approvalCommand = dom.append(approvalFallback, dom.$('code.chat-input-window-pending-approval-command'));
 		const approvalDisclaimer = dom.append(approvalFallback, dom.$('.chat-input-window-pending-approval-disclaimer'));
 		const approvalActions = dom.append(approvalFallback, dom.$('.chat-input-window-pending-approval-actions'));
+		const ciFallback = dom.append(panel, dom.$('.chat-input-window-pending-ci-fallback'));
+		const ciTitle = dom.append(ciFallback, dom.$('.chat-input-window-pending-ci-title'));
+		const ciDetail = dom.append(ciFallback, dom.$('.chat-input-window-pending-ci-detail', { 'aria-live': 'polite' }));
+		const ciActions = dom.append(ciFallback, dom.$('.chat-input-window-pending-ci-actions'));
 		const approvalActionDisposables = this._windowDisposables.add(new MutableDisposable<DisposableStore>());
 		let lastActivatedApproval: string | undefined;
 		let displayedApproval: { readonly invocation: IChatToolInvocation; readonly occurrence: string } | undefined;
+		let displayedCIFailure: IChatInputWindowPendingCIFailure | undefined;
+		const fixCIButton = this._windowDisposables.add(new Button(ciActions, {
+			title: localize('chatInputWindow.pending.fixCITooltip', "Fix failing CI checks"),
+			...defaultButtonStyles,
+			small: true,
+			buttonBackground: asCssVariable(chartsOrange),
+			buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
+			buttonBorder: asCssVariable(chartsOrange),
+		}));
+		fixCIButton.label = localize('chatInputWindow.pending.fixCI', "Fix CI");
+		this._windowDisposables.add(fixCIButton.onDidClick(() => {
+			const entry = displayedCIFailure;
+			if (entry) {
+				entry.provider.fixCI(entry.failure.sessionResource);
+				this._widget?.focusInput();
+			}
+		}));
+		const renderCIFailure = (entry: IChatInputWindowPendingCIFailure | undefined) => {
+			displayedCIFailure = entry;
+			if (!entry) {
+				ciTitle.textContent = '';
+				ciDetail.textContent = '';
+				return;
+			}
+
+			ciTitle.textContent = localize('chatInputWindow.pending.ciTitle', "CI is failing for {0}", entry.failure.label);
+			ciDetail.textContent = localize(
+				'chatInputWindow.pending.ciDetail',
+				"{0} checks failed, {1} pending",
+				entry.failure.failed,
+				entry.failure.pending,
+			);
+		};
 		const renderApprovalFallback = (approval: typeof displayedApproval) => {
 			approvalActionDisposables.value = new DisposableStore();
 			approvalActions.replaceChildren();
@@ -795,18 +861,22 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		widget.setVisible(true);
 		const list = widget.transcriptDomNode;
 
-		let pendingModels: readonly IChatModel[] = [];
+		let pendingItems: readonly ChatInputWindowPendingItem[] = [];
 		let layingOut = false;
 		let lastPendingHeight: number | undefined;
 		let lastPendingWidth: number | undefined;
 		let confirmationWidgetLayoutHeight = 0;
-		let displayedResource: string | undefined;
+		let displayedItemId: string | undefined;
 		const layout = () => {
 			if (layingOut || !panel.classList.contains('shown')) {
 				return;
 			}
 			layingOut = true;
 			try {
+				if (displayedCIFailure) {
+					this._fitWindowToContent();
+					return;
+				}
 				for (const row of getDescendantElements(list, 'monaco-list-row')) {
 					const confirmations = getDescendantElements(row, 'chat-confirmation-widget-container');
 					const hasConfirmation = confirmations.length > 0;
@@ -892,32 +962,60 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		const scheduleLayout = () => {
 			scheduledLayout.value = dom.scheduleAtNextAnimationFrame(auxiliaryWindow.window, layout);
 		};
-		const showPendingModel = (index: number) => {
-			if (pendingModels.length === 0) {
+		const showPendingItem = (index: number) => {
+			if (pendingItems.length === 0) {
 				this._pendingPromptIndex = 0;
 				lastPendingHeight = undefined;
 				lastPendingWidth = undefined;
 				confirmationWidgetLayoutHeight = 0;
-				displayedResource = undefined;
+				displayedItemId = undefined;
 				displayedApproval = undefined;
 				renderApprovalFallback(undefined);
+				renderCIFailure(undefined);
 				lastActivatedApproval = undefined;
 				this._activePendingSessionResource = undefined;
-				panel.classList.remove('shown', 'question', 'tool-approval-fallback');
+				panel.classList.remove('shown', 'question', 'tool-approval-fallback', 'ci-failure');
 				widget.setModel(undefined);
 				this._fitWindowToContent();
 				return;
 			}
-			this._pendingPromptIndex = (index + pendingModels.length) % pendingModels.length;
-			const model = pendingModels[this._pendingPromptIndex];
-			this._activePendingSessionResource = model.sessionResource;
-			const resource = model.sessionResource.toString();
-			if (displayedResource !== resource) {
-				displayedResource = resource;
+			this._pendingPromptIndex = (index + pendingItems.length) % pendingItems.length;
+			const item = pendingItems[this._pendingPromptIndex];
+			if (displayedItemId !== item.id) {
+				displayedItemId = item.id;
 				lastPendingHeight = undefined;
 				confirmationWidgetLayoutHeight = 0;
 			}
 			panel.classList.add('shown');
+
+			const hasMultiple = pendingItems.length > 1;
+			header.classList.toggle('hidden', !hasMultiple);
+			label.textContent = hasMultiple
+				? localize('chatInputWindow.pending.count', "Item {0} of {1}", this._pendingPromptIndex + 1, pendingItems.length)
+				: '';
+			navigation.classList.toggle('hidden', !hasMultiple);
+			for (const button of [previous, next]) {
+				button.classList.toggle('disabled', !hasMultiple);
+				button.setAttribute('aria-disabled', String(!hasMultiple));
+				button.tabIndex = hasMultiple ? 0 : -1;
+			}
+
+			if (item.kind === 'ciFailure') {
+				this._activePendingSessionResource = undefined;
+				displayedApproval = undefined;
+				renderApprovalFallback(undefined);
+				renderCIFailure(item);
+				panel.classList.remove('question', 'tool-approval-fallback');
+				panel.classList.add('ci-failure');
+				widget.setModel(undefined);
+				scheduleLayout();
+				return;
+			}
+
+			const model = item.model;
+			this._activePendingSessionResource = model.sessionResource;
+			renderCIFailure(undefined);
+			panel.classList.remove('ci-failure');
 			const hasPendingQuestion = this._hasPendingQuestion(model);
 			const pendingApproval = this._getPendingToolApproval(model);
 			displayedApproval = pendingApproval;
@@ -928,17 +1026,6 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			}
 			panel.classList.toggle('question', hasPendingQuestion);
 			panel.classList.toggle('tool-approval-fallback', !hasPendingQuestion && !!pendingApproval);
-			const hasMultiple = pendingModels.length > 1;
-			header.classList.toggle('hidden', !hasMultiple);
-			label.textContent = hasMultiple
-				? localize('chatInputWindow.pending.count', "Request {0} of {1}", this._pendingPromptIndex + 1, pendingModels.length)
-				: '';
-			navigation.classList.toggle('hidden', !hasMultiple);
-			for (const button of [previous, next]) {
-				button.classList.toggle('disabled', !hasMultiple);
-				button.setAttribute('aria-disabled', String(!hasMultiple));
-				button.tabIndex = hasMultiple ? 0 : -1;
-			}
 			widget.setModel(model);
 			if (pendingApproval && omniVoiceActive && pendingApproval.occurrence !== lastActivatedApproval) {
 				// The pending card is the most direct observation that this exact
@@ -952,8 +1039,8 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			scheduleLayout();
 		};
 
-		this._windowDisposables.add(dom.addDisposableListener(previous, dom.EventType.CLICK, () => showPendingModel(this._pendingPromptIndex - 1)));
-		this._windowDisposables.add(dom.addDisposableListener(next, dom.EventType.CLICK, () => showPendingModel(this._pendingPromptIndex + 1)));
+		this._windowDisposables.add(dom.addDisposableListener(previous, dom.EventType.CLICK, () => showPendingItem(this._pendingPromptIndex - 1)));
+		this._windowDisposables.add(dom.addDisposableListener(next, dom.EventType.CLICK, () => showPendingItem(this._pendingPromptIndex + 1)));
 		this._windowDisposables.add(widget.onDidChangeContentHeight(scheduleLayout));
 		const pendingMutationObserver = new auxiliaryWindow.window.MutationObserver(scheduleLayout);
 		pendingMutationObserver.observe(widget.domNode, { childList: true, subtree: true, attributes: true });
@@ -963,19 +1050,37 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		this._windowDisposables.add(autorun(reader => {
 			this.voiceSessionController.omniInputActive.read(reader);
 			const dismissedPendingRequests = this._dismissedPendingRequests.read(reader);
-			const currentResource = pendingModels[this._pendingPromptIndex]?.sessionResource.toString();
+			const currentItemId = pendingItems[this._pendingPromptIndex]?.id;
 			const activeTarget = this.voiceSessionController.targetSession.read(reader)?.toString();
-			pendingModels = [...this.chatService.chatModels.read(reader)]
+			const pendingChats: IChatInputWindowPendingChat[] = [...this.chatService.chatModels.read(reader)]
 				.filter(model => !!model.requestNeedsInput.read(reader) && !this._hasOnlyResolvedPendingTools(model, reader))
 				.filter(model => !dismissedPendingRequests.has(this._pendingRequestKey(model.sessionResource, model.lastRequest?.id)))
 				.sort((a, b) =>
 					Number(b.sessionResource.toString() === activeTarget) - Number(a.sessionResource.toString() === activeTarget)
 					|| Number(this._hasPendingQuestion(b)) - Number(this._hasPendingQuestion(a))
-					|| b.lastMessageDate - a.lastMessageDate);
-			const preservedIndex = currentResource
-				? pendingModels.findIndex(model => model.sessionResource.toString() === currentResource)
+					|| b.lastMessageDate - a.lastMessageDate)
+				.map(model => ({
+					kind: 'chat',
+					id: `chat:${this._pendingRequestKey(model.sessionResource, model.lastRequest?.id)}`,
+					model,
+				}));
+			const ciFailures: IChatInputWindowPendingCIFailure[] = [];
+			for (const provider of this._ciFailureProviders.read(reader)) {
+				for (const failure of provider.failures.read(reader)) {
+					ciFailures.push({
+						kind: 'ciFailure',
+						id: `ci:${failure.sessionResource.toString()}:${failure.occurrenceId}`,
+						failure,
+						provider,
+					});
+				}
+			}
+			ciFailures.sort((a, b) => b.failure.updatedAt - a.failure.updatedAt);
+			pendingItems = [...pendingChats, ...ciFailures];
+			const preservedIndex = currentItemId
+				? pendingItems.findIndex(item => item.id === currentItemId)
 				: -1;
-			showPendingModel(preservedIndex >= 0 ? preservedIndex : Math.min(this._pendingPromptIndex, pendingModels.length - 1));
+			showPendingItem(preservedIndex >= 0 ? preservedIndex : Math.min(this._pendingPromptIndex, pendingItems.length - 1));
 		}));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -696,8 +696,8 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		marker.appendChild(renderIcon(Codicon.gripper));
 		const label = dom.append(header, dom.$('span.chat-input-window-pending-label'));
 		const navigation = dom.append(header, dom.$('.chat-input-window-pending-navigation'));
-		const previous = this._appendPendingNavigationButton(navigation, Codicon.chevronLeft, localize('chatInputWindow.pending.previous', "Previous Request"));
-		const next = this._appendPendingNavigationButton(navigation, Codicon.chevronRight, localize('chatInputWindow.pending.next', "Next Request"));
+		const previous = this._appendPendingNavigationButton(navigation, Codicon.chevronLeft, localize('chatInputWindow.pending.previous', "Previous Item"));
+		const next = this._appendPendingNavigationButton(navigation, Codicon.chevronRight, localize('chatInputWindow.pending.next', "Next Item"));
 		const approvalFallback = dom.append(panel, dom.$('.chat-input-window-pending-approval-fallback'));
 		const approvalTitle = dom.append(approvalFallback, dom.$('.chat-input-window-pending-approval-title'));
 		const approvalMessage = dom.append(approvalFallback, dom.$('.chat-input-window-pending-approval-message'));
@@ -709,27 +709,33 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		const ciDetail = dom.append(ciFallback, dom.$('.chat-input-window-pending-ci-detail', { 'aria-live': 'polite' }));
 		const ciActions = dom.append(ciFallback, dom.$('.chat-input-window-pending-ci-actions'));
 		const approvalActionDisposables = this._windowDisposables.add(new MutableDisposable<DisposableStore>());
+		const ciActionDisposables = this._windowDisposables.add(new MutableDisposable<DisposableStore>());
 		let lastActivatedApproval: string | undefined;
 		let displayedApproval: { readonly invocation: IChatToolInvocation; readonly occurrence: string } | undefined;
 		let displayedCIFailure: IChatInputWindowPendingCIFailure | undefined;
-		const fixCIButton = this._windowDisposables.add(new Button(ciActions, {
-			title: localize('chatInputWindow.pending.fixCITooltip', "Fix failing CI checks"),
-			...defaultButtonStyles,
-			small: true,
-			buttonBackground: asCssVariable(chartsOrange),
-			buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
-			buttonBorder: asCssVariable(chartsOrange),
-		}));
-		fixCIButton.label = localize('chatInputWindow.pending.fixCI', "Fix CI");
-		this._windowDisposables.add(fixCIButton.onDidClick(() => {
-			const entry = displayedCIFailure;
-			if (entry) {
-				entry.provider.fixCI(entry.failure.sessionResource);
-				this._widget?.focusInput();
-			}
-		}));
+		let renderedCIFailureId: string | undefined;
 		const renderCIFailure = (entry: IChatInputWindowPendingCIFailure | undefined) => {
 			displayedCIFailure = entry;
+			if (renderedCIFailureId !== entry?.id) {
+				renderedCIFailureId = entry?.id;
+				ciActionDisposables.value = new DisposableStore();
+				ciActions.replaceChildren();
+				if (entry) {
+					const button = ciActionDisposables.value.add(new Button(ciActions, {
+						title: localize('chatInputWindow.pending.fixCITooltip', "Fix failing CI checks"),
+						...defaultButtonStyles,
+						small: true,
+						buttonBackground: asCssVariable(chartsOrange),
+						buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
+						buttonBorder: asCssVariable(chartsOrange),
+					}));
+					button.label = localize('chatInputWindow.pending.fixCI', "Fix CI");
+					ciActionDisposables.value.add(button.onDidClick(() => {
+						entry.provider.fixCI(entry.failure.sessionResource);
+						this._widget?.focusInput();
+					}));
+				}
+			}
 			if (!entry) {
 				ciTitle.textContent = '';
 				ciDetail.textContent = '';

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
@@ -279,6 +279,34 @@
 	display: none;
 }
 
+.chat-input-window .chat-input-window-pending-ci-fallback {
+	display: none;
+	padding: 10px 16px 16px;
+}
+
+.chat-input-window .chat-input-window-pending-panel.ci-failure .chat-input-window-pending-ci-fallback {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.chat-input-window .chat-input-window-pending-panel.ci-failure .chat-input-window-pending-widget {
+	display: none;
+}
+
+.chat-input-window .chat-input-window-pending-ci-title {
+	font-weight: var(--vscode-fontWeight-semiBold);
+}
+
+.chat-input-window .chat-input-window-pending-ci-detail {
+	color: var(--vscode-descriptionForeground);
+}
+
+.chat-input-window .chat-input-window-pending-ci-actions {
+	display: flex;
+	align-items: center;
+}
+
 .chat-input-window .chat-input-window-pending-approval-title {
 	font-weight: var(--vscode-fontWeight-semiBold);
 }

--- a/src/vs/workbench/contrib/chat/common/chatInputWindow.ts
+++ b/src/vs/workbench/contrib/chat/common/chatInputWindow.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../base/common/event.js';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IRectangle } from '../../../../platform/window/common/window.js';
 
@@ -26,6 +29,22 @@ export const enum ChatInputWindowStorageKeys {
 
 export const IChatInputWindowService = createDecorator<IChatInputWindowService>('chatInputWindowService');
 
+/** A session whose pull request has failing CI checks. */
+export interface IChatInputWindowCIFailure {
+	readonly sessionResource: URI;
+	readonly occurrenceId: string;
+	readonly label: string;
+	readonly failed: number;
+	readonly pending: number;
+	readonly updatedAt: number;
+}
+
+/** Supplies actionable failing-CI sessions to the floating chat input. */
+export interface IChatInputWindowCIFailureProvider {
+	readonly failures: IObservable<readonly IChatInputWindowCIFailure[]>;
+	fixCI(sessionResource: URI): void;
+}
+
 export interface IChatInputWindowService {
 	readonly _serviceBrand: undefined;
 
@@ -40,6 +59,11 @@ export interface IChatInputWindowService {
 	 * Fires when the window opens or closes.
 	 */
 	readonly onDidChangeOpen: Event<boolean>;
+
+	/**
+	 * Registers failing CI sessions to show in the floating input's attention panel.
+	 */
+	registerCIFailureProvider(provider: IChatInputWindowCIFailureProvider): IDisposable;
 
 	/** Routes voice input through omni when its auxiliary window owns focus. */
 	acceptVoiceInput(text: string): Promise<boolean>;

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -28,7 +28,7 @@ import { SessionActionFeedback } from '../../../../../sessions/contrib/sessions/
 // eslint-disable-next-line local/code-import-patterns
 import { SessionsTitleBarWidget } from '../../../../../sessions/contrib/sessions/browser/sessionsTitleBarWidget.js';
 // eslint-disable-next-line local/code-import-patterns
-import { BlockedSessionsCIFixModel } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsCIFixModel.js';
+import { BlockedSessionsCIFixModel, IBlockedSessionsCIFixModel } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsCIFixModel.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
@@ -115,10 +115,18 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 		?? Array.from({ length: state.blockedCount ?? 0 }, (): IBlockedSpec => ({ reason: BlockedSessionReason.NeedsInput }));
 	const { blocked, approvalModel } = buildBlocked(specs);
 
+	// A no-op CI-fix model seam: the fixture never clicks "Fix CI", so it only
+	// needs to report no sessions hidden. Supplying it avoids the real model,
+	// which would depend on services not registered in this fixture.
+	const ciFixModel = new class extends mock<BlockedSessionsCIFixModel>() {
+		override readonly hiddenSessions: IObservable<ReadonlySet<string>> = constObservable<ReadonlySet<string>>(new Set());
+	}();
+
 	const instantiationService = createEditorServices(disposableStore, {
 		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
 			registerWorkbenchServices(reg);
+			reg.defineInstance(IBlockedSessionsCIFixModel, ciFixModel);
 			reg.defineInstance(ISessionsService, new class extends mock<ISessionsService>() {
 				override readonly activeSession: IObservable<IActiveSession | undefined> = constObservable(state.activeSession);
 				override readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> = constObservable<readonly (IActiveSession | undefined)[]>([]);
@@ -166,13 +174,6 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 	const blockedSessionsModel = new class extends mock<BlockedSessions>() {
 		override readonly blockedSessions: IObservable<readonly ISession[]> = constObservable(blocked.map(entry => entry.session));
 		override readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]> = constObservable(blocked);
-	}();
-
-	// A no-op CI-fix model seam: the fixture never clicks "Fix CI", so it only
-	// needs to report no sessions hidden. Supplying it avoids the real model,
-	// which would depend on services not registered in this fixture.
-	const ciFixModel = new class extends mock<BlockedSessionsCIFixModel>() {
-		override readonly hiddenSessions: IObservable<ReadonlySet<string>> = constObservable<ReadonlySet<string>>(new Set());
 	}();
 
 	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback, approvalModel, blockedSessionsModel, ciFixModel));


### PR DESCRIPTION

<img width="662" height="218" alt="Screenshot 2026-08-13 at 3 19 08 PM" src="https://github.com/user-attachments/assets/6feb6cdf-a4d0-4e6a-81ff-edabde9225f2" />

## Summary

- surface sessions with failing pull-request CI in Omni's existing attention carousel
- reuse the Agents window blocked-session and background Fix CI models through a narrow provider boundary
- preserve pending-question priority, carousel selection, keyboard focus, and lazy chat-model loading

Fixes #330671

## Testing

- `./scripts/test.sh --grep 'BlockedSessions|OmniCIFailureProvider'`
- targeted ESLint for changed TypeScript files
- `node build/checker/layersChecker.ts`
- `git diff --check`
