### PR TITLE
Do not throw from browser tool preparation when the page id is missing

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
@@ -119,8 +119,18 @@ export function getBrowserPagesContext(
 
 /**
  * Creates a markdown link to a browser page.
+ *
+ * `pageId` may be missing when a tool call is invoked with empty parameters,
+ * which happens when the agent host synthesises a `ChatToolCallReady` without
+ * `toolInput` after the owning client disconnects mid-turn. Throwing here would
+ * escape `prepareToolInvocation` and leave the tool call stuck awaiting a
+ * completion that never arrives, so fall back to the plain (unlinked) label and
+ * let the tool's own `invoke` report the missing page id as a normal error.
  */
-export function createBrowserPageLink(pageId: string | URI): string {
+export function createBrowserPageLink(pageId: string | URI | undefined): string {
+	if (pageId === undefined || pageId === '') {
+		return BrowserEditorInput.DEFAULT_LABEL;
+	}
 	if (typeof pageId === 'string') {
 		pageId = BrowserViewUri.forId(pageId);
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers.ts
@@ -118,14 +118,9 @@ export function getBrowserPagesContext(
 }
 
 /**
- * Creates a markdown link to a browser page.
- *
- * `pageId` may be missing when a tool call is invoked with empty parameters,
- * which happens when the agent host synthesises a `ChatToolCallReady` without
- * `toolInput` after the owning client disconnects mid-turn. Throwing here would
- * escape `prepareToolInvocation` and leave the tool call stuck awaiting a
- * completion that never arrives, so fall back to the plain (unlinked) label and
- * let the tool's own `invoke` report the missing page id as a normal error.
+ * Creates a markdown link to a browser page. Returns the plain label when no
+ * page id is supplied, so callers that render a link during tool preparation
+ * cannot throw on incomplete parameters.
  */
 export function createBrowserPageLink(pageId: string | URI | undefined): string {
 	if (pageId === undefined || pageId === '') {

--- a/src/vs/workbench/contrib/browserView/test/electron-browser/tools/browserToolHelpers.test.ts
+++ b/src/vs/workbench/contrib/browserView/test/electron-browser/tools/browserToolHelpers.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { upcastPartial } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IPlaywrightService } from '../../../../../../platform/browserView/common/playwrightService.js';
+import { createBrowserPageLink } from '../../../electron-browser/tools/browserToolHelpers.js';
+import { ClickBrowserTool } from '../../../electron-browser/tools/clickBrowserTool.js';
+
+suite('browserToolHelpers', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('createBrowserPageLink', () => {
+		test('links a page id', () => {
+			const link = createBrowserPageLink('page-1');
+			assert.ok(link.includes(']('), 'expected a markdown link');
+			assert.ok(link.includes('vscodeLinkType=browser'));
+		});
+
+		// A client that disconnects mid-turn causes the agent host to synthesise a
+		// ChatToolCallReady with no toolInput, which the workbench resolves to `{}`.
+		// Every browser tool then reaches prepareToolInvocation with pageId
+		// undefined; throwing there strands the tool call.
+		test('does not throw when the page id is missing', () => {
+			assert.doesNotThrow(() => createBrowserPageLink(undefined));
+			assert.doesNotThrow(() => createBrowserPageLink(''));
+		});
+
+		test('falls back to the plain label when the page id is missing', () => {
+			const link = createBrowserPageLink(undefined);
+			assert.ok(!link.includes(']('), 'expected no markdown link target');
+			assert.ok(link.length > 0, 'expected a non-empty label');
+		});
+	});
+
+	suite('ClickBrowserTool', () => {
+		const playwrightService = upcastPartial<IPlaywrightService>({});
+
+		test('prepareToolInvocation survives empty parameters', async () => {
+			const tool = new ClickBrowserTool(playwrightService);
+
+			// Must not throw: this is the path taken after the owning client
+			// disconnects and the tool is invoked with `{}`.
+			const prepared = await tool.prepareToolInvocation(
+				upcastPartial<Parameters<ClickBrowserTool['prepareToolInvocation']>[0]>({ parameters: {} }),
+				CancellationToken.None,
+			);
+
+			assert.ok(prepared, 'expected a prepared invocation');
+			assert.ok(prepared.invocationMessage, 'expected an invocation message');
+		});
+
+		test('invoke reports the missing page id as a normal tool error', async () => {
+			const tool = new ClickBrowserTool(playwrightService);
+
+			const result = await tool.invoke(
+				upcastPartial<Parameters<ClickBrowserTool['invoke']>[0]>({ parameters: {}, context: undefined }),
+				async () => 0,
+				upcastPartial<Parameters<ClickBrowserTool['invoke']>[2]>({}),
+				CancellationToken.None,
+			);
+
+			assert.ok(result, 'expected a tool result rather than a throw');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/browserView/test/electron-browser/tools/browserToolHelpers.test.ts
+++ b/src/vs/workbench/contrib/browserView/test/electron-browser/tools/browserToolHelpers.test.ts
@@ -10,6 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { IPlaywrightService } from '../../../../../../platform/browserView/common/playwrightService.js';
 import { createBrowserPageLink } from '../../../electron-browser/tools/browserToolHelpers.js';
 import { ClickBrowserTool } from '../../../electron-browser/tools/clickBrowserTool.js';
+import { OpenPageToolId } from '../../../electron-browser/tools/openBrowserTool.js';
 
 suite('browserToolHelpers', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -64,7 +65,10 @@ suite('browserToolHelpers', () => {
 				CancellationToken.None,
 			);
 
-			assert.ok(result, 'expected a tool result rather than a throw');
+			assert.strictEqual(
+				result.toolResultError,
+				`No page ID provided. Use '${OpenPageToolId}' first.`,
+			);
 		});
 	});
 });


### PR DESCRIPTION
### Problem

`createBrowserPageLink(pageId: string | URI)` does:

```ts
if (typeof pageId === 'string') {
	pageId = BrowserViewUri.forId(pageId);
}
return `[${BrowserEditorInput.DEFAULT_LABEL}](${pageId.toString()}?vscodeLinkType=browser)`;
```

With `undefined` the `typeof` check is false, so it falls through to `undefined.toString()` and throws `Cannot read properties of undefined (reading 'toString')`.

All ten browser tools call this helper from `prepareToolInvocation` without a guard, so this is not specific to one tool. The tools already handle a missing page id correctly in `invoke` (for example `ClickBrowserTool` returns `errorResult` when `pageId` is absent), so the guard is simply one layer too late: throwing out of `prepareToolInvocation` leaves the tool call awaiting a completion that never arrives, instead of failing as an ordinary tool error.

A tool can be invoked with empty parameters when a synthesised `ChatToolCallReady` carries no `toolInput` and `resolveToolInput` falls back to `'{}'`.

### Fix

Return the plain unlinked label when there is no page id. Behaviour is unchanged for every valid input.

### Verification

Against the shipped implementation:

```
original(undefined) -> THROWS  Cannot read properties of undefined (reading 'toString')
patched(undefined)  -> "Browser"          (plain label, no link)
patched('page-1')   -> identical to original
patched(URI)        -> identical to original
```

Adds `browserToolHelpers.test.ts` covering the helper with `undefined` and `''`, plus `prepareToolInvocation` and `invoke` with empty parameters.