### PR TITLE
Add reactive rich links to the Markdown editor

### DIFF
--- a/extensions/markdown-language-features/markdown-editor-src/editor.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/editor.ts
@@ -13,6 +13,7 @@ import '@vscode/markdown-editor/commentInput.css';
 import '@vscode/markdown-editor/vscodeCommentWidgetV2.css';
 import './markdownEditor.css';
 import { WebviewSyntaxHighlighter } from './syntaxHighlighter';
+import { WebviewLinkPresentationProvider } from './linkPresentationProvider';
 
 interface VsCodeApi {
 	postMessage(message: unknown): void;
@@ -64,6 +65,9 @@ class Editor extends Disposable {
 	readonly #messageSecret: string;
 	readonly #vscode = acquireVsCodeApi();
 	readonly #syntaxHighlighter = new WebviewSyntaxHighlighter((message) => this.#vscode.postMessage(message));
+	readonly #linkPresentationProvider = this._register(new WebviewLinkPresentationProvider(
+		(message) => this.#vscode.postMessage(message),
+	));
 
 	constructor(host: HTMLElement, initialState: InitialState) {
 		super();
@@ -83,6 +87,9 @@ class Editor extends Disposable {
 				return;
 			}
 			if (this.#syntaxHighlighter.handleMessage(message)) {
+				return;
+			}
+			if (this.#linkPresentationProvider.handleMessage(message)) {
 				return;
 			}
 			switch (message.type) {
@@ -181,6 +188,7 @@ class Editor extends Disposable {
 		const view = this._register(new EditorView(model, {
 			classNames: ['md-theme-vscode-default'],
 			syntaxHighlighter: this.#syntaxHighlighter,
+			linkPresentationProvider: this.#linkPresentationProvider,
 			embeddedCodeEditorFactory,
 			onEmbeddedCodeEditorEdit: (block: CodeBlockAstNode, contentEdit: StringEdit) => {
 				const doc = model.document.get();
@@ -194,13 +202,8 @@ class Editor extends Disposable {
 					)),
 				));
 			},
-			onOpenLink: (url) => {
-				const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url)?.[1].toLowerCase();
-				if (scheme && scheme !== 'file') {
-					return false;
-				}
+			onOpenLink: url => {
 				this.#vscode.postMessage({ type: 'openLink', href: url });
-				return undefined;
 			},
 			onToggleCheckbox: (item, newChecked) => {
 				model.setTaskCheckboxChecked(item, newChecked);

--- a/extensions/markdown-language-features/markdown-editor-src/linkPresentationProvider.ts
+++ b/extensions/markdown-language-features/markdown-editor-src/linkPresentationProvider.ts
@@ -1,0 +1,220 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type {
+	ILinkPresentation,
+	ILinkPresentationProvider,
+	LinkPresentation,
+	LinkPresentationKind,
+	LinkPresentationStatusKind,
+} from '@vscode/markdown-editor';
+import { Disposable, observableValue, type ISettableObservable } from '@vscode/observables';
+
+interface LinkPresentationEntry {
+	readonly presentation: ISettableObservable<LinkPresentation | undefined>;
+	references: number;
+}
+
+export class WebviewLinkPresentationProvider extends Disposable implements ILinkPresentationProvider {
+	readonly #entries = new Map<string, LinkPresentationEntry>();
+	readonly #postMessage: (message: unknown) => void;
+	#syncScheduled = false;
+
+	constructor(postMessage: (message: unknown) => void) {
+		super();
+		this.#postMessage = postMessage;
+	}
+
+	createLinkPresentation(url: string): ILinkPresentation | undefined {
+		const initialPresentation = createInitialPresentation(url);
+		if (!initialPresentation) {
+			return undefined;
+		}
+
+		let entry = this.#entries.get(url);
+		if (!entry) {
+			entry = {
+				presentation: observableValue(`linkPresentation:${url}`, initialPresentation),
+				references: 0,
+			};
+			this.#entries.set(url, entry);
+		}
+		entry.references++;
+		this.#scheduleTargetSync();
+
+		let disposed = false;
+		return {
+			presentation: entry.presentation,
+			dispose: () => {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				this.#release(url, entry);
+			},
+		};
+	}
+
+	handleMessage(message: unknown): boolean {
+		if (!isRecord(message) || message.type !== 'richLinkPresentations' || !Array.isArray(message.presentations)) {
+			return false;
+		}
+		for (const value of message.presentations) {
+			if (!isRecord(value) || typeof value.href !== 'string') {
+				continue;
+			}
+			const entry = this.#entries.get(value.href);
+			if (!entry) {
+				continue;
+			}
+			entry.presentation.set(readLinkPresentation(value.presentation), undefined);
+		}
+		return true;
+	}
+
+	override dispose(): void {
+		this.#entries.clear();
+		super.dispose();
+	}
+
+	#release(url: string, entry: LinkPresentationEntry): void {
+		entry.references--;
+		if (entry.references === 0 && this.#entries.get(url) === entry) {
+			this.#entries.delete(url);
+			this.#scheduleTargetSync();
+		}
+	}
+
+	#scheduleTargetSync(): void {
+		if (this.#syncScheduled) {
+			return;
+		}
+		this.#syncScheduled = true;
+		queueMicrotask(() => {
+			this.#syncScheduled = false;
+			this.#postMessage({ type: 'richLinkTargets', hrefs: [...this.#entries.keys()] });
+		});
+	}
+}
+
+function createInitialPresentation(url: string): LinkPresentation | undefined {
+	const target = classifyLink(url);
+	return target ? {
+		...target,
+		status: { kind: 'pending', label: 'Loading' },
+	} : undefined;
+}
+
+interface InitialLinkTarget {
+	readonly kind: LinkPresentationKind;
+	readonly title?: string;
+}
+
+function classifyLink(url: string): InitialLinkTarget | undefined {
+	if (url.startsWith('agent-host-session://')) {
+		return { kind: 'session' };
+	}
+	if (!/^[a-z][a-z0-9+.-]*:/i.test(url)) {
+		return url.startsWith('#') ? undefined : { kind: 'file' };
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return undefined;
+	}
+	if (parsed.protocol === 'commit:') {
+		return parsed.hostname || parsed.pathname ? { kind: 'commit' } : undefined;
+	}
+	if (parsed.protocol === 'file:') {
+		return { kind: 'file' };
+	}
+	const segments = parsed.pathname.split('/').filter(Boolean);
+	const commitIndex = segments.lastIndexOf('commit');
+	if ((parsed.protocol === 'https:' || parsed.protocol === 'http:')
+		&& commitIndex >= 1
+		&& commitIndex < segments.length - 1
+	) {
+		return { kind: 'commit' };
+	}
+	if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== 'github.com') {
+		return undefined;
+	}
+	if (segments.length < 2) {
+		return undefined;
+	}
+	switch (segments[2]) {
+		case 'issues': return { kind: segments[3] ? 'issue' : 'repository' };
+		case 'pull': return segments[3]
+			? {
+				kind: 'pullRequest',
+				...(/^\d+$/.test(segments[3]) ? { title: `#${segments[3]}` } : {}),
+			}
+			: { kind: 'repository' };
+		case 'commit': return { kind: segments[3] ? 'commit' : 'repository' };
+		case 'tree': return { kind: segments[4] ? 'resource' : segments[3] ? 'branch' : 'repository' };
+		case 'blob': return { kind: segments[3] && segments[4] ? 'file' : 'repository' };
+		default: return segments.length === 2 ? { kind: 'repository' } : undefined;
+	}
+}
+
+function readLinkPresentation(value: unknown): LinkPresentation | undefined {
+	if (!isRecord(value) || !isLinkPresentationKind(value.kind)) {
+		return undefined;
+	}
+	const title = typeof value.title === 'string' ? value.title : undefined;
+	const detail = typeof value.detail === 'string' ? value.detail : undefined;
+	const reference = typeof value.reference === 'string' ? value.reference : undefined;
+	const tooltip = typeof value.tooltip === 'string' ? value.tooltip : undefined;
+	const ariaLabel = typeof value.ariaLabel === 'string' ? value.ariaLabel : undefined;
+	const status = readStatus(value.status);
+	const secondaryStatus = readStatus(value.secondaryStatus);
+	return {
+		kind: value.kind,
+		...(title ? { title } : {}),
+		...(detail ? { detail } : {}),
+		...(reference ? { reference } : {}),
+		...(status ? { status } : {}),
+		...(secondaryStatus ? { secondaryStatus } : {}),
+		...(tooltip ? { tooltip } : {}),
+		...(ariaLabel ? { ariaLabel } : {}),
+	};
+}
+
+function readStatus(value: unknown): LinkPresentation['status'] {
+	return isRecord(value) && isStatusKind(value.kind) && typeof value.label === 'string'
+		? { kind: value.kind, label: value.label }
+		: undefined;
+}
+
+function isLinkPresentationKind(value: unknown): value is LinkPresentationKind {
+	return value === 'resource'
+		|| value === 'issue'
+		|| value === 'pullRequest'
+		|| value === 'commit'
+		|| value === 'file'
+		|| value === 'folder'
+		|| value === 'session'
+		|| value === 'repository'
+		|| value === 'branch';
+}
+
+function isStatusKind(value: unknown): value is LinkPresentationStatusKind {
+	return value === 'neutral'
+		|| value === 'pending'
+		|| value === 'success'
+		|| value === 'warning'
+		|| value === 'error'
+		|| value === 'open'
+		|| value === 'closed'
+		|| value === 'merged'
+		|| value === 'draft'
+		|| value === 'notPlanned';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",
-        "@vscode/markdown-editor": "^0.0.2-70",
+        "@vscode/markdown-editor": "^0.0.2-74",
         "@vscode/observables": "^0.1.1-0",
         "dompurify": "^3.4.10",
         "highlight.js": "^11.8.0",
@@ -633,9 +633,9 @@
       "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
     },
     "node_modules/@vscode/markdown-editor": {
-      "version": "0.0.2-70",
-      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-70.tgz",
-      "integrity": "sha512-CGMcdCIV1ueDde/Aq8mCMghQjgYLYOgEOPsG1N/46Z+q6cweSPHt0NI7ir0984DicuAQ6I4PhGn40ogZMKqoVQ==",
+      "version": "0.0.2-74",
+      "resolved": "https://registry.npmjs.org/@vscode/markdown-editor/-/markdown-editor-0.0.2-74.tgz",
+      "integrity": "sha512-VVHqeLMK7lYi1cyyaUHr6CoOXgMrfgnAOuVkmHdkEGdTpNMNrfxoj7asONp5RqMyfLf1LU0f/F8pRRmpmWxOUg==",
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -10,6 +10,7 @@
   "enabledApiProposals": [
     "agentEditorComments",
     "customEditorDiffs",
+    "dataChannels",
     "documentDiff",
     "documentSyntaxHighlighting",
     "textEditorDiffInformation"
@@ -1767,7 +1768,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "@vscode/markdown-editor": "^0.0.2-70",
+    "@vscode/markdown-editor": "^0.0.2-74",
     "@vscode/observables": "^0.1.1-0",
     "dompurify": "^3.4.10",
     "highlight.js": "^11.8.0",

--- a/extensions/markdown-language-features/src/preview/agentSessionLinkPresentationResolver.ts
+++ b/extensions/markdown-language-features/src/preview/agentSessionLinkPresentationResolver.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation, LinkPresentationStatus } from '@vscode/markdown-editor';
+import { derived, observableFromEvent, type IObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import type { LinkPresentationResolver } from './linkPresentationResolver';
+
+const agentSessionLinkPrefix = 'agent-host-session://';
+
+export class AgentSessionLinkPresentationResolver implements LinkPresentationResolver {
+	readonly refreshOnInterval = false;
+
+	resolve(href: string): IObservable<LinkPresentation> | undefined {
+		if (!href.startsWith(agentSessionLinkPrefix)) {
+			return undefined;
+		}
+
+		return derived(reader => reader.store.add(new AgentSessionLinkData(vscode.Uri.parse(href))))
+			.map((value, reader) => {
+				const data = value.data.read(reader);
+				return data ? getSessionLinkPresentation(data) : {
+					kind: 'session',
+					status: { kind: 'pending', label: 'Loading' },
+				};
+			});
+	}
+
+	dispose(): void { }
+}
+
+class AgentSessionLinkData implements vscode.Disposable {
+	readonly #watcher: vscode.DataWatcher<vscode.AgentSessionData>;
+	readonly data: IObservable<vscode.AgentSessionData | undefined>;
+
+	constructor(resource: vscode.Uri) {
+		this.#watcher = vscode.window.createDataWatcher({
+			kind: vscode.DataWatcherKind.AgentSession,
+			resource,
+		});
+		this.data = observableFromEvent(this, this.#watcher.onDidChange, () => this.#watcher.data);
+	}
+
+	dispose(): void {
+		this.#watcher.dispose();
+	}
+}
+
+function sessionStatus(status: vscode.AgentSessionData['status']): LinkPresentationStatus {
+	switch (status) {
+		case vscode.AgentSessionStatus.Untitled: return { kind: 'neutral', label: 'Not started' };
+		case vscode.AgentSessionStatus.InProgress: return { kind: 'pending', label: 'Working' };
+		case vscode.AgentSessionStatus.NeedsInput: return { kind: 'warning', label: 'Needs input' };
+		case vscode.AgentSessionStatus.Completed: return { kind: 'success', label: 'Completed' };
+		case vscode.AgentSessionStatus.Error: return { kind: 'error', label: 'Error' };
+	}
+}
+
+export function getSessionLinkPresentation(value: vscode.AgentSessionData): LinkPresentation {
+	const status = sessionStatus(value.status);
+	return {
+		kind: 'session',
+		title: value.title,
+		...(value.description ? { detail: value.description } : {}),
+		status,
+		tooltip: `${value.title} · ${status.label}`,
+		ariaLabel: `Agent session ${value.title}, ${status.label}`,
+	};
+}

--- a/extensions/markdown-language-features/src/preview/gitLinkPresentationResolver.ts
+++ b/extensions/markdown-language-features/src/preview/gitLinkPresentationResolver.ts
@@ -1,0 +1,253 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation } from '@vscode/markdown-editor';
+import type { IObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import { createAsyncLinkPresentation, decodeUrlPathSegments, ImmutableLinkPresentationCache, type LinkPresentationResolver, type LinkPresentationResolverContext } from './linkPresentationResolver';
+
+export class GitLinkPresentationResolver implements LinkPresentationResolver {
+	readonly refreshOnInterval = false;
+	readonly #cache: ImmutableLinkPresentationCache;
+	readonly #onDidChangeRepositories = new vscode.EventEmitter<void>();
+	#gitApi: Promise<GitApi | undefined> | undefined;
+	#gitApiSubscriptions: vscode.Disposable | undefined;
+	#isDisposed = false;
+
+	constructor(cache: ImmutableLinkPresentationCache) {
+		this.#cache = cache;
+	}
+
+	resolve(href: string, context: LinkPresentationResolverContext): IObservable<LinkPresentation> | undefined {
+		const target = parseGitCommitTarget(href);
+		if (!target) {
+			return undefined;
+		}
+
+		return createAsyncLinkPresentation(
+			href,
+			{
+				kind: 'commit',
+				status: { kind: 'pending', label: 'Loading' },
+			},
+			context,
+			() => this.#cache.get(href, () => this.#resolve(target)),
+			error => ({
+				kind: 'commit',
+				status: { kind: 'error', label: 'Not available' },
+				tooltip: error instanceof Error ? error.message : 'The Git commit could not be resolved.',
+				ariaLabel: `Git commit ${target.sha.slice(0, 7)} could not be resolved`,
+			}),
+			[context.onDidRequestRefresh, this.#onDidChangeRepositories.event],
+		);
+	}
+
+	async open(href: string): Promise<boolean> {
+		const target = parseGitCommitTarget(href);
+		if (!target) {
+			return false;
+		}
+
+		try {
+			const result = await this.#findCommit(target);
+			const revealed = await vscode.commands.executeCommand<boolean>(
+				'_workbench.scm.revealHistoryItem',
+				result.repository.rootUri,
+				result.commit.hash,
+			);
+			if (!revealed) {
+				await vscode.window.showWarningMessage(vscode.l10n.t("The commit could not be revealed in the Source Control Graph."));
+			}
+			return true;
+		} catch (error) {
+			if (target.repository) {
+				return false;
+			}
+			await vscode.window.showWarningMessage(vscode.l10n.t(
+				"The commit could not be found in an open Git repository. {0}",
+				error instanceof Error ? error.message : '',
+			));
+			return true;
+		}
+	}
+
+	dispose(): void {
+		this.#isDisposed = true;
+		this.#gitApiSubscriptions?.dispose();
+		this.#onDidChangeRepositories.dispose();
+	}
+
+	async #resolve(target: GitCommitTarget): Promise<LinkPresentation> {
+		return getGitCommitPresentation((await this.#findCommit(target)).commit);
+	}
+
+	async #findCommit(target: GitCommitTarget): Promise<GitCommitResult> {
+		const api = await this.#getGitApi();
+		const repositories = api?.repositories.filter(repository => !target.repository || repository.state.remotes.some(remote => (
+			[remote.fetchUrl, remote.pushUrl].some(url => url && normalizeGitRemoteUrl(url) === target.repository)
+		))) ?? [];
+		if (!repositories.length) {
+			throw new Error(target.repository
+				? `No open Git repository matches ${target.repository}.`
+				: 'No Git repositories are open.');
+		}
+
+		const results = await Promise.allSettled(repositories.map(async repository => ({
+			repository,
+			commit: await repository.getCommit(target.sha),
+		})));
+		const match = results.find((result): result is PromiseFulfilledResult<GitCommitResult> => result.status === 'fulfilled');
+		if (match) {
+			return match.value;
+		}
+		throw new AggregateError(
+			results.map(result => result.status === 'rejected' ? result.reason : undefined).filter(error => error !== undefined),
+			`Commit ${target.sha} was not found in the open Git repositories.`,
+		);
+	}
+
+	#getGitApi(): Promise<GitApi | undefined> {
+		this.#gitApi ??= (async () => {
+			const extension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+			const git = await extension?.activate();
+			if (!git?.enabled) {
+				return undefined;
+			}
+			const api = git.getAPI(1);
+			const subscriptions = vscode.Disposable.from(
+				api.onDidOpenRepository(() => this.#onDidChangeRepositories.fire()),
+				api.onDidCloseRepository(() => this.#onDidChangeRepositories.fire()),
+			);
+			if (this.#isDisposed) {
+				subscriptions.dispose();
+			} else {
+				this.#gitApiSubscriptions = subscriptions;
+			}
+			return api;
+		})();
+		return this.#gitApi;
+	}
+}
+
+interface GitCommitTarget {
+	readonly repository?: string;
+	readonly sha: string;
+}
+
+function parseGitCommitTarget(href: string): GitCommitTarget | undefined {
+	let uri: URL;
+	try {
+		uri = new URL(href);
+	} catch {
+		return undefined;
+	}
+	if (uri.protocol === 'commit:') {
+		const sha = uri.hostname || uri.pathname.replace(/^\/+/, '');
+		return isGitCommitSha(sha) ? { sha } : undefined;
+	}
+	if (uri.protocol !== 'https:' && uri.protocol !== 'http:') {
+		return undefined;
+	}
+
+	const segments = decodeUrlPathSegments(uri);
+	if (!segments) {
+		return undefined;
+	}
+	const commitIndex = segments.lastIndexOf('commit');
+	if (commitIndex < 1 || commitIndex === segments.length - 1) {
+		return undefined;
+	}
+	const repositorySegments = segments[commitIndex - 1] === '-'
+		? segments.slice(0, commitIndex - 1)
+		: segments.slice(0, commitIndex);
+	if (!repositorySegments.length) {
+		return undefined;
+	}
+	const sha = segments[commitIndex + 1];
+	if (!isGitCommitSha(sha)) {
+		return undefined;
+	}
+	return {
+		repository: `${uri.hostname.toLowerCase()}/${repositorySegments.join('/').replace(/\.git$/i, '')}`,
+		sha,
+	};
+}
+
+function isGitCommitSha(value: string): boolean {
+	return /^[0-9a-f]{4,64}$/i.test(value);
+}
+
+export function normalizeGitRemoteUrl(value: string): string | undefined {
+	if (!value.includes('://')) {
+		const scp = /^(?:[^@]+@)?(?<host>[^:]+):(?<path>.+)$/.exec(value);
+		if (scp?.groups) {
+			return normalizeGitRepository(scp.groups.host, scp.groups.path);
+		}
+	}
+
+	let uri: URL;
+	try {
+		uri = new URL(value);
+	} catch {
+		return undefined;
+	}
+	return normalizeGitRepository(uri.hostname, uri.pathname);
+}
+
+function normalizeGitRepository(host: string, path: string): string {
+	return `${host.toLowerCase()}/${path.replace(/^\/+|\/+$/g, '').replace(/\.git$/i, '')}`;
+}
+
+interface GitExtension {
+	readonly enabled: boolean;
+	getAPI(version: 1): GitApi;
+}
+
+interface GitApi {
+	readonly repositories: readonly GitRepository[];
+	readonly onDidOpenRepository: vscode.Event<GitRepository>;
+	readonly onDidCloseRepository: vscode.Event<GitRepository>;
+}
+
+interface GitRepository {
+	readonly rootUri: vscode.Uri;
+	readonly state: {
+		readonly remotes: readonly GitRemote[];
+	};
+	getCommit(ref: string): Promise<GitCommit>;
+}
+
+interface GitRemote {
+	readonly fetchUrl?: string;
+	readonly pushUrl?: string;
+}
+
+interface GitCommit {
+	readonly hash: string;
+	readonly message: string;
+	readonly shortStat?: {
+		readonly insertions: number;
+		readonly deletions: number;
+	};
+}
+
+interface GitCommitResult {
+	readonly repository: GitRepository;
+	readonly commit: GitCommit;
+}
+
+export function getGitCommitPresentation(commit: GitCommit): LinkPresentation {
+	const title = commit.message.split(/\r?\n/, 1)[0];
+	const insertions = commit.shortStat?.insertions ?? 0;
+	const deletions = commit.shortStat?.deletions ?? 0;
+	const shortHash = commit.hash.slice(0, 7);
+	return {
+		kind: 'commit',
+		detail: title,
+		// TODO: Include insertion and deletion counts once the Markdown editor package supports them.
+		tooltip: `${shortHash} · ${title} · ${insertions} insertions, ${deletions} deletions`,
+		ariaLabel: `Commit ${shortHash}, ${insertions} insertions and ${deletions} deletions: ${title}`,
+	};
+}

--- a/extensions/markdown-language-features/src/preview/githubLinkPresentationResolver.ts
+++ b/extensions/markdown-language-features/src/preview/githubLinkPresentationResolver.ts
@@ -1,0 +1,540 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation, LinkPresentationStatus } from '@vscode/markdown-editor';
+import type { IObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import { createAsyncLinkPresentation, decodeUrlPathSegments, LinkPresentationCache, type LinkPresentationResolver, type LinkPresentationResolverContext } from './linkPresentationResolver';
+
+const githubRepositoryScope = 'repo';
+
+export class GitHubLinkPresentationResolver implements LinkPresentationResolver {
+	readonly refreshOnInterval = true;
+	readonly #cache: LinkPresentationCache;
+	readonly #onDidChangeAuthentication = new vscode.EventEmitter<void>();
+	readonly #authenticationSubscription: vscode.Disposable;
+	#accessToken: Promise<string> | undefined;
+
+	constructor(cache: LinkPresentationCache) {
+		this.#cache = cache;
+		this.#authenticationSubscription = vscode.authentication.onDidChangeSessions(event => {
+			if (event.provider.id === 'github') {
+				this.#accessToken = undefined;
+				this.#cache.clear();
+				this.#onDidChangeAuthentication.fire();
+			}
+		});
+	}
+
+	resolve(href: string, context: LinkPresentationResolverContext): IObservable<LinkPresentation> | undefined {
+		const target = parseGitHubTarget(href);
+		if (!target) {
+			return undefined;
+		}
+		return createAsyncLinkPresentation(
+			href,
+			{
+				kind: target.kind === 'tree' ? 'resource' : target.kind,
+				status: { kind: 'pending', label: 'Loading' },
+			},
+			context,
+			() => this.#cache.get(href, () => this.#resolve(target)),
+			error => getGitHubLookupFailurePresentationForTarget(target, error),
+			[context.onDidRequestRefresh, this.#onDidChangeAuthentication.event],
+		);
+	}
+
+	dispose(): void {
+		this.#authenticationSubscription.dispose();
+		this.#onDidChangeAuthentication.dispose();
+	}
+
+	async #resolve(target: GitHubTarget): Promise<LinkPresentation> {
+		const request = new GitHubRequest(await this.#getAccessToken());
+		switch (target.kind) {
+			case 'issue': {
+				const issue = await request.get(`/repos/${target.owner}/${target.repository}/issues/${target.number}`, readIssue);
+				const state = getGitHubIssueStatus(issue.state, issue.stateReason);
+				return {
+					kind: 'issue',
+					title: issue.title,
+					reference: `#${target.number}`,
+					status: state,
+					tooltip: `${target.owner}/${target.repository}#${target.number} · ${state.label}`,
+					ariaLabel: `Issue ${target.owner} slash ${target.repository} number ${target.number}, ${state.label}: ${issue.title}`,
+				};
+			}
+			case 'pullRequest': {
+				const pullRequest = await request.get(`/repos/${target.owner}/${target.repository}/pulls/${target.number}`, readPullRequest);
+				const state = getGitHubPullRequestStatus(pullRequest.state, pullRequest.draft, pullRequest.merged);
+				const checksStatus = shouldShowGitHubPullRequestChecks(state)
+					? checkRunStatus(await request.getAll(
+						`/repos/${target.owner}/${target.repository}/commits/${encodeURIComponent(pullRequest.headSha)}/check-runs`,
+						readCheckRuns,
+					))
+					: undefined;
+				return {
+					kind: 'pullRequest',
+					title: pullRequest.title,
+					reference: `#${target.number}`,
+					status: state,
+					...(checksStatus ? { secondaryStatus: checksStatus } : {}),
+					tooltip: [target.owner + '/' + target.repository + '#' + target.number, state.label, checksStatus?.label].filter(Boolean).join(' · '),
+					ariaLabel: `Pull request ${target.owner} slash ${target.repository} number ${target.number}, ${state.label}${checksStatus ? `, ${checksStatus.label}` : ''}: ${pullRequest.title}`,
+				};
+			}
+			case 'repository': {
+				const repository = await request.get(`/repos/${target.owner}/${target.repository}`, readRepository);
+				const details = [
+					repository.language,
+					repository.stars === undefined ? undefined : `${formatCount(repository.stars)} stars`,
+				].filter((value): value is string => !!value);
+				return {
+					kind: 'repository',
+					...(details.length ? { detail: details.join(' · ') } : {}),
+					tooltip: `${target.owner}/${target.repository}`,
+					ariaLabel: `GitHub repository ${target.owner} slash ${target.repository}`,
+				};
+			}
+			case 'tree': {
+				const refs = await request.get(
+					`/repos/${target.owner}/${target.repository}/git/matching-refs/heads/${encodeURIComponent(target.segments[0])}`,
+					readGitRefs,
+				);
+				const tree = resolveGitHubTreePath(target.segments, refs);
+				if (!tree) {
+					throw new GitHubLookupError('notFound', `GitHub did not find branch ${target.segments.join('/')}.`);
+				}
+				if (tree.path) {
+					return {
+						kind: 'folder',
+						detail: `${target.owner}/${target.repository} · ${tree.path}`,
+						tooltip: target.href,
+						ariaLabel: `Folder ${tree.path} in ${target.owner} slash ${target.repository}`,
+					};
+				}
+				const branch = await request.get(
+					`/repos/${target.owner}/${target.repository}/branches/${encodeURIComponent(tree.branch)}`,
+					readBranch,
+				);
+				return {
+					kind: 'branch',
+					detail: branch.sha.slice(0, 7),
+					tooltip: `${target.owner}/${target.repository} · ${tree.branch}`,
+					ariaLabel: `Branch ${tree.branch} in ${target.owner} slash ${target.repository}`,
+				};
+			}
+			case 'file':
+				return {
+					kind: 'file',
+					detail: `${target.owner}/${target.repository} · ${target.path}`,
+					tooltip: target.href,
+					ariaLabel: `File ${target.path} in ${target.owner} slash ${target.repository}`,
+				};
+		}
+	}
+
+	#getAccessToken(): Promise<string> {
+		if (this.#accessToken) {
+			return this.#accessToken;
+		}
+		const value = this.#readAccessToken().catch(error => {
+			if (
+				this.#accessToken === value
+				&& !(error instanceof GitHubLookupError && error.kind === 'authenticationRequired')
+			) {
+				this.#accessToken = undefined;
+			}
+			throw error;
+		});
+		this.#accessToken = value;
+		return value;
+	}
+
+	async #readAccessToken(): Promise<string> {
+		try {
+			const accounts = await vscode.authentication.getAccounts('github');
+			for (const account of accounts) {
+				const session = await vscode.authentication.getSession('github', [], { silent: true, account });
+				if (session?.scopes.includes(githubRepositoryScope)) {
+					return session.accessToken;
+				}
+			}
+			const session = await vscode.authentication.getSession('github', [githubRepositoryScope], {
+				createIfNone: {
+					detail: 'The Markdown editor needs repository access to show issue, pull request, and CI status.',
+				},
+				...(accounts.length === 1 ? { account: accounts[0] } : {}),
+			});
+			return session.accessToken;
+		} catch (error) {
+			throw new GitHubLookupError(
+				'authenticationRequired',
+				`GitHub repository access was not authorized.${error instanceof Error ? ` ${error.message}` : ''}`,
+			);
+		}
+	}
+}
+
+class GitHubRequest {
+	readonly #accessToken: string;
+
+	constructor(accessToken: string) {
+		this.#accessToken = accessToken;
+	}
+
+	async get<T>(apiPath: string, read: (value: unknown) => T | undefined): Promise<T> {
+		const response = await fetch(`https://api.github.com${apiPath}`, {
+			headers: {
+				Accept: 'application/vnd.github+json',
+				Authorization: `Bearer ${this.#accessToken}`,
+			},
+		});
+		if (!response.ok) {
+			throw GitHubLookupError.fromResponse(apiPath, response);
+		}
+		const value = read(await response.json());
+		if (!value) {
+			throw new GitHubLookupError(
+				'invalidResponse',
+				`GitHub request ${apiPath} returned an unexpected response.`,
+			);
+		}
+		return value;
+	}
+
+	async getAll<T>(apiPath: string, read: (value: unknown) => readonly T[] | undefined): Promise<readonly T[]> {
+		const values: T[] = [];
+		const pageSize = 100;
+		for (let page = 1; ; page++) {
+			const separator = apiPath.includes('?') ? '&' : '?';
+			const pageValues = await this.get(`${apiPath}${separator}per_page=${pageSize}&page=${page}`, read);
+			values.push(...pageValues);
+			if (pageValues.length < pageSize) {
+				return values;
+			}
+		}
+	}
+}
+
+type GitHubLookupFailureKind =
+	| 'authenticationRequired'
+	| 'authenticationFailed'
+	| 'accessDenied'
+	| 'rateLimited'
+	| 'notFound'
+	| 'invalidResponse'
+	| 'requestFailed';
+
+export class GitHubLookupError extends Error {
+	readonly kind: GitHubLookupFailureKind;
+
+	constructor(kind: GitHubLookupFailureKind, message: string) {
+		super(message);
+		this.name = 'GitHubLookupError';
+		this.kind = kind;
+	}
+
+	static fromResponse(apiPath: string, response: Response): GitHubLookupError {
+		const message = `GitHub request ${apiPath} failed: ${response.status} ${response.statusText}`;
+		if (response.status === 401) {
+			return new GitHubLookupError('authenticationFailed', message);
+		}
+		if (response.status === 403) {
+			return new GitHubLookupError(
+				response.headers.get('x-ratelimit-remaining') === '0' ? 'rateLimited' : 'accessDenied',
+				message,
+			);
+		}
+		if (response.status === 404) {
+			return new GitHubLookupError('notFound', message);
+		}
+		return new GitHubLookupError('requestFailed', message);
+	}
+}
+
+type GitHubTarget =
+	| { readonly kind: 'issue'; readonly href: string; readonly owner: string; readonly repository: string; readonly number: number }
+	| { readonly kind: 'pullRequest'; readonly href: string; readonly owner: string; readonly repository: string; readonly number: number }
+	| { readonly kind: 'repository'; readonly href: string; readonly owner: string; readonly repository: string }
+	| { readonly kind: 'tree'; readonly href: string; readonly owner: string; readonly repository: string; readonly segments: readonly [string, ...string[]] }
+	| { readonly kind: 'file'; readonly href: string; readonly owner: string; readonly repository: string; readonly path: string };
+
+function parseGitHubTarget(href: string): GitHubTarget | undefined {
+	let uri: URL;
+	try {
+		uri = new URL(href);
+	} catch {
+		return undefined;
+	}
+	if (uri.protocol !== 'https:' || uri.hostname.toLowerCase() !== 'github.com') {
+		return undefined;
+	}
+	const segments = decodeUrlPathSegments(uri);
+	if (!segments) {
+		return undefined;
+	}
+	const [owner, repository, category, identifier, ...rest] = segments;
+	if (!owner || !repository) {
+		return undefined;
+	}
+	if (!category) {
+		return { kind: 'repository', href, owner, repository };
+	}
+	if (category === 'issues' || category === 'pull') {
+		const number = Number(identifier);
+		return Number.isInteger(number) && number > 0
+			? { kind: category === 'issues' ? 'issue' : 'pullRequest', href, owner, repository, number }
+			: undefined;
+	}
+	if (category === 'tree' && identifier) {
+		return { kind: 'tree', href, owner, repository, segments: [identifier, ...rest] };
+	}
+	if (category === 'blob' && identifier && rest.length) {
+		return { kind: 'file', href, owner, repository, path: rest.join('/') };
+	}
+	return undefined;
+}
+
+export function getGitHubLookupFailurePresentation(
+	href: string,
+	error: unknown,
+): LinkPresentation | undefined {
+	const target = parseGitHubTarget(href);
+	if (!target) {
+		return undefined;
+	}
+	return getGitHubLookupFailurePresentationForTarget(target, error);
+}
+
+function getGitHubLookupFailurePresentationForTarget(
+	target: GitHubTarget,
+	error: unknown,
+): LinkPresentation {
+	const failure = error instanceof GitHubLookupError
+		? githubLookupFailureDescription(error.kind)
+		: { label: 'Lookup failed', detail: 'The GitHub request could not be completed.' };
+	const kind = target.kind === 'tree' ? 'resource' : target.kind;
+	return {
+		kind,
+		status: { kind: 'error', label: failure.label },
+		tooltip: `${failure.detail} ${error instanceof Error ? error.message : ''}`.trim(),
+		ariaLabel: `GitHub ${kind} lookup failed: ${failure.label}`,
+	};
+}
+
+function githubLookupFailureDescription(kind: GitHubLookupFailureKind): {
+	readonly label: string;
+	readonly detail: string;
+} {
+	switch (kind) {
+		case 'authenticationRequired':
+			return {
+				label: 'Authorization required',
+				detail: 'Authorize GitHub repository access in VS Code to load this link.',
+			};
+		case 'authenticationFailed':
+			return {
+				label: 'Authentication failed',
+				detail: 'GitHub rejected the current VS Code authentication session.',
+			};
+		case 'accessDenied':
+			return {
+				label: 'Access denied',
+				detail: 'The current GitHub account cannot access this resource.',
+			};
+		case 'rateLimited':
+			return {
+				label: 'Rate limited',
+				detail: 'GitHub API rate limiting prevented this lookup.',
+			};
+		case 'notFound':
+			return {
+				label: 'Not found',
+				detail: 'GitHub did not find this resource, or the current account cannot access it.',
+			};
+		case 'invalidResponse':
+			return {
+				label: 'Invalid response',
+				detail: 'GitHub returned data the Markdown editor could not read.',
+			};
+		case 'requestFailed':
+			return {
+				label: 'Lookup failed',
+				detail: 'GitHub returned an unsuccessful response.',
+			};
+	}
+}
+
+interface GitRefData {
+	readonly ref: string;
+}
+
+function readGitRefs(value: unknown): readonly GitRefData[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const refs: GitRefData[] = [];
+	for (const item of value) {
+		if (!isRecord(item) || typeof item.ref !== 'string') {
+			return undefined;
+		}
+		refs.push({ ref: item.ref });
+	}
+	return refs;
+}
+
+export function resolveGitHubTreePath(
+	segments: readonly string[],
+	refs: readonly GitRefData[],
+): { readonly branch: string; readonly path?: string } | undefined {
+	const target = segments.join('/');
+	const branch = refs
+		.map(ref => ref.ref.startsWith('refs/heads/') ? ref.ref.slice('refs/heads/'.length) : undefined)
+		.filter((candidate): candidate is string => !!candidate && (target === candidate || target.startsWith(`${candidate}/`)))
+		.sort((a, b) => b.length - a.length)[0];
+	if (!branch) {
+		return undefined;
+	}
+	const path = target === branch ? undefined : target.slice(branch.length + 1);
+	return { branch, ...(path ? { path } : {}) };
+}
+
+interface IssueData {
+	readonly title: string;
+	readonly state: 'open' | 'closed';
+	readonly stateReason?: 'completed' | 'not_planned' | 'reopened';
+}
+
+function readIssue(value: unknown): IssueData | undefined {
+	if (!isRecord(value) || typeof value.title !== 'string' || (value.state !== 'open' && value.state !== 'closed')) {
+		return undefined;
+	}
+	const stateReason = value.state_reason === 'completed' || value.state_reason === 'not_planned' || value.state_reason === 'reopened'
+		? value.state_reason
+		: undefined;
+	return { title: value.title, state: value.state, ...(stateReason ? { stateReason } : {}) };
+}
+
+interface PullRequestData extends IssueData {
+	readonly draft: boolean;
+	readonly merged: boolean;
+	readonly headSha: string;
+}
+
+function readPullRequest(value: unknown): PullRequestData | undefined {
+	if (!isRecord(value) || !isRecord(value.head)) {
+		return undefined;
+	}
+	const issue = readIssue(value);
+	return issue
+		&& typeof value.draft === 'boolean'
+		&& typeof value.merged === 'boolean'
+		&& typeof value.head.sha === 'string'
+		? { ...issue, draft: value.draft, merged: value.merged, headSha: value.head.sha }
+		: undefined;
+}
+
+interface CheckRunData {
+	readonly status: string;
+	readonly conclusion: string | null;
+}
+
+function readCheckRuns(value: unknown): readonly CheckRunData[] | undefined {
+	if (!isRecord(value) || !Array.isArray(value.check_runs)) {
+		return undefined;
+	}
+	const runs: CheckRunData[] = [];
+	for (const run of value.check_runs) {
+		if (!isRecord(run) || typeof run.status !== 'string' || (run.conclusion !== null && typeof run.conclusion !== 'string')) {
+			return undefined;
+		}
+		runs.push({ status: run.status, conclusion: run.conclusion });
+	}
+	return runs;
+}
+
+export function getGitHubIssueStatus(
+	state: IssueData['state'],
+	stateReason: IssueData['stateReason'],
+): LinkPresentationStatus {
+	if (state === 'open') {
+		return { kind: 'open', label: 'Open' };
+	}
+	return stateReason === 'not_planned'
+		? { kind: 'notPlanned', label: 'Not planned' }
+		: { kind: 'closed', label: 'Closed' };
+}
+
+export function getGitHubPullRequestStatus(
+	state: PullRequestData['state'],
+	draft: boolean,
+	merged: boolean,
+): LinkPresentationStatus {
+	if (merged) {
+		return { kind: 'merged', label: 'Merged' };
+	}
+	if (draft) {
+		return { kind: 'draft', label: 'Draft' };
+	}
+	return state === 'closed'
+		? { kind: 'closed', label: 'Closed' }
+		: { kind: 'open', label: 'Open' };
+}
+
+export function shouldShowGitHubPullRequestChecks(status: LinkPresentationStatus): boolean {
+	return status.kind === 'open' || status.kind === 'draft';
+}
+
+function checkRunStatus(checks: readonly CheckRunData[] | undefined): LinkPresentationStatus | undefined {
+	if (!checks?.length) {
+		return undefined;
+	}
+	if (checks.some(check => check.status !== 'completed')) {
+		return { kind: 'pending', label: 'Checks running' };
+	}
+	if (checks.some(check => check.conclusion === 'failure'
+		|| check.conclusion === 'timed_out'
+		|| check.conclusion === 'cancelled'
+		|| check.conclusion === 'action_required')) {
+		return { kind: 'error', label: 'Checks failed' };
+	}
+	return { kind: 'success', label: 'Checks passed' };
+}
+
+interface RepositoryData {
+	readonly language?: string;
+	readonly stars?: number;
+}
+
+function readRepository(value: unknown): RepositoryData | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+	return {
+		...(typeof value.language === 'string' ? { language: value.language } : {}),
+		...(typeof value.stargazers_count === 'number' ? { stars: value.stargazers_count } : {}),
+	};
+}
+
+interface BranchData {
+	readonly sha: string;
+}
+
+function readBranch(value: unknown): BranchData | undefined {
+	return isRecord(value)
+		&& isRecord(value.commit)
+		&& typeof value.commit.sha === 'string'
+		? { sha: value.commit.sha }
+		: undefined;
+}
+
+function formatCount(value: number): string {
+	return value >= 1000 ? `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k` : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/extensions/markdown-language-features/src/preview/linkPresentationResolver.ts
+++ b/extensions/markdown-language-features/src/preview/linkPresentationResolver.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation } from '@vscode/markdown-editor';
+import { derived, observableValue, type IObservable, type ISettableObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import type { ILogger } from '../logging';
+
+const cacheLifetimeMs = 60_000;
+
+export interface LinkPresentationResolver extends vscode.Disposable {
+	readonly refreshOnInterval: boolean;
+
+	resolve(href: string, context: LinkPresentationResolverContext): IObservable<LinkPresentation> | undefined;
+}
+
+export interface LinkPresentationResolverContext {
+	readonly onDidRequestRefresh: vscode.Event<void>;
+	readonly logger: ILogger;
+}
+
+export function decodeUrlPathSegments(uri: URL): string[] | undefined {
+	try {
+		return uri.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+	} catch {
+		return undefined;
+	}
+}
+
+interface LinkPresentationCacheEntry {
+	readonly value: Promise<LinkPresentation>;
+	readonly expiresAt: number;
+}
+
+export class LinkPresentationCache {
+	readonly #entries = new Map<string, LinkPresentationCacheEntry>();
+
+	get(
+		href: string,
+		resolve: () => Promise<LinkPresentation>,
+		now = Date.now(),
+	): Promise<LinkPresentation> {
+		for (const [key, entry] of this.#entries) {
+			if (entry.expiresAt <= now) {
+				this.#entries.delete(key);
+			}
+		}
+		const cached = this.#entries.get(href);
+		if (cached) {
+			return cached.value;
+		}
+
+		const value = resolve();
+		const entry = { value, expiresAt: now + cacheLifetimeMs };
+		this.#entries.set(href, entry);
+		void value.catch(() => {
+			if (this.#entries.get(href) === entry) {
+				this.#entries.delete(href);
+			}
+		});
+		return value;
+	}
+
+	clear(): void {
+		this.#entries.clear();
+	}
+}
+
+export class ImmutableLinkPresentationCache {
+	readonly #entries = new Map<string, Promise<LinkPresentation>>();
+
+	get(href: string, resolve: () => Promise<LinkPresentation>): Promise<LinkPresentation> {
+		const cached = this.#entries.get(href);
+		if (cached) {
+			return cached;
+		}
+
+		const value = resolve();
+		this.#entries.set(href, value);
+		void value.catch(() => {
+			if (this.#entries.get(href) === value) {
+				this.#entries.delete(href);
+			}
+		});
+		return value;
+	}
+}
+
+export function createAsyncLinkPresentation(
+	href: string,
+	initialPresentation: LinkPresentation,
+	context: LinkPresentationResolverContext,
+	resolve: () => Promise<LinkPresentation>,
+	getFailurePresentation: (error: unknown) => LinkPresentation,
+	onDidRequestRefresh: readonly vscode.Event<void>[] = [context.onDidRequestRefresh],
+): IObservable<LinkPresentation> {
+	return derived(reader => reader.store.add(new AsyncLinkPresentation(
+		href,
+		initialPresentation,
+		context,
+		resolve,
+		getFailurePresentation,
+		onDidRequestRefresh,
+	))).map((value, reader) => value.presentation.read(reader));
+}
+
+class AsyncLinkPresentation implements vscode.Disposable {
+	readonly presentation: ISettableObservable<LinkPresentation>;
+	readonly #subscriptions: vscode.Disposable;
+	readonly #resolve: () => Promise<LinkPresentation>;
+	readonly #getFailurePresentation: (error: unknown) => LinkPresentation;
+	readonly #context: LinkPresentationResolverContext;
+	readonly #href: string;
+	#generation = 0;
+
+	constructor(
+		href: string,
+		initialPresentation: LinkPresentation,
+		context: LinkPresentationResolverContext,
+		resolve: () => Promise<LinkPresentation>,
+		getFailurePresentation: (error: unknown) => LinkPresentation,
+		onDidRequestRefresh: readonly vscode.Event<void>[],
+	) {
+		this.#href = href;
+		this.#context = context;
+		this.#resolve = resolve;
+		this.#getFailurePresentation = getFailurePresentation;
+		this.presentation = observableValue(`linkPresentation:${href}`, initialPresentation);
+		this.#subscriptions = vscode.Disposable.from(...onDidRequestRefresh.map(event => event(() => this.#refresh())));
+		this.#refresh();
+	}
+
+	dispose(): void {
+		this.#generation++;
+		this.#subscriptions.dispose();
+	}
+
+	#refresh(): void {
+		const currentGeneration = ++this.#generation;
+		void this.#resolve().then(value => {
+			if (currentGeneration === this.#generation) {
+				this.presentation.set(value, undefined);
+			}
+		}, error => {
+			if (currentGeneration === this.#generation) {
+				this.#context.logger.trace('Markdown rich link', `Failed to resolve ${this.#href}`, error);
+				this.presentation.set(this.#getFailurePresentation(error), undefined);
+			}
+		});
+	}
+}

--- a/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorProvider.ts
@@ -17,6 +17,8 @@ import type {
 	MarkdownContributionProvider,
 } from '../markdownExtensions';
 import { generateUuid } from '../util/uuid';
+import { MarkdownEditorRichLinkController } from './markdownEditorRichLinks';
+import { ImmutableLinkPresentationCache, LinkPresentationCache } from './linkPresentationResolver';
 
 interface CodeBlockEditorProviderDefinition {
 	readonly id: string;
@@ -103,6 +105,8 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 	readonly #providerApis = new Map<string, Promise<MarkdownCodeBlockEditorProviderApi | undefined>>();
 	readonly #resolvedCodeBlockEditors = new Map<string, Promise<ResolvedCodeBlockEditor | undefined>>();
 	readonly #resolvedCodeBlockEditorResources = new Set<string>();
+	readonly #gitLinkCache = new ImmutableLinkPresentationCache();
+	readonly #githubLinkCache = new LinkPresentationCache();
 
 	constructor(
 		extensionUri: vscode.Uri,
@@ -118,6 +122,11 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		this.#contributions = contributions;
 		this.#logger = logger;
 		this.#mediaRoot = vscode.Uri.joinPath(this.#extensionUri, 'markdown-editor-out');
+		this._register(vscode.authentication.onDidChangeSessions(event => {
+			if (event.provider.id === 'github') {
+				this.#githubLinkCache.clear();
+			}
+		}));
 		this._register(new vscode.Disposable(() => {
 			void vscode.commands.executeCommand('setContext', 'markdownEditorFocus', false);
 		}));
@@ -192,6 +201,14 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 		let codeBlockEditorProviders: readonly CodeBlockEditorProviderDefinition[] | undefined;
 		let contributionUpdate = 0;
 		const resolveCancellation = new vscode.CancellationTokenSource();
+		const richLinks = new MarkdownEditorRichLinkController(
+			document,
+			this.#linkOpener,
+			this.#logger,
+			this.#gitLinkCache,
+			this.#githubLinkCache,
+			message => editorWebview.postMessage(message),
+		);
 		const postCodeBlockEditorProviders = async (): Promise<void> => {
 			if (webviewReady && codeBlockEditorProviders) {
 				await editorWebview.postMessage({ type: 'codeBlockEditorProviders', codeBlockEditorProviders });
@@ -247,6 +264,13 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 					break;
 				}
 
+				case 'richLinkTargets': {
+					if (Array.isArray(message.hrefs)) {
+						richLinks.updateTargets(message.hrefs.filter((href: unknown): href is string => typeof href === 'string'));
+					}
+					break;
+				}
+
 				case 'editorFocusChanged': {
 					if (message.focused) {
 						this.#focusedWebviewPanels.add(webviewPanel);
@@ -279,7 +303,9 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 					break;
 				}
 				case 'openLink': {
-					await this.#linkOpener.openDocumentLink(message.href as string, document.uri);
+					if (typeof message.href === 'string' && !await richLinks.openLink(message.href)) {
+						await this.#linkOpener.openDocumentLink(message.href, document.uri);
+					}
 					break;
 				}
 				case 'edit': {
@@ -378,6 +404,7 @@ export class MarkdownEditorProvider extends Disposable implements vscode.CustomT
 			onDidDeleteFiles.dispose();
 			onDidRenameFiles.dispose();
 			onDidChangeViewState.dispose();
+			richLinks.dispose();
 		});
 	}
 

--- a/extensions/markdown-language-features/src/preview/markdownEditorRichLinks.ts
+++ b/extensions/markdown-language-features/src/preview/markdownEditorRichLinks.ts
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation } from '@vscode/markdown-editor';
+import { autorun, type IObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import type { ILogger } from '../logging';
+import { Disposable } from '../util/dispose';
+import { MdLinkOpener } from '../util/openDocumentLink';
+import { AgentSessionLinkPresentationResolver } from './agentSessionLinkPresentationResolver';
+import { GitHubLinkPresentationResolver } from './githubLinkPresentationResolver';
+import { GitLinkPresentationResolver } from './gitLinkPresentationResolver';
+import { ImmutableLinkPresentationCache, LinkPresentationCache, type LinkPresentationResolver, type LinkPresentationResolverContext } from './linkPresentationResolver';
+import { WorkspaceLinkPresentationResolver } from './workspaceLinkPresentationResolver';
+
+const refreshIntervalMs = 30_000;
+
+interface LinkPresentationEntry {
+	readonly presentation: IObservable<LinkPresentation>;
+	readonly refreshOnInterval: boolean;
+	readonly subscription: vscode.Disposable;
+}
+
+export class MarkdownEditorRichLinkController extends Disposable {
+	readonly #logger: ILogger;
+	readonly #postMessage: (message: object) => Thenable<boolean>;
+	readonly #gitResolver: GitLinkPresentationResolver;
+	readonly #resolvers: readonly LinkPresentationResolver[];
+	readonly #entries = new Map<string, LinkPresentationEntry>();
+	readonly #onDidRequestRefresh = this._register(new vscode.EventEmitter<void>());
+	#refreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(
+		document: vscode.TextDocument,
+		linkOpener: MdLinkOpener,
+		logger: ILogger,
+		gitCache: ImmutableLinkPresentationCache,
+		githubCache: LinkPresentationCache,
+		postMessage: (message: object) => Thenable<boolean>,
+	) {
+		super();
+		this.#logger = logger;
+		this.#postMessage = postMessage;
+		this.#gitResolver = this._register(new GitLinkPresentationResolver(gitCache));
+		this.#resolvers = [
+			this._register(new AgentSessionLinkPresentationResolver()),
+			this.#gitResolver,
+			this._register(new GitHubLinkPresentationResolver(githubCache)),
+			this._register(new WorkspaceLinkPresentationResolver(document.uri, linkOpener)),
+		];
+		this._register(vscode.window.onDidChangeWindowState(event => {
+			if (event.focused) {
+				this.#refresh();
+			}
+		}));
+	}
+
+	openLink(href: string): Promise<boolean> {
+		return this.#gitResolver.open(href);
+	}
+
+	updateTargets(hrefs: readonly string[]): void {
+		const targets = new Set(hrefs);
+		for (const [href, entry] of this.#entries) {
+			if (!targets.has(href)) {
+				entry.subscription.dispose();
+				this.#entries.delete(href);
+			}
+		}
+		for (const href of targets) {
+			if (!this.#entries.has(href)) {
+				const entry = this.#resolve(href);
+				if (entry) {
+					this.#entries.set(href, entry);
+				}
+			}
+		}
+		this.#scheduleRefresh();
+	}
+
+	override dispose(): void {
+		this.#cancelRefresh();
+		for (const entry of this.#entries.values()) {
+			entry.subscription.dispose();
+		}
+		this.#entries.clear();
+		super.dispose();
+	}
+
+	#resolve(href: string): LinkPresentationEntry | undefined {
+		for (const resolver of this.#resolvers) {
+			const context: LinkPresentationResolverContext = {
+				onDidRequestRefresh: this.#onDidRequestRefresh.event,
+				logger: this.#logger,
+			};
+			const presentation = resolver.resolve(href, context);
+			if (!presentation) {
+				continue;
+			}
+			const subscription = autorun(reader => {
+				void this.#publishPresentation(href, presentation.read(reader));
+			});
+			return {
+				presentation,
+				refreshOnInterval: resolver.refreshOnInterval,
+				subscription,
+			};
+		}
+
+		return undefined;
+	}
+
+	async #publishPresentation(href: string, presentation: LinkPresentation): Promise<void> {
+		try {
+			await this.#postMessage({
+				type: 'richLinkPresentations',
+				presentations: [{ href, presentation }],
+			});
+		} catch (error) {
+			this.#logger.trace('Markdown rich link', `Failed to publish ${href}`, error);
+		}
+	}
+
+	#refresh(): void {
+		this.#onDidRequestRefresh.fire();
+		this.#scheduleRefresh();
+	}
+
+	#scheduleRefresh(): void {
+		this.#cancelRefresh();
+		if ([...this.#entries.values()].some(entry => entry.refreshOnInterval)) {
+			this.#refreshTimer = setTimeout(() => this.#refresh(), refreshIntervalMs);
+		}
+	}
+
+	#cancelRefresh(): void {
+		if (this.#refreshTimer !== undefined) {
+			clearTimeout(this.#refreshTimer);
+			this.#refreshTimer = undefined;
+		}
+	}
+}

--- a/extensions/markdown-language-features/src/preview/workspaceLinkPresentationResolver.ts
+++ b/extensions/markdown-language-features/src/preview/workspaceLinkPresentationResolver.ts
@@ -1,0 +1,177 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { LinkPresentation } from '@vscode/markdown-editor';
+import type { IObservable } from '@vscode/observables';
+import * as vscode from 'vscode';
+import { MdLinkOpener } from '../util/openDocumentLink';
+import { createAsyncLinkPresentation, type LinkPresentationResolver, type LinkPresentationResolverContext } from './linkPresentationResolver';
+
+export class WorkspaceLinkPresentationResolver implements LinkPresentationResolver {
+	readonly refreshOnInterval = true;
+	readonly #documentUri: vscode.Uri;
+	readonly #linkOpener: MdLinkOpener;
+	readonly #onDidChangeWorkspaceResource = new vscode.EventEmitter<void>();
+	readonly #subscriptions: vscode.Disposable;
+	#gitApi: Promise<GitApi | undefined> | undefined;
+
+	constructor(documentUri: vscode.Uri, linkOpener: MdLinkOpener) {
+		this.#documentUri = documentUri;
+		this.#linkOpener = linkOpener;
+		const refresh = () => this.#onDidChangeWorkspaceResource.fire();
+		this.#subscriptions = vscode.Disposable.from(
+			vscode.workspace.onDidCreateFiles(refresh),
+			vscode.workspace.onDidDeleteFiles(refresh),
+			vscode.workspace.onDidRenameFiles(refresh),
+			vscode.workspace.onDidSaveTextDocument(refresh),
+		);
+	}
+
+	resolve(href: string, context: LinkPresentationResolverContext): IObservable<LinkPresentation> | undefined {
+		if (!isWorkspaceResourceLink(href)) {
+			return undefined;
+		}
+		return createAsyncLinkPresentation(
+			href,
+			{
+				kind: 'file',
+				status: { kind: 'pending', label: 'Loading' },
+			},
+			context,
+			() => this.#resolve(href),
+			error => ({
+				kind: 'file',
+				status: { kind: 'error', label: 'Not found' },
+				tooltip: error instanceof Error ? error.message : 'The workspace resource could not be resolved.',
+				ariaLabel: `Workspace resource could not be resolved: ${href}`,
+			}),
+			[context.onDidRequestRefresh, this.#onDidChangeWorkspaceResource.event],
+		);
+	}
+
+	dispose(): void {
+		this.#subscriptions.dispose();
+		this.#onDidChangeWorkspaceResource.dispose();
+	}
+
+	async #resolve(href: string): Promise<LinkPresentation> {
+		if (href.startsWith('file:')) {
+			const uri = vscode.Uri.parse(href);
+			const stat = await vscode.workspace.fs.stat(uri);
+			return this.#present(uri, stat.type === vscode.FileType.Directory ? 'folder' : 'file');
+		}
+
+		const resolved = await this.#linkOpener.resolveDocumentLink(href, this.#documentUri);
+		if (!resolved || resolved.kind === 'external') {
+			throw new Error(`Workspace resource could not be resolved: ${href}`);
+		}
+		return this.#present(vscode.Uri.from(resolved.uri), resolved.kind);
+	}
+
+	async #present(uri: vscode.Uri, kind: 'file' | 'folder'): Promise<LinkPresentation> {
+		const label = vscode.workspace.asRelativePath(uri, false);
+		const repository = await this.#getGitApi().then(api => api?.getRepository(uri) ?? undefined);
+		const branch = repository?.state.HEAD?.name;
+		const changed = repository ? repositoryChangeCount(repository) : 0;
+		const isRepositoryRoot = kind === 'folder' && repository?.rootUri.fsPath === uri.fsPath;
+		if (isRepositoryRoot) {
+			const detail = [branch, changed ? `${changed} changes` : 'clean'].filter((value): value is string => !!value).join(' · ');
+			return {
+				kind: 'repository',
+				...(detail ? { detail } : {}),
+				status: branch ? { kind: changed ? 'warning' : 'success', label: branch } : undefined,
+				tooltip: uri.toString(true),
+				ariaLabel: `Local repository ${label}${branch ? ` on branch ${branch}` : ''}, ${changed ? `${changed} changes` : 'clean'}`,
+			};
+		}
+
+		const details = [
+			compactParent(label),
+			branch,
+			repository && repositoryContainsChange(repository, uri) ? 'modified' : undefined,
+		].filter((value): value is string => !!value);
+		return {
+			kind,
+			...(details.length ? { detail: details.join(' · ') } : {}),
+			tooltip: uri.toString(true),
+			ariaLabel: `${kind === 'folder' ? 'Folder' : 'File'} ${label}`,
+		};
+	}
+
+	#getGitApi(): Promise<GitApi | undefined> {
+		this.#gitApi ??= (async () => {
+			const extension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+			const git = await extension?.activate();
+			return git?.enabled ? git.getAPI(1) : undefined;
+		})();
+		return this.#gitApi;
+	}
+}
+
+function isWorkspaceResourceLink(href: string): boolean {
+	if (href.startsWith('file:')) {
+		return true;
+	}
+	return !href.startsWith('#') && !/^[a-z][a-z0-9+.-]*:/i.test(href);
+}
+
+interface GitExtension {
+	readonly enabled: boolean;
+	getAPI(version: 1): GitApi;
+}
+
+interface GitApi {
+	getRepository(uri: vscode.Uri): GitRepository | null;
+}
+
+interface GitRepository {
+	readonly rootUri: vscode.Uri;
+	readonly state: {
+		readonly HEAD?: { readonly name?: string };
+		readonly mergeChanges: readonly GitChange[];
+		readonly indexChanges: readonly GitChange[];
+		readonly workingTreeChanges: readonly GitChange[];
+		readonly untrackedChanges: readonly GitChange[];
+	};
+}
+
+interface GitChange {
+	readonly uri: vscode.Uri;
+}
+
+function repositoryChangeCount(repository: GitRepository): number {
+	const state = repository.state;
+	return state.mergeChanges.length
+		+ state.indexChanges.length
+		+ state.workingTreeChanges.length
+		+ state.untrackedChanges.length;
+}
+
+function repositoryContainsChange(repository: GitRepository, uri: vscode.Uri): boolean {
+	const key = uri.toString();
+	const state = repository.state;
+	return [
+		...state.mergeChanges,
+		...state.indexChanges,
+		...state.workingTreeChanges,
+		...state.untrackedChanges,
+	].some(change => change.uri.toString() === key);
+}
+
+function relativeParent(value: string): string | undefined {
+	const separator = Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+	return separator > 0 ? value.slice(0, separator) : undefined;
+}
+
+function compactParent(value: string): string | undefined {
+	const parent = relativeParent(value);
+	if (!parent) {
+		return undefined;
+	}
+	if (!/^(?:[a-z]:[\\/]|[\\/])/i.test(parent)) {
+		return parent;
+	}
+	return parent.split(/[\\/]+/).filter(Boolean).slice(-4).join('/');
+}

--- a/extensions/markdown-language-features/src/test/markdownEditorRichLinks.test.ts
+++ b/extensions/markdown-language-features/src/test/markdownEditorRichLinks.test.ts
@@ -1,0 +1,276 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { autorun } from '@vscode/observables';
+import 'mocha';
+import * as vscode from 'vscode';
+import {
+	getGitHubIssueStatus,
+	getGitHubLookupFailurePresentation,
+	getGitHubPullRequestStatus,
+	GitHubLookupError,
+	resolveGitHubTreePath,
+	shouldShowGitHubPullRequestChecks,
+} from '../preview/githubLinkPresentationResolver';
+import { getSessionLinkPresentation } from '../preview/agentSessionLinkPresentationResolver';
+import { getGitCommitPresentation, GitLinkPresentationResolver, normalizeGitRemoteUrl } from '../preview/gitLinkPresentationResolver';
+import { createAsyncLinkPresentation, ImmutableLinkPresentationCache, LinkPresentationCache } from '../preview/linkPresentationResolver';
+
+suite('Markdown editor rich links', () => {
+	test('separates GitHub branch names from folder paths', () => {
+		const refs = [
+			{ ref: 'refs/heads/main' },
+			{ ref: 'refs/heads/feature/rich-links' },
+		];
+
+		assert.deepStrictEqual(resolveGitHubTreePath(['main'], refs), {
+			branch: 'main',
+		});
+		assert.deepStrictEqual(resolveGitHubTreePath(['main', 'src', 'vs'], refs), {
+			branch: 'main',
+			path: 'src/vs',
+		});
+		assert.deepStrictEqual(resolveGitHubTreePath(['feature', 'rich-links'], refs), {
+			branch: 'feature/rich-links',
+		});
+		assert.deepStrictEqual(resolveGitHubTreePath(['feature', 'rich-links', 'src'], refs), {
+			branch: 'feature/rich-links',
+			path: 'src',
+		});
+	});
+
+	test('maps GitHub issue lifecycle states', () => {
+		assert.deepStrictEqual(getGitHubIssueStatus('open', undefined), { kind: 'open', label: 'Open' });
+		assert.deepStrictEqual(getGitHubIssueStatus('closed', 'completed'), { kind: 'closed', label: 'Closed' });
+		assert.deepStrictEqual(getGitHubIssueStatus('closed', 'not_planned'), { kind: 'notPlanned', label: 'Not planned' });
+	});
+
+	test('maps GitHub pull request lifecycle states', () => {
+		const open = getGitHubPullRequestStatus('open', false, false);
+		const draft = getGitHubPullRequestStatus('open', true, false);
+		const closed = getGitHubPullRequestStatus('closed', false, false);
+		const merged = getGitHubPullRequestStatus('closed', false, true);
+
+		assert.deepStrictEqual(open, { kind: 'open', label: 'Open' });
+		assert.deepStrictEqual(draft, { kind: 'draft', label: 'Draft' });
+		assert.deepStrictEqual(closed, { kind: 'closed', label: 'Closed' });
+		assert.deepStrictEqual(merged, { kind: 'merged', label: 'Merged' });
+		assert.strictEqual(shouldShowGitHubPullRequestChecks(open), true);
+		assert.strictEqual(shouldShowGitHubPullRequestChecks(draft), true);
+		assert.strictEqual(shouldShowGitHubPullRequestChecks(closed), false);
+		assert.strictEqual(shouldShowGitHubPullRequestChecks(merged), false);
+	});
+
+	test('keeps GitHub lookup failures visible and actionable', () => {
+		assert.deepStrictEqual(
+			getGitHubLookupFailurePresentation(
+				'https://github.com/hediet/demo-json-schema-validator/pull/5',
+				new GitHubLookupError('authenticationRequired', 'No GitHub session.'),
+			),
+			{
+				kind: 'pullRequest',
+				status: { kind: 'error', label: 'Authorization required' },
+				tooltip: 'Authorize GitHub repository access in VS Code to load this link. No GitHub session.',
+				ariaLabel: 'GitHub pullRequest lookup failed: Authorization required',
+			},
+		);
+		assert.deepStrictEqual(
+			getGitHubLookupFailurePresentation(
+				'https://github.com/hediet/demo-json-schema-validator/issues/1',
+				new GitHubLookupError('rateLimited', '403 Forbidden'),
+			)?.status,
+			{ kind: 'error', label: 'Rate limited' },
+		);
+		assert.strictEqual(
+			getGitHubLookupFailurePresentation('https://example.com/issues/1', new Error('offline')),
+			undefined,
+		);
+	});
+
+	test('publishes complete data-driven session presentations', () => {
+		assert.deepStrictEqual(
+			getSessionLinkPresentation({
+				title: 'Implement rich-link metadata',
+				description: 'Updating the Markdown extension',
+				status: vscode.AgentSessionStatus.InProgress,
+			}),
+			{
+				kind: 'session',
+				title: 'Implement rich-link metadata',
+				detail: 'Updating the Markdown extension',
+				status: { kind: 'pending', label: 'Working' },
+				tooltip: 'Implement rich-link metadata · Working',
+				ariaLabel: 'Agent session Implement rich-link metadata, Working',
+			},
+		);
+		assert.deepStrictEqual(
+			getSessionLinkPresentation({
+				title: 'Implement rich-link metadata',
+				status: vscode.AgentSessionStatus.NeedsInput,
+			}),
+			{
+				kind: 'session',
+				title: 'Implement rich-link metadata',
+				status: { kind: 'warning', label: 'Needs input' },
+				tooltip: 'Implement rich-link metadata · Needs input',
+				ariaLabel: 'Agent session Implement rich-link metadata, Needs input',
+			},
+		);
+	});
+
+	test('normalizes common Git remote URL formats', () => {
+		assert.deepStrictEqual([
+			normalizeGitRemoteUrl('https://github.com/microsoft/vscode.git'),
+			normalizeGitRemoteUrl('git@github.com:microsoft/vscode.git'),
+			normalizeGitRemoteUrl('ssh://git@github.com/microsoft/vscode.git'),
+		], [
+			'github.com/microsoft/vscode',
+			'github.com/microsoft/vscode',
+			'github.com/microsoft/vscode',
+		]);
+	});
+
+	test('supports local and forge Git commit links', () => {
+		const refresh = new vscode.EventEmitter<void>();
+		const resolver = new GitLinkPresentationResolver(new ImmutableLinkPresentationCache());
+		try {
+			const context = {
+				onDidRequestRefresh: refresh.event,
+				logger: { trace: () => { } },
+			};
+			assert.deepStrictEqual({
+				local: !!resolver.resolve('commit://1234567890abcdef', context),
+				github: !!resolver.resolve('https://github.com/microsoft/vscode/commit/1234567890abcdef', context),
+				gitlab: !!resolver.resolve('https://gitlab.com/microsoft/vscode/-/commit/1234567890abcdef', context),
+				invalidLocal: !!resolver.resolve('commit:--output=package.json', context),
+				invalidForge: !!resolver.resolve('https://github.com/microsoft/vscode/commit/--output=package.json', context),
+				malformedForge: !!resolver.resolve('https://github.com/microsoft/vscode/commit/%', context),
+				other: !!resolver.resolve('https://example.com/resource', context),
+			}, {
+				local: true,
+				github: true,
+				gitlab: true,
+				invalidLocal: false,
+				invalidForge: false,
+				malformedForge: false,
+				other: false,
+			});
+		} finally {
+			resolver.dispose();
+			refresh.dispose();
+		}
+	});
+
+	test('ignores malformed GitHub paths', () => {
+		assert.strictEqual(
+			getGitHubLookupFailurePresentation('https://github.com/microsoft/vscode/issues/%', new Error('failed')),
+			undefined,
+		);
+	});
+
+	test('shows Git commit metadata', () => {
+		assert.deepStrictEqual(getGitCommitPresentation({
+			hash: '1234567890abcdef',
+			message: 'Refactor rich-link resolvers\n\nUse observable lifetimes.',
+			shortStat: {
+				insertions: 20,
+				deletions: 5,
+			},
+		}), {
+			kind: 'commit',
+			detail: 'Refactor rich-link resolvers',
+			tooltip: '1234567 · Refactor rich-link resolvers · 20 insertions, 5 deletions',
+			ariaLabel: 'Commit 1234567, 20 insertions and 5 deletions: Refactor rich-link resolvers',
+		});
+	});
+
+	test('owns async resolution through observable lifetime', () => {
+		const refresh = new vscode.EventEmitter<void>();
+		let resolveCount = 0;
+		const presentation = createAsyncLinkPresentation(
+			'https://example.com/resource',
+			{ kind: 'file', status: { kind: 'pending', label: 'Loading' } },
+			{
+				onDidRequestRefresh: refresh.event,
+				logger: { trace: () => { } },
+			},
+			async () => ({ kind: 'file', detail: String(++resolveCount) }),
+			() => ({ kind: 'file', status: { kind: 'error', label: 'Error' } }),
+		);
+
+		assert.strictEqual(resolveCount, 0);
+		const observer = autorun(reader => presentation.read(reader));
+		assert.strictEqual(resolveCount, 1);
+		refresh.fire();
+		assert.strictEqual(resolveCount, 2);
+		observer.dispose();
+		refresh.fire();
+		assert.strictEqual(resolveCount, 2);
+		refresh.dispose();
+	});
+
+	test('caches immutable Git commit presentations without expiry', async () => {
+		const cache = new ImmutableLinkPresentationCache();
+		let resolveCount = 0;
+		const resolve = async () => getGitCommitPresentation({
+			hash: '1234567890abcdef',
+			message: 'Cached commit',
+			shortStat: {
+				insertions: ++resolveCount,
+				deletions: 0,
+			},
+		});
+
+		const href = 'https://github.com/microsoft/vscode/commit/1234567890abcdef';
+		const first = await cache.get(href, resolve);
+		const second = await cache.get(href, resolve);
+		const third = await cache.get(href, resolve);
+
+		assert.deepStrictEqual({
+			first,
+			second,
+			third,
+			resolveCount,
+		}, {
+			first: {
+				kind: 'commit',
+				detail: 'Cached commit',
+				tooltip: '1234567 · Cached commit · 1 insertions, 0 deletions',
+				ariaLabel: 'Commit 1234567, 1 insertions and 0 deletions: Cached commit',
+			},
+			second: {
+				kind: 'commit',
+				detail: 'Cached commit',
+				tooltip: '1234567 · Cached commit · 1 insertions, 0 deletions',
+				ariaLabel: 'Commit 1234567, 1 insertions and 0 deletions: Cached commit',
+			},
+			third: {
+				kind: 'commit',
+				detail: 'Cached commit',
+				tooltip: '1234567 · Cached commit · 1 insertions, 0 deletions',
+				ariaLabel: 'Commit 1234567, 1 insertions and 0 deletions: Cached commit',
+			},
+			resolveCount: 1,
+		});
+	});
+
+	test('expires mutable link presentations after one minute', async () => {
+		const cache = new LinkPresentationCache();
+		let resolveCount = 0;
+		const resolve = async () => ({ kind: 'issue' as const, title: String(++resolveCount) });
+
+		const first = await cache.get('https://github.com/microsoft/vscode/issues/1', resolve, 0);
+		const cached = await cache.get('https://github.com/microsoft/vscode/issues/1', resolve, 59_999);
+		const refreshed = await cache.get('https://github.com/microsoft/vscode/issues/1', resolve, 60_000);
+
+		assert.deepStrictEqual({ first, cached, refreshed, resolveCount }, {
+			first: { kind: 'issue', title: '1' },
+			cached: { kind: 'issue', title: '1' },
+			refreshed: { kind: 'issue', title: '2' },
+			resolveCount: 2,
+		});
+	});
+});

--- a/extensions/markdown-language-features/src/test/openDocumentLink.test.ts
+++ b/extensions/markdown-language-features/src/test/openDocumentLink.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import 'mocha';
+import { getAbsoluteUri } from '../util/openDocumentLink';
+
+suite('Open Markdown document link', () => {
+	test('recognizes absolute links without treating relative links as URIs', () => {
+		assert.deepStrictEqual({
+			github: getAbsoluteUri('https://github.com/microsoft/vscode/issues/123')?.toString(),
+			session: getAbsoluteUri('agent-host-session://copilotcli/session-id?chat=chat-id')?.toString(),
+			file: getAbsoluteUri('file:///workspace/readme.md')?.toString(),
+			windowsForwardSlash: getAbsoluteUri('C:/workspace/readme.md'),
+			windowsBackslash: getAbsoluteUri('C:\\workspace\\readme.md'),
+			relative: getAbsoluteUri('./readme.md'),
+		}, {
+			github: 'https://github.com/microsoft/vscode/issues/123',
+			session: 'agent-host-session://copilotcli/session-id?chat%3Dchat-id',
+			file: 'file:///workspace/readme.md',
+			windowsForwardSlash: undefined,
+			windowsBackslash: undefined,
+			relative: undefined,
+		});
+	});
+});

--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -27,6 +27,11 @@ export class MdLinkOpener {
 	}
 
 	public async openDocumentLink(linkText: string, fromResource: vscode.Uri, viewColumn?: vscode.ViewColumn): Promise<void> {
+		const absoluteUri = getAbsoluteUri(linkText);
+		if (absoluteUri && absoluteUri.scheme !== 'file') {
+			return vscode.commands.executeCommand('vscode.open', absoluteUri);
+		}
+
 		const resolved = await this.#client.resolveLinkTarget(linkText, fromResource);
 		if (!resolved) {
 			return;
@@ -75,6 +80,12 @@ export class MdLinkOpener {
 			}
 		}
 	}
+}
+
+export function getAbsoluteUri(linkText: string): vscode.Uri | undefined {
+	return !/^[a-z]:[\\/]/i.test(linkText) && /^[a-z][a-z0-9+.-]*:/i.test(linkText)
+		? vscode.Uri.parse(linkText, true)
+		: undefined;
 }
 
 function getSelectionFromLocationFragment(fragment: string): vscode.Range | undefined {
@@ -154,4 +165,3 @@ function getViewColumn(resource: vscode.Uri): vscode.ViewColumn {
 			return vscode.ViewColumn.Active;
 	}
 }
-

--- a/extensions/markdown-language-features/tsconfig.json
+++ b/extensions/markdown-language-features/tsconfig.json
@@ -13,6 +13,7 @@
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.agentEditorComments.d.ts",
 		"../../src/vscode-dts/vscode.proposed.customEditorDiffs.d.ts",
+		"../../src/vscode-dts/vscode.proposed.dataChannels.d.ts",
 		"../../src/vscode-dts/vscode.proposed.documentDiff.d.ts",
 		"../../src/vscode-dts/vscode.proposed.documentSyntaxHighlighting.d.ts",
 		"../../src/vscode-dts/vscode.proposed.textEditorDiffInformation.d.ts"

--- a/src/vs/platform/agentHost/common/openSessionLink.ts
+++ b/src/vs/platform/agentHost/common/openSessionLink.ts
@@ -20,6 +20,12 @@ import { DEFAULT_CHAT_ID, isAhpChatChannel, parseChatUri } from './state/session
  */
 export const AGENT_HOST_SESSION_LINK_SCHEME = 'agent-host-session';
 
+export interface IAgentSessionLinkPresentation {
+	readonly title: string;
+	readonly description?: string;
+	readonly status: 'untitled' | 'inProgress' | 'needsInput' | 'completed' | 'error';
+}
+
 /**
  * Whether {@link toolName} (as seen on a tool call) matches {@link bareName}.
  * Accepts the bare name and a transport prefix such as Claude's

--- a/src/vs/platform/dataChannel/common/dataChannel.ts
+++ b/src/vs/platform/dataChannel/common/dataChannel.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+import { IDisposable } from '../../../base/common/lifecycle.js';
+import { IObservable } from '../../../base/common/observable.js';
+import { URI } from '../../../base/common/uri.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 
 export const IDataChannelService = createDecorator<IDataChannelService>('dataChannelService');
@@ -23,6 +26,35 @@ export interface CoreDataChannel<T = unknown> {
 export interface IDataChannelEvent<T = unknown> {
 	channelId: string;
 	data: T;
+}
+
+export const IDataWatcherService = createDecorator<IDataWatcherService>('dataWatcherService');
+
+export const enum DataWatcherKind {
+	AgentSession = 'agentSession',
+}
+
+export interface IAgentSessionDataWatcherParams {
+	readonly kind: DataWatcherKind.AgentSession;
+	readonly resource: URI;
+}
+
+export type IDataWatcherParams =
+	| IAgentSessionDataWatcherParams;
+
+export interface IDataWatcher<T = unknown> extends IDisposable {
+	readonly data: IObservable<T | undefined>;
+}
+
+export interface IDataWatcherProvider {
+	createDataWatcher(params: IDataWatcherParams): IDataWatcher | undefined;
+}
+
+export interface IDataWatcherService {
+	readonly _serviceBrand: undefined;
+
+	registerDataWatcherProvider(kind: DataWatcherKind, provider: IDataWatcherProvider): IDisposable;
+	createDataWatcher(params: IDataWatcherParams): IDataWatcher | undefined;
 }
 
 export class NullDataChannelService implements IDataChannelService {

--- a/src/vs/sessions/contrib/chat/browser/openSessionLinkOpener.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/openSessionLinkOpener.contribution.ts
@@ -3,14 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { structuralEquals } from '../../../../base/common/equals.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derivedOpts, IObservable, IReader, observableSignalFromEvent } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IAgentHostConnectionsService } from '../../../../platform/agentHost/common/agentHostConnectionsService.js';
-import { parseOpenSessionLinkChatId, parseOpenSessionLinkUri } from '../../../../platform/agentHost/common/openSessionLink.js';
+import { IAgentSessionLinkPresentation, parseOpenSessionLinkChatId, parseOpenSessionLinkUri } from '../../../../platform/agentHost/common/openSessionLink.js';
+import { DataWatcherKind, IDataWatcher, IDataWatcherService } from '../../../../platform/dataChannel/common/dataChannel.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 
 /**
@@ -32,10 +36,16 @@ export class OpenSessionLinkOpenerContribution extends Disposable implements IWo
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@IAgentHostConnectionsService private readonly _connectionsService: IAgentHostConnectionsService,
+		@IDataWatcherService dataWatcherService: IDataWatcherService,
 	) {
 		super();
 		this._register(openerService.registerOpener({
 			open: async resource => this._open(resource),
+		}));
+		this._register(dataWatcherService.registerDataWatcherProvider(DataWatcherKind.AgentSession, {
+			createDataWatcher: params => parseOpenSessionLinkUri(params.resource)
+				? new AgentSessionDataWatcher(params.resource, this._sessionsManagementService, this._connectionsService)
+				: undefined,
 		}));
 	}
 
@@ -44,7 +54,7 @@ export class OpenSessionLinkOpenerContribution extends Disposable implements IWo
 		if (!backendSession) {
 			return false;
 		}
-		const session = this._findSession(backendSession);
+		const session = findSession(backendSession, this._sessionsManagementService, this._connectionsService);
 		if (!session) {
 			return false;
 		}
@@ -57,11 +67,82 @@ export class OpenSessionLinkOpenerContribution extends Disposable implements IWo
 		await this._sessionsService.openSession(session.resource);
 		return true;
 	}
+}
 
-	private _findSession(backendSession: URI): ISession | undefined {
-		const backend = backendSession.toString();
-		return this._sessionsManagementService.getSessions().find(session =>
-			session.resource.toString() === backend
-			|| this._connectionsService.resolveSessionResource(session.resource)?.backendSession.toString() === backend);
+class AgentSessionDataWatcher extends Disposable implements IDataWatcher<IAgentSessionLinkPresentation> {
+	readonly data: IObservable<IAgentSessionLinkPresentation | undefined>;
+
+	constructor(
+		resource: URI,
+		sessionsManagementService: ISessionsManagementService,
+		connectionsService: IAgentHostConnectionsService,
+	) {
+		super();
+		const backendSession = parseOpenSessionLinkUri(resource);
+		const chatId = parseOpenSessionLinkChatId(resource);
+		const sessionsChanged = observableSignalFromEvent(this, sessionsManagementService.onDidChangeSessions);
+		this.data = derivedOpts(
+			{ owner: this, equalsFn: structuralEquals },
+			reader => {
+				sessionsChanged.read(reader);
+				const session = backendSession
+					? findSession(backendSession, sessionsManagementService, connectionsService)
+					: undefined;
+				return session ? readSessionState(session, chatId, reader) : undefined;
+			},
+		);
+	}
+}
+
+export function readSessionState(
+	session: ISessionLinkState,
+	chatId: string | undefined,
+	reader: IReader,
+): IAgentSessionLinkPresentation {
+	const chat = findChat(session, chatId, reader);
+	const description = session.description.read(reader)?.value;
+	return {
+		title: chat?.title.read(reader) ?? session.title.read(reader),
+		...(description ? { description } : {}),
+		status: sessionStatusName(chat?.status.read(reader) ?? session.status.read(reader)),
+	};
+}
+
+export interface ISessionLinkChatState {
+	readonly resource: URI;
+	readonly title: IObservable<string>;
+	readonly status: IObservable<SessionStatus>;
+}
+
+export interface ISessionLinkState {
+	readonly title: IObservable<string>;
+	readonly description: IObservable<{ readonly value: string } | undefined>;
+	readonly status: IObservable<SessionStatus>;
+	readonly chats: IObservable<readonly ISessionLinkChatState[]>;
+}
+
+function findSession(
+	backendSession: URI,
+	sessionsManagementService: ISessionsManagementService,
+	connectionsService: IAgentHostConnectionsService,
+): ISession | undefined {
+	return sessionsManagementService.getSessions().find(session => {
+		const resolved = connectionsService.resolveSessionResource(session.resource);
+		return isEqual(session.resource, backendSession)
+			|| !!resolved && isEqual(resolved.backendSession, backendSession);
+	});
+}
+
+function findChat(session: ISessionLinkState, chatId: string | undefined, reader: IReader): ISessionLinkChatState | undefined {
+	return chatId ? session.chats.read(reader).find(chat => chat.resource.fragment === chatId) : undefined;
+}
+
+function sessionStatusName(status: SessionStatus): IAgentSessionLinkPresentation['status'] {
+	switch (status) {
+		case SessionStatus.Untitled: return 'untitled';
+		case SessionStatus.InProgress: return 'inProgress';
+		case SessionStatus.NeedsInput: return 'needsInput';
+		case SessionStatus.Completed: return 'completed';
+		case SessionStatus.Error: return 'error';
 	}
 }

--- a/src/vs/sessions/contrib/chat/test/browser/openSessionLinkOpener.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/openSessionLinkOpener.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { autorun, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionLinkChatState, ISessionLinkState, readSessionState } from '../../browser/openSessionLinkOpener.contribution.js';
+
+suite('OpenSessionLinkOpenerContribution', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reactively reads the targeted chat state', () => {
+		const chatStatus = observableValue('chatStatus', SessionStatus.Completed);
+		const chat: ISessionLinkChatState = {
+			resource: URI.parse('agent-host-copilotcli:/session?unused=true#peer'),
+			title: observableValue('chatTitle', 'Peer chat'),
+			status: chatStatus,
+		};
+		const chats = observableValue<readonly ISessionLinkChatState[]>('chats', []);
+		const session: ISessionLinkState = {
+			title: observableValue('sessionTitle', 'Parent session'),
+			description: observableValue('sessionDescription', { value: 'Session details' }),
+			status: observableValue('sessionStatus', SessionStatus.InProgress),
+			chats,
+		};
+		const values: unknown[] = [];
+		store.add(autorun(reader => {
+			values.push(readSessionState(session, 'peer', reader));
+		}));
+
+		chats.set([chat], undefined);
+		chatStatus.set(SessionStatus.NeedsInput, undefined);
+
+		assert.deepStrictEqual(values, [
+			{ title: 'Parent session', description: 'Session details', status: 'inProgress' },
+			{ title: 'Peer chat', description: 'Session details', status: 'completed' },
+			{ title: 'Peer chat', description: 'Session details', status: 'needsInput' },
+		]);
+	});
+});

--- a/src/vs/workbench/api/browser/mainThreadDataChannels.ts
+++ b/src/vs/workbench/api/browser/mainThreadDataChannels.ts
@@ -3,19 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../base/common/lifecycle.js';
-import { IDataChannelService } from '../../../platform/dataChannel/common/dataChannel.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
+import { autorun } from '../../../base/common/observable.js';
+import { URI } from '../../../base/common/uri.js';
+import { IDataChannelService, IDataWatcherService } from '../../../platform/dataChannel/common/dataChannel.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
-import { ExtHostContext, ExtHostDataChannelsShape, MainContext, MainThreadDataChannelsShape } from '../common/extHost.protocol.js';
+import { ExtHostContext, ExtHostDataChannelsShape, IDataWatcherParamsDto, MainContext, MainThreadDataChannelsShape } from '../common/extHost.protocol.js';
 
 @extHostNamedCustomer(MainContext.MainThreadDataChannels)
 export class MainThreadDataChannels extends Disposable implements MainThreadDataChannelsShape {
 
 	private readonly _proxy: ExtHostDataChannelsShape;
+	private readonly _dataWatchers = this._register(new DisposableMap<number>());
 
 	constructor(
 		extHostContext: IExtHostContext,
-		@IDataChannelService private readonly _dataChannelService: IDataChannelService
+		@IDataChannelService private readonly _dataChannelService: IDataChannelService,
+		@IDataWatcherService private readonly _dataWatcherService: IDataWatcherService,
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDataChannels);
@@ -23,5 +27,27 @@ export class MainThreadDataChannels extends Disposable implements MainThreadData
 		this._register(this._dataChannelService.onDidSendData(e => {
 			this._proxy.$onDidReceiveData(e.channelId, e.data);
 		}));
+	}
+
+	$createDataWatcher(handle: number, params: IDataWatcherParamsDto): void {
+		const watcher = this._dataWatcherService.createDataWatcher({
+			kind: params.kind,
+			resource: URI.revive(params.resource),
+		});
+		if (!watcher) {
+			this._proxy.$acceptDataWatcherData(handle, undefined);
+			return;
+		}
+
+		const store = new DisposableStore();
+		store.add(autorun(reader => {
+			this._proxy.$acceptDataWatcherData(handle, watcher.data.read(reader));
+		}));
+		store.add(watcher);
+		this._dataWatchers.set(handle, store);
+	}
+
+	$disposeDataWatcher(handle: number): void {
+		this._dataWatchers.deleteAndDispose(handle);
 	}
 }

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1067,6 +1067,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'textEditorDiffInformation');
 				return extHostQuickDiff.createSourceControlDiffInformation(uri);
 			},
+			createDataWatcher<T extends vscode.DataWatcherParams>(params: T): vscode.DataWatcher<vscode.DataWatcherData<T>> {
+				checkProposedApiEnabled(extension, 'dataChannels');
+				return extHostDataChannels.createDataWatcher(extension, params);
+			},
 			createAgentEditorComments(uri: vscode.Uri): vscode.AgentEditorCommentsProvider {
 				checkProposedApiEnabled(extension, 'agentEditorComments');
 				return extHostAgentEditorComments.createAgentEditorComments(uri);
@@ -2037,6 +2041,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			DiagnosticSeverity: extHostTypes.DiagnosticSeverity,
 			DiagnosticTag: extHostTypes.DiagnosticTag,
 			Disposable: extHostTypes.Disposable,
+			DataWatcherKind: extHostTypes.DataWatcherKind,
+			AgentSessionStatus: extHostTypes.AgentSessionStatus,
 			DocumentHighlight: extHostTypes.DocumentHighlight,
 			DocumentHighlightKind: extHostTypes.DocumentHighlightKind,
 			MultiDocumentHighlight: extHostTypes.MultiDocumentHighlight,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -34,6 +34,7 @@ import { IAccessibilityInformation } from '../../../platform/accessibility/commo
 import { ILocalizedString } from '../../../platform/action/common/action.js';
 import { ConfigurationTarget, IConfigurationChange, IConfigurationData, IConfigurationOverrides } from '../../../platform/configuration/common/configuration.js';
 import { ConfigurationScope } from '../../../platform/configuration/common/configurationRegistry.js';
+import { DataWatcherKind } from '../../../platform/dataChannel/common/dataChannel.js';
 import { IEditorOptions } from '../../../platform/editor/common/editor.js';
 import { IExtensionIdWithVersion } from '../../../platform/extensionManagement/common/extensionStorage.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
@@ -3737,11 +3738,22 @@ export interface MainThreadMcpShape {
 }
 
 export interface MainThreadDataChannelsShape extends IDisposable {
+	$createDataWatcher(handle: number, params: IDataWatcherParamsDto): void;
+	$disposeDataWatcher(handle: number): void;
 }
 
 export interface ExtHostDataChannelsShape {
 	$onDidReceiveData(channelId: string, data: unknown): void;
+	$acceptDataWatcherData(handle: number, data: unknown): void;
 }
+
+export interface IAgentSessionDataWatcherParamsDto {
+	readonly kind: DataWatcherKind.AgentSession;
+	readonly resource: UriComponents;
+}
+
+export type IDataWatcherParamsDto =
+	| IAgentSessionDataWatcherParamsDto;
 
 export interface ExtHostLocalizationShape {
 	getMessage(extensionId: string, details: IStringDetails): string;

--- a/src/vs/workbench/api/common/extHostDataChannels.ts
+++ b/src/vs/workbench/api/common/extHostDataChannels.ts
@@ -6,14 +6,18 @@
 import type * as vscode from 'vscode';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { ExtHostDataChannelsShape } from './extHost.protocol.js';
-import { checkProposedApiEnabled } from '../../services/extensions/common/extensions.js';
+import { DataWatcherKind as InternalDataWatcherKind } from '../../../platform/dataChannel/common/dataChannel.js';
 import { IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
+import { AgentSessionStatus } from './extHostTypes.js';
+import { IExtHostRpcService } from './extHostRpcService.js';
+import { ExtHostDataChannelsShape, MainContext, MainThreadDataChannelsShape } from './extHost.protocol.js';
+import { checkProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 
 export interface IExtHostDataChannels extends ExtHostDataChannelsShape {
 	readonly _serviceBrand: undefined;
 	createDataChannel<T>(extension: IExtensionDescription, channelId: string): vscode.DataChannel<T>;
+	createDataWatcher<T extends vscode.DataWatcherParams>(extension: IExtensionDescription, params: T): vscode.DataWatcher<vscode.DataWatcherData<T>>;
 }
 
 export const IExtHostDataChannels = createDecorator<IExtHostDataChannels>('IExtHostDataChannels');
@@ -22,8 +26,14 @@ export class ExtHostDataChannels implements IExtHostDataChannels {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _channels = new Map<string, DataChannelImpl<any>>();
+	private readonly _dataWatchers = new Map<number, { acceptData(data: unknown): void }>();
+	private static _dataWatcherHandlePool = 0;
+	private readonly _proxy: MainThreadDataChannelsShape;
 
-	constructor() {
+	constructor(
+		@IExtHostRpcService extHostRpc: IExtHostRpcService,
+	) {
+		this._proxy = extHostRpc.getProxy(MainContext.MainThreadDataChannels);
 	}
 
 	createDataChannel<T>(extension: IExtensionDescription, channelId: string): vscode.DataChannel<T> {
@@ -37,11 +47,40 @@ export class ExtHostDataChannels implements IExtHostDataChannels {
 		return channel;
 	}
 
+	createDataWatcher<T extends vscode.DataWatcherParams>(extension: IExtensionDescription, params: T): vscode.DataWatcher<vscode.DataWatcherData<T>> {
+		checkProposedApiEnabled(extension, 'dataChannels');
+
+		const handle = ExtHostDataChannels._dataWatcherHandlePool++;
+		let watcher: DataWatcherImpl<vscode.AgentSessionData>;
+		switch (params.kind) {
+			case 0:
+				watcher = new DataWatcherImpl(
+					handle,
+					this._proxy,
+					parseAgentSessionData,
+					disposedHandle => this._dataWatchers.delete(disposedHandle),
+				);
+				this._proxy.$createDataWatcher(handle, {
+					kind: InternalDataWatcherKind.AgentSession,
+					resource: params.resource,
+				});
+				break;
+			default:
+				throw new Error('Unknown data watcher kind');
+		}
+		this._dataWatchers.set(handle, watcher);
+		return watcher;
+	}
+
 	$onDidReceiveData(channelId: string, data: any): void {
 		const channel = this._channels.get(channelId);
 		if (channel) {
 			channel._fireDidReceiveData(data);
 		}
+	}
+
+	$acceptDataWatcherData(handle: number, data: unknown): void {
+		this._dataWatchers.get(handle)?.acceptData(data);
 	}
 }
 
@@ -60,5 +99,65 @@ class DataChannelImpl<T> extends Disposable implements vscode.DataChannel<T> {
 
 	override toString(): string {
 		return `DataChannel(${this.channelId})`;
+	}
+}
+
+function parseAgentSessionData(value: unknown): vscode.AgentSessionData {
+	if (!isRecord(value)
+		|| typeof value.title !== 'string'
+		|| (value.description !== undefined && typeof value.description !== 'string')
+	) {
+		throw new Error('Invalid agent session data watcher payload');
+	}
+	const status = parseAgentSessionStatus(value.status);
+	return {
+		title: value.title,
+		...(value.description ? { description: value.description } : {}),
+		status,
+	};
+}
+
+function parseAgentSessionStatus(value: unknown): AgentSessionStatus {
+	switch (value) {
+		case 'untitled': return AgentSessionStatus.Untitled;
+		case 'inProgress': return AgentSessionStatus.InProgress;
+		case 'needsInput': return AgentSessionStatus.NeedsInput;
+		case 'completed': return AgentSessionStatus.Completed;
+		case 'error': return AgentSessionStatus.Error;
+		default: throw new Error('Invalid agent session status');
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object';
+}
+
+class DataWatcherImpl<T> extends Disposable implements vscode.DataWatcher<T> {
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange = this._onDidChange.event;
+
+	private _data: T | undefined;
+	get data(): T | undefined {
+		return this._data;
+	}
+
+	constructor(
+		handle: number,
+		proxy: MainThreadDataChannelsShape,
+		private readonly _parseData: (value: unknown) => T,
+		onDispose: (handle: number) => void,
+	) {
+		super();
+		this._register({
+			dispose: () => {
+				proxy.$disposeDataWatcher(handle);
+				onDispose(handle);
+			},
+		});
+	}
+
+	acceptData(data: unknown): void {
+		this._data = data === undefined ? undefined : this._parseData(data);
+		this._onDidChange.fire();
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -49,6 +49,18 @@ export { SymbolInformation, SymbolKind, SymbolTag } from './extHostTypes/symbolI
 export { EndOfLine, TextEdit } from './extHostTypes/textEdit.js';
 export { FileEditType, WorkspaceEdit } from './extHostTypes/workspaceEdit.js';
 
+export enum DataWatcherKind {
+	AgentSession,
+}
+
+export enum AgentSessionStatus {
+	Untitled,
+	InProgress,
+	NeedsInput,
+	Completed,
+	Error,
+}
+
 export enum TerminalOutputAnchor {
 	Top = 0,
 	Bottom = 1

--- a/src/vs/workbench/api/test/browser/mainThreadDataChannels.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadDataChannels.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import type * as vscode from 'vscode';
+import { observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IAgentSessionLinkPresentation } from '../../../../platform/agentHost/common/openSessionLink.js';
+import { DataWatcherKind } from '../../../../platform/dataChannel/common/dataChannel.js';
+import { DataChannelService, DataWatcherService } from '../../../services/dataChannel/browser/dataChannelService.js';
+import { nullExtensionDescription } from '../../../services/extensions/common/extensions.js';
+import { MainThreadDataChannels } from '../../browser/mainThreadDataChannels.js';
+import { ExtHostDataChannels } from '../../common/extHostDataChannels.js';
+import { ExtHostDataChannelsShape } from '../../common/extHost.protocol.js';
+import { AgentSessionStatus } from '../../common/extHostTypes.js';
+import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
+
+suite('MainThreadDataChannels', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('bridges observable watcher data and disposes the subscription', () => {
+		const data = observableValue<IAgentSessionLinkPresentation | undefined>('data', undefined);
+		const dataWatcherService = new DataWatcherService();
+		store.add(dataWatcherService.registerDataWatcherProvider(DataWatcherKind.AgentSession, {
+			createDataWatcher: () => ({
+				data,
+				dispose: () => { },
+			}),
+		}));
+		const extHostProxy: ExtHostDataChannelsShape = {
+			$onDidReceiveData: (channelId, value) => extHost.$onDidReceiveData(channelId, value),
+			$acceptDataWatcherData: (handle, value) => extHost.$acceptDataWatcherData(handle, value),
+		};
+		const mainThread = store.add(new MainThreadDataChannels(
+			SingleProxyRPCProtocol(extHostProxy),
+			store.add(new DataChannelService()),
+			dataWatcherService,
+		));
+		const extHost = new ExtHostDataChannels(SingleProxyRPCProtocol(mainThread));
+		const extension = {
+			...nullExtensionDescription,
+			enabledApiProposals: ['dataChannels'],
+		};
+		const watcher = store.add(extHost.createDataWatcher(extension, {
+			kind: 0,
+			resource: URI.parse('agent-host-session://copilotcli/session'),
+		}));
+		const values: (vscode.AgentSessionData | undefined)[] = [watcher.data];
+		store.add(watcher.onDidChange(() => values.push(watcher.data)));
+
+		data.set({ title: 'Running session', status: 'inProgress' }, undefined);
+		data.set({ title: 'Running session', status: 'needsInput' }, undefined);
+		watcher.dispose();
+		data.set({ title: 'Completed session', status: 'completed' }, undefined);
+
+		assert.deepStrictEqual(values, [
+			undefined,
+			{ title: 'Running session', status: AgentSessionStatus.InProgress },
+			{ title: 'Running session', status: AgentSessionStatus.NeedsInput },
+		]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/openSessionLinkOpener.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/openSessionLinkOpener.contribution.ts
@@ -3,15 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { structuralEquals } from '../../../../../../base/common/equals.js';
+import { isCancellationError } from '../../../../../../base/common/errors.js';
+import { Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { IObservable, observableValueOpts } from '../../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
 import { LOCAL_AGENT_HOST_SCHEME_PREFIX } from '../../../../../../platform/agentHost/common/agentHostConnectionsService.js';
-import { parseOpenSessionLinkUri } from '../../../../../../platform/agentHost/common/openSessionLink.js';
+import { IAgentSessionLinkPresentation, parseOpenSessionLinkUri } from '../../../../../../platform/agentHost/common/openSessionLink.js';
+import { DataWatcherKind, IDataWatcher, IDataWatcherService } from '../../../../../../platform/dataChannel/common/dataChannel.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
+import { ChatSessionStatus, IChatSessionItem, IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../../common/model/chatUri.js';
-import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../chat.js';
 
 /**
@@ -38,26 +46,129 @@ export class AgentHostOpenSessionLinkOpenerContribution extends Disposable imple
 		@IOpenerService openerService: IOpenerService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
+		@IDataWatcherService dataWatcherService: IDataWatcherService,
+		@ILogService logService: ILogService,
 	) {
 		super();
 		this._register(openerService.registerOpener({
 			open: async resource => this._open(resource),
 		}));
+		this._register(dataWatcherService.registerDataWatcherProvider(DataWatcherKind.AgentSession, {
+			createDataWatcher: params => {
+				const clientResource = toClientSessionResource(params.resource);
+				return clientResource
+					? new WorkbenchAgentSessionDataWatcher(clientResource, this._chatSessionsService, logService)
+					: undefined;
+			},
+		}));
 	}
 
 	private async _open(resource: URI | string): Promise<boolean> {
-		const backendSession = parseOpenSessionLinkUri(resource);
-		if (!backendSession) {
+		const clientResource = toClientSessionResource(resource);
+		if (!clientResource) {
 			return false;
 		}
-		const provider = AgentSession.provider(backendSession);
-		const rawId = AgentSession.id(backendSession);
-		if (!provider || !rawId) {
-			return false;
-		}
-		const clientResource = URI.from({ scheme: `${LOCAL_AGENT_HOST_SCHEME_PREFIX}${provider}`, path: `/${rawId}` });
 		await this._chatSessionsService.activateChatSessionItemProvider(getChatSessionType(clientResource));
 		const widget = await this._chatWidgetService.openSession(clientResource, ChatViewPaneTarget, { revealIfOpened: true });
 		return !!widget;
+	}
+}
+
+class WorkbenchAgentSessionDataWatcher extends Disposable implements IDataWatcher<IAgentSessionLinkPresentation> {
+	private readonly _data = observableValueOpts<IAgentSessionLinkPresentation | undefined>(
+		{ owner: this, equalsFn: structuralEquals },
+		undefined,
+	);
+	readonly data: IObservable<IAgentSessionLinkPresentation | undefined> = this._data;
+
+	private readonly _clientResource: URI;
+	private readonly _chatSessionType: string;
+	private readonly _providerReady: Promise<void>;
+	private _refreshCancellation: CancellationTokenSource | undefined;
+
+	constructor(
+		clientResource: URI,
+		private readonly _chatSessionsService: IChatSessionsService,
+		private readonly _logService: ILogService,
+	) {
+		super();
+		this._clientResource = clientResource;
+		this._chatSessionType = getChatSessionType(this._clientResource);
+		this._providerReady = this._chatSessionsService.activateChatSessionItemProvider(this._chatSessionType);
+		this._register(Event.any(
+			this._chatSessionsService.onDidChangeAvailability,
+			this._chatSessionsService.onDidChangeInProgress,
+			this._chatSessionsService.onDidChangeItemsProviders,
+			this._chatSessionsService.onDidChangeSessionItems,
+		)(() => this._refresh()));
+		this._refresh();
+	}
+
+	override dispose(): void {
+		this._refreshCancellation?.cancel();
+		this._refreshCancellation?.dispose();
+		this._refreshCancellation = undefined;
+		super.dispose();
+	}
+
+	private _refresh(): void {
+		this._refreshCancellation?.cancel();
+		this._refreshCancellation?.dispose();
+		const cancellation = new CancellationTokenSource();
+		this._refreshCancellation = cancellation;
+		void this._resolve(cancellation.token).then(data => {
+			if (!cancellation.token.isCancellationRequested && this._refreshCancellation === cancellation) {
+				this._data.set(data, undefined);
+			}
+		}, error => {
+			if (!isCancellationError(error) && !cancellation.token.isCancellationRequested) {
+				this._logService.error('Failed to refresh agent session data watcher', error);
+			}
+		});
+	}
+
+	private async _resolve(token: CancellationToken): Promise<IAgentSessionLinkPresentation | undefined> {
+		await this._providerReady;
+		for await (const group of this._chatSessionsService.getChatSessionItems([this._chatSessionType], token)) {
+			const item = group.items.find(candidate =>
+				isEqual(candidate.resource, this._clientResource)
+				|| !!candidate.legacyResource && isEqual(candidate.legacyResource, this._clientResource));
+			if (item) {
+				return toSessionLinkPresentation(item);
+			}
+		}
+		return undefined;
+	}
+}
+
+function toClientSessionResource(resource: URI | string): URI | undefined {
+	const backendSession = parseOpenSessionLinkUri(resource);
+	if (!backendSession) {
+		return undefined;
+	}
+	const provider = AgentSession.provider(backendSession);
+	const rawId = AgentSession.id(backendSession);
+	return provider && rawId
+		? URI.from({ scheme: `${LOCAL_AGENT_HOST_SCHEME_PREFIX}${provider}`, path: `/${rawId}` })
+		: undefined;
+}
+
+function toSessionLinkPresentation(item: IChatSessionItem): IAgentSessionLinkPresentation {
+	const description = typeof item.description === 'string' ? item.description : item.description?.value;
+	return {
+		title: item.label,
+		...(description ? { description } : {}),
+		status: chatSessionStatusName(item.status),
+	};
+}
+
+function chatSessionStatusName(status: ChatSessionStatus | undefined): IAgentSessionLinkPresentation['status'] {
+	switch (status) {
+		case ChatSessionStatus.Failed: return 'error';
+		case ChatSessionStatus.InProgress: return 'inProgress';
+		case ChatSessionStatus.NeedsInput: return 'needsInput';
+		case ChatSessionStatus.Completed:
+		case undefined:
+			return 'completed';
 	}
 }

--- a/src/vs/workbench/services/dataChannel/browser/dataChannelService.ts
+++ b/src/vs/workbench/services/dataChannel/browser/dataChannelService.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from '../../../../base/common/event.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
-import { IDataChannelService, CoreDataChannel, IDataChannelEvent } from '../../../../platform/dataChannel/common/dataChannel.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { CoreDataChannel, DataWatcherKind, IDataChannelEvent, IDataChannelService, IDataWatcher, IDataWatcherParams, IDataWatcherProvider, IDataWatcherService } from '../../../../platform/dataChannel/common/dataChannel.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 
 export class DataChannelService extends Disposable implements IDataChannelService {
@@ -37,4 +37,28 @@ class CoreDataChannelImpl<T> implements CoreDataChannel<T> {
 	}
 }
 
+export class DataWatcherService implements IDataWatcherService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _providers = new Map<DataWatcherKind, IDataWatcherProvider>();
+
+	registerDataWatcherProvider(kind: DataWatcherKind, provider: IDataWatcherProvider): IDisposable {
+		if (this._providers.has(kind)) {
+			throw new Error(`Data watcher provider already registered for ${kind}`);
+		}
+
+		this._providers.set(kind, provider);
+		return toDisposable(() => {
+			if (this._providers.get(kind) === provider) {
+				this._providers.delete(kind);
+			}
+		});
+	}
+
+	createDataWatcher(params: IDataWatcherParams): IDataWatcher | undefined {
+		return this._providers.get(params.kind)?.createDataWatcher(params);
+	}
+}
+
 registerSingleton(IDataChannelService, DataChannelService, InstantiationType.Delayed);
+registerSingleton(IDataWatcherService, DataWatcherService, InstantiationType.Delayed);

--- a/src/vscode-dts/vscode.proposed.dataChannels.d.ts
+++ b/src/vscode-dts/vscode.proposed.dataChannels.d.ts
@@ -9,6 +9,45 @@ declare module 'vscode' {
 		export function getDataChannel<T>(channelId: string): DataChannel<T>;
 	}
 
+	export enum DataWatcherKind {
+		AgentSession = 0,
+	}
+
+	export interface AgentSessionDataWatcherParams {
+		readonly kind: DataWatcherKind.AgentSession;
+		readonly resource: Uri;
+	}
+
+	export type DataWatcherParams =
+		| AgentSessionDataWatcherParams;
+
+	export enum AgentSessionStatus {
+		Untitled = 0,
+		InProgress = 1,
+		NeedsInput = 2,
+		Completed = 3,
+		Error = 4,
+	}
+
+	export interface AgentSessionData {
+		readonly title: string;
+		readonly description?: string;
+		readonly status: AgentSessionStatus;
+	}
+
+	export type DataWatcherData<T extends DataWatcherParams> = {
+		[DataWatcherKind.AgentSession]: AgentSessionData;
+	}[T['kind']];
+
+	export interface DataWatcher<T> extends Disposable {
+		readonly data: T | undefined;
+		readonly onDidChange: Event<void>;
+	}
+
+	export namespace window {
+		export function createDataWatcher<T extends DataWatcherParams>(params: T): DataWatcher<DataWatcherData<T>>;
+	}
+
 	export interface DataChannel<T = unknown> {
 		readonly onDidReceiveData: Event<DataChannelEvent<T>>;
 	}


### PR DESCRIPTION
Adds reactive rich-link presentations to the Markdown editor for agent sessions, GitHub issues and pull requests, workspace resources, repositories, branches, files, and Git commits.

Highlights:
- introduces a typed proposed data-watcher API for observable agent-session state
- resolves each link through focused URL-to-observable providers with observable-owned lifetimes
- caches mutable GitHub metadata for one minute and immutable commit presentations for the provider lifetime
- supports `commit://<sha>` and local resolution of forge commit URLs
- upgrades `@vscode/markdown-editor` to the latest published package
- routes rich-link activation through the existing Markdown link opener

Commit reveal in SCM Graph is intentionally split into https://github.com/microsoft/vscode/pull/330677 for SCM ownership review. Until that lands, forge commit links fall back to normal browser opening and `commit://` links report that the commit could not be revealed.

The follow-up shared renderer changes are in https://github.com/microsoft/vscode-packages/pull/264. The published package does not yet expose changed-line rendering, so this PR retains counts in commit tooltip/ARIA metadata with a TODO to enable inline `+N`/`-N` once that package update is published.

Validation:
- Markdown extension compile and editor bundle pass
- client typecheck passes
- 14 focused tests pass
- pre-commit hygiene passes