### PR TITLE
copilot: add tadfss marker to terminal service

### DIFF
--- a/extensions/copilot/src/platform/terminal/common/terminalService.ts
+++ b/extensions/copilot/src/platform/terminal/common/terminalService.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// tadfss
+
 import type * as vscode from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Emitter, Event } from '../../../util/vs/base/common/event';


### PR DESCRIPTION
## Summary
- Add the `tadfss` marker at the top of the Copilot terminal service.

## Validation
- `git diff --check` passed.
- Extension compile was attempted but could not run because `esbuild` is missing from the checkout.