### PR TITLE
tunnels: address review follow-ups from #330480

### DIFF
--- a/cli/src/tunnels/control_server.rs
+++ b/cli/src/tunnels/control_server.rs
@@ -288,7 +288,7 @@ pub async fn serve(
 		});
 	}
 
-	machine_status::emit_connected(&tunnel.name, false, !agent_host_only);
+	machine_status::emit_connected(&tunnel.name, Some(&tunnel.id), false, !agent_host_only);
 
 	loop {
 		tokio::select! {

--- a/cli/src/tunnels/machine_status.rs
+++ b/cli/src/tunnels/machine_status.rs
@@ -25,6 +25,8 @@ const STATUS_PREFIX: &str = "__VSCODE_CLI_STATUS__";
 pub(crate) enum MachineStatus {
 	Connected {
 		tunnel_name: String,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		tunnel_id: Option<String>,
 		is_attached: bool,
 		#[serde(skip_serializing_if = "Option::is_none")]
 		link: Option<String>,
@@ -94,7 +96,12 @@ fn emit_to_stdout(status: &MachineStatus) {
 	println!("{}", status_line(status));
 }
 
-pub fn emit_connected(tunnel_name: &str, is_attached: bool, has_editor_link: bool) {
+pub fn emit_connected(
+	tunnel_name: &str,
+	tunnel_id: Option<&str>,
+	is_attached: bool,
+	has_editor_link: bool,
+) {
 	let (link, domain) = if has_editor_link {
 		match get_tunnel_web_url(tunnel_name) {
 			Some(link) => (
@@ -109,6 +116,7 @@ pub fn emit_connected(tunnel_name: &str, is_attached: bool, has_editor_link: boo
 
 	emit(MachineStatus::Connected {
 		tunnel_name: tunnel_name.to_string(),
+		tunnel_id: tunnel_id.map(ToString::to_string),
 		is_attached,
 		link,
 		domain,
@@ -150,11 +158,12 @@ mod tests {
 		assert_eq!(
 			status_line(&MachineStatus::Connected {
 				tunnel_name: "desktop-oss".to_string(),
+				tunnel_id: Some("tunnel-id".to_string()),
 				is_attached: false,
 				link: Some("https://insiders.vscode.dev/tunnel/desktop-oss/c:/some/dir".to_string()),
 				domain: Some("insiders.vscode.dev".to_string()),
 			}),
-			"__VSCODE_CLI_STATUS__{\"type\":\"connected\",\"tunnelName\":\"desktop-oss\",\"isAttached\":false,\"link\":\"https://insiders.vscode.dev/tunnel/desktop-oss/c:/some/dir\",\"domain\":\"insiders.vscode.dev\"}"
+			"__VSCODE_CLI_STATUS__{\"type\":\"connected\",\"tunnelName\":\"desktop-oss\",\"tunnelId\":\"tunnel-id\",\"isAttached\":false,\"link\":\"https://insiders.vscode.dev/tunnel/desktop-oss/c:/some/dir\",\"domain\":\"insiders.vscode.dev\"}"
 		);
 	}
 
@@ -163,6 +172,7 @@ mod tests {
 		assert_eq!(
 			status_line(&MachineStatus::Connected {
 				tunnel_name: "desktop-oss".to_string(),
+				tunnel_id: None,
 				is_attached: true,
 				link: None,
 				domain: None,

--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -380,6 +380,11 @@ pub mod singleton {
 	#[derive(Serialize, Deserialize, Clone, Default)]
 	pub struct StatusWithTunnelName {
 		pub name: Option<String>,
+		/// Whether the running singleton serves the editor, as opposed to only
+		/// the agent host. `None` from servers predating this field, in which
+		/// case a client must fall back to describing its own invocation.
+		#[serde(default)]
+		pub has_editor_link: Option<bool>,
 		#[serde(flatten)]
 		pub status: Status,
 	}
@@ -413,5 +418,38 @@ pub mod singleton {
 		#[default]
 		Disconnected,
 		Connected,
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		/// A singleton server predating `has_editor_link` omits the field
+		/// entirely; clients must still be able to read its status and fall
+		/// back to describing their own invocation.
+		#[test]
+		fn status_without_editor_link_field_deserializes_as_unknown() {
+			// Built by removing the field from a real payload rather than
+			// hand-writing the wire shape, so it stays accurate if `Status`
+			// changes.
+			let mut legacy = serde_json::to_value(StatusWithTunnelName {
+				name: Some("tunnel-name".to_string()),
+				has_editor_link: Some(true),
+				status: Status::default(),
+			})
+			.unwrap();
+			legacy
+				.as_object_mut()
+				.unwrap()
+				.remove("has_editor_link")
+				.unwrap();
+
+			let parsed: StatusWithTunnelName = serde_json::from_value(legacy).unwrap();
+
+			assert_eq!(
+				(parsed.name.as_deref(), parsed.has_editor_link),
+				(Some("tunnel-name"), None)
+			);
+		}
 	}
 }

--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -380,6 +380,10 @@ pub mod singleton {
 	#[derive(Serialize, Deserialize, Clone, Default)]
 	pub struct StatusWithTunnelName {
 		pub name: Option<String>,
+		/// The stable dev tunnel identity. `None` from servers predating this
+		/// field, so clients must not treat a missing value as an identity.
+		#[serde(default)]
+		pub tunnel_id: Option<String>,
 		/// Whether the running singleton serves the editor, as opposed to only
 		/// the agent host. `None` from servers predating this field, in which
 		/// case a client must fall back to describing its own invocation.
@@ -434,6 +438,7 @@ pub mod singleton {
 			// changes.
 			let mut legacy = serde_json::to_value(StatusWithTunnelName {
 				name: Some("tunnel-name".to_string()),
+				tunnel_id: None,
 				has_editor_link: Some(true),
 				status: Status::default(),
 			})
@@ -450,6 +455,42 @@ pub mod singleton {
 				(parsed.name.as_deref(), parsed.has_editor_link),
 				(Some("tunnel-name"), None)
 			);
+		}
+
+		#[test]
+		fn status_with_tunnel_id_round_trips() {
+			let expected = StatusWithTunnelName {
+				name: Some("tunnel-name".to_string()),
+				tunnel_id: Some("tunnel-id".to_string()),
+				has_editor_link: Some(true),
+				status: Status::default(),
+			};
+
+			let parsed: StatusWithTunnelName =
+				serde_json::from_value(serde_json::to_value(&expected).unwrap()).unwrap();
+
+			assert_eq!(
+				(parsed.name.as_deref(), parsed.tunnel_id.as_deref()),
+				(Some("tunnel-name"), Some("tunnel-id"))
+			);
+		}
+
+		/// A singleton server predating `tunnel_id` omits the field entirely,
+		/// so clients can continue to attach without treating its absence as an ID.
+		#[test]
+		fn status_without_tunnel_id_field_deserializes_as_unknown() {
+			let mut legacy = serde_json::to_value(StatusWithTunnelName {
+				name: Some("tunnel-name".to_string()),
+				tunnel_id: Some("tunnel-id".to_string()),
+				has_editor_link: Some(true),
+				status: Status::default(),
+			})
+			.unwrap();
+			legacy.as_object_mut().unwrap().remove("tunnel_id").unwrap();
+
+			let parsed: StatusWithTunnelName = serde_json::from_value(legacy).unwrap();
+
+			assert_eq!(parsed.tunnel_id, None);
 		}
 	}
 }

--- a/cli/src/tunnels/singleton_client.rs
+++ b/cli/src/tunnels/singleton_client.rs
@@ -131,8 +131,14 @@ pub async fn start_singleton_client(args: SingletonClientArgs) -> bool {
 			// connected though, it will be soon, and that'll be in the log replays.
 			if let Ok(Ok(s)) = res.await {
 				if let Some(name) = s.name {
-					print_listening(&c.log, &name, has_editor_link);
-					machine_status::emit_connected(&name, true, has_editor_link);
+					// The running singleton decides what is actually served; a
+					// full-access invocation attaching to an agent-host-only
+					// singleton must not advertise an editor link it cannot
+					// honour. Older servers omit this, so fall back to
+					// describing this invocation.
+					let serves_editor = s.has_editor_link.unwrap_or(has_editor_link);
+					print_listening(&c.log, &name, serves_editor);
+					machine_status::emit_connected(&name, true, serves_editor);
 				}
 			}
 

--- a/cli/src/tunnels/singleton_client.rs
+++ b/cli/src/tunnels/singleton_client.rs
@@ -138,7 +138,12 @@ pub async fn start_singleton_client(args: SingletonClientArgs) -> bool {
 					// describing this invocation.
 					let serves_editor = s.has_editor_link.unwrap_or(has_editor_link);
 					print_listening(&c.log, &name, serves_editor);
-					machine_status::emit_connected(&name, true, serves_editor);
+					machine_status::emit_connected(
+						&name,
+						s.tunnel_id.as_deref(),
+						true,
+						serves_editor,
+					);
 				}
 			}
 

--- a/cli/src/tunnels/singleton_server.rs
+++ b/cli/src/tunnels/singleton_server.rs
@@ -53,6 +53,10 @@ pub struct SingletonServerArgs<'a> {
 
 struct StatusInfo {
 	name: String,
+	/// Whether this singleton serves the editor as well as the agent host, so
+	/// attaching clients can describe what is actually running rather than
+	/// what their own invocation asked for.
+	has_editor_link: bool,
 	lock: StatusLock,
 }
 
@@ -110,6 +114,7 @@ pub fn make_singleton_server(
 				.as_ref()
 				.map(|s| protocol::singleton::StatusWithTunnelName {
 					name: Some(s.name.clone()),
+					has_editor_link: Some(s.has_editor_link),
 					status: s.lock.read(),
 				})
 				.unwrap_or_default())
@@ -167,6 +172,7 @@ pub async fn start_singleton_server(
 		let mut status = args.server.current_status.lock().unwrap();
 		*status = Some(StatusInfo {
 			name: args.tunnel.name.clone(),
+			has_editor_link: !args.agent_host_only,
 			lock: args.tunnel.status(),
 		})
 	}

--- a/cli/src/tunnels/singleton_server.rs
+++ b/cli/src/tunnels/singleton_server.rs
@@ -53,6 +53,7 @@ pub struct SingletonServerArgs<'a> {
 
 struct StatusInfo {
 	name: String,
+	tunnel_id: String,
 	/// Whether this singleton serves the editor as well as the agent host, so
 	/// attaching clients can describe what is actually running rather than
 	/// what their own invocation asked for.
@@ -114,6 +115,7 @@ pub fn make_singleton_server(
 				.as_ref()
 				.map(|s| protocol::singleton::StatusWithTunnelName {
 					name: Some(s.name.clone()),
+					tunnel_id: Some(s.tunnel_id.clone()),
 					has_editor_link: Some(s.has_editor_link),
 					status: s.lock.read(),
 				})
@@ -172,6 +174,7 @@ pub async fn start_singleton_server(
 		let mut status = args.server.current_status.lock().unwrap();
 		*status = Some(StatusInfo {
 			name: args.tunnel.name.clone(),
+			tunnel_id: args.tunnel.id.clone(),
 			has_editor_link: !args.agent_host_only,
 			lock: args.tunnel.status(),
 		})

--- a/src/vs/platform/agentHost/common/tunnelAgentHost.ts
+++ b/src/vs/platform/agentHost/common/tunnelAgentHost.ts
@@ -506,8 +506,20 @@ export const TUNNEL_HOST_LOG_ID = 'tunnelHostService';
 /** Information about an actively hosted tunnel. */
 export interface ITunnelHostInfo {
 	readonly tunnelName: string;
+	/** Stable dev tunnel identity, which can be absent when an older CLI reports the hosted tunnel. */
+	readonly tunnelId?: string;
 	/** Set when remote session access is being provided by full Remote Tunnel Access rather than a dedicated agent host tunnel. */
 	readonly viaRemoteTunnelAccess?: boolean;
+}
+
+/** Whether a discovered tunnel is the hosted tunnel, preferring its stable identity over its display name. */
+export function isTunnelHosted(sharingInfo: ITunnelHostInfo | undefined, tunnel: Pick<ITunnelInfo, 'tunnelId' | 'name'>): boolean {
+	if (!sharingInfo) {
+		return false;
+	}
+	return sharingInfo.tunnelId !== undefined
+		? sharingInfo.tunnelId === tunnel.tunnelId
+		: sharingInfo.tunnelName === tunnel.name;
 }
 
 /** Status of the tunnel host. */

--- a/src/vs/platform/agentHost/node/tunnelHostMainService.ts
+++ b/src/vs/platform/agentHost/node/tunnelHostMainService.ts
@@ -129,11 +129,15 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 		if (!this._request || status.connectionState !== 'connected' || !status.tunnelName) {
 			return { active: false };
 		}
+		const info = {
+			tunnelName: status.tunnelName,
+			...(status.tunnelId === undefined ? {} : { tunnelId: status.tunnelId }),
+		};
 		if (status.mode === 'remoteAccess' || status.mode === 'service') {
-			return { active: true, info: { tunnelName: status.tunnelName, viaRemoteTunnelAccess: true } };
+			return { active: true, info: { ...info, viaRemoteTunnelAccess: true } };
 		}
 		if (status.mode === 'agentHost') {
-			return { active: true, info: { tunnelName: status.tunnelName } };
+			return { active: true, info };
 		}
 		return { active: false };
 	}
@@ -145,6 +149,7 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 		}
 		if (status.active && this._lastStatus.active
 			&& status.info.tunnelName === this._lastStatus.info.tunnelName
+			&& status.info.tunnelId === this._lastStatus.info.tunnelId
 			&& status.info.viaRemoteTunnelAccess === this._lastStatus.info.viaRemoteTunnelAccess) {
 			return;
 		}

--- a/src/vs/platform/agentHost/node/tunnelHostMainService.ts
+++ b/src/vs/platform/agentHost/node/tunnelHostMainService.ts
@@ -56,9 +56,13 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 		// the start timeout elapses.
 		const store = new DisposableStore();
 		try {
-			const ready = this._waitForActiveStatus(store);
-			await this.tunnelProcessCoordinator.setAgentHostSharing({ token, authProvider, logLevel: this._logger.getLevel() });
-			const status = await ready;
+			// Awaited together so the readiness promise always has a handler
+			// attached: disposing the store below rejects it, which would
+			// otherwise go unhandled on exactly the failure path this guards.
+			const [status] = await Promise.all([
+				this._waitForActiveStatus(store),
+				this.tunnelProcessCoordinator.setAgentHostSharing({ token, authProvider, logLevel: this._logger.getLevel() }),
+			]);
 			return status.info;
 		} catch (error) {
 			// Without this the caller sees a failure while the sharing intent

--- a/src/vs/platform/agentHost/node/tunnelHostMainService.ts
+++ b/src/vs/platform/agentHost/node/tunnelHostMainService.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DeferredPromise, raceTimeout } from '../../../base/common/async.js';
+import { CancellationError } from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { localize } from '../../../nls.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
@@ -47,11 +48,34 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 	}
 
 	async startHosting(token: string, authProvider: 'github' | 'microsoft'): Promise<ITunnelHostInfo> {
-		this._request = { token };
-		const ready = this._waitForActiveStatus();
-		await this.tunnelProcessCoordinator.setAgentHostSharing({ token, authProvider, logLevel: this._logger.getLevel() });
-		const status = await ready;
-		return status.info;
+		const request = { token };
+		this._request = request;
+		// The readiness wait is created before the intent is handed over, so it
+		// can outlive a rejection from the coordinator. Owning its store here
+		// tears the wait down immediately instead of leaving it pending until
+		// the start timeout elapses.
+		const store = new DisposableStore();
+		try {
+			const ready = this._waitForActiveStatus(store);
+			await this.tunnelProcessCoordinator.setAgentHostSharing({ token, authProvider, logLevel: this._logger.getLevel() });
+			const status = await ready;
+			return status.info;
+		} catch (error) {
+			// Without this the caller sees a failure while the sharing intent
+			// survives, and a later reconcile brings hosting online anyway.
+			// A newer request owns the intent, so only roll back our own.
+			if (this._request === request) {
+				this._request = undefined;
+				try {
+					await this.tunnelProcessCoordinator.setAgentHostSharing(undefined);
+				} catch (rollbackError) {
+					this._logger.error(rollbackError);
+				}
+			}
+			throw error;
+		} finally {
+			store.dispose();
+		}
 	}
 
 	async stopHosting(): Promise<void> {
@@ -75,13 +99,12 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 		}
 	}
 
-	private async _waitForActiveStatus(): Promise<TunnelHostStatus & { active: true; info: ITunnelHostInfo }> {
+	private async _waitForActiveStatus(store: DisposableStore): Promise<TunnelHostStatus & { active: true; info: ITunnelHostInfo }> {
 		const current = this._getStatus(this.tunnelProcessCoordinator.getStatus());
 		if (current.active) {
 			return current;
 		}
 
-		const store = new DisposableStore();
 		const settled = new DeferredPromise<TunnelHostStatus & { active: true; info: ITunnelHostInfo }>();
 		store.add(this.tunnelProcessCoordinator.onDidChangeStatus(coordinatorStatus => {
 			const status = this._getStatus(coordinatorStatus);
@@ -91,16 +114,15 @@ export class TunnelHostMainService extends Disposable implements ITunnelAgentHos
 				settled.error(new Error(localize('tunnelHost.startFailed', "The agent host tunnel exited before it became ready.")));
 			}
 		}));
+		// Settles the race when the caller abandons the wait, so neither this
+		// promise nor `raceTimeout`'s timer outlives the store.
+		store.add(toDisposable(() => settled.error(new CancellationError())));
 
-		try {
-			const status = await raceTimeout(settled.p, AGENT_HOST_START_TIMEOUT_MS);
-			if (!status) {
-				throw new Error(localize('tunnelHost.startTimeout', "Timed out waiting for the agent host tunnel to start."));
-			}
-			return status;
-		} finally {
-			store.dispose();
+		const status = await raceTimeout(settled.p, AGENT_HOST_START_TIMEOUT_MS);
+		if (!status) {
+			throw new Error(localize('tunnelHost.startTimeout', "Timed out waiting for the agent host tunnel to start."));
 		}
+		return status;
 	}
 
 	private _getStatus(status: ITunnelProcessStatus): TunnelHostStatus {

--- a/src/vs/platform/agentHost/test/common/tunnelAgentHostGateway.test.ts
+++ b/src/vs/platform/agentHost/test/common/tunnelAgentHostGateway.test.ts
@@ -8,6 +8,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import {
 	parseTunnelGatewayInventory,
 	parseTunnelGatewaySelectionResponse,
+	isTunnelHosted,
 	TUNNEL_GATEWAY_MIN_PROTOCOL_VERSION,
 	TUNNEL_GATEWAY_SELECT_PATH,
 	TUNNEL_MIN_PROTOCOL_VERSION,
@@ -92,6 +93,25 @@ suite('tunnelAgentHost - gateway wire protocol', () => {
 			assert.deepStrictEqual(response, {
 				ok: true,
 				selected: { serverType: 'editor', instanceId: 'editor-1', role: 'primary', lifecycle: 'external' },
+			});
+
+			suite('isTunnelHosted', () => {
+				test('matches the stable ID when tunnels share a display name and falls back to the name when it is unavailable', () => {
+					const tunnel = {
+						tunnelId: 'other-id',
+						clusterId: 'cluster',
+						name: 'shared-name',
+						tags: [],
+						protocolVersion: 6,
+						hostConnectionCount: 1,
+					};
+
+					assert.deepStrictEqual([
+						isTunnelHosted({ tunnelName: 'shared-name', tunnelId: 'hosted-id' }, tunnel),
+						isTunnelHosted({ tunnelName: 'shared-name', tunnelId: 'other-id' }, tunnel),
+						isTunnelHosted({ tunnelName: 'shared-name' }, tunnel),
+					], [false, true, true]);
+				});
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/tunnelHostMainService.test.ts
+++ b/src/vs/platform/agentHost/test/node/tunnelHostMainService.test.ts
@@ -25,6 +25,8 @@ class TestTunnelProcessCoordinator implements ITunnelProcessCoordinator {
 	}
 
 	lastSharingRequest: IAgentHostSharingRequest | undefined;
+	sharingRequests: (IAgentHostSharingRequest | undefined)[] = [];
+	failNextSharingRequest = false;
 
 	getStatus(): ITunnelProcessStatus {
 		return this._status;
@@ -40,6 +42,11 @@ class TestTunnelProcessCoordinator implements ITunnelProcessCoordinator {
 
 	setAgentHostSharing(request: IAgentHostSharingRequest | undefined): Promise<void> {
 		this.lastSharingRequest = request;
+		this.sharingRequests.push(request);
+		if (this.failNextSharingRequest) {
+			this.failNextSharingRequest = false;
+			return Promise.reject(new Error('coordinator refused the sharing intent'));
+		}
 		return Promise.resolve();
 	}
 
@@ -117,6 +124,48 @@ suite('TunnelHostMainService', () => {
 			const startHosting = service.startHosting('token', 'github');
 			coordinator.setStatus({ mode: 'agentHost', tunnelName: 'agent', connectionState: 'disconnected', serviceInstallFailed: false });
 			await assert.rejects(startHosting, /exited before it became ready/);
+		} finally {
+			service.dispose();
+			coordinator.dispose();
+			loggerService.dispose();
+		}
+	});
+
+	test('clears the sharing intent when the agent host fails to start', async () => {
+		const coordinator = new TestTunnelProcessCoordinator({ mode: 'agentHost', tunnelName: 'agent', connectionState: 'connecting', serviceInstallFailed: false });
+		const loggerService = new NullLoggerService();
+		const service = new TunnelHostMainService(
+			loggerService,
+			{ logsHome: URI.file('logs') } as INativeEnvironmentService,
+			coordinator,
+		);
+		try {
+			const startHosting = service.startHosting('token', 'github');
+			coordinator.setStatus({ mode: 'agentHost', tunnelName: 'agent', connectionState: 'disconnected', serviceInstallFailed: false });
+			await assert.rejects(startHosting, /exited before it became ready/);
+
+			// A stale intent would let a later reconcile bring hosting online
+			// even though the caller was told it failed.
+			assert.deepStrictEqual(coordinator.sharingRequests.at(-1), undefined);
+		} finally {
+			service.dispose();
+			coordinator.dispose();
+			loggerService.dispose();
+		}
+	});
+
+	test('clears the sharing intent when the coordinator rejects the request', async () => {
+		const coordinator = new TestTunnelProcessCoordinator({ mode: 'agentHost', tunnelName: 'agent', connectionState: 'connecting', serviceInstallFailed: false });
+		const loggerService = new NullLoggerService();
+		const service = new TunnelHostMainService(
+			loggerService,
+			{ logsHome: URI.file('logs') } as INativeEnvironmentService,
+			coordinator,
+		);
+		try {
+			coordinator.failNextSharingRequest = true;
+			await assert.rejects(service.startHosting('token', 'github'), /refused the sharing intent/);
+			assert.deepStrictEqual(coordinator.sharingRequests.at(-1), undefined);
 		} finally {
 			service.dispose();
 			coordinator.dispose();

--- a/src/vs/platform/remoteTunnel/common/tunnelMachineStatus.ts
+++ b/src/vs/platform/remoteTunnel/common/tunnelMachineStatus.ts
@@ -10,6 +10,7 @@ export const TUNNEL_MACHINE_STATUS_PREFIX = '__VSCODE_CLI_STATUS__';
 export interface IConnectedTunnelMachineStatus {
 	readonly type: 'connected';
 	readonly tunnelName: string;
+	readonly tunnelId?: string;
 	readonly isAttached: boolean;
 	readonly link?: string;
 	readonly domain?: string;
@@ -42,6 +43,7 @@ export function parseTunnelMachineStatus(message: string): TunnelMachineStatus |
 
 	if (value.type === 'connected') {
 		if (!isString(value.tunnelName) || typeof value.isAttached !== 'boolean'
+			|| (value.tunnelId !== undefined && !isString(value.tunnelId))
 			|| (value.link !== undefined && !isString(value.link))
 			|| (value.domain !== undefined && !isString(value.domain))
 			|| (value.link === undefined) !== (value.domain === undefined)) {
@@ -50,6 +52,7 @@ export function parseTunnelMachineStatus(message: string): TunnelMachineStatus |
 		return {
 			type: 'connected',
 			tunnelName: value.tunnelName,
+			...(value.tunnelId === undefined ? {} : { tunnelId: value.tunnelId }),
 			isAttached: value.isAttached,
 			...(value.link === undefined ? {} : { link: value.link, domain: value.domain }),
 		};

--- a/src/vs/platform/remoteTunnel/node/codeTunnelCliProcess.ts
+++ b/src/vs/platform/remoteTunnel/node/codeTunnelCliProcess.ts
@@ -154,7 +154,7 @@ export class CodeTunnelCli {
 						onOutput(`${logLabel} error(${tunnelProcess.pid}): + ${e} `, true);
 						tunnelProcess = undefined;
 						resolveExit?.();
-						reject();
+						reject(e);
 					}
 				});
 			});

--- a/src/vs/platform/remoteTunnel/node/remoteTunnelService.ts
+++ b/src/vs/platform/remoteTunnel/node/remoteTunnelService.ts
@@ -214,7 +214,10 @@ export class RemoteTunnelService extends Disposable implements IRemoteTunnelServ
 	}
 
 	private _handleMachineStatus(event: ITunnelProcessMachineStatus): void {
-		if (event.mode !== 'remoteAccess') {
+		// `service` mode also runs a session process, which attaches to the
+		// installed service's singleton; its events are what move the public
+		// status off `connecting`.
+		if (event.mode !== 'remoteAccess' && event.mode !== 'service') {
 			return;
 		}
 		if (event.status.type === 'connected') {

--- a/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
+++ b/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
@@ -192,8 +192,8 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		if (this._status.mode !== target.mode || this._status.tunnelName !== tunnelName) {
 			return false;
 		}
-		// Only the modes that own a child process can be confirmed from here;
-		// `service` is hosted outside this process, so it always reconciles.
+		// Every mode except `none` runs a session process, even `service`, which
+		// attaches to the installed service's singleton to report its status.
 		return target.mode === 'none' || !!this._currentProcess;
 	}
 
@@ -231,15 +231,15 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		if (generation !== this._generation) {
 			return;
 		}
-		if (target.mode === 'service') {
-			let serviceInstallFailed = false;
-			if (!isServiceInstalled) {
-				serviceInstallFailed = await this._installService(target.logLevel, tunnelName!, generation) === false;
+		if (target.mode === 'service' && !isServiceInstalled) {
+			const serviceInstallFailed = await this._installService(target.logLevel, tunnelName!, generation) === false;
+			if (generation !== this._generation) {
+				return;
 			}
-			if (generation === this._generation) {
-				this._setStatus({ ...this._status, serviceInstallFailed });
-			}
-			return;
+			// A failed install is not fatal: the session tunnel below still
+			// runs, matching the pre-CLI behaviour of falling back to hosting
+			// in-session and reporting the failure alongside it.
+			this._setStatus({ ...this._status, serviceInstallFailed });
 		}
 
 		if (target.login) {
@@ -266,7 +266,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 			args.push('--accept-server-license-terms', '--log', LogLevelToString(target.logLevel));
 			args.push('--user-data-dir', this.environmentService.userDataPath, '--delegate-to-editor', '--name', tunnelName!, '--parent-process-id', String(process.pid));
 		}
-		if (target.mode === 'remoteAccess' && this._preventSleep()) {
+		if (target.mode !== 'agentHost' && this._preventSleep()) {
 			args.push('--no-sleep');
 		}
 		this._startTunnel(args, target.mode, generation);

--- a/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
+++ b/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
@@ -170,14 +170,34 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 
 	private _schedule(uninstallService: boolean, forceRestart = false): Promise<void> {
 		this._uninstallServicePending ||= uninstallService;
+
+		// Checked before stopping anything: `_reconcile` can only observe a
+		// process this method already stopped, so a no-op update would
+		// otherwise tear down a perfectly healthy tunnel.
+		if (!forceRestart && !this._uninstallServicePending && this._isTargetSatisfied()) {
+			return Promise.resolve();
+		}
+
 		const generation = ++this._generation;
 		void this._currentProcess?.stop();
-		const operation = this._queue.then(() => this._reconcile(generation, forceRestart));
+		const operation = this._queue.then(() => this._reconcile(generation));
 		this._queue = operation.catch(() => { });
 		return operation;
 	}
 
-	private async _reconcile(generation: number, forceRestart: boolean): Promise<void> {
+	/** Whether what is running already matches the resolved intent. */
+	private _isTargetSatisfied(): boolean {
+		const target = this._getTarget();
+		const tunnelName = target.mode === 'none' ? undefined : this._getTunnelName();
+		if (this._status.mode !== target.mode || this._status.tunnelName !== tunnelName) {
+			return false;
+		}
+		// Only the modes that own a child process can be confirmed from here;
+		// `service` is hosted outside this process, so it always reconciles.
+		return target.mode === 'none' || !!this._currentProcess;
+	}
+
+	private async _reconcile(generation: number): Promise<void> {
 		await this._stopCurrentProcess();
 		if (generation !== this._generation) {
 			return;
@@ -195,9 +215,6 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 
 		const target = this._getTarget();
 		const tunnelName = target.mode === 'none' ? undefined : this._getTunnelName();
-		if (!forceRestart && this._status.mode === target.mode && this._status.tunnelName === tunnelName && this._currentProcess) {
-			return;
-		}
 
 		if (target.mode === 'none') {
 			await this._runTransient('kill', ['tunnel', 'kill'], 'none', generation);

--- a/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
+++ b/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
@@ -35,6 +35,26 @@ interface ITunnelLoginCredentials {
 	readonly token: string;
 }
 
+/** The tunnel the current intents resolve to. */
+interface ITunnelTarget {
+	readonly mode: TunnelProcessMode;
+	readonly login: ITunnelLoginCredentials | undefined;
+	readonly logLevel: LogLevel;
+}
+
+/**
+ * A launched process's inputs, kept so a later intent update can tell whether
+ * it would produce the same process or genuinely needs a new one.
+ */
+interface ILaunchDescription {
+	readonly mode: TunnelProcessMode;
+	readonly tunnelName: string;
+	readonly providerId: string | undefined;
+	readonly token: string | undefined;
+	readonly logLevel: LogLevel;
+	readonly preventSleep: boolean;
+}
+
 /** A line emitted by a CLI invocation owned by the coordinator. */
 export interface ITunnelProcessOutput {
 	readonly mode: TunnelProcessMode;
@@ -115,6 +135,8 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 	 * idea an uninstall was owed. Cleared only once an uninstall succeeds.
 	 */
 	private _uninstallServicePending = false;
+	/** Inputs of the currently running process, or undefined when none runs. */
+	private _launched: ILaunchDescription | undefined;
 	private _status: ITunnelProcessStatus = { mode: 'none', tunnelName: undefined, tunnelId: undefined, connectionState: 'disconnected', serviceInstallFailed: false };
 
 	constructor(
@@ -186,16 +208,45 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		return operation;
 	}
 
-	/** Whether what is running already matches the resolved intent. */
+	/**
+	 * Whether the running process was launched from exactly the inputs the
+	 * current intent resolves to. Compares the full launch description, not
+	 * just mode and name: callers also update the session token, log level and
+	 * sleep prevention, and each of those has to reach a new process.
+	 */
 	private _isTargetSatisfied(): boolean {
 		const target = this._getTarget();
-		const tunnelName = target.mode === 'none' ? undefined : this._getTunnelName();
-		if (this._status.mode !== target.mode || this._status.tunnelName !== tunnelName) {
+		if (target.mode === 'none') {
+			return this._status.mode === 'none';
+		}
+		// A run that already reported failure cannot satisfy anything: a token
+		// error cancels the child and marks us disconnected before it exits, so
+		// treating it as healthy would skip the reconcile and leave nothing
+		// running once the cancelled child finally goes away.
+		if (!this._currentProcess || this._status.connectionState === 'disconnected') {
 			return false;
 		}
-		// Every mode except `none` runs a session process, even `service`, which
-		// attaches to the installed service's singleton to report its status.
-		return target.mode === 'none' || !!this._currentProcess;
+		const launched = this._launched;
+		const wanted = this._describeLaunch(target);
+		return !!launched
+			&& launched.mode === wanted.mode
+			&& launched.tunnelName === wanted.tunnelName
+			&& launched.providerId === wanted.providerId
+			&& launched.token === wanted.token
+			&& launched.logLevel === wanted.logLevel
+			&& launched.preventSleep === wanted.preventSleep;
+	}
+
+	/** Everything that changes what a launched tunnel process actually does. */
+	private _describeLaunch(target: ITunnelTarget): ILaunchDescription {
+		return {
+			mode: target.mode,
+			tunnelName: this._getTunnelName(),
+			providerId: target.login?.providerId,
+			token: target.login?.token,
+			logLevel: target.logLevel,
+			preventSleep: this._preventSleep(),
+		};
 	}
 
 	private async _reconcile(generation: number): Promise<void> {
@@ -270,6 +321,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		if (target.mode !== 'agentHost' && this._preventSleep()) {
 			args.push('--no-sleep');
 		}
+		this._launched = this._describeLaunch(target);
 		this._startTunnel(args, target.mode, generation);
 	}
 
@@ -278,7 +330,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 	 * {@link IRemoteTunnelSession}: agent host sharing has no session, only a
 	 * token, and fabricating one with empty ids would misrepresent that.
 	 */
-	private _getTarget(): { mode: TunnelProcessMode; login: ITunnelLoginCredentials | undefined; logLevel: LogLevel } {
+	private _getTarget(): ITunnelTarget {
 		if (this._remoteAccess.mode.active) {
 			const session = this._remoteAccess.mode.session;
 			return {
@@ -323,24 +375,16 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 	private _startTunnel(args: readonly string[], mode: TunnelProcessMode, generation: number): void {
 		const tunnelRun = this._tunnelCli.run('tunnel', args, (message, isError) => this._fireOutput(mode, message, isError, true, () => tunnelRun.result.cancel(), generation), { VSCODE_CLI_MACHINE_STATUS: '1' });
 		this._currentProcess = tunnelRun;
-		void tunnelRun.result.then(
-			() => {
-				if (this._currentProcess === tunnelRun) {
-					this._currentProcess = undefined;
-					if (generation === this._generation) {
-						this._setStatus({ ...this._status, connectionState: 'disconnected' });
-					}
+		const onSettled = () => {
+			if (this._currentProcess === tunnelRun) {
+				this._currentProcess = undefined;
+				this._launched = undefined;
+				if (generation === this._generation) {
+					this._setStatus({ ...this._status, connectionState: 'disconnected' });
 				}
-			},
-			() => {
-				if (this._currentProcess === tunnelRun) {
-					this._currentProcess = undefined;
-					if (generation === this._generation) {
-						this._setStatus({ ...this._status, connectionState: 'disconnected' });
-					}
-				}
-			},
-		);
+			}
+		};
+		void tunnelRun.result.then(onSettled, onSettled);
 	}
 
 	private async _runTransient(logLabel: string, args: readonly string[], mode: TunnelProcessMode, generation: number, env?: Record<string, string>, onOutput?: CodeTunnelCliOutput): Promise<number> {
@@ -368,6 +412,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		await run.stop();
 		if (this._currentProcess === run) {
 			this._currentProcess = undefined;
+			this._launched = undefined;
 		}
 	}
 

--- a/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
+++ b/src/vs/platform/remoteTunnel/node/tunnelProcessCoordinator.ts
@@ -53,6 +53,7 @@ export interface ITunnelProcessMachineStatus {
 export interface ITunnelProcessStatus {
 	readonly mode: TunnelProcessMode;
 	readonly tunnelName: string | undefined;
+	readonly tunnelId?: string;
 	readonly connectionState: TunnelProcessConnectionState;
 	readonly serviceInstallFailed: boolean;
 }
@@ -114,7 +115,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 	 * idea an uninstall was owed. Cleared only once an uninstall succeeds.
 	 */
 	private _uninstallServicePending = false;
-	private _status: ITunnelProcessStatus = { mode: 'none', tunnelName: undefined, connectionState: 'disconnected', serviceInstallFailed: false };
+	private _status: ITunnelProcessStatus = { mode: 'none', tunnelName: undefined, tunnelId: undefined, connectionState: 'disconnected', serviceInstallFailed: false };
 
 	constructor(
 		tunnelCliFactory: TunnelCliFactory | undefined,
@@ -219,12 +220,12 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 		if (target.mode === 'none') {
 			await this._runTransient('kill', ['tunnel', 'kill'], 'none', generation);
 			if (generation === this._generation) {
-				this._setStatus({ mode: 'none', tunnelName: undefined, connectionState: 'disconnected', serviceInstallFailed: false });
+				this._setStatus({ mode: 'none', tunnelName: undefined, tunnelId: undefined, connectionState: 'disconnected', serviceInstallFailed: false });
 			}
 			return;
 		}
 
-		this._setStatus({ mode: target.mode, tunnelName, connectionState: 'connecting', serviceInstallFailed: false });
+		this._setStatus({ mode: target.mode, tunnelName, tunnelId: undefined, connectionState: 'connecting', serviceInstallFailed: false });
 		const isServiceInstalled = target.mode === 'service' || target.mode === 'remoteAccess'
 			? await this._isServiceInstalled(generation)
 			: false;
@@ -376,7 +377,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 			const status = parseTunnelMachineStatus(message);
 			if (status) {
 				if (status.type === 'connected' && this._status.mode === mode) {
-					this._setStatus({ ...this._status, connectionState: 'connected' });
+					this._setStatus({ ...this._status, tunnelId: status.tunnelId, connectionState: 'connected' });
 				}
 				this._onDidMachineStatus.fire({ mode, status, cancel });
 			}
@@ -386,6 +387,7 @@ export class TunnelProcessCoordinator extends Disposable implements ITunnelProce
 	private _setStatus(status: ITunnelProcessStatus): void {
 		if (this._status.mode === status.mode
 			&& this._status.tunnelName === status.tunnelName
+			&& this._status.tunnelId === status.tunnelId
 			&& this._status.connectionState === status.connectionState
 			&& this._status.serviceInstallFailed === status.serviceInstallFailed) {
 			return;

--- a/src/vs/platform/remoteTunnel/test/common/tunnelMachineStatus.test.ts
+++ b/src/vs/platform/remoteTunnel/test/common/tunnelMachineStatus.test.ts
@@ -13,10 +13,12 @@ suite('Tunnel machine status', () => {
 	test('parses valid status lines and ignores invalid output', () => {
 		assert.deepStrictEqual([
 			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"connected","tunnelName":"desktop-oss","isAttached":false,"link":"https://insiders.vscode.dev/tunnel/desktop-oss/c:/dir","domain":"insiders.vscode.dev"}`),
+			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"connected","tunnelName":"desktop-oss","tunnelId":"tunnel-id","isAttached":false}`),
 			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"connected","tunnelName":"desktop-oss","isAttached":true}`),
 			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"tokenError","message":"token expired"}`),
 			parseTunnelMachineStatus(`\u001b[32m${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"connected","tunnelName":"desktop-oss","isAttached":false}\u001b[0m`),
 			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{invalid}`),
+			parseTunnelMachineStatus(`${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"connected","tunnelName":"desktop-oss","tunnelId":1,"isAttached":false}`),
 			parseTunnelMachineStatus(`noise ${TUNNEL_MACHINE_STATUS_PREFIX}{"type":"tokenError","message":"token expired"}`),
 			parseTunnelMachineStatus('unrelated noise'),
 		], [
@@ -26,6 +28,12 @@ suite('Tunnel machine status', () => {
 				isAttached: false,
 				link: 'https://insiders.vscode.dev/tunnel/desktop-oss/c:/dir',
 				domain: 'insiders.vscode.dev',
+			},
+			{
+				type: 'connected',
+				tunnelName: 'desktop-oss',
+				tunnelId: 'tunnel-id',
+				isAttached: false,
 			},
 			{
 				type: 'connected',
@@ -41,6 +49,7 @@ suite('Tunnel machine status', () => {
 				tunnelName: 'desktop-oss',
 				isAttached: false,
 			},
+			undefined,
 			undefined,
 			undefined,
 			undefined,

--- a/src/vs/platform/remoteTunnel/test/node/codeTunnelCliProcess.test.ts
+++ b/src/vs/platform/remoteTunnel/test/node/codeTunnelCliProcess.test.ts
@@ -130,6 +130,18 @@ suite('CodeTunnelCli', () => {
 		});
 	});
 
+	test('rejects with the underlying spawn error', async () => {
+		const { cli, spawnCalls } = createTestCli(true);
+		const run = cli.run('serve', ['tunnel', '--name', 'host'], () => { });
+		const spawnError = new Error('spawn code-tunnel ENOENT');
+
+		spawnCalls[0].process.child.emit('error', spawnError);
+
+		// An undefined rejection loses the actionable cause, such as a missing
+		// or non-executable tunnel binary.
+		await assert.rejects(run.result, (error: unknown) => error === spawnError);
+	});
+
 	test('kills the CLI process when cancelled', async () => {
 		const logs: string[] = [];
 		const spawnCalls: SpawnCall[] = [];

--- a/src/vs/platform/remoteTunnel/test/node/remoteTunnelService.test.ts
+++ b/src/vs/platform/remoteTunnel/test/node/remoteTunnelService.test.ts
@@ -155,6 +155,44 @@ suite('Remote tunnel', () => {
 		}
 	});
 
+	test('reaches connected from service-mode machine status', async () => {
+		const coordinator = new TestTunnelProcessCoordinator();
+		const loggerService = new NullLoggerService();
+		const storageService = new InMemoryStorageService();
+		const service = new RemoteTunnelService(
+			NullTelemetryService,
+			{ tunnelApplicationName: 'code-tunnel' } as IProductService,
+			{ appRoot: 'installation', isBuilt: true, logsHome: URI.file('logs'), userDataPath: 'custom-user-data' } as INativeEnvironmentService,
+			loggerService,
+			{ _serviceBrand: undefined, onWillShutdown: Event.None } as ISharedProcessLifecycleService,
+			new TestConfigurationService(),
+			storageService,
+			coordinator,
+		);
+		try {
+			await service.initialize({
+				active: true,
+				asService: true,
+				session: { providerId: 'github', sessionId: 'session', accountLabel: 'account' },
+			});
+
+			// The session process that attaches to the installed service reports
+			// under `service`; dropping those events left the UI on "connecting".
+			coordinator.fireMachineStatus('service', { type: 'connected', tunnelName: 'test_host', isAttached: true });
+
+			assert.deepStrictEqual(await service.getTunnelStatus(), {
+				type: 'connected',
+				info: { tunnelName: 'test_host', isAttached: true },
+				serviceInstallFailed: false,
+			});
+		} finally {
+			service.dispose();
+			coordinator.dispose();
+			loggerService.dispose();
+			storageService.dispose();
+		}
+	});
+
 	test('reports the intended tunnel name while access is inactive', async () => {
 		const coordinator = new TestTunnelProcessCoordinator();
 		const loggerService = new NullLoggerService();

--- a/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
+++ b/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
@@ -137,6 +137,54 @@ suite('TunnelProcessCoordinator', () => {
 		}
 	});
 
+	test('leaves a healthy tunnel running when the resolved target is unchanged', async () => {
+		const { coordinator, processes } = createCoordinator();
+		try {
+			await coordinator.setRemoteAccess(activeMode(), LogLevel.Info);
+			const tunnel = processes.find(process => process.args.includes('--accept-server-license-terms'))!;
+
+			// Remote Tunnel Access stays the winning target, so toggling agent
+			// host sharing must not disturb the running tunnel.
+			await coordinator.setAgentHostSharing(agentRequest());
+
+			assert.deepStrictEqual({
+				wasKilled: tunnel.wasKilled(),
+				tunnelProcessCount: processes.filter(process => process.args[0] === 'tunnel'
+					&& !process.args.includes('status')
+					&& !process.args.includes('login')
+					&& !process.args.includes('install')
+					&& !process.args.includes('kill')
+					&& !process.args.includes('uninstall')).length,
+			}, {
+				wasKilled: false,
+				tunnelProcessCount: 1,
+			});
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
+	test('restart() still replaces a healthy tunnel', async () => {
+		const { coordinator, processes } = createCoordinator();
+		try {
+			await coordinator.setRemoteAccess(activeMode(), LogLevel.Info);
+			const tunnel = processes.find(process => process.args.includes('--accept-server-license-terms'))!;
+			await coordinator.restart();
+
+			assert.strictEqual(tunnel.wasKilled(), true);
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
 	test('waits for the prior tunnel process to exit before spawning its replacement', async () => {
 		const ordering: string[] = [];
 		const { coordinator, processes } = createCoordinator(false, ordering);

--- a/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
+++ b/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
@@ -168,6 +168,59 @@ suite('TunnelProcessCoordinator', () => {
 		}
 	});
 
+	test('restarts when the session token changes even though mode and name do not', async () => {
+		const { coordinator, processes } = createCoordinator();
+		const countTunnels = () => processes.filter(p => p.args[0] === 'tunnel'
+			&& !p.args.includes('status') && !p.args.includes('login')
+			&& !p.args.includes('install') && !p.args.includes('kill') && !p.args.includes('uninstall')).length;
+		try {
+			await coordinator.setRemoteAccess(activeMode(), LogLevel.Info);
+			const before = countTunnels();
+
+			// A refreshed token has to reach a new process; skipping the
+			// reconcile would leave the tunnel running on the stale one.
+			const refreshed: ActiveTunnelMode = {
+				active: true,
+				asService: false,
+				session: { providerId: 'github', sessionId: 'session', accountLabel: 'account', token: 'refreshed-token' },
+			};
+			await coordinator.setRemoteAccess(refreshed, LogLevel.Info);
+
+			assert.deepStrictEqual({ before, after: countTunnels() }, { before: 1, after: 2 });
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
+	test('restarts a run that already reported disconnected', async () => {
+		const { coordinator, processes } = createCoordinator();
+		const countTunnels = () => processes.filter(p => p.args[0] === 'tunnel'
+			&& !p.args.includes('status') && !p.args.includes('login')
+			&& !p.args.includes('install') && !p.args.includes('kill') && !p.args.includes('uninstall')).length;
+		try {
+			await coordinator.setRemoteAccess(activeMode(), LogLevel.Info);
+			const before = countTunnels();
+
+			// A token error cancels the child and reports disconnected before it
+			// exits. Treating that run as healthy would skip the reconcile and
+			// leave nothing running once the cancelled child goes away.
+			coordinator.setRemoteAccessStatus({ type: 'disconnected' });
+			await coordinator.setRemoteAccess(activeMode(), LogLevel.Info);
+
+			assert.deepStrictEqual({ before, after: countTunnels() }, { before: 1, after: 2 });
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
 	test('restart() still replaces a healthy tunnel', async () => {
 		const { coordinator, processes } = createCoordinator();
 		try {

--- a/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
+++ b/src/vs/platform/remoteTunnel/test/node/tunnelProcessCoordinator.test.ts
@@ -27,7 +27,7 @@ interface TestChildProcess {
 	emitExit(): void;
 }
 
-function createProcess(args: readonly string[], complete: boolean, statusOutput?: string, exitOnKill = true, env?: NodeJS.ProcessEnv): TestChildProcess {
+function createProcess(args: readonly string[], complete: boolean, statusOutput?: string, exitOnKill = true, env?: NodeJS.ProcessEnv, exitCode = 0): TestChildProcess {
 	const stdout = new PassThrough();
 	const stderr = new PassThrough();
 	let killed = false;
@@ -48,7 +48,7 @@ function createProcess(args: readonly string[], complete: boolean, statusOutput?
 			if (statusOutput) {
 				stdout.write(statusOutput);
 			}
-			child.emit('exit', 0);
+			child.emit('exit', exitCode);
 		});
 	}
 	return { child, stdout, stderr, args, env, kill: child.kill.bind(child), wasKilled: () => killed, emitExit: () => child.emit('exit', null) };
@@ -62,7 +62,7 @@ function agentRequest(): IAgentHostSharingRequest {
 	return { token: 'agent-token', authProvider: 'github', logLevel: LogLevel.Info };
 }
 
-function createCoordinator(exitOnKill = true, ordering?: string[]) {
+function createCoordinator(exitOnKill = true, ordering?: string[], installExitCode = 0) {
 	const processes: TestChildProcess[] = [];
 	const spawn: CodeTunnelSpawn = (_command: string, args: readonly string[], options: SpawnOptions) => {
 		const complete = args.includes('login') || args.includes('status') || args.includes('install') || args.includes('kill') || args.includes('uninstall');
@@ -70,7 +70,7 @@ function createCoordinator(exitOnKill = true, ordering?: string[]) {
 		if (isTunnelProcess) {
 			ordering?.push(args.includes('--agent-host-only') ? 'spawn-agent-host' : 'spawn-remote-access');
 		}
-		const process = createProcess(args, complete, args.includes('status') ? '{"service_installed":false,"tunnel":null}\n' : undefined, exitOnKill || complete, options.env);
+		const process = createProcess(args, complete, args.includes('status') ? '{"service_installed":false,"tunnel":null}\n' : undefined, exitOnKill || complete, options.env, args.includes('install') ? installExitCode : 0);
 		if (isTunnelProcess && ordering) {
 			process.child.on('exit', () => ordering.push(args.includes('--agent-host-only') ? 'exit-agent-host' : 'exit-remote-access'));
 			const kill = process.child.kill;
@@ -185,6 +185,55 @@ suite('TunnelProcessCoordinator', () => {
 		}
 	});
 
+	test('starts a session tunnel alongside the installed service so readiness can advance', async () => {
+		const { coordinator, processes } = createCoordinator();
+		try {
+			await coordinator.setRemoteAccess(activeMode(true), LogLevel.Info);
+			const sessionTunnel = processes.find(process => process.args.includes('--accept-server-license-terms')
+				&& !process.args.includes('install'));
+
+			// Without a session process nothing ever reports connected, so the
+			// UI stays stuck on "connecting" after the service is installed.
+			assert.deepStrictEqual({
+				installed: processes.some(process => process.args.includes('install')),
+				startedSessionTunnel: !!sessionTunnel,
+				mode: coordinator.getStatus().mode,
+			}, {
+				installed: true,
+				startedSessionTunnel: true,
+				mode: 'service',
+			});
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
+	test('falls back to hosting in-session when the service install fails', async () => {
+		const { coordinator, processes } = createCoordinator(true, undefined, 1);
+		try {
+			await coordinator.setRemoteAccess(activeMode(true), LogLevel.Info);
+
+			assert.deepStrictEqual({
+				serviceInstallFailed: coordinator.getStatus().serviceInstallFailed,
+				startedSessionTunnel: processes.some(process => process.args.includes('--accept-server-license-terms')
+					&& !process.args.includes('install')),
+			}, {
+				serviceInstallFailed: true,
+				startedSessionTunnel: true,
+			});
+		} finally {
+			for (const process of processes) {
+				process.emitExit();
+			}
+			await new Promise<void>(resolve => setImmediate(resolve));
+			coordinator.dispose();
+		}
+	});
+
 	test('waits for the prior tunnel process to exit before spawning its replacement', async () => {
 		const ordering: string[] = [];
 		const { coordinator, processes } = createCoordinator(false, ordering);
@@ -218,19 +267,6 @@ suite('TunnelProcessCoordinator', () => {
 				['tunnel', '--agent-host-only', '--name', 'test_host', '--user-data-dir', 'custom-user-data', '--delegate-to-editor', '--parent-process-id', String(process.pid)],
 				['tunnel', '--agent-host-only', '--name', 'test_host', '--user-data-dir', 'custom-user-data', '--delegate-to-editor', '--parent-process-id', String(process.pid)],
 			]);
-		} finally {
-			coordinator.dispose();
-		}
-	});
-
-	test('uses no coordinator-owned tunnel process for service mode', async () => {
-		const { coordinator, processes } = createCoordinator();
-		try {
-			await coordinator.setRemoteAccess(activeMode(true), LogLevel.Info);
-			assert.deepStrictEqual({
-				status: coordinator.getStatus().mode,
-				tunnelProcesses: processes.filter(process => process.args[0] === 'tunnel' && !process.args.includes('status') && !process.args.includes('install')).length,
-			}, { status: 'service', tunnelProcesses: 0 });
 		} finally {
 			coordinator.dispose();
 		}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -28,7 +28,7 @@ import { IOpenerService } from '../../../../../platform/opener/common/opener.js'
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, isSSHHostKeyDeniedError, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
-import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { isTunnelHosted, ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IWSLRemoteAgentHostService, WSL_INSTALL_DOCS_URL, type IWSLDistro } from '../../../../../platform/agentHost/common/wslRemoteAgentHost.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -898,7 +898,7 @@ async function promptToConnectViaTunnel(
 		iconClass: ThemeIcon.asClassName(Codicon.trash),
 		tooltip: localize('tunnelDeleteTooltip', "Delete Dev Tunnel"),
 	};
-	const isHostedTunnel = (tunnel: ITunnelInfo): boolean => tunnelHostService?.sharingInfo?.tunnelName === tunnel.name;
+	const isHostedTunnel = (tunnel: ITunnelInfo): boolean => isTunnelHosted(tunnelHostService?.sharingInfo, tunnel);
 	const toTunnelPickItems = (tunnelInfos: readonly ITunnelInfo[]): ITunnelPickItem[] => tunnelInfos
 		.filter(tunnel => !isHostedTunnel(tunnel))
 		.map(tunnel => ({

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -8,7 +8,7 @@ import { isWeb } from '../../../../../base/common/platform.js';
 import { mainWindow } from '../../../../../base/browser/window.js';
 import * as nls from '../../../../../nls.js';
 import { IRemoteAgentHostService, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { isTunnelHosted, ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -209,8 +209,8 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		return this._tunnelService.getCachedTunnels().filter(tunnel => !this._tunnelService.isAutoConnectSuppressed(tunnel.tunnelId));
 	}
 
-	private _isHostedTunnel(tunnel: { readonly name: string }): boolean {
-		return this._tunnelHostService.sharingInfo?.tunnelName === tunnel.name;
+	private _isHostedTunnel(tunnel: Pick<ITunnelInfo, 'tunnelId' | 'name'>): boolean {
+		return isTunnelHosted(this._tunnelHostService.sharingInfo, tunnel);
 	}
 
 	private _resetHostedTunnelReconnectState(): void {


### PR DESCRIPTION
Follow-ups from @dmitrivMS's review of #330480, which merged before the comments were addressed.

### Fixed here

- **Needless tunnel restarts.** `_reconcile` guarded its no-op path on `_currentProcess`, but `_schedule` stops that process and `_reconcile` awaits the stop before reaching the guard — so it was always `undefined` and the guard was dead code. Every intent update tore down a healthy tunnel. Now compared in `_schedule` before anything is stopped, with `restart()` keeping an explicit forced path.
- **Lost sharing intent on failure.** `startHosting` left `_request` and the coordinator's sharing intent set when the coordinator rejected or readiness failed, so a later reconcile could bring hosting online after the caller was told it failed. The abandoned readiness wait also lingered for the full five minute start timeout; its store is now owned by the caller and disposed immediately.
- **Swallowed spawn errors.** The child `error` handler called `reject()` with no argument, so a missing or non-executable tunnel binary surfaced as an undefined rejection.
- **Service mode stuck connecting.** Service mode returned right after installing, so nothing advanced `connecting` -> `connected`, and a failed install dropped the in-session fallback. Service mode now falls through to the session tunnel, which attaches to the installed service's singleton and reports its status — the behaviour that predated the CLI refactor.
- **Editor link advertised for a singleton that does not serve it.** `has_editor_link` described the attaching invocation rather than the singleton attached to.
- **Hosted tunnel identified by display name.** Distinct dev tunnels can share a name, so the hosted-tunnel checks could hide, reset, or disconnect an unrelated tunnel. The dev tunnels ID is now carried from the CLI to `sharingInfo` and both call sites share one `isTunnelHosted` helper.

### Not addressed pending a decision

- `--delegate-to-editor` binds to whichever editor most recently updated the shared registry rather than the initiating one, so with multiple windows on one user-data directory another window can become newest between startup and connection. This was a deliberate simplification when the feature was built, and re-plumbing the initiating instance ID reverses that decision, so I did not make the call unilaterally. Happy to do it if you'd like.

### Notes

Every fix has a test that I verified fails without it.

Both new cross-process fields (the singleton's capability, and the tunnel ID) are optional end to end: a client attached to a singleton from an older build falls back to the previous behaviour instead of silently losing a link or failing to match.

One removal worth calling out: `uses no coordinator-owned tunnel process for service mode` asserted exactly the broken service-mode behaviour, which is why that regression went unnoticed — it is deleted rather than adjusted.
