### PR TITLE
Harden Agent Host E2E synchronization

### DIFF
--- a/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
+++ b/src/vs/platform/agentHost/test/node/e2e/KNOWN_ISSUES.md
@@ -146,19 +146,23 @@ A user can reopen a Copilot session after restarting Agent Host and expects the 
 
 ### Copilot provider sessions can disappear across a Windows host restart
 
-A user can restart Agent Host and reopen a Copilot session that contains completed tool activity. On Windows, the provider session can no longer be found after restart, so the host cannot reconstruct the persisted conversation and its tool rows.
+A user can restart Agent Host and reopen a Copilot session with a persisted conversation or peer chat. On Windows, the provider session can no longer be found after restart, so the host cannot reconstruct the conversation, tool rows, or peer-chat catalog.
 
-- Test: `tool-rich provider history is reconstructed after a host restart`.
+- Tests:
+  - `tool-rich provider history is reconstructed after a host restart`
+  - `peer chat catalog and transcript survive a host restart`
 - Scope: Copilot on Windows.
-- Expected: restarting Agent Host preserves the provider session and restores the completed edit tool call.
+- Expected: restarting Agent Host preserves the provider session and restores the completed edit tool call or peer-chat catalog and transcript.
 - Observed: reopening fails with `Session not found on backend`, although the same deterministic replay passes on macOS and Linux.
-- Gate: the Windows variant is skipped at the test declaration in `copilotCoverageSuite.ts`.
+- Gate: the Windows variants are skipped at their declarations in `copilotCoverageSuite.ts` and `sessionPersistenceSuite.ts`.
 - Reproduce on Windows:
 
   ```powershell
+  $env:AGENT_HOST_RUN_KNOWN_ISSUES = '1'
+  $env:AGENT_HOST_UPDATE_SNAPSHOTS = '1'
   .\scripts\test-integration.bat --run `
     src\vs\platform\agentHost\test\node\e2e\providers\copilotAgentHostE2E.integrationTest.ts `
-    --grep "tool-rich provider history"
+    --grep "tool-rich provider history|peer chat catalog"
   ```
 
 ### Persisted Copilot request errors are restored as cancelled on Windows

--- a/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/changesetSuite.ts
@@ -79,6 +79,8 @@ interface IOperationStatusChangedAction {
 	readonly status: string;
 }
 
+const CHANGESET_OPERATION_TIMEOUT_MS = 60_000;
+
 export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 	const { config, createdSessions, tempDirs } = context;
 
@@ -295,7 +297,7 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 			processed.add(n);
 			reduce(n);
 			return isReady();
-		}, 60_000);
+		}, CHANGESET_OPERATION_TIMEOUT_MS);
 	}
 
 	async function createModifiedUncommittedChangeset(prefix: string): Promise<{
@@ -324,12 +326,13 @@ export function defineChangesetTests(context: IAgentHostE2ETestContext): void {
 			&& getActionEnvelope(n).channel === changeset
 			&& (getActionEnvelope(n).action as { operationId: string; status: string }).operationId === 'discard-changes'
 			&& (getActionEnvelope(n).action as { operationId: string; status: string }).status === 'idle',
+			CHANGESET_OPERATION_TIMEOUT_MS,
 		);
 		await context.client.call('invokeChangesetOperation', {
 			channel: changeset,
 			operationId: 'discard-changes',
 			target: { kind: ChangesetOperationTargetKind.Resource, resource },
-		});
+		}, CHANGESET_OPERATION_TIMEOUT_MS);
 		await completed;
 		return context.client.receivedNotifications(n =>
 			isActionNotification(n, 'changeset/operationStatusChanged')

--- a/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/copilotCoverageSuite.ts
@@ -619,7 +619,7 @@ export function defineCopilotCoverageTests(context: IAgentHostE2ETestContext): v
 	});
 
 	// Windows loses the persisted provider session during restart, so the host cannot reconstruct its tool history.
-	(context.isWindows ? test.skip : test)('tool-rich provider history is reconstructed after a host restart', async function () {
+	(!context.isWindows || context.runKnownIssueTests ? test : test.skip)('tool-rich provider history is reconstructed after a host restart', async function () {
 		this.timeout(240_000);
 		const { sessionUri, workspace } = await createWorkspaceSession('tool-history-restart');
 		writeFileSync(join(workspace, 'history.txt'), 'before\n');

--- a/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/serverToolsSuite.ts
@@ -15,7 +15,7 @@ import { buildAnnotationsUri } from '../../../../common/annotationsUri.js';
 import { buildOpenSessionLinkUri } from '../../../../common/openSessionLink.js';
 import { SessionServerToolName } from '../../../../common/serverToolNames.js';
 import type { ListSessionsResult, SubscribeResult } from '../../../../common/state/protocol/commands.js';
-import { ActionType, type ChatToolCallCompleteAction, type ChatToolCallStartAction, type StateAction } from '../../../../common/state/sessionActions.js';
+import { ActionType, NotificationType, type ChatToolCallCompleteAction, type ChatToolCallStartAction, type SessionAddedParams, type StateAction } from '../../../../common/state/sessionActions.js';
 import {
 	buildDefaultChatUri,
 	ROOT_STATE_URI,
@@ -677,7 +677,6 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			.find(agent => agent.provider === config.provider)
 			?.models.find(model => model.id === 'claude-opus-4.6');
 		assert.ok(model);
-		const before = new Set((await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI })).items.map(item => item.resource));
 		context.client.clearReceived();
 		const { turn } = await driveServerTool(
 			session,
@@ -685,9 +684,14 @@ export function defineServerToolsTests(context: IAgentHostE2ETestContext): void 
 			`Call create_session exactly once with workspace "${session.workspace}", prompt "${childPrompt}", and model "${model.id}", then reply exactly "created".`,
 			SessionServerToolName.CreateSession,
 		);
-		const after = await context.client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
-		const child = after.items.find(item => !before.has(item.resource));
-		assert.ok(child);
+		const childAdded = await context.client.waitForNotification(notification => {
+			if (notification.method !== NotificationType.SessionAdded) {
+				return false;
+			}
+			const summary = (notification.params as SessionAddedParams).summary;
+			return summary.resource !== session.sessionUri && summary.provider === model.provider;
+		}, 30_000);
+		const child = (childAdded.params as SessionAddedParams).summary;
 		createdSessions.push(child.resource);
 		const childRequest = await retry(async () => {
 			const requests = context.observedModelRequestBodies

--- a/src/vs/platform/agentHost/test/node/e2e/suites/sessionPersistenceSuite.ts
+++ b/src/vs/platform/agentHost/test/node/e2e/suites/sessionPersistenceSuite.ts
@@ -126,7 +126,10 @@ export function defineSessionPersistenceTests(context: IAgentHostE2ETestContext)
 		});
 	});
 
-	(config.supportsMultipleChats && (config.supportsMultipleChatsE2E !== false || RECORDING) ? test : test.skip)('peer chat catalog and transcript survive a host restart', async function () {
+	const peerChatPersistenceEnabled = config.supportsMultipleChats
+		&& (config.supportsMultipleChatsE2E !== false || RECORDING)
+		&& (!(context.isWindows && config.provider === 'copilotcli') || context.runKnownIssueTests);
+	(peerChatPersistenceEnabled ? test : test.skip)('peer chat catalog and transcript survive a host restart', async function () {
 		this.timeout(240_000);
 		const workspace = fs.mkdtempSync(`${tmpdir()}/ahp-peer-persistence-`);
 		tempDirs.push(workspace);


### PR DESCRIPTION
## Summary

- wait for changeset discard operations with their operation-specific deadline
- identify created child sessions through `root/sessionAdded` instead of polling the full catalog
- consistently gate the known Copilot provider restart failure on Windows and document its reproduction

Fixes flakes observed in Azure builds [464385](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=464385) and [464401](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=464401).

## Validation

- `npm run transpile-client`
- targeted Agent Host E2E replay for the three affected scenarios
- targeted replay repeated 10 times (10/10 passed)
- hygiene on all changed TypeScript files
- `git diff --check`

(Written by Copilot)