### PR TITLE
chat: improve attachment UX in Omni Chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -48,6 +48,7 @@ import { IChatRequestVariableEntry, OmittedState } from '../../common/attachment
 import { ChatAgentLocation, isSupportedChatFileScheme } from '../../common/constants.js';
 import { IChatWidget, IChatWidgetService, IQuickChatService } from '../chat.js';
 import { IChatContextPickerItem, IChatContextPickService, IChatContextValueItem, isChatContextPickerPickItem } from '../attachments/chatContextPickService.js';
+import { IChatExecuteActionContext } from './chatExecuteActions.js';
 import { IChatAttachmentResolveService } from '../attachments/chatAttachmentResolveService.js';
 import { isQuickChat } from '../widget/chatWidget.js';
 import { resizeImage } from '../chatImageUtils.js';
@@ -512,8 +513,6 @@ export class AttachContextAction extends Action2 {
 			}, {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inQuickChat,
-					// Hide the attach-context button in the floating input window.
-					ChatContextKeys.inChatInputWindow.negate(),
 					ContextKeyExpr.or(
 						ChatContextKeys.lockedToCodingAgent.negate(),
 						ChatContextKeys.agentSupportsAttachments
@@ -535,7 +534,7 @@ export class AttachContextAction extends Action2 {
 		const keybindingService = accessor.get(IKeybindingService);
 		const contextPickService = accessor.get(IChatContextPickService);
 
-		const context = args[0] as { widget?: IChatWidget; placeholder?: string } | undefined;
+		const context = args[0] as (IChatExecuteActionContext & { placeholder?: string }) | undefined;
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -558,11 +557,12 @@ export class AttachContextAction extends Action2 {
 			});
 		}
 
-		instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, context?.placeholder);
+		const quickInputService = await (context?.contextPicker ?? widget.contextPicker)?.prepare();
+		instantiationService.invokeFunction(this._show.bind(this), widget, quickPickItems, context?.placeholder, quickInputService);
 	}
 
-	private _show(accessor: ServicesAccessor, widget: IChatWidget, additionPicks: IContextPickItemItem[] | undefined, placeholder?: string) {
-		const quickInputService = accessor.get(IQuickInputService);
+	private _show(accessor: ServicesAccessor, widget: IChatWidget, additionPicks: IContextPickItemItem[] | undefined, placeholder?: string, quickInputServiceOverride?: IQuickInputService) {
+		const quickInputService = quickInputServiceOverride ?? accessor.get(IQuickInputService);
 		const quickChatService = accessor.get(IQuickChatService);
 		const instantiationService = accessor.get(IInstantiationService);
 		const commandService = accessor.get(ICommandService);
@@ -589,7 +589,7 @@ export class AttachContextAction extends Action2 {
 
 					if (!isDone) {
 						// restart picker when sub-picker didn't return anything
-						instantiationService.invokeFunction(this._show.bind(this), widget, additionPicks, placeholder);
+						instantiationService.invokeFunction(this._show.bind(this), widget, additionPicks, placeholder, quickInputServiceOverride);
 						return;
 					}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -33,7 +33,7 @@ import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common
 import { ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
 import { IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
-import { type IChatAcceptInputOptions, IChatWidget, IChatWidgetService } from '../chat.js';
+import { type IChatAcceptInputOptions, IChatContextPickerDelegate, IChatWidget, IChatWidgetService } from '../chat.js';
 import { getAgentSessionProvider, AgentSessionProviders, AgentSessionTarget } from '../agentSessions/agentSessions.js';
 import { getEditingSessionContext } from '../chatEditing/chatEditingActions.js';
 import { ctxHasEditorModification, ctxHasRequestInProgress, ctxIsGlobalEditingSession } from '../chatEditing/chatEditingEditorContextKeys.js';
@@ -49,6 +49,7 @@ export interface IChatExecuteActionContext {
 	inputValue?: string;
 	acceptInputOptions?: IChatAcceptInputOptions;
 	voice?: IVoiceChatExecuteActionContext;
+	contextPicker?: IChatContextPickerDelegate;
 }
 
 abstract class SubmitAction extends Action2 {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -16,6 +16,7 @@ import { EditDeltaInfo } from '../../../../editor/common/textModelEditSource.js'
 import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { PreferredGroup } from '../../../services/editor/common/editorService.js';
 import { IChatRequestVariableEntry } from '../common/attachments/chatVariableEntries.js';
 import { IDynamicVariable } from '../common/attachments/chatVariables.js';
@@ -36,6 +37,10 @@ import { ICodeBlockActionContext, ICodeBlockRenderOptions } from './widget/chatC
 import { AgentSessionTarget } from './agentSessions/agentSessions.js';
 
 export { ChatOutline } from './chatOutline.js';
+
+export interface IChatContextPickerDelegate {
+	prepare(): Promise<IQuickInputService>;
+}
 
 /**
  * A workspace item that can be selected in the workspace picker.
@@ -332,6 +337,7 @@ export interface IChatWidgetViewOptions {
 	inputPickerContainer?: HTMLElement | (() => HTMLElement | undefined);
 	inputPickerAnchor?: (anchor: HTMLElement) => HTMLElement | IAnchor;
 	inputPickerOpenOnMouseUp?: boolean;
+	contextPicker?: IChatContextPickerDelegate;
 
 	/**
 	 * Whether we are running in the sessions window.
@@ -436,6 +442,7 @@ export interface IChatWidget {
 	lastSelectedAgent: IChatAgentData | undefined;
 	readonly scopedContextKeyService: IContextKeyService;
 	readonly input: ChatInputPart;
+	readonly contextPicker: IChatContextPickerDelegate | undefined;
 	/** The main input part at the bottom of the widget. Unlike `input`, this always returns the main input, not the inline editing input. */
 	readonly inputPart: ChatInputPart;
 	readonly attachmentModel: ChatAttachmentModel;

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -573,10 +573,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		const getRowHeight = () => {
 			let contentHeight = Math.ceil(widget.contentHeight);
 			if (widget.attachmentModel.size > 0) {
-				const inputRow = row.querySelector<HTMLElement>('.interactive-input-and-side-toolbar');
-				if (inputRow) {
-					contentHeight += Math.max(0, CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT - inputRow.offsetHeight);
-				}
+				contentHeight += Math.max(0, CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT - widget.input.inputRowHeight);
 			}
 			return Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, contentHeight);
 		};
@@ -1225,10 +1222,10 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 
 		const pendingHide = store.add(new MutableDisposable());
 		const pendingLayout = store.add(new MutableDisposable());
+		let picker: HTMLElement | undefined;
 		const anchorPicker = () => {
 			pendingLayout.value = dom.scheduleAtNextAnimationFrame(actionWidgetWindow.window, () => {
-				const picker = actionWidgetWindow.container.querySelector('.quick-input-widget');
-				if (dom.isHTMLElement(picker)) {
+				if (picker) {
 					if (picker.style.top !== 'auto') {
 						picker.style.top = 'auto';
 					}
@@ -1238,7 +1235,24 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				}
 			});
 		};
-		const pickerObserver = new actionWidgetWindow.window.MutationObserver(anchorPicker);
+		const pickerObserver = new actionWidgetWindow.window.MutationObserver(mutations => {
+			for (const mutation of mutations) {
+				if (dom.isHTMLElement(mutation.target) && mutation.target.classList.contains('quick-input-widget')) {
+					picker = mutation.target;
+				}
+				for (const node of mutation.addedNodes) {
+					if (dom.isHTMLElement(node) && node.classList.contains('quick-input-widget')) {
+						picker = node;
+					}
+				}
+				for (const node of mutation.removedNodes) {
+					if (picker && (node === picker || node.contains(picker))) {
+						picker = undefined;
+					}
+				}
+			}
+			anchorPicker();
+		});
 		pickerObserver.observe(actionWidgetWindow.container, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
 		store.add(toDisposable(() => pickerObserver.disconnect()));
 		store.add(quickInputService.onShow(() => {

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -6,6 +6,7 @@
 import './media/chatInputWindow.css';
 import * as dom from '../../../../../base/browser/dom.js';
 import { renderAsPlaintext } from '../../../../../base/browser/markdownRenderer.js';
+import { disposableTimeout, timeout } from '../../../../../base/common/async.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IAnchor } from '../../../../../base/browser/ui/contextview/contextview.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
@@ -21,6 +22,7 @@ import { mainWindow } from '../../../../../base/browser/window.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -56,7 +58,9 @@ import { IAccessibilityService } from '../../../../../platform/accessibility/com
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { getQuickInputWidth } from '../../../../../platform/quickinput/browser/quickInputController.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { QuickInputService } from '../../../../services/quickinput/browser/quickInputService.js';
 import { OmniChatEnabledSettingId } from '../../common/sessionRouter.js';
 import { AgentSessionProviders } from '../agentSessions/agentSessions.js';
 import { derivePendingId, getVoiceToolApprovalCommand, isPendingIdResolved, markPendingIdResolved } from '../../common/voiceClient/voiceClientService.js';
@@ -68,6 +72,7 @@ const CHAT_INPUT_WINDOW_ACTION_WIDGET_MARGIN = 4;
 const CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT = 44;
 const CHAT_INPUT_WINDOW_MAX_PENDING_HEIGHT = 360;
 const CHAT_INPUT_WINDOW_MIN_CONFIRMATION_HEIGHT = 112;
+const CHAT_INPUT_WINDOW_CONTEXT_PICKER_TRANSITION_DELAY = 100;
 
 type ChatInputActionWidgetPlacement = 'above' | 'right';
 
@@ -130,6 +135,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 	private _actionWidgetWindowAnchorY = 0;
 	private _actionWidgetAnchorPosition = AnchorPosition.BELOW;
 	private _actionWidgetPlacement: ChatInputActionWidgetPlacement = 'above';
+	private readonly _contextPicker = this._register(new MutableDisposable<DisposableStore>());
 	/** Bounds of the window that invoked omni, captured before the auxiliary window opens. */
 	private _invokingWindowBounds: IRectangle = this._windowBounds(mainWindow);
 	private _invokingWindow = mainWindow;
@@ -424,7 +430,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 			])
 		));
 
-		const widget = this._windowDisposables.add(scopedInstantiationService.createInstance(
+		const widget: ChatWidget = this._windowDisposables.add(scopedInstantiationService.createInstance(
 			ChatWidget,
 			ChatAgentLocation.Chat,
 			{ isQuickChat: true },
@@ -449,6 +455,9 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				inputPickerContainer: () => this._actionWidgetWindow.value?.container,
 				inputPickerAnchor: anchor => this._getActionWidgetAnchor(anchor),
 				inputPickerOpenOnMouseUp: true,
+				contextPicker: {
+					prepare: (): Promise<IQuickInputService> => this._prepareContextPicker(auxiliaryWindow, surface, scopedContextKeyService, widget),
+				},
 				editorOverflowWidgetsDomNode,
 			},
 			{
@@ -561,6 +570,16 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		let currentPosition = { x: openingBounds.x, y: openingBounds.y };
 		let pendingBounds: IRectangle | undefined;
 		let applyingBounds = false;
+		const getRowHeight = () => {
+			let contentHeight = Math.ceil(widget.contentHeight);
+			if (widget.attachmentModel.size > 0) {
+				const inputRow = row.querySelector<HTMLElement>('.interactive-input-and-side-toolbar');
+				if (inputRow) {
+					contentHeight += Math.max(0, CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT - inputRow.offsetHeight);
+				}
+			}
+			return Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, contentHeight);
+		};
 		const applyPendingBounds = async () => {
 			if (applyingBounds) {
 				return;
@@ -583,7 +602,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				return;
 			}
 			const width = this._defaultWidth();
-			const rowHeight = Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, Math.ceil(widget.contentHeight));
+			const rowHeight = getRowHeight();
 			const extraHeight = Array.from(surface.children)
 				.filter(child => child !== this._row)
 				.reduce((height, child) => {
@@ -623,7 +642,9 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				const available = Math.max(0, row.clientWidth - chrome - horizontalPadding);
 				parent.style.width = `${available}px`;
 				widget.input.layout(available);
-				widget.layoutForInputHeight(Math.max(CHAT_INPUT_WINDOW_INITIAL_SURFACE_HEIGHT, widget.contentHeight), available);
+				const rowHeight = getRowHeight();
+				row.style.height = `${rowHeight}px`;
+				widget.layoutForInputHeight(rowHeight, available);
 				fitWindowToInput();
 			} finally {
 				layingOut = false;
@@ -631,6 +652,12 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		};
 		layout();
 		this._windowDisposables.add(widget.onDidChangeContentHeight(() => fitWindowToInput()));
+		const updateAttachmentLayout = () => {
+			row.classList.toggle('has-attachments', widget.attachmentModel.size > 0);
+			layout();
+		};
+		this._windowDisposables.add(widget.attachmentModel.onDidChange(updateAttachmentLayout));
+		updateAttachmentLayout();
 		const scheduledInputLayout = this._windowDisposables.add(new MutableDisposable());
 		this._windowDisposables.add(widget.inputEditor.onDidChangeModelContent(() => {
 			// Submit controls change after the editor event; measure them in the
@@ -1152,6 +1179,91 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		});
 	}
 
+	private async _prepareContextPicker(auxiliaryWindow: IAuxiliaryWindow, surface: HTMLElement, contextKeyService: IContextKeyService, widget: ChatWidget): Promise<IQuickInputService> {
+		this._contextPicker.clear();
+		await this._setActionWidgetVisible(auxiliaryWindow, surface, undefined, true, 'above');
+
+		const actionWidgetWindow = this._actionWidgetWindow.value;
+		if (!actionWidgetWindow) {
+			throw new Error('Unable to open the chat input context picker window');
+		}
+
+		actionWidgetWindow.window.focus();
+		await timeout(0);
+
+		const pickerLayoutService: ILayoutService = {
+			_serviceBrand: undefined,
+			onDidLayoutMainContainer: Event.None,
+			onDidLayoutContainer: Event.None,
+			onDidLayoutActiveContainer: Event.None,
+			onDidAddContainer: Event.None,
+			onDidChangeActiveContainer: Event.None,
+			get mainContainerDimension() {
+				return { width: actionWidgetWindow.container.clientWidth, height: actionWidgetWindow.container.clientHeight };
+			},
+			get activeContainerDimension() {
+				return this.mainContainerDimension;
+			},
+			mainContainer: actionWidgetWindow.container,
+			activeContainer: actionWidgetWindow.container,
+			containers: [actionWidgetWindow.container],
+			getContainer: () => actionWidgetWindow.container,
+			whenContainerStylesLoaded: () => actionWidgetWindow.whenStylesHaveLoaded,
+			mainContainerOffset: { top: 0, quickPickTop: 0 },
+			activeContainerOffset: { top: 0, quickPickTop: 0 },
+			focus: () => actionWidgetWindow.window.focus(),
+		};
+		const services = new ServiceCollection(
+			[IContextKeyService, contextKeyService],
+			[ILayoutService, pickerLayoutService],
+		);
+		const scopedInstantiationService = this.instantiationService.createChild(services);
+		const store = new DisposableStore();
+		store.add(scopedInstantiationService);
+		const quickInputService = store.add(scopedInstantiationService.createInstance(QuickInputService));
+		services.set(IQuickInputService, quickInputService);
+
+		const pendingHide = store.add(new MutableDisposable());
+		const pendingLayout = store.add(new MutableDisposable());
+		const anchorPicker = () => {
+			pendingLayout.value = dom.scheduleAtNextAnimationFrame(actionWidgetWindow.window, () => {
+				const picker = actionWidgetWindow.container.querySelector('.quick-input-widget');
+				if (dom.isHTMLElement(picker)) {
+					if (picker.style.top !== 'auto') {
+						picker.style.top = 'auto';
+					}
+					if (picker.style.bottom !== '0px') {
+						picker.style.bottom = '0';
+					}
+				}
+			});
+		};
+		const pickerObserver = new actionWidgetWindow.window.MutationObserver(anchorPicker);
+		pickerObserver.observe(actionWidgetWindow.container, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
+		store.add(toDisposable(() => pickerObserver.disconnect()));
+		store.add(quickInputService.onShow(() => {
+			pendingHide.clear();
+			anchorPicker();
+		}));
+		store.add(quickInputService.onHide(() => {
+			pendingHide.value = disposableTimeout(() => {
+				if (this._contextPicker.value === store) {
+					this._contextPicker.clear();
+				}
+			}, CHAT_INPUT_WINDOW_CONTEXT_PICKER_TRANSITION_DELAY);
+		}));
+		store.add(toDisposable(() => {
+			void this._setActionWidgetVisible(auxiliaryWindow, surface, undefined, false, 'above');
+			if (this._window === auxiliaryWindow) {
+				auxiliaryWindow.window.focus();
+				widget.focusInput();
+			}
+		}));
+		this._contextPicker.value = store;
+
+		return quickInputService;
+	}
+
 	private async _openActionWidgetWindow(auxiliaryWindow: IAuxiliaryWindow, surface: HTMLElement, anchor: HTMLElement | undefined, generation: number, placement: ChatInputActionWidgetPlacement): Promise<void> {
 		const sourceWindow = auxiliaryWindow.window;
 		const sourceSurfaceBounds = surface.getBoundingClientRect();
@@ -1231,6 +1343,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 		this._lead = undefined;
 		this._trail = undefined;
 		this._activePendingSessionResource = undefined;
+		this._contextPicker.clear();
 		this._actionWidgetVisibilityCount = 0;
 		this._actionWidgetOwner = undefined;
 		this._actionWidgetOpenOperation = undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/media/chatInputWindow.css
@@ -58,6 +58,12 @@
 	padding-left: 0;
 }
 
+.chat-input-window .chat-input-window-row.has-attachments .chat-input-window-lead,
+.chat-input-window .chat-input-window-row.has-attachments .chat-input-window-trail {
+	align-self: flex-end;
+	height: 44px;
+}
+
 .chat-input-window .chat-input-window-close {
 	display: flex;
 	align-items: center;
@@ -113,12 +119,20 @@
 	padding-right: var(--vscode-spacing-size40);
 }
 
-.chat-input-window .chat-input-toolbars {
-	margin-top: 0;
+.chat-input-window .chat-input-window-row.has-attachments .interactive-input-and-edit-session {
+	display: flex;
+	flex-direction: column;
 }
 
-.chat-input-window .chat-input-toolbars .action-item > .codicon-add {
-	display: none;
+.chat-input-window .chat-input-window-row.has-attachments .chat-attachments-container {
+	order: -1;
+	margin-top: 0;
+	margin-bottom: var(--vscode-spacing-size80);
+	padding-inline: var(--vscode-spacing-size60);
+}
+
+.chat-input-window .chat-input-toolbars {
+	margin-top: 0;
 }
 
 .chat-input-window .chat-session-target-picker-item {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -819,6 +819,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return this.viewModel?.editing && this.configurationService.getValue<string>('chat.editRequests') !== 'input' ? this.inlineInputPart : this.inputPart;
 	}
 
+	get contextPicker() {
+		return this.viewOptions.contextPicker;
+	}
+
 	/**
 	 * The main input part at the buttom of the chat widget. Use `input` to get the active input (main or inline editing part).
 	 */
@@ -2212,6 +2216,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			inputPickerContainer: this.viewOptions.inputPickerContainer,
 			inputPickerAnchor: this.viewOptions.inputPickerAnchor,
 			inputPickerOpenOnMouseUp: this.viewOptions.inputPickerOpenOnMouseUp,
+			contextPicker: this.viewOptions.contextPicker,
 		};
 
 		if (this.viewModel?.editing) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -129,7 +129,7 @@ import { IChatAttachmentWidgetRegistry } from '../../attachments/chatAttachmentW
 import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, BrowserViewAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 import { ChatImplicitContexts } from '../../attachments/chatImplicitContext.js';
 import { ImplicitContextAttachmentWidget } from '../../attachments/implicitContextAttachment.js';
-import { IChatWidget, IChatWidgetService, IChatWidgetViewModelChangeEvent, ISessionTypePickerDelegate, isIChatResourceViewContext, isIChatViewViewContext, IWorkspacePickerDelegate } from '../../chat.js';
+import { IChatContextPickerDelegate, IChatWidget, IChatWidgetService, IChatWidgetViewModelChangeEvent, ISessionTypePickerDelegate, isIChatResourceViewContext, isIChatViewViewContext, IWorkspacePickerDelegate } from '../../chat.js';
 import { ChatEditingShowChangesAction, ViewPreviousEditsAction } from '../../chatEditing/chatEditingActions.js';
 import { resizeImage } from '../../chatImageUtils.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../chatSessions/chatSessionPickerActionItem.js';
@@ -269,6 +269,7 @@ export interface IChatInputPartOptions {
 	inputPickerContainer?: HTMLElement | (() => HTMLElement | undefined);
 	inputPickerAnchor?: (anchor: HTMLElement) => HTMLElement | IAnchor;
 	inputPickerOpenOnMouseUp?: boolean;
+	contextPicker?: IChatContextPickerDelegate;
 }
 
 export interface IWorkingSetEntry {
@@ -3417,7 +3418,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 		}));
 		this.inputActionsToolbar.getElement().classList.add('chat-input-toolbar');
-		this.inputActionsToolbar.context = { widget } satisfies IChatExecuteActionContext;
+		this.inputActionsToolbar.context = { widget, contextPicker: this.options.contextPicker } satisfies IChatExecuteActionContext;
 		this._register(this.inputActionsToolbar.onDidChangeMenuItems(() => {
 			// Update container reference for the pickers (cloud sessions host them in the primary toolbar)
 			const toolbarElement = this.inputActionsToolbar.getElement();
@@ -3499,7 +3500,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			},
 		}));
 		this.executeToolbar.getElement().classList.add('chat-execute-toolbar');
-		this.executeToolbar.context = { widget } satisfies IChatExecuteActionContext;
+		this.executeToolbar.context = { widget, contextPicker: this.options.contextPicker } satisfies IChatExecuteActionContext;
 		// The lone dictation / Voice Mode control drops its circular border and
 		// only regains it when both share the row (see the matching rules in
 		// chat.css). Count the voice-input actions from the toolbar's action
@@ -3539,7 +3540,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}));
 			this.inputSideToolbarContainer = toolbarSide.getElement();
 			toolbarSide.getElement().classList.add('chat-side-toolbar');
-			toolbarSide.context = { widget } satisfies IChatExecuteActionContext;
+			toolbarSide.context = { widget, contextPicker: this.options.contextPicker } satisfies IChatExecuteActionContext;
 		}
 
 		// Secondary toolbar (permissions) — below the input box.

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -449,6 +449,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatGoalBannerContainer!: HTMLElement;
 	private persistentContentContainer!: HTMLElement;
 	private inputContainer!: HTMLElement;
+	private inputAndSideToolbar!: HTMLElement;
 	private readonly _notificationWidget = this._register(new MutableDisposable<ChatInputNotificationWidget>());
 	private readonly _goalBannerWidget = this._register(new MutableDisposable<ChatGoalBannerWidget>());
 	private readonly _onDidDismissGoalBanner = this._register(new Emitter<void>());
@@ -461,6 +462,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	get inputContainerElement(): HTMLElement | undefined {
 		return this.inputContainer;
+	}
+
+	get inputRowHeight(): number {
+		return this.inputAndSideToolbar.offsetHeight;
 	}
 
 	get persistentContentContainerElement(): HTMLElement {
@@ -3102,6 +3107,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this.followupsContainer = elements.followupsContainer;
 		const inputAndSideToolbar = elements.inputAndSideToolbar; // The chat input and toolbar to the right
+		this.inputAndSideToolbar = inputAndSideToolbar;
 		const inputContainer = elements.inputContainer; // The chat editor, attachments, and toolbars
 		this.inputContainer = inputContainer;
 		const editorContainer = elements.editorContainer;


### PR DESCRIPTION
## Summary

- show the existing Add Context action in the floating Omni Chat input
- host attachment pickers in an auxiliary window anchored directly above Omni Chat, including nested pickers
- render selected attachments in a dedicated top row while preserving the original input and action layout
- restore focus to Omni Chat after the picker closes

## Verification

- `npm run typecheck-client`
- `npm run hygiene`
- verified Add Context via toolbar and `Cmd+/`
- verified nested Files & Folders picker remains bottom-anchored in the auxiliary host
- verified adding an attachment grows the window without shifting the input/action row
- verified removing the attachment restores the original 48px window height

Fixes #330679

<img width="662" height="485" alt="image" src="https://github.com/user-attachments/assets/50ae52ef-8278-41e3-8e91-d214cb428cdd" />
