### PR TITLE
chat: remove Omni Chat input focus border

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
@@ -15,10 +15,6 @@
 	overflow: hidden;
 }
 
-.chat-input-window:focus-within {
-	border-color: var(--vscode-focusBorder) !important;
-}
-
 .chat-input-window-body {
 	background: transparent !important;
 	overflow: hidden !important;


### PR DESCRIPTION
Remove the outer `focus-within` border override from the Omni Chat input window.

This keeps the input border consistent when Omni Chat is opened from the Agents Window instead of showing an unintended blue border around the entire surface. Existing caret and control-level keyboard focus indicators remain unchanged.

Validation:
- `npm run compile`
- `npm run hygiene`
- `npm run stylelint -- src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css`