### PR TITLE
Hide model promotions in Omni Chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -263,6 +263,8 @@ export interface IChatWidgetViewOptions {
 	renderInputToolbarBelowInput?: boolean;
 	inputEditorMaxHeight?: number;
 	renderGettingStartedTip?: boolean | (() => boolean);
+	/** Whether notifications deferred during first-use flows may render in this widget. */
+	deferredNotificationsEnabled?: boolean;
 	supportsFileReferences?: boolean;
 	filter?: (item: ChatTreeItem) => boolean;
 	/**

--- a/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService.ts
@@ -434,6 +434,7 @@ export class ChatInputWindowService extends Disposable implements IChatInputWind
 				renderStyle: 'compact',
 				inputEditorMaxHeight: 250,
 				renderGettingStartedTip: false,
+				deferredNotificationsEnabled: false,
 				// Show only the input box — drop every response list item.
 				filter: () => false,
 				enableImplicitContext: false,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2215,6 +2215,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			dndContainer: this.viewOptions.dndContainer,
 			inputEditorMinLines: this.viewOptions.inputEditorMinLines,
 			inputEditorMaxHeight: this.viewOptions.inputEditorMaxHeight,
+			deferredNotificationsEnabled: this.viewOptions.deferredNotificationsEnabled,
 			widgetViewKindTag: this.getWidgetViewKindTag(),
 			defaultMode: this.viewOptions.defaultMode,
 			sessionTypePickerDelegate: this.viewOptions.sessionTypePickerDelegate,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -205,6 +205,7 @@ export interface IChatInputPartOptions {
 	dndContainer?: HTMLElement;
 	inputEditorMinLines?: number;
 	inputEditorMaxHeight?: number;
+	deferredNotificationsEnabled?: boolean;
 	widgetViewKindTag: string;
 	/**
 	 * Optional delegate for the session target picker.
@@ -2910,6 +2911,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	private updateDeferredNotificationsEligibility(e?: IChatWidgetViewModelChangeEvent): void {
+		if (this.options.deferredNotificationsEnabled !== undefined) {
+			this._deferredNotificationsEnabled.set(this.options.deferredNotificationsEnabled, undefined);
+			return;
+		}
+
 		if (this.environmentService.isSessionsWindow) {
 			this._deferredNotificationsEnabled.set(true, undefined);
 			return;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
@@ -214,6 +214,7 @@ suite('ChatInputNotificationWidget', () => {
 		const deferredNotificationsEnabled = observableValue('deferredNotificationsEnabled', true);
 		let hasSessions = false;
 		const harness = {
+			options: {},
 			environmentService: { isSessionsWindow: false },
 			chatService: { hasSessions: () => hasSessions },
 			_deferredNotificationsEnabled: deferredNotificationsEnabled,
@@ -248,6 +249,7 @@ suite('ChatInputNotificationWidget', () => {
 	test('Agents window bypasses the workbench first-session gate', () => {
 		const deferredNotificationsEnabled = observableValue('deferredNotificationsEnabled', false);
 		const harness = {
+			options: {},
 			environmentService: { isSessionsWindow: true },
 			chatService: { hasSessions: () => false },
 			_deferredNotificationsEnabled: deferredNotificationsEnabled,
@@ -261,6 +263,25 @@ suite('ChatInputNotificationWidget', () => {
 		update.call(harness);
 
 		assert.strictEqual(deferredNotificationsEnabled.get(), true);
+	});
+
+	test('widget option disables deferred notifications', () => {
+		const deferredNotificationsEnabled = observableValue('deferredNotificationsEnabled', true);
+		const harness = {
+			options: { deferredNotificationsEnabled: false },
+			environmentService: { isSessionsWindow: true },
+			chatService: { hasSessions: () => true },
+			_deferredNotificationsEnabled: deferredNotificationsEnabled,
+			_isFirstWorkbenchSession: undefined as boolean | undefined,
+		};
+		const update = Reflect.get(ChatInputPart.prototype, 'updateDeferredNotificationsEligibility') as (
+			this: typeof harness,
+			event?: { previousSessionResource: URI | undefined; currentSessionResource: URI | undefined },
+		) => void;
+
+		update.call(harness);
+
+		assert.strictEqual(deferredNotificationsEnabled.get(), false);
 	});
 
 	test('renders markdown descriptions as rich content', () => {


### PR DESCRIPTION
## Summary

- add a widget-level override for deferred chat input notifications
- disable deferred notifications in Omni Chat so model promotions do not appear there
- preserve quota and error notifications and add regression coverage

## Testing

- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts` (22 passing)
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/chatPromoNotification.test.ts` (15 passing)