### PR TITLE
Sample chat editing session telemetry

### DIFF
--- a/src/vs/base/common/hash.ts
+++ b/src/vs/base/common/hash.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { encodeHex, VSBuffer } from './buffer.js';
+import { assert } from './assert.js';
 import * as strings from './strings.js';
 
 type NotSyncHashable = ArrayBufferLike | ArrayBufferView;
@@ -54,6 +55,14 @@ export function stringHash(s: string, hashVal: number) {
 		hashVal = numberHash(s.charCodeAt(i), hashVal);
 	}
 	return hashVal;
+}
+
+/**
+ * Returns whether a string belongs to a stable percentage sample.
+ */
+export function isStringInSample(value: string, samplePercentage: number): boolean {
+	assert(Number.isInteger(samplePercentage) && samplePercentage >= 0 && samplePercentage <= 100, 'samplePercentage must be an integer between 0 and 100');
+	return (stringHash(value, 0) >>> 0) % 100 < samplePercentage;
 }
 
 function arrayHash(arr: unknown[], initialHashVal: number): number {

--- a/src/vs/base/test/common/hash.test.ts
+++ b/src/vs/base/test/common/hash.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { isStringInSample } from '../../common/hash.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
+
+suite('isStringInSample', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns stable sample membership', () => {
+		assert.deepStrictEqual(
+			Array.from({ length: 9 }, (_, index) => isStringInSample(`session-${index + 60}`, 5)),
+			[false, false, true, true, true, true, true, false, false]
+		);
+	});
+
+	test('supports sample boundaries', () => {
+		assert.deepStrictEqual(
+			[isStringInSample('session', 0), isStringInSample('session', 100)],
+			[false, true]
+		);
+	});
+
+	test('rejects invalid percentages', () => {
+		assert.throws(() => isStringInSample('session', -1));
+		assert.throws(() => isStringInSample('session', 1.5));
+		assert.throws(() => isStringInSample('session', 101));
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -8,6 +8,7 @@ import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
 import { Emitter } from '../../../../../base/common/event.js';
+import { isStringInSample } from '../../../../../base/common/hash.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableStore, dispose } from '../../../../../base/common/lifecycle.js';
@@ -70,7 +71,7 @@ type ChatEditingSessionInfoEvent = {
 
 type ChatEditingSessionInfoClassification = {
 	owner: 'jrieken';
-	comment: 'Tracks the number and state of chat editing entries when a session is stored.';
+	comment: 'Tracks the number and state of chat editing entries when sessions are stored or restored. Events use stable 5% sampling by session.';
 	editSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Hashed identifier of the chat session for correlation.' };
 	entryCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of entries stored with the session.' };
 	modifiedCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of entries in Modified state when storing.' };
@@ -333,10 +334,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 	public storeState(): Promise<void> {
 		const storage = this._instantiationService.createInstance(ChatEditingSessionStorage, this.chatSessionResource);
 		const storedState = this._getStoredState();
-		this._telemetryService.publicLog2<ChatEditingSessionInfoEvent, ChatEditingSessionInfoClassification>('chatEditing/sessionStore', {
-			editSessionId: getKeyForChatSessionResource(this.chatSessionResource),
-			...this._countEntryStates(this._entriesObs.get()),
-		});
+		this._reportSessionInfo('chatEditing/sessionStore', this._entriesObs.get());
 		return storage.storeState(storedState);
 	}
 
@@ -1015,10 +1013,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		}
 
 		this._entriesObs.set(entriesArr, undefined);
-		this._telemetryService.publicLog2<ChatEditingSessionInfoEvent, ChatEditingSessionInfoClassification>('chatEditing/sessionRestore', {
-			editSessionId: getKeyForChatSessionResource(this.chatSessionResource),
-			...this._countEntryStates(entriesArr),
-		});
+		this._reportSessionInfo('chatEditing/sessionRestore', entriesArr);
 	}
 
 	private async _acceptEdits(resource: URI, textEdits: (TextEdit | ICellEditOperation)[], isLastEdits: boolean, responseModel: IChatResponseModel): Promise<void> {
@@ -1053,6 +1048,17 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				return undefined;
 			}
 		};
+	}
+
+	private _reportSessionInfo(eventName: 'chatEditing/sessionStore' | 'chatEditing/sessionRestore', entries: readonly AbstractChatEditingModifiedFileEntry[]): void {
+		const editSessionId = getKeyForChatSessionResource(this.chatSessionResource);
+		// Select 5% of edit sessions by ID, retaining all store and restore events for selected sessions and none for the rest.
+		if (isStringInSample(editSessionId, 5)) {
+			this._telemetryService.publicLog2<ChatEditingSessionInfoEvent, ChatEditingSessionInfoClassification>(eventName, {
+				editSessionId,
+				...this._countEntryStates(entries),
+			});
+		}
 	}
 
 	private _countEntryStates(entries: readonly AbstractChatEditingModifiedFileEntry[]): { entryCount: number; modifiedCount: number; acceptedCount: number; rejectedCount: number } {


### PR DESCRIPTION
Use stable session-keyed sampling for correlated store and restore events. (Written by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
