### PR TITLE
Surface a client tool's error when it returns no content

### DIFF
--- a/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolResult.ts
+++ b/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolResult.ts
@@ -35,6 +35,14 @@ const CLAUDE_CLIENT_RESOURCE_SCHEME = 'claude-client';
 export function convertToolCallResult(result: ToolCallResult, toolUseId: string): CallToolResult {
 	const blocks = result.content ?? [];
 	const content = blocks.map((block, index) => convertBlock(block, toolUseId, index));
+	// A tool can report a failure as an `error` alone, with no content: the
+	// workbench builds that shape whenever a client tool throws. Passing it
+	// straight through would hand the model an empty result and no hint that
+	// anything went wrong, so surface the message as the content it lacks.
+	// Tools that already describe the failure in `content` keep theirs.
+	if (result.error && content.length === 0) {
+		content.push({ type: 'text', text: result.error.message });
+	}
 	const out: CallToolResult = { content };
 	if (result.structuredContent !== undefined) {
 		out.structuredContent = result.structuredContent;

--- a/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolResult.ts
+++ b/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolResult.ts
@@ -35,11 +35,7 @@ const CLAUDE_CLIENT_RESOURCE_SCHEME = 'claude-client';
 export function convertToolCallResult(result: ToolCallResult, toolUseId: string): CallToolResult {
 	const blocks = result.content ?? [];
 	const content = blocks.map((block, index) => convertBlock(block, toolUseId, index));
-	// A tool can report a failure as an `error` alone, with no content: the
-	// workbench builds that shape whenever a client tool throws. Passing it
-	// straight through would hand the model an empty result and no hint that
-	// anything went wrong, so surface the message as the content it lacks.
-	// Tools that already describe the failure in `content` keep theirs.
+	// `isError` below already marks the failure; without this the model would not learn why it failed.
 	if (result.error && content.length === 0) {
 		content.push({ type: 'text', text: result.error.message });
 	}

--- a/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolResult.test.ts
+++ b/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolResult.test.ts
@@ -89,8 +89,7 @@ suite('claudeClientToolResult / convertToolCallResult', () => {
 	});
 
 	test('an error-only failure surfaces the message as content instead of an empty result', () => {
-		// The workbench builds this shape whenever a client tool throws: an error
-		// and nothing else. An empty result tells the model nothing went wrong.
+		// An error-only result still carries `isError`, but without content the model never learns the reason.
 		const errorOnly = convertToolCallResult(makeResult({
 			success: false,
 			error: { message: 'page.goto: net::ERR_EMPTY_RESPONSE at http://localhost:5173/' },

--- a/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolResult.test.ts
+++ b/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolResult.test.ts
@@ -88,6 +88,27 @@ suite('claudeClientToolResult / convertToolCallResult', () => {
 		}
 	});
 
+	test('an error-only failure surfaces the message as content instead of an empty result', () => {
+		// The workbench builds this shape whenever a client tool throws: an error
+		// and nothing else. An empty result tells the model nothing went wrong.
+		const errorOnly = convertToolCallResult(makeResult({
+			success: false,
+			error: { message: 'page.goto: net::ERR_EMPTY_RESPONSE at http://localhost:5173/' },
+		}), 'tu_7');
+
+		// A tool that already described the failure keeps its own content.
+		const withContent = convertToolCallResult(makeResult({
+			success: false,
+			content: [{ type: ToolResultContentType.Text, text: 'No browser page found' }],
+			error: { message: 'No browser page found' },
+		}), 'tu_8');
+
+		assert.deepStrictEqual({ errorOnly: errorOnly.content, withContent: withContent.content }, {
+			errorOnly: [{ type: 'text', text: 'page.goto: net::ERR_EMPTY_RESPONSE at http://localhost:5173/' }],
+			withContent: [{ type: 'text', text: 'No browser page found' }],
+		});
+	});
+
 	test('structuredContent passes through unchanged', () => {
 		const out = convertToolCallResult(makeResult({
 			structuredContent: { k: 'v' },


### PR DESCRIPTION
A client tool can report a failure as an `error` alone, with no content. The workbench builds exactly that shape whenever a client tool throws, so a browser call that cannot navigate arrives as:

```json
{"success": false, "pastTenseMessage": "openBrowserPage failed",
 "error": {"message": "page.goto: net::ERR_EMPTY_RESPONSE at http://localhost:5173/…"}}
```

`convertToolCallResult` reads only `content`, so this becomes `{content: [], isError: true}`. The model gets an empty tool result: it is told something failed but not what, and the actual reason is dropped.

Observed live in a dev container: the browser tool failed because the dev server was not listening, and the agent received nothing to act on.

This uses the error message as the content when the tool supplied none. Tools that already describe the failure in `content` (via `errorResult`) keep their own, so nothing is duplicated.

### Testing

- Added `an error-only failure surfaces the message as content instead of an empty result`, asserting both directions in one snapshot: the error-only result gains the message, and a result that already carries content is left untouched.
- `./scripts/test.sh --grep convertToolCallResult`: 7 passing.
- `./scripts/test.sh --grep ClaudeAgent`: 265 passing, 3 failing, the same 3 failing on an unmodified checkout (model catalog / credential tests, unrelated).
- `npm run typecheck-client` clean.