### PR TITLE
chat: fail closed on managed settings refresh

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
@@ -300,6 +300,8 @@ export async function withAsyncTestCodeEditorAndInlineCompletionsModel<T>(
 					managedSettingsRawResponse: null,
 					managedSettingsCompatibilityError: null,
 					onDidChangeManagedSettingsCompatibilityError: Event.None,
+					managedSettingsRefreshState: 'inactive' as const,
+					onDidChangeManagedSettingsRefreshState: Event.None,
 					getDefaultAccount: async () => null,
 					setDefaultAccountProvider: () => { },
 					getDefaultAccountAuthenticationProvider: () => { return { id: 'mockProvider', name: 'Mock Provider', enterprise: false }; },

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1136,6 +1136,8 @@ class StandaloneDefaultAccountService implements IDefaultAccountService {
 	readonly managedSettingsRawResponse: unknown = null;
 	readonly managedSettingsCompatibilityError = null;
 	readonly onDidChangeManagedSettingsCompatibilityError = Event.None;
+	readonly managedSettingsRefreshState = 'inactive' as const;
+	readonly onDidChangeManagedSettingsRefreshState = Event.None;
 
 	async getDefaultAccount(): Promise<IDefaultAccount | null> {
 		return null;

--- a/src/vs/platform/defaultAccount/common/defaultAccount.ts
+++ b/src/vs/platform/defaultAccount/common/defaultAccount.ts
@@ -35,6 +35,8 @@ export interface IManagedSettingsCompatibilityError {
 	readonly minimumClientVersion?: string;
 }
 
+export type ManagedSettingsRefreshState = 'inactive' | 'pending' | 'satisfied' | 'blocked';
+
 export interface IDefaultAccountProvider {
 	readonly defaultAccount: IDefaultAccount | null;
 	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null>;
@@ -49,6 +51,8 @@ export interface IDefaultAccountProvider {
 	readonly managedSettingsRawResponse: unknown;
 	readonly managedSettingsCompatibilityError: IManagedSettingsCompatibilityError | null;
 	readonly onDidChangeManagedSettingsCompatibilityError: Event<IManagedSettingsCompatibilityError | null>;
+	readonly managedSettingsRefreshState: ManagedSettingsRefreshState;
+	readonly onDidChangeManagedSettingsRefreshState: Event<ManagedSettingsRefreshState>;
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider;
 
 	/**
@@ -82,6 +86,8 @@ export interface IDefaultAccountService {
 	readonly managedSettingsRawResponse: unknown;
 	readonly managedSettingsCompatibilityError: IManagedSettingsCompatibilityError | null;
 	readonly onDidChangeManagedSettingsCompatibilityError: Event<IManagedSettingsCompatibilityError | null>;
+	readonly managedSettingsRefreshState: ManagedSettingsRefreshState;
+	readonly onDidChangeManagedSettingsRefreshState: Event<ManagedSettingsRefreshState>;
 	getDefaultAccount(): Promise<IDefaultAccount | null>;
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider;
 	setDefaultAccountProvider(provider: IDefaultAccountProvider): void;

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -637,6 +637,12 @@ export interface IFileManagedSettingsService {
 	readonly managedSettings: ManagedSettingsData;
 	readonly onDidChangeRawManagedSettings: Event<RawManagedSettingsData>;
 	readonly onDidChangeManagedSettings: Event<ManagedSettingsData>;
+	/**
+	 * Resolves once the initial `managed-settings.json` snapshot is available. Callers that make
+	 * decisions from file-delivered values at startup must await this, otherwise they can observe
+	 * an empty snapshot while the initial read (or its IPC round-trip) is still in flight.
+	 */
+	initialize(): Promise<ManagedSettingsData>;
 }
 
 export class NullFileManagedSettingsService implements IFileManagedSettingsService {
@@ -645,4 +651,6 @@ export class NullFileManagedSettingsService implements IFileManagedSettingsServi
 	readonly managedSettings: ManagedSettingsData = {};
 	readonly onDidChangeRawManagedSettings = Event.None;
 	readonly onDidChangeManagedSettings = Event.None;
+
+	async initialize(): Promise<ManagedSettingsData> { return this.managedSettings; }
 }

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -139,12 +139,16 @@ export function managedSettingValue(key: string): (policyData: IPolicyData) => M
  * Resolves the startup refresh control with native MDM taking precedence over the cached server
  * response. A malformed native value is treated as absent, matching the managed-settings schema.
  */
-export function shouldForceRemoteSettingsRefresh(nativeMdm: ManagedSettingsData | undefined, server: ManagedSettingsData | undefined): boolean {
+export function shouldForceRemoteSettingsRefresh(nativeMdm: ManagedSettingsData | undefined, server: ManagedSettingsData | undefined, file?: ManagedSettingsData): boolean {
 	const nativeValue = nativeMdm?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY];
 	if (typeof nativeValue === 'boolean') {
 		return nativeValue;
 	}
-	return server?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY] === true;
+	const serverValue = server?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY];
+	if (typeof serverValue === 'boolean') {
+		return serverValue;
+	}
+	return file?.[COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY] === true;
 }
 
 let managedModelValueCallback: ((policyData: IPolicyData) => ManagedSettingValue | undefined) | undefined;

--- a/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
@@ -27,8 +27,8 @@ export class FileManagedSettingsChannel implements IServerChannel {
 
 	call<T>(_: unknown, command: string): Promise<T> {
 		switch (command) {
-			case 'getRawManagedSettings': return Promise.resolve(this.service.rawManagedSettings as T);
-			case 'getManagedSettings': return Promise.resolve(this.service.managedSettings as T);
+			case 'getRawManagedSettings': return this.service.initialize().then(() => this.service.rawManagedSettings as T);
+			case 'getManagedSettings': return this.service.initialize().then(() => this.service.managedSettings as T);
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -57,20 +57,28 @@ export class FileManagedSettingsChannelClient extends Disposable implements IFil
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
 
+	private readonly initialSnapshot: Promise<void>;
+
 	constructor(channel: IChannel) {
 		super();
 		this._register(channel.listen<RawManagedSettingsData>('onDidChangeRawManagedSettings')(managedSettings => this.updateRawManagedSettings(managedSettings, true)));
 		this._register(channel.listen<ManagedSettingsData>('onDidChangeManagedSettings')(managedSettings => this.updateManagedSettings(managedSettings, true)));
-		channel.call<RawManagedSettingsData>('getRawManagedSettings').then(managedSettings => {
+		const rawSnapshot = channel.call<RawManagedSettingsData>('getRawManagedSettings').then(managedSettings => {
 			if (!this.hasReceivedRawManagedSettings) {
 				this.updateRawManagedSettings(managedSettings, true);
 			}
 		});
-		channel.call<ManagedSettingsData>('getManagedSettings').then(managedSettings => {
+		const snapshot = channel.call<ManagedSettingsData>('getManagedSettings').then(managedSettings => {
 			if (!this.hasReceivedManagedSettings) {
 				this.updateManagedSettings(managedSettings, true);
 			}
 		});
+		this.initialSnapshot = Promise.all([rawSnapshot, snapshot]).then(() => undefined, () => undefined);
+	}
+
+	async initialize(): Promise<ManagedSettingsData> {
+		await this.initialSnapshot;
+		return this._managedSettings;
 	}
 
 	private updateRawManagedSettings(managedSettings: RawManagedSettingsData, fireEvent: boolean): void {

--- a/src/vs/platform/policy/common/fileManagedSettingsService.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsService.ts
@@ -40,6 +40,8 @@ export class FileManagedSettingsService extends Disposable implements IFileManag
 
 	private readonly throttledDelayer = this._register(new ThrottledDelayer(500));
 
+	private readonly initialRefresh: Promise<unknown>;
+
 	constructor(
 		private readonly file: URI,
 		@IFileService private readonly fileService: IFileService,
@@ -54,7 +56,13 @@ export class FileManagedSettingsService extends Disposable implements IFileManag
 		// Initial read — routed through the same delayer (with no delay) so it is serialized
 		// against change-triggered refreshes and can't be clobbered by a racing read. Non-blocking;
 		// IPC clients handle eventual data arrival.
-		this.throttledDelayer.trigger(() => this.refresh(), 0);
+		this.initialRefresh = this.throttledDelayer.trigger(() => this.refresh(), 0)
+			.catch(() => undefined); // cancelled because a newer refresh superseded this one
+	}
+
+	async initialize(): Promise<ManagedSettingsData> {
+		await this.initialRefresh;
+		return this._managedSettings;
 	}
 
 	private async refresh(): Promise<void> {

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -80,12 +80,16 @@ suite('Copilot managed settings projection', () => {
 			nativeTrue: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }),
 			nativeFalse: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
 			malformedNative: shouldForceRemoteSettingsRefresh({ [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: 'true' }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
+			fileTrue: shouldForceRemoteSettingsRefresh(undefined, undefined, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
+			serverFalseOverridesFile: shouldForceRemoteSettingsRefresh(undefined, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: false }, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true }),
 			unset: shouldForceRemoteSettingsRefresh(undefined, undefined),
 		}, {
 			serverTrue: true,
 			nativeTrue: true,
 			nativeFalse: false,
 			malformedNative: true,
+			fileTrue: true,
+			serverFalseOverridesFile: false,
 			unset: false,
 		});
 	});

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -135,6 +135,8 @@ class MockDefaultAccountService implements IDefaultAccountService {
 	readonly managedSettingsRawResponse: unknown = null;
 	readonly managedSettingsCompatibilityError = null;
 	readonly onDidChangeManagedSettingsCompatibilityError = Event.None;
+	readonly managedSettingsRefreshState = 'inactive' as const;
+	readonly onDidChangeManagedSettingsRefreshState = Event.None;
 
 	async getDefaultAccount(): Promise<IDefaultAccount | null> { return MOCK_ACCOUNT; }
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider { return MOCK_ACCOUNT.authenticationProvider; }

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -69,7 +69,7 @@ import { DelayedLogChannel } from '../services/output/common/delayedLogChannel.j
 import { dirname, joinPath } from '../../base/common/resources.js';
 import { IUserDataProfile, IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
-import { INativeManagedSettingsService, NullNativeManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { IFileManagedSettingsService, INativeManagedSettingsService, NullFileManagedSettingsService, NullNativeManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
 import { IRemoteExplorerService } from '../services/remote/common/remoteExplorerService.js';
 import { DisposableTunnel, TunnelProtocol } from '../../platform/tunnel/common/tunnel.js';
 import { ILabelService } from '../../platform/label/common/label.js';
@@ -369,6 +369,7 @@ export class BrowserMain extends Disposable {
 
 		// Policies
 		serviceCollection.set(INativeManagedSettingsService, new NullNativeManagedSettingsService());
+		serviceCollection.set(IFileManagedSettingsService, new NullFileManagedSettingsService());
 		const policyService = new AccountPolicyService(logService, defaultAccountService);
 		serviceCollection.set(IPolicyService, policyService);
 		serviceCollection.set(IAccountPolicyGateService, policyService);

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -184,6 +184,9 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 		if (this.defaultAccountProvider.managedSettingsCompatibilityError) {
 			this._onDidChangeManagedSettingsCompatibilityError.fire(this.defaultAccountProvider.managedSettingsCompatibilityError);
 		}
+		if (this.defaultAccountProvider.managedSettingsRefreshState !== 'inactive') {
+			this._onDidChangeManagedSettingsRefreshState.fire(this.defaultAccountProvider.managedSettingsRefreshState);
+		}
 		provider.refresh().then(account => {
 			this.defaultAccount = account;
 		}).finally(() => {
@@ -324,6 +327,7 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 	private readonly updateThrottler = this._register(new ThrottledDelayer(100));
 	private readonly accountDataPollScheduler = this._register(new RunOnceScheduler(() => this.refetchDefaultAccount(), ACCOUNT_DATA_POLL_INTERVAL_MS));
 	private readonly managedSettingsFetchAttemptedAccounts = new Set<string>();
+	private managedSettingsFetchesInFlight = 0;
 
 	constructor(
 		private readonly defaultAccountConfig: IDefaultAccountConfig,
@@ -402,6 +406,7 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		// account state drives the title bar and the welcome walkthrough.
 		if (isWeb && !this.environmentService.remoteAuthority && !this.environmentService.isSessionsWindow) {
 			this.logService.debug('[DefaultAccount] Running in web without remote, skipping initialization');
+			this.resolvePendingRefreshStateIfIdle();
 			return;
 		}
 
@@ -545,6 +550,10 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		try {
 			const defaultAccount = await this.fetchDefaultAccount(options);
 			this.setDefaultAccount(defaultAccount);
+			// The startup gate optimistically starts as `pending` so AI features stay hidden until the
+			// forced managed-settings refresh resolves. When no fetch ran during this pass (no
+			// account, or chat disabled by entitlements) nothing will ever resolve it, so clear it.
+			this.resolvePendingRefreshStateIfIdle();
 			this.scheduleAccountDataPoll();
 		} catch (error) {
 			this.logService.error('[DefaultAccount] Error while updating default account', getErrorMessage(error));
@@ -607,16 +616,28 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		if (equals(this._managedSettingsCompatibilityError, error)) {
 			return;
 		}
-
-		private setManagedSettingsRefreshState(state: ManagedSettingsRefreshState): void {
-			if (this._managedSettingsRefreshState === state) {
-				return;
-			}
-			this._managedSettingsRefreshState = state;
-			this._onDidChangeManagedSettingsRefreshState.fire(state);
-		}
 		this._managedSettingsCompatibilityError = error;
 		this._onDidChangeManagedSettingsCompatibilityError.fire(error);
+	}
+
+	private setManagedSettingsRefreshState(state: ManagedSettingsRefreshState): void {
+		if (this._managedSettingsRefreshState === state) {
+			return;
+		}
+		this._managedSettingsRefreshState = state;
+		this._onDidChangeManagedSettingsRefreshState.fire(state);
+	}
+
+	/**
+	 * Clears a `pending` refresh gate that no in-flight fetch can ever resolve, which happens when
+	 * initialization bails out early or when a refresh pass never reaches the managed-settings
+	 * endpoint (no account, or chat disabled by entitlements). Without this the gate would keep AI
+	 * features hidden forever.
+	 */
+	private resolvePendingRefreshStateIfIdle(): void {
+		if (this._managedSettingsRefreshState === 'pending' && this.managedSettingsFetchesInFlight === 0) {
+			this.setManagedSettingsRefreshState('inactive');
+		}
 	}
 
 	private setCopilotTokenInfo(copilotTokenInfo: ICopilotTokenInfo | null): void {
@@ -970,7 +991,13 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		);
 		this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'pending' : 'inactive');
 		this.managedSettingsFetchAttemptedAccounts.add(accountId);
-		const result = await this.requestManagedSettings(sessions, forceRemoteSettingsRefresh);
+		this.managedSettingsFetchesInFlight++;
+		let result: ManagedSettingsRequestResult;
+		try {
+			result = await this.requestManagedSettings(sessions, forceRemoteSettingsRefresh);
+		} finally {
+			this.managedSettingsFetchesInFlight--;
+		}
 		const fetchedAt = Date.now();
 		switch (result.kind) {
 			case 'success':

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -984,10 +984,16 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		} catch (error) {
 			this.logService.warn('[DefaultAccount] Failed to initialize native managed settings before resolving forceRemoteSettingsRefresh; using available values', getErrorMessage(error));
 		}
+		let fileManagedSettings = this.fileManagedSettingsService.managedSettings;
+		try {
+			fileManagedSettings = await this.fileManagedSettingsService.initialize();
+		} catch (error) {
+			this.logService.warn('[DefaultAccount] Failed to initialize file managed settings before resolving forceRemoteSettingsRefresh; using available values', getErrorMessage(error));
+		}
 		const forceRemoteSettingsRefresh = shouldForceRemoteSettingsRefresh(
 			nativeManagedSettings,
 			accountPolicyData?.policyData.managedSettings,
-			this.fileManagedSettingsService.managedSettings
+			fileManagedSettings
 		);
 		this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'pending' : 'inactive');
 		this.managedSettingsFetchAttemptedAccounts.add(accountId);

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -20,10 +20,11 @@ import { Action2, registerAction2 } from '../../../../platform/actions/common/ac
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDefaultAccountProvider, IDefaultAccountService, IManagedSettingsCompatibilityError, MANAGED_SETTINGS_UPDATE_REQUIRED_ERROR_CODE, ManagedSettingsFetchStatus } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IDefaultAccountProvider, IDefaultAccountService, IManagedSettingsCompatibilityError, MANAGED_SETTINGS_UPDATE_REQUIRED_ERROR_CODE, ManagedSettingsFetchStatus, ManagedSettingsRefreshState } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IFileManagedSettingsService, INativeManagedSettingsService, shouldForceRemoteSettingsRefresh } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { asJson, asText, IRequestService, isClientError, isSuccess, readHeader, retryAfterFromHeaders } from '../../../../platform/request/common/request.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -126,6 +127,7 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 	get managedSettingsFetchedAt(): number | null { return this.defaultAccountProvider?.managedSettingsFetchedAt ?? null; }
 	get managedSettingsRawResponse(): unknown { return this.defaultAccountProvider?.managedSettingsRawResponse ?? null; }
 	get managedSettingsCompatibilityError(): IManagedSettingsCompatibilityError | null { return this.defaultAccountProvider?.managedSettingsCompatibilityError ?? null; }
+	get managedSettingsRefreshState(): ManagedSettingsRefreshState { return this.defaultAccountProvider?.managedSettingsRefreshState ?? 'inactive'; }
 
 	private readonly initBarrier = new Barrier();
 
@@ -140,6 +142,8 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 
 	private readonly _onDidChangeManagedSettingsCompatibilityError = this._register(new Emitter<IManagedSettingsCompatibilityError | null>());
 	readonly onDidChangeManagedSettingsCompatibilityError = this._onDidChangeManagedSettingsCompatibilityError.event;
+	private readonly _onDidChangeManagedSettingsRefreshState = this._register(new Emitter<ManagedSettingsRefreshState>());
+	readonly onDidChangeManagedSettingsRefreshState = this._onDidChangeManagedSettingsRefreshState.event;
 
 	private readonly defaultAccountConfig: IDefaultAccountConfig;
 	private defaultAccountProvider: IDefaultAccountProvider | null = null;
@@ -173,6 +177,7 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 
 		this.defaultAccountProvider = provider;
 		this._register(provider.onDidChangeManagedSettingsCompatibilityError(error => this._onDidChangeManagedSettingsCompatibilityError.fire(error)));
+		this._register(provider.onDidChangeManagedSettingsRefreshState(state => this._onDidChangeManagedSettingsRefreshState.fire(state)));
 		if (this.defaultAccountProvider.policyData) {
 			this._onDidChangePolicyData.fire(this.defaultAccountProvider.policyData);
 		}
@@ -296,6 +301,8 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 
 	private _managedSettingsCompatibilityError: IManagedSettingsCompatibilityError | null = null;
 	get managedSettingsCompatibilityError(): IManagedSettingsCompatibilityError | null { return this._managedSettingsCompatibilityError; }
+	private _managedSettingsRefreshState: ManagedSettingsRefreshState = 'inactive';
+	get managedSettingsRefreshState(): ManagedSettingsRefreshState { return this._managedSettingsRefreshState; }
 
 	private readonly _onDidChangeDefaultAccount = this._register(new Emitter<IDefaultAccount | null>());
 	readonly onDidChangeDefaultAccount = this._onDidChangeDefaultAccount.event;
@@ -308,6 +315,8 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 
 	private readonly _onDidChangeManagedSettingsCompatibilityError = this._register(new Emitter<IManagedSettingsCompatibilityError | null>());
 	readonly onDidChangeManagedSettingsCompatibilityError = this._onDidChangeManagedSettingsCompatibilityError.event;
+	private readonly _onDidChangeManagedSettingsRefreshState = this._register(new Emitter<ManagedSettingsRefreshState>());
+	readonly onDidChangeManagedSettingsRefreshState = this._onDidChangeManagedSettingsRefreshState.event;
 
 	private readonly accountStatusContext: IContextKey<string>;
 	private initialized = false;
@@ -331,6 +340,8 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		@IStorageService private readonly storageService: IStorageService,
 		@IHostService private readonly hostService: IHostService,
 		@ICommandService private readonly commandService: ICommandService,
+		@INativeManagedSettingsService private readonly nativeManagedSettingsService: INativeManagedSettingsService,
+		@IFileManagedSettingsService private readonly fileManagedSettingsService: IFileManagedSettingsService,
 	) {
 		super();
 		this.accountStatusContext = CONTEXT_DEFAULT_ACCOUNT_STATE.bindTo(contextKeyService);
@@ -338,6 +349,13 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		this._policyData = cachedAccountData?.accountPolicyData ?? null;
 		this._copilotTokenInfo = cachedAccountData?.copilotTokenInfo ?? null;
 		this._managedSettingsCompatibilityError = cachedAccountData?.accountPolicyData.managedSettingsCompatibilityError ?? null;
+		if (shouldForceRemoteSettingsRefresh(
+			this.nativeManagedSettingsService.managedSettings,
+			cachedAccountData?.accountPolicyData.policyData.managedSettings,
+			this.fileManagedSettingsService.managedSettings
+		)) {
+			this._managedSettingsRefreshState = 'pending';
+		}
 		this.initPromise = this.init()
 			.finally(() => {
 				this.telemetryService.publicLog2<DefaultAccountStatusTelemetry, DefaultAccountStatusTelemetryClassification>('defaultaccount:status', { status: this.defaultAccount ? 'available' : 'unavailable', initial: true });
@@ -588,6 +606,14 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 	private setManagedSettingsCompatibilityError(error: IManagedSettingsCompatibilityError | null): void {
 		if (equals(this._managedSettingsCompatibilityError, error)) {
 			return;
+		}
+
+		private setManagedSettingsRefreshState(state: ManagedSettingsRefreshState): void {
+			if (this._managedSettingsRefreshState === state) {
+				return;
+			}
+			this._managedSettingsRefreshState = state;
+			this._onDidChangeManagedSettingsRefreshState.fire(state);
 		}
 		this._managedSettingsCompatibilityError = error;
 		this._onDidChangeManagedSettingsCompatibilityError.fire(error);
@@ -931,26 +957,42 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 			return { ...cachedManagedSettings, compatibilityError: this._managedSettingsCompatibilityError };
 		}
 
+		let nativeManagedSettings = this.nativeManagedSettingsService.managedSettings;
+		try {
+			nativeManagedSettings = await this.nativeManagedSettingsService.initialize();
+		} catch (error) {
+			this.logService.warn('[DefaultAccount] Failed to initialize native managed settings before resolving forceRemoteSettingsRefresh; using available values', getErrorMessage(error));
+		}
+		const forceRemoteSettingsRefresh = shouldForceRemoteSettingsRefresh(
+			nativeManagedSettings,
+			accountPolicyData?.policyData.managedSettings,
+			this.fileManagedSettingsService.managedSettings
+		);
+		this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'pending' : 'inactive');
 		this.managedSettingsFetchAttemptedAccounts.add(accountId);
-		const result = await this.requestManagedSettings(sessions);
+		const result = await this.requestManagedSettings(sessions, forceRemoteSettingsRefresh);
 		const fetchedAt = Date.now();
 		switch (result.kind) {
 			case 'success':
+				this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'satisfied' : 'inactive');
 				return { data: result.data, fetchedAt, compatibilityError: null };
 			case 'noSettings':
+				this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'satisfied' : 'inactive');
 				return { data: { managedSettings: undefined }, fetchedAt, compatibilityError: null };
 			case 'updateRequired':
+				this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'blocked' : 'inactive');
 				return { data: { managedSettings: undefined }, fetchedAt, compatibilityError: result.error };
 			case 'unavailable':
+				this.setManagedSettingsRefreshState(forceRemoteSettingsRefresh ? 'blocked' : 'inactive');
 				return {
-					data: this._managedSettingsCompatibilityError ? { managedSettings: undefined } : cachedManagedSettings?.data,
+					data: forceRemoteSettingsRefresh || this._managedSettingsCompatibilityError ? { managedSettings: undefined } : cachedManagedSettings?.data,
 					fetchedAt,
 					compatibilityError: this._managedSettingsCompatibilityError,
 				};
 		}
 	}
 
-	private async requestManagedSettings(sessions: AuthenticationSession[]): Promise<ManagedSettingsRequestResult> {
+	private async requestManagedSettings(sessions: AuthenticationSession[], forceRefresh: boolean): Promise<ManagedSettingsRequestResult> {
 		const managedSettingsUrl = this.getManagedSettingsUrl();
 		if (!managedSettingsUrl) {
 			this.logService.debug('[DefaultAccount] No managed settings URL configured; skipping enterprise policy fetch');
@@ -960,7 +1002,7 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 
 		this.logService.debug('[DefaultAccount] Fetching managed settings from:', managedSettingsUrl);
 		const rateLimitBackoffActive = Date.now() < this._rateLimitBackoffUntil;
-		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS, getManagedSettingsClientHeaders(this.productService));
+		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS, getManagedSettingsClientHeaders(this.productService, forceRefresh));
 		if (!response) {
 			this.logService.debug('[DefaultAccount] Managed settings fetch returned no response (network error, all sessions rejected, or active rate-limit backoff); falling back to local-only policy');
 			this.reportManagedSettingsOutcome('no-response', rateLimitBackoffActive);

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -62,10 +62,13 @@ export interface IManagedSettingsResponse {
 	readonly [key: string]: unknown;
 }
 
-export function getManagedSettingsClientHeaders(product: Pick<IProductConfiguration, 'version' | 'copilotVersions'>): IHeaders {
+export function getManagedSettingsClientHeaders(product: Pick<IProductConfiguration, 'version' | 'copilotVersions'>, forceRefresh = false): IHeaders {
 	const headers: IHeaders = {
 		'Editor-Version': `vscode/${product.version}`,
 	};
+	if (forceRefresh) {
+		headers['Cache-Control'] = 'no-cache';
+	}
 	const runtimeVersion = product.copilotVersions?.runtime;
 	if (runtimeVersion) {
 		headers['Copilot-Runtime-Version'] = `copilot-runtime/${runtimeVersion}`;

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -279,7 +279,10 @@ suite('DefaultAccountProvider managed settings', () => {
 			managedSettings: nativeManagedSettings,
 			initialize: async () => nativeManagedSettings,
 		});
-		instantiationService.stub(IFileManagedSettingsService, { managedSettings: {} });
+		instantiationService.stub(IFileManagedSettingsService, {
+			managedSettings: {},
+			initialize: async () => ({}),
+		});
 
 		const provider = disposables.add(instantiationService.createInstance(DefaultAccountProvider, {
 			preferredExtensions: [],

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -15,7 +15,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
-import { COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY, IFileManagedSettingsService, INativeManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IRequestService } from '../../../../../platform/request/common/request.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
@@ -54,12 +54,14 @@ suite('DefaultAccountProvider managed settings', () => {
 			requestCount: requestService.requestCount,
 			editorVersion: requestService.requests[0].headers?.['Editor-Version'],
 			runtimeVersion: requestService.requests[0].headers?.['Copilot-Runtime-Version'],
+			cacheControl: requestService.requests[0].headers?.['Cache-Control'],
 			first: first.data,
 			second: second.data,
 		}, {
 			requestCount: 1,
 			editorVersion: 'vscode/1.132.0',
 			runtimeVersion: 'copilot-runtime/0.0.344',
+			cacheControl: 'no-cache',
 			first: cachedPolicy.policyData,
 			second: cachedPolicy.policyData,
 		});
@@ -130,6 +132,27 @@ suite('DefaultAccountProvider managed settings', () => {
 	test('failed startup fetch retains cached managed settings when no rejection is known', async () => {
 		const requestService = new TestRequestService(async () => {
 			throw new Error('managed settings unavailable');
+		});
+
+		test('failed forced refresh blocks without falling back to cached managed settings', async () => {
+			const requestService = new TestRequestService(async () => {
+				throw new Error('managed settings unavailable');
+			});
+			const provider = await createProvider(requestService);
+
+			const result = await provider['getManagedSettings'](sessions, createCachedPolicy(true));
+
+			assert.deepStrictEqual({
+				status: provider.managedSettingsFetchStatus,
+				refreshState: provider.managedSettingsRefreshState,
+				cacheControl: requestService.requests[0].headers?.['Cache-Control'],
+				data: result.data,
+			}, {
+				status: 'no-response',
+				refreshState: 'blocked',
+				cacheControl: 'no-cache',
+				data: { managedSettings: undefined },
+			});
 		});
 		const provider = await createProvider(requestService);
 		const cachedPolicy = createCachedPolicy(false);
@@ -240,6 +263,11 @@ suite('DefaultAccountProvider managed settings', () => {
 			onDidChangeFocus: Event.None,
 		});
 		instantiationService.stub(ICommandService, {});
+		instantiationService.stub(INativeManagedSettingsService, {
+			managedSettings: {},
+			initialize: async () => ({}),
+		});
+		instantiationService.stub(IFileManagedSettingsService, { managedSettings: {} });
 
 		const provider = disposables.add(instantiationService.createInstance(DefaultAccountProvider, {
 			preferredExtensions: [],

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -15,7 +15,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
-import { COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY, IFileManagedSettingsService, INativeManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY, IFileManagedSettingsService, INativeManagedSettingsService, ManagedSettingsData } from '../../../../../platform/policy/common/copilotManagedSettings.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IRequestService } from '../../../../../platform/request/common/request.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
@@ -133,27 +133,6 @@ suite('DefaultAccountProvider managed settings', () => {
 		const requestService = new TestRequestService(async () => {
 			throw new Error('managed settings unavailable');
 		});
-
-		test('failed forced refresh blocks without falling back to cached managed settings', async () => {
-			const requestService = new TestRequestService(async () => {
-				throw new Error('managed settings unavailable');
-			});
-			const provider = await createProvider(requestService);
-
-			const result = await provider['getManagedSettings'](sessions, createCachedPolicy(true));
-
-			assert.deepStrictEqual({
-				status: provider.managedSettingsFetchStatus,
-				refreshState: provider.managedSettingsRefreshState,
-				cacheControl: requestService.requests[0].headers?.['Cache-Control'],
-				data: result.data,
-			}, {
-				status: 'no-response',
-				refreshState: 'blocked',
-				cacheControl: 'no-cache',
-				data: { managedSettings: undefined },
-			});
-		});
 		const provider = await createProvider(requestService);
 		const cachedPolicy = createCachedPolicy(false);
 
@@ -167,6 +146,27 @@ suite('DefaultAccountProvider managed settings', () => {
 			requestCount: 1,
 			status: 'no-response',
 			data: cachedPolicy.policyData,
+		});
+	});
+
+	test('failed forced refresh blocks without falling back to cached managed settings', async () => {
+		const requestService = new TestRequestService(async () => {
+			throw new Error('managed settings unavailable');
+		});
+		const provider = await createProvider(requestService);
+
+		const result = await provider['getManagedSettings'](sessions, createCachedPolicy(true));
+
+		assert.deepStrictEqual({
+			status: provider.managedSettingsFetchStatus,
+			refreshState: provider.managedSettingsRefreshState,
+			cacheControl: requestService.requests[0].headers?.['Cache-Control'],
+			data: result.data,
+		}, {
+			status: 'no-response',
+			refreshState: 'blocked',
+			cacheControl: 'no-cache',
+			data: { managedSettings: undefined },
 		});
 	});
 
@@ -226,7 +226,19 @@ suite('DefaultAccountProvider managed settings', () => {
 		});
 	});
 
-	async function createProvider(requestService: TestRequestService): Promise<DefaultAccountProvider> {
+	test('startup refresh gate clears when no managed settings fetch can run', async () => {
+		const requestService = new TestRequestService(async options => {
+			if (options.url?.endsWith('/copilot_internal/user')) {
+				return jsonResponse({ chat_enabled: false });
+			}
+			throw new Error(`Unexpected request: ${options.url}`);
+		});
+		const provider = await createProvider(requestService, { [COPILOT_FORCE_REMOTE_SETTINGS_REFRESH_KEY]: true });
+
+		assert.deepStrictEqual(provider.managedSettingsRefreshState, 'inactive');
+	});
+
+	async function createProvider(requestService: TestRequestService, nativeManagedSettings: ManagedSettingsData = {}): Promise<DefaultAccountProvider> {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
 		instantiationService.stub(IAuthenticationService, {
@@ -264,8 +276,8 @@ suite('DefaultAccountProvider managed settings', () => {
 		});
 		instantiationService.stub(ICommandService, {});
 		instantiationService.stub(INativeManagedSettingsService, {
-			managedSettings: {},
-			initialize: async () => ({}),
+			managedSettings: nativeManagedSettings,
+			initialize: async () => nativeManagedSettings,
 		});
 		instantiationService.stub(IFileManagedSettingsService, { managedSettings: {} });
 

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDefaultAccountService, IManagedSettingsCompatibilityError } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IDefaultAccountService, IManagedSettingsCompatibilityError, ManagedSettingsRefreshState } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
@@ -223,7 +223,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		this.chatEntitlementService.setForceHidden(blocked);
 	}
 
-	private updateManagedSettingsRefreshState(state: 'inactive' | 'pending' | 'satisfied' | 'blocked'): void {
+	private updateManagedSettingsRefreshState(state: ManagedSettingsRefreshState): void {
 		this.updatePolicyGateState();
 		if (state !== 'blocked' || this.refreshDialogVisible || this.defaultAccountService.managedSettingsCompatibilityError) {
 			return;
@@ -239,7 +239,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			title: localize('managedSettingsRefresh.dialog.title', "Managed Settings Unavailable"),
 			message: localize(
 				'managedSettingsRefresh.dialog.message',
-				"Copilot Chat is disabled because {0} could not refresh your organization's managed settings. Check your connection or sign in again, then retry.",
+				"AI features are disabled because {0} could not refresh your organization's managed settings. Check your connection or sign in again, then retry.",
 				this.productService.nameShort
 			),
 			custom: true,

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -52,6 +52,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 
 	private readonly notificationHandle = this._register(new MutableDisposable());
 	private compatibilityDialogVisible = false;
+	private refreshDialogVisible = false;
 	private dismissedKey: string | undefined;
 
 	private initialised = false;
@@ -85,6 +86,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			this.apply(info, /*forceTelemetry*/ false, /*showNotification*/ true);
 		}));
 		this._register(this.defaultAccountService.onDidChangeManagedSettingsCompatibilityError(error => this.updateManagedSettingsCompatibilityState(error)));
+		this._register(this.defaultAccountService.onDidChangeManagedSettingsRefreshState(state => this.updateManagedSettingsRefreshState(state)));
 
 		this._register(disposableTimeout(() => {
 			if (!this.initialised) {
@@ -213,9 +215,40 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	}
 
 	private updatePolicyGateState(): void {
-		const blocked = this.isGateRestricted(this.lastInfo) || this.defaultAccountService.managedSettingsCompatibilityError !== null;
+		const blocked = this.isGateRestricted(this.lastInfo)
+			|| this.defaultAccountService.managedSettingsCompatibilityError !== null
+			|| this.defaultAccountService.managedSettingsRefreshState === 'pending'
+			|| this.defaultAccountService.managedSettingsRefreshState === 'blocked';
 		this.contextKey.set(blocked);
 		this.chatEntitlementService.setForceHidden(blocked);
+	}
+
+	private updateManagedSettingsRefreshState(state: 'inactive' | 'pending' | 'satisfied' | 'blocked'): void {
+		this.updatePolicyGateState();
+		if (state !== 'blocked' || this.refreshDialogVisible || this.defaultAccountService.managedSettingsCompatibilityError) {
+			return;
+		}
+
+		this.refreshDialogVisible = true;
+		void this.showManagedSettingsRefreshDialog().finally(() => this.refreshDialogVisible = false);
+	}
+
+	private async showManagedSettingsRefreshDialog(): Promise<void> {
+		await this.dialogService.prompt({
+			type: Severity.Warning,
+			title: localize('managedSettingsRefresh.dialog.title', "Managed Settings Unavailable"),
+			message: localize(
+				'managedSettingsRefresh.dialog.message',
+				"Copilot Chat is disabled because {0} could not refresh your organization's managed settings. Check your connection or sign in again, then retry.",
+				this.productService.nameShort
+			),
+			custom: true,
+			buttons: [{
+				label: localize('managedSettingsRefresh.dialog.retry', "Retry"),
+				run: () => this.defaultAccountService.refresh({ forceRefresh: true }),
+			}],
+			cancelButton: localize('managedSettingsRefresh.dialog.close', "Close"),
+		});
 	}
 
 	private updateManagedSettingsCompatibilityState(error: IManagedSettingsCompatibilityError | null): void {

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyGateContribution.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyGateContribution.test.ts
@@ -9,7 +9,7 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { IDefaultAccountService, IManagedSettingsCompatibilityError } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IDefaultAccountService, IManagedSettingsCompatibilityError, ManagedSettingsRefreshState } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
@@ -47,14 +47,24 @@ class TestDefaultAccountService extends mock<IDefaultAccountService>() {
 
 	private readonly _onDidChangeManagedSettingsCompatibilityError = new Emitter<IManagedSettingsCompatibilityError | null>();
 	override readonly onDidChangeManagedSettingsCompatibilityError = this._onDidChangeManagedSettingsCompatibilityError.event;
+	private _managedSettingsRefreshState: ManagedSettingsRefreshState = 'inactive';
+	override get managedSettingsRefreshState(): ManagedSettingsRefreshState { return this._managedSettingsRefreshState; }
+	private readonly _onDidChangeManagedSettingsRefreshState = new Emitter<ManagedSettingsRefreshState>();
+	override readonly onDidChangeManagedSettingsRefreshState = this._onDidChangeManagedSettingsRefreshState.event;
 
 	setManagedSettingsCompatibilityError(error: IManagedSettingsCompatibilityError | null): void {
 		this._managedSettingsCompatibilityError = error;
 		this._onDidChangeManagedSettingsCompatibilityError.fire(error);
 	}
 
+	setManagedSettingsRefreshState(state: ManagedSettingsRefreshState): void {
+		this._managedSettingsRefreshState = state;
+		this._onDidChangeManagedSettingsRefreshState.fire(state);
+	}
+
 	dispose(): void {
 		this._onDidChangeManagedSettingsCompatibilityError.dispose();
+		this._onDidChangeManagedSettingsRefreshState.dispose();
 	}
 }
 
@@ -130,9 +140,18 @@ suite('AccountPolicyGateContribution', () => {
 		captureState();
 		defaultAccountService.setManagedSettingsCompatibilityError(null);
 		captureState();
+		defaultAccountService.setManagedSettingsRefreshState('pending');
+		captureState();
+		defaultAccountService.setManagedSettingsRefreshState('blocked');
+		await Promise.resolve();
+		await Promise.resolve();
+		captureState();
+		defaultAccountService.setManagedSettingsRefreshState('satisfied');
+		captureState();
 
 		const compatibilityDialog = promptStub.firstCall.args[0];
 		const fallbackCompatibilityDialog = promptStub.secondCall.args[0];
+		const refreshDialog = promptStub.thirdCall.args[0];
 		assert.deepStrictEqual({
 			states,
 			forceHiddenValues: chatEntitlementService.forceHiddenValues,
@@ -144,6 +163,12 @@ suite('AccountPolicyGateContribution', () => {
 				cancelButton: compatibilityDialog.cancelButton,
 			},
 			fallbackCompatibilityMessage: fallbackCompatibilityDialog.message,
+			refreshDialog: {
+				title: refreshDialog.title,
+				message: refreshDialog.message,
+				buttons: refreshDialog.buttons?.map(button => button.label),
+				cancelButton: refreshDialog.cancelButton,
+			},
 		}, {
 			states: [
 				{ context: false, hidden: false },
@@ -153,8 +178,11 @@ suite('AccountPolicyGateContribution', () => {
 				{ context: true, hidden: true },
 				{ context: true, hidden: true },
 				{ context: false, hidden: false },
+				{ context: true, hidden: true },
+				{ context: true, hidden: true },
+				{ context: false, hidden: false },
 			],
-			forceHiddenValues: [false, true, false, true, false],
+			forceHiddenValues: [false, true, false, true, false, true, false],
 			compatibilityDialog: {
 				title: 'Update Required',
 				message: 'Your version of Code cannot enforce your organization\'s managed settings. Update Code to version 1.135.0 or later to continue using AI features.',
@@ -163,6 +191,12 @@ suite('AccountPolicyGateContribution', () => {
 				cancelButton: 'Close',
 			},
 			fallbackCompatibilityMessage: 'Your version of Code cannot enforce your organization\'s managed settings. Update Code to continue using AI features.',
+			refreshDialog: {
+				title: 'Managed Settings Unavailable',
+				message: 'Copilot Chat is disabled because Code could not refresh your organization\'s managed settings. Check your connection or sign in again, then retry.',
+				buttons: ['Retry'],
+				cancelButton: 'Close',
+			},
 		});
 	});
 });

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyGateContribution.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyGateContribution.test.ts
@@ -193,7 +193,7 @@ suite('AccountPolicyGateContribution', () => {
 			fallbackCompatibilityMessage: 'Your version of Code cannot enforce your organization\'s managed settings. Update Code to continue using AI features.',
 			refreshDialog: {
 				title: 'Managed Settings Unavailable',
-				message: 'Copilot Chat is disabled because Code could not refresh your organization\'s managed settings. Check your connection or sign in again, then retry.',
+				message: 'AI features are disabled because Code could not refresh your organization\'s managed settings. Check your connection or sign in again, then retry.',
 				buttons: ['Retry'],
 				cancelButton: 'Close',
 			},

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -41,6 +41,8 @@ class DefaultAccountProvider implements IDefaultAccountProvider {
 	readonly managedSettingsRawResponse: unknown = null;
 	readonly managedSettingsCompatibilityError = null;
 	readonly onDidChangeManagedSettingsCompatibilityError = Event.None;
+	readonly managedSettingsRefreshState = 'inactive' as const;
+	readonly onDidChangeManagedSettingsRefreshState = Event.None;
 
 	constructor(
 		readonly defaultAccount: IDefaultAccount,

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -613,6 +613,8 @@ suite('AccountPolicyService', () => {
 		readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
 
 		constructor(public managedSettings: ManagedSettingsData = {}) { }
+
+		async initialize(): Promise<ManagedSettingsData> { return this.managedSettings; }
 	}
 
 	async function setupGate(opts: {

--- a/src/vs/workbench/services/policies/test/browser/multiplexPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/multiplexPolicyService.test.ts
@@ -47,6 +47,8 @@ class DefaultAccountProvider implements IDefaultAccountProvider {
 	readonly managedSettingsRawResponse: unknown = null;
 	readonly managedSettingsCompatibilityError = null;
 	readonly onDidChangeManagedSettingsCompatibilityError = Event.None;
+	readonly managedSettingsRefreshState = 'inactive' as const;
+	readonly onDidChangeManagedSettingsRefreshState = Event.None;
 
 	constructor(
 		readonly defaultAccount: IDefaultAccount,

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -594,6 +594,8 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		managedSettingsRawResponse: null,
 		managedSettingsCompatibilityError: null,
 		onDidChangeManagedSettingsCompatibilityError: Event.None,
+		managedSettingsRefreshState: 'inactive' as const,
+		onDidChangeManagedSettingsRefreshState: Event.None,
 		getDefaultAccount: async () => null,
 		getDefaultAccountAuthenticationProvider: () => ({ id: 'test', name: 'Test', scopes: [], enterprise: false }),
 		resolveGitHubUrl: (path: string) => `https://github.com/${path}`,


### PR DESCRIPTION
When `forceRemoteSettingsRefresh` is effective, VS Code now keeps Copilot Chat disabled until a fresh managed-settings response succeeds. Failed forced refreshes no longer fall back to cached server settings.

This change:
- tracks pending, satisfied, and blocked refresh state through the default-account service
- composes pending/blocked freshness with the existing Account Policy and managed-settings compatibility gate
- shows a modal with remediation and retry UX when freshness is blocked
- sends `Cache-Control: no-cache` for forced requests
- honors native MDM, cached server, and file-delivered values with explicit-value precedence
- adds targeted coverage for cache bypass, failure blocking, file delivery, and Chat hiding

## Validation

- `git diff --check`
- Compile attempted; local dependency restoration completed, but the broad client compile exited from `tsgo` without surfacing a TypeScript diagnostic in captured output. Targeted tests were therefore not completed before publishing so development can continue on this branch.

Related to microsoft/vscode-internalbacklog#8825.