### PR TITLE
Polish Copilot Agent Host labels and handoff targets

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1049,7 +1049,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const failedTurnIds = new Set<string>();
 		const error: ErrorInfo = {
 			errorType: 'providerConnectionClosed',
-			message: localize('copilotAgent.connectionClosed', "The Copilot CLI stopped unexpectedly. Retry your request."),
+			message: localize('copilotAgent.connectionClosed', "Copilot stopped unexpectedly. Retry your request."),
 		};
 		for (const chat of this._allLiveSessions()) {
 			const failedTurnId = chat.failActiveTurn(error);

--- a/src/vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions.ts
@@ -14,9 +14,9 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 import { IsAgentHostSession } from './agentHostSkillButtons.js';
 
 /**
- * Sessions-app variant of "Open Copilot CLI State File". Uses the Agents
+ * Sessions-app variant of "Open Copilot State File". Uses the Agents
  * window's `ISessionsService.activeSession` to find the active
- * Copilot CLI session, then defers to the shared workbench helper for
+ * Copilot session, then defers to the shared workbench helper for
  * the actual resolution and editor opening.
  *
  * The vscode workbench registers a separate action class
@@ -31,7 +31,7 @@ export class OpenSessionEventsFileAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenSessionEventsFileAction.ID,
-			title: localize2('openSessionEventsFile', "Open Copilot CLI State File"),
+			title: localize2('openSessionEventsFile', "Open Copilot State File"),
 			f1: true,
 			category: Categories.Developer,
 			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, IsAgentHostSession),

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -1156,7 +1156,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		// `CLOUD_SANDBOX_AGENT_SLUG`.
 		[CloudSandboxEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot CLI cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs."),
+			description: nls.localize('chat.agentHost.cloudSandbox.enabled', "Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs."),
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],

--- a/src/vs/sessions/skills/troubleshoot/SKILL.md
+++ b/src/vs/sessions/skills/troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: troubleshoot
-description: Investigate unexpected behavior in the current Copilot CLI agent session by analyzing its event log. Use when the user asks why something happened, why a request was slow, why a tool was or was not used, or why instructions/skills/agents did not load.
+description: Investigate unexpected behavior in the current Copilot agent session by analyzing its event log. Use when the user asks why something happened, why a request was slow, why a tool was or was not used, or why instructions/skills/agents did not load.
 ---
 <!-- Customize this skill and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
 
@@ -8,7 +8,7 @@ description: Investigate unexpected behavior in the current Copilot CLI agent se
 
 ## Purpose
 
-This skill investigates and explains unexpected agent behavior in the **current Copilot CLI agent session** using its on-disk event log.
+This skill investigates and explains unexpected agent behavior in the **current Copilot agent session** using its on-disk event log.
 
 Use this skill for questions like:
 - Why did this request take so long?
@@ -26,7 +26,7 @@ The skill runs **inside** the session's agent, so the log is on the same machine
 1. **If a `Session log:` path is provided with this message, use it.** It may point to a session **other than** the current one (via `#session`) and may be **comma-separated paths** — investigate all of them and compare.
 2. **Sticky reference:** if no path is on the *current* message but an earlier turn in **this conversation** already established a target (a `Session log:` path, or a `#session:` reference), keep analyzing **that same session** for the follow-up. Do **not** fall back to self-discovery here — the newest log is the *current* session, which is the wrong one. Switch only if the user references a new session.
 3. **Otherwise, self-discover it:** pick the **most recently modified** `events.jsonl` under `${XDG_STATE_HOME:-$HOME}/.copilot/session-state/<sessionId>/` — this skill is appending to the current session's log, so it's reliably newest. Honor `XDG_STATE_HOME`, else `$HOME`.
-4. **If none exists** there, this isn't a Copilot CLI session — tell the user the skill supports Copilot CLI sessions only, and stop.
+4. **If none exists** there, this isn't a Copilot session — tell the user the skill supports Copilot sessions only, and stop.
 
 ## Data Source — `events.jsonl`
 
@@ -175,4 +175,4 @@ Cover **what happened and why** (root cause), **key evidence** (paraphrased — 
 
 - Base every claim on log evidence — never assume causality.
 - Search via `run_in_terminal`; never `grep_search`, and never `read_file` a whole (possibly huge) log — narrow first, then read small ranges.
-- If no Copilot CLI session log exists, say so and stop.
+- If no Copilot session log exists, say so and stop.

--- a/src/vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.ts
@@ -20,14 +20,14 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { resolveEventsUri } from '../copilotCliEventsUri.js';
 
 /**
- * Shared implementation of "Open Copilot CLI State File". Resolves the
+ * Shared implementation of "Open Copilot State File". Resolves the
  * `events.jsonl` URI for the given chat session resource and opens it in
  * an editor, or shows a notification explaining why it could not be
  * opened.
  *
  * Both the workbench-side action (uses `IChatWidgetService`) and the
  * sessions-app-side action (uses `ISessionsManagementService`) call into
- * this helper after resolving the active Copilot CLI session resource.
+ * this helper after resolving the active Copilot session resource.
  */
 export async function openCopilotCliStateFile(
 	accessor: ServicesAccessor,
@@ -51,10 +51,10 @@ export async function openCopilotCliStateFile(
 			await editorService.openEditor({ resource: result.resource });
 			return;
 		case 'no-session':
-			notificationService.info(localize('openSessionEventsFile.noSession', "No Copilot CLI session is active."));
+			notificationService.info(localize('openSessionEventsFile.noSession', "No Copilot session is active."));
 			return;
 		case 'unsupported-scheme':
-			notificationService.info(localize('openSessionEventsFile.unsupported', "The active chat session is not a Copilot CLI session."));
+			notificationService.info(localize('openSessionEventsFile.unsupported', "The active chat session is not a Copilot session."));
 			return;
 		case 'remote-not-connected':
 			notificationService.warn(localize('openSessionEventsFile.notConnected', "No active connection found for remote agent host '{0}'.", result.authority));
@@ -67,7 +67,7 @@ export async function openCopilotCliStateFile(
 
 /**
  * Workbench-side action. Uses the last-focused chat widget's view model to
- * find the active Copilot CLI chat session. Suitable for vscode where the
+ * find the active Copilot chat session. Suitable for vscode where the
  * agents-window-specific `ISessionsManagementService` is not present.
  */
 export class OpenCopilotCliStateFileAction extends Action2 {
@@ -77,7 +77,7 @@ export class OpenCopilotCliStateFileAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenCopilotCliStateFileAction.ID,
-			title: localize2('openSessionEventsFile', "Open Copilot CLI State File"),
+			title: localize2('openSessionEventsFile', "Open Copilot State File"),
 			f1: true,
 			category: Categories.Developer,
 			precondition: ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -155,6 +155,7 @@ export interface IAgentHostDelegationRequest {
 export function getAgentCanContinueIn(provider: AgentSessionTarget): boolean {
 	switch (provider) {
 		case AgentSessionProviders.Local:
+			return false;
 		case AgentSessionProviders.Background:
 		case AgentSessionProviders.Cloud:
 		case AgentSessionProviders.AgentHostCopilot:

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget.ts
@@ -231,7 +231,7 @@ export class ToolsListWidget extends Disposable {
 		DOM.append(DOM.append(this._header, $('.section-title-row')), $('h2.section-title')).textContent = localize('toolsListTitle', "Tools");
 
 		const description = DOM.append(this._header, $('p.section-title-description'));
-		DOM.append(description, $('span.section-title-description-text')).textContent = localize('toolsListSubtitle', "Enable or disable the tools available to chat. Disabled tools are not advertised to the agent. Tools other than Copilot CLI run on the client and require it to be connected.");
+		DOM.append(description, $('span.section-title-description-text')).textContent = localize('toolsListSubtitle', "Enable or disable the tools available to chat. Disabled tools are not advertised to the agent. Tools other than Copilot's built-in tools run on the client and require it to be connected.");
 		// Whitespace node so the gap collapses when the link wraps.
 		description.appendChild(document.createTextNode(' '));
 
@@ -328,7 +328,7 @@ export class ToolsListWidget extends Disposable {
 			icon: Codicon.copilot,
 			source: ToolDataSource.Internal,
 			description: localize('clientToolSet.copilotCli.description', "Copilot"),
-			detail: localize('clientToolSet.copilotCli.detail', "Built-in tools the Copilot CLI agent runs inside its own runtime."),
+			detail: localize('clientToolSet.copilotCli.detail', "Built-in tools the Copilot agent runs inside its own runtime."),
 			getTools: () => tools,
 		};
 		return [copilotCliSet];

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -429,7 +429,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'chat.implicitContext.includeActiveEditor': {
 			type: 'boolean',
-			markdownDescription: nls.localize('chat.implicitContext.includeActiveEditor', "When enabled, the active editor is automatically forwarded as context, even when it would otherwise only be suggested. Selections and explicitly attached files are always included regardless of this setting.\n\nNote: this setting currently only applies to Agent Host sessions (such as the Copilot CLI)."),
+			markdownDescription: nls.localize('chat.implicitContext.includeActiveEditor', "When enabled, the active editor is automatically forwarded as context, even when it would otherwise only be suggested. Selections and explicitly attached files are always included regardless of this setting.\n\nNote: this setting currently only applies to Agent Host sessions (such as Copilot)."),
 			default: true,
 			tags: ['experimental'],
 			agentsWindow: { default: false },
@@ -647,7 +647,7 @@ configurationRegistry.registerConfiguration({
 				},
 			},
 			default: { mode: 'interactive', approvals: ChatDefaultPermissionLevel.Default },
-			markdownDescription: nls.localize('chat.defaultConfiguration.settingDescription', "Controls the default configuration for new agent sessions (such as Copilot CLI). You can still change the mode and approval behavior per session, and each session remembers what was used."),
+			markdownDescription: nls.localize('chat.defaultConfiguration.settingDescription', "Controls the default configuration for new agent sessions (such as Copilot). You can still change the mode and approval behavior per session, and each session remembers what was used."),
 		},
 		[ChatConfiguration.DefaultModel]: {
 			type: 'string',
@@ -1557,7 +1557,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[AgentHostCopilotModelCapabilityOverridesSettingId]: {
 			type: 'object',
-			markdownDescription: nls.localize('chat.agentHost.copilot.modelCapabilityOverrides', "Per-model capability overrides for Copilot SDK agent sessions, keyed by model id (`*` matches every model; a specific entry wins field-by-field), intended for evaluating models against an existing model's profile. Declare an aliased `family` (for example `claude-opus-4.8`) to route the model to that family's tuned system prompt and tool profile without changing the model id sent to the runtime — so a preview model can be evaluated against a known prompt while still running on its own endpoint — a `reasoningEffort` to pin its effort level, `availableTools`/`excludedTools` to filter its tool set, or `modelCapabilities` to override individual capability limits (e.g. vision support, context window size) passed through to the SDK. All overrides apply when a session launches or resumes. On a mid-session model change, only the new model's `reasoningEffort` is applied; the session keeps its launch-time family, tool filters, and model capabilities. Only affects Copilot CLI agent sessions.\n\n**Note**: This is an advanced setting for experimentation."),
+			markdownDescription: nls.localize('chat.agentHost.copilot.modelCapabilityOverrides', "Per-model capability overrides for Copilot SDK agent sessions, keyed by model id (`*` matches every model; a specific entry wins field-by-field), intended for evaluating models against an existing model's profile. Declare an aliased `family` (for example `claude-opus-4.8`) to route the model to that family's tuned system prompt and tool profile without changing the model id sent to the runtime — so a preview model can be evaluated against a known prompt while still running on its own endpoint — a `reasoningEffort` to pin its effort level, `availableTools`/`excludedTools` to filter its tool set, or `modelCapabilities` to override individual capability limits (e.g. vision support, context window size) passed through to the SDK. All overrides apply when a session launches or resumes. On a mid-session model change, only the new model's `reasoningEffort` is applied; the session keeps its launch-time family, tool filters, and model capabilities. Only affects Copilot agent sessions.\n\n**Note**: This is an advanced setting for experimentation."),
 			additionalProperties: {
 				type: 'object',
 				properties: {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider.ts
@@ -1532,7 +1532,7 @@ function lastIndexOfNewline(buffer: VSBuffer): number {
  * the session id.
  */
 function fallbackSessionTitle(sessionId: string): string {
-	return localize('agentHost.debug.untitledSession', "Copilot CLI Session {0}", sessionId.slice(0, 8));
+	return localize('agentHost.debug.untitledSession', "Copilot Session {0}", sessionId.slice(0, 8));
 }
 
 /** Derives a session title from the first user message in an events stream. */

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources.ts
@@ -226,7 +226,7 @@ export async function enumerateAgentHostLogSources(
 		if (copilotLogsDir) {
 			sources.push({
 				id: 'cliLog',
-				label: localize('agentHostLogs.cliLog', "Copilot CLI Logs"),
+				label: localize('agentHostLogs.cliLog', "Copilot Logs"),
 				kind: AgentHostLogSourceKind.CliLog,
 				isRemote: !isLocal,
 				cliLogs: { dir: copilotLogsDir, rawSessionId },

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
@@ -400,7 +400,7 @@ export async function showConfigureHooksQuickPick(
 							.filter(([hookType]) => targetHookTypes.has(hookType))
 							.map(makeItem);
 					} else {
-						// No target: group into Default (shared), VS Code Only, Copilot CLI Only
+						// No target: group into Default (shared), VS Code Only, Copilot Only
 						const vscodeTypes = new Set(Object.values(HOOKS_BY_TARGET[Target.VSCode]));
 						const copilotTypes = new Set(Object.values(HOOKS_BY_TARGET[Target.GitHubCopilot]));
 						const allEntries = Object.entries(HOOK_METADATA) as [HookType, IHookTypeMeta][];
@@ -411,7 +411,7 @@ export async function showConfigureHooksQuickPick(
 
 						pickerItems = [];
 						if (shared.length > 0) {
-							pickerItems.push({ type: 'separator', label: localize('hookSection.default', "Local/Copilot CLI Agents") });
+							pickerItems.push({ type: 'separator', label: localize('hookSection.default', "Local/Copilot Agents") });
 							pickerItems.push(...shared.map(makeItem));
 						}
 						if (vscodeOnly.length > 0) {
@@ -419,7 +419,7 @@ export async function showConfigureHooksQuickPick(
 							pickerItems.push(...vscodeOnly.map(makeItem));
 						}
 						if (copilotOnly.length > 0) {
-							pickerItems.push({ type: 'separator', label: localize('hookSection.copilotCliOnly', "Copilot CLI Agents") });
+							pickerItems.push({ type: 'separator', label: localize('hookSection.copilotCliOnly', "Copilot Agents") });
 							pickerItems.push(...copilotOnly.map(makeItem));
 						}
 					}

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -490,15 +490,15 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		// session that we shouldn't try to restore on the other side.
 		const commandArgs: unknown[] = eligible && sessionResource ? [sessionResource] : [];
 
-		// Empty-workspace + local Copilot CLI: the local agent host can't
+		// Empty-workspace + local Copilot: the local agent host can't
 		// run without a folder, so frame the tip as the path forward rather
 		// than a generic "continue in agents" upsell.
 		const useEmptyWorkspaceCopy = emptyWorkspaceEligible && !eligible;
 		const message = useEmptyWorkspaceCopy
-			? localize('chat.agentsHandoff.tip.emptyWorkspace.message', "Copilot CLI [Agent Host] isn't available without an open folder")
+			? localize('chat.agentsHandoff.tip.emptyWorkspace.message', "Copilot isn't available without an open folder")
 			: localize('chat.agentsHandoff.tip.message', "Continue this session in the Agents Window");
 		const description = useEmptyWorkspaceCopy
-			? localize('chat.agentsHandoff.tip.emptyWorkspace.description', "Open the Agents Window to start a Copilot CLI session.")
+			? localize('chat.agentsHandoff.tip.emptyWorkspace.description', "Open the Agents Window to start a Copilot session.")
 			: mode === AgentsHandoffTipMode.Custom
 				? localize('chat.agentsHandoff.tip.description.copilot', "Free with your Copilot plan — get a dedicated, multi-pane view alongside your workspace.")
 				: localize('chat.agentsHandoff.tip.description', "Get a dedicated, multi-pane view alongside your workspace.");

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -2757,6 +2757,11 @@ suite('AgentSessions', () => {
 	suite('AgentSessionsViewModel - getAgentCanContinueIn', () => {
 		ensureNoDisposablesAreLeakedInTestSuite();
 
+		test('should return false for Local provider', () => {
+			const result = getAgentCanContinueIn(AgentSessionProviders.Local);
+			assert.strictEqual(result, false);
+		});
+
 		test('should return true for Cloud provider', () => {
 			const result = getAgentCanContinueIn(AgentSessionProviders.Cloud);
 			assert.strictEqual(result, true);


### PR DESCRIPTION
## Summary

- use the `Copilot` product name across current Agent Host settings, debug surfaces, hooks, and session guidance
- clarify that Copilot's built-in tools run in the agent runtime while other tools run on the connected client
- remove the legacy `Local` harness from `Continue In` targets
- preserve `Copilot CLI` wording for the legacy extension-host harness that will be removed separately

## Testing

- `scripts\test.bat --run src\vs\workbench\contrib\chat\test\browser\agentSessions\agentSessionViewModel.test.ts` (114 passing)

Fixes #321823
Fixes microsoft/vscode-internalbacklog#8829