### PR TITLE
fix(custom-editor): purge rejected model entries to allow retry on reopen (#268301)

### DIFF
--- a/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
@@ -21,7 +21,11 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 		const models = [];
 		for (const [key, entry] of this._references) {
 			if (key.startsWith(keyStart) && entry.model) {
-				models.push(await entry.model);
+				try {
+					models.push(await entry.model);
+				} catch {
+					// Ignore models that failed to load
+				}
 			}
 		}
 		return models;
@@ -47,11 +51,20 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 				object: model,
 				dispose: createSingleCallFunction(() => {
 					if (--entry.counter <= 0) {
-						entry.model.then(x => x.dispose());
-						this._references.delete(key);
+						entry.model.then(x => x.dispose(), () => { });
+						if (this._references.get(key) === entry) {
+							this._references.delete(key);
+						}
 					}
 				}),
 			};
+		}, err => {
+			if (--entry.counter <= 0) {
+				if (this._references.get(key) === entry) {
+					this._references.delete(key);
+				}
+			}
+			throw err;
 		});
 	}
 
@@ -62,14 +75,23 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 			throw new Error('Model already exists');
 		}
 
-		this._references.set(key, { viewType, model, counter: 0 });
+		const entry = { viewType, model, counter: 0 };
+		this._references.set(key, entry);
+
+		// If the model fails to load, remove it from the map so future attempts can retry
+		model.catch(() => {
+			if (this._references.get(key) === entry) {
+				this._references.delete(key);
+			}
+		});
+
 		return this.tryRetain(resource, viewType)!;
 	}
 
 	public disposeAllModelsForView(viewType: string): void {
 		for (const [key, value] of this._references) {
 			if (value.viewType === viewType) {
-				value.model.then(x => x.dispose());
+				value.model.then(x => x.dispose(), () => { });
 				this._references.delete(key);
 			}
 		}
@@ -79,7 +101,7 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 		const keyStart = `${resource.toString()}@@@`;
 		for (const [key, value] of this._references) {
 			if (key.startsWith(keyStart)) {
-				value.model.then(x => x.dispose());
+				value.model.then(x => x.dispose(), () => { });
 				this._references.delete(key);
 			}
 		}

--- a/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
+++ b/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
@@ -73,13 +73,19 @@ suite('CustomEditorModelManager', () => {
 		const viewType1 = 'customView1';
 		const viewType2 = 'customView2';
 
-		const failedPromise = Promise.reject(new Error('Failed to load'));
+		let rejectFailedPromise!: (err: any) => void;
+		const failedPromise = new Promise<ICustomEditorModel>((_, reject) => {
+			rejectFailedPromise = reject;
+		});
 		manager.add(resource, viewType1, failedPromise).catch(() => { });
 
 		const validModel = createFakeModel(viewType2, resource);
 		const ref = await manager.add(resource, viewType2, Promise.resolve(validModel));
 
-		const models = await manager.getAllModels(resource);
+		const getAllModelsPromise = manager.getAllModels(resource);
+		rejectFailedPromise(new Error('Failed to load'));
+
+		const models = await getAllModelsPromise;
 		assert.strictEqual(models.length, 1);
 		assert.strictEqual(models[0], validModel);
 

--- a/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
+++ b/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICustomEditorModel } from '../../common/customEditor.js';
+import { CustomEditorModelManager } from '../../common/customEditorModelManager.js';
+
+suite('CustomEditorModelManager', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createFakeModel(viewType: string, resource: URI): ICustomEditorModel {
+		return {
+			viewType,
+			resource,
+			backupId: undefined,
+			canHotExit: false,
+			isReadonly: () => false,
+			onDidChangeReadonly: () => ({ dispose: () => { } }),
+			isOrphaned: () => false,
+			onDidChangeOrphaned: () => ({ dispose: () => { } }),
+			isDirty: () => false,
+			onDidChangeDirty: () => ({ dispose: () => { } }),
+			revert: async () => { },
+			saveCustomEditor: async () => resource,
+			saveCustomEditorAs: async () => true,
+			dispose: () => { },
+		};
+	}
+
+	test('Retains and disposes model correctly', async () => {
+		const manager = new CustomEditorModelManager();
+		const resource = URI.parse('test://foo/bar.txt');
+		const viewType = 'customView';
+		const model = createFakeModel(viewType, resource);
+
+		const ref = await manager.add(resource, viewType, Promise.resolve(model));
+		assert.strictEqual(ref.object, model);
+
+		const ref2 = await manager.tryRetain(resource, viewType);
+		assert.strictEqual(ref2?.object, model);
+
+		ref.dispose();
+		ref2?.dispose();
+
+		assert.strictEqual(manager.tryRetain(resource, viewType), undefined);
+	});
+
+	test('Purges rejected model from map so subsequent attempts can retry', async () => {
+		const manager = new CustomEditorModelManager();
+		const resource = URI.parse('test://foo/bar.txt');
+		const viewType = 'customView';
+
+		const failedPromise = Promise.reject(new Error('File not found'));
+		await assert.rejects(manager.add(resource, viewType, failedPromise), /File not found/);
+
+		// After failure, manager should not retain the rejected model
+		assert.strictEqual(manager.tryRetain(resource, viewType), undefined);
+
+		// Retrying with a valid model should succeed
+		const model = createFakeModel(viewType, resource);
+		const ref = await manager.add(resource, viewType, Promise.resolve(model));
+		assert.strictEqual(ref.object, model);
+		ref.dispose();
+	});
+
+	test('getAllModels does not throw when an entry rejects', async () => {
+		const manager = new CustomEditorModelManager();
+		const resource = URI.parse('test://foo/bar.txt');
+		const viewType1 = 'customView1';
+		const viewType2 = 'customView2';
+
+		const failedPromise = Promise.reject(new Error('Failed to load'));
+		manager.add(resource, viewType1, failedPromise).catch(() => { });
+
+		const validModel = createFakeModel(viewType2, resource);
+		const ref = await manager.add(resource, viewType2, Promise.resolve(validModel));
+
+		const models = await manager.getAllModels(resource);
+		assert.strictEqual(models.length, 1);
+		assert.strictEqual(models[0], validModel);
+
+		ref.dispose();
+	});
+
+	test('disposeAllModelsForView cleans up even with rejected models', async () => {
+		const manager = new CustomEditorModelManager();
+		const resource = URI.parse('test://foo/bar.txt');
+		const viewType = 'customView';
+
+		const failedPromise = Promise.reject(new Error('Failed to load'));
+		manager.add(resource, viewType, failedPromise).catch(() => { });
+
+		manager.disposeAllModelsForView(viewType);
+		assert.strictEqual(manager.tryRetain(resource, viewType), undefined);
+	});
+});


### PR DESCRIPTION
Fixes #268301

## Summary
When opening a custom editor failed (e.g. because the file did not exist on disk or provider creation threw an error), `CustomEditorModelManager` cached the rejected promise in its internal references map. Subsequent attempts to reopen the custom editor or clicking "Try Again" re-threw the stale rejected promise rather than creating a fresh model.

This PR ensures that rejected model promises are automatically evicted from `CustomEditorModelManager`, allowing reopened editors to retry model creation cleanly.

## Root Cause
In `CustomEditorModelManager.add()`, `{ viewType, model, counter: 0 }` was added to `_references`. When `tryRetain()` was called and `model` rejected, `_references` was not purged. Subsequent calls to `tryRetain()` or `get()` retrieved the existing rejected promise, permanently locking the editor in an error state.

## Solution
1. Attached a rejection cleanup handler to `model` in `CustomEditorModelManager.add()` to delete the failed entry from `_references`.
2. Added error cleanup in `tryRetain()`'s rejection branch.
3. Protected `getAllModels()` with try/catch to avoid unhandled rejections during model iteration.
4. Added unit tests in `src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts` covering error purging and retry behavior.

## Testing
- Added unit test suite in `src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts`:
  - `Retains and disposes model correctly`
  - `Purges rejected model from map so subsequent attempts can retry`
  - `getAllModels does not crash when an entry rejects`
  - `disposeAllModelsForView cleans up even with rejected models`
- Verified all scenarios with standalone assertion tests.