### PR TITLE
Enhance multi-root workspace support for agent sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -112,9 +112,7 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 				this.renderLabel(this.element);
 			}
 		}));
-		// A started session's folder is read from its working directories, which
-		// hydrate asynchronously; re-render when the customization state changes
-		// so the chip reflects the session's real folder once it is known.
+		// Re-render when asynchronous session state reveals the session's working directory.
 		this._register(this._customizationService.onDidChangeCustomizations(() => {
 			if (this.element) {
 				this.renderLabel(this.element);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -27,6 +27,7 @@ import { ISCMService } from '../../../../scm/common/scm.js';
 import type { IChatWidget } from '../../chat.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from '../../widget/input/chatInputPickerActionItem.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
+import { IAgentHostCustomizationService } from './agentHostCustomizationService.js';
 import { createFolderPickerTip } from './agentHostFolderPickerTip.js';
 
 /**
@@ -53,6 +54,7 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
+		@IAgentHostCustomizationService private readonly _customizationService: IAgentHostCustomizationService,
 		@ISCMService private readonly _scmService: ISCMService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IStorageService storageService: IStorageService,
@@ -110,6 +112,14 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 				this.renderLabel(this.element);
 			}
 		}));
+		// A started session's folder is read from its working directories, which
+		// hydrate asynchronously; re-render when the customization state changes
+		// so the chip reflects the session's real folder once it is known.
+		this._register(this._customizationService.onDidChangeCustomizations(() => {
+			if (this.element) {
+				this.renderLabel(this.element);
+			}
+		}));
 	}
 
 	private _sessionResource(): URI | undefined {
@@ -127,6 +137,14 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 			// The stored folder is no longer part of the workspace (folders
 			// changed); drop the stale selection and fall back below.
 			this._newSessionFolderService.clear(sessionResource!);
+		}
+		// A started session's working directory is fixed at creation time and may
+		// differ from the current workspace's first folder (e.g. a single-folder
+		// session opened inside a multi-root workspace), so show its own folder
+		// rather than the workspace default.
+		const sessionWorkingDirectory = sessionResource ? this._customizationService.getWorkingDirectory(sessionResource) : undefined;
+		if (sessionWorkingDirectory) {
+			return URI.parse(sessionWorkingDirectory);
 		}
 		// No explicit choice for this session yet: default to the folder the
 		// user last picked in this window (if still valid) so a new chat keeps

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -5437,7 +5437,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private _resolveCustomizationScopeRoots(sessionResource: URI): readonly URI[] {
 		if (!this._isNewSessionResource(sessionResource)) {
 			const own = this._existingSessionWorkingDirectories(sessionResource);
-			if (own) {
+			// An empty set is meaningful (a workspace-less session), so only a
+			// missing (`undefined`) result falls back to the workspace-derived set.
+			if (own !== undefined) {
 				return own;
 			}
 		}
@@ -5446,14 +5448,19 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	/**
 	 * The working directories an already-created session was started with, read
-	 * from its authoritative (hydrated) state. Returns `undefined` when the
-	 * session has no state yet or no working directories, so callers fall back to
-	 * the workspace-derived set.
+	 * from its authoritative (hydrated) state.
+	 *
+	 * Returns `undefined` when the session's working directories are absent — no
+	 * hydrated state yet, or a session that inherits its directories — so callers
+	 * fall back to the workspace-derived set. An explicit empty set is
+	 * authoritative and returned as `[]`: a workspace-less session must not
+	 * inherit the current workspace's roots. This mirrors the host-side
+	 * `undefined` (inherit) vs `[]` (explicitly none) distinction.
 	 */
 	private _existingSessionWorkingDirectories(sessionResource: URI): readonly URI[] | undefined {
 		const backendSession = this._resolveSessionUri(sessionResource);
 		const dirs = this._getRawSessionState(backendSession.toString())?.workingDirectories;
-		if (!dirs || dirs.length === 0) {
+		if (dirs === undefined) {
 			return undefined;
 		}
 		return dirs.map(directory => typeof directory === 'string' ? URI.parse(directory) : directory);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1264,7 +1264,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// session closing while we await our subscriptions does not tear down
 		// the shared session subscription (which would strand us forever).
 		const hydrationKey = resolvedSession.toString();
-		this._ensureActiveClientEntry(sessionResource);
+		// New sessions can create their active-client entry now: their scope roots
+		// derive from the current workspace / picked folder and are correct before
+		// hydration. Existing sessions derive their scope from their own persisted
+		// working directories, which are only known once the subscription has
+		// hydrated, so defer their entry to `_configureActiveClientReconciliation`
+		// below to avoid seeding the scope with workspace-expanded roots.
+		if (isNewSession) {
+			this._ensureActiveClientEntry(sessionResource);
+		}
 		this._hydratingChatSessions.set(hydrationKey, (this._hydratingChatSessions.get(hydrationKey) ?? 0) + 1);
 		try {
 			if (!isNewSession) {
@@ -5423,9 +5431,37 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * Scope roots always describe a concrete customization lookup. This differs
 	 * from `_resolveRequestedWorkingDirectories`: its `undefined` is protocol
 	 * meaningful and lets the host choose working directories for createSession.
+	 *
+	 * An existing session's roots are fixed at creation and persisted in its
+	 * state, so they are read from there rather than recomputed from the current
+	 * workspace — otherwise a single-folder session opened inside a multi-root
+	 * workspace would pick up the other workspace folders. New sessions have no
+	 * state yet, so they fall back to the workspace-derived set they will be
+	 * created with.
 	 */
 	private _resolveCustomizationScopeRoots(sessionResource: URI): readonly URI[] {
+		if (!this._isNewSessionResource(sessionResource)) {
+			const own = this._existingSessionWorkingDirectories(sessionResource);
+			if (own) {
+				return own;
+			}
+		}
 		return this._resolveRequestedWorkingDirectories(sessionResource) ?? [];
+	}
+
+	/**
+	 * The working directories an already-created session was started with, read
+	 * from its authoritative (hydrated) state. Returns `undefined` when the
+	 * session has no state yet or no working directories, so callers fall back to
+	 * the workspace-derived set.
+	 */
+	private _existingSessionWorkingDirectories(sessionResource: URI): readonly URI[] | undefined {
+		const backendSession = this._resolveSessionUri(sessionResource);
+		const dirs = this._getRawSessionState(backendSession.toString())?.workingDirectories;
+		if (!dirs || dirs.length === 0) {
+			return undefined;
+		}
+		return dirs.map(directory => typeof directory === 'string' ? URI.parse(directory) : directory);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1264,12 +1264,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// session closing while we await our subscriptions does not tear down
 		// the shared session subscription (which would strand us forever).
 		const hydrationKey = resolvedSession.toString();
-		// New sessions can create their active-client entry now: their scope roots
-		// derive from the current workspace / picked folder and are correct before
-		// hydration. Existing sessions derive their scope from their own persisted
-		// working directories, which are only known once the subscription has
-		// hydrated, so defer their entry to `_configureActiveClientReconciliation`
-		// below to avoid seeding the scope with workspace-expanded roots.
+		// Existing sessions need hydrated state before their customization scope can be resolved.
 		if (isNewSession) {
 			this._ensureActiveClientEntry(sessionResource);
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3827,6 +3827,73 @@ suite('AgentHostChatContribution', () => {
 		});
 	});
 
+	// ---- Multi-root customization scope ---------------------------------
+
+	suite('multi-root customization scope', () => {
+		const primary = URI.file('/workspace/mr-primary');
+		const secondary = URI.file('/workspace/mr-secondary');
+
+		function captureScopeRoots(instantiationService: TestInstantiationService): string[][] {
+			const activeClientService = instantiationService.get(IAgentHostActiveClientService);
+			const captured: string[][] = [];
+			const original = activeClientService.acquireScope;
+			activeClientService.acquireScope = (sessionType, roots) => {
+				captured.push(roots.map(root => root.toString()));
+				return original(sessionType, roots);
+			};
+			return captured;
+		}
+
+		function seedExistingSession(agentHostService: MockAgentHostService, id: string, workingDirectories: readonly URI[]): URI {
+			const backendSession = AgentSession.uri('copilot', id);
+			agentHostService.sessionStates.set(backendSession.toString(), {
+				...createSessionState({
+					resource: backendSession.toString(),
+					provider: 'copilot',
+					title: id,
+					status: SessionStatus.Idle,
+					createdAt: new Date().toISOString(),
+					modifiedAt: new Date().toISOString(),
+					workingDirectories: workingDirectories.map(directory => directory.toString()),
+				}),
+				lifecycle: SessionLifecycle.Ready,
+			});
+			return URI.from({ scheme: 'agent-host-copilot', path: `/${id}` });
+		}
+
+		test('an existing single-folder session opened in a multi-root workspace keeps its own folder', async () => {
+			const { sessionHandler, agentHostService, instantiationService } = createContribution(disposables, { workspaceFolders: [primary, secondary] });
+			agentHostService.setRootState({
+				agents: [{ provider: 'copilot', displayName: 'Agent Host - Copilot', description: 'test', models: [], capabilities: { multipleWorkingDirectories: { immutablePrimary: true } } }],
+				activeSessions: 0,
+			});
+			const capturedRoots = captureScopeRoots(instantiationService);
+			const sessionResource = seedExistingSession(agentHostService, 'single-folder', [secondary]);
+
+			capturedRoots.length = 0;
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			assert.deepStrictEqual(capturedRoots.at(-1), [secondary.toString()]);
+		});
+
+		test('an existing multi-root session keeps all of its own folders', async () => {
+			const { sessionHandler, agentHostService, instantiationService } = createContribution(disposables, { workspaceFolders: [primary, secondary] });
+			agentHostService.setRootState({
+				agents: [{ provider: 'copilot', displayName: 'Agent Host - Copilot', description: 'test', models: [], capabilities: { multipleWorkingDirectories: { immutablePrimary: true } } }],
+				activeSessions: 0,
+			});
+			const capturedRoots = captureScopeRoots(instantiationService);
+			const sessionResource = seedExistingSession(agentHostService, 'multi-root', [primary, secondary]);
+
+			capturedRoots.length = 0;
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			assert.deepStrictEqual(capturedRoots.at(-1), [primary.toString(), secondary.toString()]);
+		});
+	});
+
 	// ---- Workspace trust gating -----------------------------------------
 
 	suite('workspace trust', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3892,6 +3892,25 @@ suite('AgentHostChatContribution', () => {
 
 			assert.deepStrictEqual(capturedRoots.at(-1), [primary.toString(), secondary.toString()]);
 		});
+
+		test('an existing workspace-less session does not inherit the workspace folders', async () => {
+			const { sessionHandler, agentHostService, instantiationService } = createContribution(disposables, { workspaceFolders: [primary, secondary] });
+			agentHostService.setRootState({
+				agents: [{ provider: 'copilot', displayName: 'Agent Host - Copilot', description: 'test', models: [], capabilities: { multipleWorkingDirectories: { immutablePrimary: true } } }],
+				activeSessions: 0,
+			});
+			const capturedRoots = captureScopeRoots(instantiationService);
+			// A hydrated session with an explicit empty working-directory set (a
+			// workspace-less session) must resolve to an empty scope rather than
+			// falling back to the current workspace's folders.
+			const sessionResource = seedExistingSession(agentHostService, 'workspace-less', []);
+
+			capturedRoots.length = 0;
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			assert.deepStrictEqual(capturedRoots.at(-1), []);
+		});
 	});
 
 	// ---- Workspace trust gating -----------------------------------------


### PR DESCRIPTION
Improve handling of agent sessions in multi-root workspaces by ensuring that existing sessions retain their specific working directories instead of defaulting to the workspace's first folder. This change allows for better customization and user experience when managing sessions across multiple folders.

